### PR TITLE
Add support for detecting firefox 33 - 35.

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -222,7 +222,13 @@ os_detect.getVersion = function(){
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
 		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
-		if ('copyWithin' in Array.prototype) {
+		if ('closest' in Element.prototype) {
+			ua_version = '35.0';
+		} else if ('matches' in Element.prototype) {
+			ua_version = '34.0';
+		} else if ('RadioNodeList' in window) {
+			ua_version = '33.0';
+		} else if ('copyWithin' in Array.prototype) {
 			ua_version = '32.0';
 		} else if ('fill' in Array.prototype) {
 			ua_version = '31.0';


### PR DESCRIPTION
#### Verification

I like to just copy and paste the `os.js` script into the browser console, and then run `console.log(os_detect.getVersion())` and make sure the version matches.
- [ ] Version 35.0 is reported correctly
- [ ] Version 34.0 is reported correctly
- [ ] Version 33.0 is reported correctly
- [ ] Version 32.0 is reported correctly
