### PR TITLE
Avoid instantiating the module during recalculate

### DIFF
--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -88,7 +88,7 @@ class PayloadSet < ModuleSet
 
       # Cache the payload's size
       begin
-        sizes[name] = p.new.size
+        sizes[name] = p.cached_size || p.new.size
       # Don't cache generic payload sizes.
       rescue NoCompatiblePayloadError
       end


### PR DESCRIPTION
This provides a speed improvement during the payload set recalculation, which also improves start time. This should have been part of #4894, but was overlooked. This shaves another ~500ms off startup.

Startup time from the master branch:

```
$ git checkout master

$ for i in `seq 1 3`; do time ./msfconsole  -q -x 'exit'; done

real    0m5.089s
user    0m4.590s
sys 0m0.393s

real    0m5.141s
user    0m4.458s
sys 0m0.586s

real    0m5.172s
user    0m4.559s
sys 0m0.521s
```

Startup time from the PR branch:

```
$ git checkout bug/use-cached-size-during-recalculate
$ for i in `seq 1 3`; do time ./msfconsole  -q -x 'exit'; done

real    0m4.591s
user    0m4.043s
sys 0m0.465s

real    0m4.783s
user    0m4.169s
sys 0m0.498s

real    0m4.535s
user    0m4.005s
sys 0m0.424s
```
