### PR TITLE
Improve (mis)Fortune Cookie (CVE-2014-9222) scanner

### DIFF
--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -98,7 +98,7 @@ class Metasploit4 < Msf::Auxiliary
       # in most cases, the canary URI will not exist and will return a 404, but
       # if everything under TARGETURI is protected by auth, a 401 may be OK too.
       # but, regardless, respect the configuration set for this module
-      return canary if res && res.code.to_s =~ @status_codes_regex
+      return [canary, res.code] if res && res.code.to_s =~ @status_codes_regex
     end
     nil
   end
@@ -118,7 +118,10 @@ class Metasploit4 < Msf::Auxiliary
   # vulnerable.
   def test_misfortune
     # find a usable canary URI (one that returns an acceptable status code already)
-    unless (canary_value = find_canary)
+    if canary = find_canary
+      canary_value, canary_code = canary
+      vprint_status("#{peer} canary URI #{canary_value} with code #{canary_code}")
+    else
       vprint_error("#{peer} Unable to find a suitable canary URI")
       return Exploit::CheckCode::Unknown
     end

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -40,12 +40,6 @@ class Metasploit4 < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'URI to test', '/'])
       ], Exploit::Remote::HttpClient
     )
-
-    register_advanced_options(
-      [
-        OptBool.new('REQUIRE_AUTH', [true, 'Require that the tested URI require authentication', false])
-      ], self.class
-    )
   end
 
   def check_host(_ip)
@@ -67,13 +61,29 @@ class Metasploit4 < Msf::Auxiliary
     end
   end
 
-  def find_canary_uri
+  def check_response_fingerprint(res, fallback_status)
+    fp = http_fingerprint(response: res)
+    if /RomPager\/(?<version>[\d\.]+)/ =~ fp
+      vprint_status("#{peer} is RomPager #{version}")
+      if Gem::Version.new(version) < Gem::Version.new('4.34')
+        return Exploit::CheckCode::Detected
+      end
+    end
+    fallback_status
+  end
+
+  def find_canary
     vprint_status("#{peer} locating suitable canary URI")
     0.upto(4) do
       canary = '/' + Rex::Text.rand_text_alpha(16)
-      res = send_request_raw('uri' => normalize_uri(canary), 'method' => 'GET', 'headers' => headers)
-      # in most cases, the canary URI will not exist and will return a 404, but if everything under
-      # TARGETURI is protected by auth, that may be fine too
+      res = send_request_raw(
+        'uri' => normalize_uri(canary),
+        'method' => 'GET',
+        'headers' => headers
+      )
+      # in most cases, the canary URI will not exist and will return a 404, but
+      # if everything under TARGETURI is protected by auth, that may be fine
+      # too
       return canary if res.code == 401 || res.code == 404
     end
     nil
@@ -81,83 +91,76 @@ class Metasploit4 < Msf::Auxiliary
 
   def headers
     {
-      'Referer' => datastore['SSL'] ? 'https' : 'http' + "://#{rhost}:#{rport}"
+      'Referer' => full_uri
     }
   end
 
-  def requires_auth?
-    res = send_request_raw(
-      'uri' => normalize_uri(target_uri.path.to_s),
-      'method' => 'GET',
-      'headers' => headers
-    )
-    return false unless res
-
-    http_fingerprint(response: res)
-    if res.code == 401
-      vprint_status("#{peer} requires authentication for #{target_uri.path}")
-      true
-    else
-      vprint_status("#{peer} does not require authentication for #{target_uri.path} -- code #{res.code}")
-      false
-    end
-  end
-
+  # To test for this vulnerability, we must first find a URI known to return
+  # a 404 (not found) which we will use as a canary.  This URI (for example,
+  # /foo) is then taken and used as the value for a carefully crafted cookie
+  # when making a request to the configured host+port+uri.  If the response
+  # is a 404 and the body includes the canary, it is likely that the cookie
+  # overwrote RomPager's concept of the requested URI, indicating that it is
+  # vulnerable.
   def test_misfortune
-    if datastore['REQUIRE_AUTH']
-      return Exploit::CheckCode::Unknown unless requires_auth?
-    end
-
-    # find a usable canary URI (one that 401/404s already)
-    unless canary = find_canary_uri
+    # find a usable canary URI (one that returns a 404 already)
+    unless (canary_value = find_canary)
       vprint_error("#{peer} Unable to find a suitable canary URI")
       return Exploit::CheckCode::Unknown
     end
 
-    # Make a request containing a malicious cookie with the canary value.
-    # If that canary shows up in the *body*, they are vulnerable
+    canary_cookie_name = 'C107373883'
+    canary_cookie = canary_cookie_name + "=#{canary_value};"
+
+    # Make a request containing a specific canary cookie name with the value set
+    # from the suitable canary value found above.
     res = send_request_raw(
       'uri' => normalize_uri(target_uri.path.to_s),
       'method' => 'GET',
-      'headers' => headers.merge('Cookie' => "C107373883=#{canary}")
+      'headers' => headers.merge('Cookie' => canary_cookie)
     )
 
     unless res
