### PR TITLE
Replace db_nmap string concat with an Array

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1740,7 +1740,7 @@ class Db
       return
     end
     save = false
-    arguments = ''
+    arguments = []
     while (arg = args.shift)
       case arg
       when 'save'
@@ -1749,7 +1749,7 @@ class Db
         cmd_db_nmap_help
         return
       else
-        arguments << arg + ' '
+        arguments << arg
       end
     end
 
@@ -1773,15 +1773,15 @@ class Db
       # Custom function needed because cygpath breaks on 8.3 dirs
       tout = Rex::Compat.cygwin_to_win32(fd.path)
       fout = Rex::Compat.cygwin_to_win32(fo.path)
-      args.push('-oX', tout)
-      args.push('-oN', fout)
+      arguments.push('-oX', tout)
+      arguments.push('-oN', fout)
     else
-      args.push('-oX', fd.path)
-      args.push('-oN', fo.path)
+      arguments.push('-oX', fd.path)
+      arguments.push('-oN', fo.path)
     end
 
     begin
-      nmap_pipe = ::Open3::popen3([nmap, 'nmap'], arguments)
+      nmap_pipe = ::Open3::popen3([nmap, 'nmap'], *arguments)
       temp_nmap_threads = []
       temp_nmap_threads << framework.threads.spawn("db_nmap-Stdout", false, nmap_pipe[1]) do |np_1|
         np_1.each_line do |nmap_out|


### PR DESCRIPTION
16eab48012d1dce6af097c7e6d52a77c57f65c58 introduced changes to
cmd_db_nmap which pass a new arguments variable to Open3 with a
list of args excluding save.

This approach created a problem wherein the address of the target
had to be passed in first and arguments could get mangled.

Reintroduce an array format, exploding when passing to Open3.
Ensure output file options are appended to the arguments being
passed to Open3, instead of the args variable.

Error example:

```
db_nmap -F 192.168.0.1
[*] Nmap: 'nmap: unrecognized option '- 192.168.0.1 ''
```
