### PR TITLE
Preserve Context in LoginScanner socket calls, fixes #4723

### DIFF
--- a/lib/metasploit/framework/ftp/client.rb
+++ b/lib/metasploit/framework/ftp/client.rb
@@ -44,7 +44,11 @@ module Metasploit
             # convert port to FTP syntax
             datahost = "#{$1}.#{$2}.#{$3}.#{$4}"
             dataport = ($5.to_i * 256) + $6.to_i
-            self.datasocket = Rex::Socket::Tcp.create('PeerHost' => datahost, 'PeerPort' => dataport)
+            self.datasocket = Rex::Socket::Tcp.create(
+              'PeerHost' => datahost,
+              'PeerPort' => dataport,
+              'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
+            )
           end
           self.datasocket
         end

--- a/lib/metasploit/framework/ftp/client.rb
+++ b/lib/metasploit/framework/ftp/client.rb
@@ -47,7 +47,7 @@ module Metasploit
             self.datasocket = Rex::Socket::Tcp.create(
               'PeerHost' => datahost,
               'PeerPort' => dataport,
-              'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
+              'Context'  => { 'Msf' => framework, 'MsfExploit' => framework_module }
             )
           end
           self.datasocket

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -12,6 +12,12 @@ module Metasploit
         include ActiveModel::Validations
 
         included do
+          # @!attribute framework
+          #   @return [Object] The framework instance object
+          attr_accessor :framework
+          # @!attribute framework_module
+          #   @return [Object] The framework module caller, if availale
+          attr_accessor :framework_module
           # @!attribute connection_timeout
           #   @return [Fixnum] The timeout in seconds for a single SSH connection
           attr_accessor :connection_timeout

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -38,7 +38,7 @@ module Metasploit
                 :Timeout => connection_timeout,
                 :Retries => 2,
                 :Transport => ::SNMP::RexUDPTransport,
-                :Socket => ::Rex::Socket::Udp.create('Context' => { 'Msf' => framework, 'MsfExploit' => self })
+                :Socket => ::Rex::Socket::Udp.create('Context' => { 'Msf' => framework, 'MsfExploit' => framework_module })
             )
 
             result_options[:proof] = test_read_access(snmp_client)

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -38,7 +38,7 @@ module Metasploit
                 :Timeout => connection_timeout,
                 :Retries => 2,
                 :Transport => ::SNMP::RexUDPTransport,
-                :Socket => ::Rex::Socket::Udp.create
+                :Socket => ::Rex::Socket::Udp.create('Context' => { 'Msf' => framework, 'MsfExploit' => self })
             )
 
             result_options[:proof] = test_read_access(snmp_client)

--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -90,7 +90,7 @@ module Metasploit
               'SSLVersion' =>  opts['SSLVersion'] || ssl_version,
               'Proxies'    => proxies,
               'Timeout'    => (opts['ConnectTimeout'] || connection_timeout || 10).to_i,
-              'Context'    => { 'Msf' => framework, 'MsfExploit' => self }
+              'Context'    => { 'Msf' => framework, 'MsfExploit' => framework_module }
               )
           # enable evasions on this socket
           set_tcp_evasions(nsock)

--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -89,7 +89,8 @@ module Metasploit
               'SSL'        =>  dossl,
               'SSLVersion' =>  opts['SSLVersion'] || ssl_version,
               'Proxies'    => proxies,
-              'Timeout'    => (opts['ConnectTimeout'] || connection_timeout || 10).to_i
+              'Timeout'    => (opts['ConnectTimeout'] || connection_timeout || 10).to_i,
+              'Context'    => { 'Msf' => framework, 'MsfExploit' => self }
               )
           # enable evasions on this socket
           set_tcp_evasions(nsock)

--- a/lib/msf/core/exploit/ftp.rb
+++ b/lib/msf/core/exploit/ftp.rb
@@ -83,7 +83,11 @@ module Exploit::Remote::Ftp
       # convert port to FTP syntax
       datahost = "#{$1}.#{$2}.#{$3}.#{$4}"
       dataport = ($5.to_i * 256) + $6.to_i
-      self.datasocket = Rex::Socket::Tcp.create('PeerHost' => datahost, 'PeerPort' => dataport)
+      self.datasocket = Rex::Socket::Tcp.create(
+        'PeerHost' => datahost,
+        'PeerPort' => dataport,
+        'Context'  => { 'Msf' => framework, 'MsfExploit' => self }
+      )
     end
     self.datasocket
   end

