### PR TITLE
Postgres Pass The Hash reference

### DIFF
--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -21,14 +21,16 @@ class Metasploit3 < Msf::Auxiliary
       'Description'    => %q{
         This module attempts to authenticate against a PostgreSQL
         instance using username and password combinations indicated
-        by the USER_FILE, PASS_FILE, and USERPASS_FILE options.
+        by the USER_FILE, PASS_FILE, and USERPASS_FILE options. Note that
+        passwords may be either plaintext or MD5 formatted hashes.
       },
       'Author'         => [ 'todb' ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
           [ 'URL', 'http://www.postgresql.org' ],
-          [ 'CVE', '1999-0502'] # Weak password
+          [ 'CVE', '1999-0502'], # Weak password
+          [ 'URL', 'https://hashcat.net/forum/archive/index.php?thread-4148.html' ] # Pass the Hash
         ]
     ))
 


### PR DESCRIPTION
Dave and William did most of the work already over on PR #4871, this just points it out in the module.
## Verification
- [x] Read the module info, like so:

```
Description:
  This module attempts to authenticate against a PostgreSQL instance 
  using username and password combinations indicated by the USER_FILE, 
  PASS_FILE, and USERPASS_FILE options. Note that passwords may be 
  either plaintext or MD5 formatted hashes.

References:
  http://www.postgresql.org
  http://cvedetails.com/cve/1999-0502/
  https://hashcat.net/forum/archive/index.php?thread-4148.html
```
