### PR TITLE
Fix #4711 - getpeername(2) error that causes BrowserAutoPwn to terminate all servers

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -732,7 +732,15 @@ module Socket
   # Return peer connection information.
   #
   def getpeername
-    return Socket.from_sockaddr(super)
+    peer_name = nil
+    begin
+      peer_name = Socket.from_sockaddr(super)
+    rescue ::Exception => e
+      # Ruby's getpeername method may call rb_sys_fail("getpeername(2)")
+      elog("#{e.message} (#{e.class})#{e.backtrace * "\n"}\n", 'core', LEV_3)
+    end
+
+    return peer_name
   end
 
   #

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -735,7 +735,7 @@ module Socket
     peer_name = nil
     begin
       peer_name = Socket.from_sockaddr(super)
-    rescue ::Exception => e
+    rescue ::Errno::EINVAL => e
       # Ruby's getpeername method may call rb_sys_fail("getpeername(2)")
       elog("#{e.message} (#{e.class})#{e.backtrace * "\n"}\n", 'core', LEV_3)
     end

--- a/lib/rex/socket/tcp_server.rb
+++ b/lib/rex/socket/tcp_server.rb
@@ -56,6 +56,9 @@ module  Rex::Socket::TcpServer
 
       pn = t.getpeername
 
+      # We hit a "getpeername(2)" from Ruby
+      return nil unless pn
+
       t.peerhost = pn[1]
       t.peerport = pn[2]
     end

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -236,6 +236,11 @@ class Metasploit3 < Msf::Auxiliary
       print_debug("NOTE: Debug Mode; javascript will not be obfuscated")
     else
       pre = Time.now
+
+      #
+      # 2/12/2015: Obfuscation is disabled because this is currently breaking BrowserAutoPwn
+      #
+
       #print_status("Obfuscating initial javascript #{pre}")
       #@init_js.obfuscate
       #print_status "Done in #{Time.now - pre} seconds"
@@ -825,6 +830,10 @@ class Metasploit3 < Msf::Auxiliary
 
     js << "#{js_debug("'starting exploits (' + global_exploit_list.length + ' total)<br>'")}\n"
     js << "window.next_exploit(0);\n"
+
+    #
+    # 2/12/2015: Obfuscation is disabled because this is currently breaking BrowserAutoPwn
+    #
 
     #js = ::Rex::Exploitation::JSObfu.new(js)
     #js.obfuscate unless datastore["DEBUG"]

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -236,9 +236,9 @@ class Metasploit3 < Msf::Auxiliary
       print_debug("NOTE: Debug Mode; javascript will not be obfuscated")
     else
       pre = Time.now
-      print_status("Obfuscating initial javascript #{pre}")
-      @init_js.obfuscate
-      print_status "Done in #{Time.now - pre} seconds"
+      #print_status("Obfuscating initial javascript #{pre}")
+      #@init_js.obfuscate
+      #print_status "Done in #{Time.now - pre} seconds"
     end
 
     #@init_js << "window.onload = #{@init_js.sym("bodyOnLoad")};";
@@ -826,8 +826,8 @@ class Metasploit3 < Msf::Auxiliary
     js << "#{js_debug("'starting exploits (' + global_exploit_list.length + ' total)<br>'")}\n"
     js << "window.next_exploit(0);\n"
 
-    js = ::Rex::Exploitation::JSObfu.new(js)
-    js.obfuscate unless datastore["DEBUG"]
+    #js = ::Rex::Exploitation::JSObfu.new(js)
+    #js.obfuscate unless datastore["DEBUG"]
 
     response.body = "#{js}"
     print_status("Responding with #{sploit_cnt} exploits")

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -10,19 +10,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
-  include Msf::Exploit::Remote::BrowserAutopwn
-  autopwn_info({
-    :ua_name    => HttpClients::IE,
-    :ua_minver  => "6.0",
-    :ua_maxver  => "8.0",
-    :javascript => true,
-    :os_name    => OperatingSystems::Match::WINDOWS,
-    :vuln_test  => %Q|
-      var v = window.os_detect.getVersion();
-      var os_name = v['os_name'];
-      if (os_name.indexOf('Windows XP') == 0) {is_vuln = true;} else { is_vuln = false; }
-    |,
-  })
 
   def initialize(info={})
     super(update_info(info,

--- a/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
+++ b/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
@@ -9,6 +9,19 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
+  include Msf::Exploit::Remote::BrowserAutopwn
+  autopwn_info({
+    :ua_name    => HttpClients::IE,
+    :ua_minver  => "8.0",
+    :ua_maxver  => "8.0",
+    :javascript => true,
+    :os_name    => OperatingSystems::Match::WINDOWS_XP,
+# BrowserAutoPwn currently has a syntax error bug so we can't use classid and method,
+# so we have these commented out for now. But it's not so bad because by default
+# Windows XP has this ActiveX, and BrowserExploitServer's check will kick in.
+#    :classid    => "{19916E01-B44E-4E31-94A4-4696DF46157B}",
+#    :method     => "requiredClaims"
+  })
 
   def initialize(info={})
     super(update_info(info,

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -11,17 +11,7 @@ class Metasploit4 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
-  #include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Powershell
-
-  #autopwn_info({
-  #  :ua_name    => HttpClients::IE,
-  #  :ua_minver  => "3.0",
-  #  :ua_maxver  => "10.0",
-  #  :javascript => true,
-  #  :os_name    => OperatingSystems::Match::WINDOWS,
-  #  :rank       => ExcellentRanking
-  #})
 
   def initialize(info={})
     super(update_info(info,

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -11,17 +11,17 @@ class Metasploit4 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
-  include Msf::Exploit::Remote::BrowserAutopwn
+  #include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Powershell
 
-  autopwn_info({
-    :ua_name    => HttpClients::IE,
-    :ua_minver  => "3.0",
-    :ua_maxver  => "10.0",
-    :javascript => true,
-    :os_name    => OperatingSystems::Match::WINDOWS,
-    :rank       => ExcellentRanking
-  })
+  #autopwn_info({
+  #  :ua_name    => HttpClients::IE,
+  #  :ua_minver  => "3.0",
+  #  :ua_maxver  => "10.0",
+  #  :javascript => true,
+  #  :os_name    => OperatingSystems::Match::WINDOWS,
+  #  :rank       => ExcellentRanking
+  #})
 
   def initialize(info={})
     super(update_info(info,


### PR DESCRIPTION
Fixes #4711

The problem here is that the browser sometimes will shutdown some of our exploit's connections (in my testing, all Java), and that will cause Ruby to call a rb_sys_fail with "getpeername(2)". The error goes all the way to Rex::IO::StreamServer's monitor_listener method, which triggers a "break" to quit monitoring. And then this causes another chain of reactions that eventually forces BrowserAutoPwn's servers to quit completely (while the JavaScript on the browser is still running, which sort of creates an illusion that you the module is still trying, except not really)

I also traded MS12-004 for MS13-090 because the new one should work better against XP.
## Test
- [ ] Prepare a Windows XP box (no patches, and no java)
- [ ] Start msfconsole
- [ ] `use auxiliary/server/browser_autopwn`
- [ ] `set verbose true`
- [ ] `set debug true`
- [ ] `run`
- [ ] Open IE8 (XP's latest IE) and try URL BrowserAutoPwn gave you
- [ ] You should get a shell
- [ ] You should not see any "Server stopped" messages (unless you manually exit, of course)
