### PR TITLE
Add CVE-ID to wp_easycart_privilege_escalation references

### DIFF
--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'         => MSF_LICENSE,
       'References'      =>
         [
+          ['CVE', '2015-2673'],
           ['WPVDB', '7808'],
           ['URL', 'http://blog.rastating.com/wp-easycart-privilege-escalation-information-disclosure']
         ],


### PR DESCRIPTION
Just a minor change to add the CVE-ID into this module.
