### PR TITLE
Fix #4773, check nil for resolve_sid in user_profiles

### DIFF
--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -50,6 +50,7 @@ module UserProfiles
   def parse_profile(hive)
     profile={}
     sidinf = resolve_sid(hive['SID'].to_s)
+    return profile unless sidinf
     profile['UserName'] = sidinf[:name]
     profile['Domain'] = sidinf[:domain]
     profile['SID'] = hive['SID']


### PR DESCRIPTION
Fix #4773. The resolve_sid method may return nil, so parse_profile should check that.
## Testing

I think just by looking code it should be enough to prove parse_profile should do this.
- [ ] You should see that the resolve_sid method can return nil in multiple places: https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/post/windows/accounts.rb#L151
- [ ] Or if you want, you can run the firefox_creds post module and make sure it's in working condition like the following:

```
meterpreter > run post/multi/gather/firefox_creds 

[*] Determining session platform and type...
[*] Checking for Firefox directory in: C:\Users\sinn3r\AppData\Roaming\Mozilla\
[*] Found Firefox installed
[*] Locating Firefox Profiles...

[+] Found Profile 0620x3hk.default
[*] C:\Users\sinn3r\AppData\Roaming\Mozilla\.
[*] C:\Users\sinn3r\AppData\Roaming\Mozilla\Firefox\Profiles\0620x3hk.default
[+] Downloading cookies.sqlite file from: C:\Users\sinn3r\AppData\Roaming\Mozilla\Firefox\Profiles\0620x3hk.default
[+] Downloading cookies.sqlite-shm file from: C:\Users\sinn3r\AppData\Roaming\Mozilla\Firefox\Profiles\0620x3hk.default
[+] Downloading cookies.sqlite-wal file from: C:\Users\sinn3r\AppData\Roaming\Mozilla\Firefox\Profiles\0620x3hk.default
[+] Downloading key3.db file from: C:\Users\sinn3r\AppData\Roaming\Mozilla\Firefox\Profiles\0620x3hk.default
meterpreter >
```

@DrDinosaur, if you'd like, feel free to test this patch. The whole point of this patch is that you should no longer see the error described in #4773, but it's possible that the module won't be able to do much anyway. I am guessing with the patch you will probably see "No users found with a Firefox directory".
