### PR TITLE
Refactor of HTTP code to support changes to Meterpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,17 +67,7 @@ external/source/exploits/**/Release
 
 # Avoid checking in Meterpreter binaries. These are supplied upstream by
 # the meterpreter_bins gem.
-data/meterpreter/elevator.*.dll
-data/meterpreter/ext_server_espia.*.dll
-data/meterpreter/ext_server_extapi.*.dll
-data/meterpreter/ext_server_incognito.*.dll
-data/meterpreter/ext_server_kiwi.*.dll
-data/meterpreter/ext_server_lanattacks.*.dll
-data/meterpreter/ext_server_mimikatz.*.dll
-data/meterpreter/ext_server_priv.*.dll
-data/meterpreter/ext_server_stdapi.*.dll
-data/meterpreter/metsrv.*.dll
-data/meterpreter/screenshot.*.dll
+data/meterpreter/*.dll
 
 # Avoid checking in Meterpreter libs that are built from
 # private source. If you're interested in this functionality,

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -297,6 +297,7 @@ protected
         Rex::Payloads::Meterpreter::Patch.patch_passive_service! blob,
           :ssl            => ssl?,
           :url            => url,
+          :ssl_cert_hash  => get_ssl_cert_hash,
           :expiration     => datastore['SessionExpirationTimeout'],
           :comm_timeout   => datastore['SessionCommunicationTimeout'],
           :ua             => datastore['MeterpreterUserAgent'],
@@ -353,6 +354,58 @@ protected
   def bind_port
     port = datastore['ReverseListenerBindPort'].to_i
     port > 0 ? port : datastore['LPORT'].to_i
+  end
+
+  # TODO: remove all that is below this when HD's PR has been landed
+  def get_ssl_cert_hash
+    unless datastore['StagerVerifySslCert'].to_s =~ /^(t|y|1)/i
+      return nil
+    end
+
+    unless datastore['HandlerSSLCert']
+      raise ArgumentError, "StagerVerifySslCert is enabled but no HandlerSSLCert is configured"
+    end
+
+    # TODO: fix this up when HD's PR has landed.
+    #hcert = Rex::Parser::X509Certificate.parse_pem_file(datastore['HandlerSSLCert'])
+    hcert = parse_pem_file(datastore['HandlerSSLCert'])
+    unless hcert and hcert[0] and hcert[1]
+      raise ArgumentError, "Could not parse a private key and certificate from #{datastore['HandlerSSLCert']}"
+    end
+
+    hash = Rex::Text.sha1_raw(hcert[1].to_der)
+    print_status("Meterpreter will verify SSL Certificate with SHA1 hash #{hash.unpack("H*").first}")
+    hash
+    nil
+  end
+
+  def parse_pem(ssl_cert)
+    cert  = nil
+    key   = nil
+    chain = nil
+
+    certs = []
+    ssl_cert.scan(/-----BEGIN\s*[^\-]+-----+\r?\n[^\-]*-----END\s*[^\-]+-----\r?\n?/nm).each do |pem|
+      if pem =~ /PRIVATE KEY/
+        key = OpenSSL::PKey::RSA.new(pem)
+      elsif pem =~ /CERTIFICATE/
+        certs << OpenSSL::X509::Certificate.new(pem)
+      end
+    end
+
+    cert = certs.shift
+    if certs.length > 0
+      chain = certs
+    end
+
+    [key, cert, chain]
+  end
+  def parse_pem_file(ssl_cert_file)
+    data = ''
+    ::File.open(ssl_cert_file, 'rb') do |fd|
+      data << fd.read(fd.stat.size)
+    end
+    parse_pem(data)
   end
 
 end

--- a/lib/msf/core/handler/reverse_https.rb
+++ b/lib/msf/core/handler/reverse_https.rb
@@ -43,7 +43,8 @@ module ReverseHttps
 
     register_advanced_options(
       [
-        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
+        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"]),
+        OptBool.new('StagerVerifySSLCert', [false, "Whether to verify the SSL certificate in Meterpreter"])
       ], Msf::Handler::ReverseHttps)
 
   end

--- a/lib/msf/core/payload/windows/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttp.rb
@@ -108,8 +108,7 @@ module Payload::Windows::ReverseWinHttp
   # @option opts [String] :url The URI to request during staging
   # @option opts [String] :host The host to connect to
   # @option opts [Fixnum] :port The port to connect to
-  # @option opts [Bool] :verify_ssl Whether or not to do SSL certificate validation
-  # @option opts [String] :verify_cert_hash A 20-byte raw SHA-1 hash of the certificate to verify
+  # @option opts [String] :verify_cert_hash A 20-byte raw SHA-1 hash of the certificate to verify, or nil
   # @option opts [String] :exitfunk The exit method to use if there is an error, one of process, thread, or seh
   # @option opts [Fixnum] :retry_count The number of times to retry a failed request before giving up
   #
@@ -121,7 +120,7 @@ module Payload::Windows::ReverseWinHttp
     encoded_url       = asm_generate_wchar_array(opts[:url])
     encoded_host      = asm_generate_wchar_array(opts[:host])
 
-    if opts[:ssl] && opts[:verify_cert] && opts[:verify_cert_hash]
+    if opts[:ssl] && opts[:verify_cert_hash]
       verify_ssl = true
       encoded_cert_hash = opts[:verify_cert_hash].unpack("C*").map{|c| "0x%.2x" % c }.join(",")
     end

--- a/lib/msf/core/payload/windows/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/stageless_meterpreter.rb
@@ -75,11 +75,8 @@ module Payload::Windows::StagelessMeterpreter
 
     # the URL might not be given, as it might be patched in some other way
     if url
-      url = "s#{url}\x00"
-      location = dll.index("https://#{'X' * 256}")
-      if location
-        dll[location, url.length] = url
-      end
+      # Patch the URL using the patcher as this upports both ASCII and WCHAR.
+      Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 256}", url)
     end
 
     # if a block is given then call that with the meterpreter dll

--- a/lib/msf/core/payload/windows/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/stageless_meterpreter.rb
@@ -1,6 +1,7 @@
 #-*- coding: binary -*-
 
 require 'msf/core'
+require 'rex/payloads/meterpreter/patch'
 
 module Msf
 

--- a/lib/msf/core/payload/windows/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/stageless_meterpreter.rb
@@ -77,7 +77,7 @@ module Payload::Windows::StagelessMeterpreter
     # the URL might not be given, as it might be patched in some other way
     if url
       # Patch the URL using the patcher as this upports both ASCII and WCHAR.
-      Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 256}", "s#{url}\x00")
+      Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 512}", "s#{url}\x00")
     end
 
     # if a block is given then call that with the meterpreter dll

--- a/lib/msf/core/payload/windows/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/stageless_meterpreter.rb
@@ -77,7 +77,7 @@ module Payload::Windows::StagelessMeterpreter
     # the URL might not be given, as it might be patched in some other way
     if url
       # Patch the URL using the patcher as this upports both ASCII and WCHAR.
-      Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 256}", url)
+      Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 256}", "s#{url}\x00")
     end
 
     # if a block is given then call that with the meterpreter dll

--- a/lib/msf/core/payload/windows/verify_ssl.rb
+++ b/lib/msf/core/payload/windows/verify_ssl.rb
@@ -1,0 +1,36 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'rex/parser/x509_certificate'
+
+module Msf
+
+###
+#
+# Implements SSL validation check options
+#
+###
+
+module Payload::Windows::VerifySsl
+
+  #
+  # Get the SSL hash from the certificate, if required.
+  #
+  def get_ssl_cert_hash(verify_cert, handler_cert)
+    unless verify_cert.to_s =~ /^(t|y|1)/i
+      return nil
+    end
+
+    unless handler_cert
+      raise ArgumentError, "Verifying SSL cert is enabled but no handler cert is configured"
+    end
+
+    hash = Rex::Parser::X509Certificate.get_cert_file_hash(handler_cert)
+    print_status("Meterpreter will verify SSL Certificate with SHA1 hash #{hash.unpack("H*").first}")
+    hash
+  end
+
+end
+
+end
+

--- a/lib/rex/parser/x509_certificate.rb
+++ b/lib/rex/parser/x509_certificate.rb
@@ -58,7 +58,7 @@ class X509Certificate
 
   #
   # Parse a certificate in unified PEM format and retrieve
-  #   the SHA1 hash.
+  # the SHA1 hash.
   #
   # @param [String] ssl_cert 
   # @return [String]
@@ -74,7 +74,7 @@ class X509Certificate
 
   #
   # Parse a file that contains a certificate in unified PEM
-  #   format and retrieve the SHA1 hash.
+  # format and retrieve the SHA1 hash.
   #
   # @param [String] ssl_cert_file
   # @return [String]

--- a/lib/rex/parser/x509_certificate.rb
+++ b/lib/rex/parser/x509_certificate.rb
@@ -56,6 +56,36 @@ class X509Certificate
     parse_pem(data)
   end
 
+  #
+  # Parse a certificate in unified PEM format and retrieve
+  #   the SHA1 hash.
+  #
+  # @param [String] ssl_cert 
+  # @return [String]
+  def self.get_cert_hash(ssl_cert)
+    hcert = parse_pem(ssl_cert)
+
+    unless hcert and hcert[0] and hcert[1]
+      raise ArgumentError, "Could not parse a private key and certificate"
+    end
+
+    Rex::Text.sha1_raw(hcert[1].to_der)
+  end
+
+  #
+  # Parse a file that contains a certificate in unified PEM
+  #   format and retrieve the SHA1 hash.
+  #
+  # @param [String] ssl_cert_file
+  # @return [String]
+  def self.get_cert_file_hash(ssl_cert_file)
+    data = ''
+    ::File.open(ssl_cert_file, 'rb') do |fd|
+      data << fd.read(fd.stat.size)
+    end
+    get_cert_hash(data)
+  end
+
 end
 
 end

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -84,6 +84,18 @@ module Rex
 
         end
 
+        # Patch the ssl cert hash
+        def self.patch_ssl_check!(blob, ssl_cert_hash)
+          # SSL cert location is an ASCII string, so no need for
+          # WCHAR support
+          if ssl_cert_hash
+            i = blob.index("METERPRETER_SSL_CERT_HASH\x00")
+            if i
+              blob[i, ssl_cert_hash.length] = ssl_cert_hash
+            end
+          end
+        end
+
         # Patch options into metsrv for reverse HTTP payloads
         def self.patch_passive_service!(blob, options)
 
@@ -92,6 +104,7 @@ module Rex
           patch_expiration! blob, options[:expiration]
           patch_comm_timeout! blob, options[:comm_timeout]
           patch_ua! blob, options[:ua]
+          patch_ssl_check! blob, options[:ssl_cert_hash]
           patch_proxy!(blob,
             options[:proxy_host],
             options[:proxy_port],

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -18,7 +18,7 @@ module Rex
 
         # Replace the URL
         def self.patch_url!(blob, url)
-          patch_string!(blob, "https://#{"X" * 256}", url)
+          patch_string!(blob, "https://#{'X' * 512}", url)
         end
 
         # Replace the session expiration timeout

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -99,12 +99,12 @@ module Rex
         # Patch options into metsrv for reverse HTTP payloads
         def self.patch_passive_service!(blob, options)
 
-          patch_transport! blob, options[:ssl]
-          patch_url! blob, options[:url]
-          patch_expiration! blob, options[:expiration]
-          patch_comm_timeout! blob, options[:comm_timeout]
-          patch_ua! blob, options[:ua]
-          patch_ssl_check! blob, options[:ssl_cert_hash]
+          patch_transport!(blob, options[:ssl])
+          patch_url!(blob, options[:url])
+          patch_expiration!(blob, options[:expiration])
+          patch_comm_timeout!(blob, options[:comm_timeout])
+          patch_ua!(blob, options[:ua])
+          patch_ssl_check!(blob, options[:ssl_cert_hash])
           patch_proxy!(blob,
             options[:proxy_host],
             options[:proxy_port],

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -11,29 +11,18 @@ module Rex
       module Patch
 
         # Replace the transport string
-        def self.patch_transport! blob, ssl
-
-          i = blob.index(wchar("METERPRETER_TRANSPORT_SSL"))
-          if i
-            str = wchar(ssl ? "METERPRETER_TRANSPORT_HTTPS\x00" : "METERPRETER_TRANSPORT_HTTP\x00")
-            blob[i, str.length] = str
-          end
-
+        def self.patch_transport!(blob, ssl)
+          str = ssl ? "METERPRETER_TRANSPORT_HTTPS\x00" : "METERPRETER_TRANSPORT_HTTP\x00"
+          patch_string!(blob, "METERPRETER_TRANSPORT_SSL", str)
         end
 
         # Replace the URL
-        def self.patch_url! blob, url
-
-          i = blob.index(wchar("https://" + ("X" * 256)))
-          if i
-            str = wchar(url)
-            blob[i, str.length] = str
-          end
-
+        def self.patch_url!(blob, url)
+          patch_string!(blob, "https://#{"X" * 256}", url)
         end
 
         # Replace the session expiration timeout
-        def self.patch_expiration! blob, expiration
+        def self.patch_expiration!(blob, expiration)
 
           i = blob.index([0xb64be661].pack("V"))
           if i
@@ -44,7 +33,7 @@ module Rex
         end
 
         # Replace the session communication timeout
-        def self.patch_comm_timeout! blob, comm_timeout
+        def self.patch_comm_timeout!(blob, comm_timeout)
 
           i = blob.index([0xaf79257f].pack("V"))
           if i
@@ -55,63 +44,48 @@ module Rex
         end
 
         # Replace the user agent string with our option
-        def self.patch_ua! blob, ua
-
-          i = blob.index(wchar("METERPRETER_UA\x00"))
-          if i
-            ua = wchar(ua[0,255] + "\x00")
-            blob[i, ua.length] = ua
-          end
-
+        def self.patch_ua!(blob, ua)
+          patch_string!(blob, "METERPRETER_UA\x00", ua[0,255] + "\x00")
         end
 
         # Activate a custom proxy
-        def self.patch_proxy! blob, proxyhost, proxyport, proxy_type
+        def self.patch_proxy!(blob, proxyhost, proxyport, proxy_type)
 
           if proxyhost && proxyhost.to_s != ""
-            i = blob.index(wchar("METERPRETER_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
-            if i
-              proxyhost = proxyhost.to_s
-              proxyport = proxyport.to_s || "8080"
-              proxyinfo = proxyhost + ":" + proxyport
-              if proxyport == "80"
-                proxyinfo = proxyhost
-              end
-              if proxy_type.to_s == 'HTTP'
-                proxyinfo = 'http://' + proxyinfo
-              else #socks
-                proxyinfo = 'socks=' + proxyinfo
-              end
-              proxyinfo << "\x00"
-              proxyinfo = wchar(proxyinfo)
-              blob[i, proxyinfo.length] = proxyinfo
+            proxyhost = proxyhost.to_s
+            proxyport = proxyport.to_s || "8080"
+            proxyinfo = proxyhost + ":" + proxyport
+            if proxyport == "80"
+              proxyinfo = proxyhost
             end
+            if proxy_type.to_s == 'HTTP'
+              proxyinfo = 'http://' + proxyinfo
+            else #socks
+              proxyinfo = 'socks=' + proxyinfo
+            end
+            proxyinfo << "\x00"
+            patch_string!(blob, "METERPRETER_PROXY#{"\x00" * 10}", proxyinfo)
           end
-
         end
 
         # Proxy authentification
-        def self.patch_proxy_auth! blob, proxy_username, proxy_password, proxy_type
+        def self.patch_proxy_auth!(blob, proxy_username, proxy_password, proxy_type)
 
           unless (proxy_username.nil? or proxy_username.empty?) or
             (proxy_password.nil? or proxy_password.empty?) or
             proxy_type == 'SOCKS'
 
-            proxy_username_loc = blob.index(wchar("METERPRETER_USERNAME_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
-            proxy_username = proxy_username << "\x00"
-            proxy_username = wchar(proxy_username)
-            blob[proxy_username_loc, proxy_username.length] = proxy_username
+            patch_string!(blob, "METERPRETER_USERNAME_PROXY#{"\x00" * 10}",
+                          proxy_username + "\x00")
 
-            proxy_password_loc = blob.index(wchar("METERPRETER_PASSWORD_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
-            proxy_password = proxy_password << "\x00"
-            proxy_password = wchar(proxy_password)
-            blob[proxy_password_loc, proxy_password.length] = proxy_password
+            patch_string!(blob, "METERPRETER_PASSWORD_PROXY#{"\x00" * 10}",
+                          proxy_password + "\x00")
           end
 
         end
 
         # Patch options into metsrv for reverse HTTP payloads
-        def self.patch_passive_service! blob, options
+        def self.patch_passive_service!(blob, options)
 
           patch_transport! blob, options[:ssl]
           patch_url! blob, options[:url]
@@ -131,8 +105,27 @@ module Rex
 
         end
 
+        #
+        # Patch an ASCII value in the given payload. If not found, try WCHAR instead.
+        #
+        def self.patch_string!(blob, search, replacement)
+          i = blob.index(search)
+          if i
+            blob[i, replacement.length] = replacement
+          else
+            i = blob.index(wchar(search))
+            if i
+              r = wchar(replacement)
+              blob[i, r.length] = r
+            end
+          end
+        end
+
         private
 
+        #
+        # Convert the given ASCII string into a WCHAR string (dumb, but works)
+        #
         def self.wchar(str)
           str.to_s.unpack("C*").pack("v*")
         end

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -178,7 +178,6 @@ module PacketDispatcher
   # Sends a packet and waits for a timeout for the given time interval.
   #
   def send_request(packet, t = self.response_timeout)
-
     if not t
       send_packet(packet)
       return nil

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -8,6 +8,8 @@ require 'msf/core/handler/reverse_https'
 require 'msf/core/payload/windows/stageless_meterpreter'
 require 'msf/base/sessions/meterpreter_x86_win'
 require 'msf/base/sessions/meterpreter_options'
+# TODO: put this in when HD's PR has been landed.
+#require 'rex/parser/x509_certificate'
 
 module Metasploit3
 
@@ -30,7 +32,7 @@ module Metasploit3
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, "Comma-separated list of extensions to load"]),
     ], self.class)
   end
 
@@ -57,6 +59,7 @@ module Metasploit3
       Rex::Payloads::Meterpreter::Patch.patch_passive_service! dll,
         :url            => url,
         :ssl            => true,
+        :ssl_cert_hash  => get_ssl_cert_hash,
         :expiration     => datastore['SessionExpirationTimeout'].to_i,
         :comm_timeout   => datastore['SessionCommunicationTimeout'].to_i,
         :ua             => datastore['MeterpreterUserAgent'],
@@ -66,6 +69,58 @@ module Metasploit3
         :proxy_username => datastore['PROXY_USERNAME'],
         :proxy_password => datastore['PROXY_PASSWORD']
     end
+
+  end
+
+  # TODO: remove all that is below this when HD's PR has been landed
+  def get_ssl_cert_hash
+    unless datastore['StagerVerifySSLCert'].to_s =~ /^(t|y|1)/i
+      return nil
+    end
+
+    unless datastore['HandlerSSLCert']
+      raise ArgumentError, "StagerVerifySSLCert is enabled but no HandlerSSLCert is configured"
+    end
+
+    # TODO: fix this up when HD's PR has landed.
+    #hcert = Rex::Parser::X509Certificate.parse_pem_file(datastore['HandlerSSLCert'])
+    hcert = parse_pem_file(datastore['HandlerSSLCert'])
+    unless hcert and hcert[0] and hcert[1]
+      raise ArgumentError, "Could not parse a private key and certificate from #{datastore['HandlerSSLCert']}"
+    end
+
+    hash = Rex::Text.sha1_raw(hcert[1].to_der)
+    print_status("Meterpreter will verify SSL Certificate with SHA1 hash #{hash.unpack("H*").first}")
+    hash
+  end
+
+  def parse_pem(ssl_cert)
+    cert  = nil
+    key   = nil
+    chain = nil
+
+    certs = []
+    ssl_cert.scan(/-----BEGIN\s*[^\-]+-----+\r?\n[^\-]*-----END\s*[^\-]+-----\r?\n?/nm).each do |pem|
+      if pem =~ /PRIVATE KEY/
+        key = OpenSSL::PKey::RSA.new(pem)
+      elsif pem =~ /CERTIFICATE/
+        certs << OpenSSL::X509::Certificate.new(pem)
+      end
+    end
+
+    cert = certs.shift
+    if certs.length > 0
+      chain = certs
+    end
+
+    [key, cert, chain]
+  end
+  def parse_pem_file(ssl_cert_file)
+    data = ''
+    ::File.open(ssl_cert_file, 'rb') do |fd|
+      data << fd.read(fd.stat.size)
+    end
+    parse_pem(data)
   end
 
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -8,8 +8,7 @@ require 'msf/core/handler/reverse_https'
 require 'msf/core/payload/windows/stageless_meterpreter'
 require 'msf/base/sessions/meterpreter_x86_win'
 require 'msf/base/sessions/meterpreter_options'
-# TODO: put this in when HD's PR has been landed.
-#require 'rex/parser/x509_certificate'
+require 'rex/parser/x509_certificate'
 
 module Metasploit3
 
@@ -72,7 +71,6 @@ module Metasploit3
 
   end
 
-  # TODO: remove all that is below this when HD's PR has been landed
   def get_ssl_cert_hash
     unless datastore['StagerVerifySSLCert'].to_s =~ /^(t|y|1)/i
       return nil
@@ -82,45 +80,9 @@ module Metasploit3
       raise ArgumentError, "StagerVerifySSLCert is enabled but no HandlerSSLCert is configured"
     end
 
-    # TODO: fix this up when HD's PR has landed.
-    #hcert = Rex::Parser::X509Certificate.parse_pem_file(datastore['HandlerSSLCert'])
-    hcert = parse_pem_file(datastore['HandlerSSLCert'])
-    unless hcert and hcert[0] and hcert[1]
-      raise ArgumentError, "Could not parse a private key and certificate from #{datastore['HandlerSSLCert']}"
-    end
-
-    hash = Rex::Text.sha1_raw(hcert[1].to_der)
+    hash = Rex::Parser::X509Certificate.get_cert_file_hash(datastore['HandlerSSLCert'])
     print_status("Meterpreter will verify SSL Certificate with SHA1 hash #{hash.unpack("H*").first}")
     hash
-  end
-
-  def parse_pem(ssl_cert)
-    cert  = nil
-    key   = nil
-    chain = nil
-
-    certs = []
-    ssl_cert.scan(/-----BEGIN\s*[^\-]+-----+\r?\n[^\-]*-----END\s*[^\-]+-----\r?\n?/nm).each do |pem|
-      if pem =~ /PRIVATE KEY/
-        key = OpenSSL::PKey::RSA.new(pem)
-      elsif pem =~ /CERTIFICATE/
-        certs << OpenSSL::X509::Certificate.new(pem)
-      end
-    end
-
-    cert = certs.shift
-    if certs.length > 0
-      chain = certs
-    end
-
-    [key, cert, chain]
-  end
-  def parse_pem_file(ssl_cert_file)
-    data = ''
-    ::File.open(ssl_cert_file, 'rb') do |fd|
-      data << fd.read(fd.stat.size)
-    end
-    parse_pem(data)
   end
 
 end


### PR DESCRIPTION
This started as MSF work to support WinHTTP, but ended up a small refactor to make use of what @hmoore-r7 had done already elsewhere.

PR contains code that does the following:
- Provides support for patching strings that are both `wchar_t` and `char` when doing the patching of `metsrv`.
- Refactors a bit of code to make it usable from various locations.
- Addition of the cert hash patching so that Meterpreter knows which SSL certificate to search for.

Full details of what needs to be done/tested are in the Meterpreter PR, located here: https://github.com/rapid7/meterpreter/pull/140
