### PR TITLE
Fixes for test modules

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -354,21 +354,13 @@ module Msf::Post::File
   # @param old_file [String] Remote file name to move
   # @param new_file [String] The new name for the remote file
   def rename_file(old_file, new_file)
-    if session.respond_to? :commands && session.commands.include?("stdapi_fs_file_move")
+    if session.type == "meterpreter"
       return (session.fs.file.mv(old_file, new_file).result == 0)
     else
       if session.platform =~ /win/
-        if cmd_exec(%Q|move /y "#{old_file}" "#{new_file}"|) =~ /moved/
-          return true
-        else
-          return false
-        end
+        cmd_exec(%Q|move /y "#{old_file}" "#{new_file}"|) =~ /moved/
       else
-        if cmd_exec(%Q|mv -f "#{old_file}" "#{new_file}"|).empty?
-          return true
-        else
-          return false
-        end
+        cmd_exec(%Q|mv -f "#{old_file}" "#{new_file}"|).empty?
       end
     end
   end

--- a/test/modules/exploits/test/cmdweb.rb
+++ b/test/modules/exploits/test/cmdweb.rb
@@ -10,7 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # =( need more targets and perhaps more OS specific return values OS specific would be preferred
 
   include Msf::Exploit::Remote::HttpClient
-  include Rex::Exploitation::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -33,7 +33,7 @@ class Metasploit4 < Msf::Post
   def setup
     @old_pwd = pwd
     tmp = (directory?("/tmp")) ? "/tmp" : "%TEMP%"
-    puts "Setup: changing working directory to #{tmp}"
+    vprint_status("Setup: changing working directory to #{tmp}")
     cd(tmp)
 
     super

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -32,8 +32,8 @@ class Metasploit4 < Msf::Post
   #
   def setup
     @old_pwd = pwd
-    tmp = (directory?("/tmp")) ? "/tmp" : "%TMP%"
-    vprint_status("Setup: changing working directory to #{tmp}")
+    tmp = (directory?("/tmp")) ? "/tmp" : "%TEMP%"
+    puts "Setup: changing working directory to #{tmp}"
     cd(tmp)
 
     super

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -35,7 +35,7 @@ class Metasploit4 < Msf::Post
     if (stat and stat.directory?)
       tmp = "/tmp"
     else
-      tmp = session.fs.file.expand_path("%TMP%")
+      tmp = session.fs.file.expand_path("%TEMP%")
     end
     vprint_status("Setup: changing working directory to #{tmp}")
     session.fs.dir.chdir(tmp)
@@ -164,10 +164,11 @@ class Metasploit4 < Msf::Post
     end
 
     it "should create and remove a dir" do
-      res = create_directory("meterpreter-test")
+      session.fs.dir.rmdir("meterpreter-test-dir") rescue nil
+      res = create_directory("meterpreter-test-dir")
       if (res)
-        session.fs.dir.rmdir("meterpreter-test")
-        res &&= !session.fs.dir.entries.include?("meterpreter-test")
+        session.fs.dir.rmdir("meterpreter-test-dir")
+        res &&= !session.fs.dir.entries.include?("meterpreter-test-dir")
         vprint_status("Directory removed successfully")
       end
 
@@ -175,16 +176,17 @@ class Metasploit4 < Msf::Post
     end
 
     it "should change directories" do
-      res = create_directory("meterpreter-test")
+      session.fs.dir.rmdir("meterpreter-test-dir") rescue nil
+      res = create_directory("meterpreter-test-dir")
 
       old_wd = session.fs.dir.pwd
       vprint_status("Old CWD: #{old_wd}")
 
       if res
-        session.fs.dir.chdir("meterpreter-test")
+        session.fs.dir.chdir("meterpreter-test-dir")
         new_wd = session.fs.dir.pwd
         vprint_status("New CWD: #{new_wd}")
-        res &&= (new_wd =~ /meterpreter-test$/)
+        res &&= (new_wd =~ /meterpreter-test-dir$/)
 
         if res
           session.fs.dir.chdir("..")
@@ -192,8 +194,8 @@ class Metasploit4 < Msf::Post
           vprint_status("Back to old CWD: #{wd}")
         end
       end
-      session.fs.dir.rmdir("meterpreter-test")
-      res &&= !session.fs.dir.entries.include?("meterpreter-test")
+      session.fs.dir.rmdir("meterpreter-test-dir")
+      res &&= !session.fs.dir.entries.include?("meterpreter-test-dir")
       vprint_status("Directory removed successfully")
 
       res
@@ -220,8 +222,9 @@ class Metasploit4 < Msf::Post
 
     it "should upload a file" do
       res = true
-      remote = "HACKING.remote.txt"
-      local  = "HACKING"
+
+      remote = "meterpreter-test-file.txt"
+      local  = __FILE__
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)
       vprint_status("done")
@@ -270,8 +273,8 @@ class Metasploit4 < Msf::Post
 
     it "should do md5 and sha1 of files" do
       res = true
-      remote = "HACKING.remote.txt"
-      local  = "HACKING"
+      remote = "meterpreter-test-file.txt"
+      local  = __FILE__
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)
       vprint_status("done")


