### PR TITLE
Rails 4 finder conversion: convert find_or_initialize_by_x_and_y

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -166,9 +166,9 @@ module Msf::DBManager::Host
       end
 
       if opts[:comm] and opts[:comm].length > 0
-        host = wspace.hosts.find_or_initialize_by_address_and_comm(addr, opts[:comm])
+        host = wspace.hosts.where(address: addr, comm: opts[:comm]).first_or_initialize
       else
-        host = wspace.hosts.find_or_initialize_by_address(addr)
+        host = wspace.hosts.where(address: addr).first_or_initialize
       end
     else
       host = addr
@@ -257,9 +257,9 @@ module Msf::DBManager::Host
       end
 
       if opts[:comm] and opts[:comm].length > 0
-        host = wspace.hosts.find_or_initialize_by_address_and_comm(addr, opts[:comm])
+        host = wspace.hosts.where(address: addr, comm: opts[:comm]).first_or_initialize
       else
-        host = wspace.hosts.find_or_initialize_by_address(addr)
+        host = wspace.hosts.where(address: addr).first_or_initialize
       end
     else
       host = addr


### PR DESCRIPTION
### Verification
- [x] MSP-12140 must be landed first
- [x] `cd pro/ui && foreman start`
- [x] open MSP app in your browser
- [x] create a new workspace
- [x] import file: `pro/ui/features/data/basic_data_set.xml`
- [x] confirm 11 new hosts
