### PR TITLE
Calls to Rex::Proto::Http::Client.new were passing in empty context

### DIFF
--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -17,7 +17,7 @@ module Metasploit
         # (see Base#attempt_login)
         def attempt_login(credential)
           http_client = Rex::Proto::Http::Client.new(
-            host, port, {}, ssl, ssl_version, proxies
+            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
           )
 
           http_client = config_client(http_client)

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -34,7 +34,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version)
             cli.connect
             req = cli.request_cgi({
               'method'=>'POST',

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -61,7 +61,7 @@ module Metasploit
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version, proxies)
+          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
           cli.connect
           req = cli.request_raw(opts)
           res = cli.send_recv(req)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -47,7 +47,7 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           http_client = Rex::Proto::Http::Client.new(
-            host, port, {}, ssl, ssl_version, proxies
+            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
           )
           request = http_client.request_cgi(
             'uri' => uri,

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -10,7 +10,7 @@ module Metasploit
         # (see Base#attempt_login)
         def attempt_login(credential)
           http_client = Rex::Proto::Http::Client.new(
-              host, port, {}, ssl, ssl_version, proxies
+              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
           )
 
           http_client = config_client(http_client)

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -33,7 +33,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version, proxies)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
             cli.connect
             req = cli.request_cgi({
               'method'=>'POST',

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -35,7 +35,7 @@ module Metasploit
           begin
             cred = Rex::Text.uri_encode(credential.private)
             body = "data%5BLogin%5D%5Bowner_name%5D=admin&data%5BLogin%5D%5Bowner_passwd%5D=#{cred}"
-            cli = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version)
             cli.connect
             req = cli.request_cgi(
               'method' => method,

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -33,7 +33,7 @@ module Metasploit
           res = nil
 
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version, proxies)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
             cli.connect
             req = cli.request_cgi(req_opts)
             res = cli.send_recv(req)

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -10,7 +10,7 @@ module Metasploit
         # (see Base#attempt_login)
         def attempt_login(credential)
           http_client = Rex::Proto::Http::Client.new(
-              host, port, {}, ssl, ssl_version, proxies
+              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
           )
 
           result_opts = {


### PR DESCRIPTION
Same issue as #4737, except this catches instances where Rex::Proto::Http::Client was used, which needs the context for when it creates its own sockets via Rex.
