### PR TITLE
Update MS14-070 module information and references

### DIFF
--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -18,11 +18,11 @@ class Metasploit3 < Msf::Exploit::Local
 
   def initialize(info={})
     super(update_info(info, {
-      'Name'           => 'Windows tcpip.sys Arbitrary Write Privilege Escalation',
+      'Name'           => 'Windows tcpip!SetAddrOptions NULL Pointer Dereference',
       'Description'    => %q{
         A vulnerability within the Microsoft TCP/IP protocol driver tcpip.sys,
-        can allow an attacker to inject controlled memory into an arbitrary
-        location within the kernel.
+        can allow an attacker to trigger a NULL pointer dereference by using a
+        specially crafted IOCTL.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
@@ -51,6 +51,9 @@ class Metasploit3 < Msf::Exploit::Local
       'References'    =>
         [
           ['CVE', '2014-4076'],
+          ['MSB', 'MS14-070'],
+          ['OSVDB', '114532'],
+          ['URL', 'https://blog.korelogic.com/blog/2015/01/28/2k3_tcpip_setaddroptions_exploit_dev'],
           ['URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2015-001.txt']
         ],
       'DisclosureDate'=> 'Nov 11 2014',


### PR DESCRIPTION
The original exploit module and advisory stated that the vulnerability was an arbitrary write in kernel memory. The blog that this PR added to the references and further analysis showed that the vulnerability is actually a NULL pointer dereference.

This PR updates the modules name and description to be more accurate as well as adds the MSB, and OSVDB references.

Verification steps
- [x] Load the new module and display the information
- [x] See the new, more accurate info and additional references

Example output:

```
msf-git (S:0 J:0) exploit(ms14_070_tcpip_ioctl) > info

       Name: Windows tcpip!SetAddrOptions NULL Pointer Dereference
     Module: exploit/windows/local/ms14_070_tcpip_ioctl
   Platform: Windows
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Average
  Disclosed: 2014-11-11

Provided by:
  Matt Bergin <level@korelogic.com>
  Jay Smith <jsmith@korelogic.com>

Available targets:
  Id  Name
  --  ----
  0   Windows Server 2003 SP2

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  SESSION                   yes       The session to run this module on.

Payload information:

Description:
  A vulnerability within the Microsoft TCP/IP protocol driver 
  tcpip.sys, can allow an attacker to trigger a NULL pointer 
  dereference by using a specially crafted IOCTL.

References:
  http://cvedetails.com/cve/2014-4076/
  http://technet.microsoft.com/en-us/security/bulletin/MS14-070
  http://www.osvdb.org/114532
  https://blog.korelogic.com/blog/2015/01/28/2k3_tcpip_setaddroptions_exploit_dev
  https://www.korelogic.com/Resources/Advisories/KL-001-2015-001.txt

msf-git (S:0 J:0) exploit(ms14_070_tcpip_ioctl) > exit
```
