### PR TITLE
Resolve #4507 - Preserve the necessary evilness of respond_to? + send

### DIFF
--- a/lib/msf/core/event_dispatcher.rb
+++ b/lib/msf/core/event_dispatcher.rb
@@ -179,23 +179,23 @@ class EventDispatcher
       if respond_to?(subscribers, true)
         found = true
         self.send(subscribers).each do |sub|
-          next if not sub.respond_to?(name)
+          next if not sub.respond_to?(name, true)
           sub.send(name, *args)
         end
       else
         (general_event_subscribers + custom_event_subscribers).each do |sub|
-          next if not sub.respond_to?(name)
+          next if not sub.respond_to?(name, true)
           sub.send(name, *args)
           found = true
         end
       end
     when "add"
-      if respond_to?(subscribers)
+      if respond_to?(subscribers, true)
         found = true
         add_event_subscriber(self.send(subscribers), *args)
       end
     when "remove"
-      if respond_to?(subscribers)
+      if respond_to?(subscribers, true)
         found = true
         remove_event_subscriber(self.send(subscribers), *args)
       end

--- a/lib/msf/core/exploit/ftpserver.rb
+++ b/lib/msf/core/exploit/ftpserver.rb
@@ -78,7 +78,7 @@ module Exploit::Remote::FtpServer
     return if not cmd
 
     # Allow per-command overrides
-    if(self.respond_to?("on_client_command_#{cmd.downcase}"))
+    if self.respond_to?("on_client_command_#{cmd.downcase}", true)
       return self.send("on_client_command_#{cmd.downcase}", c, arg)
     end
 

--- a/lib/msf/core/post/osx/ruby_dl.rb
+++ b/lib/msf/core/post/osx/ruby_dl.rb
@@ -32,7 +32,7 @@ module RubyDL
         def method_missing(meth, *args, &block)
           str = meth.to_s
           lower = str[0,1].downcase + str[1..-1]
-          if self.respond_to? lower
+          if self.respond_to?(lower, true)
             self.send lower, *args
           else
             super

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -39,7 +39,7 @@ class Auxiliary
   # Allow modules to define their own commands
   #
   def method_missing(meth, *args)
-    if (mod and mod.respond_to?(meth.to_s))
+    if (mod and mod.respond_to?(meth.to_s, true) )
 
       # Initialize user interaction
       mod.init_ui(driver.input, driver.output)

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1088,13 +1088,13 @@ class Db
             end
           elsif term == "output"
             orderlist << make_sortable(note.data["output"])
-          elsif note.respond_to?(term)
+          elsif note.respond_to?(term, true)
             orderlist << make_sortable(note.send(term))
-          elsif note.respond_to?(term.to_sym)
+          elsif note.respond_to?(term.to_sym, true)
             orderlist << make_sortable(note.send(term.to_sym))
-          elsif note.respond_to?("data") && note.send("data").respond_to?(term)
+          elsif note.respond_to?("data", true) && note.send("data").respond_to?(term, true)
             orderlist << make_sortable(note.send("data").send(term))
-          elsif note.respond_to?("data") && note.send("data").respond_to?(term.to_sym)
+          elsif note.respond_to?("data", true) && note.send("data").respond_to?(term.to_sym, true)
             orderlist << make_sortable(note.send("data").send(term.to_sym))
           else
             orderlist << ""
@@ -1682,7 +1682,7 @@ class Db
       end
     end
     meth = "db_connect_#{framework.db.driver}"
-    if(self.respond_to?(meth))
+    if(self.respond_to?(meth, true))
       self.send(meth, *args)
       if framework.db.active and not framework.db.modules_cached
         print_status("Rebuilding the module cache in the background...")

--- a/lib/rabal/tree.rb
+++ b/lib/rabal/tree.rb
@@ -173,7 +173,7 @@ class Tree
   # Tree that responds to the call.
   #
   def method_missing(method_id,*params,&block)
-    if not parameters.nil? and parameters.respond_to?(method_id) then
+    if not parameters.nil? and parameters.respond_to?(method_id, true) then
       return parameters.send(method_id, *params, &block)
     elsif not is_root? then
       @parent.send method_id, *params, &block

--- a/lib/rex/parser/foundstone_nokogiri.rb
+++ b/lib/rex/parser/foundstone_nokogiri.rb
@@ -293,7 +293,7 @@ module Rex
     # XXX: Actually implement more of these
     def process_service(service,banner)
       meth = "process_service_#{service.gsub("-","_")}"
-      if self.respond_to? meth
+      if self.respond_to?(meth, true)
         self.send meth, banner
       else
         return (first_line banner)

--- a/lib/rex/payloads/win32/kernel.rb
+++ b/lib/rex/payloads/win32/kernel.rb
@@ -24,7 +24,7 @@ module Kernel
     payload = nil
 
     # Generate the recovery stub
