### PR TITLE
Resolve #4986, add support for IE11 for fingerprint_user_agent

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -305,7 +305,7 @@ module Exploit::Remote::HttpServer
       when /opera\/(\d+(:?\.\d+)*)/
         fp[:ua_name] = HttpClients::OPERA
         fp[:ua_ver] = $1
-      when /mozilla\/[0-9]+\.[0-9] \(compatible; msie ([0-9]+\.[0-9]+)/, /mozilla\/[0-9]+\.[0-9] \(.+ rv:([0-9]+\.[0-9])\)/
+      when /mozilla\/[0-9]+\.[0-9] \(compatible; msie ([0-9]+\.[0-9]+)/i, /mozilla\/[0-9]+\.[0-9] \(.+ rv:([0-9]+\.[0-9])\)/i
         fp[:ua_name] = HttpClients::IE
         fp[:ua_ver] = $1
       else

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -305,7 +305,7 @@ module Exploit::Remote::HttpServer
       when /opera\/(\d+(:?\.\d+)*)/
         fp[:ua_name] = HttpClients::OPERA
         fp[:ua_ver] = $1
-      when /mozilla\/[0-9]+\.[0-9] \(compatible; msie ([0-9]+\.[0-9]+)/
+      when /mozilla\/[0-9]+\.[0-9] \(compatible; msie ([0-9]+\.[0-9]+)/, /mozilla\/[0-9]+\.[0-9] \(.+ rv:([0-9]+\.[0-9])\)/
         fp[:ua_name] = HttpClients::IE
         fp[:ua_ver] = $1
       else


### PR DESCRIPTION
Resolve #4986.

This patch will correctly detect IE11 for the fingerprint_user_agent method in HttpServer.
## Testing
- [x] Prepare a Windows 8 box with Internet Explorer 11
- [x] Download this test module: https://gist.github.com/wchen-r7/161baa5a0499e556b139
- [x] Put the module as: auxiliary/gather/test.rb
- [x] Start msfconsole
- [x] Do: `use auxiliary/gather/test`
- [x] Do: `run`
- [x] Browse to the URL w/ IE11
- [x] Without the patch, you should see that the :ua_ver key is "Unknown". Like this:

```
msf auxiliary(test) > run

[*] Using URL: http://0.0.0.0:8080/JkqG0zkzWlNsXa
[*]  Local IP: http://192.168.1.64:8080/JkqG0zkzWlNsXa
[*] Server started.
[!] 192.168.1.145    test - {:ua_string=>"Mozilla/5.0 (Windows NT 6.3; Trident/7.0; Touch; rv:11.0) like Gecko", :ua_name=>"Unknown", :os_name=>"Windows 8.1", :arch=>"x86"}
```
- [x] With the patch, you should see that the :ua_ver key is "11.0", like this:

```
msf auxiliary(test) > run

[*] Using URL: http://0.0.0.0:8080/Loo4fgedQ5
[*]  Local IP: http://192.168.1.64:8080/Loo4fgedQ5
[*] Server started.
[!] 192.168.1.145    test - {:ua_string=>"Mozilla/5.0 (Windows NT 6.3; Trident/7.0; Touch; rv:11.0) like Gecko", :ua_name=>"MSIE", :ua_ver=>"11.0", :os_name=>"Windows 8.1", :arch=>"x86"}
```
