### PR TITLE
Bug/msp 9972/appscan import

### DIFF
--- a/lib/rex/parser/appscan_nokogiri.rb
+++ b/lib/rex/parser/appscan_nokogiri.rb
@@ -193,12 +193,12 @@ module Rex
       return unless(request_headers && response_headers)
       req_header = Rex::Proto::Http::Packet::Header.new
       res_header = Rex::Proto::Http::Packet::Header.new
-      req_header.from_s request_headers.dup
-      res_header.from_s response_headers.dup
+      req_header.from_s request_headers.lstrip
+      res_header.from_s response_headers.lstrip
       @state[:request_headers] = req_header
-      @state[:request_body] = request_body
+      @state[:request_body] = request_body.lstrip
       @state[:response_headers] = res_header
-      @state[:response_body] = response_body
+      @state[:response_body] = response_body.lstrip
     end
 
     # Appscan tab-indents which makes parsing a little difficult. They

--- a/lib/rex/parser/appscan_nokogiri.rb
+++ b/lib/rex/parser/appscan_nokogiri.rb
@@ -195,6 +195,9 @@ module Rex
       res_header = Rex::Proto::Http::Packet::Header.new
       req_header.from_s request_headers.lstrip
       res_header.from_s response_headers.lstrip
+      if response_body.blank?
+        response_body = ''
+      end
       @state[:request_headers] = req_header
       @state[:request_body] = request_body.lstrip
       @state[:response_headers] = res_header

--- a/lib/rex/parser/appscan_nokogiri.rb
+++ b/lib/rex/parser/appscan_nokogiri.rb
@@ -141,9 +141,9 @@ module Rex
 
     def report_web_page(&block)
       return unless(in_issue && has_text)
-      return unless @state[:web_site]
-      return unless @state[:response_headers]
-      return unless @state[:uri]
+      return unless @state[:web_site].present?
+      return unless @state[:response_headers].present?
+      return unless @state[:uri].present?
       web_page_info = {}
       web_page_info[:web_site] = @state[:web_site]
       web_page_info[:path] = @state[:uri].path

--- a/lib/rex/parser/appscan_nokogiri.rb
+++ b/lib/rex/parser/appscan_nokogiri.rb
@@ -187,31 +187,18 @@ module Rex
 
     def record_request_and_response
       return unless(in_issue && has_text)
-      return unless @state[:web_site]
+      return unless @state[:web_site].present?
       really_original_traffic = unindent_and_crlf(@text)
-      split_traffic = really_original_traffic.split(/\r\n\r\n/)
-      request_headers_text = split_traffic.first
-      content_length = 0
-      if request_headers_text =~ /\ncontent-length:\s+([0-9]+)/mni
-        content_length = $1.to_i
-      end
-      if(content_length > 0) and (split_traffic[1].to_s.size >= content_length)
-        request_body_text = split_traffic[1].to_s[0,content_length]
-      else
-        request_body_text = nil
-      end
-      response_headers_text = split_traffic[1].to_s[content_length,split_traffic[1].to_s.size].lstrip
-      request = request_headers_text
-      return unless(request && response_headers_text)
-      response_body_text = split_traffic[2]
+      request_headers, request_body, response_headers, response_body = really_original_traffic.split(/\r\n\r\n/)
+      return unless(request_headers && response_headers)
       req_header = Rex::Proto::Http::Packet::Header.new
       res_header = Rex::Proto::Http::Packet::Header.new
-      req_header.from_s request_headers_text.dup
-      res_header.from_s response_headers_text.dup
+      req_header.from_s request_headers.dup
+      res_header.from_s response_headers.dup
       @state[:request_headers] = req_header
-      @state[:request_body] = request_body_text
+      @state[:request_body] = request_body
       @state[:response_headers] = res_header
-      @state[:response_body] = response_body_text
+      @state[:response_body] = response_body
     end
 
     # Appscan tab-indents which makes parsing a little difficult. They


### PR DESCRIPTION
This fixes customer reported bugs affecting the database imports for IBM Rational AppScan XML files. With certain XML files, importing would trigger a stack trace. This uncovered multiple bugs in the AppScan Nokogiri parser which are fixed herein. 

This PR must be reviewed by an internal team member as verification requires the use of specific XML files which are not public.
## PRO VERIFICATION STEPS
- [x] start Metasploit Pro
- [x] create a new workspace
- [x] download the AppScan.zip attached to the Jira ticket
- [x] extract the xml file from the zip
- [x] in Metasploit Pro go to Import and select the AppScan.xml
- [x] VERIFY the import completes successfully
- [x] Also verify with QE test import file
## MSF VERIFICATION STEPS
- [x] `./msfconsole`
- [x] Connect to a DB, new workspace
- [x] `db_import AppScan.xml`
- [ ] Verify objects in workspace