--- a/modules/auxiliary/scanner/acpp/login.rb
+++ b/modules/auxiliary/scanner/acpp/login.rb
@@ -71,7 +71,9 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: datastore['ConnectTimeout'],
       max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay']
+      send_delay: datastore['TCP::send_delay'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -67,6 +67,8 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: 30,
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -65,6 +65,8 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: 30,
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -78,7 +78,9 @@ class Metasploit3 < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
-        connection_timeout: 30
+        connection_timeout: 30,
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -83,6 +83,8 @@ class Metasploit3 < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -88,7 +88,9 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 5,
       user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST']
+      vhost: datastore['VHOST'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -52,7 +52,9 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 10,
       user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST']
+      vhost: datastore['VHOST'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -101,7 +101,9 @@ class Metasploit3 < Msf::Auxiliary
       cred_details:       @cred_collection,
       stop_on_success:    datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5
+      connection_timeout: 5,
+      framework: framework,
+      framework_module: self,
     )
 
     @scanner.ssl         = datastore['SSL']

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -83,7 +83,9 @@ class Metasploit3 < Msf::Auxiliary
       cred_details:       @cred_collection,
       stop_on_success:    datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5
+      connection_timeout: 5,
+      framework: framework,
+      framework_module: self,
     )
 
     @scanner.ssl         = datastore['SSL']

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -163,7 +163,9 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 5,
       user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST']
+      vhost: datastore['VHOST'],
+      framework: framework,
+      framework_module: self,
     )
 
     msg = scanner.check_setup

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -47,7 +47,9 @@ class Metasploit3 < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         user_agent: datastore['UserAgent'],
-        vhost: datastore['VHOST']
+        vhost: datastore['VHOST'],
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -51,7 +51,9 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 10,
       user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST']
+      vhost: datastore['VHOST'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -63,7 +63,9 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 10,
       user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST']
+      vhost: datastore['VHOST'],
+      framework: framework,
+      framework_module: self,
     )
 
     if ssl

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -114,7 +114,9 @@ class Metasploit3 < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
         user_agent: datastore['UserAgent'],
-        vhost: datastore['VHOST']
+        vhost: datastore['VHOST'],
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -72,6 +72,8 @@ class Metasploit3 < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -55,7 +55,9 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: 30,
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
-        windows_authentication: datastore['USE_WINDOWS_AUTHENT']
+        windows_authentication: datastore['USE_WINDOWS_AUTHENT'],
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -64,6 +64,8 @@ class Metasploit3 < Msf::Auxiliary
             connection_timeout: 30,
             max_send_size: datastore['TCP::max_send_size'],
             send_delay: datastore['TCP::send_delay'],
+            framework: framework,
+            framework_module: self,
         )
 
         scanner.scan! do |result|

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -74,6 +74,8 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       max_send_size: datastore['TCP::max_send_size'],
       send_delay: datastore['TCP::send_delay'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -70,7 +70,9 @@ class Metasploit3 < Msf::Auxiliary
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 30
+      connection_timeout: 30,
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -77,6 +77,8 @@ class Metasploit3 < Msf::Auxiliary
       connection_timeout: 5,
       max_send_size: datastore['TCP::max_send_size'],
       send_delay: datastore['TCP::send_delay'],
+      framework: framework,
+      framework_module: self,
     )
 
     bogus_result = @scanner.attempt_bogus_login(domain)

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -61,7 +61,9 @@ class Metasploit3 < Msf::Auxiliary
           cred_details: collection,
           stop_on_success: datastore['STOP_ON_SUCCESS'],
           bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-          connection_timeout: 2
+          connection_timeout: 2,
+          framework: framework,
+          framework_module: self,
       )
 
       scanner.scan! do |result|

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -117,6 +117,8 @@ class Metasploit3 < Msf::Auxiliary
       stop_on_success: datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: datastore['SSH_TIMEOUT'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -210,6 +210,8 @@ class Metasploit3 < Msf::Auxiliary
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       proxies: datastore['Proxies'],
       connection_timeout: datastore['SSH_TIMEOUT'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -70,6 +70,8 @@ class Metasploit3 < Msf::Auxiliary
         send_delay: datastore['TCP::send_delay'],
         banner_timeout: datastore['TelnetBannerTimeout'],
         telnet_timeout: datastore['TelnetTimeout']
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
         banner_timeout: datastore['TelnetBannerTimeout'],
-        telnet_timeout: datastore['TelnetTimeout']
+        telnet_timeout: datastore['TelnetTimeout'],
         framework: framework,
         framework_module: self,
     )

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -76,6 +76,8 @@ class Metasploit3 < Msf::Auxiliary
       connection_timeout: 30,
       max_send_size: datastore['TCP::max_send_size'],
       send_delay: datastore['TCP::send_delay'],
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -81,6 +81,8 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: datastore['ConnectTimeout'],
         max_send_size: datastore['TCP::max_send_size'],
         send_delay: datastore['TCP::send_delay'],
+        framework: framework,
+        framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -61,6 +61,8 @@ class Metasploit3 < Msf::Auxiliary
       stop_on_success: datastore['STOP_ON_SUCCESS'],
       bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
       connection_timeout: 10,
+      framework: framework,
+      framework_module: self,
     )
 
     scanner.scan! do |result|

