### PR TITLE
Rex should not use String#blank? as it's not stdlib Ruby

### DIFF
--- a/lib/rex/exploitation/js/memory.rb
+++ b/lib/rex/exploitation/js/memory.rb
@@ -27,7 +27,7 @@ class Memory
   def self.heaplib2(custom_js='', opts={})
     js = ::File.read(::File.join(Msf::Config.data_directory, "js", "memory", "heaplib2.js"))
 
-    unless custom_js.blank?
+    unless custom_js.to_s.empty?
       js << custom_js
     end
 

--- a/lib/rex/mime/message.rb
+++ b/lib/rex/mime/message.rb
@@ -126,7 +126,7 @@ class Message
     header_string = self.header.to_s
 
     msg = header_string.empty? ? '' : force_crlf(self.header.to_s + "\r\n")
-    msg << force_crlf(self.content + "\r\n") unless self.content.blank?
+    msg << force_crlf(self.content + "\r\n") unless self.content.to_s.empty?
 
     self.parts.each do |part|
       msg << force_crlf("--" + self.bound + "\r\n")

--- a/lib/rex/parser/fusionvm_nokogiri.rb
+++ b/lib/rex/parser/fusionvm_nokogiri.rb
@@ -59,7 +59,7 @@ module Parser
     unless in_tag("JobOrder")
       case name
       when "OS"
-        unless @host.nil? or @text.blank?
+        unless @host.nil? or @text.to_s.empty?
           tnote = {
             :type       => "host.os.fusionvm_fingerprint",
             :data       => { :os => @text.strip },
@@ -86,7 +86,7 @@ module Parser
       when "CVE"
         @vuln[:refs] << "CVE-#{@text.strip}"
       when "References"
-        unless @text.blank?
+        unless @text.to_s.empty?
           @text.split(' ').each do |ref|
             next unless ref.start_with? "http"
             if ref =~ /MS\d{2}-\d{3}/

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -219,7 +219,7 @@ class ClientCore < Extension
     end
 
     if client.platform =~ /linux/
-      if writable_dir.blank?
+      if writable_dir.to_s.empty?
         writable_dir = tmp_folder
       end
 
@@ -440,7 +440,7 @@ class ClientCore < Extension
   def tmp_folder
     tmp = client.sys.config.getenv('TMPDIR')
 
-    if tmp.blank?
+    if tmp.to_s.empty?
       tmp = '/tmp'
     end
 

--- a/lib/rex/post/meterpreter/extensions/extapi/wmi/wmi.rb
+++ b/lib/rex/post/meterpreter/extensions/extapi/wmi/wmi.rb
@@ -31,7 +31,7 @@ class Wmi
   def query(query, root = nil)
     request = Packet.create_request('extapi_wmi_query')
 
-    request.add_tlv(TLV_TYPE_EXT_WMI_DOMAIN, root) unless root.blank?
+    request.add_tlv(TLV_TYPE_EXT_WMI_DOMAIN, root) unless root.to_s.empty?
     request.add_tlv(TLV_TYPE_EXT_WMI_QUERY, query)
 
     response = client.send_request(request)

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -69,7 +69,7 @@ class Webcam
 
     remote_browser_path = get_webrtc_browser_path
 
-    if remote_browser_path.blank?
+    if remote_browser_path.to_s.empty?
       raise RuntimeError, "Unable to find a suitable browser on the target machine"
     end
 

--- a/lib/rex/proto/kademlia/bootstrap_response.rb
+++ b/lib/rex/proto/kademlia/bootstrap_response.rb
@@ -51,14 +51,14 @@ module Kademlia
       bootstrap_peer_id = Rex::Proto::Kademlia.decode_peer_id(message.body.slice!(0, 16))
       bootstrap_tcp_port, bootstrap_version, num_peers = message.body.slice!(0, 5).unpack('vCv')
       # protocol says there are no peers and the body confirms this, so just return with no peers
-      if num_peers == 0 && message.body.blank?
+      if num_peers == 0 && message.body.to_s.empty?
         peers = []
       else
         peers_data = message.body
         # peers data is too long/short, abort
         return if peers_data.size % BOOTSTRAP_PEER_SIZE != 0
         peers = []
-        until peers_data.blank?
+        until peers_data.to_s.empty?
           peer_data = peers_data.slice!(0, BOOTSTRAP_PEER_SIZE)
           peer_id = Rex::Proto::Kademlia.decode_peer_id(peer_data.slice!(0, 16))
           ip, udp_port, tcp_port, version = peer_data.unpack('VvvC')

--- a/lib/rex/zip/blocks.rb
+++ b/lib/rex/zip/blocks.rb
@@ -116,7 +116,7 @@ class CentralDir
   end
 
   def pack
-    if @entry.central_dir_name.blank?
+    if @entry.central_dir_name.to_s.empty?
       path = @entry.relative_path
     else
       path = @entry.central_dir_path

--- a/lib/rex/zip/entry.rb
+++ b/lib/rex/zip/entry.rb
@@ -76,7 +76,7 @@ class Entry
   end
 
   def central_dir_path
-    return nil if @central_dir_name.blank?
+    return nil if @central_dir_name.to_s.empty?
     get_relative_path(@central_dir_name)
   end
 


### PR DESCRIPTION
A few instances of `.blank?` have crept into the Rex code over the years. Since we maintain rex as a standalone gem, this currently triggers an exception when these classes are called unless the caller also happens to load ActiveSupport. In the interest of reducing dependencies in Rex, these `.blank?` calls have been converted to standard Ruby. 

See [this ticket](https://github.com/rapid7/rex/issues/1) for more information. 
