### PR TITLE
Fix #3982, allow URIs to be user configurable

### DIFF
--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -21,7 +21,7 @@ module Metasploit
 
           req_opts = {
             'method' => 'POST',
-            'uri'    => '/proxy/ssllogin',
+            'uri'    => uri,
             'vars_post' => {
               'redirecturl'         => '',
               'redirectquerystring' => '',

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -32,6 +32,13 @@ class Metasploit3 < Msf::Auxiliary
           'PASS_FILE' => File.join(Msf::Config.data_directory, "wordlists", "unix_passwords.txt")
         }
     ))
+
+    register_advanced_options([
+      OptString.new('LOGIN_URL', [true, 'The URL that handles the login process', '/proxy/ssllogin']),
+      OptString.new('CPQLOGIN', [true, 'The homepage of the login', '/cpqlogin.htm']),
+      OptString.new('LOGIN_REDIRECT', true, 'The URL to redirect to', '/cpqlogin')
+
+    ], self.class)
   end
 
   def get_version(res)
@@ -78,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
     @scanner = Metasploit::Framework::LoginScanner::Smh.new(
       host:               ip,
       port:               rport,
-      uri:                datastore['URI'],
+      uri:                datastore['LOGIN_URL'],
       proxies:            datastore["PROXIES"],
       cred_details:       @cred_collection,
       stop_on_success:    datastore['STOP_ON_SUCCESS'],
@@ -163,10 +170,10 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
     res = send_request_cgi({
-      'uri' => '/cpqlogin.htm',
+      'uri' => datastore['CPQLOGIN'],
       'method' => 'GET',
       'vars_get' => {
-        'RedirectUrl' => '/cpqlogin',
+        'RedirectUrl' => datastore['LOGIN_REDIRECT'],
         'RedirectQueryString' => ''
       }
     })

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Auxiliary
     register_advanced_options([
       OptString.new('LOGIN_URL', [true, 'The URL that handles the login process', '/proxy/ssllogin']),
       OptString.new('CPQLOGIN', [true, 'The homepage of the login', '/cpqlogin.htm']),
-      OptString.new('LOGIN_REDIRECT', true, 'The URL to redirect to', '/cpqlogin')
+      OptString.new('LOGIN_REDIRECT', [true, 'The URL to redirect to', '/cpqlogin'])
 
     ], self.class)
   end

--- a/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
@@ -55,7 +55,7 @@ describe Metasploit::Framework::LoginScanner::Smh do
       before :each do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
 
-          if req.opts['uri'] && req.opts['uri'].include?('/proxy/ssllogin') &&
+          if req.opts['uri'] &&
               req.opts['vars_post'] &&
               req.opts['vars_post']['user'] &&
               req.opts['vars_post']['user'] == username &&


### PR DESCRIPTION
Fix #3982 

This patch allows the URIs to be user configurable for hp_sys_mgmt_login.rb.
## For testing:
- [x] Start msfconsole
- [x] Do `use auxiliary/scanner/http/hp_sys_mgmt_login`
- [x] Do `show advanced`
- [x] You should see option LOGIN_URL, CPQLOGIN, LOGIN_REDIRECT

If you'd like additional testing, you can do:
- [ ] Set up a Windows Server 2003 box
- [ ] Download the software: http://www8.hp.com/us/en/products/server-software/product-detail.html?oid=344313
- [ ] Install it
- [ ] Make sure you know your username/password
- [ ] Try the module. When successful, it should say "Successful login"
