### PR TITLE
Potential Fix For OpenVAS DB Import Issue

### DIFF
--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -113,6 +113,8 @@ module Parser
       return if not in_tag("result")
       @state[:has_text] = true
       @text = nil
+    when "count"
+      @text = nil
     end
     @state[:current_tag].delete name
   end

--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -113,7 +113,7 @@ module Parser
       return if not in_tag("result")
       @state[:has_text] = true
       @text = nil
-    when "count"
+    else
       @text = nil
     end
     @state[:current_tag].delete name


### PR DESCRIPTION
I'm not entirely sure why, but this small addition seems to fix the issue for my test run.  I'm not sure if its the real solution, or if there are other key names we need to unset as well.  In that case we might want to use an `else` instead of `when "count"`.  This is in reference to issue #4571 
