### PR TITLE
Rewind error handling to normal (Round 2)

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -151,18 +151,16 @@ protected
     rescue ::Exception => e
       mod.error = e
       mod.print_error("Auxiliary failed: #{e.class} #{e}")
-      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
-      else
+      if(e.class.to_s != 'Msf::OptionValidateError')
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.auxiliary.rb/
           mod.print_error("  #{line}")
         end
-        elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
       end
+
+      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
+      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
 
       mod.cleanup
 
@@ -184,3 +182,4 @@ end
 
 end
 end
+

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -147,17 +147,7 @@ module Exploit
       exploit.error = e
       exploit.print_error("Exploit failed: #{e}")
       elog("Exploit failed (#{exploit.refname}): #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
-        exploit.print_error("Call stack:")
-        e.backtrace.each do |line|
-          break if line =~ /lib.msf.base.simple.exploit.rb/
-          exploit.print_error("  #{line}")
-        end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
-      end
+      dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
     end
 
     return driver.session if driver
@@ -209,3 +199,4 @@ end
 
 end
 end
+

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -121,18 +121,16 @@ protected
     rescue ::Exception => e
       mod.error = e
       mod.print_error("Post failed: #{e.class} #{e}")
-      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
-      else
+      if(e.class.to_s != 'Msf::OptionValidateError')
         mod.print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple.post.rb/
           mod.print_error("  #{line}")
         end
-        elog("Call stack:\n#{$@.join("\n")}", 'core', LEV_0)
       end
+
+      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
+      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
 
       mod.cleanup
 
@@ -156,3 +154,4 @@ end
 
 end
 end
+

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -271,20 +271,14 @@ protected
           exploit.fail_reason = Msf::Exploit::Failure::Unknown
         end
 
-        elog("Exploit failed (#{exploit.refname}): #{msg}", 'core', LEV_0)
-
         if exploit.fail_reason == Msf::Exploit::Failure::Unknown
           exploit.print_error("Exploit failed: #{msg}")
-          exploit.print_error("Call stack:")
-          e.backtrace.each do |line|
-            break if line =~ /lib.msf.base.core.exploit_driver.rb/
-            exploit.print_error("  #{line}")
-          end
-          elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
         else
           exploit.print_error("Exploit failed [#{exploit.fail_reason}]: #{msg}")
-          dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
         end
+
+        elog("Exploit failed (#{exploit.refname}): #{msg}", 'core', LEV_0)
+        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
       end
 
       # Record the error to various places
@@ -335,3 +329,4 @@ protected
 end
 
 end
+

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -120,17 +120,12 @@ class Auxiliary
       print_error("Auxiliary interrupted by the console user")
     rescue ::Exception => e
       print_error("Auxiliary failed: #{e.class} #{e}")
-      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
+      if(e.class.to_s != 'Msf::OptionValidateError')
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
 
       return false
@@ -157,3 +152,4 @@ class Auxiliary
 end
 
 end end end end
+

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -121,18 +121,12 @@ class Exploit
       raise $!
     rescue ::Exception => e
       print_error("Exploit exception (#{mod.refname}): #{e.class} #{e}")
-
-      elog("Exploit exception (#{mod.refname}): #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
+      if(e.class.to_s != 'Msf::OptionValidateError')
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -122,18 +122,12 @@ class Post
       print_error("Post interrupted by the console user")
     rescue ::Exception => e
       print_error("Post failed: #{e.class} #{e}")
-
-      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
-
-      if e.kind_of?(Msf::OptionValidateError)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
-      else
+      if (e.class.to_s != 'Msf::OptionValidateError')
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
-        elog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_0)
       end
 
       return false
@@ -160,3 +154,4 @@ class Post
 end
 
 end end end end
+


### PR DESCRIPTION
This should rewind everything this pull request did: https://github.com/rapid7/metasploit-framework/pull/4473

The reason we want to rewind this is because the errors are way too verbose, and we're frequently getting complaints about it. You see a backtrace even though there is no bug.

This PR replaces #4630. It also does not fix #4552, but related.
