### PR TITLE
fix incorrect usage of .class

### DIFF
--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -224,7 +224,7 @@ protected
       # Record the detailed reason
       exploit.fail_detail ||= e.to_s
 
-      case e.class
+      case e
       when Msf::Exploit::Complete
         # Nothing to show in this case
         return

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1169,7 +1169,7 @@ class Db
   end
 
   def make_sortable(input)
-    case input.class
+    case input
     when String
       input = input.downcase
     when Fixnum


### PR DESCRIPTION
This is a fresh rebase of #4529.

Description of original PR:

This PR fixes some incorrect usages of .class

In exploit_driver the else was always hit on the case statement due to the wrong use of class. This printed out the stacktrace everytime a fail_with(Unknown, ...) was called. Now the correct code path is taken. This may also change the error output because the rest of the case was never hit, so maybe you want to look over this too.

I also found another wrong case statement in db.rb which was also fixed
