### PR TITLE
Known private key modules should report success

### DIFF
--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -119,6 +119,14 @@ class Metasploit3 < Msf::Exploit::Remote
     conn = do_login("root")
     if conn
       print_good "Successful login"
+      report_vuln(
+        :host         => rhost,
+        :port         => rport,
+        :proto        => 'tcp',
+        :name         => self.name,
+        :refs         => self.references,
+        :exploited_at => Time.now.utc
+      )
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -117,6 +117,14 @@ class Metasploit3 < Msf::Exploit::Remote
     conn = do_login("root")
     if conn
       print_good "#{rhost}:#{rport} - Successful login"
+      report_vuln(
+        :host         => rhost,
+        :port         => rport,
+        :proto        => 'tcp',
+        :name         => self.name,
+        :refs         => self.references,
+        :exploited_at => Time.now.utc
+      )
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -115,6 +115,14 @@ class Metasploit3 < Msf::Exploit::Remote
     conn = do_login("root")
     if conn
       print_good "#{rhost}:#{rport} - Successful login"
+      report_vuln(
+        :host         => rhost,
+        :port         => rport,
+        :proto        => 'tcp',
+        :name         => self.name,
+        :refs         => self.references,
+        :exploited_at => Time.now.utc
+      )
       handler(conn.lsock)
     end
   end


### PR DESCRIPTION
I noticed that the special-purpose "known private key" style modules do not rely on the normal LoginScanners, so they are not reporting valid credentials even when they have them. Also, they're aux modules, so they do not report_vuln by default when a session is opened. This fixes at least the second part. It'd be nice to pick up the first part, but the references cited should be enough to go on to recover the private key if it's desired (they're not very useful, though, outside of these specific vulnerability contexts).
## Verification

Assuming you don't have a test device in question:
- [ ] Extract a private key from one of these modules with your favorite text editor, save it to `~/tmp/exposed-key`
- [ ] Generate a public key part: `ssh-keygen -y -f ~/tmp/exposed-key > /tmp/exposed-key.pub`
- [ ] Drop the public key on a test machine running sshd, in some user's `.ssh/authorized_keys`. Which user depends on the module in question (usually root). Kali works well for this since it doesn't prohibit remote root logins.
- [ ] Run the module: `run -j` (running as a background job is more convenient).

Before the fix, you should see no `cred` and no `vuln` reported.

After the fix, you should at least see a `vuln` reported with the correct references.
