### PR TITLE
Fix #4987 - undef payload_exe for ams_xfr

### DIFF
--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -57,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
     execute_cmdstager({ :temp => '.' })
-    @payload_exe = payload_exe
+    @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")
     execute_command(@payload_exe)


### PR DESCRIPTION
Fix #4987 

You can repro the problem by doing this:
- [x] `ruby -run -e httpd . -p 12174` (i don't think the vulnerable service is actually an http server, but this is enough to fake it)
- [x] `rvmsudo ./msfconsole`
- [x] `set rhost [IP]`
- [x] `run`
- [x] Without the patch, you will hit this:

```
msf exploit(ams_xfr) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] Sending request to 192.168.1.64:12174
[-] Did not received data. Failed?
[*] Command Stager progress -  59.09% done (26/44 bytes)
[-] Did not received data. Failed?
[*] Command Stager progress - 100.00% done (44/44 bytes)
[-] Exploit failed: NameError undefined local variable or method `payload_exe' for #<Msf::Modules::Mod6578706c6f69742f77696e646f77732f616e746976697275732f616d735f786672::Metasploit3:0x007fab63d4cc98>
```
- [x] With the patch, you will not see that error again
