### PR TITLE
Resolve #4891, new arguments for the hosts command

### DIFF
--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -391,6 +391,9 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -o <file>         Send output to a file in csv format",
           "  -R,--rhosts       Set RHOSTS from the results of the search",
           "  -S,--search       Search string to filter by",
+          "  -i,--info         Change the info of a host",
+          "  -n,--name         Change the name of a host",
+          "  -m,--comment      Change the comment of a host",
           "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count"
         ]
       end


### PR DESCRIPTION
This patch provides new arguments for the hosts command (for #4891), such as:

| Argument | Description |
| --- | --- |
| -i,--info | Change the info of a host |
| -n,--name | Change the name of a host |
| -m,--comment | Change the comment of a host |
## Testing

Please at least to make sure do the following tests:
- [x] Start msfconsole
- [x] Create a new workspace: `workspace -a mytest` so you don't have any hosts
- [x] Create a new host: `hosts -a 192.168.1.123`
- [x] Do: `hosts`, and make sure there is only one host (192.168.1.123)
- [x] Do: `hosts -R 192.168.1.123 -i "I got new info"`
- [x] Do: `hosts`, and you should see that the the host's info column has your new info.
- [x] Do: `hosts -R 192.168.1.123 -n "madcow"`
- [x] Do: `hosts` again, you should see the host's name column with your new name.
- [x] Do: `hosts -R 192.168.1.123 -m "new comment"`
- [x] Do: Do `hosts` again, you should see the host's comments column w/ your new comment.

More testing:
- [x] Create another workspace: `workspace -a another_test`
- [x] Create the name host: `hosts -a 192.168.1.123`
- [x] Do: `hosts -R 192.168.1.123 -n "blahblahblah"`
- [x] Switch to the "mytest" workspace: `workspace mytest`
- [x] The 192.168.1.123 host in mytest should remain "madcow"
