### PR TITLE
Feature Request #4944: Standalone egghunter

### DIFF
--- a/spec/tools/egghunter_spec.rb
+++ b/spec/tools/egghunter_spec.rb
@@ -4,11 +4,32 @@ require 'rex/proto/http/response'
 require 'stringio'
 
 describe Egghunter do
+
   subject do
     Egghunter::Driver.new
   end
 
   describe '#run' do
-  end
 
+    context 'when the platform is windows' do
+      it 'returns a windows egghunter' do
+      end
+    end
+
+    context 'when the platform is linux' do
+      it 'returns a linux egghunter' do
+      end
+    end
+
+    context 'when the output format is java' do
+      it 'returns java format egghunter' do
+      end
+    end
+
+    context 'when the egg is WOOT' do
+      it 'includes W00TW00T in the egghunter' do
+      end
+    end
+
+  end
 end

--- a/spec/tools/egghunter_spec.rb
+++ b/spec/tools/egghunter_spec.rb
@@ -1,0 +1,14 @@
+load Metasploit::Framework.root.join('tools/egghunter.rb').to_path
+
+require 'rex/proto/http/response'
+require 'stringio'
+
+describe Egghunter do
+  subject do
+    Egghunter::Driver.new
+  end
+
+  describe '#run' do
+  end
+
+end

--- a/spec/tools/egghunter_spec.rb
+++ b/spec/tools/egghunter_spec.rb
@@ -5,31 +5,100 @@ require 'stringio'
 
 describe Egghunter do
 
-  subject do
-    Egghunter::Driver.new
+  describe Egghunter::Driver do
+
+    subject do
+      Egghunter::Driver.new
+    end
+
+    let(:egg) {
+      'W00T'
+    }
+
+    describe '#run' do
+
+      def get_stdout(&block)
+        out = $stdout
+        $stdout = fake = StringIO.new
+        begin
+          yield
+        ensure
+          $stdout = out
+        end
+        fake.string
+      end
+
+      let(:default_opts) {
+        { :platform => 'windows', :format => 'c', :eggtag => egg, :arch => 'x86' }
+      }
+
+      before(:each) do
+        allow(Egghunter::OptsConsole).to receive(:parse).with(any_args).and_return(options)
+      end
+
+      context 'when the platform is windows' do
+        let(:options) { default_opts }
+
+        it 'returns a windows egghunter' do
+          output = get_stdout { subject.run }
+          expect(output).to include("\\x66\\x81\\xca\\xff")
+        end
+      end
+
+      context 'when the platform is linux' do
+        let(:options) do
+          { :platform => 'linux', :format => 'c', :eggtag => egg, :arch => 'x86' }
+        end
+
+        it 'returns a linux egghunter' do
+          output = get_stdout { subject.run }
+          expect(output).to include("\\xfc\\x66\\x81\\xc9\\xff")
+        end
+      end
+
+      context 'when the egg is WOOT' do
+        let(:options) { default_opts }
+
+        it 'includes W00T in the egghunter' do
+          output = get_stdout { subject.run }
+          expect(output).to include("\\x57\\x30\\x30\\x54")
+        end
+      end
+    end
   end
 
-  describe '#run' do
 
-    context 'when the platform is windows' do
-      it 'returns a windows egghunter' do
+  describe Egghunter::OptsConsole do
+    subject do
+      Egghunter::OptsConsole
+    end
+
+    context 'when no options are given' do
+      it 'raises OptionParser::MissingArgument' do
+        expect{subject.parse([])}.to raise_error(OptionParser::MissingArgument)
       end
     end
 
-    context 'when the platform is linux' do
-      it 'returns a linux egghunter' do
+    context 'when no format is specified and --list-formats isn\'t used' do
+      it 'raises OptionParser::MissingArgument' do
+        args = '-e AAAA'.split
+        expect{subject.parse(args)}.to raise_error(OptionParser::MissingArgument)
       end
     end
 
-    context 'when the output format is java' do
-      it 'returns java format egghunter' do
+    context 'when no egg is specified and --list-formats isn\'t used' do
+      it 'raises OptionParser::MissingArgument' do
+        args = '-f python'.split
+        expect{subject.parse(args)}.to raise_error(OptionParser::MissingArgument)
       end
     end
 
-    context 'when the egg is WOOT' do
-      it 'includes W00TW00T in the egghunter' do
+    context 'when :depsize is a string' do
+      it 'raises OptionParser::InvalidOption' do
+        args = '-e AAAA -f c --depsize STRING'.split
+        expect{subject.parse(args)}.to raise_error(OptionParser::InvalidOption)
       end
     end
