### PR TITLE
Adding help and tab functions for db_nmap

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1594,7 +1594,6 @@ class Db
       print_status("Usage: db_nmap [nmap options]")
       return
     end
-    
     save = false
     arguments = ''
     while (arg = args.shift)
@@ -1637,7 +1636,7 @@ class Db
     end
 
     begin
-      nmap_pipe = ::Open3::popen3([nmap, "nmap"], arguments)
+      nmap_pipe = ::Open3::popen3([nmap, 'nmap'], arguments)
       temp_nmap_threads = []
       temp_nmap_threads << framework.threads.spawn("db_nmap-Stdout", false, nmap_pipe[1]) do |np_1|
         np_1.each_line do |nmap_out|
@@ -1706,7 +1705,7 @@ class Db
       print_error(err_line.strip)
     end
 
-    return tabs
+    tabs
   end
 
   #


### PR DESCRIPTION
These functions address certain problems listed in GitHub issue #4353, but do not address all issues in that ticket.  Most notably, this commit adds basic tab completion for db_nmap. Sorry about the commit message coming across as one line.  Please let me know how this should be adjusted so that it can be landed; I am sure there will need to be changes.
