### PR TITLE
Allow SMBDirect to be optional

### DIFF
--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -45,7 +45,7 @@ module Msf
 
         register_advanced_options(
         [
-          OptBool.new('SMBDirect', [ true, 'The target port is a raw SMB service (not NetBIOS)', true ]),
+          OptBool.new('SMBDirect', [ false, 'The target port is a raw SMB service (not NetBIOS)', true ]),
           OptString.new('SMBUser', [ false, 'The username to authenticate as', '']),
           OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
           OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.']),


### PR DESCRIPTION
The smb_version module needs to deregister the SMBDirect option (and manage its own SMBDirect, see https://github.com/rapid7/metasploit-framework/commit/7e05ff343eab3c00ce6574a58275e815a2a2e372), but cannot do this because SMBDirect is a required option. By having it as optional, the user no longer needs to set it. Also, since SMBDirect already has a default value, having it as optional should not change the mixin's default behavior.

Bug originally reported here:
https://twitter.com/n1tr0g3n_com/status/580396557150846976
## To test
- [x] Start msfconsole
- [x] `use auxiliary/scanner/smb/smb_version`
- [x] `set rhosts [IP]`
- [x] `run`
- [x] Without the patch, you should see "Msf::OptionValidateError The following options failed to validate: SMBDirect"
- [x] With the patch, you should not see the error.
