### PR TITLE
MSP-12014: Convert find_all_by_X to Rails 4 compatible syntax

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -473,7 +473,7 @@ module Auxiliary::Report
     cred_opts = opts.merge(:workspace => myworkspace)
     cred_host = myworkspace.hosts.find_by_address(cred_opts[:host])
     unless opts[:port]
-      possible_services = myworkspace.services.find_all_by_host_id_and_name(cred_host[:id],cred_opts[:sname])
+      possible_services = myworkspace.services.where(host_id: cred_host[:id], name: cred_opts[:sname])
       case possible_services.size
       when 0
         case cred_opts[:sname].downcase
@@ -514,7 +514,7 @@ module Auxiliary::Report
       end
     end
     if opts[:collect_session]
-      session = myworkspace.sessions.find_all_by_local_id(opts[:collect_session]).last
+      session = myworkspace.sessions.where(local_id: opts[:collect_session]).last
       if !session.nil?
         cred_opts[:source_id] = session.id
         cred_opts[:source_type] = "exploit"

--- a/lib/msf/core/db_export.rb
+++ b/lib/msf/core/db_export.rb
@@ -343,7 +343,7 @@ class Export
 
       # Service sub-elements
       report_file.write("    <services>\n")
-      @services.find_all_by_host_id(host_id).each do |e|
+      @services.where(host_id: host_id).each do |e|
         report_file.write("      <service>\n")
         e.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
@@ -355,7 +355,7 @@ class Export
 
       # Notes sub-elements
       report_file.write("    <notes>\n")
-      @notes.find_all_by_host_id(host_id).each do |e|
+      @notes.where(host_id: host_id).each do |e|
         report_file.write("      <note>\n")
         e.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)
@@ -367,7 +367,7 @@ class Export
 
       # Vulns sub-elements
       report_file.write("    <vulns>\n")
-      @vulns.find_all_by_host_id(host_id).each do |e|
+      @vulns.where(host_id: host_id).each do |e|
         report_file.write("      <vuln>\n")
         e.attributes.each_pair do |k,v|
           el = create_xml_element(k,v)

--- a/lib/msf/core/db_manager/web.rb
+++ b/lib/msf/core/db_manager/web.rb
@@ -55,7 +55,7 @@ module Msf::DBManager::Web
     # comparisons through ruby and not SQL.
 
     form = nil
-    ::Mdm::WebForm.find_all_by_web_site_id_and_path_and_method_and_query(site[:id], path, meth, quer).each do |xform|
+    ::Mdm::WebForm.where(web_site_id: site[:id], path: path, method: meth, query: quer).each do |xform|
       if xform.params == para
         form = xform
         break

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -133,7 +133,7 @@ class SessionManager < Hash
         # framework instance.
         #
         ::ActiveRecord::Base.connection_pool.with_connection do |conn|
-          ::Mdm::Session.find_all_by_closed_at(nil).each do |db_session|
+          ::Mdm::Session.where(closed_at: nil).each do |db_session|
             if db_session.last_seen.nil? or ((Time.now.utc - db_session.last_seen) > (2*LAST_SEEN_INTERVAL))
               db_session.closed_at    = db_session.last_seen || Time.now.utc
               db_session.close_reason = "Orphaned"

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1332,7 +1332,7 @@ class Db
 
     # Handle hostless loot
     if host_ranges.compact.empty? # Wasn't a host search
-      hostless_loot = framework.db.loots.find_all_by_host_id(nil)
+      hostless_loot = framework.db.loots.where(host_id: nil)
       hostless_loot.each do |loot|
         row = []
         row.push("")

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -269,7 +269,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def existing_loot(ltype, key_id)
-    framework.db.loots(myworkspace).find_all_by_ltype(ltype).select {|l| l.info == key_id}.first
+    framework.db.loots(myworkspace).where(ltype: ltype).select {|l| l.info == key_id}.first
   end
 
   def store_keyfile(ip,user,key_id,key_data)

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -1418,7 +1418,7 @@ class Plugin::Wmap < Msf::Plugin
             inipath = '/'
           end
 
-          #site.web_forms.find_all_by_path(target.path).each do |form|
+          #site.web_forms.where(path: target.path).each do |form|
             ckey = [ site.vhost, host.address, serv.port, inipath].join("|")
 
             if not self.targets[ckey]


### PR DESCRIPTION
This PR updates the #find_all_by_X to rails 4 #where syntax.
## Verification

In general, create necessary datasets for each query to be tested. Then load up rails console and manually test queries using old #find_all_by_X and compare to #where syntax. You may need to use explicit values for variables. For example, the following line:

Old syntax: `services.find_all_by_host_id(host_id).each do |e|`
New syntax: `services.where(host_id: host_id).each do |e|`

We would test in console:

```
> services = Mdm::Service.all
> services.find_all_by_host_id(1).map(&:id)
> services.where(host_id: 1).map(&:id)
```
- [ ] Verify the returned IDs and order are the same for both queries
- [ ] Verify the generated SQL query is the same

Repeat this verification for each line updated in this PR.
