### PR TITLE
Fix up build and missing uri_checksum stuff

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -1,8 +1,8 @@
 # -*- coding: binary -*-
 require 'rex/io/stream_abstraction'
 require 'rex/sync/ref'
-require 'msf/core/handler/reverse_http/uri_checksum'
 require 'rex/payloads/meterpreter/patch'
+require 'rex/payloads/meterpreter/uri_checksum'
 require 'rex/parser/x509_certificate'
 require 'msf/core/payload/windows/verify_ssl'
 
@@ -17,7 +17,7 @@ module Handler
 module ReverseHttp
 
   include Msf::Handler
-  include Msf::Handler::ReverseHttp::UriChecksum
+  include Rex::Payloads::Meterpreter::UriChecksum
   include Msf::Payload::Windows::VerifySsl
 
   #

--- a/lib/msf/core/handler/reverse_http/stageless.rb
+++ b/lib/msf/core/handler/reverse_http/stageless.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'rex/parser/x509_certificate'
+require 'rex/payloads/meterpreter/uri_checksum'
 
 module Msf
 
@@ -17,6 +18,7 @@ module Msf
 module Handler::ReverseHttp::Stageless
 
   include Msf::Payload::Windows::VerifySsl
+  include Rex::Payloads::Meterpreter::UriChecksum
 
   def initialize_stageless
     register_options([
@@ -25,7 +27,7 @@ module Handler::ReverseHttp::Stageless
   end
 
   def generate_stageless(&block)
-    checksum = generate_uri_checksum(Handler::ReverseHttp::UriChecksum::URI_CHECKSUM_CONN)
+    checksum = generate_uri_checksum(URI_CHECKSUM_CONN)
     rand = Rex::Text.rand_text_alphanumeric(16)
     url = "https://#{datastore['LHOST']}:#{datastore['LPORT']}/#{checksum}_#{rand}/"
 

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -99,14 +99,14 @@ module Payload::Windows::ReverseHttp
       raise ArgumentError, "Minimum StagerURILength is 5"
     end
 
-    "/" + generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITW, uri_req_len)
+    "/" + generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITW, uri_req_len)
   end
 
   #
   # Generate the URI for the initial stager
   #
   def generate_small_uri
-    "/" + generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITW)
+    "/" + generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITW)
   end
 
   #

--- a/lib/rex/payloads/meterpreter/uri_checksum.rb
+++ b/lib/rex/payloads/meterpreter/uri_checksum.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
-module Msf
-  module Handler
-    module ReverseHttp
+module Rex
+  module Payloads
+    module Meterpreter
       module UriChecksum
 
         #

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -54,7 +54,7 @@ module Metasploit3
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
     c << "/"
-    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ, uri_req_len)
+    c << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
     c << "\n"
 
     c

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -56,7 +56,7 @@ module Metasploit3
     c << "URL=https://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
     c << "/"
-    c << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITJ, uri_req_len)
+    c << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
     c << "\n"
 
     c

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -106,7 +106,7 @@ module Metasploit3
       uri_req_len = 5
     end
 
-    generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITP, uri_req_len)
+    generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITP, uri_req_len)
   end
 
 end

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -120,7 +120,7 @@ module Metasploit3
       uri_req_len = 5
     end
 
-    generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITP, uri_req_len)
+    generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITP, uri_req_len)
   end
 
 end

--- a/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
+++ b/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
@@ -99,7 +99,7 @@ module Metasploit3
   def generate
     p = super
     i = p.index("/12345\x00")
-    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITW) + "\x00"
+    u = "/" + generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITW) + "\x00"
     p[i, u.length] = u
     p + datastore['LHOST'].to_s + "\x00"
   end

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -6,7 +6,6 @@
 
 require 'msf/core'
 require 'msf/core/handler/reverse_https'
-#require 'msf/core/payload/windows/x64/reverse_https'
 
 module Metasploit3
 

--- a/spec/lib/rex/payloads/meterpreter/uri_checksum_spec.rb
+++ b/spec/lib/rex/payloads/meterpreter/uri_checksum_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'msf/core/handler/reverse_http/uri_checksum'
+require 'rex/payloads/meterpreter/uri_checksum'
 
-describe Msf::Handler::ReverseHttp::UriChecksum do
+describe Rex::Payloads::Meterpreter::UriChecksum do
    class DummyClass
-     include Msf::Handler::ReverseHttp::UriChecksum
+     include Rex::Payloads::Meterpreter::UriChecksum
    end
 
   subject(:dummy_object) { DummyClass.new }
@@ -23,7 +23,7 @@ describe Msf::Handler::ReverseHttp::UriChecksum do
     context 'when it fails to generate a random URI' do
       it 'should use the pre-calculated checksum string' do
         Rex::Text.stub(:checksum8) { false }
-        expect(dummy_object.generate_uri_checksum(checksum_value)).to eq Msf::Handler::ReverseHttp::UriChecksum::URI_CHECKSUM_PRECALC[checksum_value]
+        expect(dummy_object.generate_uri_checksum(checksum_value)).to eq Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_PRECALC[checksum_value]
       end
 
     end


### PR DESCRIPTION
Somehow this made it into a merge when it shouldn't have. This fix moves the URI checksum module to where it needs to be and updates all the references where required. This will result in a class with the dynamic transport branch, but I can fix that after.
