### PR TITLE
Fix #4458, more informative errors for ms04_011

### DIFF
--- a/modules/exploits/windows/ssl/ms04_011_pct.rb
+++ b/modules/exploits/windows/ssl/ms04_011_pct.rb
@@ -112,7 +112,12 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    connect
+    begin
+      connect
+    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused => e
+      print_error("Cannot connect: #{e.message}")
+      return
+    end
 
     print_status("Trying target #{target.name} with proto #{datastore['PROTO']}...")
 
@@ -133,22 +138,51 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Connect to a SMTP service, call STARTTLS
     if (datastore['PROTO'] == 'smtp')
-      greeting = sock.get_once
+      begin
+        greeting = sock.get_once
+      rescue ::EOFError => e
+        print_error("Failed to receive data for the protocol greeting: #{e.message}")
+        return
+      end
 
-      sock.put('HELO ' + (rand_text_alphanumeric(rand(10)+1)) + "\r\n")
-      resp = sock.get_once
+      begin
+        sock.put('HELO ' + (rand_text_alphanumeric(rand(10)+1)) + "\r\n")
+        resp = sock.get_once
+      rescue ::Timeout::Error
+        print_error("Timedout while sending HELO")
+        return
+      rescue ::EOFError => e
+        print_error("Failed to receive a response for HELO: #{e.message}")
+        return
+      end
 
-      sock.put("STARTTLS\r\n")
-      resp = sock.get_once
+      begin
+        sock.put("STARTTLS\r\n")
+        resp = sock.get_once
+      rescue ::Timeout::Error
+        print_error("Timed out while sending STARTTLS")
+        return
+      rescue ::EOFError => e
+        print_error("Failed to receive a response for STARTTLS: #{e.message}")
+        return
+      end
 
       if (resp and resp !~ /^220/)
         print_warning("Warning: this server may not support STARTTLS")
       end
-
     end
 
-    sock.put(buf)
-    resp = sock.get_once
+
+    begin
+      sock.put(buf)
+      resp = sock.get_once
+    rescue ::Timeout::Error => e
+      print_error("Timed out while sending the malicious data")
+      return
+    rescue ::EOFError => e
+      print_error("Failed to receive a response after the malicious data: #{e.message}")
+      return
+    end
 
     if (resp == "\x00\x00\x01")
       print_status("The response indicates that the PCT protocol is disabled")


### PR DESCRIPTION
Fix #4458

This patch allows the MS04-11 exploit to be more informative about which part of the attack has failed.
## Testing

To be honest, the exploit is really old and I don't even have a box for testing anymore. But what you can do to make sure you exercise all the exploit is:
- [x] Set up a fake server: `ruby -run -e httpd . -p 8181`
- [x] Start msfconsole
- [x] `use exploit/windows/ssl/ms04_011_pct`
- [x] `set rport 8181`
- [x] `set rhost [IP]`
- [x] `run`
- [x] In the Ruby server, you should see some malicious data from the exploit. The malicious data portion is sent pretty much at the end of the exploit method, so this is a good indication you've exercised the code.
