### PR TITLE
Remove symbols that aren't used in GlassFish login module

### DIFF
--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -133,11 +133,9 @@ class Metasploit3 < Msf::Auxiliary
       when Metasploit::Model::Login::Status::SUCCESSFUL
         print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}'"
         do_report(ip, rport, result)
-        :next_user
       when Metasploit::Model::Login::Status::DENIED_ACCESS
         print_brute :level => :status, :ip => ip, :msg => "Correct credentials, but unable to login: '#{result.credential}'"
         do_report(ip, rport, result)
-        :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         if datastore['VERBOSE']
           print_brute :level => :verror, :ip => ip, :msg => "Could not connect"
@@ -152,7 +150,6 @@ class Metasploit3 < Msf::Auxiliary
             realm_value: result.credential.realm,
             status: result.status
         )
-        :abort
       when Metasploit::Model::Login::Status::INCORRECT
         if datastore['VERBOSE']
           print_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"


### PR DESCRIPTION
These symbols belong to the AuthBrute mixin, but we are not using AuthBrute for login testing.
## Verification

You can verify this by reviewing Authbrute mixin and Metasploit::Framework::LoginScanner::Base.
- [x] As you can see, the login module is using the #scan! method to do the bruteforcing.
- [x] The #scan! method comes from Metasploit::Framework::LoginScanner::Base, and as you can see, it does not check our symbols like :next_user or :abort: https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/base.rb#L187
- [x] :next_user and :abort are only supported by Authbrute, as you can see here: https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/auxiliary/auth_brute.rb#L213

And since I am using the LoginScanner API, I don't need :next_user and :abort.