-
   end
+
 end

--- a/spec/tools/egghunter_spec.rb
+++ b/spec/tools/egghunter_spec.rb
@@ -1,6 +1,5 @@
 load Metasploit::Framework.root.join('tools/egghunter.rb').to_path
 
-require 'rex/proto/http/response'
 require 'stringio'
 
 describe Egghunter do

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -140,9 +140,6 @@ if __FILE__ == $PROGRAM_NAME
   driver = Egghunter::Driver.new
   begin
     driver.run
-  rescue Interrupt
-    $stdout.puts
-    $stdout.puts "Good bye"
   rescue ::Exception => e
     elog("#{e.class}: #{e.message}\n#{e.backtrace * "\n"}")
     $stderr.puts "[x] #{e.class}: #{e.message}"

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -14,7 +14,7 @@ module Egghunter
     def self.parse(args)
       options = {}
       parser = OptionParser.new do |opt|
-        opt.banner = "Usage: #{__FILE__} [options]"
+        opt.banner = "Usage: #{__FILE__} [options]\nExample: #{__FILE__} -f python -e W00T"
         opt.separator ''
         opt.separator 'Specific options:'
 

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -6,16 +6,97 @@ $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', 'lib')))
 require 'msfenv'
 require 'rex'
 require 'msf/core'
+require 'msf/base'
 require 'optparse'
 
 module Egghunter
-  class Driver < Msf::Auxiliary
-    include Msf::Exploit::Remote::Egghunter
+  class OptsConsole
+    def self.parse(args)
+      options = {}
+      parser = OptionParser.new do |opt|
+        opt.banner = "Usage: #{__FILE__} [options]"
+        opt.separator ''
+        opt.separator 'Specific options:'
 
-    def initialize(opts={})
+        options[:badchars] = ''
+        options[:platform] = 'windows'
+        options[:arch]     = ARCH_X86 # 'x86'
+
+        opt.on('-f', '--format <String>', "See --list-formats for a list of supported output formats") do |v|
+          options[:format] = v
+        end
+
+        opt.on('-b', '--badchars <String>', "(Optional) Bad characters to avoid for the egg") do |v|
+          options[:badchars] = v
+        end
+
+        opt.on('-e', '--egg <String>', "Egg") do |v|
+          options[:eggtag] = v
+        end
+
+        opt.on('-p', '--platform <String>', "(Optional) Platform") do |v|
+          options[:platform] = v
+        end
+
+        opt.on('-a', '--arch <String>', "(Optional) Architecture") do |v|
+          options[:arch] = v
+        end
+
+        opt.on('--list-formats', "List all supported output formats") do
+          options[:list_formats] = true
+        end
+
+        opt.on_tail('-h', '--help', 'Show this message') do
+          $stdout.puts opt
+          exit
+        end
+      end
+
+      parser.parse!(args)
+
+      if options.empty?
+        raise OptionParser::MissingArgument, 'No options set, try -h for usage'
+      elsif options[:format].blank? && !options[:list_formats]
+        raise OptionParser::MissingArgument, '-f is required'
+      elsif options[:format] && !::Msf::Simple::Buffer.transform_formats.include?(options[:format])
+        raise OptionParser::InvalidOption, "#{options[:format]} is not a valid format"
+      elsif options[:eggtag].blank?
+        raise OptionParser::MissingArgument, '-e is required'
+      end
+
+      options
+    end
+  end
+
+  class Driver
+    def initialize
+      begin
+        @opts = OptsConsole.parse(ARGV)
+      rescue OptionParser::ParseError => e
+        $stderr.puts "[x] #{e.message}"
+        exit
+      end
     end
 
     def run
+      # list_formats should check first
+      if @opts[:list_formats]
+        list_formats
+        return
+      end
+
+      egghunter = Rex::Exploitation::Egghunter.new(@opts[:platform], @opts[:arch])
+      raw_code = egghunter.hunter_stub('', @opts[:badchars], @opts)
+      output_stream = $stdout
+      output_stream.binmode
+      output_stream.write ::Msf::Simple::Buffer.transform(raw_code, @opts[:format])
+    end
+
+    private
+
+    def list_formats
+      $stderr.puts "[*] Supported output formats:"
+      $stderr.puts ::Msf::Simple::Buffer.transform_formats.join(", ")
     end
 
   end
@@ -29,5 +110,9 @@ if __FILE__ == $PROGRAM_NAME
   rescue Interrupt
     $stdout.puts
     $stdout.puts "Good bye"
