### PR TITLE
Fix undefined esize in Rex::Exploitation::Egghunter

### DIFF
--- a/lib/rex/exploitation/egghunter.rb
+++ b/lib/rex/exploitation/egghunter.rb
@@ -46,7 +46,7 @@ class Egghunter
         startreg      = opts[:startreg]
         searchforward = opts[:searchforward]
 
-        raise RuntimeError, "Invalid egg string! Need #{esize} bytes." if opts[:eggtag].length != 4
+        raise RuntimeError, "Invalid egg string! Need 4 bytes." if opts[:eggtag].length != 4
         marker = "0x%x" % opts[:eggtag].unpack('V').first
 
         checksum = checksum_stub(payload, badchars, opts)


### PR DESCRIPTION
esize is not a valid variable, and we don't need it either. I hit this bug while working on #4975.
## Verification

As you can see in the patch, the if condition is looking for a length of 4 bytes, so it's obvious that it should just tell the user it needs 4 bytes.
