### PR TITLE
fix backward meterpreter packet timeout logic

### DIFF
--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -356,7 +356,7 @@ module PacketDispatcher
           begin
           if ! dispatch_inbound_packet(pkt)
             # Only requeue packets newer than the timeout
-            if (::Time.now.to_i - pkt.created_at.to_i < PacketTimeout)
+            if (::Time.now.to_i - pkt.created_at.to_i > PacketTimeout)
               incomplete << pkt
             end
           end


### PR DESCRIPTION
The current logic times out every packet almost immediately, making it possible
for almost any non-trivial meterpreter session to receive duplicate packets.

This causes problems especially with any interactions that involve passing
resource handles or pointers back and forth between MSF and meterpreter, since
meterpreter can be told to operate on freed pointers, double-closes, etc.

The only reason this doesn't show up all the time is usually meterpreter is fast
enough to get the reply back before the ruby thread scheduler runs. Faster ruby
or slower metepreter make this bug hit more often.

This probably fixes tons of heisenbugs, including the root cause for #3693.

To reproduce this, I enabled all debug messages in meterpreter to slow it
down, then ran this RC script with a reverse TCP meterpreter, after linking in
the test modules:

(cd modules/post
 ln -s ../../test/modules/post/test)

die.rc:
use exploit/multi/handler
set payload windows/meterpreter/reverse_tcp
set lhost 192.168.43.1
exploit -j
sleep 5
use post/test/services
set SESSION 1
run
