### PR TITLE
Switch to docker container for faster build startup and bundler cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 bundler_args: --without coverage development pcap
+cache: bundler
 env:
   - RAKE_TASKS="cucumber cucumber:boot"
   - RAKE_TASKS=spec SPEC_OPTS="--tag content"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-bundler_args: --without development coverage
+bundler_args: --without coverage development pcap
 env:
   - RAKE_TASKS="cucumber cucumber:boot"
   - RAKE_TASKS=spec SPEC_OPTS="--tag content"
@@ -10,8 +10,6 @@ matrix:
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - rake --version
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libpcap-dev
   # Uncomment when we have fewer shipping msftidy warnings.
   # Merge committers will still be checking, just not autofailing.
   # - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 script:
   # fail build if db/schema.rb update is not committed
   - git diff --exit-code && bundle exec rake $RAKE_TASKS
-
+sudo: false
 rvm:
   - '1.9.3'
   - '2.1'


### PR DESCRIPTION
MSP-11931

Remove the need for `sudo` by not installing `pcap`.  None of the current specs or features use `pcap`, so there is no loss in test coverage.  Enable docker builds with `sudo: false`.  With the docker build, we can start using travis-ci's bundler cache with `cache: bundler`.  Using the bundler cache shaved ~2 minutes of the build time for each job between [just using the docker build](https://travis-ci.org/limhoff-r7/metasploit-framework/builds/45569440) and [with the cache](https://travis-ci.org/limhoff-r7/metasploit-framework/builds/45570948).  A lot of the jobs are around 4 minutes, so this effectively cuts the build time in half.  For reference, [without containers](https://travis-ci.org/limhoff-r7/metasploit-framework/builds/45569194) the jobs on master are slower.
# Verification Steps
- [x] Look at the [build log](https://travis-ci.org/limhoff-r7/metasploit-framework/jobs/45570949)
- [x] VERIFY containerized message in log: `This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.`
- [x] VERIFY bundler cache in log: `adding /home/travis/build/rapid7/metasploit-model/vendor/bundle to cache`
