### PR TITLE
Add REG_MULTI_SZ registry key type

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -381,13 +381,16 @@ class Registry
   # type (like REG_SZ).
   #
   def self.type2str(type)
-    return REG_SZ if (type == 'REG_SZ')
-    return REG_MULTI_SZ if (type == 'REG_MULTI_SZ')
-    return REG_DWORD if (type == 'REG_DWORD')
-    return REG_BINARY if (type == 'REG_BINARY')
-    return REG_EXPAND_SZ if (type == 'REG_EXPAND_SZ')
-    return REG_NONE if (type == 'REG_NONE')
-    return nil
+    case type
+    when 'REG_BINARY'    then REG_BINARY
+    when 'REG_DWORD'     then REG_DWORD
+    when 'REG_EXPAND_SZ' then REG_EXPAND_SZ
+    when 'REG_MULTI_SZ'  then REG_MULTI_SZ
+    when 'REG_NONE'      then REG_NONE
+    when 'REG_SZ'        then REG_SZ
+    else
+      nil
+    end
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -380,6 +380,9 @@ class Registry
   # Returns the integer value associated with the supplied registry value
   # type (like REG_SZ).
   #
+  # @see https://msdn.microsoft.com/en-us/library/windows/desktop/ms724884(v=vs.85).aspx
+  # @param type [String] A Windows registry type constant name, e.g. 'REG_SZ'
+  # @return [Integer] one of the `REG_*` constants
   def self.type2str(type)
     case type
     when 'REG_BINARY'    then REG_BINARY

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -382,6 +382,7 @@ class Registry
   #
   def self.type2str(type)
     return REG_SZ if (type == 'REG_SZ')
+    return REG_MULTI_SZ if (type == 'REG_MULTI_SZ')
     return REG_DWORD if (type == 'REG_DWORD')
     return REG_BINARY if (type == 'REG_BINARY')
     return REG_EXPAND_SZ if (type == 'REG_EXPAND_SZ')

--- a/spec/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_spec.rb
+++ b/spec/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_spec.rb
@@ -1,0 +1,34 @@
+require 'rex/post/meterpreter/extensions/stdapi/sys/registry'
+
+RSpec.describe Rex::Post::Meterpreter::Extensions::Stdapi::Sys::Registry do
+
+  describe '.type2str' do
+    subject { described_class.type2str(type) }
+
+    context "with 'REG_BINARY'" do
+      let(:type) { 'REG_BINARY' }
+      it { should eq(3) }
+    end
+    context "with 'REG_DWORD'" do
+      let(:type) { 'REG_DWORD' }
+      it { should eq(4) }
+    end
+    context "with 'REG_EXPAND_SZ'" do
+      let(:type) { 'REG_EXPAND_SZ' }
+      it { should eq(2) }
+    end
+    context "with 'REG_MULTI_SZ'" do
+      let(:type) { 'REG_MULTI_SZ' }
+      it { should eq(7) }
+    end
+    context "with 'REG_NONE'" do
+      let(:type) { 'REG_NONE' }
+      it { should eq(0) }
+    end
+    context "with 'REG_SZ'" do
+      let(:type) { 'REG_SZ' }
+      it { should eq(1) }
+    end
+  end
+
+end


### PR DESCRIPTION
This is necessary for dealing with multi-string values in the registry through the Post API `registry_setvaldata` method.
### Verification
- [x] use any post module that includes `Post::Windows::Registry`
  - [x] `use post/windows/gather/lsa_secrets`
- [x] `pry`
- [x] `registry_setvaldata('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager', 'PendingFileRenameOperations', 'c:\deleteme.exe', 'REG_MULTI_SZ')`
- [x] **VERIFY** it doesn't blow up with a `TypeError`

Note that you don't really need a session to test this. It will blow up with a `NoMethodError` on nil when it tries to actually perform the registry write, but at that point we've already exercised the errant code that this PR tests and proven that the fix works.
