### PR TITLE
fix incorrect usage of .class

### DIFF
--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -215,7 +215,7 @@ protected
 
       # Build a user-friendly error message
       msg = "#{e}"
-      unless e.class == Msf::Exploit::Failed
+      unless e == Msf::Exploit::Failed
         msg = "#{e.class} #{e}"
       end
 
@@ -224,7 +224,7 @@ protected
       # Record the detailed reason
       exploit.fail_detail ||= e.to_s
 
-      case e.class
+      case e
       when Msf::Exploit::Complete
         # Nothing to show in this case
         return

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -215,7 +215,7 @@ protected
 
       # Build a user-friendly error message
       msg = "#{e}"
-      unless e == Msf::Exploit::Failed
+      unless e.class == Msf::Exploit::Failed
         msg = "#{e.class} #{e}"
       end
 

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -908,7 +908,7 @@ class Db
         ::File.open(output_file, "wb") { |f| f.write(tbl.to_csv) }
         print_status("Wrote creds to #{output_file}")
       end
-      
+
       print_status("Deleted #{delete_count} creds") if delete_count > 0
     }
   end
@@ -1138,7 +1138,7 @@ class Db
   end
 
   def make_sortable(input)
-    case input.class
+    case input
     when String
       input = input.downcase
     when Fixnum


### PR DESCRIPTION
This PR fixes some incorrect usages of `.class`

In exploit_driver the else was always hit on the case statement due to the wrong use of class. This printed out the stacktrace everytime a `fail_with(Unknown, ...)` was called. Now the correct code path is taken. This may also change the error output because the rest of the case was never hit, so maybe you want to look over this too.

I also found another wrong case statement in db.rb which was also fixed
