### PR TITLE
Implement payload size caching, speeding up framework loads

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -159,12 +159,20 @@ class Payload < Msf::Module
     (@staged or payload_type == Type::Stager or payload_type == Type::Stage)
   end
 
-
   #
   # This method returns an optional cached size value
   #
   def self.cached_size
-    (const_defined?('CachedSize')) ? const_get('CachedSize') : nil
+    csize = (const_defined?('CachedSize')) ? const_get('CachedSize') : nil
+    csize == :dynamic ? nil : csize
+  end
+
+  #
+  # This method returns whether the payload generates variable-sized output
+  #
+  def self.dynamic_size?
+    csize = (const_defined?('CachedSize')) ? const_get('CachedSize') : nil
+    csize == :dynamic
   end
 
   #
@@ -172,6 +180,13 @@ class Payload < Msf::Module
   #
   def cached_size
       self.class.cached_size
+  end
+
+  #
+  # This method returns whether the payload generates variable-sized output
+  #
+  def dynamic_size?
+      self.class.dynamic_size?
   end
 
   #

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -159,6 +159,21 @@ class Payload < Msf::Module
     (@staged or payload_type == Type::Stager or payload_type == Type::Stage)
   end
 
+
+  #
+  # This method returns an optional cached size value
+  #
+  def self.cached_size
+    (const_defined?('CachedSize')) ? const_get('CachedSize') : nil
+  end
+
+  #
+  # This method returns an optional cached size value
+  #
+  def cached_size
+      self.class.cached_size
+  end
+
   #
   # Returns the payload's size.  If the payload is staged, the size of the
   # first stage is returned.
@@ -499,6 +514,12 @@ class Payload < Msf::Module
   # attribute will point to that exploit instance.
   #
   attr_accessor :assoc_exploit
+
+  #
+  # The amount of space available to the payload, which may be nil,
+  # indicating that the smallest possible payload should be used.
+  #
+  attr_accessor :available_space
 
 protected
 

--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -154,6 +154,7 @@ class PayloadSet < ModuleSet
           'type'  => op[5]['type']})
         new_keys.push combined
 
+        # Cache the payload's size
         sizes[combined] = p.cached_size || p.new.size
       }
     }

--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -235,7 +235,7 @@ class PayloadSet < ModuleSet
       next if (handler and not p.handler_klass.ancestors.include?(handler))
 
       # Check to see if the session classes match.
-      next if (session and not p.session.ancestors.include?(session))
+      next if (session and p.session and not p.session.ancestors.include?(session))
 
       # Check for matching payload types
       next if (payload_type and p.payload_type != payload_type)

--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -154,8 +154,7 @@ class PayloadSet < ModuleSet
           'type'  => op[5]['type']})
         new_keys.push combined
 
-        # Cache the payload's size
-        sizes[combined] = p.new.size
+        sizes[combined] = p.cached_size || p.new.size
       }
     }
 
@@ -236,7 +235,7 @@ class PayloadSet < ModuleSet
       next if (handler and not p.handler_klass.ancestors.include?(handler))
 
       # Check to see if the session classes match.
-      next if (session and p.session and not p.session.ancestors.include?(session))
+      next if (session and not p.session.ancestors.include?(session))
 
       # Check for matching payload types
       next if (payload_type and p.payload_type != payload_type)

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -59,7 +59,7 @@ class PayloadCachedSize
   # @param mod [Msf::Payload] The class of the payload module to update
   # @return [Fixnum]
   def self.compute_cached_size(mod)
-    return :dynamic if is_dynamic?(mod)
+    return ":dynamic" if is_dynamic?(mod)
     return mod.new.size
   end
 

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -14,6 +14,12 @@ module Util
 
 class PayloadCachedSize
 
+  # Insert a new CachedSize value into the text of a payload module
+  #
+  # @param data [String] The source code of a payload module
+  # @param cached_size [String] The new value for cached_size, which
+  #   which should be either numeric or the string :dynamic
+  # @return [String]
   def self.update_cache_constant(data, cached_size)
     data.
       gsub(/^\s*CachedSize\s*=\s*(\d+|:dynamic).*/, '').
@@ -22,6 +28,12 @@ class PayloadCachedSize
       end
   end
 
+  # Insert a new CachedSize value into a payload module file
+  #
+  # @param mod [Msf::Payload] The class of the payload module to update
+  # @param cached_size [String] The new value for cached_size, which
+  #   which should be either numeric or the string :dynamic
+  # @return [void]
   def self.update_cached_size(mod, cached_size)
     mod_data = ""
 
@@ -34,19 +46,37 @@ class PayloadCachedSize
     end
   end
 
+  # Updates the payload module specified with the current CachedSize
+  #
+  # @param mod [Msf::Payload] The class of the payload module to update
+  # @return [void]
   def self.update_module_cached_size(mod)
     update_cached_size(mod, compute_cached_size(mod))
   end
 
+  # Calculates the CachedSize value for a payload module
+  #
+  # @param mod [Msf::Payload] The class of the payload module to update
+  # @return [Fixnum]
   def self.compute_cached_size(mod)
     return :dynamic if is_dynamic?(mod)
     return mod.new.size
   end
 
+  # Determines whether a payload generates a static sized output
+  #
+  # @param mod [Msf::Payload] The class of the payload module to update
+  # @param generation_count [Fixnum] The number of iterations to use to
+  #   verify that the size is static.
+  # @return [Fixnum]
   def self.is_dynamic?(mod,generation_count=5)
     [*(1..generation_count)].map{|x| mod.new.size}.uniq.length != 1
   end
 
+  # Determines whether a payload's CachedSize is up to date
+  #
+  # @param mod [Msf::Payload] The class of the payload module to update
+  # @return [Boolean]
   def self.is_cached_size_accurate?(mod)
     return true if mod.dynamic_size?
     return false if mod.cached_size.nil?

--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+###
+#
+#
+###
+
+module Msf
+module Util
+
+#
+# The class provides helper methods for verifying and updating the embedded CachedSize
+# constant within payload modules.
+#
+
+class PayloadCachedSize
+
+  def self.update_cache_constant(data, cached_size)
+    data.
+      gsub(/^\s*CachedSize\s*=\s*(\d+|:dynamic).*/, '').
+      gsub(/^(module Metasploit\d+)\s*\n/) do |m|
+        "#{m.strip}\n\n  CachedSize = #{cached_size}\n\n"
+      end
+  end
+
+  def self.update_cached_size(mod, cached_size)
+    mod_data = ""
+
+    ::File.open(mod.file_path, 'rb') do |fd|
+      mod_data = fd.read(fd.stat.size)
+    end
+
+    ::File.open(mod.file_path, 'wb') do |fd|
+      fd.write update_cache_constant(mod_data, cached_size)
+    end
+  end
+
+  def self.update_module_cached_size(mod)
+    update_cached_size(mod, compute_cached_size(mod))
+  end
+
+  def self.compute_cached_size(mod)
+    return :dynamic if is_dynamic?(mod)
+    return mod.new.size
+  end
+
+  def self.is_dynamic?(mod,generation_count=5)
+    [*(1..generation_count)].map{|x| mod.new.size}.uniq.length != 1
+  end
+
+  def self.is_cached_size_accurate?(mod)
+    return true if mod.dynamic_size?
+    return false if mod.cached_size.nil?
+    mod.cached_size == mod.new.size
+  end
+
+end
+
+end
+end

--- a/modules/payloads/singles/aix/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/aix/ppc/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 264
+
   include Msf::Payload::Single
   include Msf::Payload::Aix
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/aix/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/aix/ppc/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 220
+
   include Msf::Payload::Single
   include Msf::Payload::Aix
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/aix/ppc/shell_interact.rb
+++ b/modules/payloads/singles/aix/ppc/shell_interact.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 56
+
   include Msf::Payload::Single
   include Msf::Payload::Aix
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/aix/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/aix/ppc/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 204
+
   include Msf::Payload::Single
   include Msf::Payload::Aix
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/sparc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/sparc/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 164
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/sparc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/sparc/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 128
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -17,6 +17,8 @@ require 'msf/core'
 ###
 module Metasploit3
 
+  CachedSize = 107
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
 

--- a/modules/payloads/singles/bsd/x86/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/metsvc_bind_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = 65
+
   include Msf::Payload::Bsd
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/bsd/x86/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/metsvc_reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = 65
+
   include Msf::Payload::Bsd
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/bsd/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 138
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x86/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/bsd/x86/shell_bind_tcp_ipv6.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 152
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x86/shell_find_port.rb
+++ b/modules/payloads/singles/bsd/x86/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 125
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x86/shell_find_tag.rb
+++ b/modules/payloads/singles/bsd/x86/shell_find_tag.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 135
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 129
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x86/shell_reverse_tcp_ipv6.rb
+++ b/modules/payloads/singles/bsd/x86/shell_reverse_tcp_ipv6.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 161
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsdi/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsdi/x86/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 90
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/bsdi/x86/shell_find_port.rb
+++ b/modules/payloads/singles/bsdi/x86/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 77
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/bsdi/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsdi/x86/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 77
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_awk.rb
+++ b/modules/payloads/singles/cmd/unix/bind_awk.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
+  CachedSize = 96
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_inetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_inetd.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 487
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
+  CachedSize = 223
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 24
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 25
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 1843
+
   include Msf::Payload::Single
   include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_perl.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 240
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 152
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 137
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 142
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/bind_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/bind_zsh.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
+  CachedSize = 112
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/generic.rb
+++ b/modules/payloads/singles/cmd/unix/generic.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/interact.rb
+++ b/modules/payloads/singles/cmd/unix/interact.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse.rb
+++ b/modules/payloads/singles/cmd/unix/reverse.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 100
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 95
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_lua.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 209
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 20
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 1911
+
   include Msf::Payload::Single
   include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 152
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 219
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 129
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 117
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 567
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 118
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 170
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 106
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/unix/reverse_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_zsh.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 95
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -9,6 +9,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 258
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/bind_lua.rb
+++ b/modules/payloads/singles/cmd/windows/bind_lua.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
+  CachedSize = 223
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/bind_perl.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 139
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 140
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/bind_ruby.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 128
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
@@ -9,6 +9,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
@@ -9,6 +9,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/generic.rb
+++ b/modules/payloads/singles/cmd/windows/generic.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_lua.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 209
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 133
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 1189
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 111
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Firefox

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Firefox
 

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Firefox
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Firefox

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Firefox
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Firefox

--- a/modules/payloads/singles/generic/custom.rb
+++ b/modules/payloads/singles/generic/custom.rb
@@ -8,6 +8,8 @@ require 'msf/core/payload/generic'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Payload::Generic
 

--- a/modules/payloads/singles/generic/debug_trap.rb
+++ b/modules/payloads/singles/generic/debug_trap.rb
@@ -10,6 +10,8 @@ require 'msf/core/payload/generic'
 
 module Metasploit3
 
+  CachedSize = 1
+
   include Msf::Payload::Single
 
   def initialize(info = {})

--- a/modules/payloads/singles/generic/shell_bind_tcp.rb
+++ b/modules/payloads/singles/generic/shell_bind_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Payload::Generic
 

--- a/modules/payloads/singles/generic/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/generic/shell_reverse_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Payload::Generic
 

--- a/modules/payloads/singles/generic/tight_loop.rb
+++ b/modules/payloads/singles/generic/tight_loop.rb
@@ -8,6 +8,8 @@ require 'msf/core/payload/generic'
 
 module Metasploit3
 
+  CachedSize = 2
+
   include Msf::Payload::Single
 
   def initialize(info = {})

--- a/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 1593
+
   include Msf::Payload::Single
   include Msf::Payload::JSP
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Payload::JSP
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 7748
+
   include Msf::Payload::Single
   include Msf::Payload::Java
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/armle/adduser.rb
+++ b/modules/payloads/singles/linux/armle/adduser.rb
@@ -16,6 +16,8 @@ require 'msf/core'
 ###
 module Metasploit3
 
+  CachedSize = 119
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/armle/exec.rb
+++ b/modules/payloads/singles/linux/armle/exec.rb
@@ -15,6 +15,8 @@ require 'msf/core'
 ###
 module Metasploit3
 
+  CachedSize = 22
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 208
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 172
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/mipsbe/exec.rb
+++ b/modules/payloads/singles/linux/mipsbe/exec.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 48
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/mipsbe/reboot.rb
+++ b/modules/payloads/singles/linux/mipsbe/reboot.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 32
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/mipsbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 232
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 48
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/mipsle/reboot.rb
+++ b/modules/payloads/singles/linux/mipsle/reboot.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 32
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 232
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 223
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 171
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 183
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/ppc64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 223
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/ppc64/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 171
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/ppc64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 183
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -7,6 +7,9 @@
 require 'msf/core'
 
 module Metasploit3
