### PR TITLE
Fix README.md Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Metasploit [![Build Status](https://travis-ci.org/rapid7/metasploit-framework.png)](https://travis-ci.org/rapid7/metasploit-framework) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/rapid7/metasploit-framework)
+Metasploit [![Build Status](https://travis-ci.org/rapid7/metasploit-framework.png?branch=master)](https://travis-ci.org/rapid7/metasploit-framework) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/rapid7/metasploit-framework)
 ==
 The Metasploit Framework is released under a BSD-style license. See
 COPYING for more details.


### PR DESCRIPTION
Currently, the badge is https://travis-ci.org/rapid7/metasploit-framework.png, which seems to just take the most recent branch. What we really want is master, https://travis-ci.org/rapid7/metasploit-framework.png?branch=master .
## Verification
- [x] Land this PR
- [x] See the build status be correct after landing, assuming you didn't wang up the merge.
