### PR TITLE
Fix #4616 and Fix #3798 - Correctly use OptRegexp

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -528,7 +528,7 @@ class OptRegexp < OptBase
   end
 
   def default
-    @default.to_s
+    @default
   end
 
   def display_value(value)

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptString.new('PATH', [ true,  "The test path to the page to analize", '/']),
-        OptRegexp.new('PATTERN', [ true,  "The regex to use (default regex is a sample to grab page title)", %r{<title>(.*)</title>}i])
+        OptRegexp.new('PATTERN', [ true,  "The regex to use (default regex is a sample to grab page title)", '<title>(.*)</title>'])
 
       ], self.class)
 


### PR DESCRIPTION
This patch fixes a problem with OptRegexp. The OptRegexp class is always forcing the value to be converted to a string first, which causes the EXCLUDE option in browser_autopwn to kick in and match every found autopwn module, so it ignores all of them and you load nothing (#4616).

It is important to understand that nil actually represents an option not being set, which is a completely different behavior than having an empty value (technically "" is still a value, and if there's a value, it means the option is set). We need to watch out and handle these scenarios.

I am restoring the #default method to avoid forcing a to_s, which should fix the browser autopwn loading problem. And then I changed scraper.rb's default value for datastore option PATTERN to a string, and that should still fixe #3798. The way I see it, #3798 is actually a module-specific issue.

Fix #4616
Fix #3798

Note that this problem has bee around since Dec 22 2014 (see 725a17c70b5fb8eddf0e662c2f480c0abce3a001), which probably affects Metasploit Community and Pro users. Can't remember if I need to put a Jira label here, so just would like to point this out. If the Jira label is necessary, please go ahead and add it. Thanks.
## Verification Steps

**First off, with the patch, please retest #3798**
- [x] Start msfconsole
- [x] At the msf prompt, do `msgrpc ServerPort=23234 Pass=12345`
- [x] Make sure you have msfrpc_irb: https://github.com/rapid7/msfrpc-client
- [x] If necessary, you might need to modify the msfbase path in msfrpc_irb to it can find the msf lib
- [x] If necessary, you might need to gem install msfrpc-client
- [x] Start msfrpc_irb like this: `$ ./msfrpc_irb.rb  --rpc-host 127.0.0.1 --rpc-port 23234 --rpc-user msf --rpc-pass 12345 --rpc-ssl false`
- [x] It automatically puts you in irb, do: `rpc.call("module.options","auxiliary","scanner/http/scraper")`
- [x] You should NOT see a RuntimeError. Instead, you should see the options of scraper.rb.

**After #3798 is tested, please test browser autopwn**
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn`
- [x] Do: `set lhost [Your IP]`
- [x] Do: `run`
- [x] You should see some browser exploits being loaded (loading takes time btw)
