### PR TITLE
Filter creds by type and reinstance creds -R

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -885,7 +885,6 @@ class Db
             core.private ? core.private.class.model_name.human : "",
           ]
         else
-          rhosts = []
           core.logins.each do |login|
             if svcs.present? && !svcs.include?(login.service.name)
               next


### PR DESCRIPTION
This allows you to specify the filter -t with the options password, ntlm, or hash to filter the creds output. And to specify the rhosts via passing the -R option.
## Verification
- [x] `creds -h` should display the -t --type help option and example
- [x] Add some users

```
creds add-ntlm user01 00093E46C1B33DFCAAD3B435B51404EE:69596D59EA3B19E414A47BD3A3ABDCCC
creds add-password user02 password
```
- [x] `creds -t password` should only display user02
- [x] `creds -t ntlm` should only display user01
- [x] `creds -t hash` should only display user01 
- [x] `creds --type password` etc works too!
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] `creds -R` sets the RHOSTS field.
