### PR TITLE
Ensure logging in ~/.msf4/log

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module Metasploit
     class Application < Rails::Application
       include Metasploit::Framework::CommonEngine
 
+      config.paths['log']             = "#{Msf::Config.log_directory}/#{Rails.env}.log"
       config.paths['config/database'] = [Metasploit::Framework::Database.configurations_pathname.try(:to_path)]
     end
   end


### PR DESCRIPTION
 Fix #4511 
### Verification steps
- [x] Launch msfconsole
- [x] Drop into irb: `irb`
- [x] VERIFY: this contains a path in ~/.msf4/log -- `Rails.logger.instance_variable_get("@logger").instance_variable_get("@log_dest")`
