### PR TITLE
fixes #4490, class.to_s should not be used for checks

### DIFF
--- a/lib/msf/core/db_manager/ip_address.rb
+++ b/lib/msf/core/db_manager/ip_address.rb
@@ -13,18 +13,18 @@ module Msf::DBManager::IPAddress
   end
 
   def rfc3330_reserved(ip)
-    case ip.class.to_s
-    when "PacketFu::Octets"
+    case ip
+    when PacketFu::Octets
       ip_x = ip.to_x
       ip_i = ip.to_i
-    when "String"
+    when String
       if ipv46_validator(ip)
         ip_x = ip
         ip_i = Rex::Socket.addr_atoi(ip)
       else
         raise ArgumentError, "Invalid IP address: #{ip.inspect}"
       end
-    when "Fixnum"
+    when Fixnum
       if (0..2**32-1).include? ip
         ip_x = Rex::Socket.addr_itoa(ip)
         ip_i = ip

--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -224,12 +224,12 @@ module Exploit::CmdStager
   def guess_flavor
     # First try to guess a compatible flavor based on the module & target information.
     unless target_flavor.nil?
-      case target_flavor.class.to_s
-      when 'Array'
+      case target_flavor
+      when Array
         return target_flavor[0].to_sym
-      when 'String'
+      when String
         return target_flavor.to_sym
-      when 'Symbol'
+      when Symbol
         return target_flavor
       end
     end
@@ -283,12 +283,12 @@ module Exploit::CmdStager
   # @return [Boolean] true if compatible, false otherwise.
   def compatible_flavor?(f)
     return true if target_flavor.nil?
-    case target_flavor.class.to_s
-    when 'String'
+    case target_flavor
+    when String
       return true if target_flavor == f.to_s
-    when 'Array'
+    when Array
       target_flavor.each { |tr| return true if tr.to_sym == f }
-    when 'Symbol'
+    when Symbol
       return true if target_flavor == f
     end
     false

--- a/lib/msf/core/exploit/java.rb
+++ b/lib/msf/core/exploit/java.rb
@@ -87,7 +87,7 @@ module Exploit::Java
       raise RuntimeError, "Could not load rjb and/or the JVM: " + @java_error.to_s
     end
 
-    if compile_options.class.to_s != "Array" && compile_options
+    if !compile_options.is_a?(Array) && compile_options
       raise RuntimeError, "Compiler options must be of type Array."
     end
 

--- a/lib/msf/core/exploit/local/windows_kernel.rb
+++ b/lib/msf/core/exploit/local/windows_kernel.rb
@@ -123,7 +123,7 @@ module Exploit::Local::WindowsKernel
     arch = target.opts['Arch'] if arch.nil? && target && target.opts['Arch']
     if arch.nil? && module_info['Arch']
       arch = module_info['Arch']
-      arch = arch[0] if arch.class.to_s == 'Array' and arch.length == 1
+      arch = arch[0] if arch.is_a?(Array) and arch.length == 1
     end
     if arch.nil?
       print_error('Can not determine the target architecture')

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2834,73 +2834,72 @@ class Core
     res = []
     res << o.default.to_s if o.default
 
-    case o.class.to_s
-
-      when 'Msf::OptAddress'
-        case o.name.upcase
-          when 'RHOST'
-            option_values_target_addrs().each do |addr|
-              res << addr
-            end
-          when 'LHOST'
-            rh = self.active_module.datastore["RHOST"]
-            if rh and not rh.empty?
-              res << Rex::Socket.source_address(rh)
-            else
-              res << Rex::Socket.source_address()
-            end
-          else
+    case o
+    when Msf::OptAddress
+      case o.name.upcase
+      when 'RHOST'
+        option_values_target_addrs().each do |addr|
+          res << addr
         end
-
-      when 'Msf::OptAddressRange'
-        case str
-          when /^file:(.*)/
-            files = tab_complete_filenames($1, words)
-            res += files.map { |f| "file:" + f } if files
-          when /\/$/
-            res << str+'32'
-            res << str+'24'
-            res << str+'16'
-          when /\-$/
-            res << str+str[0, str.length - 1]
-          else
-            option_values_target_addrs().each do |addr|
-              res << addr+'/32'
-              res << addr+'/24'
-              res << addr+'/16'
-            end
+      when 'LHOST'
+        rh = self.active_module.datastore["RHOST"]
+        if rh and not rh.empty?
+          res << Rex::Socket.source_address(rh)
+        else
+          res << Rex::Socket.source_address()
         end
