### PR TITLE
MSP-12018: Convert find_or_initialize_by_X to Rails 4 compatible

### DIFF
--- a/lib/msf/core/db_manager/client.rb
+++ b/lib/msf/core/db_manager/client.rb
@@ -36,7 +36,7 @@ module Msf::DBManager::Client
     ret = {}
 
     host = get_host(:workspace => wspace, :host => addr)
-    client = host.clients.find_or_initialize_by_ua_string(opts[:ua_string])
+    client = host.clients.where(ua_string: opts[:ua_string]).first_or_initialize
 
     opts[:ua_string] = opts[:ua_string].to_s
 

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -102,28 +102,28 @@ module Msf::DBManager::Cred
     # If duplicate usernames are okay, find by both user and password (allows
     # for actual duplicates to get modified updated_at, sources, etc)
       if token[0].nil? or token[0].empty?
-        cred = service.creds.find_or_initialize_by_user_and_ptype_and_pass(token[0] || "", ptype, token[1] || "")
+        cred = service.creds.where(user: token[0] || "", ptype: ptype, pass: token[1] || "").first_or_initialize
       else
         cred = service.creds.find_by_user_and_ptype_and_pass(token[0] || "", ptype, token[1] || "")
         unless cred
           dcu = token[0].downcase
           cred = service.creds.find_by_user_and_ptype_and_pass( dcu || "", ptype, token[1] || "")
           unless cred
-            cred = service.creds.find_or_initialize_by_user_and_ptype_and_pass(token[0] || "", ptype, token[1] || "")
+            cred = service.creds.where(user: token[0] || "", ptype: ptype, pass: token[1] || "").first_or_initialize
           end
         end
       end
     else
       # Create the cred by username only (so we can change passwords)
       if token[0].nil? or token[0].empty?
-        cred = service.creds.find_or_initialize_by_user_and_ptype(token[0] || "", ptype)
+        cred = service.creds.where(user: token[0] || "", ptype: ptype).first_or_initialize
       else
         cred = service.creds.find_by_user_and_ptype(token[0] || "", ptype)
         unless cred
           dcu = token[0].downcase
           cred = service.creds.find_by_user_and_ptype_and_pass( dcu || "", ptype, token[1] || "")
           unless cred
-            cred = service.creds.find_or_initialize_by_user_and_ptype(token[0] || "", ptype)
+            cred = service.creds.where(user: token[0] || "", ptype: ptype).first_or_initialize
           end
         end
       end

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -166,9 +166,9 @@ module Msf::DBManager::Host
       end
 
       if opts[:comm] and opts[:comm].length > 0
-        host = wspace.hosts.find_or_initialize_by_address_and_comm(addr, opts[:comm])
+        host = wspace.hosts.where(address: addr, comm: opts[:comm]).first_or_initialize
       else
-        host = wspace.hosts.find_or_initialize_by_address(addr)
+        host = wspace.hosts.where(address: addr).first_or_initialize
       end
     else
       host = addr
@@ -257,9 +257,9 @@ module Msf::DBManager::Host
       end
 
       if opts[:comm] and opts[:comm].length > 0
-        host = wspace.hosts.find_or_initialize_by_address_and_comm(addr, opts[:comm])
+        host = wspace.hosts.where(address: addr, comm: opts[:comm]).first_or_initialize
       else
-        host = wspace.hosts.find_or_initialize_by_address(addr)
+        host = wspace.hosts.where(address: addr).first_or_initialize
       end
     else
       host = addr

--- a/lib/msf/core/db_manager/ref.rb
+++ b/lib/msf/core/db_manager/ref.rb
@@ -8,7 +8,7 @@ module Msf::DBManager::Ref
     return ret[:ref] if ret[:ref]
 
   ::ActiveRecord::Base.connection_pool.with_connection {
-    ref = ::Mdm::Ref.find_or_initialize_by_name(opts[:name])
+    ref = ::Mdm::Ref.where(name: opts[:name]).first_or_initialize
     if ref and ref.changed?
       ref.save!
     end

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -87,7 +87,7 @@ module Msf::DBManager::Service
 
     proto = opts[:proto] || 'tcp'
 
-    service = host.services.find_or_initialize_by_port_and_proto(opts[:port].to_i, proto)
+    service = host.services.where(port: opts[:port].to_i, proto: proto).first_or_initialize
     opts.each { |k,v|
       if (service.attribute_names.include?(k.to_s))
         service[k] = ((v and k == :name) ? v.to_s.downcase : v)

--- a/lib/msf/core/db_manager/web.rb
+++ b/lib/msf/core/db_manager/web.rb
@@ -135,7 +135,7 @@ module Msf::DBManager::Web
 
     ret = {}
 
-    page = ::Mdm::WebPage.find_or_initialize_by_web_site_id_and_path_and_query(site[:id], path, query)
+    page = ::Mdm::WebPage.where(web_site_id: site[:id], path: path, query: query).first_or_initialize
     page.code     = code
     page.body     = body
     page.headers  = headers
@@ -243,7 +243,7 @@ module Msf::DBManager::Web
 =end
 
     vhost ||= host.address
-    site = ::Mdm::WebSite.find_or_initialize_by_vhost_and_service_id(vhost, serv[:id])
+    site = ::Mdm::WebSite.where(vhost: vhost, service_id: serv[:id]).first_or_initialize
     site.options = opts[:options] if opts[:options]
 
     # XXX:
@@ -342,7 +342,7 @@ module Msf::DBManager::Web
 
     meth = meth.to_s.upcase
 
-    vuln = ::Mdm::WebVuln.find_or_initialize_by_web_site_id_and_path_and_method_and_pname_and_name_and_category_and_query(site[:id], path, meth, pname, name, cat, quer)
+    vuln = ::Mdm::WebVuln.where(web_site_id: site[:id], path: path, method: meth, pname: pname, name: name, category: cat, query: quer).first_or_initialize
     vuln.name     = name
     vuln.risk     = risk
     vuln.params   = para


### PR DESCRIPTION
This PR updates the #find_or_initialize_by_X to rails 4 #where().first_or_initialize syntax.

For example:

Old syntax: `::Mdm::WebSite.find_or_initialize_by_vhost_and_service_id(vhost, serv[:id])`
New syntax: `::Mdm::WebSite.where(vhost: vhost, service_id: serv[:id]).first_or_initialize`
# Verification
- [ ] Verify specs pass: `$ rake spec`
- [ ] Verify no other instances of find_or_create_by. `$ ack 'find_or_initialize_by' --ignore-dir=log --ignore-dir=coverage`
