### PR TITLE
Normalize HTTP LoginScanner modules

### DIFF
--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -20,7 +20,7 @@ module Metasploit
             host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
           )
 
-          http_client = config_client(http_client)
+          configure_http_client(http_client)
 
           result_opts = {
               credential: credential,

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -35,6 +35,7 @@ module Metasploit
           end
           begin
             cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version)
+            configure_http_client(cli)
             cli.connect
             req = cli.request_cgi({
               'method'=>'POST',

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -63,6 +63,7 @@ module Metasploit
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
           cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies)
+          configure_http_client(cli)
           cli.connect
           req = cli.request_raw(opts)
           res = cli.send_recv(req)

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -62,6 +62,7 @@ module Metasploit
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
           cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
+          configure_http_client(cli)
           cli.connect
           req = cli.request_raw(opts)
           res = cli.send_recv(req)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -286,7 +286,7 @@ module Metasploit
           # Set the parameter only if it is not nil
           possible_params.each_pair do |k,v|
             next if v.nil?
-            http_client.set_config(k,v)
+            http_client.set_config(k => v)
           end
 
           http_client

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -122,7 +122,7 @@ module Metasploit
         attr_accessor :evade_header_folding
 
         # @!attribute ntlm_use_ntlmv2_session
-        #   @return [Boolean] Whtehr to activate the 'Negotiate NTLM2 key' flag, forcing the use of a NTLMv2_session
+        #   @return [Boolean] Whether to activate the 'Negotiate NTLM2 key' flag, forcing the use of a NTLMv2_session
         attr_accessor :ntlm_use_ntlmv2_session
 
         # @!attribute ntlm_use_ntlmv2

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -37,6 +37,122 @@ module Metasploit
         #   @return [String] the Virtual Host name for the target Web Server
         attr_accessor :vhost
 
+        # @!attribute evade_uri_encode_mode
+        #   @return [String] The type of URI encoding to use
+        attr_accessor :evade_uri_encode_mode
+
+        # @!attribute evade_uri_full_url
+        #   @return [Boolean] Whether to use the full URL for all HTTP requests
+        attr_accessor :evade_uri_full_url
+
+        # @!attribute evade_pad_method_uri_count
+        #   @return [Fixnum] How many whitespace characters to use between the method and uri
+        attr_accessor :evade_pad_method_uri_count
+
+        # @!attribute evade_pad_uri_version_count
+        #   @return [Fixnum] How many whitespace characters to use between the uri and version
+        attr_accessor :evade_pad_uri_version_count
+
+        # @!attribute evade_pad_method_uri_type
+        #   @return [String] What type of whitespace to use between the method and uri
+        attr_accessor :evade_pad_method_uri_type
+
+        # @!attribute evade_pad_uri_version_type
+        #   @return [String] What type of whitespace to use between the uri and version
+        attr_accessor :evade_pad_uri_version_type
+
+        # @!attribute evade_method_random_valid
+        #   @return [Boolean] Whether to use a random, but valid, HTTP method for request
+        attr_accessor :evade_method_random_valid
+
+        # @!attribute evade_method_random_invalid
+        #   @return [Boolean] Whether to use a random invalid, HTTP method for request
+        attr_accessor :evade_method_random_invalid
+
+        # @!attribute evade_method_random_case
+        #   @return [Boolean] Whether to use random casing for the HTTP method
+        attr_accessor :evade_method_random_case
+
+        # @!attribute evade_uri_dir_self_reference
+        #   @return [Boolean] Whether to insert self-referential directories into the uri
+        attr_accessor :evade_uri_dir_self_reference
+
+        # @!attribute evade_uri_dir_fake_relative
+        #   @return [Boolean] Whether to insert fake relative directories into the uri
+        attr_accessor :evade_uri_dir_fake_relative
+
+        # @!attribute evade_uri_use_backslashes
+        #   @return [Boolean] Whether to use back slashes instead of forward slashes in the uri
+        attr_accessor :evade_uri_use_backslashes
+
+        # @!attribute evade_pad_fake_headers
+        #   @return [Boolean] Whether to insert random, fake headers into the HTTP request
+        attr_accessor :evade_pad_fake_headers
+
+        # @!attribute evade_pad_fake_headers_count
+        #   @return [Fixnum] How many fake headers to insert into the HTTP request
+        attr_accessor :evade_pad_fake_headers_count
+
+        # @!attribute evade_pad_get_params
+        #   @return [Boolean] Whether to insert random, fake query string variables into the request
+        attr_accessor :evade_pad_get_params
+
+        # @!attribute evade_pad_get_params_count
+        #   @return [Fixnum] How many fake query string variables to insert into the request
+        attr_accessor :evade_pad_get_params_count
+
+        # @!attribute evade_pad_post_params
+        #   @return [Boolean] Whether to insert random, fake post variables into the request
+        attr_accessor :evade_pad_post_params
+
+        # @!attribute evade_pad_post_params_count
+        #   @return [Fixnum] How many fake post variables to insert into the request
+        attr_accessor :evade_pad_post_params_count
+
+        # @!attribute evade_uri_fake_end
+        #   @return [Boolean] Whether to add a fake end of URI (eg: /%20HTTP/1.0/../../)
+        attr_accessor :evade_uri_fake_end
+
+        # @!attribute evade_uri_fake_params_start
+        #   @return [Boolean] Whether to add a fake start of params to the URI (eg: /%3fa=b/../)
+        attr_accessor :evade_uri_fake_params_start
+
+        # @!attribute evade_header_folding
+        #   @return [Boolean]  Whether to enable folding of HTTP headers
+        attr_accessor :evade_header_folding
+
+        # @!attribute ntlm_use_ntlmv2_session
+        #   @return [Boolean] Whtehr to activate the 'Negotiate NTLM2 key' flag, forcing the use of a NTLMv2_session
+        attr_accessor :ntlm_use_ntlmv2_session
+
+        # @!attribute ntlm_use_ntlmv2
+        #   @return [Boolean] Whether to use NTLMv2 instead of NTLM2_session when 'Negotiate NTLM2' is enabled
+        attr_accessor :ntlm_use_ntlmv2
+
+        # @!attribute ntlm_send_lm
+        #   @return [Boolean] Whether to always send the LANMAN response (except when NTLMv2_session is specified)
+        attr_accessor :ntlm_send_lm
+
+        # @!attribute ntlm_send_ntlm
+        #   @return [Boolean] Whether to activate the 'Negotiate NTLM key' flag, indicating the use of NTLM responses
+        attr_accessor :ntlm_send_ntlm
+
+        # @!attribute ntlm_send_spn
+        #   @return [Boolean] Whether to send an avp of type SPN in the NTLMv2 client blob.
+        attr_accessor :ntlm_send_spn
+
+        # @!attribute ntlm_use_lm_key
+        #   @return [Boolean] Activate the 'Negotiate Lan Manager Key' flag, using the LM key when the LM response is sent
+        attr_accessor :ntlm_use_lm_key
+
+        # @!attribute ntlm_domain
+        #   @return [String] The NTLM domain to use during authentication
+        attr_accessor :ntlm_domain
+
+        # @!attribute digest_auth_iis
+        #   @return [Boolean] Whether to conform to IIS digest authentication mode.
+        attr_accessor :digest_auth_iis
+
 
         validates :uri, presence: true, length: { minimum: 1 }
 
@@ -99,7 +215,7 @@ module Metasploit
             proxies, credential.public, credential.private
           )
 
