### PR TITLE
Fix NoMethodError in plugins/nessus.rb

### DIFF
--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -232,10 +232,10 @@ module Msf
         if !args[0]
           if File.exist?(nessus_yaml)
             lconfig = YAML.load_file(nessus_yaml)
-            @user = lconfig['default']['username']
-            @pass = lconfig['default']['password']
-            @host = lconfig['default']['server']
-            @port = lconfig['default']['port']
+            @user = lconfig['default']['username'].to_s
+            @pass = lconfig['default']['password'].to_s
+            @host = lconfig['default']['server'].to_s
+            @port = lconfig['default']['port'].to_s
             nessus_login
             return
           else


### PR DESCRIPTION
```
[-] Error while running command nessus_connect: undefined method `length' for 8834:Fixnum

Call stack:
/home/wvu/metasploit-framework/plugins/nessus.rb:326:in `nessus_login'
/home/wvu/metasploit-framework/plugins/nessus.rb:239:in `cmd_nessus_connect'
/home/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
/home/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
/home/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
/home/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
/home/wvu/metasploit-framework/lib/msf/ui/console/driver.rb:248:in `block in initialize'
/home/wvu/metasploit-framework/lib/msf/ui/console/driver.rb:247:in `each'
/home/wvu/metasploit-framework/lib/msf/ui/console/driver.rb:247:in `initialize'
/home/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:52:in `new'
/home/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:52:in `driver'
/home/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:38:in `start'
/home/wvu/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```

Triggered by `@port.length` in `nessus_login` from YAML. Also fixed for other cases (e.g., password is 123456).
- [x] `echo $'default:\n  username: batman\n  password: fairbanks\n  server: 127.0.0.1\n  port: 8834' > ~/.msf4/nessus.yaml`
- [x] `./msfconsole -qx 'load nessus; nessus_connect; exit'`

Discovered by evilbit on IRC.
