### PR TITLE
Update for f5_bigip_cookie_disclosure module

### DIFF
--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       'Author'         => [ 'Thanat0s <thanspam[at]trollprod.org>', 
                             'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
                             'Nikita Oleksov <neoleksov[at]gmail.com>',
-							'Denis Kolegov <dnkolegov[at]gmail.com>'
+			    'Denis Kolegov <dnkolegov[at]gmail.com>'
                           ],
       'References'     =>
         [
@@ -121,7 +121,7 @@ class Metasploit3 < Msf::Auxiliary
 
       # Print the cookie name on the first request
       if i == 0
-        print_status("#{peer} - F5 BigIP load balancing cookie \"#{cookie[:id]}\" found")
+        print_status("#{peer} - F5 BigIP load balancing cookie \"#{cookie[:id]} = #{cookie[:value]}\" found")
 	if cookie[:id].start_with?('BIGipServer')
 	  print_status("#{peer} - Load balancing pool name \"#{cookie[:id].split('BIGipServer')[1]}\" found")
 	end

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -16,12 +16,11 @@ class Metasploit3 < Msf::Auxiliary
       'Description'    => %q{
         This module identifies F5 BigIP load balancers and leaks backend
         information (pool name, backend's IP address and port, routed domain) through cookies inserted by the BigIP system.
-	
       },
       'Author'         => [ 'Thanat0s <thanspam[at]trollprod.org>', 
                             'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
                             'Nikita Oleksov <neoleksov[at]gmail.com>',
-			    'Denis Kolegov <dnkolegov[at]gmail.com>'
+                            'Denis Kolegov <dnkolegov[at]gmail.com>'
                           ],
       'References'     =>
         [
@@ -122,15 +121,15 @@ class Metasploit3 < Msf::Auxiliary
       # Print the cookie name on the first request
       if i == 0
         print_status("#{peer} - F5 BigIP load balancing cookie \"#{cookie[:id]} = #{cookie[:value]}\" found")
-	if cookie[:id].start_with?('BIGipServer')
-	  print_status("#{peer} - Load balancing pool name \"#{cookie[:id].split('BIGipServer')[1]}\" found")
-	end
-	if cookie[:value].start_with?('rd')
-	  print_status("#{peer} - Route domain \"#{cookie[:value].split('rd')[1].split('o')[0]}\" found")
-	end
+        if cookie[:id].start_with?('BIGipServer')
+          print_status("#{peer} - Load balancing pool name \"#{cookie[:id].split('BIGipServer')[1]}\" found")
+        end
+        if cookie[:value].start_with?('rd')
+          print_status("#{peer} - Route domain \"#{cookie[:value].split('rd')[1].split('o')[0]}\" found")
+        end
         if cookie[:value].start_with?('!')
-	  print_status("#{peer} - F5 BigIP cookie is probably encrypted") 		
-	end
+          print_status("#{peer} - F5 BigIP cookie is probably encrypted") 		
+        end
       end
 
       back_end = cookie_decode(cookie[:value])
@@ -150,5 +149,4 @@ class Metasploit3 < Msf::Auxiliary
     end
 
   end
-end 
-
+end

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       'Author'         => [ 'Thanat0s <thanspam[at]trollprod.org>', 
                             'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
                             'Nikita Oleksov <neoleksov[at]gmail.com>',
-			    'Denis Kolegov <dnkolegov[at]gmail.com>'
+							'Denis Kolegov <dnkolegov[at]gmail.com>'
                           ],
       'References'     =>
         [
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Auxiliary
       # 4. IPv6 pool members in non-default route domains - "BIGipServerWEB=rd3o20010112000000000000000000000030o80",
       # 5. Encrypted cookies - "BIGipServerWEB=!dcdlUciYEFlt1QzXtD7QKx22XJx7Uuj2I0dYdFTwJASsJyJySME9/GACjztr7WYJIvHxTSNreeve7foossGzKS3vT9ECJscSg1LAc3rc"
 
-      m = res.get_cookies.match(/([\-\w\d]+)=(((?:\d+\.){2}\d+)|(rd\d+o0{20}f{4}\w+o\d{1,5})|(vi([a-f0-9]{32})\.(\d{1,5}))|(rd\d+o([a-f0-9]{32})o(\d{1,5}))|(!(.){104}))(?:$|,|;|\s)/)
+      m = res.get_cookies.match(/([~_\.\-\w\d]+)=(((?:\d+\.){2}\d+)|(rd\d+o0{20}f{4}\w+o\d{1,5})|(vi([a-f0-9]{32})\.(\d{1,5}))|(rd\d+o([a-f0-9]{32})o(\d{1,5}))|(!(.){104}))(?:$|,|;|\s)/)
       cookie[:id] = (m.nil?) ? nil : m[1]
       cookie[:value] = (m.nil?) ? nil : m[2]
 

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -15,9 +15,14 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'F5 BigIP Backend Cookie Disclosure',
       'Description'    => %q{
         This module identifies F5 BigIP load balancers and leaks backend
-        information through cookies inserted by the BigIP devices.
+        information (pool name, backend's IP address and port, routed domain) through cookies inserted by the BigIP system.
+	
       },
-      'Author'         => [ 'Thanat0s <thanspam[at]trollprod.org>' ],
+      'Author'         => [ 'Thanat0s <thanspam[at]trollprod.org>', 
+                            'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
+                            'Nikita Oleksov <neoleksov[at]gmail.com>',
+			    'Denis Kolegov <dnkolegov[at]gmail.com>'
+                          ],
       'References'     =>
         [
           ['URL', 'http://support.f5.com/kb/en-us/solutions/public/6000/900/sol6917.html'],
@@ -34,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def change_endianness(value, size=4)
-    conversion = value
+    conversion = nil
 
     if size == 4
       conversion = [value].pack("V").unpack("N").first
@@ -46,21 +51,30 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def cookie_decode(cookie_value)
-    back_end = ""
-
-    if cookie_value =~ /(\d{8})\.(\d{5})\./
+    if cookie_value =~ /(\d{8,10})\.(\d{1,5})\./
       host = $1.to_i
       port = $2.to_i
-
       host = change_endianness(host)
       host = Rex::Socket.addr_itoa(host)
-
       port = change_endianness(port, 2)
-
-      back_end = "#{host}:#{port}"
+    elsif cookie_value.downcase =~ /rd\d+o0{20}f{4}([a-f0-9]{8})o(\d{1,5})/
+      host = $1.to_i(16)
+      port = $2.to_i
+      host = Rex::Socket.addr_itoa(host)
+    elsif cookie_value.downcase =~ /vi([a-f0-9]{32})\.(\d{1,5})/
+      host = $1.to_i(16)
+      port = $2.to_i
+      host = Rex::Socket.addr_itoa(host, v6=true)
+      port = change_endianness(port, 2)
+    elsif cookie_value.downcase =~ /rd\d+o([a-f0-9]{32})o(\d{1,5})/
+      host = $1.to_i(16)
+      port = $2.to_i
+      host = Rex::Socket.addr_itoa(host, v6=true)
+    elsif cookie_value =~ /!(.){104}/
+      host = nil
+      port = nil
     end
-
-    back_end
+    back_end = (host.nil?) ? nil : "#{host}:#{port}" 
   end
 
   def get_cookie # request a page and extract a F5 looking cookie.
@@ -71,13 +85,17 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     unless res.nil?
-      # Get the SLB session ID, like "TestCookie=2263487148.3013.0000"
-      m = res.get_cookies.match(/([\-\w\d]+)=((?:\d+\.){2}\d+)(?:$|,|;|\s)/)
-      unless m.nil?
-        cookie[:id] = (m.nil?) ? nil : m[1]
-        cookie[:value] = (m.nil?) ? nil : m[2]
-      end
-    end
+      # Get the SLB session IDs for all cases, like
+      # IPv4 pool members - "BIGipServerWEB=2263487148.3013.0000",
+      # IPv4 pool members in non-default routed domains - "BIGipServerWEB=rd5o00000000000000000000ffffc0000201o80",
+      # IPv6 pool members - "BIGipServerWEB=vi20010112000000000000000000000030.20480",
+      # IPv6 pool members in non-default route domains - "BIGipServerWEB=rd3o20010112000000000000000000000030o80",
+      # Encrypted cookies - "BIGipServerWEB=!dcdlUciYEFlt1QzXtD7QKx22XJx7Uuj2I0dYdFTwJASsJyJySME9/GACjztr7WYJIvHxTSNreeve7foossGzKS3vT9ECJscSg1LAc3rc"
+      m = res.get_cookies.match(/([\-\w\d]+)=(((?:\d+\.){2}\d+)|(rd\d+o0{20}f{4}\w+o\d{1,5})|(vi([a-f0-9]{32})\.(\d{1,5}))|(rd\d+o([a-f0-9]{32})o(\d{1,5}))|(!(.){104}))(?:$|,|;|\s)/)
+      cookie[:id] = (m.nil?) ? nil : m[1]
+      cookie[:value] = (m.nil?) ? nil : m[2]
+
+   end
 
     cookie
   end
@@ -97,16 +115,25 @@ class Metasploit3 < Msf::Auxiliary
       # If the cookie is not found, stop process
       if cookie.empty? || cookie[:id].nil?
         print_error("#{peer} - F5 Server load balancing cookie not found")
-        break
+          break
       end
 
       # Print the cookie name on the first request
       if i == 0
-        print_status("#{peer} - F5 Server load balancing cookie \"#{cookie[:id]}\" found")
+        print_status("#{peer} - F5 BigIP load balancing cookie \"#{cookie[:id]}\" found")
+	if cookie[:id].start_with?('BIGipServer')
+	  print_status("#{peer} - Load balancing pool name \"#{cookie[:id].split('BIGipServer')[1]}\" found")
+	end
+	if cookie[:value].start_with?('rd')
+	  print_status("#{peer} - Route domain \"#{cookie[:value].split('rd')[1].split('o')[0]}\" found")
+	end
+        if cookie[:id].start_with?('BIGipServer') and cookie[:value].start_with?('!')
+	  print_status("#{peer} - BigIP cookie is probably encrypted") 		
+	end
       end
 
       back_end = cookie_decode(cookie[:value])
-      unless back_ends.include?(back_end)
+      unless back_end.nil? || back_ends.include?(back_end)
         print_status("#{peer} - Backend #{back_end} found")
         back_ends.push(back_end)
       end
@@ -122,4 +149,5 @@ class Metasploit3 < Msf::Auxiliary
     end
 
   end
-end
+end 
+

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Auxiliary
         This module identifies F5 BigIP load balancers and leaks backend
         information (pool name, backend's IP address and port, routed domain) through cookies inserted by the BigIP system.
       },
-      'Author'         => [ 'Thanat0s <thanspam[at]trollprod.org>', 
+      'Author'         => [ 'Thanat0s <thanspam[at]trollprod.org>',
                             'Oleg Broslavsky <ovbroslavsky[at]gmail.com>',
                             'Nikita Oleksov <neoleksov[at]gmail.com>',
                             'Denis Kolegov <dnkolegov[at]gmail.com>'
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Auxiliary
       host = nil
       port = nil
     end
-    back_end = (host.nil?) ? nil : "#{host}:#{port}" 
+    back_end = (host.nil?) ? nil : "#{host}:#{port}"
   end
 
   def get_cookie # request a page and extract a F5 looking cookie.
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Auxiliary
           print_status("#{peer} - Route domain \"#{cookie[:value].split('rd')[1].split('o')[0]}\" found")
         end
         if cookie[:value].start_with?('!')
-          print_status("#{peer} - F5 BigIP cookie is probably encrypted") 		
+          print_status("#{peer} - F5 BigIP cookie is probably encrypted")
         end
       end
 

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -85,12 +85,13 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     unless res.nil?
-      # Get the SLB session IDs for all cases, like
-      # IPv4 pool members - "BIGipServerWEB=2263487148.3013.0000",
-      # IPv4 pool members in non-default routed domains - "BIGipServerWEB=rd5o00000000000000000000ffffc0000201o80",
-      # IPv6 pool members - "BIGipServerWEB=vi20010112000000000000000000000030.20480",
-      # IPv6 pool members in non-default route domains - "BIGipServerWEB=rd3o20010112000000000000000000000030o80",
-      # Encrypted cookies - "BIGipServerWEB=!dcdlUciYEFlt1QzXtD7QKx22XJx7Uuj2I0dYdFTwJASsJyJySME9/GACjztr7WYJIvHxTSNreeve7foossGzKS3vT9ECJscSg1LAc3rc"
+      # Get the SLB session IDs for all cases:
+      # 1. IPv4 pool members - "BIGipServerWEB=2263487148.3013.0000",
+      # 2. IPv4 pool members in non-default routed domains - "BIGipServerWEB=rd5o00000000000000000000ffffc0000201o80",
+      # 3. IPv6 pool members - "BIGipServerWEB=vi20010112000000000000000000000030.20480",
+      # 4. IPv6 pool members in non-default route domains - "BIGipServerWEB=rd3o20010112000000000000000000000030o80",
+      # 5. Encrypted cookies - "BIGipServerWEB=!dcdlUciYEFlt1QzXtD7QKx22XJx7Uuj2I0dYdFTwJASsJyJySME9/GACjztr7WYJIvHxTSNreeve7foossGzKS3vT9ECJscSg1LAc3rc"
+
       m = res.get_cookies.match(/([\-\w\d]+)=(((?:\d+\.){2}\d+)|(rd\d+o0{20}f{4}\w+o\d{1,5})|(vi([a-f0-9]{32})\.(\d{1,5}))|(rd\d+o([a-f0-9]{32})o(\d{1,5}))|(!(.){104}))(?:$|,|;|\s)/)
       cookie[:id] = (m.nil?) ? nil : m[1]
       cookie[:value] = (m.nil?) ? nil : m[2]
@@ -114,7 +115,7 @@ class Metasploit3 < Msf::Auxiliary
       cookie = get_cookie() # Get the cookie
       # If the cookie is not found, stop process
       if cookie.empty? || cookie[:id].nil?
-        print_error("#{peer} - F5 Server load balancing cookie not found")
+        print_error("#{peer} - F5 BigIP load balancing cookie not found")
           break
       end
 
@@ -127,8 +128,8 @@ class Metasploit3 < Msf::Auxiliary
 	if cookie[:value].start_with?('rd')
 	  print_status("#{peer} - Route domain \"#{cookie[:value].split('rd')[1].split('o')[0]}\" found")
 	end
-        if cookie[:id].start_with?('BIGipServer') and cookie[:value].start_with?('!')
-	  print_status("#{peer} - BigIP cookie is probably encrypted") 		
+        if cookie[:value].start_with?('!')
+	  print_status("#{peer} - F5 BigIP cookie is probably encrypted") 		
 	end
       end
 


### PR DESCRIPTION
f5_bigip_cookie_disclosure module was updated.

The old version of f5_bigip_cookie_disclosure module contains errors and does not considers all possible cases for BigIP persistence cookie. It decodes only IPv4 pool members cookie.

The following features were added:
- Correct IPv4 pool members cookie decoding 
- Decoding of IPv6 pool members cookie  
- Decoding of IPv4 pool members in non-default route domains cookie
- Decoding of IPv6 pool members in non-default route domains cookie
- Detecting of encrypted cookie value
- Detecting of BigIP persistence cookie with non-default name
- Routed domain retrieving from cookie value
- Backend pool name retrieving from cookie value

Authors:
- Oleg Broslavsky(@ovbroslavsky)
- Nikita Oleksov(@neoleksov)
- Denis Kolegov (@dnkolegov)

Links:
- [SOL6917: Overview of BIG-IP persistence cookie encoding](https://support.f5.com/kb/en-us/solutions/public/6000/900/sol6917.html)
