### PR TITLE
Avoid spinner on Windows

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -8,7 +8,15 @@ require 'metasploit/framework/command/base'
 # Based on pattern used for lib/rails/commands in the railties gem.
 class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::Base
 
+  # Provides an animated spinner in a seperate thread.
+  #
+  # See GitHub issue #4147, as this may be blocking some
+  # Windows instances, which is why Windows platforms
+  # should simply return immediately.
+
   def spinner
+    return if Rex::Compat.is_windows
+    return if Rex::Compat.is_cygwin
     return if $msf_spinner_thread
     $msf_spinner_thread = Thread.new do
       $stderr.print "[*] Starting the Metasploit Framework console..."


### PR DESCRIPTION
Fixes #4147, probably.
## Verification
- [x] Start `./msfconsole -L` on a non-Windows system, and amaze at the hypnotic beauty of the spinner.
- [x] Start `./msfconsole -L` on a Windows system, and feel the cold emptiness of its absence wash over you.
  - [x] Ditto for an undecorated `./msfconsole` start of the MSF console.
