### PR TITLE
Add the /ews/ path to enable easy OWA brute force

### DIFF
--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -74,6 +74,7 @@ class Metasploit3 < Msf::Auxiliary
         /auth/
         /manager/
         /Management.asp
+        /ews/
       }
     end
 


### PR DESCRIPTION
Note that this depends on #4828 to get SSL support. 
