### PR TITLE
remove wininet workaround in meterpreter http/s

### DIFF
--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -114,9 +114,6 @@ module PacketDispatcher
       cli.send_response(resp)
     end
 
-    # Force a closure for older WinInet implementations
-    self.passive_service.close_client( cli )
-
     rescue ::Exception => e
       elog("Exception handling request: #{cli.inspect} #{req.inspect} #{e.class} #{e} #{e.backtrace}")
     end


### PR DESCRIPTION
In the packet dispatcher, there is a workaround to close connections on very old WinInet implementations that would not do it themselves. With the new WinHttp API-using Meterpreters and stagers, we no longer should use this workaround. It can actually be actively bad and prematurely close the connection.

This needs testing around different payloads, and they should be on real networks, ideally where TCP really has to work to get data transferred.

I'm filing this ticket as an observer and participant of the HTTP reliability testing carnage between HD and OJ.
