### PR TITLE
Use version 0.3.0 of jsobfu 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 3.2.21, < 4.0.0)
       activesupport (>= 3.2.21, < 4.0.0)
       bcrypt
-      jsobfu (~> 0.2.0)
+      jsobfu (~> 0.3.0)
       json
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.29.0)
@@ -103,7 +103,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.11)
     journey (1.0.4)
-    jsobfu (0.2.1)
+    jsobfu (0.3.0)
       rkelly-remix (= 0.0.6)
     json (1.8.1)
     mail (2.5.4)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.2.0'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.3.0'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks


### PR DESCRIPTION
After land https://github.com/rapid7/jsobfu/pull/9 we need to upgrade the jsobfu used on framework in order to benefit of :memory_sensitive obfuscation.
## Verification
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY all specs pass
- [ ] Feel free to test any module using JSObfu (several browser modules do) and verify which the exploit is running as in master.
