### PR TITLE
Bump MDM and Credential

### DIFF
--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Metasploit::Credential database models
-  spec.add_runtime_dependency 'metasploit-credential', '~> 0.13.19'
+  spec.add_runtime_dependency 'metasploit-credential', '~> 0.13.20'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models', '~> 0.22.8'
+  spec.add_runtime_dependency 'metasploit_data_models', '~> 0.22.10'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code
   spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
   # Needed for module caching in Mdm::ModuleDetails


### PR DESCRIPTION
MSP-11994
Add vuln_id to Mdm::Note so we can add notes to vulns.

VERIFICATION STEPS
- [ ] LAND https://github.com/rapid7/metasploit-credential/pull/96
- [ ] `bundle install`
- [ ] `rake spec`
- [ ] VERIFY all specs pass
