### PR TITLE
Fix #4128 by switching to rb-readline fork

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       nokogiri
       packetfu (= 1.1.9)
       railties
-      rb-readline
+      rb-readline-r7
       recog (~> 1.0)
       robots
       rubyzip (~> 1.1)
@@ -172,7 +172,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     rake (10.4.2)
-    rb-readline (0.5.2)
+    rb-readline-r7 (0.5.2.0)
     rdoc (3.12.2)
       json (~> 1.4)
     recog (1.0.16)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -80,7 +80,8 @@ Gem::Specification.new do |spec|
   #   NoMethodError undefined method `dlopen' for Fiddle:Module
   unless Gem.win_platform?
     # Command line editing, history, and tab completion in msfconsole
-    spec.add_runtime_dependency 'rb-readline'
+    # Use the Rapid7 fork until the official gem catches up
+    spec.add_runtime_dependency 'rb-readline-r7'
   end
 
   # Needed by anemone crawler


### PR DESCRIPTION
This commit changes the gemspec dependency from rb-readline to rb-readline-r7 (built from the rapid7 branch of [rapid7/rb-readline](https://github.com/rapid7/rb-readline). We can swap back to upstream once they cut a new gem. This fixes #4128 
