### PR TITLE
Bug/msp 11986/db all pass

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -2,6 +2,18 @@ require 'metasploit/framework/credential'
 
 class Metasploit::Framework::CredentialCollection
 
+  # @!attribute additional_privates
+  #   Additional privates to be combined
+  #
+  #   @return [Array<String>]
+  attr_accessor :additional_privates
+
+  # @!attribute additional_publics
+  #   Additional public to be combined
+  #
+  #   @return [Array<String>]
+  attr_accessor :additional_publics
+
   # @!attribute blank_passwords
   #   Whether each username should be tried with a blank password
   #   @return [Boolean]
@@ -60,6 +72,24 @@ class Metasploit::Framework::CredentialCollection
       public_send("#{attribute}=", value)
     end
     self.prepended_creds ||= []
+  end
+
+  # Adds a string as an addition private credential
+  # to be combined in the collection.
+  #
+  # @param [String] :private_str the string to use as a private
+  # @return [void]
+  def add_private(private_str='')
+    additional_privates << private_str
+  end
+
+  # Adds a string as an addition public credential
+  # to be combined in the collection.
+  #
+  # @param [String] :public_str the string to use as a public
+  # @return [void]
+  def add_public(public_str='')
+    additional_publics << public_str
   end
 
   # Add {Credential credentials} that will be yielded by {#each}

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -112,7 +112,7 @@ module Auxiliary::AuthBrute
   #    the credential collection to add to
   # @return [Metasploit::Framework::CredentialCollection] the modified Credentialcollection
   def prepend_db_keys(cred_collection)
-    if datastore['DB_ALL_CREDS'] && framework.db.active
+    if prepend_db_creds?
       each_ssh_cred do |cred|
         process_cred_for_collection(cred_collection,cred)
       end
@@ -127,7 +127,7 @@ module Auxiliary::AuthBrute
   #    the credential collection to add to
   # @return [Metasploit::Framework::CredentialCollection] the modified Credentialcollection
   def prepend_db_passwords(cred_collection)
-    if datastore['DB_ALL_CREDS'] && framework.db.active
+    if prepend_db_creds?
       each_password_cred do |cred|
         process_cred_for_collection(cred_collection,cred)
       end

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -49,6 +49,47 @@ module Auxiliary::AuthBrute
     @@max_per_service = nil
   end
 
+  # Yields each {Metasploit::Credential::Core} in the {Mdm::Workspace} with
+  # a private type of 'ntlm_hash'
+  #
+  # @yieldparam [Metasploit::Credential::Core]
+  def each_ntlm_cred
+    creds = Metasploit::Credential::Core.joins(:private).where(metasploit_credential_privates: { type: 'Metasploit::Credential::NTLMHash' }, workspace_id: myworkspace.id)
+    creds.each do |cred|
+      yield cred
+    end
+  end
+
+  # Yields each {Metasploit::Credential::Core} in the {Mdm::Workspace} with
+  # a private type of 'password'
+  #
+  # @yieldparam [Metasploit::Credential::Core]
+  def each_password_cred
+    creds = Metasploit::Credential::Core.joins(:private).where(metasploit_credential_privates: { type: 'Metasploit::Credential::Password' }, workspace_id: myworkspace.id)
+    creds.each do |cred|
+      yield cred
+    end
+  end
+
+  # Yields each {Metasploit::Credential::Core} in the {Mdm::Workspace} with
+  # a private type of 'ssh_key'
+  #
+  # @yieldparam [Metasploit::Credential::Core]
+  def each_ssh_cred
+    creds = Metasploit::Credential::Core.joins(:private).where(metasploit_credential_privates: { type: 'Metasploit::Credential::SSHKey' }, workspace_id: myworkspace.id)
+    creds.each do |cred|
+      yield cred
+    end
+  end
+
+  # Checks whether we should be adding creds from the DB to a CredCollection
+  #
+  # @return [TrueClass] if any of the datastore options for db creds are selected and the db is active
+  # @return [FalseClass] if none of the datastore options are selected OR the db is not active
+  def prepend_db_creds?
+    (datastore['DB_ALL_CREDS'] || datastore['DB_ALL_PASS'] || datastore['DB_ALL_USERS']) && framework.db.active
+  end
+
   # This method takes a {Metasploit::Framework::CredentialCollection} and prepends existing NTLMHashes
   # from the database. This allows the users to use the DB_ALL_CREDS option.
   #
