### PR TITLE
Fix #4665: Improve utility of meterpreter file upload command

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -246,9 +246,10 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   #
   # Upload a single file.
   #
-  def File.upload_file(dest_file, src_file)
+  def File.upload_file(dest_file, src_file, &stat)
     # Open the file on the remote side for writing and read
     # all of the contents of the local file
+    stat.call('uploading', src_file, dest_file) if (stat)
     dest_fd = client.fs.file.new(dest_file, "wb")
     src_buf = ''
 
@@ -261,6 +262,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     ensure
       dest_fd.close
     end
+    stat.call('uploaded', src_file, dest_file) if (stat)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -503,10 +503,17 @@ class Console::CommandDispatcher::Stdapi::Fs
           client.framework.events.on_session_upload(client, src, dest) if msf_loaded?
         }
       elsif (stat.file?)
-        client.fs.file.upload(dest, src) { |step, src, dst|
-          print_status("#{step.ljust(11)}: #{src} -> #{dst}")
-          client.framework.events.on_session_upload(client, src, dest) if msf_loaded?
-        }
+        if client.fs.file.exists?(dest) and client.fs.file.stat(dest).directory?
+          client.fs.file.upload(dest, src) { |step, src, dst|
+            print_status("#{step.ljust(11)}: #{src} -> #{dst}")
+            client.framework.events.on_session_upload(client, src, dest) if msf_loaded?
+          }
+        else
+          client.fs.file.upload_file(dest, src) { |step, src, dst|
+            print_status("#{step.ljust(11)}: #{src} -> #{dst}")
+            client.framework.events.on_session_upload(client, src, dest) if msf_loaded?
+          }
+        end
       end
     }
 


### PR DESCRIPTION
Rather than assume that the destination argument is a directory, check
first, and then do the same thing that 'cp' would do.
- If dest exists and is a directory, copy to the directory.
- If dest exists and is a file, copy over the file.
- If dest does not exist and is a directory, fail.
- If dest does not exist and is a file, create the file.
# Verification

Start a meterpreter session and:
- [x] Upload a file by specifying only source, e.g. upload HACKING
- [x] Upload a file to a specific destination, e.g. upload HACKING c:\
- [x] Upload a file to a specific destination name, e.g. upload HACKING c:\MONKEY

Something like this:

```
meterpreter > upload HACKING
[*] uploading  : HACKING -> HACKING
[*] uploaded   : HACKING -> HACKING
meterpreter > upload HACKING MONKEY
[*] uploading  : HACKING -> MONKEY
[*] uploaded   : HACKING -> MONKEY
meterpreter > upload HACKING tmp
[*] uploading  : HACKING -> tmp
[*] uploaded   : HACKING -> tmp\HACKING
meterpreter > upload HACKING tmp/monkey
[*] uploading  : HACKING -> tmp/monkey
[*] uploaded   : HACKING -> tmp/monkey
```

Note, you can use forward slashes on windows just as easily as backslashes - it does not really care, and it saves some typing.
