### PR TITLE
Fix #4520 - Add missing method io_ref for adobe_reader_pdf_js_interface

### DIFF
--- a/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
+++ b/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
@@ -72,6 +72,10 @@ class Metasploit3 < Msf::Exploit::Remote
     file_create(pdf(js))
   end
 
+  def io_ref(root_obj)
+    "%d 0 R" % root_obj
+  end
+
   def trailer(root_obj)
     id = @xref.keys.max+1
     "trailer" << eol << "<</Size %d/Root " % id << io_ref(root_obj) << ">>" << eol


### PR DESCRIPTION
Fix #4520 

The io_ref method is missing. It's actually a common method that is used for PDF exploits.
## Verification
- [ ] If you run exploit/android/fileformat/adobe_reader_pdf_js_interface without this patch, you should get an error saying the io_ref is missing (NoMethodError).
- [ ] With the patch, you should be able to generate the exploit.
