### PR TITLE
Make the title whitelist check for msftidy nicer

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -12,6 +12,16 @@ require 'time'
 
 CHECK_OLD_RUBIES = !!ENV['MSF_CHECK_OLD_RUBIES']
 SUPPRESS_INFO_MESSAGES = !!ENV['MSF_SUPPRESS_INFO_MESSAGES']
+WHITELIST = %w{
+  a an and as at avserve callmenum configdir connect debug docbase dtspcd
+  execve file for from getinfo goaway gsad hetro historysearch htpasswd
+  ibstat id in inetd iseemedia jhot libxslt lmgrd lnk load main map
+  migrate mimencode multisort name net netcat nodeid ntpd nttrans of
+  on onreadystatechange or ovutil path pbot pfilez pgpass pingstr pls
+  popsubfolders prescan readvar relfile rev rexec rlogin rsh rsyslog sa
+  sadmind say sblistpack spamd sreplace tagprinter the to twikidraw udev
+  uplay user username via welcome with ypupdated zsudo
+}
 
 if CHECK_OLD_RUBIES
   require 'rvm'
@@ -419,21 +429,10 @@ class Msftidy
   end
 
   def check_title_casing
-    whitelist = %w{
-      a an and as at avserve callmenum configdir connect debug docbase dtspcd
-      execve file for from getinfo goaway gsad hetro historysearch htpasswd
-      ibstat id in inetd iseemedia jhot libxslt lmgrd lnk load main map
-      migrate mimencode multisort name net netcat nodeid ntpd nttrans of
-      on onreadystatechange or ovutil path pbot pfilez pgpass pingstr pls
-      popsubfolders prescan readvar relfile rev rexec rlogin rsh rsyslog sa
-      sadmind say sblistpack spamd sreplace tagprinter the to twikidraw udev
-      uplay user username via welcome with ypupdated zsudo
-    }
-
     if @source =~ /["']Name["'][[:space:]]*=>[[:space:]]*['"](.+)['"],*$/
       words = $1.split
       words.each do |word|
-        if whitelist.include?(word)
+        if WHITELIST.include?(word)
           next
         elsif word =~ /^[a-z]+$/
           warn("Suspect capitalization in module title: '#{word}'")

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -12,15 +12,15 @@ require 'time'
 
 CHECK_OLD_RUBIES = !!ENV['MSF_CHECK_OLD_RUBIES']
 SUPPRESS_INFO_MESSAGES = !!ENV['MSF_SUPPRESS_INFO_MESSAGES']
-WHITELIST = %w{
+TITLE_WHITELIST = %w{
   a an and as at avserve callmenum configdir connect debug docbase dtspcd
   execve file for from getinfo goaway gsad hetro historysearch htpasswd
   ibstat id in inetd iseemedia jhot libxslt lmgrd lnk load main map
   migrate mimencode multisort name net netcat nodeid ntpd nttrans of
   on onreadystatechange or ovutil path pbot pfilez pgpass pingstr pls
   popsubfolders prescan readvar relfile rev rexec rlogin rsh rsyslog sa
-  sadmind say sblistpack spamd sreplace tagprinter the to twikidraw udev
-  uplay user username via welcome with ypupdated zsudo
+  sadmind say sblistpack spamd sreplace tagprinter the tnftp to twikidraw
+  udev uplay user username via welcome with ypupdated zsudo
 }
 
 if CHECK_OLD_RUBIES
@@ -432,7 +432,7 @@ class Msftidy
     if @source =~ /["']Name["'][[:space:]]*=>[[:space:]]*['"](.+)['"],*$/
       words = $1.split
       words.each do |word|
-        if WHITELIST.include?(word)
+        if TITLE_WHITELIST.include?(word)
           next
         elsif word =~ /^[a-z]+$/
           warn("Suspect capitalization in module title: '#{word}'")


### PR DESCRIPTION
Recast the whitelist as a toplevel constant, add 'tnftp' to the list.
## Verification
- [x] Run `tools/msftidy.rb modules`
- [x] See a lack of "Suspect capitalization" offenses.
