### PR TITLE
latest credential for postgres hash import/export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       tzinfo
     metasploit-framework-db (4.11.0.pre.dev)
       activerecord (>= 3.2.21, < 4.0.0)
-      metasploit-credential (~> 0.14.2)
+      metasploit-credential (~> 0.14.3)
       metasploit-framework (= 4.11.0.pre.dev)
       metasploit_data_models (~> 0.23.0)
       pg (>= 0.11)
@@ -112,7 +112,7 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.14.2)
+    metasploit-credential (0.14.3)
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.29.0)
       metasploit_data_models (~> 0.23.0)

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Metasploit::Credential database models
-  spec.add_runtime_dependency 'metasploit-credential', '~> 0.14.2'
+  spec.add_runtime_dependency 'metasploit-credential', '~> 0.14.3'
   # Database models shared between framework and Pro.
   spec.add_runtime_dependency 'metasploit_data_models', '~> 0.23.0'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code


### PR DESCRIPTION
This PR brings in the newest version of Metasploit-Credential. This version adds support for PostgresMD5 hashes to the import/export functionality. The Travis-CI tests will fail until the new gem is built.

VERIFICATION STEPS
- [x] Land https://github.com/rapid7/metasploit-credential/pull/99
- [x] ping me to update the Lockfile once Credential has been released
- [x] `rake spec`
- [x] VERIFY all specs pass
- [x] start msfconsole
- [x] `use auxiliary/scanner/postgres/postgres_login`
- [x] target a metasploitable2 instance
- [x] set username to `postgres`
- [x] set password to `md53175bce1d3201d16594cebf9d7eb3f9d`
- [x] `run`
- [x] VERIFY that it logged in with the hash
- [x] `db_export -f pwdump postgres.pwdump`
- [x] create new workspace
- [x] `db_import postgres.pwdump`
- [x] `creds`
- [x] VERIFY the Postgres hash re-imported
