### PR TITLE
update tools/missing-payload-tests to give correct advice

### DIFF
--- a/tools/missing-payload-tests.rb
+++ b/tools/missing-payload-tests.rb
@@ -61,7 +61,7 @@ File.open('log/untested-payloads.log') { |f|
 
          $stderr.puts
          $stderr.puts "  context '#{reference_name}' do\n" \
-                      "    it_should_behave_like 'payload can be instantiated',\n" \
+                      "    it_should_behave_like 'payload cached size is consistent',\n" \
                       "                          ancestor_reference_names: ["
 
          ancestor_reference_names = options[:ancestor_reference_names]
@@ -74,6 +74,7 @@ File.open('log/untested-payloads.log') { |f|
          end
 
          $stderr.puts "                          ],\n" \
+                      "                          dynamic_size: false,\n" \
                       "                          modules_pathname: modules_pathname,\n" \
                       "                          reference_name: '#{reference_name}'\n" \
                       "  end"


### PR DESCRIPTION
The template spec for new payloads needed updating to match the new cached payload sizes, as part of #4894
# To Verify
- [x] Delete a payload entry from spec/modules/payloads_spec.rb
- [x] Run tools/missing-payload-tests.rb
- [x] Paste the result back into spec/modules/payloads_spec.rb, adjust as needed
- [x] Running the specs still works, e.g. 'bundle exec rake spec'
