### PR TITLE
modernize msfrpc code a little

### DIFF
--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -31,7 +31,7 @@ class Client
 
   def login(user,pass)
     res = self.call("auth.login", user, pass)
-    if(not (res and res['result'] == "success"))
+    unless (res && res['result'] == "success")
       raise RuntimeError, "authentication failed"
     end
     self.token = res['token']
@@ -41,8 +41,8 @@ class Client
   # Prepend the authentication token as the first parameter
   # of every call except auth.login. Requires the
   def call(meth, *args)
-    if(meth != "auth.login")
-      if(not self.token)
+    unless meth == "auth.login"
+      unless self.token
         raise RuntimeError, "client not authenticated"
       end
       args.unshift(self.token)
@@ -50,7 +50,7 @@ class Client
 
     args.unshift(meth)
 
-    if not @cli
+    unless @cli
       @cli = Rex::Proto::Http::Client.new(info[:host], info[:port], info[:context], info[:ssl], info[:ssl_version])
       @cli.set_config(
         :vhost => info[:host],
@@ -69,10 +69,10 @@ class Client
     res = @cli.send_recv(req)
     @cli.close
 
-    if res and [200, 401, 403, 500].include?(res.code)
+    if res && [200, 401, 403, 500].include?(res.code)
       resp = MessagePack.unpack(res.body)
 
-      if resp and resp.kind_of?(::Hash) and resp['error'] == true
+      if resp && resp.kind_of?(::Hash) && resp['error']
         raise Msf::RPC::ServerException.new(resp['error_code'] || res.code, resp['error_message'] || resp['error_string'], resp['error_class'], resp['error_backtrace'])
       end
 
@@ -83,7 +83,7 @@ class Client
   end
 
   def close
-    if @cli and @cli.conn?
+    if @cli && @cli.conn?
       @cli.close
     end
     @cli = nil

--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -112,13 +112,13 @@ class Service
         end
       end
 
-      if not (req.headers["Content-Type"] and req.headers["Content-Type"] == "binary/message-pack")
+      unless (req.headers["Content-Type"] && req.headers["Content-Type"] == "binary/message-pack")
         raise ArgumentError, "Invalid Content Type"
       end
 
       msg = MessagePack.unpack(req.body)
 
-      if not (msg and msg.kind_of?(::Array) and msg.length > 0)
+      unless (msg && msg.kind_of?(::Array) && msg.length > 0)
         raise ArgumentError, "Invalid Message Format"
       end
 
@@ -126,7 +126,7 @@ class Service
 
       group, funct = msg.shift.split(".", 2)
 
-      if not self.handlers[group]
+      unless self.handlers[group]
         raise ArgumentError, "Unknown API Group: '#{group.inspect}'"
       end
 
@@ -138,13 +138,13 @@ class Service
         mname << '_noauth'
       end
 
-      if not self.handlers[group].respond_to?(mname)
+      unless self.handlers[group].respond_to?(mname)
         raise ArgumentError, "Unknown API Call: '#{mname.inspect}'"
       end
 
       if doauth
         token = msg.shift
-        if not authenticate(token)
+        unless authenticate(token)
           raise ::Msf::RPC::Exception.new(401, "Invalid Authentication Token")
         end
       end
@@ -203,7 +203,7 @@ class Service
     stale = []
 
 
-    if not (token and token.kind_of?(::String))
+    unless (token && token.kind_of?(::String))
       return false
     end
 
@@ -212,17 +212,17 @@ class Service
 
     self.tokens.each_key do |t|
       user,ctime,mtime,perm = self.tokens[t]
-      if ! perm and mtime + self.token_timeout < Time.now.to_i
+      if !perm && mtime + self.token_timeout < Time.now.to_i
         stale << t
       end
     end
 
     stale.each { |t| self.tokens.delete(t) }
 
-    if not self.tokens[token]
+    unless self.tokens[token]
 
       begin
-        if framework.db.active and ::Mdm::ApiKey.find_by_token(token)
+        if framework.db.active && ::Mdm::ApiKey.find_by_token(token)
           return true
         end
       rescue ::Exception => e

--- a/msfrpc
+++ b/msfrpc
@@ -84,8 +84,6 @@ rpc = Msf::RPC::Client.new(
 )
 
 rpc.login(opts['User'], opts['Pass'])
-rpc.call('console.create')
-# => "consoles"=>[ {"id"=>"0", "prompt"=>"msf > ", "busy"=>false} ]
 
 puts "[*] The 'rpc' object holds the RPC client interface"
 puts "[*] Use rpc.call('group.command') to make RPC calls"

--- a/msfrpc
+++ b/msfrpc
@@ -41,7 +41,7 @@ opts = {
 }
 
 # Parse command line arguments.
-arguments.parse(ARGV) { |opt, idx, val|
+arguments.parse(ARGV) do |opt, idx, val|
   case opt
     when "-a"
       opts['ServerHost'] = val
@@ -57,16 +57,16 @@ arguments.parse(ARGV) { |opt, idx, val|
       print("\nUsage: #{File.basename(__FILE__)} <options>\n" +	arguments.usage)
       exit
   end
-}
+end
 
 
-if(not opts['ServerHost'])
+unless opts['ServerHost']
   $stderr.puts "[-] Error: a server IP must be specified (-a)"
   $stderr.puts arguments.usage
   exit(0)
 end
 
-if(not opts['Pass'])
+unless opts['Pass']
   $stderr.puts "[-] Error: a password must be specified (-P)"
   $stderr.puts arguments.usage
   exit(0)
@@ -83,10 +83,13 @@ rpc = Msf::RPC::Client.new(
   :ssl  => opts['SSL']
 )
 
-res = rpc.login(opts['User'], opts['Pass'])
+rpc.login(opts['User'], opts['Pass'])
+rpc.call('console.create')
+# => "consoles"=>[ {"id"=>"0", "prompt"=>"msf > ", "busy"=>false} ]
 
 puts "[*] The 'rpc' object holds the RPC client interface"
-puts ""
+puts "[*] Use rpc.call('group.command') to make RPC calls"
+puts
 
 while(ARGV.shift)
 end

--- a/msfrpcd
+++ b/msfrpcd
@@ -72,7 +72,7 @@ arguments.parse(ARGV) { |opt, idx, val|
   end
 }
 
-if(not opts['Pass'])
+unless opts['Pass']
   $stderr.puts "[-] Error: a password must be specified (-P)"
   exit(0)
 end
@@ -83,7 +83,7 @@ rpctype = 'MSG'
 
 $stderr.puts "[*] #{rpctype}RPC starting on #{opts['ServerHost']}:#{opts['ServerPort']} (#{opts['SSL'] ? "SSL" : "NO SSL"}):#{opts['ServerType']}..."
 
-$stderr.puts "[*] URI: #{opts['URI']}" if(opts['URI'])
+$stderr.puts "[*] URI: #{opts['URI']}" if opts['URI']
 
 require 'msf/base'
 require 'msf/ui'

--- a/plugins/msgrpc.rb
+++ b/plugins/msgrpc.rb
@@ -1,14 +1,10 @@
 #!/usr/bin/env ruby
 #
-# $Id$
-#
 # This plugin provides an msf daemon interface that spawns a listener on a
 # defined port (default 55552) and gives each connecting client its own
 # console interface.  These consoles all share the same framework instance.
 # Be aware that the console instance that spawns on the port is entirely
 # unauthenticated, so realize that you have been warned.
-#
-# $Revision$
 #
 
 require "msf/core/rpc/v10/service"

--- a/plugins/msgrpc.rb
+++ b/plugins/msgrpc.rb
@@ -43,7 +43,7 @@ class Plugin::MSGRPC < Msf::Plugin
 
     host = opts['ServerHost'] || DefaultHost
     port = opts['ServerPort'] || DefaultPort
-    ssl  = (opts['SSL'] and opts['SSL'].to_s =~ /^[ty]/i) ? true : false
+    ssl  = (opts['SSL'] && opts['SSL'].to_s =~ /^[ty]/i) ? true : false
     cert = opts['SSLCert']
 
     user = opts['User'] || "msf"
@@ -67,7 +67,7 @@ class Plugin::MSGRPC < Msf::Plugin
 
     # If the run in foreground flag is not specified, then go ahead and fire
     # it off in a worker thread.
-    if (opts['RunInForeground'] != true)
+    unless opts['RunInForeground']
       # Store a handle to the thread so we can kill it during
       # cleanup when we get unloaded.
       self.thread = Thread.new { run }


### PR DESCRIPTION
much of the msfrpc code is not up to part w/modern idiomatic ruby.  This fixes a number of instances as well as removes some svn vestiges and updates the msfrpc startup banner a little to be more informative.  There is still some work to be done w/various rpc groups, I'll get to that later.
- [x] setup msfrpcd

``` Shell
 $ ruby msfrpcd -P lamepass -U lameuser                                                                                                                                                            [15:29:54]
[*] MSGRPC starting on 0.0.0.0:55553 (SSL):Msg...
[*] MSGRPC backgrounding at 2015-02-22 15:35:33 -0600...
```
- [x] Connect w/msfrpc

``` Shell
 $ ruby msfrpc -P lamepass -U lameuser -a 192.168.1.1                                                                                                                                         [15:35:40]
[*] The 'rpc' object holds the RPC client interface
[*] Use rpc.call('group.command') to make RPC calls

>>
```
- [x] Make sure commands still work

``` Shell
>> rpc.call("core.version")
=> {"version"=>"4.11.0-dev", "ruby"=>"2.1.5 i686-linux 2014-11-13", "api"=>"1.0"}
>> rpc.call("console.create")
=> {"id"=>"0", "prompt"=>"msf > ", "busy"=>false}
```
