### PR TITLE
handle nil results from MeterpreterBinaries.path

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -159,6 +159,10 @@ class ClientCore < Extension
       path = opts['ExtensionPath']
     end
 
+    if path == nil
+      raise RuntimeError, "No module of the name #{modname}.#{client.binary_suffix} found", caller
+    end
+
     path = ::File.expand_path(path)
 
     # Load the extension DLL
@@ -225,7 +229,12 @@ class ClientCore < Extension
 
     # Create the migrate stager
     migrate_stager = c.new()
-    migrate_stager.datastore['DLL'] = MeterpreterBinaries.path('metsrv',binary_suffix)
+
+    dll = MeterpreterBinaries.path('metsrv',binary_suffix)
+    if dll == nil
+      raise RuntimeError, "metsrv.#{binary_suffix} not found", caller
+    end
+    migrate_stager.datastore['DLL'] = dll
 
     blob = migrate_stager.stage_payload
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -68,18 +68,18 @@ class ClientCore < Extension
     load_flags   = LOAD_LIBRARY_FLAG_LOCAL
 
     # No library path, no cookie.
-    if (library_path == nil)
+    if library_path.nil?
       raise ArgumentError, "No library file path was supplied", caller
     end
 
     # Set up the proper loading flags
-    if (opts['UploadLibrary'])
+    if opts['UploadLibrary']
       load_flags &= ~LOAD_LIBRARY_FLAG_LOCAL
     end
-    if (opts['SaveToDisk'])
+    if opts['SaveToDisk']
       load_flags |= LOAD_LIBRARY_FLAG_ON_DISK
     end
-    if (opts['Extension'])
+    if opts['Extension']
       load_flags |= LOAD_LIBRARY_FLAG_EXTENSION
     end
 
@@ -87,14 +87,14 @@ class ClientCore < Extension
     request = Packet.create_request('core_loadlib')
 
     # If we must upload the library, do so now
-    if ((load_flags & LOAD_LIBRARY_FLAG_LOCAL) != LOAD_LIBRARY_FLAG_LOCAL)
+    if (load_flags & LOAD_LIBRARY_FLAG_LOCAL) != LOAD_LIBRARY_FLAG_LOCAL
       image = ''
 
       ::File.open(library_path, 'rb') { |f|
         image = f.read
       }
 
-      if (image != nil)
+      if !image.nil?
         request.add_tlv(TLV_TYPE_DATA, image, false, client.capabilities[:zlib])
       else
         raise RuntimeError, "Failed to serialize library #{library_path}.", caller
@@ -103,7 +103,7 @@ class ClientCore < Extension
       # If it's an extension we're dealing with, rename the library
       # path of the local and target so that it gets loaded with a random
       # name
-      if (opts['Extension'])
+      if opts['Extension']
         library_path = "ext" + rand(1000000).to_s + ".#{client.binary_suffix}"
         target_path  = library_path
       end
@@ -113,7 +113,7 @@ class ClientCore < Extension
     request.add_tlv(TLV_TYPE_LIBRARY_PATH, library_path)
     request.add_tlv(TLV_TYPE_FLAGS, load_flags)
 
-    if (target_path != nil)
+    if !target_path.nil?
       request.add_tlv(TLV_TYPE_TARGET_PATH, target_path)
     end
 
@@ -121,9 +121,9 @@ class ClientCore < Extension
     response = self.client.send_packet_wait_response(request, self.client.response_timeout)
 
     # No response?
-    if (response == nil)
+    if response.nil?
       raise RuntimeError, "No response was received to the core_loadlib request.", caller
-    elsif (response.result != 0)
+    elsif response.result != 0
       raise RuntimeError, "The core_loadlib request failed with result: #{response.result}.", caller
     end
 
@@ -147,7 +147,7 @@ class ClientCore < Extension
   #		memory on the remote machine
   #
   def use(mod, opts = { })
-    if (mod == nil)
+    if mod.nil?
       raise RuntimeError, "No modules were specified", caller
     end
     # Get us to the installation root and then into data/meterpreter, where
