### PR TITLE
Update outlook.rb execute_script time_out

### DIFF
--- a/modules/post/windows/gather/outlook.rb
+++ b/modules/post/windows/gather/outlook.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Post
     base_script = File.read(File.join(Msf::Config.data_directory, "post", "powershell", "outlook.ps1"))
     psh_script = base_script << command
     compressed_script = compress_script(psh_script)
-    cmd_out, runnings_pids, open_channels = execute_script(compressed_script)
+    cmd_out, runnings_pids, open_channels = execute_script(compressed_script, 120)
     while(d = cmd_out.channel.read)
       print ("#{d}")
     end


### PR DESCRIPTION
I have been using the script in real life cases which have bigger e-mailboxes then in the testing environment. Because of execute_script default time_out no results return, as the powershell scripts run longer then 15 seconds. Changed the timeout to 120.
