### PR TITLE
MSP-12016: Convert #find_or_create_by_x

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -168,7 +168,7 @@ module Msf::DBManager::Vuln
           sname = opts[:proto]
         end
 
-        service = host.services.find_or_create_by_port_and_proto(opts[:port].to_i, proto)
+        service = host.services.where(port: opts[:port].to_i, proto: proto).first_or_create
       end
 
       # Try to find an existing vulnerability with the same service & references

--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -4,7 +4,7 @@ module Msf::DBManager::Workspace
   #
   def add_workspace(name)
   ::ActiveRecord::Base.connection_pool.with_connection {
-    ::Mdm::Workspace.find_or_create_by_name(name)
+    ::Mdm::Workspace.where(name: name).first_or_create
   }
   end
 


### PR DESCRIPTION
This PR updates the #find_or_create_by_X to rails 4 #where().first_or_create syntax.

For example:

Old syntax: `Apps::AppCategory.find_or_create_by_name!(cat)`
New syntax: `Apps::AppCategory.where(name: cat).first_or_create!`

Old syntax: `workspace = Mdm::Workspace.find_or_create_by_name(WORKSPACE, owner_id: user.id)`
New syntax: `workspace = Mdm::Workspace.where(name: WORKSPACE).first_or_create(owner_id: user.id)`
# Verification
- [ ] In Rails console, manually check the new finder queries work for each line change in this PR. i.e. check generated SQL matches old syntax.
- [ ] Verify no other instances of find_or_create_by
