### PR TITLE
Fix EXE::Custom

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -48,7 +48,7 @@ module Exploit::EXE
   end
 
   def generate_payload_exe(opts = {})
-    return get_custom_exe if datastore.include? 'EXE::Custom'
+    return get_custom_exe unless datastore['EXE::Custom'].to_s.empty?
     return get_eicar_exe if datastore['EXE::EICAR']
 
     exe_init_options(opts)
@@ -73,7 +73,7 @@ module Exploit::EXE
   end
 
   def generate_payload_exe_service(opts = {})
-    return get_custom_exe if datastore.include? 'EXE::Custom'
+    return get_custom_exe unless datastore['EXE::Custom'].to_s.empty?
     return get_eicar_exe if datastore['EXE::EICAR']
 
     exe_init_options(opts)
@@ -96,7 +96,7 @@ module Exploit::EXE
   end
 
   def generate_payload_dll(opts = {})
-    return get_custom_exe if datastore.include? 'EXE::Custom'
+    return get_custom_exe unless datastore['EXE::Custom'].to_s.empty?
     return get_eicar_exe if datastore['EXE::EICAR']
 
     exe_init_options(opts)
@@ -125,7 +125,7 @@ module Exploit::EXE
   end
 
   def generate_payload_msi(opts = {})
-    return get_custom_exe(datastore['MSI::Custom']) if datastore.include? 'MSI::Custom'
+    return get_custom_exe(datastore['MSI::Custom']) unless datastore['MSI::Custom'].to_s.empty?
     return get_eicar_exe if datastore['MSI::EICAR']
 
     exe = generate_payload_exe(opts)


### PR DESCRIPTION
Exploit::EXE methods check if the `datastore.include? 'EXE::Custom'`. This is a case insensitive check. However `EXE::Custom` will be instantiated within the datastore depending on the case the user uses when they first `set` the value.

Output from datastore.inspect...
- First run of psexec without setting EXE::Custom - note EXE::Custom isn't there?! This seems like a separate issue...

```
"LHOST"=>"192.168.5.101", "CPORT"=>0, "EXE::EICAR"=>false, "EXE::Inject"=>false, "EXE::OldMethod"=>false, "EXE::FallBack"=>false, "MSI::EICAR"=>false, "MSI::UAC"=>false, "LPORT"=>4444,
```
- Second run of psexec when setting EXE::Custom:

```
EXE::Custom => /tmp/payload.dll

 "LHOST"=>"192.168.5.101", "EXE::Custom"=>"/tmp/payload.dll", "CPORT"=>0, "EXE::EICAR"=>false, "EXE::Inject"=>false, "EXE::OldMethod"=>false, "EXE::FallBack"=>false, "MSI::EICAR"=>false, "MSI::UAC"=>false, "LPORT"=>4444,
```
- Restart msfconsole
- Third run of psexec when setting EXE::CUSTOM (note case):

```
EXE::CUSTOM => /tmp/payload.dll

 "EXE::CUSTOM"=>"/tmp/payload.dll", "PAYLOAD"=>"windows/meterpreter/reverse_tcp", "LHOST"=>"192.168.153.142", "RHOST"=>"192.168.5.100", "CPORT"=>0, "EXE::EICAR"=>false, "EXE::Inject"=>false, "EXE::OldMethod"=>false, "EXE::FallBack"=>false, "MSI::EICAR"=>false, "MSI::UAC"=>false, "LPORT"=>4444,
```
## Verification
- [x] psexec runs as normal
- [x] set EXE::CUSTOM - a custom executable is delivered
- [x] unset EXE::CUSTOM - psexec runs as normal
- [x] set exe::custom - a custom executable is delivered
- [x] unset exe::custom - psexec runs as normal
- [x] set EXE::Custom "" - psexec runs as normal
