### PR TITLE
Make Msf::Exploit::PDF follow the Ruby method naming convention

### DIFF
--- a/lib/msf/core/exploit/pdf.rb
+++ b/lib/msf/core/exploit/pdf.rb
@@ -30,7 +30,7 @@ module Exploit::PDF
   #Original Filters
   ##
 
-  def ASCIIHexWhitespaceEncode(str)
+  def ascii_hex_whitespace_encode(str)
     return str if not datastore['PDF::Obfuscate']
     result = ""
     whitespace = ""
@@ -44,7 +44,7 @@ module Exploit::PDF
   ##
   #Filters from Origami parser
   ##
-  def RunLengthEncode(stream)
+  def run_length_encode(stream)
     eod = 128
     result = ""
     i = 0
@@ -85,7 +85,7 @@ module Exploit::PDF
     result << eod.chr
   end
 
-  def RandomNonASCIIString(count)
+  def random_non_ascii_string(count)
     result = ""
     count.times do
       result << (rand(128) + 128).chr
@@ -93,7 +93,7 @@ module Exploit::PDF
     result
   end
 
-  def ASCII85Encode(stream)
+  def ascii85_encode(stream)
     eod = "~>"
     i = 0
     code = ""
@@ -130,7 +130,7 @@ module Exploit::PDF
   end
 
   # http://blog.didierstevens.com/2008/04/29/pdf-let-me-count-the-ways/
-  def nObfu(str)
+  def nobfu(str)
     return str if not datastore['PDF::Obfuscate']
 
     result = ""
@@ -149,13 +149,13 @@ module Exploit::PDF
   ##
   def header(version = '1.5')
     hdr = "%PDF-#{version}" << eol
-    hdr << "%" << RandomNonASCIIString(4) << eol
+    hdr << "%" << random_non_ascii_string(4) << eol
     hdr
   end
 
   def add_object(num, data)
     @xref[num] = @pdf.length
-    @pdf << ioDef(num)
+    @pdf << io_def(num)
     @pdf << data
     @pdf << endobj
   end
@@ -186,7 +186,7 @@ module Exploit::PDF
   end
 
   def trailer(root_obj)
-    ret = "trailer" << nObfu("<</Size %d/Root " % (@xref.length + 1)) << ioRef(root_obj) << ">>" << eol
+    ret = "trailer" << nObfu("<</Size %d/Root " % (@xref.length + 1)) << io_ref(root_obj) << ">>" << eol
     ret
   end
 
@@ -209,18 +209,18 @@ module Exploit::PDF
     "endobj" << eol
   end
 
-  def ioDef(id)
+  def io_def(id)
     "%d 0 obj" % id
   end
 
-  def ioRef(id)
+  def io_ref(id)
     "%d 0 R" % id
   end
 
   ##
   #Controller funtion, should be entrypoint for pdf exploits
   ##
-  def CreatePDF(js)
+  def create_pdf(js)
     strFilter = ""
     arrResults = []
     numIterations = 0
@@ -233,10 +233,10 @@ module Exploit::PDF
     end
     for i in (0..numIterations-1)
       if i == 0
-        arrResults = SelectEncoder(js,arrEncodings[i],strFilter)
+        arrResults = select_encoder(js,arrEncodings[i],strFilter)
         next
       end
-      arrResults = SelectEncoder(arrResults[0],arrEncodings[i],arrResults[1])
+      arrResults = select_encoder(arrResults[0],arrEncodings[i],arrResults[1])
     end
     case datastore['PDF::Method']
     when 'PAGE'
@@ -251,19 +251,19 @@ module Exploit::PDF
   ##
   #Select an encoder and build a filter specification
   ##
-  def SelectEncoder(js,strEncode,strFilter)
+  def select_encoder(js,strEncode,strFilter)
     case strEncode
     when 'ASCII85'
-      js = ASCII85Encode(js)
+      js = ascii85_encode(js)
       strFilter = "/ASCII85Decode"<<strFilter
     when 'ASCIIHEX'
-      js = ASCIIHexWhitespaceEncode(js)
+      js = ascii_hex_whitespace_encode(js)
       strFilter = "/ASCIIHexDecode"<<strFilter
     when 'FLATE'
       js = Zlib::Deflate.deflate(js)
       strFilter = "/FlateDecode"<<strFilter
     when 'RUN'
-      js = RunLengthEncode(js)
+      js = run_length_encode(js)
       strFilter = "/RunLengthDecode"<<strFilter
     end
     return js,strFilter
@@ -277,10 +277,10 @@ module Exploit::PDF
     @pdf = ''
 
     @pdf << header
-    add_object(1, nObfu("<</Type/Catalog/Outlines ") << ioRef(2) << nObfu("/Pages ") << ioRef(3) << ">>")
+    add_object(1, nObfu("<</Type/Catalog/Outlines ") << io_ref(2) << nObfu("/Pages ") << io_ref(3) << ">>")
     add_object(2, nObfu("<</Type/Outlines/Count 0>>"))