+
+  CachedSize = 209
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp.rb
@@ -10,6 +10,9 @@ require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
+
+  CachedSize = 255
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 226
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/x64/shell_find_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 91
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_reverse_tcp.rb
@@ -10,6 +10,9 @@ require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
+
+  CachedSize = 243
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x86/adduser.rb
+++ b/modules/payloads/singles/linux/x86/adduser.rb
@@ -17,6 +17,8 @@ require 'msf/core'
 ###
 module Metasploit3
 
+  CachedSize = 219
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/x86/chmod.rb
+++ b/modules/payloads/singles/linux/x86/chmod.rb
@@ -11,6 +11,9 @@ require 'msf/core'
 #  Kris Katterjohn - 03/03/2008
 ###
 module Metasploit3
+
+  CachedSize = 158
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -15,6 +15,8 @@ require 'msf/core'
 ###
 module Metasploit3
 
+  CachedSize = 158
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/x86/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x86/metsvc_bind_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = 122
+
   include Msf::Payload::Linux
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/metsvc_reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = 122
+
   include Msf::Payload::Linux
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 184
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/x86/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_ipv6_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 212
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 200
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 179
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
 

--- a/modules/payloads/singles/linux/x86/shell_find_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 184
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x86/shell_find_tag.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_tag.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 191
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 190
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 103
+
   include Msf::Payload::Single
   include Msf::Payload::Linux
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -14,6 +14,8 @@ require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
+  CachedSize = 456
+
   include Msf::Payload::Single
   include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
@@ -14,6 +14,8 @@ require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
+  CachedSize = 473
+
   include Msf::Payload::Single
   include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 501
+
   include Msf::Payload::Single
   include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/armle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/armle/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 200
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/armle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/armle/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 152
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/armle/vibrate.rb
+++ b/modules/payloads/singles/osx/armle/vibrate.rb
@@ -9,6 +9,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 16
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
 

--- a/modules/payloads/singles/osx/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/ppc/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 224
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/ppc/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 164
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x64/exec.rb
+++ b/modules/payloads/singles/osx/x64/exec.rb
@@ -8,6 +8,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 23
+
   include Msf::Payload::Single
 
   def initialize(info = {})

--- a/modules/payloads/singles/osx/x64/say.rb
+++ b/modules/payloads/singles/osx/x64/say.rb
@@ -8,6 +8,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 53
+
   include Msf::Payload::Single
 
   def initialize(info = {})

--- a/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 136
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x64/shell_find_tag.rb
+++ b/modules/payloads/singles/osx/x64/shell_find_tag.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 107
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 108
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -17,6 +17,8 @@ require 'msf/core'
 ###
 module Metasploit3
 
+  CachedSize = 81
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
 

--- a/modules/payloads/singles/osx/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x86/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 139
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x86/shell_find_port.rb
+++ b/modules/payloads/singles/osx/x86/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 126
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x86/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 130
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x86/vforkshell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x86/vforkshell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 217
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/osx/x86/vforkshell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x86/vforkshell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 196
+
   include Msf::Payload::Single
   include Msf::Payload::Osx
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/php/bind_perl.rb
+++ b/modules/payloads/singles/php/bind_perl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 230
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/php/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/php/bind_perl_ipv6.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 230
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/php/bind_php.rb
+++ b/modules/payloads/singles/php/bind_php.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Php

--- a/modules/payloads/singles/php/bind_php.rb
+++ b/modules/payloads/singles/php/bind_php.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Php
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/php/bind_php_ipv6.rb
+++ b/modules/payloads/singles/php/bind_php_ipv6.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Php

--- a/modules/payloads/singles/php/bind_php_ipv6.rb
+++ b/modules/payloads/singles/php/bind_php_ipv6.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Php
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/php/download_exec.rb
+++ b/modules/payloads/singles/php/download_exec.rb
@@ -10,7 +10,7 @@ require 'msf/core/payload/php'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Php
   include Msf::Payload::Single

--- a/modules/payloads/singles/php/download_exec.rb
+++ b/modules/payloads/singles/php/download_exec.rb
@@ -10,6 +10,8 @@ require 'msf/core/payload/php'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Php
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/php/exec.rb
+++ b/modules/payloads/singles/php/exec.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Php

--- a/modules/payloads/singles/php/exec.rb
+++ b/modules/payloads/singles/php/exec.rb
@@ -12,6 +12,8 @@ require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Php
 

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -10,6 +10,9 @@ require 'msf/base/sessions/meterpreter_options'
 
 
 module Metasploit3
+
+  CachedSize = 24643
+
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions
 

--- a/modules/payloads/singles/php/reverse_perl.rb
+++ b/modules/payloads/singles/php/reverse_perl.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Php

--- a/modules/payloads/singles/php/reverse_perl.rb
+++ b/modules/payloads/singles/php/reverse_perl.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Php
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/php/reverse_php.rb
+++ b/modules/payloads/singles/php/reverse_php.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Php

--- a/modules/payloads/singles/php/reverse_php.rb
+++ b/modules/payloads/singles/php/reverse_php.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Php
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/php/shell_findsock.rb
+++ b/modules/payloads/singles/php/shell_findsock.rb
@@ -12,6 +12,8 @@ require 'msf/core/handler/find_shell'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Php
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/php/shell_findsock.rb
+++ b/modules/payloads/singles/php/shell_findsock.rb
@@ -12,7 +12,7 @@ require 'msf/core/handler/find_shell'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Php

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 381
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 537
+
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
 

--- a/modules/payloads/singles/ruby/shell_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 516
+
   include Msf::Payload::Single
   include Msf::Payload::Ruby
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 524
+
   include Msf::Payload::Single
   include Msf::Payload::Ruby
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/ruby/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 496
+
   include Msf::Payload::Single
   include Msf::Payload::Ruby
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 424
+
   include Msf::Payload::Single
   include Msf::Payload::Ruby
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/solaris/sparc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 180
+
   include Msf::Payload::Single
   include Msf::Payload::Solaris
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/solaris/sparc/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_find_port.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Solaris

--- a/modules/payloads/singles/solaris/sparc/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
   include Msf::Payload::Single
   include Msf::Payload::Solaris
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/solaris/sparc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 144
+
   include Msf::Payload::Single
   include Msf::Payload::Solaris
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 160
+
   include Msf::Payload::Single
   include Msf::Payload::Solaris
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/solaris/x86/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/x86/shell_find_port.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 151
+
   include Msf::Payload::Single
   include Msf::Payload::Solaris
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 156
+
   include Msf::Payload::Single
   include Msf::Payload::Solaris
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/tty/unix/interact.rb
+++ b/modules/payloads/singles/tty/unix/interact.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Single
 
   def initialize(info = {})

--- a/modules/payloads/singles/windows/adduser.rb
+++ b/modules/payloads/singles/windows/adduser.rb
@@ -15,6 +15,8 @@ require 'msf/core/payload/windows/exec'
 ###
 module Metasploit3
 
+  CachedSize = 443
+
   include Msf::Payload::Windows::Exec
 
   def initialize(info = {})

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 275
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -8,6 +8,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 439
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/windows/exec.rb
+++ b/modules/payloads/singles/windows/exec.rb
@@ -13,6 +13,8 @@ require 'msf/core/payload/windows/exec'
 ###
 module Metasploit3
 
+  CachedSize = 185
+
   include Msf::Payload::Windows::Exec
 
 end

--- a/modules/payloads/singles/windows/format_all_drives.rb
+++ b/modules/payloads/singles/windows/format_all_drives.rb
@@ -16,6 +16,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 393
+
   Rank = ManualRanking
 
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/loadlibrary.rb
+++ b/modules/payloads/singles/windows/loadlibrary.rb
@@ -13,6 +13,8 @@ require 'msf/core/payload/windows/loadlibrary'
 ###
 module Metasploit3
 
+  CachedSize = 183
+
   include Msf::Payload::Windows::LoadLibrary
 
 end

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -9,6 +9,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 272
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/windows/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_bind_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
+  CachedSize = 0
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/windows/shell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 328
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/windows/shell_bind_tcp_xpfw.rb
+++ b/modules/payloads/singles/windows/shell_bind_tcp_xpfw.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 529
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/windows/shell_hidden_bind_tcp.rb
+++ b/modules/payloads/singles/windows/shell_hidden_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 386
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/windows/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 324
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/windows/speak_pwned.rb
+++ b/modules/payloads/singles/windows/speak_pwned.rb
@@ -40,6 +40,8 @@ require 'msf/core/payload/windows/exec'
 
 module Metasploit3
 
+  CachedSize = 247
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/windows/x64/exec.rb
+++ b/modules/payloads/singles/windows/x64/exec.rb
@@ -9,6 +9,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 268
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/windows/x64/loadlibrary.rb
+++ b/modules/payloads/singles/windows/x64/loadlibrary.rb
@@ -9,6 +9,8 @@ require 'msf/core'
 
 module Metasploit3
 
+  CachedSize = 267
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/windows/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/shell_bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 505
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/windows/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/shell_reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 460
+
   include Msf::Payload::Windows
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -8,9 +8,9 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -8,6 +8,10 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
+  CachedSize = dynamic
+
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
 

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -10,8 +10,6 @@ module Metasploit3
 
   CachedSize = :dynamic
 
-  CachedSize = :dynamic
-
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
 

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -8,9 +8,9 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -8,6 +8,10 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
+  CachedSize = dynamic
+
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
 

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -10,8 +10,6 @@ module Metasploit3
 
   CachedSize = :dynamic
 
-  CachedSize = :dynamic
-
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -10,6 +10,10 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = dynamic
+
+  CachedSize = dynamic
+
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -12,8 +12,6 @@ module Metasploit3
 
   CachedSize = :dynamic
 
-  CachedSize = :dynamic
-
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -10,9 +10,9 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
-  CachedSize = dynamic
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik

--- a/modules/payloads/stagers/bsd/x86/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/bind_ipv6_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 63
+
   include Msf::Payload::Stager
 
   def self.handler_type_alias

--- a/modules/payloads/stagers/bsd/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/bind_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 54
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/bsd/x86/find_tag.rb
+++ b/modules/payloads/stagers/bsd/x86/find_tag.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/find_tag'
 ###
 module Metasploit3
 
+  CachedSize = 40
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/bsd/x86/reverse_ipv6_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/reverse_ipv6_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 81
+
   include Msf::Payload::Stager
 
 

--- a/modules/payloads/stagers/bsd/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/reverse_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 43
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/bsdi/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/bsdi/x86/bind_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 69
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/bsdi/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/bsdi/x86/reverse_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 59
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/java/bind_tcp.rb
+++ b/modules/payloads/stagers/java/bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 5487
+
   include Msf::Payload::Stager
   include Msf::Payload::Java
 

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -8,6 +8,8 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
+  CachedSize = 5500
+
   include Msf::Payload::Stager
   include Msf::Payload::Java
 

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -8,6 +8,8 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
+  CachedSize = 6308
+
   include Msf::Payload::Stager
   include Msf::Payload::Java
 

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 5487
+
   include Msf::Payload::Stager
   include Msf::Payload::Java
 

--- a/modules/payloads/stagers/linux/armle/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/bind_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 232
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 200
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 212
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 212
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x64/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/bind_tcp.rb
@@ -8,6 +8,9 @@ require 'msf/core'
 require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
+
+  CachedSize = 247
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -8,6 +8,9 @@ require 'msf/core'
 require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
+
+  CachedSize = 237
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/bind_tcp'
 # Linux Bind TCP/IPv6 Stager
 module Metasploit3
 
+  CachedSize = 207
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 185
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 201
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x86/find_tag.rb
+++ b/modules/payloads/stagers/linux/x86/find_tag.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/find_tag'
 ###
 module Metasploit3
 
+  CachedSize = 159
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x86/reverse_ipv6_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_ipv6_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/reverse_tcp'
 # Linux Reverse TCP/IPv6 Stager
 module Metasploit3
 
+  CachedSize = 199
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 172
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 193
+
   include Msf::Payload::Stager
   include Msf::Payload::Linux
 

--- a/modules/payloads/stagers/netware/reverse_tcp.rb
+++ b/modules/payloads/stagers/netware/reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 279
+
   include Msf::Payload::Stager
   include Msf::Payload::Netware
 

--- a/modules/payloads/stagers/osx/armle/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/armle/bind_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 248
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/osx/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/armle/reverse_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 184
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/osx/ppc/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/ppc/bind_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 152
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/osx/ppc/find_tag.rb
+++ b/modules/payloads/stagers/osx/ppc/find_tag.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/find_tag'
 ###
 module Metasploit3
 
