### PR TITLE
Add workspace saving to msfconsole's save command

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -387,8 +387,17 @@ class Driver < Msf::Ui::Driver
     if (conf.group?(ConfigGroup))
       conf[ConfigGroup].each_pair { |k, v|
         case k.downcase
-          when "activemodule"
+          when 'activemodule'
             run_single("use #{v}")
+          when 'activeworkspace'
+            if framework.db.active
+              workspace = framework.db.find_workspace(v)
+              if workspace
+                framework.db.workspace = workspace
+              else
+                framework.db.workspace = framework.db.add_workspace(v)
+              end
+            end
         end
       }
     end
@@ -403,6 +412,12 @@ class Driver < Msf::Ui::Driver
 
     if (active_module)
       group['ActiveModule'] = active_module.fullname
+    end
+
+    if framework.db.active
+      unless framework.db.workspace.default?
+        group['ActiveWorkspace'] = framework.db.workspace.name
+      end
     end
 
     # Save it

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -392,11 +392,7 @@ class Driver < Msf::Ui::Driver
           when 'activeworkspace'
             if framework.db.active
               workspace = framework.db.find_workspace(v)
-              if workspace
-                framework.db.workspace = workspace
-              else
-                framework.db.workspace = framework.db.add_workspace(v)
-              end
+              framework.db.workspace = workspace if workspace
             end
         end
       }


### PR DESCRIPTION
**Feature description:**

Resolves #3804.

**Verification steps:**
- [x] `workspace -a not_default`
- [x] `save`
- [x] `^D`
- [x] `!!`
- [x] `workspace`
- [x] `* not_default`

**Sample run:**

```
msf > workspace -a not_default
[*] Added workspace: not_default
msf > save
Saved configuration to: /home/wvu/.msf4/config
msf > wvu@kharak:~/metasploit-framework:feature/workspace$ !!
./msfconsole -qL
msf > workspace 
  default
* not_default
msf > 
```
