### PR TITLE
Add #send_request to Metasploit::Framework::LoginScanner::HTTP

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -189,8 +189,14 @@ module Metasploit
 
         # Sends a HTTP request with Rex
         #
-        # @param (see Rex::Proto::Http::Request#request_raw)
-        # @raise [Rex::ConnectionError] Something has gone wrong while sending the HTTP request
+        # @param [Hash] Native support includes the following (also see Rex::Proto::Http::Request#request_cgi)
+        # @option opts[String] 'host' The remote host
+        # @option opts[Fixnum] 'port' The remote port
+        # @option opts[Boolean] 'ssl' The SSL setting, TrueClass or FalseClass
+        # @option opts[String]  'proxies' The proxies setting
+        # @option opts[Credential] 'credential' A credential object
+        # @option opts['Hash'] 'context' A context
+        # @raise [Rex::ConnectionError] One of these errors has occured: EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
           rhost           = opts['host'] || host

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -218,7 +218,7 @@ module Metasploit
             cli.connect
             req = cli.request_cgi(opts)
             res = cli.send_recv(req)
-          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error => e]
+          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error => e
             raise Rex::ConnectionError, e.message
           ensure
             cli.close

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -208,11 +208,7 @@ module Metasploit
             cli.connect
             req = cli.request_cgi(opts)
             res = cli.send_recv(req)
-          rescue ::Errno::EPIPE, ::Timeout::Error => e
-            # We are trying to mimic the same type of exception rescuing in
-            # Msf::Exploit::Remote::HttpClient. But instead of returning nil, we'll consistently
-            # raise Rex::ConnectionError so the #attempt_login can return the error message back
-            # to the login module.
+          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error => e
             raise Rex::ConnectionError, e.message
           ensure
             cli.close

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -193,22 +193,32 @@ module Metasploit
         # @raise [Rex::ConnectionError] Something has gone wrong while sending the HTTP request
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
+          rhost           = opts['host'] || host
+          rport           = opts['rport'] || port
+          cli_ssl         = opts['ssl'] || ssl
+          cli_ssl_version = opts['ssl_version'] || ssl_version
+          cli_proxies     = opts['proxies'] || proxies
+          username        = opts['username'] || ''
+          password        = opts['password'] || ''
+          context         = opts['context'] || { 'Msf' => framework, 'MsfExploit' => framework_module}
+
           res = nil
-          cli = Rex::Proto::Http::Client.new(host, port,
-            {
-              'Msf' => framework,
-              'MsfExploit' => framework_module
-            },
-            ssl,
-            ssl_version,
-            proxies
+          cli = Rex::Proto::Http::Client.new(
+            rhost,
+            rport,
+            context,
+            cli_ssl,
+            cli_ssl_version,
+            cli_proxies,
+            username,
+            password
           )
           configure_http_client(cli)
           begin
             cli.connect
             req = cli.request_cgi(opts)
             res = cli.send_recv(req)
-          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error => e
+          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error => e]
             raise Rex::ConnectionError, e.message
           ensure
             cli.close

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -198,6 +198,7 @@ module Metasploit
         # @option opts['Hash'] 'context' A context
         # @raise [Rex::ConnectionError] One of these errors has occured: EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
         # @return [Rex::Proto::Http::Response] The HTTP response
+        # @return [NilClass] An error has occured while reading the response (see #Rex::Proto::Http::Client#read_response)
         def send_request(opts)
           rhost           = opts['host'] || host
           rport           = opts['rport'] || port

--- a/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
+++ b/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
@@ -27,41 +27,6 @@ module Metasploit
         end
 
 
-        # Sends a HTTP request with Rex
-        #
-        # @param (see Rex::Proto::Http::Request#request_raw)
-        # @raise [Rex::ConnectionError] Something has gone wrong while sending the HTTP request
-        # @return [Rex::Proto::Http::Response] The HTTP response
-        def send_request(opts)
-          res = nil
-          cli = Rex::Proto::Http::Client.new(host, port,
-            {
-              'Msf' => framework,
-              'MsfExploit' => framework_module
-            },
-            ssl,
-            ssl_version,
-            proxies
-          )
-          configure_http_client(cli)
-          begin
-            cli.connect
-            req = cli.request_cgi(opts)
-            res = cli.send_recv(req)
-          rescue ::Errno::EPIPE, ::Timeout::Error => e
-            # We are trying to mimic the same type of exception rescuing in
-            # Msf::Exploit::Remote::HttpClient. But instead of returning nil, we'll consistently
-            # raise Rex::ConnectionError so the #attempt_login can return the error message back
-            # to the login module.
-            raise Rex::ConnectionError, e.message
-          ensure
-            cli.close
-          end
-
-          res
-        end
-
-
         # Returns the latest sid from Symantec Web Gateway.
         #
         # @returns [String] The PHP Session ID for Symantec Web Gateway login

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -8,4 +8,26 @@ describe Metasploit::Framework::LoginScanner::HTTP do
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
   it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
 
+  subject do
+    described_class.new
+  end
+
+  let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }
+
+  before(:each) do
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:close)
+    allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
+  end
+
+  describe '#send_request' do
+    context 'when a valid request is sent' do
+      it 'returns a response object' do
+        expect(subject.send_request({'uri'=>'/'})).to be_kind_of(Rex::Proto::Http::Response)
+      end
+    end
+  end
+
 end

--- a/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
@@ -72,14 +72,6 @@ describe Metasploit::Framework::LoginScanner::SymantecWebGateway do
       end
     end
 
-    describe '#send_request' do
-      context 'when a valid request is sent' do
-        it 'returns a response object' do
-          expect(subject.send_request({'uri'=>'/'})).to be_kind_of(Rex::Proto::Http::Response)
-        end
-      end
-    end
-
     describe '#get_last_sid' do
       let(:response) do
         res = Rex::Proto::Http::Response.new(200, 'OK')


### PR DESCRIPTION
This is a patch for Metasploit::Framework::LoginScanner::HTTP that allows module developers to send an HTTP request without building it from scratch with Rex. It should feel kind of like using the send_request_cgi method in HttpClient, but this one is more for Metasploit::Framework::LoginScanner::HTTP.
## Usage example

You will probably use this new method in your #attempt_login method. This is the most basic example:

``` ruby
res = send_request(
    'uri'    => login_uri,
    'method' => 'POST',
    'vars_post' => {
        'username' => username,
        'password' => password
})
```

If you are trying to do use #send_auth from Rex::Proto::Http::Client (which is the case if you're doing basic_auth or something like that), then you can do this:

``` ruby
res = send_request(
    'uri'    => login_uri,
    'method' => 'GET',
    'credential' => credential # This is a credential object
})
```
## Verification

As code examples, there are two login modules that use this new method: the http_login module and symantec_web_gateway. I used the http_login module to test basic_auth, and then used the symantec_web_gateway for form-based auth via HTTPS

**To test the http_login module**
- [ ] Pick your favorite HTTP server and enable basic_auth
- [ ] Start msfconsole
- [ ] `use auxiliary/scanner/http/http_login`
- [ ] `set username [valid username]`
- [ ] `set password [valid password]`
- [ ] `run`
- [ ] The module should give you a successful login

**To test the symantec module**
- [ ] Please just follow the same instructions in https://github.com/rapid7/metasploit-framework/pull/4945

@dmaloney-r7 Can I please have you look at https://github.com/rapid7/metasploit-framework/pull/5004/files#diff-4db955150c9c3dba9861be9d2961cb68R202, and see if you're okay with the new method? Thanks.