@@ -56,10 +97,9 @@ module Auxiliary::AuthBrute
   #   the credential collection to add to
   # @return [Metasploit::Framework::CredentialCollection] the modified Credentialcollection
   def prepend_db_hashes(cred_collection)
-    if datastore['DB_ALL_CREDS'] && framework.db.active
-      creds = Metasploit::Credential::Core.joins(:private).where(metasploit_credential_privates: { type: 'Metasploit::Credential::NTLMHash' }, workspace_id: myworkspace.id)
-      creds.each do |cred|
-        cred_collection.prepend_cred(cred.to_credential)
+    if prepend_db_creds?
+      each_ntlm_cred do |cred|
+        process_cred_for_collection(cred_collection,cred)
       end
     end
     cred_collection
@@ -73,9 +113,8 @@ module Auxiliary::AuthBrute
   # @return [Metasploit::Framework::CredentialCollection] the modified Credentialcollection
   def prepend_db_keys(cred_collection)
     if datastore['DB_ALL_CREDS'] && framework.db.active
-      creds = Metasploit::Credential::Core.joins(:private).where(metasploit_credential_privates: { type: 'Metasploit::Credential::SSHKey' }, workspace_id: myworkspace.id)
-      creds.each do |cred|
-        cred_collection.prepend_cred(cred.to_credential)
+      each_ssh_cred do |cred|
+        process_cred_for_collection(cred_collection,cred)
       end
     end
     cred_collection
@@ -89,14 +128,26 @@ module Auxiliary::AuthBrute
   # @return [Metasploit::Framework::CredentialCollection] the modified Credentialcollection
   def prepend_db_passwords(cred_collection)
     if datastore['DB_ALL_CREDS'] && framework.db.active
-      creds = Metasploit::Credential::Core.joins(:private).where(metasploit_credential_privates: { type: 'Metasploit::Credential::Password' }, workspace_id: myworkspace.id)
-      creds.each do |cred|
-        cred_collection.prepend_cred(cred.to_credential)
+      each_password_cred do |cred|
+        process_cred_for_collection(cred_collection,cred)
       end
     end
     cred_collection
   end
 
+  # Takes a {Metasploit::Credential::Core} and converts it into a
+  # {Metasploit::Framework::Credential} and processes it into the
+  # {Metasploit::Framework::CredentialCollection} as dictated by the
+  # selected datastore options.
+  #
+  # @param [Metasploit::Framework::CredentialCollection] the credential collection to add to
+  # @param [Metasploit::Credential::Core] the Credential Core to process
+  def process_cred_for_collection(cred_collection, cred)
+    msf_cred = cred.to_credential
+    cred_collection.prepend_cred(msf_cred) if datastore['DB_ALL_CREDS']
+    cred_collection.add_private(msf_cred.private) if datastore['DB_ALL_PASS']
+    cred_collection.add_public(msf_cred.public) if datastore['DB_ALL_USERS']
+  end
 
 
   # Checks all three files for usernames and passwords, and combines them into


### PR DESCRIPTION
Addresses issue https://github.com/rapid7/metasploit-framework/issues/4532

AuthBrute modules were respecting DB_ALL_CREDS but not DB_ALL_USERS or DB_ALL_PASS. 
This should now be fixed

VERIFICATION STEPS
- [x] start up msfconsole
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] have at least one credential in your database
- [x] unset SMBUser
- [x] `set DB_ALL_USERS true`
- [x] `set DB_ALL_CREDS false`
- [x] `set SMBPass boguspassword`
- [x] target any smb service
- [x] run the scanner
- [x] VERIFY you see it attempt the existing username(s) with 'boguspassword'
- [x] unset SMBPass
- [x] `set SMBUser bogususer`
- [x] `set DB_ALL_USERS false`
- [x] `set DB_ALL_PASS true`
- [x] run the scanner
- [x] VERIFY you see it attempt bogususer with the existing password(s)
