### PR TITLE
Allow 'creds -u "" ' to return blank usernames

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -868,6 +868,16 @@ class Db
         # Exclude creds that don't match the given type
         next if type.present? && !core.private.kind_of?(type)
 
+        # Exclude non-blank username creds if that's what we're after
+        if user_regex.present? && user_regex == // && !core.public.username.blank?
+          next
+        end
+
+        # Exclude non-blank password creds if that's what we're after
+        if pass_regex.present? && pass_regex == // && !core.private.data.blank?
+          next
+        end
+
         # Exclude creds that don't match the given user
         if user_regex.present? && !core.public.username.match(user_regex)
           next

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -141,15 +141,29 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         end
       end
       context "when the credential is absent" do
-        it "should return a blank set" do
-          db.cmd_creds("-u", nomatch_username)
-          @output.should =~ [
-            "===========",
-            "Credentials",
-            "",
-            "----  -------  ------  -------  -----  ------------",
-            "host  service  public  private  realm  private_type"
-          ]
+        context "due to a nonmatching username" do
+          it "should return a blank set" do
+            db.cmd_creds("-u", nomatch_username)
+            @output.should =~ [
+              "===========",
+              "Credentials",
+              "",
+              "----  -------  ------  -------  -----  ------------",
+              "host  service  public  private  realm  private_type"
+            ]
+          end
+        end
+        context "due to a nonmatching password" do
+          it "should return a blank set" do
+            db.cmd_creds("-P", nomatch_password)
+            @output.should =~ [
+              "===========",
+              "Credentials",
+              "",
+              "----  -------  ------  -------  -----  ------------",
+              "host  service  public  private  realm  private_type"
+            ]
+          end
         end
       end
     end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -92,6 +92,14 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
                                   public: blank_pub,
                                   realm: nil,
                                   workspace: framework.db.workspace)
+        nonblank_pub = FactoryGirl.create(:metasploit_credential_username, username: nonblank_username)
+        blank_priv = FactoryGirl.create(:metasploit_credential_password, data: blank_password)
+        core = FactoryGirl.create(:metasploit_credential_core,
+                                  origin: FactoryGirl.create(:metasploit_credential_origin_import),
+                                  private: blank_priv,
+                                  public: nonblank_pub,
+                                  realm: nil,
+                                  workspace: framework.db.workspace)
       end
       context "when the credential is present" do
         it "should show a user that matches the given expression" do
@@ -107,7 +115,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         end
         context "and when the username is blank" do
           it "should show a user that matches the given expression" do
-            db.cmd_creds("-u", "")
+            db.cmd_creds("-u", blank_username )
             @output.should =~ [
               "Credentials",
               "===========",
@@ -115,6 +123,19 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
               "host  service  public  private        realm  private_type",
               "----  -------  ------  -------        -----  ------------",
               "                       nonblank_pass         Password"
+            ]
+          end
+        end
+        context "and when the password is blank" do
+          it "should show a user that matches the given expression" do
+            db.cmd_creds("-P", blank_password )
+            @output.should =~ [
+              "Credentials",
+              "===========",
+              "",
+              "host  service  public         private  realm  private_type",
+              "----  -------  ------         -------  -----  ------------",
+              "               nonblank_user                  Password"
             ]
           end
         end
@@ -132,6 +153,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         end
       end
     end
+
     describe "add-password" do
       let(:username) { "username" }
       let(:password) { "password" }


### PR DESCRIPTION
This is somewhat related to #4634, in that I found that it's impossible to search for credentials that have blank usernames, since `""` (blank) gets turned into a username regex of `//` which matches everything. I think this is going to be the usually intended case.
## Verification
- [x] Run the specs!
- [x] If you don't believe the specs, simply replicate those steps:
  - [x] In `msfconsole`, add a blank-named user, then search for it, with `creds add-password "" foobar` and `creds -u ""`
