### PR TITLE
Fix #4783 - Handle incompatible payload architecture in BrowserExploitServer

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -20,6 +20,8 @@ require 'msf/core/exploit/jsobfu'
 module Msf
   module Exploit::Remote::BrowserExploitServer
 
+    class BESException < RuntimeError; end
+
     include Msf::Exploit::Remote::HttpServer::HTML
     include Msf::Exploit::RopDb
     include Msf::Exploit::JSObfu
@@ -521,7 +523,13 @@ module Msf
           try_set_target(profile)
           bad_reqs = get_bad_requirements(profile)
           if bad_reqs.empty?
-            method(:on_request_exploit).call(cli, request, profile)
+            begin
+              method(:on_request_exploit).call(cli, request, profile)
+            rescue BESException => e
+              elog("BESException: #{e.message}\n#{e.backtrace * "\n"}")
+              send_not_found(cli)
+              print_error("BESException: #{e.message}")
+            end
           else
             print_warning("Exploit requirement(s) not met: #{bad_reqs * ', '}. For more info: http://r-7.co/PVbcgx")
             if bad_reqs.include?(:vuln_test)
@@ -586,7 +594,15 @@ module Msf
       platform = platform.gsub(/^Mac OS X$/, 'OSX')
       platform = platform.gsub(/^Windows.*$/, 'Windows')
 
-      regenerate_payload(cli, platform, arch).encoded
+      p = regenerate_payload(cli, platform, arch)
+
+      unless p.arch.include?(arch)
+        err =  "The payload arch (#{p.arch * ", "}) is incompatible with the #{arch} target. "
+        err << "Please check your payload setting."
+        raise BESException, err
+      end
+
+      return p.encoded
     end
 
     # @return [String] custom Javascript to check if a vulnerability is present

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -4,7 +4,7 @@ require 'msf/core'
 describe Msf::Exploit::Remote::BrowserExploitServer do
 
   subject(:server) do
-    mod = Msf::Exploit.allocate
+    mod = Msf::Exploit::Remote.allocate
     mod.extend described_class
     mod.send(:initialize, {})
     mod
@@ -17,6 +17,10 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     service
   end
 
+  let(:expected_user_agent) do
+    'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'
+  end
+
   let(:profile_name) do
     'random'
   end
@@ -25,26 +29,22 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     'linux'
   end
 
-  let(:expected_user_agent) do
-    'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'
-  end
-
   let(:exploit_page) do
     server.instance_variable_get(:@exploit_receiver_page)
   end
 
   let(:expected_profile) do
     {
-      :source=>'script',
-      :os_name=>'Windows XP',
-      :ua_name=>'MSIE',
-      :ua_ver=>'8.0',
-      :arch=>'x86',
-      :office=>'null',
-      :activex=>'true',
-      :proxy=>false,
-      :language=>'en-us',
-      :tried=>true
+      :source   =>'script',
+      :os_name  =>'Windows XP',
+      :ua_name  =>'MSIE',
+      :ua_ver   =>'8.0',
+      :arch     =>'x86',
+      :office   =>'null',
+      :activex  =>'true',
+      :proxy    =>false,
+      :language =>'en-us',
+      :tried    => true
     }
   end
 
@@ -296,6 +296,43 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
         server.on_request_uri(cli, request)
       end
     end
+
+
+  describe '#get_payload' do
+    let(:cli) {
+      Rex::Socket::Tcp
+    }
+
+    before(:each) do
+      allow(cli).to receive(:peerhost).and_return('0.0.0.0')
+      allow(cli).to receive(:peerport).and_return(4444)
+    end
+
+    let(:encoded) { '@EXE@' }
+
+    let(:x86_payload) {
+      double(:encoded => encoded, :arch => ['x86'])
+    }
+
+    let(:x86_64_payload) {
+      double(:encoded => encoded, :arch => ['x86_64'])
+    }
+
+    context 'when the payload supports the visitor\'s browser architecture' do
+      it 'returns a payload' do
+        allow(server).to receive(:regenerate_payload).and_return(x86_payload)
+        expect(server.get_payload(cli, expected_profile)).to eq(encoded)
+      end
+    end
+
+    context 'when the payload does not support the visitor\'s browser architecture'  do
+      it 'raises a BESException' do
+        allow(server).to receive(:regenerate_payload).and_return(x86_64_payload)
+        expect{server.get_payload(cli, expected_profile)}.to raise_error(Msf::Exploit::Remote::BrowserExploitServer::BESException)
+      end
+    end
+  end
+
   end
 
 end


### PR DESCRIPTION
This patch fixes #4783, an issue with how sometimes the payload's architecture is incompatible with the one chosen by the user. Instead of letting the exploit crash due to this kind of scenario, BES should raise an exception warning the user about the problem, and then send a 404 to the target machine.
## To verify

Here's a test module you can try:
https://gist.github.com/wchen-r7/6cb1aaa6ac9e01810098
- [x] Set up a x86 Windows XP for testing
- [x] Let's put this test module in modules/exploits/windows/browser/test.rb
- [x] Start msfconsole
- [x] Do `use exploit/windows/browser/test`
- [x] Do `set payload windows/x64/meterpreter/bind_tcp`
- [x] Do `run`, and that should start the exploit
- [x] On the XP box, go to the URL the exploit gave you
- [x] On msfconsole, you should see this error: "BESException: The payload arch (x86_64) is incompatible with the x86 target. Please check your payload setting."
- [x] On the browser, you should also see "webpage cannot be found." This is the fake 404 sent by the mixin.

Now, another try. This time with the correct payload setting:
- [x] Do: `jobs -K` to kill the exploit
- [x] Do: `set payload windows/meterpreter/bind_tcp`
- [x] Do: `run`
- [x] On the XP box, go to the URL the exploit gave you
- [x] On the browser, you should see an "OK".

And finally:
- [x] Make sure Travis is green.
