### PR TITLE
Fix msfconsole -L

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -725,7 +725,7 @@ protected
     if opts['RealReadline']
       # Remove the gem version from load path to be sure we're getting the
       # stdlib readline.
-      gem_dir = Gem::Specification.find_all_by_name('rb-readline').first.gem_dir
+      gem_dir = Gem::Specification.find_all_by_name('rb-readline-r7').first.gem_dir
       rb_readline_path = File.join(gem_dir, "lib")
       index = $LOAD_PATH.index(rb_readline_path)
       # Bundler guarantees that the gem will be there, so it should be safe to


### PR DESCRIPTION
```
wvu@kharak:~/metasploit-framework:master$ ./msfconsole -L
[*] Starting the Metasploit Framework console...|/home/wvu/metasploit-framework/lib/msf/ui/console/driver.rb:728:in `choose_readline': undefined method `gem_dir' for nil:NilClass (NoMethodError)
    from /home/wvu/metasploit-framework/lib/msf/ui/console/driver.rb:57:in `initialize'
    from /home/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:52:in `new'
    from /home/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:52:in `driver'
    from /home/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:38:in `start'
    from /home/wvu/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
    from ./msfconsole:48:in `<main>'
wvu@kharak:~/metasploit-framework:master$ 
```

s/rb-readline/rb-readline-r7/

Should have been in #4816 (#4128).
- [x] `./msfconsole -L`
- [x] See the error
- [x] Be the error
- [x] Merge this
- [ ] Be happy
