### PR TITLE
Gitlab Login Scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -1,0 +1,98 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # Gitlab login scanner
+      class Gitlab < HTTP
+
+        # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
+        CAN_GET_SESSION = false
+        DEFAULT_PORT    = 80
+        PRIVATE_TYPES   = [ :password ]
+
+        # (see Base#set_sane_defaults)
+        def set_sane_defaults
+          self.uri = '/users/sign_in' if self.uri.nil?
+          self.method = 'POST' if self.method.nil
+
+          super
+        end
+
+        def attempt_login(credential)
+          result_opts = {
+              credential: credential,
+              host: host,
+              port: port,
+              protocol: 'tcp',
+              service_name: ssl ? 'https' : 'http'
+          }
+          begin
+            cli = Rex::Proto::Http::Client.new(host,
+                                               port,
+                                               {
+                                                 'Msf' => framework,
+                                                 'MsfExploit' => framework_module
+                                               },
+                                               ssl,
+                                               ssl_version,
+                                               proxies)
+            configure_http_client(cli)
+            cli.connect
+
+            # Get a valid session cookie and authenticity_token for the next step
+            req = cli.request_cgi({
+              'method' => 'GET',
+              'cookie' => 'request_method=GET',
+              'uri'    => self.uri
+            })
+
+            res = cli.send_recv(req)
+
+            if res.body.include? 'user[email]'
+              user_field = 'user[email]'
+            elsif res.body.include? 'user[login]'
+              user_field = 'user[login]'
+            else
+              raise RuntimeError, 'Not a valid Gitlab login page'
+            end
+
+            local_session_cookie = res.get_cookies.scan(/(_gitlab_session=[A-Za-z0-9%-]+)/).flatten[0]
+            auth_token = res.body.scan(/<input name="authenticity_token" type="hidden" value="(.*?)"/).flatten[0]
+
+            raise RuntimeError, 'Unable to get Session Cookie' unless local_session_cookie
+            raise RuntimeError, 'Unable to get Authentication Token' unless auth_token
+
+            # Perform the actual login
+            req = cli.request_cgi({
+                                    'method' => 'POST',
+                                    'cookie' => local_session_cookie,
+                                    'uri'    => self.uri,
+                                    'vars_post' =>
+                                      {
+                                        'utf8' => "\xE2\x9C\x93",
+                                        'authenticity_token' => auth_token,
+                                        "#{user_field}" => credential.public,
+                                        'user[password]' => credential.private,
+                                        'user[remember_me]' => 0
+                                      }
+            })
+
+            res = cli.send_recv(req)
+            if res && res.code == 302
+              result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
+            else
+              result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
+            end
+          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error => e
+            result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
+          ensure
+            cli.close
+          end
+          Result.new(result_opts)
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -3,8 +3,8 @@ require 'metasploit/framework/login_scanner/http'
 module Metasploit
   module Framework
     module LoginScanner
-      # Gitlab login scanner
-      class Gitlab < HTTP
+      # GitLab login scanner
+      class GitLab < HTTP
         # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
         CAN_GET_SESSION = false
         DEFAULT_PORT    = 80
@@ -53,7 +53,7 @@ module Metasploit
             elsif res.body.include? 'user[login]'
               user_field = 'user[login]'
             else
-              fail RuntimeError, 'Not a valid Gitlab login page'
+              fail RuntimeError, 'Not a valid GitLab login page'
             end
 
             local_session_cookie = res.get_cookies.scan(/(_gitlab_session=[A-Za-z0-9%-]+)/).flatten[0]

--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -13,7 +13,7 @@ module Metasploit
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = '/users/sign_in' if uri.nil?
-          self.method = 'POST' if method.nil
+          self.method = 'POST' if method.nil?
 
           super
         end

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -15,8 +15,8 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'Gitlab Login Utility',
-      'Description'    => 'This module attempts to login to a Gitlab instance using a specific user/pass.',
+      'Name'           => 'GitLab Login Utility',
+      'Description'    => 'This module attempts to login to a GitLab instance using a specific user/pass.',
       'Author'         => [ 'Ben Campbell' ],
       'License'        => MSF_LICENSE
     )
@@ -26,7 +26,7 @@ class Metasploit3 < Msf::Auxiliary
         Opt::RPORT(80),
         OptString.new('USERNAME', [ true, 'The username to test', 'root' ]),
         OptString.new('PASSWORD', [ true, 'The password to test', '5iveL!fe' ]),
-        OptString.new('TARGETURI', [true, 'The path to Gitlab', '/'])
+        OptString.new('TARGETURI', [true, 'The path to GitLab', '/'])
       ], self.class)
 
     register_autofilter_ports([ 80, 443 ])
