### PR TITLE
Fix #4382, Make errors more meaningful

### DIFF
--- a/lib/rex/elfparsey/exceptions.rb
+++ b/lib/rex/elfparsey/exceptions.rb
@@ -18,7 +18,7 @@ end
 class BoundsError < ElfError
 end
 
-class WtfError < ElfError
+class ElfParseyError < ElfError
 end
 
 end

--- a/lib/rex/elfscan/scanner.rb
+++ b/lib/rex/elfscan/scanner.rb
@@ -94,7 +94,7 @@ class JmpRegScanner < Generic
         return 3
     end
 
-    raise "wtf"
+    raise "Cannot read at offset: #{offset}"
   end
 
   def _parse_ret(data)
@@ -136,7 +136,7 @@ class JmpRegScanner < Generic
           message = "push #{regname}; " + _parse_ret(elf.read(offset+2, retsize))
           offset += 2 + retsize
         else
-          raise "wtf"
+          raise "Unexpected value at #{offset}"
         end
       else
         regname = Rex::Arch::X86.reg_name32(byte1 & 0x7)

--- a/lib/rex/machparsey/exceptions.rb
+++ b/lib/rex/machparsey/exceptions.rb
@@ -18,9 +18,6 @@ end
 class BoundsError < MachError
 end
 
-#class WtfError < MachError
-#end
-
 class FatError < ::RuntimeError
 end
 

--- a/lib/rex/machscan/scanner.rb
+++ b/lib/rex/machscan/scanner.rb
@@ -125,7 +125,7 @@ class JmpRegScanner < Generic
             message = "push #{regname}; " + _parse_ret(mach.read(offset+2, retsize))
             offset += 2 + retsize
         else
-            raise "wtf"
+            raise "Unexpected value at offset: #{offset}"
         end
       else
         regname = Rex::Arch::X86.reg_name32(byte1 & 0x7)

--- a/lib/rex/peparsey/exceptions.rb
+++ b/lib/rex/peparsey/exceptions.rb
@@ -21,7 +21,7 @@ end
 class BoundsError < PeError
 end
 
-class WtfError < PeError
+class PeParseyError < PeError
 end
 
 class SkipError < PeError

--- a/lib/rex/peparsey/pebase.rb
+++ b/lib/rex/peparsey/pebase.rb
@@ -1196,7 +1196,7 @@ class PeBase
         return section.rva_to_file_offset(rva)
       end
     end
-    raise WtfError, "wtf!", caller
+    raise PeParseyError, "No section contains RVA", caller
   end
 
   def vma_to_file_offset(vma)
@@ -1205,7 +1205,7 @@ class PeBase
 
   def file_offset_to_rva(foffset)
     if foffset < 0
-      raise WtfError, "lame", caller
+      raise PeParseyError, "Offset should not be less than 0. The value is: #{foffset}", caller
     end
 
     all_sections.each do |section|
@@ -1214,7 +1214,7 @@ class PeBase
       end
     end
 
-    raise WtfError, "wtf! #{foffset}", caller
+    raise PeParseyError, "No section contains file offset #{foffset}", caller
   end
 
   def file_offset_to_vma(foffset)
@@ -1245,7 +1245,7 @@ class PeBase
     section = _find_section_by_rva(rva)
 
     if !section
-      raise WtfError, "Cannot find rva! #{rva}", caller
+      raise PeParseyError, "Cannot find rva! #{rva}", caller
     end
 
     return section

--- a/lib/rex/pescan/search.rb
+++ b/lib/rex/pescan/search.rb
@@ -30,7 +30,7 @@ module Search
 
       begin
         buf = pe.read_rva(@address, suf)
-      rescue ::Rex::PeParsey::WtfError
+      rescue ::Rex::PeParsey::PeParseyError
         return
       end
 


### PR DESCRIPTION
Fix #4382

This patch changes some of error classes and messages to make them more meaningful.

You can test these parsers by running the msfbinscan utility. Do:
- [x] msfbinscan a pe file
- [x] msfbinscan an elf file
