### PR TITLE
add missing data to loginscanner results

### DIFF
--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -24,7 +24,14 @@ module Metasploit
         # @param credential [Metasploit::Framework::Credential] The credential object
         # @return [Result]
         def attempt_login(credential)
-          result_opts = { credential: credential }
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
 
           begin
             status = try_login(credential)

--- a/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
+++ b/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
@@ -95,7 +95,14 @@ module Metasploit
         # @param credential [Metasploit::Framework::Credential] The credential object
         # @return [Result] A Result object indicating success or failure
         def attempt_login(credential)
-          result_opts = { credential: credential }
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
 
           begin
             result_opts.merge!(get_login_state(credential.public, credential.private))


### PR DESCRIPTION
the chef web ui and symantec web gateway
loginscanners do not save the target(host/port/proto) info
in the Result object. This can cause modules to break as they
expected the Result to contain that information

MSP-12499
