### PR TITLE
Fix persistence module to use correct Windows path

### DIFF
--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -135,8 +135,8 @@ class Metasploit3 < Msf::Exploit::Local
     begin
       write_file(tempvbs, vbs)
       print_good("Persistent Script written to #{tempvbs}")
-      tempvbs = tempvbs.gsub(/\\/, '//')      # Escape windows pathname separators.
-      @clean_up_rc << "rm #{tempvbs}\n"
+      # Escape windows pathname separators.
+      @clean_up_rc << "rm #{tempvbs.gsub(/\\/, '//')}\n"
     rescue
       print_error("Could not write the payload on the target hosts.")
       # return nil since we could not write the file on the target host.

--- a/scripts/meterpreter/persistence.rb
+++ b/scripts/meterpreter/persistence.rb
@@ -123,8 +123,8 @@ def write_script_to_target(target_dir,vbs)
   fd.write(vbs)
   fd.close
   print_good("Persistent Script written to #{tempvbs}")
-  tempvbs = tempvbs.gsub(/\\/, '//')      # Escape windows pathname separators.
-  file_local_write(@clean_up_rc, "rm #{tempvbs}\n")
+  # Escape windows pathname separators.
+  file_local_write(@clean_up_rc, "rm #{tempvbs.gsub(/\\/, '//')}\n")
   return tempvbs
 end
 


### PR DESCRIPTION
This fixes a bug in the write_script_to_target function, which alters the path that is returned and used for startup.
Currently an escaped path "C://Users//..." is being used instead of using windows standards "C:\Users...".

Issue introduced by #2395