-    add_object(3, nObfu("<</Type/Pages/Kids[") << ioRef(4) << nObfu("]/Count 1>>"))
-    add_object(4, nObfu("<</Type/Page/Parent ") << ioRef(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /AA << /O << /JS ") << ioRef(5) << nObfu("/S /JavaScript >>>>>>"))
+    add_object(3, nObfu("<</Type/Pages/Kids[") << io_ref(4) << nObfu("]/Count 1>>"))
+    add_object(4, nObfu("<</Type/Page/Parent ") << io_ref(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /AA << /O << /JS ") << io_ref(5) << nObfu("/S /JavaScript >>>>>>"))
     compressed = js
     stream = "<</Length %s/Filter[" % compressed.length << strFilter << "]>>" << eol
     stream << "stream" << eol
@@ -301,10 +301,10 @@ module Exploit::PDF
 
     @pdf << header
 
-    add_object(1, nObfu("<</Type/Catalog/Outlines ") << ioRef(2) << nObfu("/Pages ") << ioRef(3) << ">>")
+    add_object(1, nObfu("<</Type/Catalog/Outlines ") << io_ref(2) << nObfu("/Pages ") << io_ref(3) << ">>")
     add_object(2, nObfu("<</Type/Outlines/Count 0>>"))
-    add_object(3, nObfu("<</Type/Pages/Kids[") << ioRef(4) << nObfu("]/Count 1>>"))
-    add_object(4, nObfu("<</Type/Page/Parent ") << ioRef(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /AA << /O << /JS ") << ioRef(5) << nObfu("/S /JavaScript >>>>>>"))
+    add_object(3, nObfu("<</Type/Pages/Kids[") << io_ref(4) << nObfu("]/Count 1>>"))
+    add_object(4, nObfu("<</Type/Page/Parent ") << io_ref(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /AA << /O << /JS ") << io_ref(5) << nObfu("/S /JavaScript >>>>>>"))
     compressed = js
     stream = "<</Length %s/Filter[" % compressed.length << strFilter << "]>>" << eol
     stream << "stream" << eol
@@ -324,11 +324,11 @@ module Exploit::PDF
 
     @pdf << header
 
-    add_object(1, nObfu("<</Type/Catalog/Outlines ") << ioRef(2) << nObfu("/Pages ") << ioRef(3) << ">>")
+    add_object(1, nObfu("<</Type/Catalog/Outlines ") << io_ref(2) << nObfu("/Pages ") << io_ref(3) << ">>")
     add_object(2, nObfu("<</Type/Outlines/Count 0>>"))
-    add_object(3, nObfu("<</Type/Pages/Kids[") << ioRef(4) << nObfu("]/Count 1>>"))
-    add_object(4, nObfu("<</Type/Page/Parent ") << ioRef(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /Annots [") << ioRef(5) << nObfu("]>>"))
-    add_object(5, nObfu("<</Type/Annot /Subtype /Screen /Rect [%s %s %s %s] /AA << /PO << /JS " % [rand(200),rand(200),rand(300),rand(300)]) << ioRef(6) << nObfu("/S /JavaScript >>>>>>"))
+    add_object(3, nObfu("<</Type/Pages/Kids[") << io_ref(4) << nObfu("]/Count 1>>"))
+    add_object(4, nObfu("<</Type/Page/Parent ") << io_ref(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /Annots [") << io_ref(5) << nObfu("]>>"))
+    add_object(5, nObfu("<</Type/Annot /Subtype /Screen /Rect [%s %s %s %s] /AA << /PO << /JS " % [rand(200),rand(200),rand(300),rand(300)]) << io_ref(6) << nObfu("/S /JavaScript >>>>>>"))
     compressed = js
     stream = "<</Length %s/Filter[" % compressed.length << strFilter << "]>>" << eol
     stream << "stream" << eol

--- a/lib/msf/core/exploit/pdf.rb
+++ b/lib/msf/core/exploit/pdf.rb
@@ -186,7 +186,7 @@ module Exploit::PDF
   end
 
   def trailer(root_obj)
-    ret = "trailer" << nObfu("<</Size %d/Root " % (@xref.length + 1)) << io_ref(root_obj) << ">>" << eol
+    ret = "trailer" << nobfu("<</Size %d/Root " % (@xref.length + 1)) << io_ref(root_obj) << ">>" << eol
     ret
   end
 
@@ -277,10 +277,10 @@ module Exploit::PDF
     @pdf = ''
 
     @pdf << header
-    add_object(1, nObfu("<</Type/Catalog/Outlines ") << io_ref(2) << nObfu("/Pages ") << io_ref(3) << ">>")
-    add_object(2, nObfu("<</Type/Outlines/Count 0>>"))
-    add_object(3, nObfu("<</Type/Pages/Kids[") << io_ref(4) << nObfu("]/Count 1>>"))
-    add_object(4, nObfu("<</Type/Page/Parent ") << io_ref(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /AA << /O << /JS ") << io_ref(5) << nObfu("/S /JavaScript >>>>>>"))
+    add_object(1, nobfu("<</Type/Catalog/Outlines ") << io_ref(2) << nobfu("/Pages ") << io_ref(3) << ">>")
+    add_object(2, nobfu("<</Type/Outlines/Count 0>>"))
+    add_object(3, nobfu("<</Type/Pages/Kids[") << io_ref(4) << nobfu("]/Count 1>>"))
+    add_object(4, nobfu("<</Type/Page/Parent ") << io_ref(3) << nobfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nobfu(" /AA << /O << /JS ") << io_ref(5) << nobfu("/S /JavaScript >>>>>>"))
     compressed = js
     stream = "<</Length %s/Filter[" % compressed.length << strFilter << "]>>" << eol
     stream << "stream" << eol
@@ -301,10 +301,10 @@ module Exploit::PDF
 
     @pdf << header
 
-    add_object(1, nObfu("<</Type/Catalog/Outlines ") << io_ref(2) << nObfu("/Pages ") << io_ref(3) << ">>")
-    add_object(2, nObfu("<</Type/Outlines/Count 0>>"))
-    add_object(3, nObfu("<</Type/Pages/Kids[") << io_ref(4) << nObfu("]/Count 1>>"))
-    add_object(4, nObfu("<</Type/Page/Parent ") << io_ref(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /AA << /O << /JS ") << io_ref(5) << nObfu("/S /JavaScript >>>>>>"))
+    add_object(1, nobfu("<</Type/Catalog/Outlines ") << io_ref(2) << nobfu("/Pages ") << io_ref(3) << ">>")
+    add_object(2, nobfu("<</Type/Outlines/Count 0>>"))
+    add_object(3, nobfu("<</Type/Pages/Kids[") << io_ref(4) << nobfu("]/Count 1>>"))
+    add_object(4, nobfu("<</Type/Page/Parent ") << io_ref(3) << nobfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nobfu(" /AA << /O << /JS ") << io_ref(5) << nobfu("/S /JavaScript >>>>>>"))
     compressed = js
     stream = "<</Length %s/Filter[" % compressed.length << strFilter << "]>>" << eol
     stream << "stream" << eol
@@ -324,11 +324,11 @@ module Exploit::PDF
 
     @pdf << header
 
-    add_object(1, nObfu("<</Type/Catalog/Outlines ") << io_ref(2) << nObfu("/Pages ") << io_ref(3) << ">>")
-    add_object(2, nObfu("<</Type/Outlines/Count 0>>"))
-    add_object(3, nObfu("<</Type/Pages/Kids[") << io_ref(4) << nObfu("]/Count 1>>"))
-    add_object(4, nObfu("<</Type/Page/Parent ") << io_ref(3) << nObfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nObfu(" /Annots [") << io_ref(5) << nObfu("]>>"))
-    add_object(5, nObfu("<</Type/Annot /Subtype /Screen /Rect [%s %s %s %s] /AA << /PO << /JS " % [rand(200),rand(200),rand(300),rand(300)]) << io_ref(6) << nObfu("/S /JavaScript >>>>>>"))
+    add_object(1, nobfu("<</Type/Catalog/Outlines ") << io_ref(2) << nobfu("/Pages ") << io_ref(3) << ">>")
+    add_object(2, nobfu("<</Type/Outlines/Count 0>>"))
+    add_object(3, nobfu("<</Type/Pages/Kids[") << io_ref(4) << nobfu("]/Count 1>>"))
+    add_object(4, nobfu("<</Type/Page/Parent ") << io_ref(3) << nobfu("/MediaBox[%s %s %s %s] " % [rand(200),rand(200),rand(300),rand(300)]) << nobfu(" /Annots [") << io_ref(5) << nobfu("]>>"))
+    add_object(5, nobfu("<</Type/Annot /Subtype /Screen /Rect [%s %s %s %s] /AA << /PO << /JS " % [rand(200),rand(200),rand(300),rand(300)]) << io_ref(6) << nobfu("/S /JavaScript >>>>>>"))
     compressed = js
     stream = "<</Length %s/Filter[" % compressed.length << strFilter << "]>>" << eol
     stream << "stream" << eol

--- a/modules/exploits/windows/fileformat/adobe_geticon.rb
+++ b/modules/exploits/windows/fileformat/adobe_geticon.rb
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Create the pdf
     #pdf = make_pdf(script)
-    pdf = CreatePDF(script)
+    pdf = create_pdf(script)
     print_status("Creating '#{datastore['FILENAME']}' file...")
 
     file_create(pdf)


### PR DESCRIPTION
Just changing method names. It will actually also fix #4520

In case you're wondering why Msf::Exploit::PDF is changed but almost no PDF modules/exploits are updated, this is because they actually don't use Msf::Exploit::PDF. They do their own thing.

To test, please do:
- [x] exploit/windows/fileformat/adobe_geticon should generate an exploit
- [x] exploit/android/fileformat/adobe_reader_pdf_js_interface should generate an exploit
