### PR TITLE
Add real tagging to msfconsole

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -220,6 +220,11 @@ class Db
   end
 
   def change_host_info(rws, data)
+    if rws == [nil]
+      print_error("In order to change the host info, you must provide a range of hosts")
+      return
+    end
+
     rws.each do |rw|
       rw.each do |ip|
         id = framework.db.get_host(:address => ip).id
@@ -230,6 +235,11 @@ class Db
   end
 
   def change_host_name(rws, data)
+    if rws == [nil]
+      print_error("In order to change the host name, you must provide a range of hosts")
+      return
+    end
+
     rws.each do |rw|
       rw.each do |ip|
         id = framework.db.get_host(:address => ip).id
@@ -240,6 +250,11 @@ class Db
   end
 
   def change_host_comment(rws, data)
+    if rws == [nil]
+      print_error("In order to change the comment, you must provide a range of hosts")
+      return
+    end
+
     rws.each do |rw|
       rw.each do |ip|
         id = framework.db.get_host(:address => ip).id
@@ -250,6 +265,11 @@ class Db
   end
 
   def add_host_tag(rws, tag_name)
+    if rws == [nil]
+      print_error("In order to add a tag, you must provide a range of hosts")
+      return
+    end
+
     addrs = []
     rws.each do |rw|
       rw.each do |ip|

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -326,9 +326,9 @@ class Db
     output = nil
     default_columns = ::Mdm::Host.column_names.sort
     default_columns << 'tags' # Special case
-    virtual_columns = [ 'svcs', 'vulns', 'workspace' ]
+    virtual_columns = [ 'svcs', 'vulns', 'workspace', 'tags' ]
 
-    col_search = [ 'address', 'mac', 'name', 'os_name', 'os_flavor', 'os_sp', 'purpose', 'info', 'comments', 'tags']
+    col_search = [ 'address', 'mac', 'name', 'os_name', 'os_flavor', 'os_sp', 'purpose', 'info', 'comments']
 
     default_columns.delete_if {|v| (v[-2,2] == "id")}
     while (arg = args.shift)
@@ -469,13 +469,13 @@ class Db
             when "svcs";      host.services.length
             when "vulns";     host.vulns.length
             when "workspace"; host.workspace.name
+            when "tags"
+              found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ?", framework.db.workspace.id, host.address).order("tags.id DESC")
+              tag_names = []
+              found_tags.each {|t| tag_names << t.name}
+              found_tags * ", "
             end
           # Otherwise, it's just an attribute
-          elsif n == 'tags'
-            found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ?", framework.db.workspace.id, host.address).order("tags.id DESC")
-            tag_names = []
-            found_tags.each {|t| tag_names << t.name}
-            found_tags * ", "
           else
             host.attributes[n] || ""
           end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -287,20 +287,27 @@ class Db
 
   def delete_host_tag(rws, tag_name)
     wspace = framework.db.workspace
+    tag_ids = []
     if rws == [nil]
       found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and tags.name = ?", wspace.id, tag_name)
       found_tags.each do |t|
-        t.delete
+        tag_ids << t.id
       end
     else
       rws.each do |rw|
         rw.each do |ip|
           found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", wspace.id, ip, tag_name)
             found_tags.each do |t|
-            t.delete
+            tag_ids << t.id
           end
         end
       end
+    end
+
+    tag_ids.each do |id|
+      tag = Mdm::Tag.find_by_id(id)
+      tag.hosts.delete
+      tag.destroy
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -288,14 +288,14 @@ class Db
   def delete_host_tag(rws, tag_name)
     wspace = framework.db.workspace
     if rws == [nil]
-      found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and tags.name = ?", wspace.id, tag_name).order("tags.id DESC")
+      found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and tags.name = ?", wspace.id, tag_name)
       found_tags.each do |t|
         t.delete
       end
     else
       rws.each do |rw|
         rw.each do |ip|
-          found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", wspace.id, ip, tag_name).order("tags.id DESC")
+          found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", wspace.id, ip, tag_name)
             found_tags.each do |t|
             t.delete
           end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -441,7 +441,7 @@ class Db
       begin
         add_host_tag(host_ranges, tag_name)
       rescue ::Exception => e
-        if e.message =~ /Validation failed/
+        if e.message.include?('Validation failed')
           print_error(e.message)
         else
           raise e
@@ -457,7 +457,7 @@ class Db
       framework.db.hosts(framework.db.workspace, onlyup, host_search).each do |host|
         if search_term
           next unless (
-            host.attribute_names.any? { |a| host[a.intern].to_s.match(search_term) } or
+            host.attribute_names.any? { |a| host[a.intern].to_s.match(search_term) } ||
             !Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", framework.db.workspace.id, host.address, search_term.source).order("tags.id DESC").empty?
           )
         end
@@ -472,7 +472,7 @@ class Db
             when "tags"
               found_tags = Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ?", framework.db.workspace.id, host.address).order("tags.id DESC")
               tag_names = []
-              found_tags.each {|t| tag_names << t.name}
+              found_tags.each { |t| tag_names << t.name }
               found_tags * ", "
             end
           # Otherwise, it's just an attribute

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -394,7 +394,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -i,--info         Change the info of a host",
           "  -n,--name         Change the name of a host",
           "  -m,--comment      Change the comment of a host",