+  CachedSize = 76
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/osx/ppc/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/ppc/reverse_tcp.rb
@@ -18,6 +18,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 100
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/osx/x64/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/x64/bind_tcp.rb
@@ -8,6 +8,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 185
+
   include Msf::Payload::Stager
 
   def initialize(info = { })

--- a/modules/payloads/stagers/osx/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/x64/reverse_tcp.rb
@@ -8,6 +8,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 154
+
   include Msf::Payload::Stager
 
   def initialize(info = { })

--- a/modules/payloads/stagers/osx/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/x86/bind_tcp.rb
@@ -16,6 +16,8 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 144
+
   include Msf::Payload::Stager
 
   def initialize(info = { })

--- a/modules/payloads/stagers/osx/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/x86/reverse_tcp.rb
@@ -16,6 +16,8 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
+  CachedSize = 123
+
   include Msf::Payload::Stager
 
   def initialize(info = { })

--- a/modules/payloads/stagers/php/bind_tcp.rb
+++ b/modules/payloads/stagers/php/bind_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 1418
+
   include Msf::Payload::Stager
   include Msf::Payload::Php
 

--- a/modules/payloads/stagers/php/bind_tcp_ipv6.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 1350
+
   include Msf::Payload::Stager
   include Msf::Payload::Php
 

--- a/modules/payloads/stagers/php/reverse_tcp.rb
+++ b/modules/payloads/stagers/php/reverse_tcp.rb
@@ -11,6 +11,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 1303
+
   include Msf::Payload::Stager
   include Msf::Payload::Php
 

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 374
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -35,7 +35,7 @@ module Metasploit3
   # Constructs the payload
   #
   def generate
-    lhost = datastore['LHOST'] || Rex::Socket.source_address
+    lhost = datastore['LHOST'] || '127.127.127.127'
 
     var_escape = lambda { |txt|
       txt.gsub('\\', '\\'*4).gsub('\'', %q(\\\'))

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -8,6 +8,8 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
+  CachedSize = 438
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = 438
+  CachedSize = 442
 
   include Msf::Payload::Stager
 

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 342
+
   include Msf::Payload::Stager
 
   def initialize(info = {})

--- a/modules/payloads/stagers/windows/bind_hidden_ipknock_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_hidden_ipknock_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 359
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/bind_hidden_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_hidden_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 343
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_ipv6_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 285
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/bind_nonx_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_nonx_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 201
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/bind_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 285
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/bind_tcp_rc4.rb
+++ b/modules/payloads/stagers/windows/bind_tcp_rc4.rb
@@ -11,6 +11,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 398
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/findtag_ord.rb
+++ b/modules/payloads/stagers/windows/findtag_ord.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/find_tag'
 
 module Metasploit3
 
+  CachedSize = 92
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_hop_http.rb
+++ b/modules/payloads/stagers/windows/reverse_hop_http.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/reverse_hop_http'
 
 module Metasploit3
 
+  CachedSize = 353
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = 318
+  CachedSize = 322
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -74,7 +74,7 @@ module Metasploit3
     u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITW) + "\x00"
     p[i, u.length] = u
 
-    lhost = datastore['LHOST'] || Rex::Socket.source_address
+    lhost = datastore['LHOST'] || '127.127.127.127'
     if Rex::Socket.is_ipv6?(lhost)
       lhost = "[#{lhost}]"
     end

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
+  CachedSize = 318
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
+++ b/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
+  CachedSize = 650
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_https.rb
+++ b/modules/payloads/stagers/windows/reverse_https.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
+  CachedSize = 327
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_https_proxy'
 
 module Metasploit3
 
+  CachedSize = 391
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_ipv6_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_ipv6_tcp.rb
@@ -9,6 +9,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 289
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_nonx_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_nonx_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 177
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_ord_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_ord_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 93
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 281
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_tcp_allports.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_allports.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp_allports'
 
 module Metasploit3
 
+  CachedSize = 282
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_tcp_dns.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_dns.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 356
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_tcp_rc4.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_rc4.rb
@@ -11,6 +11,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 394
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/reverse_tcp_rc4_dns.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_rc4_dns.rb
@@ -11,6 +11,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 469
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/x64/bind_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/bind_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
+  CachedSize = 467
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
+  CachedSize = 578
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/modules/payloads/stagers/windows/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
+  CachedSize = 422
+
   include Msf::Payload::Stager
   include Msf::Payload::Windows
 

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -6,7 +6,8 @@ describe 'modules/payloads', :content do
   include_context 'untested payloads', modules_pathname: modules_pathname
 
   context 'aix/ppc/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_bind_tcp'
                           ],
@@ -15,7 +16,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'aix/ppc/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_find_port'
                           ],
@@ -24,7 +26,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'aix/ppc/shell_interact' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_interact'
                           ],
@@ -33,7 +36,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'aix/ppc/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_reverse_tcp'
                           ],
@@ -42,7 +46,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'android/meterpreter/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_http',
                               'stages/android/meterpreter'
@@ -52,7 +57,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'android/meterpreter/reverse_https' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_https',
                               'stages/android/meterpreter'
@@ -62,7 +68,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'android/meterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_tcp',
                               'stages/android/meterpreter'
@@ -72,7 +79,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'android/shell/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_http',
                               'stages/android/shell'
@@ -82,7 +90,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'android/shell/reverse_https' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_https',
                               'stages/android/shell'
@@ -92,7 +101,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'android/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_tcp',
                               'stages/android/shell'
@@ -102,7 +112,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/sparc/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/sparc/shell_bind_tcp'
                           ],
@@ -111,7 +122,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/sparc/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/sparc/shell_reverse_tcp'
                           ],
@@ -120,7 +132,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/exec'
                           ],
@@ -129,7 +142,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/metsvc_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/metsvc_bind_tcp'
                           ],
@@ -138,7 +152,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/metsvc_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/metsvc_reverse_tcp'
                           ],
@@ -147,7 +162,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/bind_ipv6_tcp',
                               'stages/bsd/x86/shell'
@@ -157,7 +173,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/bind_tcp',
                               'stages/bsd/x86/shell'
@@ -167,7 +184,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/find_tag',
                               'stages/bsd/x86/shell'
@@ -177,7 +195,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/reverse_ipv6_tcp',
                               'stages/bsd/x86/shell'
@@ -187,7 +206,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/reverse_tcp',
                               'stages/bsd/x86/shell'
@@ -197,7 +217,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_bind_tcp'
                           ],
@@ -206,7 +227,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell_bind_tcp_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_bind_tcp_ipv6'
                           ],
@@ -215,7 +237,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_find_port'
                           ],
@@ -224,7 +247,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell_find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_find_tag'
                           ],
@@ -233,7 +257,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_reverse_tcp'
                           ],
@@ -242,7 +267,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsd/x86/shell_reverse_tcp_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_reverse_tcp_ipv6'
                           ],
@@ -251,7 +277,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsdi/x86/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsdi/x86/bind_tcp',
                               'stages/bsdi/x86/shell'
@@ -261,7 +288,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsdi/x86/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsdi/x86/reverse_tcp',
                               'stages/bsdi/x86/shell'
@@ -271,7 +299,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsdi/x86/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_bind_tcp'
                           ],
@@ -280,7 +309,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsdi/x86/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_find_port'
                           ],
@@ -289,7 +319,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'bsdi/x86/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_reverse_tcp'
                           ],
@@ -298,7 +329,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_awk' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_awk'
                           ],
@@ -307,7 +339,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_inetd' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_inetd'
                           ],
@@ -316,7 +349,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_lua' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_lua'
                           ],
@@ -325,7 +359,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_netcat' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat'
                           ],
@@ -334,7 +369,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_netcat_gaping' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat_gaping'
                           ],
@@ -343,7 +379,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_netcat_gaping_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat_gaping_ipv6'
                           ],
@@ -352,7 +389,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_nodejs' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_nodejs'
                           ],
@@ -361,7 +399,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_perl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_perl'
                           ],
@@ -370,7 +409,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_perl_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_perl_ipv6'
                           ],
@@ -379,7 +419,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_ruby' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_ruby'
                           ],
@@ -388,7 +429,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_ruby_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_ruby_ipv6'
                           ],
@@ -397,7 +439,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/bind_zsh' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_zsh'
                           ],
@@ -406,7 +449,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/generic' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/generic'
                           ],
@@ -415,7 +459,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/interact' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/interact'
                           ],
@@ -424,7 +469,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse'
                           ],
@@ -433,7 +479,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_awk' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_awk'
                           ],
@@ -442,7 +489,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_bash' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_bash'
                           ],
@@ -451,7 +499,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_bash_telnet_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_bash_telnet_ssl'
                           ],
@@ -460,7 +509,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_lua' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_lua'
                           ],
@@ -469,7 +519,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_netcat' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_netcat'
                           ],
@@ -478,7 +529,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_netcat_gaping' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_netcat_gaping'
                           ],
@@ -487,7 +539,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_nodejs' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_nodejs'
                           ],
@@ -496,7 +549,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_openssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_openssl'
                           ],
@@ -505,7 +559,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_perl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_perl'
                           ],
@@ -514,7 +569,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_perl_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_perl_ssl'
                           ],
@@ -523,7 +579,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_php_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_php_ssl'
                           ],
@@ -532,7 +589,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_python' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_python'
                           ],
@@ -541,7 +599,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_python_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_python_ssl'
                           ],
@@ -550,7 +609,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_ruby' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ruby'
                           ],
@@ -559,7 +619,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_ruby_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ruby_ssl'
                           ],
@@ -568,7 +629,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_ssl_double_telnet' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ssl_double_telnet'
                           ],
@@ -577,7 +639,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/unix/reverse_zsh' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_zsh'
                           ],
@@ -586,7 +649,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/adduser' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/adduser'
                           ],
@@ -595,7 +659,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/bind_lua' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_lua'
                           ],
@@ -604,7 +669,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/bind_perl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_perl'
                           ],
@@ -613,7 +679,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/bind_perl_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_perl_ipv6'
                           ],
@@ -622,7 +689,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/bind_ruby' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_ruby'
                           ],
@@ -631,7 +699,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/download_eval_vbs' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/windows/download_eval_vbs'
                           ],
@@ -640,7 +709,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/download_exec_vbs' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/windows/download_exec_vbs'
                           ],
@@ -649,7 +719,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/generic' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/generic'
                           ],
@@ -658,7 +729,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/reverse_lua' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_lua'
                           ],
@@ -667,7 +739,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/reverse_perl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_perl'
                           ],
@@ -676,7 +749,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/reverse_powershell' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_powershell'
                           ],
@@ -685,7 +759,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'cmd/windows/reverse_ruby' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_ruby'
                           ],
@@ -694,7 +769,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'firefox/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/firefox/exec'
                           ],
@@ -703,7 +779,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'firefox/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/firefox/shell_bind_tcp'
                           ],
@@ -712,7 +789,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'firefox/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/firefox/shell_reverse_tcp'
                           ],
@@ -721,7 +799,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'generic/custom' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/custom'
                           ],
@@ -730,7 +809,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'generic/debug_trap' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/debug_trap'
                           ],
@@ -739,7 +819,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'generic/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/shell_bind_tcp'
                           ],
@@ -748,7 +829,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'generic/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/shell_reverse_tcp'
                           ],
@@ -757,7 +839,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'generic/tight_loop' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/tight_loop'
                           ],
@@ -766,7 +849,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/jsp_shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/java/jsp_shell_bind_tcp'
                           ],
@@ -775,7 +859,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/jsp_shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/java/jsp_shell_reverse_tcp'
                           ],
@@ -784,7 +869,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/meterpreter/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/bind_tcp',
                               'stages/java/meterpreter'
@@ -794,7 +880,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/meterpreter/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_http',
                               'stages/java/meterpreter'
@@ -804,7 +891,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/meterpreter/reverse_https' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_https',
                               'stages/java/meterpreter'
@@ -814,7 +902,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/meterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_tcp',
                               'stages/java/meterpreter'
@@ -824,7 +913,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/bind_tcp',
                               'stages/java/shell'
@@ -834,7 +924,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_tcp',
                               'stages/java/shell'
@@ -844,7 +935,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'java/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/java/shell_reverse_tcp'
                           ],
@@ -853,7 +945,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/armle/adduser' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/adduser'
                           ],
@@ -862,7 +955,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/armle/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/exec'
                           ],
@@ -871,7 +965,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/armle/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/armle/bind_tcp',
                               'stages/linux/armle/shell'
@@ -881,7 +976,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/armle/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/armle/reverse_tcp',
                               'stages/linux/armle/shell'
@@ -891,7 +987,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/armle/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/shell_bind_tcp'
                           ],
@@ -900,7 +997,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/armle/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/shell_reverse_tcp'
                           ],
