### PR TITLE
Rewind error handling to normal

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -151,18 +151,16 @@ protected
     rescue ::Exception => e
       mod.error = e
       mod.print_error("Auxiliary failed: #{e.class} #{e}")
-      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
-      else
+      if(e.class.to_s != 'Msf::OptionValidateError')
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.auxiliary.rb/
           mod.print_error("  #{line}")
         end
-        elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
       end
+
+      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
+      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
 
       mod.cleanup
 
@@ -184,3 +182,4 @@ end
 
 end
 end
+

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -147,17 +147,7 @@ module Exploit
       exploit.error = e
       exploit.print_error("Exploit failed: #{e}")
       elog("Exploit failed (#{exploit.refname}): #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
-        exploit.print_error("Call stack:")
-        e.backtrace.each do |line|
-          break if line =~ /lib.msf.base.simple.exploit.rb/
-          exploit.print_error("  #{line}")
-        end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
-      end
+      dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
     end
 
     return driver.session if driver
@@ -209,3 +199,4 @@ end
 
 end
 end
+

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -121,18 +121,16 @@ protected
     rescue ::Exception => e
       mod.error = e
       mod.print_error("Post failed: #{e.class} #{e}")
-      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
-      else
+      if(e.class.to_s != 'Msf::OptionValidateError')
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.post.rb/
           mod.print_error("  #{line}")
         end
-        elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
       end
+
+      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
+      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
 
       mod.cleanup
 
@@ -156,3 +154,4 @@ end
 
 end
 end
+

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -271,20 +271,14 @@ protected
           exploit.fail_reason = Msf::Exploit::Failure::Unknown
         end
 
-        elog("Exploit failed (#{exploit.refname}): #{msg}", 'core', LEV_0)
-
         if exploit.fail_reason == Msf::Exploit::Failure::Unknown
           exploit.print_error("Exploit failed: #{msg}")
-          exploit.print_error("Call stack:")
-          e.backtrace.each do |line|
-            break if line =~ /lib.msf.base.core.exploit_driver.rb/
-            exploit.print_error("  #{line}")
-          end
-          elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
         else
           exploit.print_error("Exploit failed [#{exploit.fail_reason}]: #{msg}")
-          dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
         end
+
+        elog("Exploit failed (#{exploit.refname}): #{msg}", 'core', LEV_0)
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
       end
 
       # Record the error to various places
@@ -335,3 +329,4 @@ protected
 end
 
 end
+

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -120,17 +120,10 @@ class Auxiliary
       print_error("Auxiliary interrupted by the console user")
     rescue ::Exception => e
       print_error("Auxiliary failed: #{e.class} #{e}")
-      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
-        print_error("Call stack:")
-        e.backtrace.each do |line|
-          break if line =~ /lib.msf.base.simple/
-          print_error("  #{line}")
-        end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
+      print_error("Call stack:")
+      e.backtrace.each do |line|
+        break if line =~ /lib.msf.base.simple/
+        print_error("  #{line}")
       end
 
       return false

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -121,18 +121,12 @@ class Exploit
       raise $!
     rescue ::Exception => e
       print_error("Exploit exception (#{mod.refname}): #{e.class} #{e}")
-
-      elog("Exploit exception (#{mod.refname}): #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
+      if(e.class.to_s != 'Msf::OptionValidateError')
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -122,18 +122,12 @@ class Post
       print_error("Post interrupted by the console user")
     rescue ::Exception => e
       print_error("Post failed: #{e.class} #{e}")
-
-      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
+      if (e.class.to_s != 'Msf::OptionValidateError')
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
 
       return false
@@ -160,3 +154,4 @@ class Post
 end
 
 end end end end
+


### PR DESCRIPTION
This should rewind everything this pull request did: https://github.com/rapid7/metasploit-framework/pull/4473

The reason we want to rewind this is because the errors are way too verbose, and we're frequently getting complaints about it. You see a backtrace even though there is no bug.

As a developer, it's really not a super huge deal if you don't see the backtrace on the console. I mean it's pretty nice to see it so we don't have to go through a bunch of steps (setg LogLevel and then watch framework.log), but without this we should be able to figure out how to fix something anyway.

We are NOT trying to reject the idea of #4473, but clearly we need to figure out how to implement this better.

A ticket is being discussed in #4552, but it looks like we're losing traction and we really need the arch team to elaborate on this since it's kind of an arch question. Before that happens and us coming up with an agreeable fix that's ready to merge (which is unlikely to happen anytime soon), we need to go back to the old way first.

This ticket is related to #4552, but does not fix it.
## Verification

You should compare the code changes in #4473 vs this one. Whatever code was added in #4473 should be gone. And if you play around msfconsole, you should not see errors as verbose as before (such as #4572), but when you hit a real bug or whatever (create one for testing purposes if you want to), when you setg LogLevel 3, you should still see the backtrace in framework.log.
