### PR TITLE
Fix #4865, undef method 'ancestors' in lib/msf/core/payload_set.rb

### DIFF
--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -236,7 +236,7 @@ class PayloadSet < ModuleSet
       next if (handler and not p.handler_klass.ancestors.include?(handler))
 
       # Check to see if the session classes match.
-      next if (session and not p.session.ancestors.include?(session))
+      next if (session and p.session and not p.session.ancestors.include?(session))
 
       # Check for matching payload types
       next if (payload_type and p.payload_type != payload_type)


### PR DESCRIPTION
Fix #4865

To test:
- [x] `./msfvenom -p generic/shell_reverse_tcp arch=x86 platform=Windows -f raw`
- [x] It should generate a payload