@@ -155,11 +155,11 @@ class ClientCore < Extension
     modname = "ext_server_#{mod.downcase}"
     path = MeterpreterBinaries.path(modname, client.binary_suffix)
 
-    if (opts['ExtensionPath'])
+    if opts['ExtensionPath']
       path = opts['ExtensionPath']
     end
 
-    if path == nil
+    if path.nil?
       raise RuntimeError, "No module of the name #{modname}.#{client.binary_suffix} found", caller
     end
 
@@ -191,24 +191,24 @@ class ClientCore < Extension
 
     # Determine the architecture for the pid we are going to migrate into...
     client.sys.process.processes.each { | p |
-      if( p['pid'] == pid )
+      if p['pid'] == pid
         process = p
         break
       end
     }
 
     # We cant migrate into a process that does not exist.
-    if( process == nil )
+    if process.nil?
       raise RuntimeError, "Cannot migrate into non existent process", caller
     end
 
     # We cant migrate into a process that we are unable to open
-    if( process['arch'] == nil or process['arch'].empty? )
+    if process['arch'].nil? or process['arch'].empty?
       raise RuntimeError, "Cannot migrate into this process (insufficient privileges)", caller
     end
 
     # And we also cant migrate into our own current process...
-    if( process['pid'] == client.sys.process.getpid )
+    if process['pid'] == client.sys.process.getpid
       raise RuntimeError, "Cannot migrate into current process", caller
     end
 
@@ -217,10 +217,10 @@ class ClientCore < Extension
     c.include( ::Msf::Payload::Stager )
 
     # Include the appropriate reflective dll injection module for the target process architecture...
-    if( process['arch'] == ARCH_X86 )
+    if process['arch'] == ARCH_X86
       c.include( ::Msf::Payload::Windows::ReflectiveDllInject )
       binary_suffix = "x86.dll"
-    elsif( process['arch'] == ARCH_X86_64 )
+    elsif process['arch'] == ARCH_X86_64
       c.include( ::Msf::Payload::Windows::ReflectiveDllInject_x64 )
       binary_suffix = "x64.dll"
     else
@@ -231,7 +231,7 @@ class ClientCore < Extension
     migrate_stager = c.new()
 
     dll = MeterpreterBinaries.path('metsrv',binary_suffix)
-    if dll == nil
+    if dll.nil?
       raise RuntimeError, "metsrv.#{binary_suffix} not found", caller
     end
     migrate_stager.datastore['DLL'] = dll
@@ -262,7 +262,7 @@ class ClientCore < Extension
     request.add_tlv( TLV_TYPE_MIGRATE_PID, pid )
     request.add_tlv( TLV_TYPE_MIGRATE_LEN, blob.length )
     request.add_tlv( TLV_TYPE_MIGRATE_PAYLOAD, blob, false, client.capabilities[:zlib])
-    if( process['arch'] == ARCH_X86_64 )
+    if process['arch'] == ARCH_X86_64
       request.add_tlv( TLV_TYPE_MIGRATE_ARCH, 2 ) # PROCESS_ARCH_X64
     else
       request.add_tlv( TLV_TYPE_MIGRATE_ARCH, 1 ) # PROCESS_ARCH_X86
@@ -310,7 +310,7 @@ class ClientCore < Extension
     # Update the meterpreter platform/suffix for loading extensions as we may have changed target architecture
     # sf: this is kinda hacky but it works. As ruby doesnt let you un-include a module this is the simplest solution I could think of.
     # If the platform specific modules Meterpreter_x64_Win/Meterpreter_x86_Win change significantly we will need a better way to do this.
-    if( process['arch'] == ARCH_X86_64 )
+    if process['arch'] == ARCH_X86_64
       client.platform      = 'x64/win64'
       client.binary_suffix = 'x64.dll'
     else

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -46,7 +46,7 @@ class Priv < Extension
     elevator_name = Rex::Text.rand_text_alpha_lower( 6 )
 
     elevator_path = MeterpreterBinaries.path('elevator', client.binary_suffix)
