### PR TITLE
Fix #4646 - get_module_resource should check nil before using get_resource

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -106,7 +106,7 @@ module Msf
     # @return [String] URI to the exploit page
     #
     def get_module_resource
-      "#{get_resource.chomp("/")}/#{@exploit_receiver_page}/"
+      "#{get_resource.to_s.chomp("/")}/#{@exploit_receiver_page}/"
     end
 
     #


### PR DESCRIPTION
Fix #4646. The get_module_resource needs to check nil first before using the get_resource method (from HttpServer)

So here's how you can verify this:
- [x] Open lib/msf/core/exploit/http/server.rb, and then go to line 455: https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/exploit/http/server.rb#L455
- [x] As you can see, it's possible #get_resource can return nil

And that's all this path does: it converts nil to a string w/ to_s, that way it can use #chomp safely.
