### PR TITLE
Fix msftidy warning, and make sure all print_*s in check() are vprint_*s

### DIFF
--- a/modules/exploits/multi/http/pandora_upload_exec.rb
+++ b/modules/exploits/multi/http/pandora_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
       return Exploit::CheckCode::Safe
     rescue ::Rex::ConnectionError
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
     end
     return Exploit::CheckCode::Unknown
 


### PR DESCRIPTION
I updated my repo and saw this msftidy warning, so I was like "eh why not"
