### PR TITLE
Enum_ad modules should retrive userPrincipalName

### DIFF
--- a/modules/post/windows/gather/enum_ad_user_comments.rb
+++ b/modules/post/windows/gather/enum_ad_user_comments.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Post
 
     register_options([
       OptBool.new('STORE_LOOT', [true, 'Store file in loot.', false]),
-      OptString.new('FIELDS', [true, 'Fields to retrieve.','sAMAccountName,userAccountControl,comment,description']),
+      OptString.new('FIELDS', [true, 'Fields to retrieve.','userPrincipalName,sAMAccountName,userAccountControl,comment,description']),
       OptString.new('FILTER', [true, 'Search filter.','(&(&(objectCategory=person)(objectClass=user))(|(description=*pass*)(comment=*pass*)))']),
     ], self.class)
   end
@@ -63,7 +63,6 @@ class Metasploit3 < Msf::Post
     q[:results].each do |result|
       row = []
 
-      report = {}
       result.each do |field|
         if field[:value].nil?
           row << ""

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -12,7 +12,13 @@ class Metasploit3 < Msf::Post
   include Msf::Post::Windows::Accounts
 
   UAC_DISABLED = 0x02
-  USER_FIELDS = ['sAMAccountName', 'userAccountControl', 'lockoutTime', 'mail', 'primarygroupid', 'description'].freeze
+  USER_FIELDS = ['userPrincipalName',
+                 'sAMAccountName',
+                 'userAccountControl',
+                 'lockoutTime',
+                 'mail',
+                 'primarygroupid',
+                 'description'].freeze
 
   def initialize(info = {})
     super(update_info(
@@ -108,8 +114,8 @@ class Metasploit3 < Msf::Post
       end
 
       username = result.first[:value]
-      uac = result[1][:value]
-      lockout_time = result[2][:value]
+      uac = result[2][:value]
+      lockout_time = result[3][:value]
       store_username(username, uac, lockout_time, domain, domain_ip)
 
       results_table << row

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -41,6 +41,7 @@ class Metasploit3 < Msf::Post
       OptBool.new('STORE_LOOT', [true, 'Store file in loot.', false]),
       OptBool.new('EXCLUDE_LOCKED', [true, 'Exclude in search locked accounts..', false]),
       OptBool.new('EXCLUDE_DISABLED', [true, 'Exclude from search disabled accounts.', false]),
+      OptString.new('ADDITIONAL_FIELDS', [false, 'Additional fields to retrieve, comma sperated', nil]),
       OptEnum.new('UAC', [true, 'Filter on User Account Control Setting.', 'ANY',
                           [
                             'ANY',
@@ -54,10 +55,17 @@ class Metasploit3 < Msf::Post
   end
 
   def run
+    @user_fields = USER_FIELDS.dup
+
+    if datastore['ADDITIONAL_FIELDS']
+      additional_fields = datastore['ADDITIONAL_FIELDS'].gsub(/\s+/,"").split(',')
+      @user_fields.push(*additional_fields)
+    end
+
     max_search = datastore['MAX_SEARCH']
 
     begin
-      q = query(query_filter, max_search, USER_FIELDS)
+      q = query(query_filter, max_search, @user_fields)
     rescue ::RuntimeError, ::Rex::Post::Meterpreter::RequestError => e
       # Can't bind or in a network w/ limited accounts
       print_error(e.message)
@@ -99,7 +107,7 @@ class Metasploit3 < Msf::Post
       'Header'     => "Domain Users",
       'Indent'     => 1,
       'SortIndex'  => -1,
-      'Columns'    => USER_FIELDS
+      'Columns'    => @user_fields 
     )
 
     results.each do |result|
@@ -113,9 +121,9 @@ class Metasploit3 < Msf::Post
         end
       end
 
-      username = result[USER_FIELDS.index('sAMAccountName')][:value]
-      uac = result[USER_FIELDS.index('userAccountControl')][:value]
-      lockout_time = result[USER_FIELDS.index('lockoutTime')][:value]
+      username = result[@user_fields.index('sAMAccountName')][:value]
+      uac = result[@user_fields.index('userAccountControl')][:value]
+      lockout_time = result[@user_fields.index('lockoutTime')][:value]
       store_username(username, uac, lockout_time, domain, domain_ip)
 
       results_table << row

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -12,8 +12,8 @@ class Metasploit3 < Msf::Post
   include Msf::Post::Windows::Accounts
 
   UAC_DISABLED = 0x02
-  USER_FIELDS = ['userPrincipalName',
-                 'sAMAccountName',
+  USER_FIELDS = ['sAMAccountName',
+                 'userPrincipalName',
                  'userAccountControl',
                  'lockoutTime',
                  'mail',
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Post
         end
       end
 
-      username = result[USER_FIELDS.index('userPrincipalName')][:value]
+      username = result[USER_FIELDS.index('sAMAccountName')][:value]
       uac = result[USER_FIELDS.index('userAccountControl')][:value]
       lockout_time = result[USER_FIELDS.index('lockoutTime')][:value]
       store_username(username, uac, lockout_time, domain, domain_ip)

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Post
       OptBool.new('STORE_LOOT', [true, 'Store file in loot.', false]),
       OptBool.new('EXCLUDE_LOCKED', [true, 'Exclude in search locked accounts..', false]),
       OptBool.new('EXCLUDE_DISABLED', [true, 'Exclude from search disabled accounts.', false]),
-      OptString.new('ADDITIONAL_FIELDS', [false, 'Additional fields to retrieve, comma sperated', nil]),
+      OptString.new('ADDITIONAL_FIELDS', [false, 'Additional fields to retrieve, comma separated', nil]),
       OptEnum.new('UAC', [true, 'Filter on User Account Control Setting.', 'ANY',
                           [
                             'ANY',

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -113,9 +113,9 @@ class Metasploit3 < Msf::Post
         end
       end
 
-      username = result.first[:value]
-      uac = result[2][:value]
-      lockout_time = result[3][:value]
+      username = result[USER_FIELDS.index('userPrincipalName')][:value]
+      uac = result[USER_FIELDS.index('userAccountControl')][:value]
+      lockout_time = result[USER_FIELDS.index('lockoutTime')][:value]
       store_username(username, uac, lockout_time, domain, domain_ip)
 
       results_table << row

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Post
       'Header'     => "Domain Users",
       'Indent'     => 1,
       'SortIndex'  => -1,
-      'Columns'    => @user_fields 
+      'Columns'    => @user_fields
     )
 
     results.each do |result|


### PR DESCRIPTION
The sAMAccountName and userPrincipalName may not match, we should pull down both values. 

Allow the enum_ad_users module to pull down additional fields.
