### PR TITLE
Fix #4764, NameError unitialized constant Net::DNS in shodan_search

### DIFF
--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -84,19 +84,22 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   # Check to see if api.shodan.io resolves properly
-  def shodan_rhost
-    @res = Net::DNS::Resolver.new
-    dns_query = @res.query('api.shodan.io', 'A')
-    if dns_query.answer.length == 0
-      print_error('Could not resolve api.shodan.io')
-      raise ::Rex::ConnectError('api.shodan.io', '443')
+  def shodan_resolvable?
+    begin
+      Rex::Socket.resolv_to_dotted("api.shodan.io")
+    rescue RuntimeError, SocketError
+      return false
     end
-    dns_query.answer[0].to_s.split(/[\s,]+/)[4]
+
+    true
   end
 
   def run
     # check to ensure api.shodan.io is resolvable
-    shodan_rhost
+    unless shodan_resolvable?
+      print_error("Unable to resolve api.shodan.io")
+      return
+    end
 
     # create our Shodan request parameters
     query = datastore['QUERY']


### PR DESCRIPTION
This patch fixes #4764, NameError unitialized constant Net::DNS in shodan_search.

To verify:
- [x] You will need an API key from Shodan if you don't have one: http://www.shodanhq.com/
- [x] Start msfconsole
- [x] `auxiliary/gather/shodan_search`
- [x] `set database true`
- [x] `set maxpage 1`
- [x] `set shodan_apikey [YOUR API KEY]`
- [x] `set query apache`
- [x] `run`
- [x] You should get some search results
