### PR TITLE
Fix invalid use of RPORT (should be RHOST)

### DIFF
--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
-    connect(true, { 'RPORT' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
+    connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
     unless is_rmi?
       return Exploit::CheckCode::Unknown
     end
@@ -136,7 +136,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_good("#{peer} - JMXRMI endpoint on #{mbean_server[:address]}:#{mbean_server[:port]}")
     end
 
-    connect(true, { 'RPORT' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
+    connect(true, { 'RHOST' => mbean_server[:address], 'RPORT' => mbean_server[:port] })
     unless is_rmi?
       fail_with(Failure::NoTarget, "#{peer} - Failed to negotiate RMI protocol with the MBean server")
     end


### PR DESCRIPTION
Found while working on #4818.
