### PR TITLE
Resolve #4513 - Change #inspect to #to_s

### DIFF
--- a/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
@@ -188,7 +188,7 @@ class Metasploit3 < Msf::Auxiliary
         end
       else
         next if (res.code == 500 or res.code == 404 or res.code == 302)
-        print_error("#{ip} #{res.inspect}")
+        print_error("#{ip} #{res.to_s}")
       end
     end
 

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
 
         else
           print_error("http://#{vhost}:#{rport} - Lotus Domino - Unrecognized #{res.code} response")
-          print_error(res.inspect)
+          print_error(res.to_s)
           return :abort
 
         end

--- a/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
+++ b/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
@@ -122,7 +122,7 @@ EOS
     end
 
     print_error("Encountered unexpected #{res.code} response:")
-    print_error(res.inspect)
+    print_error(res.to_s)
 
     return nil
   end

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -116,7 +116,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if (res)
       print_error("The server unexpectedly responded, this is not good.")
-      print_status(res.inspect)
+      print_status(res.to_s)
     end
 
     handler

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -237,7 +237,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_error("Eek! We weren't expecting a response, but we got one")
       if datastore['DEBUG']
         print_line()
-        print_error(res.inspect)
+        print_error(res.to_s)
       end
     end
 

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code != 502
       print_error("Eek! We weren't expecting a response, but we got one")
-      print_status(res.inspect) if datastore['NNM_DEBUG']
+      print_status(res.to_s) if datastore['NNM_DEBUG']
     end
 
     handler

--- a/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
+++ b/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
@@ -162,7 +162,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code != 502
       print_error("Eek! We weren't expecting a response, but we got one")
-      print_status(res.inspect) if datastore['NNM_DEBUG']
+      print_status(res.to_s) if datastore['NNM_DEBUG']
     end
 
     handler

--- a/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
@@ -159,7 +159,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_error("Eek! We weren't expecting a response, but we got one")
       if datastore['DEBUG']
         print_error('')
-        print_error(res.inspect)
+        print_error(res.to_s)
       end
     end
 

--- a/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
@@ -159,7 +159,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_error("Eek! We weren't expecting a response, but we got one")
       if datastore['DEBUG']
         print_error('')
-        print_error(res.inspect)
+        print_error(res.to_s)
       end
     end
 

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -48,7 +48,6 @@ class Metasploit3 < Msf::Post
       addr = [mem].pack("V")
       len = [data.length].pack("V")
       ret = rg.crypt32.CryptUnprotectData("#{len}#{addr}", 16, nil, nil, nil, 0, 8)
-      #print_status("#{ret.inspect}")
       len, addr = ret["pDataOut"].unpack("V2")
     else
       addr = [mem].pack("Q")

--- a/modules/post/windows/recon/computer_browser_discovery.rb
+++ b/modules/post/windows/recon/computer_browser_discovery.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Post
     end
 
     result = client.railgun.netapi32.NetServerEnum(nil,101,4,-1,4,4,lookuptype,datastore['DOMAIN'],0)
-    # print_error(result.inspect)
+
     if result['totalentries'] == 0
       print_error("No systems found of that type")
       return


### PR DESCRIPTION
Resolve #4513 
## Here's the problem

For a response object, if you do inspect() for it in Ruby 1.9, it will call to_s() and the output is the raw HTTP response. In Ruby 2.0, it doesn't call to_s anymore, so what you get is an object inspection.

If you're curious, you can see #4513 and there's an example about this.
## The Fix

Instead of inspect(), always call to_s()
