### PR TITLE
ManageEngine AppManager / OpManager directory content disclosure

### DIFF
--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -35,9 +35,9 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2014-7863'],
-          ['OSVDB', 'TODO'],
+          ['OSVDB', '117696'],
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_failservlet.txt'],
-          ['URL', 'FULLDISC_URL']
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114']
         ],
       'DisclosureDate' => 'Jan 28 2015'))
 


### PR DESCRIPTION
This module exploits another "part" of CVE-2014-7863, which is an directory content disclosure in AppManager, OpManager and IT360.
I've also proposed a companion module #4658 that allows to download any file in the system.
This module has been well tested, and should be ready to go pending your comments!
