### PR TITLE
Fix bug #4340 with a loop, rather than a sleep retry

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -101,9 +101,6 @@ class Core
   # Constant for disclosure date formatting in search functions
   DISCLOSURE_DATE_FORMAT = "%Y-%m-%d"
 
-  # Constant for a retry timeout on using modules before they're loaded
-  CMD_USE_TIMEOUT = 3
-
   # Returns the list of commands supported by this command dispatcher
   def commands
     {
@@ -2543,15 +2540,9 @@ class Core
     mod_name = args[0]
 
     begin
-      mod = framework.modules.create(mod_name)
-      unless mod
-        # Try one more time; see #4549
-        sleep CMD_USE_TIMEOUT
-        mod = framework.modules.create(mod_name)
-        unless mod
-          print_error("Failed to load module: #{mod_name}")
-          return false
-        end
+      if ((mod = framework.modules.create(mod_name)) == nil)
+        print_error("Failed to load module: #{mod_name}")
+        return false
       end
     rescue Rex::AmbiguousArgumentError => info
       print_error(info.to_s)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -102,10 +102,10 @@ class Core
   DISCLOSURE_DATE_FORMAT = "%Y-%m-%d"
 
   # Sleep time in seconds between module use retries (see #4340)
-  CMD_USE_TIMEOUT = 1
+  CMD_USE_TIMEOUT = 0.1
 
   # Total retry attempts before giving up on using a module (see #4340)
-  CMD_USE_ATTEMPTS = 30
+  CMD_USE_ATTEMPTS = 300
 
   # Returns the list of commands supported by this command dispatcher
   def commands
@@ -2544,9 +2544,9 @@ class Core
 
     # Try to create an instance of the supplied module name
     mod_name = args[0]
+    mod = nil
 
     begin
-      mod = nil
       CMD_USE_ATTEMPTS.times do
         mod = framework.modules.create(mod_name)
         break if mod
@@ -2562,7 +2562,7 @@ class Core
       log_error("The supplied module name is ambiguous: #{$!}.")
     end
 
-    return false if (mod == nil)
+    return false unless mod
 
     # Enstack the command dispatcher for this module type
     dispatcher = nil


### PR DESCRIPTION
While I can't repro the race condition in any reliable way, this should resolve the race on even really slow filesystems.

This tries to use a module 300 times with 0.1 delay in between, defined by constants.

The verification is the same as on #4615 -- try loading a module several times, and note the times in between:
## Module exists, but is slow to load:
- [ ] Run `for i in {1..20}; do echo Attempt $i; time ./msfconsole -nq -x 'use exploit/multi/handler; set PAYLOAD windows/meterpreter/reverse_http; set LHOST 0.0.0.0; set LPORT 4444; run -j; exit';done`
- [ ] See that the module does load eventually.
## Module is typo'ed and/or doesn't exist at all:
- [ ] Run `time ./msfconsole -nq -x 'use exploit/multi/MISSING_handler; set PAYLOAD windows/meterpreter/reverse_http; set LHOST 0.0.0.0; set LPORT 4444; run -j; exit'`
- [ ] See that the use command will expire after some time (at least 30 seconds, practically, about a minute).

Unfortunately, there's no way to tell if the module will ever appear. So, if you're using msfconsole interactively, and you typo a name, then you're also stuck on the wait time. Ctrl-C seems to work fine though:

```
> use auxiliary/scanner/http/http_asffasfsa
^C[-] Error while running command use: 
```

As mentioned in #4615, a better solution would be to signal when modules are loaded "completely." and defer runnging the `cmd_use` command until then. That's a much more complicated solution, though. This should get us farther out of the woods in the meantime (/cc @limhoff-r7 @trosen-r7 ).

If 30 seconds is an intolerable amount of time to wait on a load error, it's easy enough to alter the CMD_USE_ATTEMPTS constant to something less than 300, shorten the sleep time, etc.
