### PR TITLE
This fixes a race condition with the WinHTTP meterpreters

### DIFF
--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -114,9 +114,6 @@ module PacketDispatcher
       cli.send_response(resp)
     end
 
-    # Force a closure for older WinInet implementations
-    self.passive_service.close_client( cli )
-
     rescue ::Exception => e
       elog("Exception handling request: #{cli.inspect} #{req.inspect} #{e.class} #{e} #{e.backtrace}")
     end


### PR DESCRIPTION
In the past we forcibly closed the HTTP socket to work around a bug in old WinInet. Now that Meterpreters have switched to WinHTTP, this forced close creating race conditions and reliability problems. Removing this change has no effect on non-WinInet Meterpreters and fixes a reliability issue with WinHTTP Meterpreters.

To test this, first verify that master has problems by creating a session with the 64-bit Meterpreter payload using the reverse_winhttps stager. Inside of the Meterpreter shell, open irb and run:

```
1.upto(1000){|i| p i; p client.sys.config.sysinfo }
```

Notice that in the first ~20 or so requests, you will get a timeout.

Switch to this PR branch and do the same, notice that you will not get a timeout.
