### PR TITLE
MSP-12011: Convert #find(:all)

### DIFF
--- a/lib/metasploit/framework/jtr/wordlist.rb
+++ b/lib/metasploit/framework/jtr/wordlist.rb
@@ -224,7 +224,7 @@ module Metasploit
           end
 
           # Yield any capture MSSQL Instance names
-          workspace.notes.find(:all, :conditions => ['ntype=?', 'mssql.instancename']).each do |note|
+          workspace.notes.where(['ntype=?', 'mssql.instancename']).each do |note|
             expanded_words(note.data['InstanceName']) do |word|
               yield word
             end

--- a/lib/msf/core/db_export.rb
+++ b/lib/msf/core/db_export.rb
@@ -223,7 +223,7 @@ class Export
       # Authors sub-elements
       # @todo https://www.pivotaltracker.com/story/show/48451001
       report_file.write("    <module_authors>\n")
-      m.authors.find(:all).each do |d|
+      m.authors.each do |d|
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
           report_file.write("        #{el}\n")
@@ -234,7 +234,7 @@ class Export
       # Refs sub-elements
       # @todo https://www.pivotaltracker.com/story/show/48451001
       report_file.write("    <module_refs>\n")
-      m.refs.find(:all).each do |d|
+      m.refs.each do |d|
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
           report_file.write("        #{el}\n")
@@ -246,7 +246,7 @@ class Export
       # Archs sub-elements
       # @todo https://www.pivotaltracker.com/story/show/48451001
       report_file.write("    <module_archs>\n")
-      m.archs.find(:all).each do |d|
+      m.archs.each do |d|
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
           report_file.write("        #{el}\n")
@@ -258,7 +258,7 @@ class Export
       # Platforms sub-elements
       # @todo https://www.pivotaltracker.com/story/show/48451001
       report_file.write("    <module_platforms>\n")
-      m.platforms.find(:all).each do |d|
+      m.platforms.each do |d|
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
           report_file.write("        #{el}\n")
@@ -270,7 +270,7 @@ class Export
       # Targets sub-elements
       # @todo https://www.pivotaltracker.com/story/show/48451001
       report_file.write("    <module_targets>\n")
-      m.targets.find(:all).each do |d|
+      m.targets.each do |d|
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
           report_file.write("        #{el}\n")
@@ -281,7 +281,7 @@ class Export
       # Actions sub-elements
       # @todo https://www.pivotaltracker.com/story/show/48451001
       report_file.write("    <module_actions>\n")
-      m.actions.find(:all).each do |d|
+      m.actions.each do |d|
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
           report_file.write("        #{el}\n")
@@ -292,7 +292,7 @@ class Export
       # Mixins sub-elements
       # @todo https://www.pivotaltracker.com/story/show/48451001
       report_file.write("    <module_mixins>\n")
-      m.mixins.find(:all).each do |d|
+      m.mixins.each do |d|
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
           report_file.write("        #{el}\n")
@@ -319,7 +319,7 @@ class Export
 
       # Host details sub-elements
       report_file.write("    <host_details>\n")
-      h.host_details.find(:all).each do |d|
+      h.host_details.each do |d|
         report_file.write("        <host_detail>\n")
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
@@ -331,7 +331,7 @@ class Export
 
       # Host exploit attempts sub-elements
       report_file.write("    <exploit_attempts>\n")
-      h.exploit_attempts.find(:all).each do |d|
+      h.exploit_attempts.each do |d|
         report_file.write("        <exploit_attempt>\n")
         d.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
@@ -385,7 +385,7 @@ class Export
 
         # Vuln details sub-elements
         report_file.write("            <vuln_details>\n")
-        e.vuln_details.find(:all).each do |d|
+        e.vuln_details.each do |d|
           report_file.write("                <vuln_detail>\n")
           d.attributes.each_pair do |k,v|
             el = create_xml_element(k,v)
@@ -398,7 +398,7 @@ class Export
 
         # Vuln attempts sub-elements
         report_file.write("            <vuln_attempts>\n")
