### PR TITLE
Add CVE reference for ie_uxss_injection

### DIFF
--- a/modules/auxiliary/gather/ie_uxss_injection.rb
+++ b/modules/auxiliary/gather/ie_uxss_injection.rb
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Auxiliary
         ],
       'References'     =>
         [
+          [ 'CVE', '2015-0072' ],
           [ 'OSVDB', '117876' ],
           [ 'URL', 'http://www.deusen.co.uk/items/insider3show.3362009741042107/'],
           [ 'URL', 'http://innerht.ml/blog/ie-uxss.html' ],


### PR DESCRIPTION
This adds the CVE for ie_uxss_injection

Make sure that:
- [x] Travis is green
- [x] CVE-2015-0072 is from: http://cve.mitre.org/cgi-bin/cvename.cgi?name=2015-0072
