### PR TITLE
Update .mailmap for @joevennix

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -75,6 +75,7 @@ jcran <jcran@github>                   Jonathan Cran <jcran@0x0e.org>
 jcran <jcran@github>                   Jonathan Cran <jcran@rapid7.com>
 jduck <jduck@github>                   Joshua Drake <github.jdrake@qoop.org>
 jgor <jgor@github>                     jgor <jgor@indiecom.org>
+joevennix <joevennix@github>           joe <joev@metasploit.com>
 joevennix <joevennix@github>           Joe Vennix <Joe_Vennix@rapid7.com>
 joevennix <joevennix@github>           Joe Vennix <joev@metasploit.com>
 joevennix <joevennix@github>           joev <joev@metasploit.com>

--- a/.mailmap
+++ b/.mailmap
@@ -13,11 +13,6 @@ jhart-r7 <jhart-r7@github>         Jon Hart <jon_hart@rapid7.com>
 jlee-r7 <jlee-r7@github>           egypt <egypt@metasploit.com> # aka egypt
 jlee-r7 <jlee-r7@github>           James Lee <egypt@metasploit.com> # aka egypt
 jlee-r7 <jlee-r7@github>           James Lee <James_Lee@rapid7.com>
-joev-r7 <joev-r7@github>           Joe Vennix <Joe_Vennix@rapid7.com>
-joev-r7 <joev-r7@github>           Joe Vennix <joev@metasploit.com>
-joev-r7 <joev-r7@github>           joev <joev@metasploit.com>
-joev-r7 <joev-r7@github>           jvennix-r7 <Joe_Vennix@rapid7.com>
-joev-r7 <joev-r7@github>           jvennix-r7 <joev@metasploit.com>
 jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan.vazquez@metasploit.com>
 jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan_vazquez@rapid7.com>
 kgray-r7 <kgray-r7@github>         Kyle Gray <kyle_gray@rapid7.com>
@@ -80,9 +75,14 @@ jcran <jcran@github>                   Jonathan Cran <jcran@0x0e.org>
 jcran <jcran@github>                   Jonathan Cran <jcran@rapid7.com>
 jduck <jduck@github>                   Joshua Drake <github.jdrake@qoop.org>
 jgor <jgor@github>                     jgor <jgor@indiecom.org>
+joevennix <joevennix@github>           Joe Vennix <Joe_Vennix@rapid7.com>
+joevennix <joevennix@github>           Joe Vennix <joev@metasploit.com>
+joevennix <joevennix@github>           joev <joev@metasploit.com>
+joevennix <joevennix@github>           jvennix-r7 <Joe_Vennix@rapid7.com>
+joevennix <joevennix@github>           jvennix-r7 <joev@metasploit.com>
 kernelsmith <kernelsmith@github>       Joshua Smith <kernelsmith@kernelsmith.com>
-kernelsmith <kernelsmith@github>       kernelsmith <kernelsmith@kernelsmith>
 kernelsmith <kernelsmith@github>       Joshua Smith <kernelsmith@metasploit.com>
+kernelsmith <kernelsmith@github>       kernelsmith <kernelsmith@kernelsmith>
 kost <kost@github>                     Vlatko Kosturjak <kost@linux.hr>
 kris <kris@???>                        kris <>
 m-1-k-3 <m-1-k-3@github>               m-1-k-3 <github@s3cur1ty.de>


### PR DESCRIPTION
This remaps @jvennix-r7 to @joevennix so the .mailmap comments aren't a lie.
## Verification
- [ ] `git log --format="%aN %aE" | grep joev | uniq -c` should only show one Joe.