--- a/plugins/socket_logger.rb
+++ b/plugins/socket_logger.rb
@@ -31,12 +31,11 @@ class Plugin::SocketLogger < Msf::Plugin
 
     def on_socket_created(comm, sock, param)
       # Sockets created by the exploit have MsfExploit set and MsfPayload not set
-      if (param.context['MsfExploit'] and (! param.context['MsfPayload'] ))
+      if param.context and param.context['MsfExploit'] and (! param.context['MsfPayload'])
         sock.extend(SocketLogger::SocketTracer)
         sock.context = param.context
         sock.params = param
         sock.initlog(@path, @prefix)
-
       end
     end
   end
@@ -60,7 +59,7 @@ class Plugin::SocketLogger < Msf::Plugin
   end
 
   def desc
-    "Logs all socket operations to hex dumps in /tmp"
+    "Log socket operations to a directory as individual files"
   end
 
 protected
@@ -78,17 +77,16 @@ module SocketTracer
 
   # Hook the write method
   def write(buf, opts = {})
-    @fd.puts "WRITE (#{buf.length} bytes)"
-    @fd.puts Rex::Text.to_hex_dump(buf)
+    @fd.puts "WRITE\t#{buf.length}\t#{Rex::Text.encode_base64(buf)}"
+    @fd.flush
     super(buf, opts)
   end
 
   # Hook the read method
   def read(length = nil, opts = {})
     r = super(length, opts)
-
-    @fd.puts "READ (#{r.length} bytes)"
-    @fd.puts Rex::Text.to_hex_dump(r)
+    @fd.puts "READ\t#{ r ? r.length : 0}\t#{Rex::Text.encode_base64(r.to_s)}"
+    @fd.flush
     return r
   end
 
@@ -97,15 +95,28 @@ module SocketTracer
     @fd.close
   end
 
+  def format_socket_conn
+    "#{params.proto.upcase} #{params.localhost}:#{params.localport} > #{params.peerhost}:#{params.peerport}"
+  end
+
+  def format_module_info
+    return "" unless params.context and params.context['MsfExploit']
+    if params.context['MsfExploit'].respond_to? :fullname
+      return "via " + params.context['MsfExploit'].fullname
+    end
+    "via " + params.context['MsfExploit'].to_s
+  end
+
   def initlog(path, prefix)
     @log_path    = path
     @log_prefix  = prefix
     @log_id      = @@last_id
     @@last_id   += 1
     @fd = File.open(File.join(@log_path, "#{@log_prefix}#{@log_id}.log"), "w")
-    @fd.puts "Socket created at #{Time.now}"
-    @fd.puts "Info: #{params.proto} #{params.localhost}:#{params.localport} -> #{params.peerhost}:#{params.peerport}"
+    @fd.puts "Socket created at #{Time.now} (#{Time.now.to_i})"
+    @fd.puts "Info: #{format_socket_conn} #{format_module_info}"
     @fd.puts ""
+    @fd.flush
   end
 
 end


### PR DESCRIPTION
During the LoginScanner rework, a bunch of code was pulled from mixins and moved into the LoginScanner namespace, but in doing so, did not pass the Context hash into the Rex::Socket.create calls. Without the Context hash, any code using the socket event handlers are unable to determine what module created the socket. This is a fairly obscure feature, but has been consistently implemented since the first version of Metasploit Framework 3.x.

To demonstrate the issue, a modified version of the socket_logger plugin has been included in this PR. 

Using the new code:

