### PR TITLE
fixes bug with smtp header order

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -141,6 +141,8 @@ module Exploit::Remote::SMTPDeliver
     raw_send_recv("MAIL FROM: <#{datastore['MAILFROM']}>\r\n", nsock)
     raw_send_recv("RCPT TO: <#{datastore['MAILTO']}>\r\n", nsock)
 
+    resp = raw_send_recv("DATA\r\n", nsock)
+
     # If the user supplied a Date field, use that, else use the current
     # DateTime in the proper RFC2822 format.
     if datastore['DATE'].present?
@@ -153,8 +155,6 @@ module Exploit::Remote::SMTPDeliver
     if datastore['SUBJECT'].present?
       raw_send_recv("Subject: #{datastore['SUBJECT']}\r\n", nsock)
     end
-
-    resp = raw_send_recv("DATA\r\n", nsock)
 
     # Avoid sending tons of data and killing the connection if the server
     # didn't like us.


### PR DESCRIPTION
SMTP servers that support pipelining will not accept any
commands other than MAILFROM and RCPTTO before the DATA
command. We were sending Date and Subject before Data
which would cause some mailservers to suddenly drop
the connection refusing to send the mail.

MSP-12133

VERIFICATION STEPS 
- [x] configure a local postfix relay with default config
- [x] create a file /tmp/targets.csv with email addresses to send to in (Fname Lname,email) format
- [x] create a file /tmp/email_body.txt with some sample text
- [x] create a file with any text in it called /tmp/sig.txt
- [x] start msfconsole
- [x] `use auxiliary/client/smtp/emailer`
- [x] run
- [x] VERIFY you don't get an EOF error
