### PR TITLE
Add support for heap-only search in regular egghunter

### DIFF
--- a/lib/rex/exploitation/egghunter.rb
+++ b/lib/rex/exploitation/egghunter.rb
@@ -23,6 +23,7 @@ module Exploitation
 # Startreg code added by corelanc0d3r
 # Added routine to disable DEP for discovered egg (for win, added by corelanc0d3r)
 # Added support for searchforward option (true or false)
+# Added support for heap-only search option (true or false)
 #
 ###
 class Egghunter
@@ -58,6 +59,11 @@ class Egghunter
           else
             startstub = "\n\tjmp next_addr"
           end
+        # search only in heap?
+        elsif opts[:heaponly]
+          startstub  = "\n\tpush 0x30\n\tpop edx\n\tmov edx,fs:[edx]"
+          startstub << "\n\tadd dl,0x90\n\tmov edx,[edx]"
+          startstub << "\n\tmov edx,[edx]\n\tjmp next_addr"
         end
         startstub << "\n\t" if startstub.length > 0
 

--- a/lib/rex/exploitation/egghunter.rb
+++ b/lib/rex/exploitation/egghunter.rb
@@ -23,7 +23,6 @@ module Exploitation
 # Startreg code added by corelanc0d3r
 # Added routine to disable DEP for discovered egg (for win, added by corelanc0d3r)
 # Added support for searchforward option (true or false)
-# Added support for heap-only search option (true or false)
 #
 ###
 class Egghunter
@@ -71,12 +70,10 @@ class Egghunter
         flippage = "\n\tor dx,0xfff"
         edxdirection = "\n\tinc edx"
 
-        if searchforward
-          if searchforward.to_s.downcase == 'false'
-            # go backwards
-            flippage = "\n\txor dl,dl"
-            edxdirection = "\n\tdec edx"
-          end
+        if searchforward == false
+          # go backwards
+          flippage = "\n\txor dl,dl"
+          edxdirection = "\n\tdec edx"
         end
 
         # other vars


### PR DESCRIPTION
This PR adds support for heap-only search in the regular egghunter routine for Windows.

Usage:

```
badchars = ""
eggoptions =
{
    :checksum => false,
    :eggtag => "w00t",
    :heaponly => true
}
hunter,egg = generate_egghunter(payload.encoded,badchars,eggoptions)
```
