### PR TITLE
Bump version of metasploit-credential

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ PATH
       activerecord (>= 3.2.21, < 4.0.0)
       metasploit-credential (~> 0.13.17)
       metasploit-framework (= 4.11.0.pre.dev)
-      metasploit_data_models (~> 0.22.6)
+      metasploit_data_models (~> 0.22.7)
       pg (>= 0.11)
     metasploit-framework-pcap (4.11.0.pre.dev)
       metasploit-framework (= 4.11.0.pre.dev)
@@ -112,10 +112,10 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.13.17)
+    metasploit-credential (0.13.18)
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
-      metasploit_data_models (~> 0.22.6)
+      metasploit_data_models (~> 0.22.7)
       pg
       railties (< 4.0.0)
       rubyntlm
@@ -123,7 +123,7 @@ GEM
     metasploit-model (0.28.0)
       activesupport
       railties (< 4.0.0)
-    metasploit_data_models (0.22.6)
+    metasploit_data_models (0.22.7)
       activerecord (>= 3.2.13, < 4.0.0)
       activesupport
       arel-helpers

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # Metasploit::Credential database models
   spec.add_runtime_dependency 'metasploit-credential', '~> 0.13.17'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models', '~> 0.22.6'
+  spec.add_runtime_dependency 'metasploit_data_models', '~> 0.22.7'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code
   spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
   # Needed for module caching in Mdm::ModuleDetails


### PR DESCRIPTION
Bumped version of metasploit-credential to pull in bumped version of MDM, which fixes some old Rails-3 style ActiveRecord calls.

MSP-12127

Since this is a simple version bump, if Travis passes, we're good to merge.
