### PR TITLE
fix #4669: stop the http service when the reverse http handler stops

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -172,11 +172,11 @@ module ReverseHttp
   end
 
   #
-  # Removes the / handler, possibly stopping the service if no sessions are
-  # active on sub-urls.
+  # Removes the / handler and stop the service.
   #
   def stop_handler
     self.service.remove_resource("/") if self.service
+    self.service.stop
   end
 
   attr_accessor :service # :nodoc:


### PR DESCRIPTION
fix #4669. There has always been a comment here that this stops the service if no sessions are active on sub-urls. However, I could not find evidence that was true - maybe I didn't know exactly where to look.

At any rate, this makes stop_handler stop the service as well.
# Verification steps:
- [x] Start a reverse_http / https payload handler in the foreground
- [x] Connect to it via telnet, http client, etc. - ensure the port is listening
- [x] Hit Ctrl-C to stop the handler
- [x] Existing connection should be disconnected, no more connections are allowed

See #4669 for an example:

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_http
payload => windows/meterpreter/reverse_http
msf exploit(handler) > set LHOST monkey.org
LHOST => monkey.org
msf exploit(handler) > run

[*] Started HTTP reverse handler on http://0.0.0.0:8080/
[*] Starting the payload handler...
^C[-] Exploit failed: Interrupt
[-] Exploit failed: closed stream
```

Meanwhile:

```
bcook@AUS-MAC:~$ telnet 127.0.0.1 8080
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
Connection closed by foreign host.
```
