### PR TITLE
MSP-12152: Fix finder query in Msf::DBManager::Vuln

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -31,7 +31,7 @@ module Msf::DBManager::Vuln
     vuln = nil
 
     if service
-      vuln = service.vulns.includes(:vuln_details).where(:crit).first
+      vuln = service.vulns.includes(:vuln_details).where(crit).first
     end
 
     # Return if we matched based on service
@@ -39,7 +39,7 @@ module Msf::DBManager::Vuln
 
     # Prevent matches against other services
     crit["vulns.service_id"] = nil if service
-    vuln = host.vulns.includes(:vuln_details).where(:crit).first
+    vuln = host.vulns.includes(:vuln_details).where(crit).first
 
     return vuln
   end


### PR DESCRIPTION
This PR fixes a finder query in `Msf::DBManager::Vuln` concerning a conditions hash.

Previously was breaking cucumber test in `pro/ui/features/import/import_3rd_party.feature` for import file  `nexpose_xmlv1.xml`.

MSP-12152
- This is part of updating finder queries to be Rails 4 compatibile
- In #find_vuln_by_details, pass in conditons hash crit rather than symbol :crit
  See:
  https://github.com/rapid7/metasploit-framework/commit/f0bf881cc33a91c2c3468fbdd74962f54a019ba0
  https://github.com/rapid7/metasploit-framework/pull/4720
## Validation
- [x] In framework: `git checkout bug/MSP-12152/third-party-import-fix && bundle install`
- [x] In pro/ui: `git checkout master && bundle install`
- [x] In pro/engine start prosvc: `rvmsudo ./prosvc.rb -E test`
- [x] In pro/ui: `FEATURE=features/import/import_3rd_party.feature rake cucumber`. All should pass.