@@ -909,7 +1007,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsbe/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/exec'
                           ],
@@ -918,7 +1017,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsbe/reboot' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/reboot'
                           ],
@@ -927,7 +1027,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsbe/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/mipsbe/reverse_tcp',
                               'stages/linux/mipsbe/shell'
@@ -937,7 +1038,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsbe/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/shell_bind_tcp'
                           ],
@@ -946,7 +1048,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsbe/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/shell_reverse_tcp'
                           ],
@@ -955,7 +1058,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsle/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/exec'
                           ],
@@ -964,7 +1068,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsle/reboot' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/reboot'
                           ],
@@ -973,7 +1078,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsle/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/mipsle/reverse_tcp',
                               'stages/linux/mipsle/shell'
@@ -983,7 +1089,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsle/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/shell_bind_tcp'
                           ],
@@ -992,7 +1099,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/mipsle/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/shell_reverse_tcp'
                           ],
@@ -1001,7 +1109,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/ppc/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_bind_tcp'
                           ],
@@ -1010,7 +1119,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/ppc/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_find_port'
                           ],
@@ -1019,7 +1129,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/ppc/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_reverse_tcp'
                           ],
@@ -1028,7 +1139,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/ppc64/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_bind_tcp'
                           ],
@@ -1037,7 +1149,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/ppc64/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_find_port'
                           ],
@@ -1046,7 +1159,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/ppc64/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_reverse_tcp'
                           ],
@@ -1055,7 +1169,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x64/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/exec'
                           ],
@@ -1064,7 +1179,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x64/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x64/bind_tcp',
                               'stages/linux/x64/shell'
@@ -1074,7 +1190,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x64/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x64/reverse_tcp',
                               'stages/linux/x64/shell'
@@ -1084,7 +1201,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x64/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_bind_tcp'
                           ],
@@ -1093,7 +1211,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x64/shell_bind_tcp_random_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_bind_tcp_random_port'
                           ],
@@ -1102,7 +1221,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x64/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_find_port'
                           ],
@@ -1111,7 +1231,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x64/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_reverse_tcp'
                           ],
@@ -1120,7 +1241,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/adduser' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/adduser'
                           ],
@@ -1129,7 +1251,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/chmod' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/chmod'
                           ],
@@ -1138,7 +1261,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/exec'
                           ],
@@ -1147,7 +1271,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/meterpreter/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_ipv6_tcp',
                               'stages/linux/x86/meterpreter'
@@ -1157,7 +1282,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/meterpreter/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_nonx_tcp',
                               'stages/linux/x86/meterpreter'
@@ -1167,7 +1293,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/meterpreter/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/meterpreter'
@@ -1177,7 +1304,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/meterpreter/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/find_tag',
                               'stages/linux/x86/meterpreter'
@@ -1187,7 +1315,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/meterpreter/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_ipv6_tcp',
                               'stages/linux/x86/meterpreter'
@@ -1197,7 +1326,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/meterpreter/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_nonx_tcp',
                               'stages/linux/x86/meterpreter'
@@ -1207,7 +1337,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/meterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_tcp',
                               'stages/linux/x86/meterpreter'
@@ -1217,7 +1348,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/metsvc_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/metsvc_bind_tcp'
                           ],
@@ -1226,7 +1358,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/metsvc_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/metsvc_reverse_tcp'
                           ],
@@ -1235,7 +1368,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/read_file' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/read_file'
                           ],
@@ -1244,7 +1378,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_ipv6_tcp',
                               'stages/linux/x86/shell'
@@ -1254,7 +1389,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_nonx_tcp',
                               'stages/linux/x86/shell'
@@ -1264,7 +1400,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/shell'
@@ -1274,7 +1411,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/find_tag',
                               'stages/linux/x86/shell'
@@ -1284,7 +1422,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_ipv6_tcp',
                               'stages/linux/x86/shell'
@@ -1294,7 +1433,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_nonx_tcp',
                               'stages/linux/x86/shell'
@@ -1304,7 +1444,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_tcp',
                               'stages/linux/x86/shell'
@@ -1314,7 +1455,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell_bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_ipv6_tcp'
                           ],
@@ -1323,7 +1465,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_tcp'
                           ],
@@ -1332,7 +1475,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell_bind_tcp_random_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_tcp_random_port'
                           ],
@@ -1341,7 +1485,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_find_port'
                           ],
@@ -1350,7 +1495,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell_find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_find_tag'
                           ],
@@ -1359,7 +1505,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_reverse_tcp'
                           ],
@@ -1368,7 +1515,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'linux/x86/shell_reverse_tcp2' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_reverse_tcp2'
                           ],
@@ -1377,7 +1525,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'netware/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/netware/reverse_tcp',
                               'stages/netware/shell'
@@ -1387,7 +1536,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'nodejs/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/nodejs/shell_bind_tcp'
                           ],
@@ -1396,7 +1546,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'nodejs/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/nodejs/shell_reverse_tcp'
                           ],
@@ -1405,7 +1556,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'nodejs/shell_reverse_tcp_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/nodejs/shell_reverse_tcp_ssl'
                           ],
@@ -1414,7 +1566,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/armle/execute/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/bind_tcp',
                               'stages/osx/armle/execute'
@@ -1424,7 +1577,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/armle/execute/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/reverse_tcp',
                               'stages/osx/armle/execute'
@@ -1434,7 +1588,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/armle/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/bind_tcp',
                               'stages/osx/armle/shell'
@@ -1444,7 +1599,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/armle/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/reverse_tcp',
                               'stages/osx/armle/shell'
@@ -1454,7 +1610,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/armle/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/armle/shell_bind_tcp'
                           ],
@@ -1463,7 +1620,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/armle/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/armle/shell_reverse_tcp'
                           ],
@@ -1472,7 +1630,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/armle/vibrate' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/armle/vibrate'
                           ],
@@ -1481,7 +1640,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/ppc/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/ppc/bind_tcp',
                               'stages/osx/ppc/shell'
@@ -1491,7 +1651,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/ppc/shell/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/ppc/find_tag',
                               'stages/osx/ppc/shell'
@@ -1501,7 +1662,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/ppc/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/ppc/reverse_tcp',
                               'stages/osx/ppc/shell'
@@ -1511,7 +1673,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/ppc/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/ppc/shell_bind_tcp'
                           ],
@@ -1520,7 +1683,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/ppc/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/ppc/shell_reverse_tcp'
                           ],
@@ -1529,7 +1693,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x64/dupandexecve/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x64/bind_tcp',
                               'stages/osx/x64/dupandexecve'
@@ -1539,7 +1704,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x64/dupandexecve/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x64/reverse_tcp',
                               'stages/osx/x64/dupandexecve'
@@ -1549,7 +1715,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x64/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/exec'
                           ],
@@ -1558,7 +1725,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x64/say' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/say'
                           ],
@@ -1567,7 +1735,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x64/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_bind_tcp'
                           ],
@@ -1576,7 +1745,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x64/shell_find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_find_tag'
                           ],
@@ -1585,7 +1755,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x64/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_reverse_tcp'
                           ],
@@ -1594,7 +1765,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/bundleinject/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/bundleinject'
@@ -1604,7 +1776,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/bundleinject/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/bundleinject',
@@ -1614,7 +1787,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/exec'
                           ],
@@ -1623,7 +1797,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/isight/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/isight'
@@ -1633,7 +1808,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/isight/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/isight'
@@ -1643,7 +1819,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_bind_tcp'
                           ],
@@ -1652,7 +1829,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_find_port'
                           ],
@@ -1661,7 +1839,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_reverse_tcp'
                           ],
@@ -1670,7 +1849,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/vforkshell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/vforkshell'
@@ -1680,7 +1860,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/vforkshell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/vforkshell'
@@ -1690,7 +1871,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/vforkshell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/vforkshell_bind_tcp'
                           ],
@@ -1699,7 +1881,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'osx/x86/vforkshell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/vforkshell_reverse_tcp'
                           ],
@@ -1708,7 +1891,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/bind_perl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/php/bind_perl'
                           ],
@@ -1717,7 +1901,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/bind_perl_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/php/bind_perl_ipv6'
                           ],
@@ -1726,7 +1911,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/bind_php' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/bind_php'
                           ],
@@ -1735,7 +1921,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/bind_php_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/bind_php_ipv6'
                           ],
@@ -1744,7 +1931,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/download_exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/download_exec'
                           ],
@@ -1753,7 +1941,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/exec'
                           ],
@@ -1762,7 +1951,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/meterpreter/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/php/bind_tcp',
                               'stages/php/meterpreter'
@@ -1772,7 +1962,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/meterpreter/bind_tcp_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/php/bind_tcp_ipv6',
                               'stages/php/meterpreter'
@@ -1782,7 +1973,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/meterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/php/reverse_tcp',
                               'stages/php/meterpreter'
@@ -1792,7 +1984,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/meterpreter_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/php/meterpreter_reverse_tcp'
                           ],
@@ -1801,7 +1994,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/reverse_perl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/reverse_perl'
                           ],
@@ -1810,7 +2004,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/reverse_php' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/reverse_php'
                           ],
@@ -1819,7 +2014,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'php/shell_findsock' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/shell_findsock'
                           ],
@@ -1828,7 +2024,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'python/meterpreter/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/python/bind_tcp',
                               'stages/python/meterpreter'
@@ -1838,7 +2035,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'python/meterpreter/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/python/reverse_http',
                             'stages/python/meterpreter'
@@ -1848,7 +2046,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'python/meterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/python/reverse_tcp',
                               'stages/python/meterpreter'
@@ -1858,7 +2057,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'python/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp'
                           ],
@@ -1867,7 +2067,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'python/shell_reverse_tcp_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp_ssl'
                           ],
@@ -1876,7 +2077,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'ruby/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_bind_tcp'
                           ],
@@ -1885,7 +2087,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'ruby/shell_bind_tcp_ipv6' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_bind_tcp_ipv6'
                           ],
@@ -1894,7 +2097,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'ruby/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_reverse_tcp'
                           ],
@@ -1903,7 +2107,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'ruby/shell_reverse_tcp_ssl' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_reverse_tcp_ssl'
                           ],
@@ -1912,7 +2117,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'solaris/sparc/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_bind_tcp'
                           ],
@@ -1921,7 +2127,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'solaris/sparc/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_find_port'
                           ],
@@ -1930,7 +2137,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'solaris/sparc/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_reverse_tcp'
                           ],
@@ -1939,7 +2147,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'solaris/x86/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_bind_tcp'
                           ],
@@ -1948,7 +2157,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'solaris/x86/shell_find_port' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_find_port'
                           ],
@@ -1957,7 +2167,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'solaris/x86/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_reverse_tcp'
                           ],
@@ -1966,7 +2177,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'tty/unix/interact' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/tty/unix/interact'
                           ],
@@ -1975,7 +2187,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/adduser' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/adduser'
                           ],
@@ -1984,7 +2197,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/dllinject'
@@ -1994,7 +2208,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/dllinject'
@@ -2004,7 +2219,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/dllinject'
@@ -2014,7 +2230,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/bind_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/dllinject'
@@ -2024,7 +2241,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/dllinject'
@@ -2034,7 +2252,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_hop_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/dllinject'
@@ -2044,7 +2263,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/dllinject'
@@ -2054,7 +2274,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_http_proxy_pstore' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/dllinject'
@@ -2064,7 +2285,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/dllinject'
@@ -2074,7 +2296,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/dllinject'
@@ -2084,7 +2307,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_ord_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/dllinject'
@@ -2094,7 +2318,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/dllinject'
@@ -2104,7 +2329,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_tcp_allports' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/dllinject'
@@ -2114,7 +2340,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_tcp_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/dllinject'
@@ -2124,7 +2351,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/dllinject'
@@ -2134,7 +2362,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/reverse_tcp_rc4_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/dllinject'
@@ -2144,7 +2373,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dns_txt_query_exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/dns_txt_query_exec'
                           ],
@@ -2153,7 +2383,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/download_exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/download_exec'
                           ],
@@ -2162,7 +2393,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/exec'
                           ],
@@ -2171,7 +2403,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/format_all_drives' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/format_all_drives'
                           ],
@@ -2180,7 +2413,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/loadlibrary' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/loadlibrary'
                           ],
@@ -2189,7 +2423,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/messagebox' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/messagebox'
                           ],
@@ -2198,7 +2433,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/meterpreter'
@@ -2208,7 +2444,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/meterpreter'
@@ -2218,7 +2455,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/meterpreter'
@@ -2228,7 +2466,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/bind_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/meterpreter'
@@ -2238,7 +2477,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/meterpreter'
@@ -2248,7 +2488,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_hop_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/meterpreter'
@@ -2258,7 +2499,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/meterpreter'
@@ -2268,7 +2510,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_http_proxy_pstore' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/meterpreter'
@@ -2278,7 +2521,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_https' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_https',
                               'stages/windows/meterpreter'