-        e.vuln_attempts.find(:all).each do |d|
+        e.vuln_attempts.each do |d|
           report_file.write("                <vuln_attempt>\n")
           d.attributes.each_pair do |k,v|
             el = create_xml_element(k,v)

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -52,7 +52,7 @@ module Msf::DBManager::Vuln
     # If there are multiple matches, choose the one with the most matches
     if service
       refs_ids = refs.map{|x| x.id }
-      vuln = service.vulns.find(:all, :include => [:refs], :conditions => { 'refs.id' => refs_ids }).sort { |a,b|
+      vuln = service.vulns.where({ 'refs.id' => refs_ids }).includes(:refs).sort { |a,b|
         ( refs_ids - a.refs.map{|x| x.id } ).length <=> ( refs_ids - b.refs.map{|x| x.id } ).length
       }.first
     end
@@ -63,7 +63,7 @@ module Msf::DBManager::Vuln
     # Try to find an existing vulnerability with the same host & references
     # If there are multiple matches, choose the one with the most matches
     refs_ids = refs.map{|x| x.id }
-    vuln = host.vulns.find(:all, :include => [:refs], :conditions => { 'service_id' => nil, 'refs.id' => refs_ids }).sort { |a,b|
+    vuln = host.vulns.where({ 'service_id' => nil, 'refs.id' => refs_ids }).includes(:refs).sort { |a,b|
       ( refs_ids - a.refs.map{|x| x.id } ).length <=> ( refs_ids - b.refs.map{|x| x.id } ).length
     }.first
 

--- a/lib/msf/core/db_manager/wmap.rb
+++ b/lib/msf/core/db_manager/wmap.rb
@@ -128,7 +128,7 @@ module Msf::DBManager::WMAP
   # This methods returns a list of all targets in the database
   def requests
   ::ActiveRecord::Base.connection_pool.with_connection {
-    ::Mdm::WmapRequest.find(:all)
+    ::Mdm::WmapRequest.all
   }
   end
 
@@ -183,7 +183,7 @@ module Msf::DBManager::WMAP
   # This methods returns a list of all targets in the database
   def targets
   ::ActiveRecord::Base.connection_pool.with_connection {
-    ::Mdm::WmapTarget.find(:all)
+    ::Mdm::WmapTarget.all
   }
   end
 end

--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -30,7 +30,7 @@ module Msf::DBManager::Workspace
 
   def workspaces
   ::ActiveRecord::Base.connection_pool.with_connection {
-    ::Mdm::Workspace.find(:all)
+    ::Mdm::Workspace.all
   }
   end
 end

--- a/lib/msf/core/rpc/v10/rpc_auth.rb
+++ b/lib/msf/core/rpc/v10/rpc_auth.rb
@@ -57,7 +57,7 @@ end
     res = self.service.tokens.keys
     begin
       if framework.db and framework.db.active
-        ::Mdm::ApiKey.find(:all).each do |k|
+        ::Mdm::ApiKey.all.each do |k|
           res << k.token
         end
       end

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -1563,7 +1563,7 @@ class Plugin::Wmap < Msf::Plugin
       wtree = Tree.new(s.vhost)
 
       # Load site pages
-      s.web_pages.find(:all, :order => 'path').each do |req|
+      s.web_pages.order(path: :asc).each do |req|
         tarray = req.path.to_s.split(pathchr)
         tarray.delete("")
         tpath = Pathname.new(pathchr)


### PR DESCRIPTION
This PR updates the #find(:all) to rails 4 #where or #all syntax.

For example:

Old syntax: `Mdm::Note.find(:all).each do |note|`
New syntax: `Mdm::Note.all.each do |note|`

Old syntax: `Mdm::Task.find(:all, :conditions => { :completed_at => nil }).each do |t|`
New syntax: `Mdm::Task.where(completed_at:nil).each do |t|`

Old syntax: `all_hosts = myworkspace.hosts.find(:all)`
New syntax: `all_hosts = myworkspace.hosts`
# Verification
- [ ] In Rails console, manually check the new finder queries work for each line change in this PR. i.e. check generated SQL matches old syntax.
- [ ] Verify no other instances of find(:all)
