### PR TITLE
the http service needs to keep running to handle meterpreter loading

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -172,11 +172,11 @@ module ReverseHttp
   end
 
   #
-  # Removes the / handler and stop the service.
+  # Removes the / handler, possibly stopping the service if no sessions are
+  # active on sub-urls.
   #
   def stop_handler
     self.service.remove_resource("/") if self.service
-    self.service.stop
   end
 
   attr_accessor :service # :nodoc:


### PR DESCRIPTION
revert a8f44ca68f9ab4eb237c1fe57416a1a731b97f27

see #4669 

While it seems that stopping the http service when the stop_handler is called would work, the stop handler is actually called multiple times while meterpreter/reverse_http is loading.  We really need to determine why this is before we can safely stop the service.

Found running my meterpreter regression tests, which I hope to have automated at some point soon!
