### PR TITLE
phish_windows_credentials XML output on Windows 8.1

### DIFF
--- a/data/post/powershell/Invoke-LoginPrompt.ps1
+++ b/data/post/powershell/Invoke-LoginPrompt.ps1
@@ -18,5 +18,5 @@ while($DS.ValidateCredentials("$full","$password") -ne $True){
     }
  $output = $newcred = $cred.GetNetworkCredential() | select-object UserName, Domain, Password
  $output
- R{START_PROCESS}
+ #R{START_PROCESS}
 }

--- a/modules/post/windows/gather/phish_windows_credentials.rb
+++ b/modules/post/windows/gather/phish_windows_credentials.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Post
     base_script = File.read(File.join(Msf::Config.data_directory, "post", "powershell", "Invoke-LoginPrompt.ps1"))
     if process.nil?
        sdescription = description.gsub("{PROCESS_NAME} needs your permissions to start. ", "")
-       psh_script = base_script.gsub("#R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"
+       psh_script = base_script.gsub("R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"
     else
        sdescription = description.gsub("{PROCESS_NAME}", process)
        psh_script2 = base_script.gsub("R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"

--- a/modules/post/windows/gather/phish_windows_credentials.rb
+++ b/modules/post/windows/gather/phish_windows_credentials.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Post
     else
        sdescription = description.gsub("{PROCESS_NAME}", process)
        psh_script2 = base_script.gsub("R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"
-       psh_script = psh_script2.gsub("R{START_PROCESS}", "start-process \"#{path}\"")
+       psh_script = psh_script2.gsub("#R{START_PROCESS}", "start-process \"#{path}\"")
     end
     compressed_script = compress_script(psh_script)
     cmd_out, runnings_pids, open_channels = execute_script(compressed_script, datastore['TIMEOUT'])

--- a/modules/post/windows/gather/phish_windows_credentials.rb
+++ b/modules/post/windows/gather/phish_windows_credentials.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Post
     base_script = File.read(File.join(Msf::Config.data_directory, "post", "powershell", "Invoke-LoginPrompt.ps1"))
     if process.nil?
        sdescription = description.gsub("{PROCESS_NAME} needs your permissions to start. ", "")
-       psh_script = base_script.gsub("R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"
+       psh_script = base_script.gsub("#R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"
     else
        sdescription = description.gsub("{PROCESS_NAME}", process)
        psh_script2 = base_script.gsub("R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"


### PR DESCRIPTION
When running the Powershell phishing credential module on windows 8.1 without specifying a process, you get the XML below outputted. Sometimes, the XML takes over and you are unable to see the credentials. 

This is because when you don't specify a process, it leaves "R{START_PROCESS}" in Invoke-LoginPrompt.ps1. I verified that this causes the unwanted output by commenting it out and running the module.

To fix this, you need to edit Invoke-LoginPrompt.ps1 and phish_windows_credentials.rb. The changes to each are here.