-          "  -t,--tag          Add or specify a tag to a range of hosts"
+          "  -t,--tag          Add or specify a tag to a range of hosts",
           "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count, tags"
         ]
       end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -394,7 +394,8 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -i,--info         Change the info of a host",
           "  -n,--name         Change the name of a host",
           "  -m,--comment      Change the comment of a host",
-          "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count"
+          "  -t,--tag          Add or specify a tag to a range of hosts"
+          "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count, tags"
         ]
       end
     end


### PR DESCRIPTION
Due to popular demand, this new patch allows you to really tag/label a range of hosts. I originally only thought of using the Info or Comments column as a way to tag hosts, and then Luke suggested I might as well just use Mdm::Tag for proper tagging (which makes sense because it's already in Framework). I asked @wvu-r7 to help me testing, so I am assigning this ticket to him. (Thanks!)
## To prepare for testing
- [x] Start msfconsole
- [x] Do: `workspace`
- [x] Make sure you don't have a workspace named "label_test_1"
- [x] Make sure you don't have a workspace named "label_test_2"
- [x] Download this script: https://gist.github.com/wchen-r7/004d88d8abedf725d2ba, it will automatically build the workspaces for you so testing is easier. Let's save this one as: /tmp/test.rc
- [x] Run the resource script: `./msfconsole -q -r /tmp/test.rc`
- [x] You now should have workspace "label_test_1" and "label_test_2". Right after building everything, the `workspace` should tell you are currently in `label_test_2`
- [x] If you do `hosts -c 'address,name,os_name,os_flavor,os_sp,info,comments,tags'`, msfconsole should show you this:

```
Hosts
=====

address       name      os_name            os_flavor  os_sp  info  comments  tags
-------       ----      -------            ---------  -----  ----  --------  ----
192.168.1.2   Bob       Microsoft Windows  Windows 7  SP1                    Intern, Sales
192.168.1.3   Alice     Microsoft Windows  Windows 7  SP1                    Intern, Sales
192.168.1.4   John      Microsoft Windows  Windows 7  SP1                    Intern, Sales
192.168.1.5   Miller    Microsoft Windows  Windows 7  SP1                    Intern, Sales
192.168.1.6   Ken       Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.7   Tim       Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.8   Wayne     Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.9   Alex      Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.10  Diane     Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.11  Joe       Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.12  Chris     Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.13  Jane      Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.14  Kyle      Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.15  Nora      Microsoft Windows  Windows 7  SP1                    Account_Exec, Sales
192.168.1.16  Ann       Microsoft Windows  Windows 7  SP1                    Director_of_Sales, Sales
192.168.1.17  Kim       Microsoft Windows  Windows 7  SP1                    Regional_Manager, Sales
192.168.1.18  Anderson  Microsoft Windows  Windows 7  SP1                    Regional_Manager, Sales
192.168.1.19  William   Microsoft Windows  Windows 7  SP1                    Regional_Manager, Sales
192.168.1.20  Sarah     Microsoft Windows  Windows 7  SP1                    Senior_VP, Sales
```
## Real testing

**First thing**
- [x] Make sure Travis is green

**Testing for removing labels**
- [x] First, do: `hosts -h`. Make sure you see `--tag` being an option.
- [x] "tags" should also appear in the "Available columns" section when you do `hosts -h`
- [x] Do: `hosts -R 192.168.1.6 -d -t "Account_Exec"`
- [x] Do: `hosts -c 'address,name,os_name,os_flavor,os_sp,info,comments,tags'`
- [x] You should see that host 192.168.1.6 no longer has the tag "Account_Exec"
- [x] Do: `hosts -R 192.168.1.7-192.168.1.10 -d -t "Account_Exec"`
- [x] Do: `hosts -c 'address,name,os_name,os_flavor,os_sp,info,comments,tags'` again
- [x] You should see that hosts 192.168.1.7 to 192.168.1.10 no longer have the tag "Account_Exec"
- [x] Do: `hosts -d -t "Intern"`
- [x] Do: `hosts -c 'address,name,os_name,os_flavor,os_sp,info,comments,tags'` again
- [x] You should see that no hosts are using the tag "Intern" anymore

**Testing for adding labels**
- [x] Do: `hosts -R 192.168.1.2 -t 'New_Guy'`
- [x] Do: `hosts -c 'address,name,os_name,os_flavor,os_sp,info,comments,tags'`
- [x] You should see that host 192.168.1.2 now has a new tag named "New_Guy"
- [x] Do `hosts -R 192.168.1.1/24 -t 'Slave'`
- [x] Do: `hosts -c 'address,name,os_name,os_flavor,os_sp,info,comments,tags'`
- [x] You should see that all hosts have the new tag "Slave"
- [x] Do: `hosts -R 192.168.1.2 -t 'White Space'` (Notice the space in the tag)
- [x] msfconsole should say "Validation failed: Name must be alphanumeric, dots, dashes, or underscores"

**Testing for searching**
- [x] Switch the workspace: `workspace label_test_1`
- [x] Do: `hosts -S "Regional_Manager" -c 'address,name,os_name,os_flavor,os_sp,info,comments,tags'`
- [x] You should only see hosts that are tagged as "Regional_Manager"

**Finally**

I at one point hit a backtrace while doing this, so please also verify:
- [x] Do: `workspace label_test_1` and make sure you are in label_test_1
- [x] Do: `workspace -d label_test_2`
- [x] You should see that workspace "label_test_2" is successfully deleted
