### PR TITLE
Fix #4966, tell the user the resource script path is invalid

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -423,6 +423,7 @@ class Driver < Msf::Ui::Driver
     elsif ::File.readable?(path)
       resource_file = ::File.read(path)
     else
+      print_error "Cannot find resource script: #{path}"
       return
     end
 


### PR DESCRIPTION
Fix #4966 

This patch allows msfconsole to tell you if you've supplied an invalid resource script path or not.
## To verify
- [x] Do: `./msfconsole -q -r blah.rc`
- [x] You should see: "Cannot find resource script: blah.rc"
- [x] And then do: `./msfconsole -q -r scripts/resource/auto_win32_multihandler.rc`
- [x] It should run auto_win32_multihandler.rc (this script will generate a payload and start a handler for it)
