### PR TITLE
disable reverse_http methods from upexec and shell payloads

### DIFF
--- a/modules/payloads/stages/windows/shell.rb
+++ b/modules/payloads/stages/windows/shell.rb
@@ -23,7 +23,7 @@ module Metasploit3
       'Session'       => Msf::Sessions::CommandShellWindows,
       'PayloadCompat' =>
         {
-          'Convention' => 'sockedi -https'
+          'Convention' => 'sockedi -http -https'
         },
       'Stage'         =>
         {

--- a/modules/payloads/stages/windows/upexec.rb
+++ b/modules/payloads/stages/windows/upexec.rb
@@ -23,7 +23,7 @@ module Metasploit3
       'Session'       => Msf::Sessions::CommandShellWindows,
       'PayloadCompat' =>
         {
-          'Convention' => 'sockedi -https'
+          'Convention' => 'sockedi -http -https'
         },
       'Stage'         =>
         {

--- a/modules/payloads/stages/windows/x64/shell.rb
+++ b/modules/payloads/stages/windows/x64/shell.rb
@@ -23,7 +23,7 @@ module Metasploit3
       'Session'       => Msf::Sessions::CommandShellWindows,
       'PayloadCompat' =>
         {
-          'Convention' => 'sockrdi'
+          'Convention' => 'sockrdi -http -https'
         },
       'Stage'         =>
         {


### PR DESCRIPTION
The windows shell and upexec stages don't work over http/https as far back as I could test. They appear to have inherited this trait by accident.
# To verify
- [x] Check that msfvenom does not show shell reverse_http/s payloads for windows

```
$ ./msfvenom -l |awk '/windows.*reverse_http/ {print $1}'
windows/dllinject/reverse_http
windows/dllinject/reverse_http_proxy_pstore
windows/meterpreter/reverse_http
windows/meterpreter/reverse_http_proxy_pstore
windows/meterpreter/reverse_https
windows/meterpreter/reverse_https_proxy
windows/vncinject/reverse_http
windows/vncinject/reverse_http_proxy_pstore
windows/x64/meterpreter/reverse_https
windows/x64/vncinject/reverse_https
```
