### PR TITLE
Add custom cookie as a datastore option

### DIFF
--- a/modules/exploits/multi/http/drupal_drupageddon.rb
+++ b/modules/exploits/multi/http/drupal_drupageddon.rb
@@ -48,6 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
     register_advanced_options(
     [
       OptString.new('ADMIN_ROLE', [ true, "The administrator role", 'administrator']),
+      OptString.new('COOKIE', [false, 'The session cookie']),
       OptInt.new('ITER', [ true, "Hash iterations (2^ITER)", 10])
     ], self.class)
   end
@@ -201,7 +202,7 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "No response or response body, bailing.")
     end
 
-    cookie = res.get_cookies
+    cookie = datastore['COOKIE'] || res.get_cookies
     vprint_debug("#{peer} - cookie: #{cookie}")
 
     # call admin interface to extract CSRF token and enabled modules


### PR DESCRIPTION
> 09:46 < Eagle11> Howdy all - trying to modify a msf module drupal_drupageddon.rb because the site I am testing has a session cookie set before you can access it. I know the key and value of this cookie so i just need to figure out how to set that in the module before running it... Anybody know how I could set that cookie before the exploit runs?