-    if opts['Recovery'] and Kernel::Recovery.respond_to?(opts['Recovery'])
+    if opts['Recovery'] and Kernel::Recovery.respond_to?(opts['Recovery'], true)
       opts['RecoveryStub'] = Kernel::Recovery.send(opts['Recovery'], opts)
     end
 
@@ -35,10 +35,10 @@ module Kernel
     end
 
     # Generate the stager
-    if opts['Stager'] and Kernel::Stager.respond_to?(opts['Stager'])
+    if opts['Stager'] and Kernel::Stager.respond_to?(opts['Stager'], true)
       payload = Kernel::Stager.send(opts['Stager'], opts)
     # Or, generate the migrator
-    elsif opts['Migrator'] and Kernel::Migration.respond_to?(opts['Migrator'])
+    elsif opts['Migrator'] and Kernel::Migration.respond_to?(opts['Migrator'], true)
       payload = Kernel::Migration.send(opts['Migrator'], opts)
     else
       raise ArgumentError, "A stager or a migrator must be specified."

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -105,7 +105,7 @@ module DispatcherShell
       print_error "The #{cmd} command is DEPRECATED"
       if cmd == "db_autopwn"
         print_error "See http://r-7.co/xY65Zr instead"
-      elsif method and self.respond_to?("cmd_#{method}")
+      elsif method and self.respond_to?("cmd_#{method}", true)
         print_error "Use #{method} instead"
         self.send("cmd_#{method}", *args)
       end
@@ -116,7 +116,7 @@ module DispatcherShell
       print_error "The #{cmd} command is DEPRECATED"
       if cmd == "db_autopwn"
         print_error "See http://r-7.co/xY65Zr instead"
-      elsif method and self.respond_to?("cmd_#{method}_help")
+      elsif method and self.respond_to?("cmd_#{method}_help", true)
         print_error "Use 'help #{method}' instead"
         self.send("cmd_#{method}_help")
       end
@@ -150,9 +150,9 @@ module DispatcherShell
           next if (dispatcher.commands.nil?)
           next if (dispatcher.commands.length == 0)
 
-          if dispatcher.respond_to?("cmd_#{cmd}")
+          if dispatcher.respond_to?("cmd_#{cmd}", true)
             cmd_found = true
-            break unless dispatcher.respond_to? "cmd_#{cmd}_help"
+            break unless dispatcher.respond_to?("cmd_#{cmd}_help", true)
             dispatcher.send("cmd_#{cmd}_help")
             help_found = true
             break

--- a/modules/exploits/linux/misc/hikvision_rtsp_bof.rb
+++ b/modules/exploits/linux/misc/hikvision_rtsp_bof.rb
@@ -79,7 +79,7 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def exploit
-    unless self.respond_to?(target[:callback])
+    unless self.respond_to?(target[:callback], true)
       fail_with(Failure::NoTarget, "Invalid target specified: no callback function defined")
     end
 

--- a/modules/exploits/windows/misc/bigant_server_sch_dupf_bof.rb
+++ b/modules/exploits/windows/misc/bigant_server_sch_dupf_bof.rb
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sploit << [target.ret].pack("V")
     sploit << [target['FakeObject']].pack("V")
     sploit << [target['FakeObject']].pack("V")
-    if target[:callback_rop] and self.respond_to?(target[:callback_rop])
+    if target[:callback_rop] and self.respond_to?(target[:callback_rop], true)
       sploit << self.send(target[:callback_rop])
     else
       sploit << [target['JmpESP']].pack("V")

--- a/modules/post/osx/capture/keylog_recorder.rb
+++ b/modules/post/osx/capture/keylog_recorder.rb
@@ -178,7 +178,7 @@ child_pid = fork do
         def method_missing(meth, *args, &block)
           str = meth.to_s
           lower = str[0,1].downcase + str[1..-1]
-          if self.respond_to? lower
+          if self.respond_to? lower, true
             self.send lower, *args
           else
             super

--- a/plugins/wiki.rb
+++ b/plugins/wiki.rb
@@ -140,9 +140,9 @@ class Plugin::Wiki < Msf::Plugin
       outputs = []
 
       # Output the table
-      if respond_to? "#{command}_to_table"
+      if respond_to? "#{command}_to_table", true
         table = send "#{command}_to_table", tbl_opts
-        if table.respond_to? "to_#{wiki_type}"
+        if table.respond_to? "to_#{wiki_type}", true
           if tbl_opts[:file_name]
             print_status("Wrote the #{command} table to a file as a #{wiki_type} formatted table")
             File.open(tbl_opts[:file_name],"wb") {|f|


### PR DESCRIPTION
Since Ruby 2.1, the respond_to? method is more strict because it does not check protected methods. So when you use send() to go with that type of check, clearly you're ignoring the access control, and it's evil. The patch is meant to preserve evil... I mean, preserve the original behavior to avoid potential breakage. 

Resolve #4507
