### PR TITLE
override default attr for OptRegexp

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -527,6 +527,10 @@ class OptRegexp < OptBase
     return Regexp.compile(value)
   end
 
+  def default
+    @default.to_s
+  end
+
   def display_value(value)
     if value.kind_of?(Regexp)
       return value.source


### PR DESCRIPTION
Rather than literally returning the default Regex object, override the accessor
to return the string representation. This allows the RPC backend to properly
serialize the options hash values, since msgpack does not know how to serialize
a Regexp object. Fixes #3798.
# To verify the fix:
- [x] run the steps for issue #3798 and ensure that the module
  options are returned instead of a backtrace.
- [x] ensure that the module continues to work as expected:

```
$ ./msfconsole -q
msf > use auxiliary/scanner/http/scraper
msf auxiliary(scraper) > info

       Name: HTTP Page Scraper
     Module: auxiliary/scanner/http/scraper
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  et <et@metasploit.com>

Basic options:
  Name     Current Setting               Required  Description
  ----     ---------------               --------  -----------
  PATH     /                             yes       The test path to the page to analize
  PATTERN  (?i-mx:<title>(.*)<\/title>)  yes       The regex to use (default regex is a sample to grab page title)
  Proxies                                no        Use a proxy chain
  RHOSTS                                 yes       The target address range or CIDR identifier
  RPORT    80                            yes       The target port
  THREADS  1                             yes       The number of concurrent threads
  VHOST                                  no        HTTP server virtual host

override default attr for OptRegexp
Description:
  Scrap defined data from a specific web page based on a regular
  expresion

msf auxiliary(scraper) > set RHOSTS lwn.net
RHOSTS => lwn.net
msf auxiliary(scraper) > set RHOSTS 72.51.34.34
RHOSTS => 72.51.34.34
msf auxiliary(scraper) > set VHOST lwn.net
VHOST => lwn.net
msf auxiliary(scraper) > run

[*] [72.51.34.34] / [Welcome to LWN.net [LWN.net]]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
