### PR TITLE
Python Meterpreter Unicode File and Directory Support

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -632,7 +632,7 @@ def channel_open_stdapi_fs_file(request, response):
 		fmode = fmode.replace('bb', 'b')
 	else:
 		fmode = 'rb'
-	file_h = open(fpath, fmode)
+	file_h = open(unicode(fpath), fmode)
 	channel_id = meterpreter.add_channel(MeterpreterFile(file_h))
 	response += tlv_pack(TLV_TYPE_CHANNEL_ID, channel_id)
 	return ERROR_SUCCESS, response
@@ -937,7 +937,8 @@ def stdapi_fs_delete(request, response):
 @meterpreter.register_function
 def stdapi_fs_delete_dir(request, response):
 	dir_path = packet_get_tlv(request, TLV_TYPE_DIRECTORY_PATH)['value']
-	if os.path.islink(unicode(dir_path)):
+	dir_path = unicode(dir_path)
+	if os.path.islink(dir_path):
 		del_func = os.unlink
 	else:
 		del_func = shutil.rmtree
@@ -973,7 +974,7 @@ def stdapi_fs_file_expand_path(request, response):
 def stdapi_fs_file_move(request, response):
 	oldname = packet_get_tlv(request, TLV_TYPE_FILE_NAME)['value']
 	newname = packet_get_tlv(request, TLV_TYPE_FILE_PATH)['value']
-	os.rename(oldname, newname)
+	os.rename(unicode(oldname), unicode(newname))
 	return ERROR_SUCCESS, response
 
 @meterpreter.register_function
@@ -988,8 +989,8 @@ def stdapi_fs_getwd(request, response):
 @meterpreter.register_function
 def stdapi_fs_ls(request, response):
 	path = packet_get_tlv(request, TLV_TYPE_DIRECTORY_PATH)['value']
-	path = os.path.abspath(path)
-	dir_contents = os.listdir(unicode(path))
+	path = os.path.abspath(unicode(path))
+	dir_contents = os.listdir(path)
 	dir_contents.sort()
 	for file_name in dir_contents:
 		file_path = os.path.join(path, file_name)
@@ -1014,6 +1015,7 @@ def stdapi_fs_md5(request, response):
 @meterpreter.register_function
 def stdapi_fs_mkdir(request, response):
 	dir_path = packet_get_tlv(request, TLV_TYPE_DIRECTORY_PATH)['value']
+	dir_path = unicode(dir_path)
 	if not os.path.isdir(dir_path):
 		os.mkdir(dir_path)
 	return ERROR_SUCCESS, response
@@ -1022,6 +1024,7 @@ def stdapi_fs_mkdir(request, response):
 def stdapi_fs_search(request, response):
 	search_root = packet_get_tlv(request, TLV_TYPE_SEARCH_ROOT).get('value', '.')
 	search_root = ('' or '.') # sometimes it's an empty string
+	search_root = unicode(search_root)
 	glob = packet_get_tlv(request, TLV_TYPE_SEARCH_GLOB)['value']
 	recurse = packet_get_tlv(request, TLV_TYPE_SEARCH_RECURSE)['value']
 	if recurse:
@@ -1033,7 +1036,7 @@ def stdapi_fs_search(request, response):
 				file_tlv += tlv_pack(TLV_TYPE_FILE_SIZE, os.stat(os.path.join(root, f)).st_size)
 				response += tlv_pack(TLV_TYPE_SEARCH_RESULTS, file_tlv)
 	else:
-		for f in filter(lambda f: fnmatch.fnmatch(f, glob), os.listdir(unicode(search_root))):
+		for f in filter(lambda f: fnmatch.fnmatch(f, glob), os.listdir(search_root)):
 			file_tlv  = ''
 			file_tlv += tlv_pack(TLV_TYPE_FILE_PATH, search_root)
 			file_tlv += tlv_pack(TLV_TYPE_FILE_NAME, f)

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -45,9 +45,11 @@ else:
 	if isinstance(__builtins__, dict):
 		is_str = lambda obj: issubclass(obj.__class__, __builtins__['str'])
 		str = lambda x: __builtins__['str'](x, 'UTF-8')
+		unicode = __builtins__['str']
 	else:
 		is_str = lambda obj: issubclass(obj.__class__, __builtins__.str)
 		str = lambda x: __builtins__.str(x, 'UTF-8')
+		unicode = __builtins__.str
 	is_bytes = lambda obj: issubclass(obj.__class__, bytes)
 	NULL_BYTE = bytes('\x00', 'UTF-8')
 	long = int
@@ -262,7 +264,9 @@ def tlv_pack(*args):
 		data = struct.pack('>II', 9, tlv['type']) + bytes(chr(int(bool(tlv['value']))), 'UTF-8')
 	else:
 		value = tlv['value']
-		if not is_bytes(value):
+		if sys.version_info[0] < 3 and isinstance(value, unicode):
+			value = value.encode('UTF-8')
+		elif not is_bytes(value):
 			value = bytes(value, 'UTF-8')
 		if (tlv['type'] & TLV_META_TYPE_STRING) == TLV_META_TYPE_STRING:
 			data = struct.pack('>II', 8 + len(value) + 1, tlv['type']) + value + NULL_BYTE

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -41,18 +41,18 @@ if sys.version_info[0] < 3:
 	is_bytes = lambda obj: issubclass(obj.__class__, str)
 	bytes = lambda *args: str(*args[:1])
 	NULL_BYTE = '\x00'
+	unicode = lambda x: (x.decode('UTF-8') if isinstance(x, str) else x)
 else:
 	if isinstance(__builtins__, dict):
 		is_str = lambda obj: issubclass(obj.__class__, __builtins__['str'])
 		str = lambda x: __builtins__['str'](x, 'UTF-8')
-		unicode = __builtins__['str']
 	else:
 		is_str = lambda obj: issubclass(obj.__class__, __builtins__.str)
 		str = lambda x: __builtins__.str(x, 'UTF-8')
-		unicode = __builtins__.str
 	is_bytes = lambda obj: issubclass(obj.__class__, bytes)
 	NULL_BYTE = bytes('\x00', 'UTF-8')
 	long = int
+	unicode = lambda x: (x.decode('UTF-8') if isinstance(x, bytes) else x)
 
 #
 # Constants
@@ -264,7 +264,7 @@ def tlv_pack(*args):
 		data = struct.pack('>II', 9, tlv['type']) + bytes(chr(int(bool(tlv['value']))), 'UTF-8')
 	else:
 		value = tlv['value']
-		if sys.version_info[0] < 3 and isinstance(value, unicode):
+		if sys.version_info[0] < 3 and isinstance(value, __builtins__['unicode']):
 			value = value.encode('UTF-8')
 		elif not is_bytes(value):
 			value = bytes(value, 'UTF-8')


### PR DESCRIPTION
Fix for Unicode directories and files in the Python meterpreter. Fixes #4958.

Calls to the `os` module which deal with files and directories should take in unicode arguments on Python versions below 3, and not string arguments. Additionally this fixes some unicode related issues with the working directory, namley using `os.getcwdu()` when it's available. This is required to list the contents of directories with unicode names.

Testing steps for Windows:
- [x] List a directory which has a unicode file and unicode directory in it
- [x] Can change into a directory with a unicode name and list it's contents
- [x] Can delete a directory via `rmdir` with a unicode name
- [x] Can delete a file via `rm` with a unicode name
- [x] post/test/meterpreter checks pass

Tested on
- Windows 2.7
- Windows 3.4
- Linux 2.5
- Linux 2.7
- Linux 3.1
- Linux 3.4
