### PR TITLE
Allow custom 404 as an option for BrowserExploitServer

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -95,6 +95,14 @@ module Msf
       ], Exploit::Remote::BrowserExploitServer)
     end
 
+    def setup
+      custom_404 = get_custom_404_url
+      if !custom_404.blank? && custom_404 !~ /^http/i
+        raise Msf::OptionValidateError.new(['Custom404 (must begin with http or https)'])
+      end
+      super
+    end
+
     #
     # Returns the custom 404 URL set by the user
     #

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -535,6 +535,7 @@ module Msf
         end
 
       else
+        print_error("Target has requested an unknown path: #{request.uri}")
         send_not_found(cli)
       end
     end

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -11,6 +11,9 @@ require 'msf/core/exploit/jsobfu'
 #
 # The BrowserExploitServer mixin provides methods to do common tasks seen in modern browser
 # exploitation, and is designed to work against common setups such as on Windows, OSX, and Linux.
+# Wiki documentations about this mixin can be found here:
+# https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-browser-exploit-using-BrowserExploitServer
+# https://github.com/rapid7/metasploit-framework/wiki/Information-About-Unmet-Browser-Exploit-Requirements
 #
 ###
 
@@ -87,8 +90,18 @@ module Msf
 
       register_advanced_options([
         OptString.new('CookieName', [false,  "The name of the tracking cookie", DEFAULT_COOKIE_NAME]),
-        OptString.new('CookieExpiration', [false,  "Cookie expiration in years (blank=expire on exit)"])
+        OptString.new('CookieExpiration', [false,  "Cookie expiration in years (blank=expire on exit)"]),
+        OptString.new('Custom404', [false, "An external custom 404 URL (Example: http://example.com/404.html)"])
       ], Exploit::Remote::BrowserExploitServer)
+    end
+
+    #
+    # Returns the custom 404 URL set by the user
+    #
+    # @return [String]
+    #
+    def get_custom_404_url
+      datastore['Custom404'].to_s
     end
 
     #
@@ -575,6 +588,20 @@ module Msf
         'Function(('+JSON.generate(:code => code)+').code)()'
       else
         'true'
+      end
+    end
+
+    private
+
+    #
+    # Sends a 404 respons. If a custom 404 is configured, then it will redirect to that instead.
+    #
+    def send_not_found(cli)
+      custom_404_url = get_custom_404_url
+      if custom_404_url.blank?
+        super(cli)
+      else
+        send_redirect(cli, custom_404_url)
       end
     end
 


### PR DESCRIPTION
When something fails, the target is given a hardcoded 404 message generated by the framework. But the user (attacker) now can configure this. When the Custom404 option is set, the mixin will actually redirect (302) to that URL.

There are several scenarios that can trigger a 404 by BES (custom or default):
- When the browser doesn't allow javascript
- When the browser directly visits the exploit URL, which is forbidden. If this actually happens, it probably means the attacker gave the wrong URL.
- The attacker doesn't allow the browser auto-recovery to retry the URL.
- If some browser requirements aren't met.
- The browser attempts to go to access a resource not set up by the mixin.
## Setup

To test all this, please make sure you have the following:
- [x] A unpatched Windows XP box
- [x] This Win XP box should have Internet Explorer 8
## Verification

**Basic testing**
- [x] Start msfconsole
- [x] `use exploit/windows/browser/ms13_090_cardspacesigninhelper`
- [x] `run`
- [x] Test the exploit against the IE8, it should serve the exploit.
- [x] Test the same exploit against Chrome or Firefox or whatever browser you use. The browser should get the fake Apache 404.

**Custom 404 testing**
- [x] Start msfconsole
- [x] `use exploit/windows/browser/ms13_090_cardspacesigninhelper`
- [x] `set Custom404 https://youtube.googleapis.com/v/g13gs5a8HZ4?fs=1&autoplay=1&loop=1&disablekb=1&modestbranding=1&iv_load_policy=3&controls=0&showinfo=0&rel=0`
- [x] `run`
- [x] Test the exploit again against the same IE8, it should serve the exploit
- [x] Test the exploit against a non-IE browser, you should get the epic custom 404 error
