### PR TITLE
Msftidy: Fix explicit rubygems

### DIFF
--- a/modules/auxiliary/crawler/msfcrawler.rb
+++ b/modules/auxiliary/crawler/msfcrawler.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options([
       OptString.new('PATH',	[true,	"Starting crawling path", '/']),
-      OptInt.new('RPORT', [true, "Remote port", 80 ]),
+      OptInt.new('RPORT', [true, "Remote port", 80 ])
     ], self.class)
 
     register_advanced_options([
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Auxiliary
       OptInt.new('TakeTimeout', [ true, "Timeout for loop ending", 15]),
       OptInt.new('ReadTimeout', [ true, "Read timeout (-1 forever)", 3]),
       OptInt.new('ThreadNum', [ true, "Threads number", 20]),
-      OptString.new('DontCrawl',	[true,	"Filestypes not to crawl", '.exe,.zip,.tar,.bz2,.run,.asc,.gz']),
+      OptString.new('DontCrawl',	[true,	"Filestypes not to crawl", '.exe,.zip,.tar,.bz2,.run,.asc,.gz'])
     ], self.class)
   end
 

--- a/modules/auxiliary/crawler/msfcrawler.rb
+++ b/modules/auxiliary/crawler/msfcrawler.rb
@@ -13,7 +13,6 @@
 # openssl before rubygems mac os
 require 'msf/core'
 require 'openssl'
-require 'rubygems'
 require 'rinda/tuplespace'
 require 'pathname'
 require 'uri'


### PR DESCRIPTION
This knocks out the last non-datastore (and now non-comma) msftidy complaint.
## Verification
- [x] When running msftidy, you should **not** see any results. For example, after fix, you should see:

```
$ tools/msftidy.rb modules/ | grep -v -e datastore -e comma
$
```

and not:

```
$ tools/msftidy.rb modules/ | grep -v -e datastore -e comma
modules/auxiliary/crawler/msfcrawler.rb - [WARNING] Explicitly requiring/loading rubygems is not necessary
```