-          http_client = config_client(http_client)
+          configure_http_client(http_client)
 
           if credential.realm
             http_client.set_config('domain' => credential.realm)
@@ -127,12 +243,53 @@ module Metasploit
 
         private
 
-        def config_client(client)
-          client.set_config(
-            'vhost' => vhost || host,
-            'agent' => user_agent
+        # This method is responsible for mapping the caller's datastore options to the
+        # Rex::Proto::Http::Client configuration parameters.
+        def configure_http_client(http_client)
+          http_client.set_config(
+            'vhost'                  => vhost || host,
+            'agent'                  => user_agent
           )
-          client
+
+          possible_params = {
+            'uri_encode_mode'        => evade_uri_encode_mode,
+            'uri_full_url'           => evade_uri_full_url,
+            'pad_method_uri_count'   => evade_pad_method_uri_count,
+            'pad_uri_version_count'  => evade_pad_uri_version_count,
+            'pad_method_uri_type'    => evade_pad_method_uri_type,
+            'pad_uri_version_type'   => evade_pad_uri_version_type,
+            'method_random_valid'    => evade_method_random_valid,
+            'method_random_invalid'  => evade_method_random_invalid,
+            'method_random_case'     => evade_method_random_case,
+            'uri_dir_self_reference' => evade_uri_dir_self_reference,
+            'uri_dir_fake_relative'  => evade_uri_dir_fake_relative,
+            'uri_use_backslashes'    => evade_uri_use_backslashes,
+            'pad_fake_headers'       => evade_pad_fake_headers,
+            'pad_fake_headers_count' => evade_pad_fake_headers_count,
+            'pad_get_params'         => evade_pad_get_params,
+            'pad_get_params_count'   => evade_pad_get_params_count,
+            'pad_post_params'        => evade_pad_post_params,
+            'pad_post_params_count'  => evade_pad_post_params_count,
+            'uri_fake_end'           => evade_uri_fake_end,
+            'uri_fake_params_start'  => evade_uri_fake_params_start,
+            'header_folding'         => evade_header_folding,
+            'usentlm2_session'       => ntlm_use_ntlmv2_session,
+            'use_ntlmv2'             => ntlm_use_ntlmv2,
+            'send_lm'                => ntlm_send_lm,
+            'send_ntlm'              => ntlm_send_ntlm,
+            'SendSPN'                => ntlm_send_spn,
+            'UseLMKey'               => ntlm_use_lm_key,
+            'domain'                 => ntlm_domain,
+            'DigestAuthIIS'          => digest_auth_iis
+          }
+
+          # Set the parameter only if it is not nil
+          possible_params.each_pair do |k,v|
+            next if v.nil?
+            http_client.set_config(k,v)
+          end
+
+          http_client
         end
 
         # This method sets the sane defaults for things

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -12,8 +12,7 @@ module Metasploit
           http_client = Rex::Proto::Http::Client.new(
               host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
           )
-
-          http_client = config_client(http_client)
+          configure_http_client(http_client)
 
           result_opts = {
               credential: credential,

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -34,6 +34,7 @@ module Metasploit
           end
           begin
             cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
+            configure_http_client(cli)
             cli.connect
             req = cli.request_cgi({
               'method'=>'POST',

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -36,6 +36,7 @@ module Metasploit
             cred = Rex::Text.uri_encode(credential.private)
             body = "data%5BLogin%5D%5Bowner_name%5D=admin&data%5BLogin%5D%5Bowner_passwd%5D=#{cred}"
             cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version)
+            configure_http_client(cli)
             cli.connect
             req = cli.request_cgi(
               'method' => method,

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -34,6 +34,7 @@ module Metasploit
 
           begin
             cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
+            configure_http_client(cli)
             cli.connect
             req = cli.request_cgi(req_opts)
             res = cli.send_recv(req)

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -12,6 +12,7 @@ module Metasploit
           http_client = Rex::Proto::Http::Client.new(
               host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
           )
+          configure_http_client(http_client)
 
           result_opts = {
               credential: credential,

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -67,6 +67,7 @@ module Metasploit
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
           cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies)
+          configure_http_client(cli)
           cli.connect
           req = cli.request_raw(opts)
           res = cli.send_recv(req)

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -211,6 +211,54 @@ module Exploit::Remote::HttpClient
   end
 
   #
+  # Converts datastore options into configuration parameters for the
+  # Metasploit::LoginScanner::Http class. Any parameters passed into
+  # this method will override the defaults.
+  #
+  def configure_http_login_scanner(conf)
+    {
+      host:                          rhost,
+      port:                          rport,
+      ssl:                           dossl,
+      ssl_version:                   ssl_version,
+      proxies:                       datastore['PROXIES'],
+      framework:                     framework,
+      framework_module:              self,
+      vhost:                         vhost,
+      user_agent:                    datastore['UserAgent'],
+      evade_uri_encode_mode:         datastore['HTTP::uri_encode_mode'],
+      evade_uri_full_url:            datastore['HTTP::uri_full_url'],
+      evade_pad_method_uri_count:    datastore['HTTP::pad_method_uri_count'],
+      evade_pad_uri_version_count:   datastore['HTTP::pad_uri_version_count'],
+      evade_pad_method_uri_type:     datastore['HTTP::pad_method_uri_type'],
+      evade_pad_uri_version_type:    datastore['HTTP::pad_uri_version_type'],
+      evade_method_random_valid:     datastore['HTTP::method_random_valid'],
+      evade_method_random_invalid:   datastore['HTTP::method_random_invalid'],
+      evade_method_random_case:      datastore['HTTP::method_random_case'],
+      evade_uri_dir_self_reference:  datastore['HTTP::uri_dir_self_reference'],
+      evade_uri_dir_fake_relative:   datastore['HTTP::uri_dir_fake_relative'],
+      evade_uri_use_backslashes:     datastore['HTTP::uri_use_backslashes'],
+      evade_pad_fake_headers:        datastore['HTTP::pad_fake_headers'],
+      evade_pad_fake_headers_count:  datastore['HTTP::pad_fake_headers_count'],
+      evade_pad_get_params:          datastore['HTTP::pad_get_params'],
+      evade_pad_get_params_count:    datastore['HTTP::pad_get_params_count'],
+      evade_pad_post_params:         datastore['HTTP::pad_post_params'],
+      evade_pad_post_params_count:   datastore['HTTP::pad_post_params_count'],
+      evade_uri_fake_end:            datastore['HTTP::uri_fake_end'],
+      evade_uri_fake_params_start:   datastore['HTTP::uri_fake_params_start'],
+      evade_header_folding:          datastore['HTTP::header_folding'],
+      ntlm_use_ntlmv2_session:       datastore['NTLM::UseNTLM2_session'],
+      ntlm_use_ntlmv2:               datastore['NTLM::UseNTLMv2'],
+      ntlm_send_lm:                  datastore['NTLM::SendLM'],
+      ntlm_send_ntlm:                datastore['NTLM::SendNTLM'],
+      ntlm_send_spn:                 datastore['NTLM::SendSPN'],
+      ntlm_use_lm_key:               datastore['NTLM::UseLMKey'],
+      ntlm_domain:                   datastore['DOMAIN'],
+      digest_auth_iis:               datastore['DigestAuthIIS']
+    }.merge(conf)
+  end
+
+  #
   # Passes the client connection down to the handler to see if it's of any
   # use.
   #

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -219,7 +219,7 @@ module Exploit::Remote::HttpClient
     {
       host:                          rhost,
       port:                          rport,
-      ssl:                           dossl,
+      ssl:                           ssl,
       ssl_version:                   ssl_version,
       proxies:                       datastore['PROXIES'],
       framework:                     framework,

--- a/lib/msf/core/exploit/ntlm.rb
+++ b/lib/msf/core/exploit/ntlm.rb
@@ -52,7 +52,7 @@ module Exploit::NTLM
       # SendSPN will send an avp of type 9/SPN in the ntlmv2 client blob, this is mandatory on windows seven / 2008 r2 if
       # Microsoft network server : Server SPN target name validation level is set to <Required from client> or we get an STATUS_ACCESS_DENIED
       #
-      OptBool.new('NTLM::SendSPN', [ true, 'Send an avp of type SPN in the ntlmv2 client Blob, this allow authentification on windows Seven/2008r2 when SPN is required', true]),
+      OptBool.new('NTLM::SendSPN', [ true, 'Send an avp of type SPN in the ntlmv2 client blob, this allows authentication on Windows 7+/Server 2008 R2+ when SPN is required', true]),
       ], Msf::Exploit::NTLM::Client)
     end
   end

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -75,16 +75,15 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     scanner = Metasploit::Framework::LoginScanner::HTTP.new(
+      configure_http_login_scanner(
         host: ip,
         port: rport,
         uri: "/stop",
-        proxies: datastore["PROXIES"],
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        framework: framework,
-        framework_module: self,
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -76,8 +76,6 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::HTTP.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         uri: "/stop",
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -80,8 +80,6 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::Axis2.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         uri: uri,
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -79,18 +79,15 @@ class Metasploit3 < Msf::Auxiliary
     cred_collection = prepend_db_passwords(cred_collection)
 
     scanner = Metasploit::Framework::LoginScanner::Axis2.new(
-      host: ip,
-      port: rport,
-      uri: uri,
-      proxies: proxies,
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5,
-      user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST'],
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host: ip,
+        port: rport,
+        uri: uri,
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 5
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -34,27 +34,24 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
     cred_collection = Metasploit::Framework::CredentialCollection.new(
-            blank_passwords: datastore['BLANK_PASSWORDS'],
-            pass_file: datastore['PASS_FILE'],
-            password: datastore['PASSWORD'],
-            user_file: datastore['USER_FILE'],
-            userpass_file: datastore['USERPASS_FILE'],
-            username: datastore['USERNAME'],
-            user_as_pass: datastore['USER_AS_PASS']
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
     )
 
     scanner = Metasploit::Framework::LoginScanner::Buffalo.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['PROXIES'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 10,
-      user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST'],
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 10
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -45,8 +45,6 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::Buffalo.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -143,8 +143,6 @@ class Metasploit3 < Msf::Auxiliary
 
     @scanner = Metasploit::Framework::LoginScanner::ChefWebUI.new(
       configure_http_login_scanner(
-        host:               ip,
-        port:               rport,
         uri:                datastore['TARGETURI'],
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
@@ -152,9 +150,6 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: 5
       )
     )
-
-    @scanner.ssl         = datastore['SSL']
-    @scanner.ssl_version = datastore['SSLVERSION']
   end
 
 end

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -142,16 +142,15 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     @scanner = Metasploit::Framework::LoginScanner::ChefWebUI.new(
-      host:               ip,
-      port:               rport,
-      proxies:            datastore['PROXIES'],
-      uri:                datastore['TARGETURI'],
-      cred_details:       @cred_collection,
-      stop_on_success:    datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5,
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host:               ip,
+        port:               rport,
+        uri:                datastore['TARGETURI'],
+        cred_details:       @cred_collection,
+        stop_on_success:    datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 5
+      )
     )
 
     @scanner.ssl         = datastore['SSL']

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -52,11 +52,6 @@ class Metasploit3 < Msf::Auxiliary
   # the LoginScanner class so the authentication can proceed properly
   #
 
-  # Overrides the ssl method from HttpClient
-  def ssl
-    @scanner.ssl || datastore['SSL']
-  end
-
   #
   # For a while, older versions of Glassfish didn't need to set a password for admin,
   # but looks like no longer the case anymore, which means this method is getting useless
@@ -96,17 +91,12 @@ class Metasploit3 < Msf::Auxiliary
 
     @scanner = Metasploit::Framework::LoginScanner::Glassfish.new(
       configure_http_login_scanner(
-        host:               ip,
-        port:               rport,
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5
       )
     )
-
-    @scanner.ssl         = datastore['SSL']
-    @scanner.ssl_version = datastore['SSLVERSION']
   end
 
   def do_report(ip, port, result)

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -95,15 +95,14 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     @scanner = Metasploit::Framework::LoginScanner::Glassfish.new(
-      host:               ip,
-      port:               rport,
-      proxies:            datastore["PROXIES"],
-      cred_details:       @cred_collection,
-      stop_on_success:    datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5,
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host:               ip,
+        port:               rport,
+        cred_details:       @cred_collection,
+        stop_on_success:    datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 5
+      )
     )
 
     @scanner.ssl         = datastore['SSL']

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -77,8 +77,6 @@ class Metasploit3 < Msf::Auxiliary
 
     @scanner = Metasploit::Framework::LoginScanner::Smh.new(
       configure_http_login_scanner(
-        host:               ip,
-        port:               rport,
         uri:                datastore['URI'],
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
@@ -86,9 +84,6 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: 5
       )
     )
-
-    @scanner.ssl         = datastore['SSL']
-    @scanner.ssl_version = datastore['SSLVERSION']
   end
 
  def do_report(ip, port, result)

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -76,16 +76,15 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     @scanner = Metasploit::Framework::LoginScanner::Smh.new(
-      host:               ip,
-      port:               rport,
-      uri:                datastore['URI'],
-      proxies:            datastore["PROXIES"],
-      cred_details:       @cred_collection,
-      stop_on_success:    datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5,
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host:               ip,
+        port:               rport,
+        uri:                datastore['URI'],
+        cred_details:       @cred_collection,
+        stop_on_success:    datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 5
+      )
     )
 
     @scanner.ssl         = datastore['SSL']

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -153,19 +153,16 @@ class Metasploit3 < Msf::Auxiliary
     cred_collection = prepend_db_passwords(cred_collection)
 
     scanner = Metasploit::Framework::LoginScanner::HTTP.new(
-      host: ip,
-      port: rport,
-      uri: @uri,
-      method: datastore['REQUESTTYPE'],
-      proxies: datastore["PROXIES"],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5,
-      user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST'],
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host: ip,
+        port: rport,
+        uri: @uri,
+        method: datastore['REQUESTTYPE'],
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 5
+      )
     )
 
     msg = scanner.check_setup

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -154,8 +154,6 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::HTTP.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         uri: @uri,
         method: datastore['REQUESTTYPE'],
         cred_details: cred_collection,

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -39,8 +39,6 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::IPBoard.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         uri: normalize_uri(target_uri.path),
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -38,18 +38,15 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::IPBoard.new(
+      configure_http_login_scanner(
         host: ip,
         port: rport,
         uri: normalize_uri(target_uri.path),
-        proxies: datastore["PROXIES"],
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5,
-        user_agent: datastore['UserAgent'],
-        vhost: datastore['VHOST'],
-        framework: framework,
-        framework_module: self,
+        connection_timeout: 5
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -43,17 +43,14 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::Jenkins.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['PROXIES'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 10,
-      user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST'],
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 10
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -33,19 +33,17 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
     cred_collection = Metasploit::Framework::CredentialCollection.new(
-            blank_passwords: datastore['BLANK_PASSWORDS'],
-            pass_file: datastore['PASS_FILE'],
-            password: datastore['PASSWORD'],
-            user_file: datastore['USER_FILE'],
-            userpass_file: datastore['USERPASS_FILE'],
-            username: datastore['USERNAME'],
-            user_as_pass: datastore['USER_AS_PASS']
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
     )
 
     scanner = Metasploit::Framework::LoginScanner::Jenkins.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -56,19 +56,12 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::MyBookLive.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
       )
     )
-
-    if ssl
-      scanner.ssl = datastore['SSL']
-      scanner.ssl_version = datastore['SSLVERSION']
-    end
 
     scanner.scan! do |result|
       credential_data = result.to_h

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -55,17 +55,14 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::MyBookLive.new(
-      host: ip,
-      port: rport,
-      proxies: datastore['PROXIES'],
-      cred_details: cred_collection,
-      stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 10,
-      user_agent: datastore['UserAgent'],
-      vhost: datastore['VHOST'],
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host: ip,
+        port: rport,
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 10,
+      )
     )
 
     if ssl

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -107,8 +107,6 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::Tomcat.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -94,29 +94,26 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     cred_collection = Metasploit::Framework::CredentialCollection.new(
-        blank_passwords: datastore['BLANK_PASSWORDS'],
-        pass_file: datastore['PASS_FILE'],
-        password: datastore['PASSWORD'],
-        user_file: datastore['USER_FILE'],
-        userpass_file: datastore['USERPASS_FILE'],
-        username: datastore['USERNAME'],
-        user_as_pass: datastore['USER_AS_PASS'],
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS'],
     )
 
     cred_collection = prepend_db_passwords(cred_collection)
 
     scanner = Metasploit::Framework::LoginScanner::Tomcat.new(
+      configure_http_login_scanner(
         host: ip,
         port: rport,
-        proxies: datastore['PROXIES'],
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 10,
-        user_agent: datastore['UserAgent'],
-        vhost: datastore['VHOST'],
-        framework: framework,
-        framework_module: self,
+        connection_timeout: 10
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -64,16 +64,15 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::WordpressRPC.new(
+      configure_http_login_scanner(
         host: ip,
         port: rport,
         uri: wordpress_url_xmlrpc,
-        proxies: datastore["PROXIES"],
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        framework: framework,
-        framework_module: self,
+      )
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -65,8 +65,6 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::WordpressRPC.new(
       configure_http_login_scanner(
-        host: ip,
-        port: rport,
         uri: wordpress_url_xmlrpc,
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -150,8 +150,6 @@ class Metasploit3 < Msf::Auxiliary
 
     @scanner = Metasploit::Framework::LoginScanner::Zabbix.new(
       configure_http_login_scanner(
-        host:               ip,
-        port:               rport,
         uri:                datastore['TARGETURI'],
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
@@ -159,9 +157,6 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: 5,
       )
     )
-
-    @scanner.ssl         = datastore['SSL']
-    @scanner.ssl_version = datastore['SSLVERSION']
   end
 
   #

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -149,16 +149,15 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     @scanner = Metasploit::Framework::LoginScanner::Zabbix.new(
-      host:               ip,
-      port:               rport,
-      proxies:            datastore['PROXIES'],
-      uri:                datastore['TARGETURI'],
-      cred_details:       @cred_collection,
-      stop_on_success:    datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      connection_timeout: 5,
-      framework: framework,
-      framework_module: self,
+      configure_http_login_scanner(
+        host:               ip,
+        port:               rport,
+        uri:                datastore['TARGETURI'],
+        cred_details:       @cred_collection,
+        stop_on_success:    datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 5,
+      )
     )
 
     @scanner.ssl         = datastore['SSL']


### PR DESCRIPTION
This set of commits:
- Now passes all HTTP & NTLM mixin options into the LoginScanner::Http object
- Fixes numerous cases where SSL/VHOST/User-Agent were being ignored entirely
- Creates a mapping between the HTTP mixin, loginscanner, and the actual client
- Removes redundant parameters from the LoginScanner modules

This is a partial fix for #4803, the non-HTTP modules still need to undergo review and likely a separate PR.
