### PR TITLE
fix for properly stopping the reverse_http/https handler

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -158,19 +158,6 @@ module ReverseHttp
   end
 
   #
-  # Simply calls stop handler to ensure that things are cool.
-  #
-  def cleanup_handler
-  end
-
-  #
-  # Basically does nothing.  The service is already started and listening
-  # during set up.
-  #
-  def start_handler
-  end
-
-  #
   # Removes the / handler, possibly stopping the service if no sessions are
   # active on sub-urls.
   #

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -161,7 +161,6 @@ module ReverseHttp
   # Simply calls stop handler to ensure that things are cool.
   #
   def cleanup_handler
-    stop_handler
   end
 
   #
@@ -176,7 +175,10 @@ module ReverseHttp
   # active on sub-urls.
   #
   def stop_handler
-    self.service.remove_resource("/") if self.service
+    if self.service
+      self.service.remove_resource("/")
+      Rex::ServiceManager.stop_service(self.service) if self.pending_connections == 0
+    end
   end
 
   attr_accessor :service # :nodoc:
@@ -228,6 +230,7 @@ protected
           :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
           :ssl                => ssl?,
         })
+        self.pending_connections += 1
 
       when /^\/INITJM/
         conn_id = generate_uri_checksum(URI_CHECKSUM_CONN) + "_" + Rex::Text.rand_text_alphanumeric(16)


### PR DESCRIPTION
Take 2. I hope someone who is more familiar with the Rex service management architecture could take a look to make sure this is correct.

The issue seems to be at the root of #4669 is that reverse_http registers an HTTP service but never releases its reference to it, so the HTTP listener service never stops. If we stop it directly, there may be a session already connected to it that we kill, so we can't do that. Instead, track if we got a connection or not, and conditionally release our reference based on whether the connection succeeded.

There is a little cargo-culty looking extra call to stop_handler in cleanup_handler that I also removed. The service management code seems to simply call both, so this seems unneeded. If anyone knows why this would be needed, I would like to know!

This should fix #4669
# Verification
- start a reverse http/https session. I have been using:

```
./msfconsole -qx 'sleep 1; use exploit/multi/handler; set lhost yo.ur.ip.ad; set payload windows/meterpreter/reverse_http; run'
```
- [x] Verify that starting and stopping it start and stop the listening service
- [x] Start the handler again and launch a revert_http meterpreter payload
- [x] Verify that meterpreter loads, can load extensions, etc.
- [x] Stop and restart the service, try meterpreter again
