### PR TITLE
Fix #4672 - Fix Hardcoded false for screenshot -v

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -150,7 +150,7 @@ class Console::CommandDispatcher::Stdapi::Ui
         when "-p"
           path = val
         when "-v"
-          view = false if ( val =~ /^(f|n|0)/i )
+          view = true if ( val =~ /^(t|y|1)/i )
       end
     }
 


### PR DESCRIPTION
Fix #4672 

To verify:
- [x] Get a Windows meterpreter session
- [x] At the meterpreter prompt, do: `screenshot`
- [x] It should grab the screenshot, but does not open the image file automatically
- [x] At the meterpreter prompt, do: `screenshot -v true`
- [x] It should grab the screenshot again, and opens the image file automatically
