### PR TITLE
Added a new pair of default Tomcat credentials. 

### DIFF
--- a/data/wordlists/tomcat_mgr_default_userpass.txt
+++ b/data/wordlists/tomcat_mgr_default_userpass.txt
@@ -5,3 +5,4 @@ root owaspbwa
 ADMIN ADMIN
 xampp xampp
 tomcat s3cret
+QCC QLogic66


### PR DESCRIPTION
QLogic's QConvergeConsole comes with a bundled Tomcat with a hard-coded username and password for the manager app. There is no option to change this during the installation. The Tomcat manager application is also installed at the same time and listening on 8080/tcp. Tested with QCC 5.1.0.167 running on Windows, other versions may be affected as well.
