### PR TITLE
Handle ICMP "protocol not available" errors as connection errors

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -281,7 +281,7 @@ class Rex::Socket::Comm::Local
             raise ::Errno::ETIMEDOUT
           end
 
-        rescue ::Errno::EHOSTUNREACH,::Errno::ENETDOWN,::Errno::ENETUNREACH,::Errno::ENETRESET,::Errno::EHOSTDOWN,::Errno::EACCES,::Errno::EINVAL
+        rescue ::Errno::EHOSTUNREACH,::Errno::ENETDOWN,::Errno::ENETUNREACH,::Errno::ENETRESET,::Errno::EHOSTDOWN,::Errno::EACCES,::Errno::EINVAL,::Errno::ENOPROTOOPT
 
           # Rescue errors caused by a bad Scope ID for a link-local address
           if retry_scopes and @@ip6_lla_scopes[ ip6_scope_idx ]


### PR DESCRIPTION
This fixes a stack trace when a TCP connection attempt triggers an ICMP "protocol unreachable" error. Example reported on IRC below:

```
[*] Building list of scan ports and modules
[*] Launching TCP scan
msf > use auxiliary/scanner/portscan/tcp
msf auxiliary(tcp) > set THREADS 24
THREADS => 24
msf auxiliary(tcp) > set PORTS 50000, 21, 1720, 80, 443, 143, 623, 3306, 110, 5432, 25, 22, 23, 1521, 50013, 161, 2222, 17185, 135, 8080, 4848, 1433, 5560, 512, 513, 514, 445, 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909, 5038, 111, 139, 49, 515, 7787, 2947, 7144, 9080, 8812, 2525, 2207, 3050, 5405, 1723, 1099, 5555, 921, 10001, 123, 3690, 548, 617, 6112, 6667, 3632, 783, 10050, 38292, 12174, 2967, 5168, 3628, 7777, 6101, 10000, 6504, 41523, 41524, 2000, 1900, 10202, 6503, 6070, 6502, 6050, 2103, 41025, 44334, 2100, 5554, 12203, 26000, 4000, 1000, 8014, 5250, 34443, 8028, 8008, 7510, 9495, 1581, 8000, 18881, 57772, 9090, 9999, 81, 3000, 8300, 8800, 8090, 389, 10203, 5093, 1533, 13500, 705, 4659, 20031, 16102, 6080, 6660, 11000, 19810, 3057, 6905, 1100, 10616, 10628, 5051, 1582, 65535, 105, 22222, 30000, 113, 1755, 407, 1434, 2049, 689, 3128, 20222, 20034, 7580, 7579, 38080, 12401, 910, 912, 11234, 46823, 5061, 5060, 2380, 69, 5800, 62514, 42, 5631, 902, 5985, 5986, 6000, 6001, 6002, 6003, 6004, 6005, 6006, 6007, 47001, 523, 3500, 6379, 8834
PORTS => 50000, 21, 1720, 80, 443, 143, 623, 3306, 110, 5432, 25, 22, 23, 1521, 50013, 161, 2222, 17185, 135, 8080, 4848, 1433, 5560, 512, 513, 514, 445, 5900, 5901, 5902, 5903, 5904, 5905, 5906, 5907, 5908, 5909, 5038, 111, 139, 49, 515, 7787, 2947, 7144, 9080, 8812, 2525, 2207, 3050, 5405, 1723, 1099, 5555, 921, 10001, 123, 3690, 548, 617, 6112, 6667, 3632, 783, 10050, 38292, 12174, 2967, 5168, 3628, 7777, 6101, 10000, 6504, 41523, 41524, 2000, 1900, 10202, 6503, 6070, 6502, 6050, 2103, 41025, 44334, 2100, 5554, 12203, 26000, 4000, 1000, 8014, 5250, 34443, 8028, 8008, 7510, 9495, 1581, 8000, 18881, 57772, 9090, 9999, 81, 3000, 8300, 8800, 8090, 389, 10203, 5093, 1533, 13500, 705, 4659, 20031, 16102, 6080, 6660, 11000, 19810, 3057, 6905, 1100, 10616, 10628, 5051, 1582, 65535, 105, 22222, 30000, 113, 1755, 407, 1434, 2049, 689, 3128, 20222, 20034, 7580, 7579, 38080, 12401, 910, 912, 11234, 46823, 5061, 5060, 2380, 69, 5800, 62514, 42, 5631, 902, 5985, 5986, 6000, 6001, 6002, 6003, 6004, 6005, 6006, 6007, 47001, 523, 3500, 6379, 8834
msf auxiliary(tcp) > set RHOSTS 192.168.99.1, 192.168.99.2, 192.168.99.3, 192.168.99.5, 192.168.99.14, 192.168.99.18, 192.168.99.21, 192.168.99.180, 192.168.99.182, 192.168.99.183, 192.168.99.185, 192.168.99.186, 192.168.99.187, 192.168.99.188
RHOSTS => 192.168.99.1, 192.168.99.2, 192.168.99.3, 192.168.99.5, 192.168.99.14, 192.168.99.18, 192.168.99.21, 192.168.99.180, 192.168.99.182, 192.168.99.183, 192.168.99.185, 192.168.99.186, 192.168.99.187, 192.168.99.188
msf auxiliary(tcp) > run -j
[*] Auxiliary module running as background job
[-] 192.168.99.187:22 exception Errno::ENOPROTOOPT Protocol not available - connect(2) for 192.168.99.187:22 ["/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:278:in `connect'", "/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:278:in `block in create_by_type'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:91:in `block in timeout'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:35:in `block in catch'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:35:in `catch'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:35:in `catch'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:106:in `timeout'", "/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:277:in `create_by_type'", "/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:33:in `create'", "/usr/share/metasploit-framework/lib/rex/socket.rb:47:in `create_param'", "/usr/share/metasploit-framework/lib/rex/socket/tcp.rb:37:in `create_param'", "/usr/share/metasploit-framework/lib/rex/socket/tcp.rb:28:in `create'", "/usr/share/metasploit-framework/lib/msf/core/exploit/tcp.rb:102:in `connect'", "/usr/share/metasploit-framework/modules/auxiliary/scanner/portscan/tcp.rb:56:in `block (2 levels) in run_host'", "/usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `call'", "/usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'"]
[-] 192.168.99.187:25 exception Errno::ENOPROTOOPT Protocol not available - connect(2) for 192.168.99.187:25 ["/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:278:in `connect'", "/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:278:in `block in create_by_type'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:91:in `block in timeout'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:35:in `block in catch'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:35:in `catch'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:35:in `catch'", "/opt/metasploit/ruby/lib/ruby/2.1.0/timeout.rb:106:in `timeout'", "/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:277:in `create_by_type'", "/usr/share/metasploit-framework/lib/rex/socket/comm/local.rb:33:in `create'", "/usr/share/metasploit-framework/lib/rex/socket.rb:47:in `create_param'", "/usr/share/metasploit-framework/lib/rex/socket/tcp.rb:37:in `create_param'", "/usr/share/metasploit-framework/lib/rex/socket/tcp.rb:28:in `create'", "/usr/share/metasploit-framework/lib/msf/core/exploit/tcp.rb:102:in `connect'", "/usr/share/metasploit-framework/modules/auxiliary/scanner/portscan/tcp.rb:56:in `block (2 levels) in run_host'", "/usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `call'", "/usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'"]
```
