### PR TITLE
Add a second chance on cmd_use for bug #4549

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2418,9 +2418,15 @@ class Core
     mod_name = args[0]
 
     begin
-      if ((mod = framework.modules.create(mod_name)) == nil)
-        print_error("Failed to load module: #{mod_name}")
-        return false
+      mod = framework.modules.create(mod_name)
+      if mod.nil?
+        # Try one more time; see #4549
+        sleep 3
+        mod = framework.modules.create(mod_name)
+        if mod.nil?
+          print_error("Failed to load module: #{mod_name}")
+          return false
+        end
       end
     rescue Rex::AmbiguousArgumentError => info
       print_error(info.to_s)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2419,11 +2419,11 @@ class Core
 
     begin
       mod = framework.modules.create(mod_name)
-      if mod.nil?
+      unless mod
         # Try one more time; see #4549
         sleep 3
         mod = framework.modules.create(mod_name)
-        if mod.nil?
+        unless mod
           print_error("Failed to load module: #{mod_name}")
           return false
         end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -101,6 +101,9 @@ class Core
   # Constant for disclosure date formatting in search functions
   DISCLOSURE_DATE_FORMAT = "%Y-%m-%d"
 
+  # Constant for a retry timeout on using modules before they're loaded
+  CMD_USE_TIMEOUT = 3
+
   # Returns the list of commands supported by this command dispatcher
   def commands
     {
@@ -2421,7 +2424,7 @@ class Core
       mod = framework.modules.create(mod_name)
       unless mod
         # Try one more time; see #4549
-        sleep 3
+        sleep CMD_USE_TIMEOUT
         mod = framework.modules.create(mod_name)
         unless mod
           print_error("Failed to load module: #{mod_name}")


### PR DESCRIPTION
This is a weak attempt to solve a race condition between modules loading and cmd_use being fired. Upon startup, saved configurations, running resource scripts, and running commands will sometimes jump ahead of the module loading procedure.

I have not discovered where the race actually is and how to cause the race to happen. However, the timing seems to be fairly close to a second; by waiting three seconds after trying use again, we seem to be in the clear, at least according to testing.

Fixes #4549, but better solutions are welcome.
## Verification
- [x] The following bash script may be sufficient to catch the failing condition. Run it.

`for i in {1..20}; do echo Attempt $i; time ./msfconsole -Lqx "use auxiliary/scanner/http/http_version;exit"; echo Sleeping...; sleep 5; done`

In the usual case, where the modules load before you try to use the one, you should see something like this:

```
todb@mazikeen:~/git/rapid7/metasploit-framework$ for i in {1..20}; do echo Attempt $i; time ./msfconsole -Lqx "use auxiliary/scanner/http/http_version;exit"; echo Sleeping...; sleep 5; done
Attempt 1

real    0m4.805s
user    0m4.407s
sys 0m0.297s
Sleeping...

[etc for 20 more times]
```

If you're currently unlucky, or enter a period of unluckiness, you will see see a result like this:

```
Attempt 2

real    0m7.825s
user    0m4.611s
sys 0m0.332s
Sleeping...
```

Note the three second difference between `Attempt 1` and `Attempt 2`.

Yes, this is a test that relies on luck. Totally scientific, I know.

I don't know what causes the initial fail, but it is resolved after a three second delay. This delayed `cmd_use` functionality will only last as long as the conditions are that the `cmd_use` would otherwise normally fail.
- [x] In order to show that nonexistent modules will continue to fail to load normally, run: `time ./msfconsole -Lqx "use auxiliary/fake/module/here;exit"`

Note that the time taken should be three seconds longer than normal, just as in the caught failure case.

@limhoff-r7 or @jlee-r7 will likely have a better solution for this some time, but please don't let that block you landing this. I'm not thrilled with the fix but it's better than having automated jobs fail out. It's also better than asking users to remember to drop in `sleep` commands in their rc scripts.
