### PR TITLE
log errors into framework.log and show the callstack

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -151,16 +151,18 @@ protected
     rescue ::Exception => e
       mod.error = e
       mod.print_error("Auxiliary failed: #{e.class} #{e}")
+      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
+
       if(e.class.to_s != 'Msf::OptionValidateError')
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.auxiliary.rb/
           mod.print_error("  #{line}")
         end
+        elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
+      else
+        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
       end
-
-      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
-      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
 
       mod.cleanup
 
@@ -182,4 +184,3 @@ end
 
 end
 end
-

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -153,15 +153,15 @@ protected
       mod.print_error("Auxiliary failed: #{e.class} #{e}")
       elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
 
-      if(e.class.to_s != 'Msf::OptionValidateError')
+      if e.kind_of?(Msf::OptionValidateError)
+        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
+      else
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.auxiliary.rb/
           mod.print_error("  #{line}")
         end
         elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
-      else
-        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
       end
 
       mod.cleanup

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -148,15 +148,15 @@ module Exploit
       exploit.print_error("Exploit failed: #{e}")
       elog("Exploit failed (#{exploit.refname}): #{e}", 'core', LEV_0)
 
-      if(e.class.to_s != 'Msf::OptionValidateError')
+      if e.kind_of?(Msf::OptionValidateError)
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+      else
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.exploit.rb/
           mod.print_error("  #{line}")
         end
         elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
-      else
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
       end
     end
 

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -147,7 +147,17 @@ module Exploit
       exploit.error = e
       exploit.print_error("Exploit failed: #{e}")
       elog("Exploit failed (#{exploit.refname}): #{e}", 'core', LEV_0)
-      dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+
+      if(e.class.to_s != 'Msf::OptionValidateError')
+        mod.print_error("Call stack:")
+        e.backtrace.each do |line|
+          break if line =~ /lib.msf.base.simple.exploit.rb/
+          mod.print_error("  #{line}")
+        end
+        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
+      else
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+      end
     end
 
     return driver.session if driver
@@ -199,4 +209,3 @@ end
 
 end
 end
-

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -121,16 +121,18 @@ protected
     rescue ::Exception => e
       mod.error = e
       mod.print_error("Post failed: #{e.class} #{e}")
+      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
+
       if(e.class.to_s != 'Msf::OptionValidateError')
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.post.rb/
           mod.print_error("  #{line}")
         end
+        elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
+      else
+        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
       end
-
-      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
-      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
 
       mod.cleanup
 
@@ -154,4 +156,3 @@ end
 
 end
 end
-

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -123,15 +123,15 @@ protected
       mod.print_error("Post failed: #{e.class} #{e}")
       elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
 
-      if(e.class.to_s != 'Msf::OptionValidateError')
+      if e.kind_of?(Msf::OptionValidateError)
+        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
+      else
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.post.rb/
           mod.print_error("  #{line}")
         end
         elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
-      else
-        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
       end
 
       mod.cleanup

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -271,14 +271,20 @@ protected
           exploit.fail_reason = Msf::Exploit::Failure::Unknown
         end
 
+        elog("Exploit failed (#{exploit.refname}): #{msg}", 'core', LEV_0)
+
         if exploit.fail_reason == Msf::Exploit::Failure::Unknown
           exploit.print_error("Exploit failed: #{msg}")
+          exploit.print_error("Call stack:")
+          e.backtrace.each do |line|
+            break if line =~ /lib.msf.base.core.exploit_driver.rb/
+            exploit.print_error("  #{line}")
+          end
+          elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
         else
           exploit.print_error("Exploit failed [#{exploit.fail_reason}]: #{msg}")
+          dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
         end
-
-        elog("Exploit failed (#{exploit.refname}): #{msg}", 'core', LEV_0)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
       end
 
       # Record the error to various places
@@ -329,4 +335,3 @@ protected
 end
 
 end