+  rescue ::Exception => e
+    elog("#{e.class}: #{e.message}\n#{e.backtrace * "\n"}")
+    $stderr.puts "[x] #{e.class}: #{e.message}"
+    $stderr.puts "[*] If necessary, please refer to framework.log for more details."
   end
 end

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -93,7 +93,7 @@ module Egghunter
         raise OptionParser::MissingArgument, '-e is required'
       elsif options[:format] && !::Msf::Simple::Buffer.transform_formats.include?(options[:format])
         raise OptionParser::InvalidOption, "#{options[:format]} is not a valid format"
-      elsif options[:depsize] && options[:depsize] =~ /^\d+$/
+      elsif options[:depsize] && options[:depsize] !~ /^\d+$/
         raise OptionParser::InvalidOption, "--depsize must be a Fixnum"
       end
 

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -39,26 +39,32 @@ module Egghunter
         end
 
         opt.on('--startreg <String>', "(Optional) The starting register") do |v|
+          # Do not change this key. This should matching the one in Rex::Exploitation::Egghunter
           options[:startreg] = v
         end
 
         opt.on('--forward', "(Optional) To search forward") do |v|
+          # Do not change this key. This should matching the one in Rex::Exploitation::Egghunter
           options[:startreg] = true
         end
 
         opt.on('--depreg <String>', "(Optional) The DEP register") do |v|
+          # Do not change this key. This should matching the one in Rex::Exploitation::Egghunter
           options[:depreg] = v
         end
 
         opt.on('--depdest <String>', "(Optional) The DEP destination") do |v|
+          # Do not change this key. This should matching the one in Rex::Exploitation::Egghunter
           options[:depdest] = v
         end
 
         opt.on('--depsize <Fixnum>', "(Optional) The DEP size") do |v|
+          # Do not change this key. This should matching the one in Rex::Exploitation::Egghunter
           options[:depsize] = v
         end
 
         opt.on('--depmethod <String>', "(Optional) The DEP method to use (virtualprotect/virtualalloc/copy/copy_size)") do |v|
+          # Do not change this key. This should matching the one in Rex::Exploitation::Egghunter
           options[:depmethod] = v
         end
 

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -102,6 +102,7 @@ module Egghunter
       options[:badchars] = '' unless options[:badchars]
       options[:platform] = 'windows' unless options[:platform]
       options[:arch]     = ARCH_X86  unless options[:arch]
+      options[:var_name] = 'buf'     unless options[:var_name]
 
       options
     end

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -20,10 +20,6 @@ module Egghunter
         opt.separator ''
         opt.separator 'Specific options:'
 
-        options[:badchars] = ''
-        options[:platform] = 'windows'
-        options[:arch]     = ARCH_X86 # 'x86'
-
         opt.on('-f', '--format <String>', "See --list-formats for a list of supported output formats") do |v|
           options[:format] = v
         end
@@ -47,7 +43,7 @@ module Egghunter
 
         opt.on('--forward', "(Optional) To search forward") do |v|
           # Do not change this key. This should matching the one in Rex::Exploitation::Egghunter
-          options[:startreg] = true
+          options[:searchforward] = true
         end
 
         opt.on('--depreg <String>', "(Optional) The DEP register") do |v|
@@ -98,6 +94,10 @@ module Egghunter
       elsif options[:depsize] && options[:depsize] !~ /^\d+$/
         raise OptionParser::InvalidOption, "--depsize must be a Fixnum"
       end
+
+      options[:badchars] = '' unless options[:badchars]
+      options[:platform] = 'windows' unless options[:platform]
+      options[:arch]     = ARCH_X86  unless options[:arch]
 
       options
     end

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -69,6 +69,7 @@ module Egghunter
         end
 
         opt.on('-a', '--arch <String>', "(Optional) Architecture") do |v|
+          # Although this is an option, this is currently useless because we don't have x64 egghunters
           options[:arch] = v
         end
 

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -1,0 +1,33 @@
+msfbase = __FILE__
+while File.symlink?(msfbase)
+  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', 'lib')))
+require 'msfenv'
+require 'rex'
+require 'msf/core'
+require 'optparse'
+
+module Egghunter
+  class Driver < Msf::Auxiliary
+    include Msf::Exploit::Remote::Egghunter
+
+    def initialize(opts={})
+    end
+
+    def run
+    end
+
+  end
+end
+
+
+if __FILE__ == $PROGRAM_NAME
+  driver = Egghunter::Driver.new
+  begin
+    driver.run
+  rescue Interrupt
+    $stdout.puts
+    $stdout.puts "Good bye"
+  end
+end

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -75,6 +75,10 @@ module Egghunter
           options[:list_formats] = true
         end
 
