### PR TITLE
Skip the error message for prepend_sleep in Powershell

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -296,8 +296,8 @@ EOS
     if opts[:prepend_sleep]
       if opts[:prepend_sleep].to_i > 0
         psh_payload = "Start-Sleep -s #{opts[:prepend_sleep]};" << psh_payload
-      else
-        vprint_error('Sleep time must be greater than 0 seconds')
+      elsif opts[:prepend_sleep].to_i < 0
+        vprint_error('Sleep time must be greater than or equal to 0 seconds')
       end
     end
 


### PR DESCRIPTION
When `opts[:prepend_sleep]` is undefined, or set to nil, 0, or false the Poweshell mixin will print an error message with `vprint_error`.

If the caller of the module or the user specifies a prepend sleep time of 0, the expected behavior does not change. This PR will skip the error message unless a negative number is specified.

Example output:

```
exploit(psexec_psh) > exploit

[-] [2015.02.09-14:46:32] Sleep time must be greater than 0 seconds
[*] [2015.02.09-14:46:32] Powershell command length: 2205
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Executing the payload...
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.90.133[\svcctl] ...
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.90.133[\svcctl] ...
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Obtaining a service manager handle...
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Creating the service...
[+] [2015.02.09-14:46:32] 192.168.90.133:445 - Successfully created the service
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Starting the service...
[+] [2015.02.09-14:46:32] 192.168.90.133:445 - Service start timed out, OK if running a command or non-service executable...
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Removing the service...
[+] [2015.02.09-14:46:32] 192.168.90.133:445 - Successfully removed the sevice
[*] [2015.02.09-14:46:32] 192.168.90.133:445 - Closing service handle...
[*] [2015.02.09-14:46:33] Sending stage (770048 bytes) to 192.168.90.133
```

Verification steps:
- [x] Run `exploit/windows/smb/psexec_psh` with VERBOSE as true and `Powershell::prepend_sleep` as the default (unset) value.
- [x] Do not see the error message regarding the sleep time
- [x] Get a working session
