### PR TITLE
Bump metasploit-credential to 0.13.11: login import/export fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       tzinfo
     metasploit-framework-db (4.11.0.pre.dev)
       activerecord (>= 3.2.21, < 4.0.0)
-      metasploit-credential (~> 0.13.10)
+      metasploit-credential (~> 0.13.11)
       metasploit-framework (= 4.11.0.pre.dev)
       metasploit_data_models (~> 0.21.3)
       pg (>= 0.11)
@@ -112,7 +112,7 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.13.10)
+    metasploit-credential (0.13.11)
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
       metasploit_data_models (~> 0.21.0)

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Metasploit::Credential database models
-  spec.add_runtime_dependency 'metasploit-credential', '~> 0.13.10'
+  spec.add_runtime_dependency 'metasploit-credential', '~> 0.13.11'
   # Database models shared between framework and Pro.
   spec.add_runtime_dependency 'metasploit_data_models', '~> 0.21.3'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code


### PR DESCRIPTION
This pulls in 0.13.11 which adds last_attempted_at and access_level to credential export and import: https://github.com/rapid7/metasploit-credential/pull/84
## Verification
- [ ] `bundle install`
- [ ] VERIFY `bundle show metasploit-credential` indicates installed version is 0.13.11
