### PR TITLE
fix #4337: handle resolve_sid failure enumerating user profiles

### DIFF
--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -49,9 +49,6 @@ module UserProfiles
   #
   def parse_profile(hive)
     profile={}
-    sidinf = resolve_sid(hive['SID'].to_s)
-    profile['UserName'] = sidinf[:name]
-    profile['Domain'] = sidinf[:domain]
     profile['SID'] = hive['SID']
     profile['ProfileDir'] = hive['PROF']
     profile['AppData'] = registry_getvaldata("#{hive['HKU']}\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders", 'AppData')
@@ -64,6 +61,12 @@ module UserProfiles
     profile['Cookies'] = registry_getvaldata("#{hive['HKU']}\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders", 'Cookies')
     profile['Temp'] = registry_getvaldata("#{hive['HKU']}\\Environment", 'TEMP').to_s.sub('%USERPROFILE%',profile['ProfileDir'])
     profile['Path'] = registry_getvaldata("#{hive['HKU']}\\Environment", 'PATH')
+
+    sidinf = resolve_sid(hive['SID'].to_s)
+    if sidinf
+      profile['UserName'] = sidinf[:name]
+      profile['Domain'] = sidinf[:domain]
+    end
 
     return profile
   end


### PR DESCRIPTION
fix #4337

Rather than throwing a backtrace with an unresolvable SID, try to get as
much profile data as possible if resolve_sid fails. Here is an example run with an unknown SID inserted in the hive:

```
--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -86,6 +86,7 @@ module UserProfiles
           print_error("Error loading USER #{hive['SID']}: Profile doesn't exist or cannot be accessed")
         end
       end
+      hive['SID'] = 'S-1-5-21-1235416723-3835986592-711878957-500'
       hives << hive
     end
     return hives
```

```
[*] Determining session platform and type...
[-] Unexpected windows error 1332
[*] Checking for Firefox directory in:
C:\Users\Administrator\AppData\Roaming\Mozilla\
[-] Firefox not found
[*] Post module execution completed
```

See #4779 for more info and discussion.
