### PR TITLE
Spelling fix for DOMAIN option description

### DIFF
--- a/modules/post/multi/gather/dns_bruteforce.rb
+++ b/modules/post/multi/gather/dns_bruteforce.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Post
     register_options(
       [
 
-        OptString.new('DOMAIN', [true, 'Domain to do a fordward lookup bruteforce against.']),
+        OptString.new('DOMAIN', [true, 'Domain to do a forward lookup bruteforce against.']),
         OptPath.new('NAMELIST',[true, "List of hostnames or subdomains to use.",
             ::File.join(Msf::Config.data_directory, "wordlists", "namelist.txt")])
 


### PR DESCRIPTION
Minor spelling correction of fordward to forward for the DOMAIN option description.
