### PR TITLE
Utility for adding PR fetch refs

### DIFF
--- a/tools/dev/add-pr-remote.rb
+++ b/tools/dev/add-pr-remote.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+toplevel = %x{git rev-parse --show-toplevel}.strip
+infile = "#{toplevel}/.git/config"
+outfile = infile
+$stderr.puts "Rewriting #{infile}"
+data = File.open(infile, 'rb') {|f| f.read f.stat.size}
+newdata = ""
+data.each_line do |line|
+  newdata << line
+  case line
+  when /^(\s*)fetch\s*=.*remotes\/([^\/]+)\//
+    ws = $1
+    remote = $2
+    pr_line = "fetch = +refs/pull/*/head:refs/remotes/#{remote}/pr/*"
+    next if line.strip == pr_line.strip
+    if data.include? pr_line
+      $stderr.puts "Skipping #{remote}, already present"
+      next
+    else
+      @new_pr_line ||= true
+      $stderr.puts "Adding pull request fetch for #{remote}"
+      newdata << "#{ws}#{pr_line}\n"
+    end
+  end
+end
+
+if @new_pr_line
+  File.open(outfile, 'wb') {|f| f.write newdata}
+  $stderr.puts "Wrote #{outfile}"
+else
+  $stderr.puts "No changes to #{outfile}"
+end


### PR DESCRIPTION
It's so annoying to have to hand-edit my .git/config to add `fetch` references for a repository's pull requests. This utility does the job for me.
## Verification
- [x] Check your local `.git/config` Do you have `fetch` references to `upstream/pr` and all other remotes?
- [x] If so, run `tools/dev/add-pr-remote.rb`. You should see no changes.
- [x] If you have only some remote branches with pr fetch refs, `add-pr-remote.rb` should fill in the rest.
- [x] If you have no remote branches with pr fetch refs, then you should see all of them added.
- [x] Running the tool multiple times shouldn't create more fetch refs.

Example:

```
todb@mazikeen:~/git/rapid7/metasploit-framework$ tools/dev/add-pr-remote.rb 
Rewriting /home/todb/git/rapid7/metasploit-framework/.git/config
Skipping upstream, already present
Skipping origin, already present
Adding pull request fetch for joevennix
Adding pull request fetch for limhoff-r7
Wrote /home/todb/git/rapid7/metasploit-framework/.git/config
[ruby-2.1.5@metasploit-framework](add-pr-fetches) 
todb@mazikeen:~/git/rapid7/metasploit-framework$ tools/dev/add-pr-remote.rb 
Rewriting /home/todb/git/rapid7/metasploit-framework/.git/config
Skipping upstream, already present
Skipping origin, already present
Skipping joevennix, already present
Skipping limhoff-r7, already present
No changes to /home/todb/git/rapid7/metasploit-framework/.git/config
```