@@ -2288,7 +2532,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_https_proxy' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_https_proxy',
                               'stages/windows/meterpreter'
@@ -2298,7 +2543,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/meterpreter'
@@ -2308,7 +2554,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/meterpreter'
@@ -2318,7 +2565,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_ord_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/meterpreter'
@@ -2328,7 +2576,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/meterpreter'
@@ -2338,7 +2587,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_tcp_allports' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/meterpreter'
@@ -2348,7 +2598,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_tcp_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/meterpreter'
@@ -2358,7 +2609,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/meterpreter'
@@ -2368,7 +2620,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/reverse_tcp_rc4_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/meterpreter'
@@ -2378,7 +2631,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/metsvc_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/metsvc_bind_tcp'
                           ],
@@ -2387,7 +2641,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/metsvc_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/metsvc_reverse_tcp'
                           ],
@@ -2396,7 +2651,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/patchupdllinject'
@@ -2406,7 +2662,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/patchupdllinject'
@@ -2416,7 +2673,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/patchupdllinject'
@@ -2426,7 +2684,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/bind_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/patchupdllinject'
@@ -2436,7 +2695,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/patchupdllinject'
@@ -2446,7 +2706,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/patchupdllinject'
@@ -2456,7 +2717,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/patchupdllinject'
@@ -2466,7 +2728,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_ord_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/patchupdllinject'
@@ -2476,7 +2739,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/patchupdllinject'
@@ -2486,7 +2750,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_tcp_allports' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/patchupdllinject'
@@ -2496,7 +2761,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_tcp_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/patchupdllinject'
@@ -2506,7 +2772,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/patchupdllinject'
@@ -2516,7 +2783,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/reverse_tcp_rc4_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/patchupdllinject'
@@ -2526,7 +2794,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/patchupmeterpreter'
@@ -2536,7 +2805,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/patchupmeterpreter'
@@ -2546,7 +2816,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/patchupmeterpreter'
@@ -2556,7 +2827,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/bind_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/patchupmeterpreter'
@@ -2566,7 +2838,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/patchupmeterpreter'
@@ -2576,7 +2849,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/patchupmeterpreter'
@@ -2586,7 +2860,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/patchupmeterpreter'
@@ -2596,7 +2871,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_ord_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/patchupmeterpreter'
@@ -2606,7 +2882,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/patchupmeterpreter'
@@ -2616,7 +2893,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_allports' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/patchupmeterpreter'
@@ -2626,7 +2904,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/patchupmeterpreter'
@@ -2636,7 +2915,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/patchupmeterpreter'
@@ -2646,7 +2926,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_rc4_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/patchupmeterpreter'
@@ -2656,7 +2937,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/shell'
@@ -2666,7 +2948,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/shell'
@@ -2676,7 +2959,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/shell'
@@ -2686,7 +2970,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/bind_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/shell'
@@ -2696,7 +2981,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/shell'
@@ -2706,7 +2992,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_hop_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/shell'
@@ -2716,7 +3003,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/shell'
@@ -2726,7 +3014,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_http_proxy_pstore' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/shell'
@@ -2736,7 +3025,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/shell'
@@ -2746,7 +3036,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/shell'
@@ -2756,7 +3047,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_ord_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/shell'
@@ -2766,7 +3058,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/shell'
@@ -2776,7 +3069,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_tcp_allports' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/shell'
@@ -2786,7 +3080,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_tcp_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/shell'
@@ -2796,7 +3091,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/shell'
@@ -2806,7 +3102,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/reverse_tcp_rc4_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/shell'
@@ -2816,7 +3113,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_bind_tcp'
                           ],
@@ -2825,7 +3123,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell_bind_tcp_xpfw' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_bind_tcp_xpfw'
                           ],
@@ -2834,7 +3133,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell_hidden_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_hidden_bind_tcp'
                           ],
@@ -2843,7 +3143,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_reverse_tcp'
                           ],
@@ -2852,7 +3153,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/speak_pwned' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/speak_pwned'
                           ],
@@ -2861,7 +3163,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/upexec'
@@ -2871,7 +3174,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/upexec'
@@ -2881,7 +3185,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/upexec'
@@ -2891,7 +3196,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/bind_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/upexec'
@@ -2901,7 +3207,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/upexec'
@@ -2911,7 +3218,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_hop_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/upexec'
@@ -2921,7 +3229,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/upexec'
@@ -2931,7 +3240,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_http_proxy_pstore' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/upexec'
@@ -2941,7 +3251,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/upexec'
@@ -2951,7 +3262,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/upexec'
@@ -2961,7 +3273,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_ord_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/upexec'
@@ -2971,7 +3284,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/upexec'
@@ -2981,7 +3295,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_tcp_allports' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/upexec'
@@ -2991,7 +3306,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_tcp_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/upexec'
@@ -3001,7 +3317,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/upexec'
@@ -3011,7 +3328,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/reverse_tcp_rc4_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/upexec'
@@ -3021,7 +3339,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/bind_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/vncinject'
@@ -3031,7 +3350,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/bind_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/vncinject'
@@ -3041,7 +3361,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/vncinject'
@@ -3051,7 +3372,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/bind_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/vncinject'
@@ -3061,7 +3383,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/find_tag' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/vncinject'
@@ -3071,7 +3394,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_hop_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/vncinject'
@@ -3081,7 +3405,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_http' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/vncinject'
@@ -3091,7 +3416,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_http_proxy_pstore' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/vncinject'
@@ -3101,7 +3427,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_ipv6_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/vncinject'
@@ -3111,7 +3438,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_nonx_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/vncinject'
@@ -3121,7 +3449,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_ord_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/vncinject'
@@ -3131,7 +3460,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/vncinject'
@@ -3141,7 +3471,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_tcp_allports' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/vncinject'
@@ -3151,7 +3482,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_tcp_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/vncinject'
@@ -3161,7 +3493,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_tcp_rc4' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/vncinject'
@@ -3171,7 +3504,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/reverse_tcp_rc4_dns' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/vncinject'
@@ -3181,7 +3515,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/exec' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/exec'
                           ],
@@ -3190,7 +3525,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/loadlibrary' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/loadlibrary'
                           ],
@@ -3199,7 +3535,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/meterpreter/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/meterpreter'
@@ -3209,7 +3546,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/meterpreter/reverse_https' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_https',
                               'stages/windows/x64/meterpreter'
@@ -3219,7 +3557,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/meterpreter/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/meterpreter'
@@ -3229,7 +3568,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/shell/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/shell'
@@ -3239,7 +3579,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/shell/reverse_https' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_https',
                               'stages/windows/x64/shell'
@@ -3249,7 +3590,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/shell/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/shell'
@@ -3259,7 +3601,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/shell_bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/shell_bind_tcp'
                           ],
@@ -3268,7 +3611,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/shell_reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/shell_reverse_tcp'
                           ],
@@ -3277,7 +3621,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/vncinject/bind_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/vncinject'
@@ -3287,7 +3632,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/vncinject/reverse_https' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_https',
                               'stages/windows/x64/vncinject'
@@ -3297,7 +3643,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/x64/vncinject/reverse_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/vncinject'
@@ -3307,7 +3654,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/bind_hidden_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/dllinject'
@@ -3317,7 +3665,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/bind_hidden_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/meterpreter'
@@ -3327,7 +3676,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/bind_hidden_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/patchupdllinject'
@@ -3337,7 +3687,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/bind_hidden_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/patchupmeterpreter'
@@ -3347,7 +3698,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/bind_hidden_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/shell'
@@ -3357,7 +3709,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/bind_hidden_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/upexec'
@@ -3367,7 +3720,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/bind_hidden_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/vncinject'
@@ -3377,7 +3731,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/dllinject/bind_hidden_ipknock_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/dllinject'
@@ -3387,7 +3742,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/meterpreter/bind_hidden_ipknock_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/meterpreter'
@@ -3397,7 +3753,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupdllinject/bind_hidden_ipknock_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/patchupdllinject'
@@ -3407,7 +3764,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/patchupmeterpreter/bind_hidden_ipknock_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/patchupmeterpreter'
@@ -3417,7 +3775,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/shell/bind_hidden_ipknock_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/shell'
@@ -3427,7 +3786,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/upexec/bind_hidden_ipknock_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/upexec'
@@ -3437,7 +3797,8 @@ describe 'modules/payloads', :content do
   end
 
   context 'windows/vncinject/bind_hidden_ipknock_tcp' do
