### PR TITLE
Fix #4693 - Uninit Rex::OLE in MS14-064 exploits

### DIFF
--- a/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
+++ b/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'rex/ole'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/windows/fileformat/ms14_064_packager_python.rb
+++ b/modules/exploits/windows/fileformat/ms14_064_packager_python.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'rex/ole'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/windows/fileformat/ms14_064_packager_run_as_admin.rb
+++ b/modules/exploits/windows/fileformat/ms14_064_packager_run_as_admin.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'rex/ole'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking


### PR DESCRIPTION
Fix #4693 

This is a patch for the uninit issue with exploits that use rex ole code.
## To verify:
- [x] Make sure you can create the exploit with exploit/windows/fileformat/ms14_060_sandworm
- [x] Make sure you can create the exploit with exploit/windows/fileformat/ms14_064_packager_python
- [x] Make sure you can create the exploit with exploit/windows/fileformat/ms14_064_packager_run_as_admin
