### PR TITLE
Add SSH root password 'arcsight' for HP ArcSight Logger

### DIFF
--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1002,3 +1002,4 @@ sq!us3r
 adminpasswd
 raspberry
 74k&^*nh#$
+arcsight


### PR DESCRIPTION
The default password for root is 'arcsight' for HP ArcSight Logger. Found in the trial VM (CentOS release 6.5)

Sort-of a proof (had to mask the IPs):

```
sinn3r@ubuntu:~$ sshpass -p 'arcsight' ssh root@xxx.xxx.xxx.xxx
Last login: Thu Apr  2 04:21:18 2015 from xxx.xxx.xxx.xxx
[root@logger ~]#
```