@@ -43,11 +43,11 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     if res && res.body && res.body.include?('user[email]')
-      vprint_status("#{peer} - Gitlab v5 login page")
+      vprint_status("#{peer} - GitLab v5 login page")
     elsif res && res.body && res.body.include?('user[login]')
-      vprint_status("#{peer} - Gitlab v7 login page")
+      vprint_status("#{peer} - GitLab v7 login page")
     else
-      vprint_error('Not a valid Gitlab login page')
+      vprint_error('Not a valid GitLab login page')
       return
     end
 
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Auxiliary
       user_as_pass: datastore['USER_AS_PASS']
     )
 
-    scanner = Metasploit::Framework::LoginScanner::Gitlab.new(
+    scanner = Metasploit::Framework::LoginScanner::GitLab.new(
       configure_http_login_scanner(
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'metasploit/framework/credential_collection'
+require 'metasploit/framework/login_scanner/gitlab'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+
+  def initialize
+    super(
+      'Name'           => 'Gitlab Login Utility',
+      'Description'    => 'This module attempts to login to a Gitlab instance using a specific user/pass.',
+      'Author'         => [ 'Ben Campbell' ],
+      'License'        => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('USERNAME', [ true, 'The username to test', 'root' ]),
+        OptString.new('PASSWORD', [ true, 'The password to test', '5iveL!fe' ]),
+        OptString.new('TARGETURI', [true, 'The path to Gitlab', '/'])
+      ], self.class)
+
+    register_autofilter_ports([ 80, 443 ])
+
+    deregister_options('RHOST')
+  end
+
+  def run_host(ip)
+    uri = normalize_uri(target_uri.path.to_s, 'users', 'sign_in')
+    res = send_request_cgi(
+                            'method' => 'GET',
+                            'cookie' => 'request_method=GET',
+                            'uri'    => uri
+    )
+
+    if res && res.body && res.body.include?('user[email]')
+      vprint_status("#{peer} - Gitlab v5 login page")
+    elsif res && res.body && res.body.include?('user[login]')
+      vprint_status("#{peer} - Gitlab v7 login page")
+    else
+      vprint_error('Not a valid Gitlab login page')
+      return
+    end
+
+    cred_collection = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
+    )
+
+    scanner = Metasploit::Framework::LoginScanner::Gitlab.new(
+      configure_http_login_scanner(
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        uri: uri,
+        connection_timeout: 10
+      )
+    )
+
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+          module_fullname: fullname,
+          workspace_id: myworkspace_id
+      )
+      if result.success?
+        credential_core = create_credential(credential_data)
+        credential_data[:core] = credential_core
+        create_credential_login(credential_data)
+
+        print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential}"
+      else
+        invalidate_login(credential_data)
+        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/framework/login_scanner/gitlab_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/gitlab_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/gitlab'
 
-describe Metasploit::Framework::LoginScanner::Gitlab do
+describe Metasploit::Framework::LoginScanner::GitLab do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/gitlab_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/gitlab_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/gitlab'
+
+describe Metasploit::Framework::LoginScanner::Gitlab do
+
+    it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
+    it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
+    it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
+
+end


### PR DESCRIPTION
Login scanner for gitlab. I have only tested it against v7 - the logic is from the existing gitlab_shell_exec module...
## Example

```
[*] 127.1.1.1:80 Gitlab - v7 login page
[-] 127.1.1.1:80 GITLAB - LOGIN FAILED: root:Password1 (Incorrect)
[-] 127.1.1.1:80 GITLAB - LOGIN FAILED: root:root (Incorrect)
[+] 127.1.1.1:80 - LOGIN SUCCESSFUL: test:Password1
[-] 127.1.1.1:80 GITLAB - LOGIN FAILED: Administrator:Password1 (Incorrect)
[-] 127.1.1.1:80 GITLAB - LOGIN FAILED: Administrator:Administrator (Incorrect)
[-] 127.1.1.1:80 GITLAB - LOGIN FAILED: ldap_user1:Password1 (Incorrect)
[-] 127.1.1.1:80 GITLAB - LOGIN FAILED: ldap_user1:ldap_user1 (Incorrect)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
## Verification
- [x] wget https://downloads-packages.s3.amazonaws.com/ubuntu-12.04/gitlab_7.4.5-omnibus.5.1.0.ci-1_amd64.deb
- [x] sudo dpkg -i gitlab_7.4.5-omnibus.5.1.0.ci-1_amd64.deb
- [x] sudo vim /etc/gitlab/gitlab.rb 
- [x] Change  `external_url 'host'` to `external_url = 'host'` to fix deployment bug.
- [x] sudo gitlab-ctl reconfigure
- [x] Login to console with root:5iveL!fe
- [x] Add some users
- [x] Run module
- [x] `creds` and see if users are reported
- [x] Fire against an invalid host - should skip host if it cant find the correct fields...
