### PR TITLE
Feature/msp 12012/convert find first

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -130,7 +130,7 @@ class Msf::DBManager
   #
   def check
   ::ActiveRecord::Base.connection_pool.with_connection {
-    res = ::Mdm::Host.find(:first)
+    res = ::Mdm::Host.first
   }
   end
 

--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -31,7 +31,7 @@ module Msf::DBManager::Vuln
     vuln = nil
 
     if service
-      vuln = service.vulns.find(:first, :include => [:vuln_details], :conditions => crit)
+      vuln = service.vulns.includes(:vuln_details).where(:crit).first
     end
 
     # Return if we matched based on service
@@ -39,7 +39,7 @@ module Msf::DBManager::Vuln
 
     # Prevent matches against other services
     crit["vulns.service_id"] = nil if service
-    vuln = host.vulns.find(:first, :include => [:vuln_details], :conditions => crit)
+    vuln = host.vulns.includes(:vuln_details).where(:crit).first
 
     return vuln
   end


### PR DESCRIPTION
### Description

Convert Rails 3 `find(:first)` syntax to Rails 4 `first`, e.g.

from: `vuln = service.vulns.find(:first, :include => [:vuln_details], :conditions => crit)`

to: `vuln = service.vulns.includes(:vuln_details).where(:crit).first`
### Verification
- [ ] cd framework
- [ ] verify no find(:first) - `ack 'find\(:first' lib/msf/core`
- [ ] specs pass - `rake spec`
