### PR TITLE
Fixes SSL support for http_login (variable shadowing)

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -193,7 +193,6 @@ module Metasploit
         #   login with.
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
-          ssl = false if ssl.nil?
 
           result_opts = {
             credential: credential,
@@ -312,6 +311,10 @@ module Metasploit
             self.ssl = false
           elsif self.ssl.nil? && self.port == self.class::DEFAULT_SSL_PORT
             self.ssl = true
+          end
+
+          if self.ssl.nil?
+            self.ssl = false
           end
 
           nil

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
@@ -40,7 +40,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::HTTP' do
     context "without ssl, with non-default port" do
       subject(:http_scanner) { described_class.new(port:0) }
       it "should not set ssl" do
-        expect(http_scanner.ssl).to be_nil
+        expect(http_scanner.ssl).to be_falsey
         expect(http_scanner.port).to eq(0)
       end
     end


### PR DESCRIPTION
This bug prevents the http_login module from working with SSL. The fix is to move this into set_sane_defaults and not to shadow an attribute with a local variable.
