### PR TITLE
modify msftidy regex

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -593,7 +593,7 @@ class Msftidy
   # This module then got copied and committed 20+ times and is used in numerous other places.
   # This ensures that this stops.
   def check_invalid_url_scheme
-    test = @source.scan(/^#.+http\/\/metasploit.com/)
+    test = @source.scan(/^#.+http\/\/(?:www\.)?metasploit.com/)
     unless test.empty?
       test.each { |item|
         info("Invalid URL: #{item}")


### PR DESCRIPTION
This PR changes the msftidy invalid url regex to also detect www.metasploit.com.

See this cleanup-commit for #4550 for more details: https://github.com/rapid7/metasploit-framework/commit/d4d1a535330a79064507cde60e195741e2c2f527
