### PR TITLE
ManageEngine AppManager / OpManager arbitrary file download

### DIFF
--- a/modules/auxiliary/admin/http/manageengine_file_download.rb
+++ b/modules/auxiliary/admin/http/manageengine_file_download.rb
@@ -33,9 +33,9 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2014-7863'],
-          ['OSVDB', 'TODO'],
+          ['OSVDB', '117695'],
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_failservlet.txt'],
-          ['URL', 'FULLDISC_URL']
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114']
         ],
       'DisclosureDate' => 'Jan 28 2015'))
 


### PR DESCRIPTION
This module exploits CVE-2014-7863, which is an arbitrary file download vulnerability in AppManager, OpManager and IT360.
There is a companion module which I will put up shortly that allows for a directory listing.
This module has been well tested, and should be ready to go pending your comments!
