### PR TITLE
Fix store_loot when database is not present (msfconsole -n)

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -73,7 +73,7 @@ module Msf::DBManager::Host
   # address
   #
   def normalize_host(host)
-    return host if host.kind_of? ::Mdm::Host
+    return host if defined?(::Mdm) and host.kind_of? ::Mdm::Host
     norm_host = nil
 
     if (host.kind_of? String)
@@ -92,7 +92,7 @@ module Msf::DBManager::Host
       else
         norm_host = Rex::Socket.getaddress(host, true)
       end
-    elsif host.kind_of? ::Mdm::Session
+    elsif defined?(::Mdm) and host.kind_of? ::Mdm::Session
       norm_host = host.host
     elsif host.respond_to?(:session_host)
       # Then it's an Msf::Session object


### PR DESCRIPTION
I verified with `auxiliary/gather/apple_safari_webarchive_uxss`:

```
$ ./msfconsole -n
msf> use auxiliary/gather/apple_safari_webarchive_uxss
msf> set URLS 'http://example.com'
msf> run -j
```

Then, in another console;

```
$ curl --data "{}" -X POST http://0.0.0.0:8080/grab
```
- [x] The POST data should be stored as loot and you should see a message in msfconsole:
  
  ```
  [+] 192.168.0.2      apple_safari_webarchive_uxss - 2 chars received and stored to /Users/joe/.msf4/loot/20150305233045_default_127.0.0.1_safari.client_761260.txt
  ```
- [x] The file contains `[{}]`
