### PR TITLE
Alias Rex::Ui::Text::Output::Tee print_raw to write, fixes #4469 and #4363

### DIFF
--- a/lib/rex/ui/text/output/tee.rb
+++ b/lib/rex/ui/text/output/tee.rb
@@ -44,6 +44,8 @@ class Output::Tee < Rex::Ui::Text::Output
     msg
   end
 
+  alias :write :print_raw
+
   def close
     self.fd.close if self.fd
     self.fd = nil


### PR DESCRIPTION
This just does what `Rex::Ui::Text::Output::Buffer::StdOut` already does, which is why both of these work without this PR:

```
./msfconsole -q  -x "spool /tmp/blah.foo; date; exit" -L
./msfconsole -q  -x "spool /tmp/blah.foo; date; exit"
```

If you run those commands interactively, however, the later one kills `msfconsole` as #4469 reported.  This PR fixes #4469.

Validation:

Before:

```
$  ./msfconsole -q
[*] Processing /home/jhart/.msf4/msfconsole.rc for ERB directives.
resource (/home/jhart/.msf4/msfconsole.rc)> db_connect -y ~/.msf4/database.yml
[*] Rebuilding the module cache in the background...
msf > spool /tmp/blah.foo
[*] Spooling to file /tmp/blah.foo...
/home/jhart/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rb-readline-0.5.1/lib/rbreadline.rb:3865:in `_rl_output_some_chars': undefined method `write' for #<Rex::Ui::Text::Output::Tee:0x007faadcba88d8> (NoMethodError)
    from /home/jhart/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rb-readline-0.5.1/lib/rbreadline.rb:3044:in `update_line'
    from /home/jhart/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rb-readline-0.5.1/lib/rbreadline.rb:3535:in `rl_redisplay'
    from /home/jhart/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rb-readline-0.5.1/lib/rbreadline.rb:3953:in `readline_internal_setup'
    from /home/jhart/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rb-readline-0.5.1/lib/rbreadline.rb:4800:in `readline_internal'
    from /home/jhart/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/rb-readline-0.5.1/lib/rbreadline.rb:4823:in `readline'
    from /home/jhart/labs/git/metasploit-framework/lib/rex/ui/text/input/readline.rb:132:in `readline_with_output'
    from /home/jhart/labs/git/metasploit-framework/lib/rex/ui/text/input/readline.rb:86:in `pgets'
    from /home/jhart/labs/git/metasploit-framework/lib/rex/ui/text/shell.rb:184:in `run'
    from /home/jhart/labs/git/metasploit-framework/lib/metasploit/framework/command/console.rb:30:in `start'
    from /home/jhart/labs/git/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
    from ./msfconsole:48:in `<main>'
```

This shows that the workaround from #4363 does work:

```
$  ./msfconsole -qL
[*] Processing /home/jhart/.msf4/msfconsole.rc for ERB directives.
resource (/home/jhart/.msf4/msfconsole.rc)> db_connect -y ~/.msf4/database.yml
[*] Rebuilding the module cache in the background...
msf > spool /tmp/blah.foo
[*] Spooling to file /tmp/blah.foo...
msf >
```

Afterwards, all variants function as expected.