-      vprint_error("#{peer} no response")
+      vprint_error("#{full_uri} no response")
       return Exploit::CheckCode::Unknown
     end
 
-    # fingerprint because this is useful and also necessary if the canary is not
-    # in the body
-    fp = http_fingerprint(response: res)
+    unless res.code == 404
+      vprint_status("#{full_uri} unexpected HTTP code #{res.code} response")
+      return check_response_fingerprint(res, Exploit::CheckCode::Unknown)
+    end
 
     unless res.body
-      vprint_status("#{peer} HTTP code #{res.code} had no body")
-      return Exploit::CheckCode::Unknown
+      vprint_status("#{full_uri} HTTP code #{res.code} had no body")
+      return check_response_fingerprint(res, Exploit::CheckCode::Unknown)
     end
 
-    if res.body.include?(canary)
-      vprint_good("#{peer} HTTP code #{res.code} response contained canary URI #{canary}")
-      report_vuln(
-        host: rhost,
-        port: rport,
-        name: name,
-        refs: references
-      )
-      return Exploit::CheckCode::Appears
-    end
-
-    vprint_status("#{peer} HTTP code #{res.code} response did not contain canary URI #{canary}")
-    if /RomPager\/(?<version>[\d\.]+)/ =~ fp
-      vprint_status("#{peer} is RomPager #{version}")
-      if Gem::Version.new(version) < Gem::Version.new('4.34')
-        return Exploit::CheckCode::Detected
+    # If that canary *value* shows up in the *body*, then there are two possibilities:
+    #
+    # 1) If the canary cookie *name* is also in the *body*, it is likely that
+    # the endpoint is puppeting back our request to some extent and therefore
+    # it is expected that the canary cookie *value* would also be there.
+    # return Exploit::CheckCode::Unknown
+    #
+    # 2) If the canary cookie *name* is *not* in the *body*, return
+    # Exploit::CheckCode::Appears
+    if res.body.include?(canary_value)
+      if res.body.include?(canary_cookie_name)
+        vprint_status("#{full_uri} HTTP code #{res.code} response contained test cookie name #{canary_cookie_name}")
+        return check_response_fingerprint(res, Exploit::CheckCode::Unknown)
+      else
+        vprint_good("#{full_uri} HTTP code #{res.code} response contained canary cookie value #{canary_value} as URI")
+        report_vuln(
+          host: rhost,
+          port: rport,
+          name: name,
+          refs: references
+        )
+        return Exploit::CheckCode::Appears
       end
     end
 
-    # TODO: ensure that the canary page doesn't exist in the first place
-    # (returns a 404), and then ensure that the malcious request with the
-    # carary in the cookie then returns a 404.
-    Exploit::CheckCode::Safe
+    vprint_status("#{full_uri} HTTP code #{res.code} response did not contain canary cookie value #{canary_value} as URI")
+    check_response_fingerprint(res, Exploit::CheckCode::Safe)
   end
 end

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -65,7 +65,7 @@ class Metasploit4 < Msf::Auxiliary
     when Exploit::CheckCode::Vulnerable
       print_good("#{peer} #{status.last}")
     else
-      vprint_status("#{peer} is not vulnerable")
+      vprint_status("#{peer} #{status.last}")
     end
   end
 
@@ -171,7 +171,7 @@ class Metasploit4 < Msf::Auxiliary
     # Exploit::CheckCode::Vulnerable
     if res.body.include?(canary_value)
       if res.body.include?(canary_cookie_name)
-        vprint_status("#{full_uri} HTTP code #{res.code} response contained test cookie name #{canary_cookie_name}")
+        vprint_status("#{full_uri} HTTP code #{res.code} response contained canary cookie name #{canary_cookie_name}")
         return check_response_fingerprint(res, Exploit::CheckCode::Detected)
       else
         vprint_good("#{full_uri} HTTP code #{res.code} response contained canary cookie value #{canary_value} as URI")

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -27,38 +27,116 @@ class Metasploit4 < Msf::Auxiliary
       ],
       'References' => [
         ['CVE', '2014-9222'],
-        ['URL', 'http://mis.fortunecook.ie']
+        ['URL', 'http://mis.fortunecook.ie'],
+        ['URL', 'http://mis.fortunecook.ie/misfortune-cookie-suspected-vulnerable.pdf'], # list of likely vulnerable devices
+        ['URL', 'http://mis.fortunecook.ie/too-many-cooks-exploiting-tr069_tal-oppenheim_31c3.pdf'] # 31C3 presentation with POC
       ],
       'DisclosureDate' => 'Dec 17 2014',
       'License' => MSF_LICENSE
     ))
