### PR TITLE
Fix #4625 Reenable channel receive packet requeueing logic

### DIFF
--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -355,8 +355,14 @@ module PacketDispatcher
 
           begin
           if ! dispatch_inbound_packet(pkt)
-            # Only requeue packets newer than the timeout
-            if (::Time.now.to_i - pkt.created_at.to_i > PacketTimeout)
+            # Keep Packets in the receive queue until a handler is registered
+            # for them. Packets will live in the receive queue for up to
+            # PacketTimeout, after which they will be dropped.
+            #
+            # A common reason why there would not immediately be a handler for
+            # a received Packet is in channels, where a connection may
+            # open and receive data before anything has asked to read.
+            if (::Time.now.to_i - pkt.created_at.to_i < PacketTimeout)
               incomplete << pkt
             end
           end


### PR DESCRIPTION
In #4475, I incorrectly interpreted the role of the 'incomplete' array in monitor_socket, and that change should be reverted.

What appears to happen is, we play a kind of 3-card monty with the list of received packets that are waiting for a handler to use them. monitor_socket continually loops between putting the packets on @pqueue, then into backlog[] to sort them, then into incomplete[] to list all of the packets that did not have handlers, finally back into @pqueue again. If packets don't continually get shuffled back into incomplete, they are not copied back into @pqueue to get rescanned again.

The only reason anything should really get into incomplete[] is if we receive a packet, but there is nothing to handle it. This scenario sounds like a bug, but it is exactly what happens with the Tcp Client channel - one can open a new channel, and receive a response packet back from the channel before the subsequent read_once code runs to register a handler to actually process it. This would be akin to your OS speculatively accepting data on a TCP socket with no listener, then when you open the socket for the first time, its already there.

While it would be nice if the handlers were setup before the data was sent back, as TCP Server appears to do, rather than relying on a handler being registered some time between connect and PacketTimeout, this needs to get in now to stop the bleeding.

The original meterpreter crash issue from #4475 appears to be gone as well, though I will continue testing to see what we can simplify from this logic and think about corner cases in the current logic.
# Verification
- [x] Pivot TCP client channels work as expected. I used this script to automate testing of #4625's scenario with two VMs on the same virtual subnet and a direct host route.

```
use exploit/multi/handler
set lhost MSFIP
set payload windows/x86_64/meterpreter/reverse_tcp
run -j
sleep 5
route add LINUXIP 255.255.255.255 1
use auxiliary/scanner/ssh/ssh_version
set RHOSTS 192.168.43.185
run
```
- [x] Meterpreter can run the thrashy service scan tests continually without crashing on duplicate closes

```
loadpath test/modules
use exploit/multi/handler
set payload windows/meterpreter/reverse_tcp
set lhost MSFIP
exploit -j
sleep 5
use post/test/services
set SESSION 1
run
run
run
run
```