+      else
+      end
 
-      when 'Msf::OptPort'
-        case o.name.upcase
-          when 'RPORT'
-          option_values_target_ports().each do |port|
-            res << port
-          end
+    when Msf::OptAddressRange
+      case str
+      when /^file:(.*)/
+        files = tab_complete_filenames($1, words)
+        res += files.map { |f| "file:" + f } if files
+      when /\/$/
+        res << str+'32'
+        res << str+'24'
+        res << str+'16'
+      when /\-$/
+        res << str+str[0, str.length - 1]
+      else
+        option_values_target_addrs().each do |addr|
+          res << addr+'/32'
+          res << addr+'/24'
+          res << addr+'/16'
         end
+      end
 
-        if (res.empty?)
-          res << (rand(65534)+1).to_s
+    when Msf::OptPort
+      case o.name.upcase
+      when 'RPORT'
+        option_values_target_ports().each do |port|
+          res << port
         end
+      end
 
-      when 'Msf::OptEnum'
-        o.enums.each do |val|
-          res << val
-        end
+      if (res.empty?)
+        res << (rand(65534)+1).to_s
+      end
 
-      when 'Msf::OptPath'
-        files = tab_complete_filenames(str, words)
-        res += files if files
+    when Msf::OptEnum
+      o.enums.each do |val|
+        res << val
+      end
 
-      when 'Msf::OptBool'
-        res << 'true'
-        res << 'false'
+    when Msf::OptPath
+      files = tab_complete_filenames(str, words)
+      res += files if files
 
-      when 'Msf::OptString'
-        if (str =~ /^file:(.*)/)
-          files = tab_complete_filenames($1, words)
-          res += files.map { |f| "file:" + f } if files
-        end
+    when Msf::OptBool
+      res << 'true'
+      res << 'false'
+
+    when Msf::OptString
+      if (str =~ /^file:(.*)/)
+        files = tab_complete_filenames($1, words)
+        res += files.map { |f| "file:" + f } if files
+      end
     end
 
     return res

--- a/lib/rapid7/nexpose.rb
+++ b/lib/rapid7/nexpose.rb
@@ -1291,7 +1291,7 @@ class Site
     xml << ' <ScanTriggers>'
     @site_config.scanConfig.scanTriggers.each do |s|
 
-      if (s.class.to_s == "Nexpose::AutoUpdate")
+      if s.kind_of?(Nexpose::AutoUpdate)
         xml << ' <autoUpdate enabled="' + s.enabled + '" incremental="' + s.incremental + '"/>'
       end
     end

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -86,7 +86,7 @@ class Client
       typ = self.config_types[var] || 'string'
 
       # These are enum types
-      if(typ.class.to_s == 'Array')
+      if typ.is_a?(Array)
         if not typ.include?(val)
           raise RuntimeError, "The specified value for #{var} is not one of the valid choices"
         end
@@ -719,4 +719,3 @@ end
 end
 end
 end
-

--- a/modules/auxiliary/spoof/dns/compare_results.rb
+++ b/modules/auxiliary/spoof/dns/compare_results.rb
@@ -97,16 +97,16 @@ class Metasploit3 < Msf::Auxiliary
 
           name = name.to_s
           anst = data.class.to_s.gsub(/^.*Resolv::DNS::Resource::IN::/, '')
-          case anst
-          when 'NS'
+          case data
+          when Resolv::DNS::Resource::IN::NS
             data = data.name.to_s
-          when 'MX'
+          when Resolv::DNS::Resource::IN::MX
             data = data.exchange.to_s
-          when 'A'
+          when Resolv::DNS::Resource::IN::A
             data = data.address.to_s
-          when 'TXT'
+          when Resolv::DNS::Resource::IN::TXT
             data = data.strings.join
-          when 'CNAME'
+          when Resolv::DNS::Resource::IN::CNAME
             data = data.name.to_s
           else
             data = anst


### PR DESCRIPTION
This fixes #4490. object.class.to_s was used in many places to check the class type.
