### PR TITLE
Update MS15-001 reference

### DIFF
--- a/modules/exploits/windows/local/ntapphelpcachecontrol.rb
+++ b/modules/exploits/windows/local/ntapphelpcachecontrol.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def initialize(info={})
     super(update_info(info, {
-      'Name'           => 'Microsoft Windows NtApphelpCacheControl Improper Authorization Check',
+      'Name'           => 'MS15-001 Microsoft Windows NtApphelpCacheControl Improper Authorization Check',
       'Description'    => %q{
         On Windows, the system call NtApphelpCacheControl (the code is actually in ahcache.sys)
         allows application compatibility data to be cached for quick reuse when new processes are
@@ -58,6 +58,7 @@ class Metasploit3 < Msf::Exploit::Local
         },
       'References'     =>
         [
+          [ 'MSB', 'MS15-001' ],
           [ 'CVE', '2015-0002' ],
           [ 'OSVEB', '116497' ],
           [ 'EDB', '35661' ],


### PR DESCRIPTION
exploits/windows/local/ntapphelpcachecontrol.rb is MS15-001.

To double check:
- [x] Read http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0002