-

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -120,12 +120,17 @@ class Auxiliary
       print_error("Auxiliary interrupted by the console user")
     rescue ::Exception => e
       print_error("Auxiliary failed: #{e.class} #{e}")
-      if(e.class.to_s != 'Msf::OptionValidateError')
+      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
+
+      if e.kind_of?(Msf::OptionValidateError)
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+      else
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
+        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
 
       return false
@@ -152,4 +157,3 @@ class Auxiliary
 end
 
 end end end end
-

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -121,12 +121,18 @@ class Exploit
       raise $!
     rescue ::Exception => e
       print_error("Exploit exception (#{mod.refname}): #{e.class} #{e}")
-      if(e.class.to_s != 'Msf::OptionValidateError')
+
+      elog("Exploit exception (#{mod.refname}): #{e.class} #{e}", 'core', LEV_0)
+
+      if e.kind_of?(Msf::OptionValidateError)
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+      else
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
+        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -122,12 +122,18 @@ class Post
       print_error("Post interrupted by the console user")
     rescue ::Exception => e
       print_error("Post failed: #{e.class} #{e}")
-      if (e.class.to_s != 'Msf::OptionValidateError')
+
+      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
+
+      if e.kind_of?(Msf::OptionValidateError)
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+      else
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
+        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
 
       return false
@@ -154,4 +160,3 @@ class Post
 end
 
 end end end end
-


### PR DESCRIPTION
See #4122 for discussion on this one.

Basicially this PR is all about logging a stacktracke when a module fails dua to coding errors (undefined method xxx on nil and so on).

Test module:

```
##
# This module requires Metasploit: http://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

require 'msf/core'

class Metasploit3 < Msf::Exploit::Remote
  Rank = ExcellentRanking

  def initialize(info = {})
    super(update_info(
    info,
    'Name'           => 'XXXX',
    'Description'    => %q{
      XXX
    },
    'Author'         =>
    [
      'Christian Mehlmauer' # metasploit module
    ],
    'License'        => MSF_LICENSE,
    'References'     =>
    [
      ['URL', 'https://www.google.com']
    ],
    'Privileged'     => false,
    'Platform'       => ['php'],
    'Arch'           => ARCH_PHP,
    'Targets'        => [['XXXX', {}]],
    'DefaultTarget'  => 0,
    'DisclosureDate' => 'Dec 3 2014'))
    end

    def exploit
      test = nil
      test.asdf
    end
  end
```

Example output of exploit_driver.rb:

```
msf exploit(test) > run

[*] Started reverse handler on 10.0.0.5:4444 
[-] Exploit failed: NoMethodError undefined method `asdf' for nil:NilClass
[-] Call stack:
[-]   /Users/firefart/.msf4/modules/exploits/test.rb:37:in `exploit'
[-]   /Users/firefart/Coding/metasploit-framework/lib/msf/core/exploit_driver.rb:205:in `job_run_proc'
[-]   /Users/firefart/Coding/metasploit-framework/lib/msf/core/exploit_driver.rb:166:in `run'
[-]   /Users/firefart/Coding/metasploit-framework/lib/msf/base/simple/exploit.rb:136:in `exploit_simple'
[-]   /Users/firefart/Coding/metasploit-framework/lib/msf/base/simple/exploit.rb:171:in `exploit_simple'
[-]   /Users/firefart/Coding/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:111:in `cmd_exploit'
[-]   /Users/firefart/Coding/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
[-]   /Users/firefart/Coding/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
[-]   /Users/firefart/Coding/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
[-]   /Users/firefart/Coding/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
[-]   /Users/firefart/Coding/metasploit-framework/lib/rex/ui/text/shell.rb:200:in `run'
[-]   /Users/firefart/Coding/metasploit-framework/lib/metasploit/framework/command/console.rb:30:in `start'
[-]   /Users/firefart/Coding/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
[-]   ./msfconsole:48:in `<main>'
```