-
-    register_options([
-      OptString.new('TARGETURI', [true, 'Path to fingerprint RomPager from', '/Allegro'])
-    ], self.class)
   end
 
-  def check_host(ip)
-    res = send_request_cgi('uri' => normalize_uri(target_uri.path.to_s), 'method' => 'GET')
-    fp = http_fingerprint(response: res)
-    if /RomPager\/(?<version>[\d\.]+)$/ =~ fp
-      if Gem::Version.new(version) < Gem::Version.new('4.34')
-        report_vuln(
-          host: ip,
-          port: rport,
-          name: name,
-          refs: references
-        )
-        return Exploit::CheckCode::Appears
-      else
-        return Exploit::CheckCode::Detected
-      end
-    else
-      return Exploit::CheckCode::Safe
+  def check_host(_ip)
+    begin
+      test_misfortune
+    ensure
+      disconnect
     end
   end
 
   def run_host(ip)
-    print_good("#{peer} appears to be vulnerable") if check_host(ip) == Exploit::CheckCode::Appears
+    case check_host(ip)
+    when Exploit::CheckCode::Appears
+      print_good("#{peer} is vulnerable")
+    when Exploit::CheckCode::Detected
+      print_good("#{peer} uses a vulnerable version")
+    else
+      vprint_status("#{peer} is not vulnerable")
+    end
+  end
+
+  def find_canary_uri
+    vprint_status("#{peer} locating suitable canary URI")
+    0.upto(4) do
+      canary = '/' + Rex::Text.rand_text_alpha(16)
+      res = send_request_cgi('uri' => normalize_uri(canary), 'method' => 'GET')
+      # in most cases, the canary URI will not exist and will return a 404, but if everything under
+      # TARGETURI is protected by auth, that may be fine too
+      return canary if res.code == 401 || res.code == 404
+    end
+    nil
+  end
+
+  def requires_auth?
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path.to_s),
+      'method' => 'GET'
+    )
+    return false unless res
+
+    http_fingerprint(response: res)
+    if res.code == 401
+      vprint_status("#{peer} requires authentication for #{target_uri.path}")
+      true
+    else
+      vprint_status("#{peer} does not require authentication for #{target_uri.path} -- code #{res.code}")
+      false
+    end
+  end
+
+  def test_misfortune
+    return Exploit::CheckCode::Unknown unless requires_auth?
+
+    # find a usable canary URI (one that 401/404s already)
+    unless canary = find_canary_uri
+      vprint_error("#{peer} Unable to find a suitable canary URI")
+      return Exploit::CheckCode::Unknown
+    end
+
+    # Make a request containing a malicious cookie with the canary value.
+    # If that canary shows up in the *body*, they are vulnerable
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path.to_s),
+      'method' => 'GET',
+      'headers' => { 'Cookie' => "C107373883=#{canary}" }
+    )
+
+    unless res
+      vprint_error("#{peer} no response")
+      return Exploit::CheckCode::Unknown
+    end
+
+    # fingerprint because this is useful and also necessary if the canary is not
+    # in the body
+    fp = http_fingerprint(response: res)
+
+    unless res.body
+      vprint_status("#{peer} HTTP code #{res.code} had no body")
+      return Exploit::CheckCode::Unknown
+    end
+
+    if res.body.include?(canary)
+      vprint_good("#{peer} HTTP code #{res.code} response contained canary URI #{canary}")
+      report_vuln(
+        host: rhost,
+        port: rport,
+        name: name,
+        refs: references
+      )
+      return Exploit::CheckCode::Appears
+    end
+
+    vprint_status("#{peer} HTTP code #{res.code} response did not contain canary URI #{canary}")
+    if /RomPager\/(?<version>[\d\.]+)/ =~ fp
+      vprint_status("#{peer} is RomPager #{version}")
+      if Gem::Version.new(version) < Gem::Version.new('4.34')
+        return Exploit::CheckCode::Detected
+      end
+    end
+
+    # TODO: ensure that the canary page doesn't exist in the first place
+    # (returns a 404), and then ensure that the malcious request with the
+    # carary in the cookie then returns a 404.
+    Exploit::CheckCode::Safe
   end
 end

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -34,6 +34,12 @@ class Metasploit4 < Msf::Auxiliary
       'DisclosureDate' => 'Dec 17 2014',
       'License' => MSF_LICENSE
     ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'URI to test', '/'])
+      ], Exploit::Remote::HttpClient
+    )
   end
 
   def check_host(_ip)

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -79,7 +79,7 @@ class Metasploit4 < Msf::Auxiliary
   def find_canary
     vprint_status("#{peer} locating suitable canary URI")
     0.upto(4) do
