### PR TITLE
Add McAfee Hashdump

### DIFF
--- a/modules/post/windows/gather/credentials/mcafee_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mcafee_hashdump.rb
@@ -118,9 +118,9 @@ class Metasploit3 < Msf::Post
 
       create_credential(credential_data)
 
-      # TODO: store_loot the file in the appropriate format, which likely means
-      # iterating over hashes_and_versions differently so that they are grouped
-      # by version (because john can only crack one format at a time)
+      # Store McAfee password hash as loot
+      loot_path = store_loot('mcafee.hash', 'text/plain', session, 'mcafee:'+hash, 'mcafee_hashdump.txt', 'McAfee Password Hash')
+      print_status("McAfee password hash saved in: #{loot_path}")
     end
   end
 end


### PR DESCRIPTION
Module for grabbing McAfee password hash. Users will need to create a JTR dynamic format for cracking  version 8.x hashes of McAfee as below:

https://raw.githubusercontent.com/m7x/stuff/master/john.local.conf

Version 5.x hashes can be cracked with option --format=md5u instead.

More info: https://www.dionach.com/blog/disabling-mcafee-on-access-scanning

Many thanks,
Mike