-    it_should_behave_like 'payload can be instantiated',
+    it_should_behave_like 'payload cached size is consistent',
+                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/vncinject'

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2131,7 +2131,7 @@ describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_find_port'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_find_port'
   end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -7,3802 +7,3802 @@ describe 'modules/payloads', :content do
 
   context 'aix/ppc/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_bind_tcp'
   end
 
   context 'aix/ppc/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_find_port'
   end
 
   context 'aix/ppc/shell_interact' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_interact'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_interact'
   end
 
   context 'aix/ppc/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_reverse_tcp'
   end
 
   context 'android/meterpreter/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_http',
                               'stages/android/meterpreter'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter/reverse_http'
   end
 
   context 'android/meterpreter/reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_https',
                               'stages/android/meterpreter'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter/reverse_https'
   end
 
   context 'android/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_tcp',
                               'stages/android/meterpreter'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter/reverse_tcp'
   end
 
   context 'android/shell/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_http',
                               'stages/android/shell'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/shell/reverse_http'
   end
 
   context 'android/shell/reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_https',
                               'stages/android/shell'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/shell/reverse_https'
   end
 
   context 'android/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'stagers/android/reverse_tcp',
                               'stages/android/shell'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/shell/reverse_tcp'
   end
 
   context 'bsd/sparc/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/sparc/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/sparc/shell_bind_tcp'
   end
 
   context 'bsd/sparc/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/sparc/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/sparc/shell_reverse_tcp'
   end
 
   context 'bsd/x86/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/exec'
   end
 
   context 'bsd/x86/metsvc_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/metsvc_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/metsvc_bind_tcp'
   end
 
   context 'bsd/x86/metsvc_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/metsvc_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/metsvc_reverse_tcp'
   end
 
   context 'bsd/x86/shell/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/bind_ipv6_tcp',
                               'stages/bsd/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/bind_ipv6_tcp'
   end
 
   context 'bsd/x86/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/bind_tcp',
                               'stages/bsd/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/bind_tcp'
   end
 
   context 'bsd/x86/shell/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/find_tag',
                               'stages/bsd/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/find_tag'
   end
 
   context 'bsd/x86/shell/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/reverse_ipv6_tcp',
                               'stages/bsd/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/reverse_ipv6_tcp'
   end
 
   context 'bsd/x86/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsd/x86/reverse_tcp',
                               'stages/bsd/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/reverse_tcp'
   end
 
   context 'bsd/x86/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_bind_tcp'
   end
 
   context 'bsd/x86/shell_bind_tcp_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_bind_tcp_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_bind_tcp_ipv6'
   end
 
   context 'bsd/x86/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_find_port'
   end
 
   context 'bsd/x86/shell_find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_find_tag'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_find_tag'
   end
 
   context 'bsd/x86/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_reverse_tcp'
   end
 
   context 'bsd/x86/shell_reverse_tcp_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_reverse_tcp_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_reverse_tcp_ipv6'
   end
 
   context 'bsdi/x86/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsdi/x86/bind_tcp',
                               'stages/bsdi/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell/bind_tcp'
   end
 
   context 'bsdi/x86/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/bsdi/x86/reverse_tcp',
                               'stages/bsdi/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell/reverse_tcp'
   end
 
   context 'bsdi/x86/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell_bind_tcp'
   end
 
   context 'bsdi/x86/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell_find_port'
   end
 
   context 'bsdi/x86/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell_reverse_tcp'
   end
 
   context 'cmd/unix/bind_awk' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_awk'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_awk'
   end
 
   context 'cmd/unix/bind_inetd' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_inetd'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_inetd'
   end
 
   context 'cmd/unix/bind_lua' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_lua'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_lua'
   end
 
   context 'cmd/unix/bind_netcat' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_netcat'
   end
 
   context 'cmd/unix/bind_netcat_gaping' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat_gaping'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_netcat_gaping'
   end
 
   context 'cmd/unix/bind_netcat_gaping_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat_gaping_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_netcat_gaping_ipv6'
   end
 
   context 'cmd/unix/bind_nodejs' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_nodejs'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_nodejs'
   end
 
   context 'cmd/unix/bind_perl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_perl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_perl'
   end
 
   context 'cmd/unix/bind_perl_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_perl_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_perl_ipv6'
   end
 
   context 'cmd/unix/bind_ruby' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_ruby'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_ruby'
   end
 
   context 'cmd/unix/bind_ruby_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_ruby_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_ruby_ipv6'
   end
 
   context 'cmd/unix/bind_zsh' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_zsh'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_zsh'
   end
 
   context 'cmd/unix/generic' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/generic'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/generic'
   end
 
   context 'cmd/unix/interact' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/interact'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/interact'
   end
 
   context 'cmd/unix/reverse' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse'
   end
 
   context 'cmd/unix/reverse_awk' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_awk'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_awk'
   end
 
   context 'cmd/unix/reverse_bash' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_bash'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_bash'
   end
 
   context 'cmd/unix/reverse_bash_telnet_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_bash_telnet_ssl'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_bash_telnet_ssl'
   end
 
   context 'cmd/unix/reverse_lua' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_lua'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_lua'
   end
 
   context 'cmd/unix/reverse_netcat' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_netcat'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_netcat'
   end
 
   context 'cmd/unix/reverse_netcat_gaping' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_netcat_gaping'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_netcat_gaping'
   end
 
   context 'cmd/unix/reverse_nodejs' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_nodejs'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_nodejs'
   end
 
   context 'cmd/unix/reverse_openssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_openssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_openssl'
   end
 
   context 'cmd/unix/reverse_perl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_perl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_perl'
   end
 
   context 'cmd/unix/reverse_perl_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_perl_ssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_perl_ssl'
   end
 
   context 'cmd/unix/reverse_php_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_php_ssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_php_ssl'
   end
 
   context 'cmd/unix/reverse_python' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_python'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_python'
   end
 
   context 'cmd/unix/reverse_python_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_python_ssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_python_ssl'
   end
 
   context 'cmd/unix/reverse_ruby' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ruby'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ruby'
   end
 
   context 'cmd/unix/reverse_ruby_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ruby_ssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ruby_ssl'
   end
 
   context 'cmd/unix/reverse_ssl_double_telnet' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ssl_double_telnet'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ssl_double_telnet'
   end
 
   context 'cmd/unix/reverse_zsh' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_zsh'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_zsh'
   end
 
   context 'cmd/windows/adduser' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/adduser'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/adduser'
   end
 
   context 'cmd/windows/bind_lua' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_lua'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_lua'
   end
 
   context 'cmd/windows/bind_perl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_perl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_perl'
   end
 
   context 'cmd/windows/bind_perl_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_perl_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_perl_ipv6'
   end
 
   context 'cmd/windows/bind_ruby' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_ruby'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_ruby'
   end
 
   context 'cmd/windows/download_eval_vbs' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/windows/download_eval_vbs'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/download_eval_vbs'
   end
 
   context 'cmd/windows/download_exec_vbs' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/cmd/windows/download_exec_vbs'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/download_exec_vbs'
   end
 
   context 'cmd/windows/generic' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/generic'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/generic'
   end
 
   context 'cmd/windows/reverse_lua' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_lua'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_lua'
   end
 
   context 'cmd/windows/reverse_perl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_perl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_perl'
   end
 
   context 'cmd/windows/reverse_powershell' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_powershell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_powershell'
   end
 
   context 'cmd/windows/reverse_ruby' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_ruby'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_ruby'
   end
 
   context 'firefox/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/firefox/exec'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'firefox/exec'
   end
 
   context 'firefox/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/firefox/shell_bind_tcp'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'firefox/shell_bind_tcp'
   end
 
   context 'firefox/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/firefox/shell_reverse_tcp'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'firefox/shell_reverse_tcp'
   end
 
   context 'generic/custom' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/custom'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/custom'
   end
 
   context 'generic/debug_trap' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/debug_trap'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/debug_trap'
   end
 
   context 'generic/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/shell_bind_tcp'
   end
 
   context 'generic/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/shell_reverse_tcp'
   end
 
   context 'generic/tight_loop' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/generic/tight_loop'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/tight_loop'
   end
 
   context 'java/jsp_shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/java/jsp_shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/jsp_shell_bind_tcp'
   end
 
   context 'java/jsp_shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/java/jsp_shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/jsp_shell_reverse_tcp'
   end
 
   context 'java/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/bind_tcp',
                               'stages/java/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/bind_tcp'
   end
 
   context 'java/meterpreter/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_http',
                               'stages/java/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_http'
   end
 
   context 'java/meterpreter/reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_https',
                               'stages/java/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_https'
   end
 
   context 'java/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_tcp',
                               'stages/java/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_tcp'
   end
 
   context 'java/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/bind_tcp',
                               'stages/java/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/shell/bind_tcp'
   end
 
   context 'java/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/java/reverse_tcp',
                               'stages/java/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/shell/reverse_tcp'
   end
 
   context 'java/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/java/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/shell_reverse_tcp'
   end
 
   context 'linux/armle/adduser' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/adduser'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/adduser'
   end
 
   context 'linux/armle/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/exec'
   end
 
   context 'linux/armle/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/armle/bind_tcp',
                               'stages/linux/armle/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell/bind_tcp'
   end
 
   context 'linux/armle/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/armle/reverse_tcp',
                               'stages/linux/armle/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell/reverse_tcp'
   end
 
   context 'linux/armle/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell_bind_tcp'
   end
 
   context 'linux/armle/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/armle/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell_reverse_tcp'
   end
 
   context 'linux/mipsbe/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/exec'
   end
 
   context 'linux/mipsbe/reboot' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/reboot'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/reboot'
   end
 
   context 'linux/mipsbe/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/mipsbe/reverse_tcp',
                               'stages/linux/mipsbe/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/shell/reverse_tcp'
   end
 
   context 'linux/mipsbe/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/shell_bind_tcp'
   end
 
   context 'linux/mipsbe/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/shell_reverse_tcp'
   end
 
   context 'linux/mipsle/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/exec'
   end
 
   context 'linux/mipsle/reboot' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/reboot'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/reboot'
   end
 
   context 'linux/mipsle/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/mipsle/reverse_tcp',
                               'stages/linux/mipsle/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/shell/reverse_tcp'
   end
 
   context 'linux/mipsle/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/shell_bind_tcp'
   end
 
   context 'linux/mipsle/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/mipsle/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/shell_reverse_tcp'
   end
 
   context 'linux/ppc/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/shell_bind_tcp'
   end
 
   context 'linux/ppc/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/shell_find_port'
   end
 
   context 'linux/ppc/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/shell_reverse_tcp'
   end
 
   context 'linux/ppc64/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64/shell_bind_tcp'
   end
 
   context 'linux/ppc64/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64/shell_find_port'
   end
 
   context 'linux/ppc64/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64/shell_reverse_tcp'
   end
 
   context 'linux/x64/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/exec'
   end
 
   context 'linux/x64/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x64/bind_tcp',
                               'stages/linux/x64/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell/bind_tcp'
   end
 
   context 'linux/x64/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x64/reverse_tcp',
                               'stages/linux/x64/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell/reverse_tcp'
   end
 
   context 'linux/x64/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_bind_tcp'
   end
 
   context 'linux/x64/shell_bind_tcp_random_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_bind_tcp_random_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_bind_tcp_random_port'
   end
 
   context 'linux/x64/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_find_port'
   end
 
   context 'linux/x64/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_reverse_tcp'
   end
 
   context 'linux/x86/adduser' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/adduser'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/adduser'
   end
 
   context 'linux/x86/chmod' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/chmod'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/chmod'
   end
 
   context 'linux/x86/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/exec'
   end
 
   context 'linux/x86/meterpreter/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_ipv6_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_ipv6_tcp'
   end
 
   context 'linux/x86/meterpreter/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_nonx_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_nonx_tcp'
   end
 
   context 'linux/x86/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_tcp'
   end
 
   context 'linux/x86/meterpreter/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/find_tag',
                               'stages/linux/x86/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/find_tag'
   end
 
   context 'linux/x86/meterpreter/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_ipv6_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/reverse_ipv6_tcp'
   end
 
   context 'linux/x86/meterpreter/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_nonx_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/reverse_nonx_tcp'
   end
 
   context 'linux/x86/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/reverse_tcp'
   end
 
   context 'linux/x86/metsvc_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/metsvc_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/metsvc_bind_tcp'
   end
 
   context 'linux/x86/metsvc_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/metsvc_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/metsvc_reverse_tcp'
   end
 
   context 'linux/x86/read_file' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/read_file'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/read_file'
   end
 
   context 'linux/x86/shell/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_ipv6_tcp',
                               'stages/linux/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_ipv6_tcp'
   end
 
   context 'linux/x86/shell/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_nonx_tcp',
                               'stages/linux/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_nonx_tcp'
   end
 
   context 'linux/x86/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_tcp'
   end
 
   context 'linux/x86/shell/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/find_tag',
                               'stages/linux/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/find_tag'
   end
 
   context 'linux/x86/shell/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_ipv6_tcp',
                               'stages/linux/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/reverse_ipv6_tcp'
   end
 
   context 'linux/x86/shell/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_nonx_tcp',
                               'stages/linux/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/reverse_nonx_tcp'
   end
 
   context 'linux/x86/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/linux/x86/reverse_tcp',
                               'stages/linux/x86/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/reverse_tcp'
   end
 
   context 'linux/x86/shell_bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_ipv6_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_bind_ipv6_tcp'
   end
 
   context 'linux/x86/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_bind_tcp'
   end
 
   context 'linux/x86/shell_bind_tcp_random_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_tcp_random_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_bind_tcp_random_port'
   end
 
   context 'linux/x86/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_find_port'
   end
 
   context 'linux/x86/shell_find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_find_tag'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_find_tag'
   end
 
   context 'linux/x86/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_reverse_tcp'
   end
 
   context 'linux/x86/shell_reverse_tcp2' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_reverse_tcp2'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_reverse_tcp2'
   end
 
   context 'netware/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/netware/reverse_tcp',
                               'stages/netware/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'netware/shell/reverse_tcp'
   end
 
   context 'nodejs/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/nodejs/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'nodejs/shell_bind_tcp'
   end
 
   context 'nodejs/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/nodejs/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'nodejs/shell_reverse_tcp'
   end
 
   context 'nodejs/shell_reverse_tcp_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/nodejs/shell_reverse_tcp_ssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'nodejs/shell_reverse_tcp_ssl'
   end
 
   context 'osx/armle/execute/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/bind_tcp',
                               'stages/osx/armle/execute'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/execute/bind_tcp'
   end
 
   context 'osx/armle/execute/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/reverse_tcp',
                               'stages/osx/armle/execute'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/execute/reverse_tcp'
   end
 
   context 'osx/armle/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/bind_tcp',
                               'stages/osx/armle/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell/bind_tcp'
   end
 
   context 'osx/armle/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/armle/reverse_tcp',
                               'stages/osx/armle/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell/reverse_tcp'
   end
 
   context 'osx/armle/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/armle/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell_bind_tcp'
   end
 
   context 'osx/armle/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/armle/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell_reverse_tcp'
   end
 
   context 'osx/armle/vibrate' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/armle/vibrate'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/vibrate'
   end
 
   context 'osx/ppc/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/ppc/bind_tcp',
                               'stages/osx/ppc/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell/bind_tcp'
   end
 
   context 'osx/ppc/shell/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/ppc/find_tag',
                               'stages/osx/ppc/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell/find_tag'
   end
 
   context 'osx/ppc/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/ppc/reverse_tcp',
                               'stages/osx/ppc/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell/reverse_tcp'
   end
 
   context 'osx/ppc/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/ppc/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell_bind_tcp'
   end
 
   context 'osx/ppc/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/ppc/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell_reverse_tcp'
   end
 
   context 'osx/x64/dupandexecve/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x64/bind_tcp',
                               'stages/osx/x64/dupandexecve'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/dupandexecve/bind_tcp'
   end
 
   context 'osx/x64/dupandexecve/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x64/reverse_tcp',
                               'stages/osx/x64/dupandexecve'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/dupandexecve/reverse_tcp'
   end
 
   context 'osx/x64/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/exec'
   end
 
   context 'osx/x64/say' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/say'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/say'
   end
 
   context 'osx/x64/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/shell_bind_tcp'
   end
 
   context 'osx/x64/shell_find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_find_tag'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/shell_find_tag'
   end
 
   context 'osx/x64/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/shell_reverse_tcp'
   end
 
   context 'osx/x86/bundleinject/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/bundleinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/bundleinject/bind_tcp'
   end
 
   context 'osx/x86/bundleinject/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/bundleinject',
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/bundleinject/reverse_tcp'
   end
 
   context 'osx/x86/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/exec'
   end
 
   context 'osx/x86/isight/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/isight'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/isight/bind_tcp'
   end
 
   context 'osx/x86/isight/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/isight'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/isight/reverse_tcp'
   end
 
   context 'osx/x86/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/shell_bind_tcp'
   end
 
   context 'osx/x86/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/shell_find_port'
   end
 
   context 'osx/x86/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/shell_reverse_tcp'
   end
 
   context 'osx/x86/vforkshell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/vforkshell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell/bind_tcp'
   end
 
   context 'osx/x86/vforkshell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/vforkshell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell/reverse_tcp'
   end
 
   context 'osx/x86/vforkshell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/vforkshell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell_bind_tcp'
   end
 
   context 'osx/x86/vforkshell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/osx/x86/vforkshell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell_reverse_tcp'
   end
 
   context 'php/bind_perl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/php/bind_perl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_perl'
   end
 
   context 'php/bind_perl_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/php/bind_perl_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_perl_ipv6'
   end
 
   context 'php/bind_php' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/bind_php'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_php'
   end
 
   context 'php/bind_php_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/bind_php_ipv6'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_php_ipv6'
   end
 
   context 'php/download_exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/download_exec'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/download_exec'
   end
 
   context 'php/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/exec'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/exec'
   end
 
   context 'php/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/php/bind_tcp',
                               'stages/php/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/bind_tcp'
   end
 
   context 'php/meterpreter/bind_tcp_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/php/bind_tcp_ipv6',
                               'stages/php/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/bind_tcp_ipv6'
   end
 
   context 'php/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/php/reverse_tcp',
                               'stages/php/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/reverse_tcp'
   end
 
   context 'php/meterpreter_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/php/meterpreter_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter_reverse_tcp'
   end
 
   context 'php/reverse_perl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/reverse_perl'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/reverse_perl'
   end
 
   context 'php/reverse_php' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/reverse_php'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/reverse_php'
   end
 
   context 'php/shell_findsock' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: true,
                           ancestor_reference_names: [
                               'singles/php/shell_findsock'
                           ],
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/shell_findsock'
   end
 
   context 'python/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/python/bind_tcp',
                               'stages/python/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/bind_tcp'
   end
 
   context 'python/meterpreter/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/python/reverse_http',
                             'stages/python/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_http'
   end
 
   context 'python/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/python/reverse_tcp',
                               'stages/python/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_tcp'
   end
 
   context 'python/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_tcp'
   end
 
   context 'python/shell_reverse_tcp_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp_ssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_tcp_ssl'
   end
 
   context 'ruby/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_bind_tcp'
   end
 
   context 'ruby/shell_bind_tcp_ipv6' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_bind_tcp_ipv6'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_bind_tcp_ipv6'
   end
 
   context 'ruby/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_reverse_tcp'
   end
 
   context 'ruby/shell_reverse_tcp_ssl' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/ruby/shell_reverse_tcp_ssl'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_reverse_tcp_ssl'
   end
 
   context 'solaris/sparc/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_bind_tcp'
   end
 
   context 'solaris/sparc/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_find_port'
   end
 
   context 'solaris/sparc/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_reverse_tcp'
   end
 
   context 'solaris/x86/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/x86/shell_bind_tcp'
   end
 
   context 'solaris/x86/shell_find_port' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_find_port'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/x86/shell_find_port'
   end
 
   context 'solaris/x86/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/x86/shell_reverse_tcp'
   end
 
   context 'tty/unix/interact' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/tty/unix/interact'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'tty/unix/interact'
   end
 
   context 'windows/adduser' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/adduser'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/adduser'
   end
 
   context 'windows/dllinject/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_ipv6_tcp'
   end
 
   context 'windows/dllinject/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_nonx_tcp'
   end
 
   context 'windows/dllinject/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_tcp'
   end
 
   context 'windows/dllinject/bind_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_tcp_rc4'
   end
 
   context 'windows/dllinject/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/find_tag'
   end
 
   context 'windows/dllinject/reverse_hop_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_hop_http'
   end
 
   context 'windows/dllinject/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_http'
   end
 
   context 'windows/dllinject/reverse_http_proxy_pstore' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_http_proxy_pstore'
   end
 
   context 'windows/dllinject/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_ipv6_tcp'
   end
 
   context 'windows/dllinject/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_nonx_tcp'
   end
 
   context 'windows/dllinject/reverse_ord_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_ord_tcp'
   end
 
   context 'windows/dllinject/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp'
   end
 
   context 'windows/dllinject/reverse_tcp_allports' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_allports'
   end
 
   context 'windows/dllinject/reverse_tcp_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_dns'
   end
 
   context 'windows/dllinject/reverse_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_rc4'
   end
 
   context 'windows/dllinject/reverse_tcp_rc4_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_rc4_dns'
   end
 
   context 'windows/dns_txt_query_exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/dns_txt_query_exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dns_txt_query_exec'
   end
 
   context 'windows/download_exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/download_exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/download_exec'
   end
 
   context 'windows/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/exec'
   end
 
   context 'windows/format_all_drives' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/format_all_drives'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/format_all_drives'
   end
 
   context 'windows/loadlibrary' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/loadlibrary'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/loadlibrary'
   end
 
   context 'windows/messagebox' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/messagebox'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/messagebox'
   end
 
   context 'windows/meterpreter/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_ipv6_tcp'
   end
 
   context 'windows/meterpreter/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_nonx_tcp'
   end
 
   context 'windows/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_tcp'
   end
 
   context 'windows/meterpreter/bind_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_tcp_rc4'
   end
 
   context 'windows/meterpreter/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/find_tag'
   end
 
   context 'windows/meterpreter/reverse_hop_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_hop_http'
   end
 
   context 'windows/meterpreter/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_http'
   end
 
   context 'windows/meterpreter/reverse_http_proxy_pstore' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_http_proxy_pstore'
   end
 
   context 'windows/meterpreter/reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_https',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_https'
   end
 
   context 'windows/meterpreter/reverse_https_proxy' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_https_proxy',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_https_proxy'
   end
 
   context 'windows/meterpreter/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_ipv6_tcp'
   end
 
   context 'windows/meterpreter/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_nonx_tcp'
   end
 
   context 'windows/meterpreter/reverse_ord_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_ord_tcp'
   end
 
   context 'windows/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp'
   end
 
   context 'windows/meterpreter/reverse_tcp_allports' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_allports'
   end
 
   context 'windows/meterpreter/reverse_tcp_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_dns'
   end
 
   context 'windows/meterpreter/reverse_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_rc4'
   end
 
   context 'windows/meterpreter/reverse_tcp_rc4_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_rc4_dns'
   end
 
   context 'windows/metsvc_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/metsvc_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/metsvc_bind_tcp'
   end
 
   context 'windows/metsvc_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/metsvc_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/metsvc_reverse_tcp'
   end
 
   context 'windows/patchupdllinject/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_ipv6_tcp'
   end
 
   context 'windows/patchupdllinject/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_nonx_tcp'
   end
 
   context 'windows/patchupdllinject/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_tcp'
   end
 
   context 'windows/patchupdllinject/bind_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_tcp_rc4'
   end
 
   context 'windows/patchupdllinject/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/find_tag'
   end
 
   context 'windows/patchupdllinject/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_ipv6_tcp'
   end
 
   context 'windows/patchupdllinject/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_nonx_tcp'
   end
 
   context 'windows/patchupdllinject/reverse_ord_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_ord_tcp'
   end
 
   context 'windows/patchupdllinject/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp'
   end
 
   context 'windows/patchupdllinject/reverse_tcp_allports' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_allports'
   end
 
   context 'windows/patchupdllinject/reverse_tcp_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_dns'
   end
 
   context 'windows/patchupdllinject/reverse_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_rc4'
   end
 
   context 'windows/patchupdllinject/reverse_tcp_rc4_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_rc4_dns'
   end
 
   context 'windows/patchupmeterpreter/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_ipv6_tcp'
   end
 
   context 'windows/patchupmeterpreter/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_nonx_tcp'
   end
 
   context 'windows/patchupmeterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_tcp'
   end
 
   context 'windows/patchupmeterpreter/bind_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_tcp_rc4'
   end
 
   context 'windows/patchupmeterpreter/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/find_tag'
   end
 
   context 'windows/patchupmeterpreter/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_ipv6_tcp'
   end
 
   context 'windows/patchupmeterpreter/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_nonx_tcp'
   end
 
   context 'windows/patchupmeterpreter/reverse_ord_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_ord_tcp'
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp'
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_allports' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_allports'
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_dns'
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_rc4'
   end
 
   context 'windows/patchupmeterpreter/reverse_tcp_rc4_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_rc4_dns'
   end
 
   context 'windows/shell/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_ipv6_tcp'
   end
 
   context 'windows/shell/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_nonx_tcp'
   end
 
   context 'windows/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_tcp'
   end
 
   context 'windows/shell/bind_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_tcp_rc4'
   end
 
   context 'windows/shell/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/find_tag'
   end
 
   context 'windows/shell/reverse_hop_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_hop_http'
   end
 
   context 'windows/shell/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_http'
   end
 
   context 'windows/shell/reverse_http_proxy_pstore' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_http_proxy_pstore'
   end
 
   context 'windows/shell/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_ipv6_tcp'
   end
 
   context 'windows/shell/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_nonx_tcp'
   end
 
   context 'windows/shell/reverse_ord_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_ord_tcp'
   end
 
   context 'windows/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp'
   end
 
   context 'windows/shell/reverse_tcp_allports' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_allports'
   end
 
   context 'windows/shell/reverse_tcp_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_dns'
   end
 
   context 'windows/shell/reverse_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_rc4'
   end
 
   context 'windows/shell/reverse_tcp_rc4_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_rc4_dns'
   end
 
   context 'windows/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_bind_tcp'
   end
 
   context 'windows/shell_bind_tcp_xpfw' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_bind_tcp_xpfw'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_bind_tcp_xpfw'
   end
 
   context 'windows/shell_hidden_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_hidden_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_hidden_bind_tcp'
   end
 
   context 'windows/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_reverse_tcp'
   end
 
   context 'windows/speak_pwned' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/speak_pwned'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/speak_pwned'
   end
 
   context 'windows/upexec/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_ipv6_tcp'
   end
 
   context 'windows/upexec/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_nonx_tcp'
   end
 
   context 'windows/upexec/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_tcp'
   end
 
   context 'windows/upexec/bind_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_tcp_rc4'
   end
 
   context 'windows/upexec/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/find_tag'
   end
 
   context 'windows/upexec/reverse_hop_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_hop_http'
   end
 
   context 'windows/upexec/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_http'
   end
 
   context 'windows/upexec/reverse_http_proxy_pstore' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_http_proxy_pstore'
   end
 
   context 'windows/upexec/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_ipv6_tcp'
   end
 
   context 'windows/upexec/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_nonx_tcp'
   end
 
   context 'windows/upexec/reverse_ord_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_ord_tcp'
   end
 
   context 'windows/upexec/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp'
   end
 
   context 'windows/upexec/reverse_tcp_allports' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_allports'
   end
 
   context 'windows/upexec/reverse_tcp_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_dns'
   end
 
   context 'windows/upexec/reverse_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_rc4'
   end
 
   context 'windows/upexec/reverse_tcp_rc4_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_rc4_dns'
   end
 
   context 'windows/vncinject/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_ipv6_tcp'
   end
 
   context 'windows/vncinject/bind_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_nonx_tcp'
   end
 
   context 'windows/vncinject/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_tcp'
   end
 
   context 'windows/vncinject/bind_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_tcp_rc4'
   end
 
   context 'windows/vncinject/find_tag' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/findtag_ord',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/find_tag'
   end
 
   context 'windows/vncinject/reverse_hop_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_hop_http'
   end
 
   context 'windows/vncinject/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_http',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_http'
   end
 
   context 'windows/vncinject/reverse_http_proxy_pstore' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_http_proxy_pstore'
   end
 
   context 'windows/vncinject/reverse_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_ipv6_tcp'
   end
 
   context 'windows/vncinject/reverse_nonx_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_nonx_tcp'
   end
 
   context 'windows/vncinject/reverse_ord_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_ord_tcp'
   end
 
   context 'windows/vncinject/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp'
   end
 
   context 'windows/vncinject/reverse_tcp_allports' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_allports'
   end
 
   context 'windows/vncinject/reverse_tcp_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_dns'
   end
 
   context 'windows/vncinject/reverse_tcp_rc4' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_rc4'
   end
 
   context 'windows/vncinject/reverse_tcp_rc4_dns' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_rc4_dns'
   end
 
   context 'windows/x64/exec' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/exec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/exec'
   end
 
   context 'windows/x64/loadlibrary' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/loadlibrary'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/loadlibrary'
   end
 
   context 'windows/x64/meterpreter/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/bind_tcp'
   end
 
   context 'windows/x64/meterpreter/reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_https',
                               'stages/windows/x64/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_https'
   end
 
   context 'windows/x64/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_tcp'
   end
 
   context 'windows/x64/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/bind_tcp'
   end
 
   context 'windows/x64/shell/reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_https',
                               'stages/windows/x64/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/reverse_https'
   end
 
   context 'windows/x64/shell/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/reverse_tcp'
   end
 
   context 'windows/x64/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/shell_bind_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell_bind_tcp'
   end
 
   context 'windows/x64/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'singles/windows/x64/shell_reverse_tcp'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell_reverse_tcp'
   end
 
   context 'windows/x64/vncinject/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/bind_tcp'
   end
 
   context 'windows/x64/vncinject/reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_https',
                               'stages/windows/x64/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/reverse_https'
   end
 
   context 'windows/x64/vncinject/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/reverse_tcp'
   end
 
   context 'windows/dllinject/bind_hidden_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_hidden_tcp'
   end
 
   context 'windows/meterpreter/bind_hidden_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_hidden_tcp'
   end
 
   context 'windows/patchupdllinject/bind_hidden_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_hidden_tcp'
   end
 
   context 'windows/patchupmeterpreter/bind_hidden_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_hidden_tcp'
   end
 
   context 'windows/shell/bind_hidden_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_hidden_tcp'
   end
 
   context 'windows/upexec/bind_hidden_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_hidden_tcp'
   end
 
   context 'windows/vncinject/bind_hidden_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_hidden_tcp'
   end
 
   context 'windows/dllinject/bind_hidden_ipknock_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/dllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_hidden_ipknock_tcp'
   end
 
   context 'windows/meterpreter/bind_hidden_ipknock_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/meterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_hidden_ipknock_tcp'
   end
 
   context 'windows/patchupdllinject/bind_hidden_ipknock_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/patchupdllinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_hidden_ipknock_tcp'
   end
 
   context 'windows/patchupmeterpreter/bind_hidden_ipknock_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/patchupmeterpreter'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_hidden_ipknock_tcp'
   end
 
   context 'windows/shell/bind_hidden_ipknock_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/shell'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_hidden_ipknock_tcp'
   end
 
   context 'windows/upexec/bind_hidden_ipknock_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/upexec'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_hidden_ipknock_tcp'
   end
 
   context 'windows/vncinject/bind_hidden_ipknock_tcp' do
     it_should_behave_like 'payload cached size is consistent',
