### PR TITLE
Add deprecation check to msftidy

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -130,6 +130,12 @@ class Msftidy
     end
   end
 
+  def check_deprecated
+    if @source.include?('include Msf::Module::Deprecated')
+      warn('Module is deprecated')
+    end
+  end
+
   # Updated this check to see if Nokogiri::XML.parse is being called
   # specifically. The main reason for this concern is that some versions
   # of libxml2 are still vulnerable to XXE attacks. REXML is safer (and
@@ -627,6 +633,7 @@ def run_checks(full_filepath)
   tidy = Msftidy.new(full_filepath)
   tidy.check_mode
   tidy.check_shebang
+  tidy.check_deprecated
   tidy.check_nokogiri
   tidy.check_rubygems
   tidy.check_ref_identifiers


### PR DESCRIPTION
I can yank out the deprecation date and display that if you want.

If you're using our [pre-commit hook](https://github.com/rapid7/metasploit-framework/blob/master/tools/dev/pre-commit-hook.rb), you'll need to use `--no-verify` when committing a deprecation warning to a module. No big deal.
