### PR TITLE
Fix up titles, descriptions

### DIFF
--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -14,16 +14,17 @@ class Metasploit4 < Msf::Exploit::Local
 
   def initialize(info={})
     super( update_info( info, {
-        'Name'          => 'Android Futex Requeue Kernel Exploit',
+        'Name'          => "Android 'Towelroot' Futex Requeue Kernel Exploit",
         'Description'   => %q{
-            This module exploits a bug in futex_requeue in the linux kernel.
-            Any android phone with a kernel built before June 2014 should be vulnerable.
+            This module exploits a bug in futex_requeue in the Linux kernel, using
+            similiar techniques employed by the towelroot exploit. Any Android device
+            with a kernel built before June, 2014 is likely to be vulnerable.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [
-            'Pinkie Pie', #discovery
-            'geohot', #towelroot
-            'timwr' #metasploit module
+            'Pinkie Pie', # discovery
+            'geohot',     # towelroot
+            'timwr'       # metasploit module
         ],
         'References'    =>
         [

--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -18,7 +18,7 @@ class Metasploit4 < Msf::Exploit::Local
         'Description'   => %q{
             This module exploits a bug in futex_requeue in the Linux kernel, using
             similiar techniques employed by the towelroot exploit. Any Android device
-            with a kernel built before June, 2014 is likely to be vulnerable.
+            with a kernel built before June 2014 is likely to be vulnerable.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -18,11 +18,12 @@ class Metasploit3 < Msf::Exploit::Local
 
   def initialize(info={})
     super(update_info(info, {
-      'Name'           => 'Windows tcpip!SetAddrOptions NULL Pointer Dereference',
+      'Name'           => 'MS14-070 Windows tcpip!SetAddrOptions NULL Pointer Dereference',
       'Description'    => %q{
-        A vulnerability within the Microsoft TCP/IP protocol driver tcpip.sys,
-        can allow an attacker to trigger a NULL pointer dereference by using a
-        specially crafted IOCTL.
+        A vulnerability within the Microsoft TCP/IP protocol driver tcpip.sys
+        can allow a local attacker to trigger a NULL pointer dereference by using a
+        specially crafted IOCTL. This flaw can be abused to elevate privileges to
+        SYSTEM.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>

--- a/modules/exploits/windows/misc/achat_bof.rb
+++ b/modules/exploits/windows/misc/achat_bof.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a Unicode SEH buffer overflow in Achat. By
         sending a crafted message to the default port 9256/UDP, it's possible to overwrite the
-        SEH handler. Even when the exploit is reliable, it depends of timing since there are
+        SEH handler. Even when the exploit is reliable, it depends on timing since there are
         two threads overflowing the stack in the same time. This module has been tested on
         Achat v0.150 running on Windows XP SP3 and Windows 7.
       },

--- a/modules/exploits/windows/misc/achat_bof.rb
+++ b/modules/exploits/windows/misc/achat_bof.rb
@@ -13,10 +13,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Achat Stack Based Buffer Overflow',
+      'Name'           => 'Achat Unicode SEH Buffer Overflow',
       'Description'    => %q{
-        This module exploits a Unicode SEH based stack based buffer overflow in Achat. By
-        sending a crafted message to the default port UDP/9256, it's possible to overwrite the
+        This module exploits a Unicode SEH buffer overflow in Achat. By
+        sending a crafted message to the default port 9256/UDP, it's possible to overwrite the
         SEH handler. Even when the exploit is reliable, it depends of timing since there are
         two threads overflowing the stack in the same time. This module has been tested on
         Achat v0.150 running on Windows XP SP3 and Windows 7.

--- a/modules/exploits/windows/misc/achat_bof.rb
+++ b/modules/exploits/windows/misc/achat_bof.rb
@@ -13,13 +13,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Achat v0.150 beta7 Buffer Overflow',
+      'Name'           => 'Achat Stack Based Buffer Overflow',
       'Description'    => %q{
-        This module exploits an unicode SEH based stack buffer overflow in Achat v0.150. By
-        sending a crafted message to the default port 9256 it's possible to overwrites the
-        SEH handler. Even when the exploit is reliable it depends of timing since there are
+        This module exploits a Unicode SEH based stack based buffer overflow in Achat. By
+        sending a crafted message to the default port UDP/9256, it's possible to overwrite the
+        SEH handler. Even when the exploit is reliable, it depends of timing since there are
         two threads overflowing the stack in the same time. This module has been tested on
-        Windows XP SP3 and Windows 7.
+        Achat v0.150 running on Windows XP SP3 and Windows 7.
       },
       'Author'         =>
         [

--- a/modules/post/windows/gather/file_from_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_from_raw_ntfs.rb
@@ -14,10 +14,11 @@ class Metasploit3 < Msf::Post
   def initialize(info = {})
     super(update_info(info,
       'Name'         => 'Windows File Gather File from Raw NTFS',
-      'Description'  => %q(
+      'Description'  => %q{
           This module gathers a file using the raw NTFS device, bypassing some Windows restrictions
           such as open file with write lock. Because it avoids the usual file locking issues, it can
-          be used to retrieve files such as NTDS.dit.),
+          be used to retrieve files such as NTDS.dit.
+       },
       'License'      => 'MSF_LICENSE',
       'Platform'     => ['win'],
       'SessionTypes' => ['meterpreter'],

--- a/modules/post/windows/gather/file_from_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_from_raw_ntfs.rb
@@ -16,7 +16,8 @@ class Metasploit3 < Msf::Post
       'Name'         => 'Windows File Gather File from Raw NTFS',
       'Description'  => %q(
           This module gathers a file using the raw NTFS device, bypassing some Windows restrictions
-          such as open file with write lock. Can be used to retrieve files such as NTDS.dit.),
+          such as open file with write lock. Because it avoids the usual file locking issues, it can
+          be used to retrieve files such as NTDS.dit.),
       'License'      => 'MSF_LICENSE',
       'Platform'     => ['win'],
       'SessionTypes' => ['meterpreter'],


### PR DESCRIPTION
This fixes up some of the titles and descriptions in recently landed modules. Of special note, the string 'towelroot' is mentioned in the title of the Android futex bug (since it seems like a pretty likely keyword for searching), and the version number was dropped from the Achat module. Note the Achat module seemed to be erroneously described as a "stack overflow," one of @wchen-r7's favorite pet peeves.
## Verification
- [x] See the new titles and descriptions make sense.
## Avoiding this in the future

As Batman says,

![](http://ih1.redbubble.net/image.30342034.2358/flat,550x550,075,f.jpg)
