### PR TITLE
Fixes #4897 by corrected kernel32!Interlocked function definitions

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
@@ -2159,13 +2159,13 @@ class Def_kernel32
       ])
 
     dll.add_function( 'InterlockedCompareExchange', 'DWORD',[
-      ["PDWORD","Destination","inout"],
+      ["PDWORD","Destination","in"],
       ["DWORD","ExChange","in"],
       ["DWORD","Comperand","in"],
       ])
 
     dll.add_function( 'InterlockedCompareExchange64', 'LPVOID',[
-      ["PBLOB","Destination","inout"],
+      ["PBLOB","Destination","in"],
       ["PBLOB","ExChange","in"],
       ["PBLOB","Comperand","in"],
       ])
@@ -2175,7 +2175,7 @@ class Def_kernel32
       ])
 
     dll.add_function( 'InterlockedExchange', 'DWORD',[
-      ["PDWORD","Target","inout"],
+      ["PDWORD","Target","in"],
       ["DWORD","Value","in"],
       ])
 


### PR DESCRIPTION
Small update to kernel32!InterlockedCompareExchange and kernel32!InterlockedExchange function definitions in railgun. I don't have a handy test for these, but nothing in the framework today depends on these definitions as written. This fixes #4897
