### PR TITLE
Implement "-" for msfconsole -r from stdin

### DIFF
--- a/external/zsh/_msfconsole
+++ b/external/zsh/_msfconsole
@@ -33,7 +33,7 @@ _arguments \
   {-o,--output}"[Output to the specified file]:output file" \
   {-p,--plugin}"[Load a plugin on startup]:plugin file:_files" \
   {-q,--quiet}"[Do not print the banner on start up]" \
-  {-r,--resource}"[Execute the specified resource file]:resource file:_files" \
+  {-r,--resource}"[Execute the specified resource file (- for stdin)]:resource file:_files" \
   {-v,--version}"[Show version]" \
   {-x,--execute-command}"[Execute the specified string as console commands]:commands" \
   {-y,--yaml}"[Specify a YAML file containing database settings]:yaml file:_files"

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -60,7 +60,7 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
           options.console.quiet = true
         end
 
-        option_parser.on('-r', '--resource FILE', 'Execute the specified resource file') do |file|
+        option_parser.on('-r', '--resource FILE', 'Execute the specified resource file (- for stdin)') do |file|
           options.console.resources << file
         end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -417,8 +417,14 @@ class Driver < Msf::Ui::Driver
   # @param path [String] Path to a resource file to run
   # @return [void]
   def load_resource(path)
-    return if not ::File.readable?(path)
-    resource_file = ::File.read(path)
+    if path == '-'
+      resource_file = $stdin.read
+      path = 'stdin'
+    elsif ::File.readable?(path)
+      resource_file = ::File.read(path)
+    else
+      return
+    end
 
     self.active_resource = resource_file
 


### PR DESCRIPTION
More predictable than `/dev/stdin`, which is usually a symlink to `/proc/self/fd/0` or `/dev/fd/0`, but the feature is not guaranteed to be present.

This isn't _terribly_ useful, but it can be. `-x` is recommended, but it doesn't allow for ERB directives. This is mostly for hax.

```
wvu@kharak:~/metasploit-framework:feature/stdin$ ./msfconsole -qr - <<<$'<ruby>\nprint_status("hello, world")\n</ruby>\nexit'
[*] Processing stdin for ERB directives.
[*] resource (stdin)> Ruby Code (29 bytes)
[*] hello, world
resource (stdin)> exit
wvu@kharak:~/metasploit-framework:feature/stdin$ 
```