-                          dynamic_size: false,
                           ancestor_reference_names: [
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/vncinject'
                           ],
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_hidden_ipknock_tcp'
   end

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -63,23 +63,23 @@
 #   single payloads, there will be one ancestor reference name from `modules/payloads/singles`, while for staged
 #   payloads there with be one ancestor reference name from `modules/payloads/stagers` and one ancestor reference name
 #   from `modules/payloads/stages`.
+# @option options [Boolean] :dynamic_size The dynamic_size flag determines whether we expect this module to generate a
+#   variable size payload or to have a valid cached_size
 # @option options [Pathname] :modules_pathname The `modules` directory from which to load `:ancestor_reference_names`.
 # @option options [String] :reference_name The reference name for payload class that should be instantiated from mixing
 #   `:ancestor_reference_names`.
-# @option options [Boolean] :dynamic_size The dynamic_size flag determines whether we expect this module to generate a
-#   variable size payload or to have a valid cached_size
 # @return [void]
 shared_examples_for 'payload cached size is consistent' do |options|
   options.assert_valid_keys(:ancestor_reference_names, :modules_pathname, :reference_name, :dynamic_size)
 
   ancestor_reference_names = options.fetch(:ancestor_reference_names)
 
+  dynamic_size = options.fetch(:dynamic_size)
+
   modules_pathname = options.fetch(:modules_pathname)
   modules_path = modules_pathname.to_path
 
   reference_name = options.fetch(:reference_name)