### PR DESCRIPTION
I have been working to make sure the test modules work so that regression tests in meterpreter and other session handlers can be done automatically. This really fixes 3 out of 4 things that make the test/scripts/test-sessions.rc script fail.
# Improve the tests themselves

550e6efff8cb240c34ed7dc77af3677e1a2b4a3e fixes some problems running the tests against newer versions of Windows and improves test resiliency when running many times in a row in an automated fashion:
- Use separate names for files and directories to avoid cascading failures if one test fails and leaves a file or directory behind.
- Use %TEMP% rather than %TMP - the former is defined on all Windows versions, whereas the later is not defined on Windows 2012, causing the test to fail.
- Don't assume 'HACKING' is in the current working directory, which breaks remote test harnesses. Instead, send the source code to the current **FILE** as the test file to upload, since that works from any directory or remotely.
# Really fix the cmdweb test

I didn't quite fix it in c96c8a03cfec3dbbb9f014e4aae019e9c4ede43d, or something changed in the mean time, but it now works again and doesn't pollute the log with a big backtrace when running 'loadpath test/modules'
# Fix the rename_file msf/core/post/file.rb method for Meterpreter

The surrounding methods are already updated to use 'session.type == "meterpreter"'. Without the fix, calling rename simply dies with:

```
[-] Exception: TypeError : true is not a symbol
```
# Steps to verify
- [x] Run the sessions test RC script against a meterpreter session:

```
loadpath test/modules
use exploit/multi/handler
set lhost 172.28.128.1
set payload windows/meterpreter/reverse_http
run -j
sleep 5
resource test/scripts/test-sessions.rc
```

This should yield something passing like this, though there may be one failure:

```
[*] resource (../../test/scripts/test-sessions.rc)> Ruby Code (600 bytes)
post/test/meterpreter
SESSION => 1
[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[+] should return its own process id
[+] should return a list of processes
[+] should return a user id
[+] should return a sysinfo Hash
[+] should return network interfaces
[+] should have an interface that matches session_host
[+] should return network routes
[+] should return the proper directory separator
[+] should return the current working directory
[+] should list files in the current directory
[+] should stat a directory
[+] should create and remove a dir
[+] should change directories
[+] should create and remove files
[+] should upload a file
[+] should move files
[+] should do md5 and sha1 of files
[*] Passed: 17; Failed: 0
[*] Post module execution completed
post/test/registry
SESSION => 1
[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[*] PENDING: should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should return normalized values
[+] should enumerate keys and values
[+] should create keys
[+] should write REG_SZ values
[+] should write REG_DWORD values
[+] should delete keys
[*] Passed: 7; Failed: 0
[*] Post module execution completed
post/test/services
SESSION => 1
[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[+] should start W32Time
[+] should stop W32Time
[+] should list services
[+] should return info on a given service  winmgmt
[+] should create a service  testes
[+] should return info on the newly-created service testes
[+] should delete the new service testes
[+] should return status on a given service winmgmt
[+] should modify config on a given service axrezi
[+] should start a disabled service ahOqfq
[+] should restart a started service W32Time
[+] should raise a runtime exception if no access to service
[+] should raise a runtime exception if services doesnt exist
[*] Passed: 13; Failed: 0
[*] Post module execution completed
post/test/railgun_reverse_lookups
SESSION => 1
[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[+] should return a constant name given a const and a filter
[+] should return an error string given an error code
[+] should look up arbitrary constants
[+] should look up arbitrary error codes
[*] Passed: 4; Failed: 0
[*] Post module execution completed
post/test/file
SESSION => 1
Setup: changing working directory to %TEMP%
[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[+] should test for file existence
[+] should test for directory existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[+] should write binary data
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[*] Passed: 11; Failed: 0
[*] Post module execution completed
resource (../../test/scripts/test-sessions.rc)> use multi/handler
```
- [x] The cmdweb test should load and run.

```
msf > loadpath test/modules
Loaded 33 modules:
    8 posts
    12 auxiliarys
    13 exploits
msf > use exploit/test/cmdweb
msf exploit(cmdweb) > info

       Name: Command Stager Web Test
     Module: exploit/test/cmdweb
   Platform: Windows
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Manual
  Disclosed: 2010-02-03

Provided by:
  bannedit <bannedit@metasploit.com>

Available targets:
  Id  Name
  --  ----
  0   Automatic Targeting

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                     yes       The target address
  RPORT    8080             yes       The target port
  VHOST                     no        HTTP server virtual host

Payload information:

Description:
  This module tests the command stager mixin against a shell.jsp
  application installed on an Apache Tomcat server.

msf exploit(cmdweb) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf exploit(cmdweb) > run

[*] Started reverse handler on 127.0.0.1:4444
[*] Command Stager progress -   2.01% done (2046/101881 bytes)
[*] Command Stager progress -   4.02% done (4092/101881 bytes)
[*] Command Stager progress -   6.02% done (6138/101881 bytes)
[*] Command Stager progress -   8.03% done (8184/101881 bytes)
[*] Command Stager progress -  10.04% done (10230/101881 bytes)
[*] Command Stager progress -  12.05% done (12276/101881 bytes)
[*] Command Stager progress -  14.06% done (14322/101881 bytes)
[*] Command Stager progress -  16.07% done (16368/101881 bytes)
[*] Command Stager progress -  18.07% done (18414/101881 bytes)
...
```
