### PR TITLE
Fix #4695, allow ms09_067_excel_featheader to save file

### DIFF
--- a/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
+++ b/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
@@ -96,7 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('FILENAME', [ true, 'The file name.',  'msf.xls']),
-        OptString.new('OUTPUTPATH', [ true, 'The output path to use.', Msf::Config.config_directory + "/data/exploits/"]),
+        OptString.new('OUTPUTPATH', [ true, 'The output path to use.', Msf::Config.local_directory]),
       ], self.class)
   end
 
@@ -146,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Creating Excel spreadsheet ...")
 
-    out = File.expand_path(File.join(datastore['OUTPUTPATH'], datastore['FILENAME']))
+    out = File.join(File.join(datastore['OUTPUTPATH'], datastore['FILENAME']))
     stg = Rex::OLE::Storage.new(out, Rex::OLE::STGM_WRITE)
     if (not stg)
       fail_with(Failure::Unknown, 'Unable to create output file')


### PR DESCRIPTION
According to my analysis ms09_067_excel_featheader is not missing nothing, on my system, just trying to write to a nonexistent directory. I've fixed the default value for `OUTPUTPATH` to use `Msf::Config.local_directory` as `FILEFORMAT` mixin does.

Verification
- [x] Init the console
- [x] `use exploit/windows/fileformat/ms09_067_excel_featheader`
- [x] `set TARGET 4`
- [x] `exploit` verify which it doesn't raise errors:

```
msf exploit(ms09_067_excel_featheader) > rexploit
[*] Reloading module...

[*] Creating Excel spreadsheet ...
[*] Generated output file /Users/jvazquez/.msf4/local/msf.xls
```
- [x] exit the console and verify which the file exists:

```
msf exploit(ms09_067_excel_featheader) > exit -y
AUS-MAC-0916:metasploit-framework jvazquez$ file /Users/jvazquez/.msf4/local/msf.xls
/Users/jvazquez/.msf4/local/msf.xls: CDF V2 Document, No summary info
```
