### PR TITLE
Tell payloads and encoders how much space they have to work with

### DIFF
--- a/lib/msf/base/simple/payload.rb
+++ b/lib/msf/base/simple/payload.rb
@@ -51,12 +51,13 @@ module Payload
 
     # Generate the payload
     e = EncodedPayload.create(payload,
-        'BadChars' => opts['BadChars'],
-        'MinNops'  => opts['NopSledSize'],
-        'Encoder'  => opts['Encoder'],
+        'BadChars'    => opts['BadChars'],
+        'MinNops'     => opts['NopSledSize'],
+        'Encoder'     => opts['Encoder'],
         'Iterations'  => opts['Iterations'],
         'ForceEncode' => opts['ForceEncode'],
-        'Space'    => opts['MaxSize'])
+        'DisableNops' => opts['DisableNops'],
+        'Space'       => opts['MaxSize'])
 
     fmt = opts['Format'] || 'raw'
 

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -34,6 +34,7 @@ class EncodedPayload
     self.framework = framework
     self.pinst     = pinst
     self.reqs      = reqs
+    self.space     = reqs['Space']
   end
 
   #
@@ -63,6 +64,9 @@ class EncodedPayload
     begin
       # First, validate
       pinst.validate()
+
+      # Tell the payload how much space is available
+      pinst.available_space = self.space
 
       # Generate the raw version of the payload first
       generate_raw() if self.raw.nil?
@@ -190,6 +194,9 @@ class EncodedPayload
             'core', LEV_1)
           next
         end
+
+        # Tell the encoder how much space is available
+        self.encoder.available_space = self.space
 
         eout = self.raw.dup
 
@@ -456,7 +463,10 @@ class EncodedPayload
   # The number of encoding iterations used
   #
   attr_reader :iterations
-
+  #
+  # The maximum number of bytes acceptable for the encoded payload
+  #
+  attr_reader :space
 protected
 
   attr_writer :raw # :nodoc:
@@ -467,6 +477,7 @@ protected
   attr_writer :encoder # :nodoc:
   attr_writer :nop # :nodoc:
   attr_writer :iterations # :nodoc:
+  attr_writer :space # :nodoc
 
   #
   # The payload instance used to generate the payload

--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -434,6 +434,12 @@ class Encoder < Module
     false
   end
 
+  #
+  # The amount of space available to the encoder, whch may be nil,
+  # indicating that the smallest possible encoding should be used.
+  #
+  attr_accessor :available_space
+
 protected
 
   #

--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -435,7 +435,7 @@ class Encoder < Module
   end
 
   #
-  # The amount of space available to the encoder, whch may be nil,
+  # The amount of space available to the encoder, which may be nil,
   # indicating that the smallest possible encoding should be used.
   #
   attr_accessor :available_space

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -501,7 +501,7 @@ class Payload < Msf::Module
   attr_accessor :assoc_exploit
 
   #
-  # The amount of space available to the payload, whch may be nil,
+  # The amount of space available to the payload, which may be nil,
   # indicating that the smallest possible payload should be used.
   #
   attr_accessor :available_space

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -500,6 +500,12 @@ class Payload < Msf::Module
   #
   attr_accessor :assoc_exploit
 
+  #
+  # The amount of space available to the payload, whch may be nil,
+  # indicating that the smallest possible payload should be used.
+  #
+  attr_accessor :available_space
+
 protected
 
   #

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -184,6 +184,7 @@ module Msf
         encoder_list.each do |encoder_mod|
           cli_print "Attempting to encode payload with #{iterations} iterations of #{encoder_mod.refname}"
           begin
+            encoder_mod.available_space = @space
             return run_encoder(encoder_mod, shellcode.dup)
           rescue ::Msf::EncoderSpaceViolation => e
             cli_print "#{encoder_mod.refname} failed with #{e.message}"
@@ -298,9 +299,11 @@ module Msf
         end
 
         payload_module.generate_simple(
-            'Format'   => 'raw',
-            'Options'  => datastore,
-            'Encoder'  => nil
+            'Format'      => 'raw',
+            'Options'     => datastore,
+            'Encoder'     => nil,
+            'MaxSize'     => @space,
+            'DisableNops' => true
         )
       end
     end


### PR DESCRIPTION
This change allows payload and encoder modules to become much more dynamic by providing an `available_space` accessor that is set by the `EncodedPayload` wrapper. As it stands today, this does nothing, but it opens the door for evasive encoders and payloads that can enable features and randomization based on available room. The actual payloads that use this are being implemented in the [complex payload](https://github.com/rapid7/metasploit-framework/compare/master...hmoore-r7:feature/complex-payloads) branch.