-
-  dynamic_size = options.fetch(:dynamic_size)
 
   module_type = 'payload'
 

--- a/spec/support/shared/examples/payload_can_be_instantiated.rb
+++ b/spec/support/shared/examples/payload_can_be_instantiated.rb
@@ -99,7 +99,7 @@ shared_examples_for 'payload can be instantiated' do |options|
     end
 
     it 'can be instantiated' do
-      pinst = load_and_create_module(
+      load_and_create_module(
           ancestor_reference_names: ancestor_reference_names,
           module_type: module_type,
           modules_path: modules_path,

--- a/spec/support/shared/examples/payload_can_be_instantiated.rb
+++ b/spec/support/shared/examples/payload_can_be_instantiated.rb
@@ -99,12 +99,32 @@ shared_examples_for 'payload can be instantiated' do |options|
     end
 
     it 'can be instantiated' do
-      load_and_create_module(
+      pinst = load_and_create_module(
           ancestor_reference_names: ancestor_reference_names,
           module_type: module_type,
           modules_path: modules_path,
           reference_name: reference_name
       )
     end
+
+    it 'has a valid cached_size or is dynamic_size' do
+      pinst = load_and_create_module(
+          ancestor_reference_names: ancestor_reference_names,
+          module_type: module_type,
+          modules_path: modules_path,
+          reference_name: reference_name
+      )
+
+      if pinst.dynamic_size?
+        expect(pinst.cached_size).to(be_nil,
+          "Payload #{module_type}/#{reference_name} has a dynamic size but a non-nil cached_size")
+      else
+        expect(pinst.cached_size).not_to(be_nil,
+          "Payload #{module_type}/#{reference_name} is missing CachedSize")
+        expect(pinst.size).to(eq(pinst.cached_size),
+          "Payload #{module_type}/#{reference_name} generated size does not match CachedSize")
+      end
+    end
+
   end
 end

--- a/tools/update_payload_cached_sizes.rb
+++ b/tools/update_payload_cached_sizes.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+#
+# $Id$
+#
+# This script lists each exploit module by its compatible payloads
+#
+# $Revision$
+#
+
+msfbase = __FILE__
+while File.symlink?(msfbase)
+  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
+
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', 'lib')))
+require 'msfenv'
+
+$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+
+require 'rex'
+require 'msf/ui'
+require 'msf/base'
+
+
+def print_status(msg)
+  print_line "[*] #{msg}"
+end
+
+def print_error(msg)
+  print_line "[-] #{msg}"
+end
+
+def print_line(msg)
+  $stderr.puts msg
+end
+
+def is_dynamic_size?(mod)
+  [*(1..5)].map{|x| mod.new.size}.uniq.length != 1
+end
+
+def update_cache_size(mod)
+  data = ''
+  File.open(mod.file_path, 'rb'){|fd| data = fd.read(fd.stat.size)}
+  data = data.gsub(/^\s*CachedSize\s*=\s*\d+.*/, '')
+  data = data.gsub(/^(module Metasploit\d+)/) {|m| "#{m}\n  CachedSize = #{mod.new.size}\n" }
+  File.open(mod.file_path, 'wb'){|fd| fd.write(data) }
+end
+
+# Initialize the simplified framework instance.
+$framework = Msf::Simple::Framework.create('DisableDatabase' => true)
+
+$framework.payloads.each_module do |name, mod|
+  gsize = mod.new.size
+
+  if is_dynamic_size?(mod)
+    print_status("#{mod.file_path} has a dynamic size, skipping...")
+    next
+  end
+
+  if mod.cached_size.nil?
+    print_status("#{mod.file_path} has size #{gsize}, updating cache...")
+    update_cache_size(mod)
+  else
+    next if gsize == mod.cached_size
+    print_error("#{mod.file_path} has cached size #{mod.cached_size} but generated #{gsize}")
+    update_cache_size(mod)
+    next
+  end
+end
+

--- a/tools/update_payload_cached_sizes.rb
+++ b/tools/update_payload_cached_sizes.rb
@@ -1,10 +1,6 @@
 #!/usr/bin/env ruby
 #
-# $Id$
-#
-# This script lists each exploit module by its compatible payloads
-#
-# $Revision$
+# This script updates the CachedSize constants in payload modules
 #
 
 msfbase = __FILE__
@@ -20,54 +16,14 @@ $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 require 'rex'
 require 'msf/ui'
 require 'msf/base'
-
-
-def print_status(msg)
-  print_line "[*] #{msg}"
-end
-
-def print_error(msg)
-  print_line "[-] #{msg}"
-end
-
-def print_line(msg)
-  $stderr.puts msg
-end
-
-def is_dynamic_size?(mod)
-  [*(1..5)].map{|x| mod.new.size}.uniq.length != 1
-end
-
-def update_cache_size(mod, val)
-  data = ''
-  File.open(mod.file_path, 'rb'){|fd| data = fd.read(fd.stat.size)}
-  data = data.gsub(/^\s*CachedSize\s*=\s*(\d+|:dynamic).*/, '')
-  data = data.gsub(/^(module Metasploit\d+)\s*\n/) {|m| "#{m.strip}\n\n  CachedSize = #{val}\n\n" }
-  File.open(mod.file_path, 'wb'){|fd| fd.write(data) }
-end
+require 'msf/util/payload_cached_size'
 
 # Initialize the simplified framework instance.
-$framework = Msf::Simple::Framework.create('DisableDatabase' => true)
+framework = Msf::Simple::Framework.create('DisableDatabase' => true)
 
-$framework.payloads.each_module do |name, mod|
-  gsize = mod.new.size
-
-  if is_dynamic_size?(mod) && ! mod.dynamic_size?
-    print_status("#{mod.file_path} has a dynamic size, updating cache...")
-    update_cache_size(mod, ":dynamic")
-    next
-  end
-
-  next if mod.dynamic_size?
-
-  if mod.cached_size.nil?
-    print_status("#{mod.file_path} has size #{gsize}, updating cache...")
-    update_cache_size(mod, gsize)
-  else
-    next if gsize == mod.cached_size
-    print_error("#{mod.file_path} has cached size #{mod.cached_size} but generated #{gsize}, updating cache...")
-    update_cache_size(mod, gsize)
-    next
-  end
+framework.payloads.each_module do |name, mod|
+  next if Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod)
+  $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
+  Msf::Util::PayloadCachedSize.update_module_cached_size(mod)
 end
 


### PR DESCRIPTION
Quick and dirty benchmark:

```
$ for i in `seq 1 3`; do time ./msfconsole -q -x 'exit'; done

real  0m5.829s
user  0m5.185s
sys 0m0.530s

real  0m5.897s
user  0m5.358s
sys 0m0.434s

real  0m5.593s
user  0m5.073s
sys 0m0.424s
```

Generate the cache:

```
$ ./tools/update_payload_cached_sizes.rb 

[*] /data/work/msf-hdm/modules/payloads/singles/aix/ppc/shell_bind_tcp.rb has size 264, updating cache...
[*] /data/work/msf-hdm/modules/payloads/singles/aix/ppc/shell_find_port.rb has size 220, updating cache...
[*] /data/work/msf-hdm/modules/payloads/singles/aix/ppc/shell_interact.rb has size 56, updating cache...
[*] /data/work/msf-hdm/modules/payloads/singles/aix/ppc/shell_reverse_tcp.rb has size 204, updating cache...
[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_http.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_https.rb has a dynamic size, skipping...
[..]
```

Verify the cache:

```
$ ./tools/update_payload_cached_sizes.rb 

[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_http.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_https.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_tcp.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_http.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_https.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/stagers/android/reverse_tcp.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/cmd/unix/bind_netcat.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/cmd/unix/reverse_bash.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/cmd/unix/reverse_netcat.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/cmd/unix/reverse_python.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/cmd/windows/download_eval_vbs.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/cmd/windows/download_exec_vbs.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/firefox/exec.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/firefox/shell_bind_tcp.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/firefox/shell_reverse_tcp.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/php/bind_php.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/php/bind_php_ipv6.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/php/download_exec.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/php/exec.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/php/reverse_perl.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/php/reverse_php.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/php/shell_findsock.rb has a dynamic size, skipping...
[*] /data/work/msf-hdm/modules/payloads/singles/solaris/sparc/shell_find_port.rb has a dynamic size, skipping...
```

Bask in the glory:

```
$ for i in `seq 1 3`; do time ./msfconsole -q -x 'exit'; done

real  0m5.100s
user  0m4.511s
sys 0m0.483s

real  0m4.895s
user  0m4.371s
sys 0m0.438s

real  0m5.056s
user  0m4.549s
sys 0m0.427s
```

Spec coverage is still a TODO and will handle build-time verification of cached sizes.

This change would let us move to Metasm payload generators without a startup-time performance penalty.
