### PR TITLE
Add support for newer Splunk versions

### DIFF
--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -154,24 +154,30 @@ class Metasploit3 < Msf::Auxiliary
           }
       })
 
-      if not res or res.code != 303
+      if not res
         vprint_error("FAILED LOGIN. '#{user}' : '#{pass}' with code #{res.code}")
         return :skip_pass
-      else
-        print_good("SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
-
-        report_hash = {
-          :host   => datastore['RHOST'],
-          :port   => datastore['RPORT'],
-          :sname  => 'splunk-web',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'}
-
-        report_auth_info(report_hash)
-        return :next_user
       end
+
+      unless res.code == 303 || (res.code == 200 && res.body.to_s.index('{"status":0}'))
+        vprint_error("FAILED LOGIN. '#{user}' : '#{pass}' with code #{res.code}")
+        return :skip_pass
+      end
+
+      print_good("SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
+
+      report_hash = {
+        :host   => datastore['RHOST'],
+        :port   => datastore['RPORT'],
+        :sname  => 'splunk-web',
+        :user   => user,
+        :pass   => pass,
+        :active => true,
+        :type => 'password'}
+
+      report_auth_info(report_hash)
+      return :next_user
+
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
       print_error("HTTP Connection Failed, Aborting")
       return :abort

--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -155,7 +155,7 @@ class Metasploit3 < Msf::Auxiliary
       })
 
       if not res
-        vprint_error("FAILED LOGIN. '#{user}' : '#{pass}' with code #{res.code}")
+        vprint_error("FAILED LOGIN. '#{user}' : '#{pass}' returned no response")
         return :skip_pass
       end
 


### PR DESCRIPTION
Prior to this change, Splunk version 6.2.1 would not successfully register a login with the default username 'admin' and password 'changeme'. This change is backwards compatible with older versions and a placeholder until we convert this into a LoginScanner module.

Fixed module:

```
msf auxiliary(splunk_web_login) > rerun 
[*] Reloading module...

[*] Checking if authentication is required...
[*] Brute-forcing...
[*] Trying username:'connect' with password:'connect'
[-] FAILED LOGIN. 'connect' : 'connect' with code 401
[*] Trying username:'sitecom' with password:'sitecom'
[-] FAILED LOGIN. 'sitecom' : 'sitecom' with code 401
[*] Trying username:'admin' with password:'1234'
[-] FAILED LOGIN. 'admin' : '1234' with code 401
[*] Trying username:'cisco' with password:'cisco'
[-] FAILED LOGIN. 'cisco' : 'cisco' with code 401
[*] Trying username:'cisco' with password:'sanfran'
[-] FAILED LOGIN. 'cisco' : 'sanfran' with code 401
[*] Trying username:'private' with password:'private'
[-] FAILED LOGIN. 'private' : 'private' with code 401
[*] Trying username:'wampp' with password:'xampp'
[-] FAILED LOGIN. 'wampp' : 'xampp' with code 401
[*] Trying username:'newuser' with password:'wampp'
[-] FAILED LOGIN. 'newuser' : 'wampp' with code 401
[*] Trying username:'xampp-dav-unsecure' with password:'ppmax2011'
[-] FAILED LOGIN. 'xampp-dav-unsecure' : 'ppmax2011' with code 401
[*] Trying username:'admin' with password:'turnkey'
[-] FAILED LOGIN. 'admin' : 'turnkey' with code 401
[*] Trying username:'admin' with password:'changeme'
[+] SUCCESSFUL LOGIN. 'admin' : 'changeme'
[-] *** auxiliary/scanner/http/splunk_web_login is still calling the deprecated report_auth_info method! This needs to be updated!
^C
```
