### PR TITLE
allows loginscanners to work without db

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -13,33 +13,33 @@ module Auxiliary::Report
   optionally_include_metasploit_credential_creation
 
   def create_cracked_credential(opts={})
-    begin
+    if active_db?
       super(opts)
-    rescue NoMethodError => e
+    else
       print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
     end
   end
 
   def create_credential(opts={})
-    begin
+    if active_db?
       super(opts)
-    rescue NoMethodError => e
+    else
       print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
     end
   end
 
   def create_credential_login(opts={})
-    begin
+    if active_db?
       super(opts)
-    rescue NoMethodError => e
+    else
       print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
     end
   end
 
   def invalidate_login(opts={})
-    begin
+    if active_db?
       super(opts)
-    rescue NoMethodError => e
+    else
       print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
     end
   end

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -12,6 +12,38 @@ module Auxiliary::Report
 
   optionally_include_metasploit_credential_creation
 
+  def create_cracked_credential(opts={})
+    begin
+      super(opts)
+    rescue NoMethodError => e
+      print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
+    end
+  end
+
+  def create_credential(opts={})
+    begin
+      super(opts)
+    rescue NoMethodError => e
+      print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
+    end
+  end
+
+  def create_credential_login(opts={})
+    begin
+      super(opts)
+    rescue NoMethodError => e
+      print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
+    end
+  end
+
+  def invalidate_login(opts={})
+    begin
+      super(opts)
+    rescue NoMethodError => e
+      print_error "There does not appear to be a functioning DB, Credential Data will not be saved!"
+    end
+  end
+
   # This method overrides the method from Metasploit::Credential to check for an active db
   def active_db?
     framework.db.active


### PR DESCRIPTION
created stub methods around the credential
creation methods modules would use from
Metasploit::Credential, they try to call the real ones
but rescue a NoMethodError that arises if framework is setup
without the db. it just prints a message to the console
telling the user the cred data will not be saved

MSP-10969

VERIFICATION STEPS
- [x] `bundle install --without db`
- [x] `msfconsole`
- [x] use any login scanner module you want
- [x] VERIFY you don't get a stack trace
- [x] VERIFY you get errors printed to the console that cred details will not be saved
- [x] exit msfconsole
- [x] `rm -rf .bundle`
- [x] `bundle install`
- [x] `msfconsole`
- [x] rerun the same loginscanner
- [x] VERIFY it now saves the creds to the db properly
