### PR TITLE
patch metsvc to use MeterpreterBinaries.path

### DIFF
--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -92,7 +92,8 @@ if client.platform =~ /win32|win64/
     to ||= from
     print_status(" >> Uploading #{from}...")
     fd = client.fs.file.new(tempdir + "\\" + to, "wb")
-    fd.write(::File.read(File.join(based, from), ::File.size(::File.join(based, from))))
+    path = (from == 'metsrv.x86.dll') ? MeterpreterBinaries.path('metsrv','x86.dll') : File.join(based, from)
+    fd.write(::File.read(path, ::File.size(path)))
     fd.close
   end
 


### PR DESCRIPTION
stops the bleeding, without going too far down the path of reworking it.
fixes #4472
