### PR TITLE
update wordpress readme regex

### DIFF
--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -98,7 +98,7 @@ module Msf::HTTP::Wordpress::Version
     # try to extract version from readme
     # Example line:
     # Stable tag: 2.6.6
-    version = res.body.to_s[/stable tag: ([^\r\n"\']+\.[^\r\n"\']+)/i, 1]
+    version = res.body.to_s[/(?:stable tag|version): (?!trunk)([0-9a-z.-]+)/i, 1]
 
     # readme present, but no version number
     return Msf::Exploit::CheckCode::Detected if version.nil?

--- a/spec/lib/msf/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/http/wordpress/version_spec.rb
@@ -129,6 +129,13 @@ describe Msf::HTTP::Wordpress::Version do
       it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
     end
 
+    context 'when installed version is newer (text in version number)' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.5.3' }
+      let(:wp_body) { 'Stable tag: 2.0.0-beta1' }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+    end
+
   end
 
 end


### PR DESCRIPTION
This updates the Wordpress version detection regex for readmes.

This PR updates the regex to the current one we use in wpscan:
https://github.com/wpscanteam/wpscan/blob/master/lib/common/models/wp_item/versionable.rb#L16
