### PR TITLE
update wordpress version detection regex

### DIFF
--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -98,7 +98,7 @@ module Msf::HTTP::Wordpress::Version
     # try to extract version from readme
     # Example line:
     # Stable tag: 2.6.6
-    version = res.body.to_s[/(?:stable tag|version): (?!trunk)([0-9a-z.-]+)/i, 1]
+    version = res.body.to_s[/(?:stable tag|version):\s+(?!trunk)([0-9a-z.-]+)/i, 1]
 
     # readme present, but no version number
     return Msf::Exploit::CheckCode::Detected if version.nil?

--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -98,7 +98,7 @@ module Msf::HTTP::Wordpress::Version
     # try to extract version from readme
     # Example line:
     # Stable tag: 2.6.6
-    version = res.body.to_s[/(?:stable tag|version):\s+(?!trunk)([0-9a-z.-]+)/i, 1]
+    version = res.body.to_s[/(?:stable tag|version):\s*(?!trunk)([0-9a-z.-]+)/i, 1]
 
     # readme present, but no version number
     return Msf::Exploit::CheckCode::Detected if version.nil?


### PR DESCRIPTION
Another update on the regex. This makes sure multiple spaces are handled and the regex is in sync with wpscan