-      canary = '/' + Rex::Text.rand_text_alpha(16)
+      canary = target_uri.path.to_s + '/' + Rex::Text.rand_text_alpha(16)
       res = send_request_raw(
         'uri' => normalize_uri(canary),
         'method' => 'GET',

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -44,7 +44,7 @@ class Metasploit4 < Msf::Auxiliary
     register_advanced_options(
       [
         OptString.new('CANARY_URI', [false, 'Try overwriting the requested URI with this canary value (empty for random)']),
-        OptString.new('STATUS_CODES_REGEX', [true, 'Ensure that canary pages and probe responses have status codes that match this regex', '^4\d{2}$'])
+        OptString.new('STATUS_CODES_REGEX', [true, 'Ensure that canary pages and probe responses have status codes that match this regex', '^40[134]$'])
       ], self.class
     )
   end

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -40,6 +40,12 @@ class Metasploit4 < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'URI to test', '/'])
       ], Exploit::Remote::HttpClient
     )
+
+    register_advanced_options(
+      [
+        OptBool.new('REQUIRE_AUTH', [true, 'Require that the tested URI require authentication', false])
+      ], self.class
+    )
   end
 
   def check_host(_ip)
@@ -98,7 +104,9 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def test_misfortune
-    return Exploit::CheckCode::Unknown unless requires_auth?
+    if datastore['REQUIRE_AUTH']
+      return Exploit::CheckCode::Unknown unless requires_auth?
+    end
 
     # find a usable canary URI (one that 401/404s already)
     unless canary = find_canary_uri


### PR DESCRIPTION
A more reliable method for detecting this vulnerability was shown during 31C3.  I've updated this scanner module to utilize this method and be much more robust.

I have two hosts, both claiming to be running a vulnerable RomPager:

```
msf auxiliary(allegro_rompager_misfortune_cookie) > services 

Services
========

host         port  proto  name  state  info
----         ----  -----  ----  -----  ----
10.0.1.18    80    tcp    http  open   RomPager/4.07 UPnP/1.0
192.168.1.1  80    tcp    http  open   RomPager/4.07 UPnP/1.0 ( 401-Basic realm="TD-8616" )
```

192.168.1.1 is a TP-Link TD-8616 hardware version 8 (http://www.tp-link.com/en/support/download/?model=TD-8616&version=V8), which is from 2013 and doesn't look to be vulnerable.

10.0.1.18 is a TP-Link TD-W8901G hardware version 3.0 running Firmware Version:3.0.0 Build 100726 Rel.08012.  It does appear to be vulnerable.

Default check/run:

```
msf auxiliary(allegro_rompager_misfortune_cookie) > check
[*] 192.168.1.1:80 - The target service is running, but could not be validated.
[*] Checked 1 of 2 hosts (050% complete)
[*] 10.0.1.18:80 - The target appears to be vulnerable.
[*] Checked 2 of 2 hosts (100% complete)
msf auxiliary(allegro_rompager_misfortune_cookie) > run

[+] 192.168.1.1:80 uses a vulnerable version
[*] Scanned 1 of 2 hosts (50% complete)
[+] 10.0.1.18:80 is vulnerable
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```

With `VERBOSE` enabled:

```
msf auxiliary(allegro_rompager_misfortune_cookie) > check

[*] 192.168.1.1:80 requires authentication for /
[*] 192.168.1.1:80 locating suitable canary URI
[*] 192.168.1.1:80 HTTP code 401 response did not contain canary URI /BGfvYhXnjUqZCkso
[*] 192.168.1.1:80 is RomPager 4.07
[*] 192.168.1.1:80 - The target service is running, but could not be validated.
[*] Checked 1 of 2 hosts (050% complete)
[*] 10.0.1.18:80 requires authentication for /
[*] 10.0.1.18:80 locating suitable canary URI
[+] 10.0.1.18:80 HTTP code 404 response contained canary URI /PuhFUtgVsUWLRyxk
[*] 10.0.1.18:80 - The target appears to be vulnerable.
[*] Checked 2 of 2 hosts (100% complete)
msf auxiliary(allegro_rompager_misfortune_cookie) > run

[*] 192.168.1.1:80 requires authentication for /
[*] 192.168.1.1:80 locating suitable canary URI
[*] 192.168.1.1:80 HTTP code 401 response did not contain canary URI /FxqxgWTQupqcnfvq
[*] 192.168.1.1:80 is RomPager 4.07
[+] 192.168.1.1:80 uses a vulnerable version
[*] Scanned 1 of 2 hosts (50% complete)
[*] 10.0.1.18:80 requires authentication for /
[*] 10.0.1.18:80 locating suitable canary URI
[+] 10.0.1.18:80 HTTP code 404 response contained canary URI /TJFpKmDvWgbttUKE
[+] 10.0.1.18:80 is vulnerable
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
