### PR TITLE
add missing HKLM root to regkey

### DIFF
--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -251,7 +251,7 @@ class Metasploit3 < Msf::Post
       end
     end
     if not vm
-      srvvals = registry_enumkeys('HARDWARE\ACPI\FADT')
+      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
       if srvvals and srvvals.include?("Xen")
         vm = true
       end


### PR DESCRIPTION
the chevkm windows post module had HKLM missing from the front of one of it's reg key paths. This was missed in Rails 3 due to the error being swallowed unexpectedly. in rails 4 we actually see this cause a stack trace

MSP-12384