-    if elevator_path == nil
+    if elevator_path.nil?
       raise RuntimeError, "elevator.#{binary_suffix} not found", caller
     end
 

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -46,6 +46,9 @@ class Priv < Extension
     elevator_name = Rex::Text.rand_text_alpha_lower( 6 )
 
     elevator_path = MeterpreterBinaries.path('elevator', client.binary_suffix)
+    if elevator_path == nil
+      raise RuntimeError, "elevator.#{binary_suffix} not found", caller
+    end
 
     elevator_path = ::File.expand_path( elevator_path )
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -157,7 +157,7 @@ class UI < Rex::Post::UI
     # include the x64 screenshot dll if the host OS is x64
     if( client.sys.config.sysinfo['Architecture'] =~ /^\S*x64\S*/ )
       screenshot_path = MeterpreterBinaries.path('screenshot','x64.dll')
-      if screenshot_path == nil
+      if screenshot_path.nil?
         raise RuntimeError, "screenshot.x64.dll not found", caller
       end
       screenshot_path = ::File.expand_path( screenshot_path )
@@ -170,7 +170,7 @@ class UI < Rex::Post::UI
     end
     # but always include the x86 screenshot dll as we can use it for wow64 processes if we are on x64
     screenshot_path = MeterpreterBinaries.path('screenshot','x86.dll')
-    if screenshot_path == nil
+    if screenshot_path.nil?
       raise RuntimeError, "screenshot.x86.dll not found", caller
     end
     screenshot_path = ::File.expand_path( screenshot_path )

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -157,6 +157,9 @@ class UI < Rex::Post::UI
     # include the x64 screenshot dll if the host OS is x64
     if( client.sys.config.sysinfo['Architecture'] =~ /^\S*x64\S*/ )
       screenshot_path = MeterpreterBinaries.path('screenshot','x64.dll')
+      if screenshot_path == nil
+        raise RuntimeError, "screenshot.x64.dll not found", caller
+      end
       screenshot_path = ::File.expand_path( screenshot_path )
       screenshot_dll  = ''
       ::File.open( screenshot_path, 'rb' ) do |f|
@@ -165,8 +168,11 @@ class UI < Rex::Post::UI
       request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_BUFFER, screenshot_dll, false, true )
       request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_LENGTH, screenshot_dll.length )
     end
-    # but allways include the x86 screenshot dll as we can use it for wow64 processes if we are on x64
+    # but always include the x86 screenshot dll as we can use it for wow64 processes if we are on x64
     screenshot_path = MeterpreterBinaries.path('screenshot','x86.dll')
+    if screenshot_path == nil
+      raise RuntimeError, "screenshot.x86.dll not found", caller
+    end
     screenshot_path = ::File.expand_path( screenshot_path )
     screenshot_dll  = ''
     ::File.open( screenshot_path, 'rb' ) do |f|

--- a/spec/lib/rex/post/meterpreter/client_core_spec.rb
+++ b/spec/lib/rex/post/meterpreter/client_core_spec.rb
@@ -43,7 +43,7 @@ describe Rex::Post::Meterpreter::ClientCore do
     context 'with a missing a module' do
       let(:mod) {"eaten_by_av"}
       it 'should be available' do
-        expect { client_core.use(mod) }.to raise_error(TypeError)
+        expect { client_core.use(mod) }.to raise_error(RuntimeError)
       end
     end
 


### PR DESCRIPTION
When a meterpreter binary cannot be found, give the user some hint about what
went wrong. This fixes #4474 

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.43.1
lhost => 192.168.43.1
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.43.1:4444
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 192.168.43.252
[*] Meterpreter session 1 opened (192.168.43.1:4444 -> 192.168.43.252:49297) at 2014-12-29 12:32:37 -0600

meterpreter > use mack
Loading extension mack...
[-] Failed to load extension: No module of the name ext_server_mack.x86.dll found
```

This is also useful for not scaring away would-be developers who replaced only
half (the wrong half) of their DLLs from a fresh meterpreter build and
everything exploded. Not that thats ever happened to me :)
