### PR TITLE
add comma check to msftidy

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -601,6 +601,18 @@ class Msftidy
     end
   end
 
+  # This checks looks for extranous commas
+  # Stuff with comments should match too: , #metasploit module ]
+  # but it should not match interpolation #{
+  def check_comma
+    test = @source.scan(/[^\n]+,(?:\s*#[^{][^\n]+)?\s*[\]\}]/)
+    unless test.empty?
+      test.each { |item|
+        info("Extra comma: #{item}")
+      }
+    end
+  end
+
   private
 
   def load_file(file)
@@ -650,6 +662,7 @@ def run_checks(full_filepath)
   tidy.check_sock_get
   tidy.check_udp_sock_get
   tidy.check_invalid_url_scheme
+  tidy.check_comma
   return tidy
 end
 

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -595,9 +595,9 @@ class Msftidy
   def check_invalid_url_scheme
     test = @source.scan(/^#.+http\/\/metasploit.com/)
     unless test.empty?
-      test.each { |item|
+      test.each do |item|
         info("Invalid URL: #{item}")
-      }
+      end
     end
   end
 
@@ -607,9 +607,9 @@ class Msftidy
   def check_comma
     test = @source.scan(/[^\n]+,(?:\s*#[^{][^\n]+)?\s*[\]\}]/)
     unless test.empty?
-      test.each { |item|
-        info("Extra comma: #{item}")
-      }
+      test.each do |item|
+        info("Extraneous comma: #{item}")
+      end
     end
   end
 


### PR DESCRIPTION
This adds a check for a extra comma to msftidy. This should adress stuff like

```
'Author'         =>
[
   'XXX <XXX[at]gmail.com>', #metasploit module
],
```