+        opt.on('-v', '--var-name <name>', String, '(Optional) Specify a custom variable name to use for certain output formats') do |v|
+          options[:var_name] = v
+        end
+
         opt.on_tail('-h', '--help', 'Show this message') do
           $stdout.puts opt
           exit
@@ -124,7 +128,7 @@ module Egghunter
       raw_code = egghunter.hunter_stub('', @opts[:badchars], @opts)
       output_stream = $stdout
       output_stream.binmode
-      output_stream.write ::Msf::Simple::Buffer.transform(raw_code, @opts[:format])
+      output_stream.write ::Msf::Simple::Buffer.transform(raw_code, @opts[:format], @opts[:var_name])
     end
 
     private

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -82,10 +82,10 @@ module Egghunter
         raise OptionParser::MissingArgument, 'No options set, try -h for usage'
       elsif options[:format].blank? && !options[:list_formats]
         raise OptionParser::MissingArgument, '-f is required'
+      elsif options[:eggtag].blank? && !options[:list_formats]
+        raise OptionParser::MissingArgument, '-e is required'
       elsif options[:format] && !::Msf::Simple::Buffer.transform_formats.include?(options[:format])
         raise OptionParser::InvalidOption, "#{options[:format]} is not a valid format"
-      elsif options[:eggtag].blank?
-        raise OptionParser::MissingArgument, '-e is required'
       elsif options[:depsize] && options[:depsize] =~ /^\d+$/
         raise OptionParser::InvalidOption, "--depsize must be a Fixnum"
       end

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -30,12 +30,36 @@ module Egghunter
           options[:badchars] = v
         end
 
-        opt.on('-e', '--egg <String>', "Egg") do |v|
+        opt.on('-e', '--egg <String>', "The egg (Please give 4 bytes)") do |v|
           options[:eggtag] = v
         end
 
         opt.on('-p', '--platform <String>', "(Optional) Platform") do |v|
           options[:platform] = v
+        end
+
+        opt.on('--startreg <String>', "(Optional) The starting register") do |v|
+          options[:startreg] = v
+        end
+
+        opt.on('--forward', "(Optional) To search forward") do |v|
+          options[:startreg] = true
+        end
+
+        opt.on('--depreg <String>', "(Optional) The DEP register") do |v|
+          options[:depreg] = v
+        end
+
+        opt.on('--depdest <String>', "(Optional) The DEP destination") do |v|
+          options[:depdest] = v
+        end
+
+        opt.on('--depsize <Fixnum>', "(Optional) The DEP size") do |v|
+          options[:depsize] = v
+        end
+
+        opt.on('--depmethod <String>', "(Optional) The DEP method to use (virtualprotect/virtualalloc/copy/copy_size)") do |v|
+          options[:depmethod] = v
         end
 
         opt.on('-a', '--arch <String>', "(Optional) Architecture") do |v|
@@ -62,6 +86,8 @@ module Egghunter
         raise OptionParser::InvalidOption, "#{options[:format]} is not a valid format"
       elsif options[:eggtag].blank?
         raise OptionParser::MissingArgument, '-e is required'
+      elsif options[:depsize] && options[:depsize] =~ /^\d+$/
+        raise OptionParser::InvalidOption, "--depsize must be a Fixnum"
       end
 
       options

--- a/tools/egghunter.rb
+++ b/tools/egghunter.rb
@@ -130,6 +130,7 @@ module Egghunter
       output_stream = $stdout
       output_stream.binmode
       output_stream.write ::Msf::Simple::Buffer.transform(raw_code, @opts[:format], @opts[:var_name])
+      $stderr.puts
     end
 
     private


### PR DESCRIPTION
Resolves #4944

This is a new tool that allows exploit developers to use Metasploit's egghunter without writing a Metasploit module (for example: OSCE training).
## Testing
- [x] Make sure Travis is green.
- [x] Do: `ruby tools/egghunter.rb -h`
- [x] It should show you the help menu
- [x] Do: `ruby tools/egghunter.rb --list-formats`
- [x] It should show you what output formats are supported
- [x] Do: `ruby tools/egghunter.rb -f python -e W00T`
- [x] It should show you the egghunter in python format
- [x] Do: `ruby tools/egghunter.rb -f raw -e W00T | ./msfvenom -p - -a x86 --platform windows -b "\x00" -f c`
- [x] It should encode the egghunter

Ideally, you should also actually try the egghunter in a debugger and make sure it works. @FireFart would you like to try this pull request?

To the pull request reviewer/handler: I forgot to tag the ticket in my commits, so when landing, please make sure to add `Resolve #4944` in your commit message. Thanks.