```
msf> use auxiliary/scanner/ftp/ftp_login
msf auxiliary(ftp_login) > set RHOSTS ftp.openbsd.org
msf auxiliary(ftp_login) > set USERNAME ftp
msf auxiliary(ftp_login) > set PASSWORD hello@metasploit.com

msf auxiliary(ftp_login) > load socket_logger
[*] Successfully loaded plugin: socket_logger

msf auxiliary(ftp_login) > run
[*] 129.128.5.191:21 - Starting FTP login sweep
[+] 129.128.5.191:21 - LOGIN SUCCESSFUL: ftp:hello@metasploit.com
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

msf auxiliary(ftp_login) > ls -la /tmp/socket_*
[*] exec: ls -la /tmp/socket_*
-rw-r--r-- 1 hdm hdm 3149 Feb  9 12:30 /tmp/socket_0.log

msf auxiliary(ftp_login) > cat /tmp/socket_0.log
[*] exec: cat /tmp/socket_0.log

Socket created at 2015-02-09 12:30:42 -0600 (1423506642)
Info: TCP 0.0.0.0:0 > 129.128.5.191:21 via auxiliary/scanner/ftp/ftp_login

READ    47  MjIwIG9wZW5ic2Quc3J2LnVhbGJlcnRhLmNhIEZUUCBzZXJ2ZXIgcmVhZHkuDQo=
WRITE   10  VVNFUiBmdHANCg==
READ    58  MzMxIEd1ZXN0IGxvZ2luIG9rLCBzZW5kIHlvdXIgZW1haWwgYWRkcmVzcyBhcyBwYXNzd29yZC4NCg==
WRITE   27  UEFTUyBoZWxsb0BtZXRhc3Bsb2l0LmNvbQ0K
READ    65  MjMwLSAgIFdlbGNvbWUgdG8gZnRwLm9wZW5ic2Qub3JnIGF0IHRoZSBVbml2ZXJzaXR5IG9mIEFsYmVydGEgDQo=
READ    1448    MjMwLSAgIGluIEVkbW9udG9uLCBBbGJlcnRhLCBDYW5hZGEuDQoyMzAtICAgRm9yIG90aGVyIG1pcnJvciBzaXRlcyB2aXNpdCBodHRwOi8vd3d3Lm9wZW5ic2Qub3JnL2Z0cC5odG1sDQoyMzAtIA0KMjMwLSAgICAgICAgIF9fX19fICAgICAgICAgICAgICAgICBfX19fICAgX19fX18gX19fX18NCjIzMC0gICAgICAgIC8gX19fIFwgICAgICAgICAgICAgICB8ICBfIFwgLyBfX19ffCAgX18gXA0KMjMwLSAgICAgICAvIC8gIC8gL19fXyAgX19fICBfX19fIHwgfF8pIHwgKF9fXyB8IHwgIHwgfA0KMjMwLSAgICAgIC8gLyAgLyAvIF9fIFwvIF8gXC8gX18gXHwgIF8gPCBcX19fIFx8IHwgIHwgfA0KMjMwLSAgICAgLyAvX18vIC8gL18vIC8gIF9fLyAvIC8gL3wgfF8pIHxfX19fKSB8IHxfX3wgfA0KMjMwLSAgICAgXF9fX19fLyAuX19fL1xfX18vXy8gL18vIHxfX19fL3xfX19fXy98X19fX18vDQoyMzAtICAgICAgICAgIC9fLw0KMjMwLSAgICAgICAgICAgICAgICAgfCAgICAuICAgICAgICAgICAgVGhlIHByb2FjdGl2ZWx5IHNlY3VyZSBVbml4LWxpa2UNCjIzMC0gICAgICAgICAgICAgLiAgIHxMICAvfCAgIC4gICAgICAgIE9wZXJhdGluZyBTeXN0ZW0uDQoyMzAtICAgICAgICAgXyAuIHxcIF98IFwtLSsuXy98IC4gICAgICBQbGVhc2UgdmlzaXQgdGhlIE9wZW5CU0Qgd2ViIHNpdGUNCjIzMC0gICAgICAgIC8gfHxcfCBZIEogICkgICAvIHwvfCAuLyAgICAgIGF0IGh0dHA6Ly93d3cub3BlbmJzZC5vcmcvDQoyMzAtICAgICAgIEogIHwpJyggfCAgICAgICAgYCBGYC4nLw0KMjMwLSAgICAgLTx8ICBGICAgICAgICAgX18gICAgIC4tPCAgICAgQWxsIHRyYW5zZmVycyBhcmUgbG9nZ2VkLCBpZiB5b3UgZG9uJ3QNCjIzMC0gICAgICAgfCAvICAgICAgIC4tJy4gYC4gIC8tLiBMX19fIGxpa2UgdGhpcyBwb2xpY3ksIGRpc2Nvbm5lY3Qgbm93IQ0KMjMwLSAgICAgICBKIFwgICAgICA8ICAgIFwgIHwgfCBPXHwuLScNCjIzMC0gICAgIF9KIFwgIC4tICAgIFwvIE8gfCB8IFwgIHxGDQoyMzAtICAgICctRiAgLTxfLiAgICAgXCAgIC4tJyAgYC0nIExfXyBPcGVuQlNEIGlzIGF2YWlsYWJsZSBmb3Igb3JkZXIhDQoyMzAtICAgX19KICBfICAgXy4gICAgID4tJyAgKS5fLiAgIHwtJyBZb3UgY2FuIG9yZGVyIE9wZW5CU0QgQ0QncyBmcm9tIA0KMjMwLSAgIGAtfC4nICAgL18uICAgICAgICAgICBcX3wgICBGICAgaHR0cDovL3d3dy5vcGVuYnNkLm9yZy9vcmRlcnMuaHRtbC4NCjIzMC0gICAgIC8uLSAgIC4gICAgICAgICAgICAgICAgXy48ICAgIENEIHNhbGVzIGFyZSB2ZXJ5IGltcG9ydGFudCB0byBzdXBwb3J0DQoyMzAtICAgIC8nICAgIC8uJyAgICAgICAgICAgICAuJyAgYFwgICB0aGUgY29udGludWVkIGRldmVsb3BtZW50IG9mIHRoZSBwcm9qZWN0Lg0KMjMwLSAgICAgL0wgIC8nICAgfC8gICAgICBfLi0nLVwNCjIzMC0gICAgLydKICAgICAgIF8=
READ    549 X18uLS0tJ1x8DQoyMzAtICAgICAgfFwgIC4tLScgViAgfCBgLiBgDQoyMzAtICAgICAgfC9gLiBgLS4gICAgIGAuXykNCjIzMC0gICAgICAgICAvIC4tLlwNCjIzMC0gICBWSyAgICBcICggIGBcDQoyMzAtICAgICAgICAgIGAuXA0KMjMwLSAgDQoyMzAtICAgKkRPIE5PVCogbWlycm9yIG9wZW5ic2QgZnJvbSB0aGlzIHNpdGUhIHVzZSBvbmUgb2YgdGhlDQoyMzAtICAic2Vjb25kIGxldmVsIG1pcnJvcnMiIGxpc3RlZCBhdCBodHRwOi8vd3d3Lm9wZW5ic2Qub3JnL2Z0cC5odG1sDQoyMzAtICBpbnN0ZWFkIG9mIHRoaXMgc2l0ZS4gIElmIHlvdSBtaXJyb3IgZnJvbSB0aGlzIHNpdGUgeW91IHdpbGwgbG9zZSANCjIzMC0gIGFjY2VzcyB0byBpdC4NCjIzMC0gDQoyMzAtICBFLW1haWwgY29tbWVudHMsIHF1ZXN0aW9ucywgdHJvdWJsZSByZXBvcnRzLCBhbmQgY29tcGxhaW50cw0KMjMwLSAgdG8gYmVja0BvcGVuYnNkLm9yZy4gIFBsZWFzZSBkcml2ZSBzYWZlbHkuDQoyMzAtIA0KMjMwIEd1ZXN0IGxvZ2luIG9rLCBhY2Nlc3MgcmVzdHJpY3Rpb25zIGFwcGx5Lg0K
```

Switching back to master, the socket log isn't even being created:

```
$ rm -f /tmp/socket_[0-9]
$ git checkout master
$ ./msfconsole
msf> use auxiliary/scanner/ftp/ftp_login
msf auxiliary(ftp_login) > set RHOSTS ftp.openbsd.org
msf auxiliary(ftp_login) > set USERNAME ftp
msf auxiliary(ftp_login) > set PASSWORD hello@metasploit.com

msf auxiliary(ftp_login) > load socket_logger
[*] Successfully loaded plugin: socket_logger

msf auxiliary(ftp_login) > run
[*] 129.128.5.191:21 - Starting FTP login sweep
[+] 129.128.5.191:21 - LOGIN SUCCESSFUL: ftp:hello@metasploit.com
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

msf auxiliary(ftp_login) > ls -la /tmp/socket_*
[*] exec: ls -la /tmp/socket_*
ls: cannot access /tmp/socket_*: No such file or directory
```

In other words, without passing Context into each Rex::Socket call, the socket event handler in Framework doesn't see and has no ability to hook socket operations. This is a regression introduced with the new LoginScanner code and was not a problem prior to this change.
