### PR TITLE
Support and embed payload UUIDs

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -219,8 +219,8 @@ protected
     uuid = info[:uuid] || Msf::Payload::UUID.new
 
     # Configure the UUID architecture and payload if necessary
-    uuid.arch      = obj.arch if uuid.arch.nil?
-    uuid.platform  = obj.platform if uuid.platform.nil?
+    uuid.arch      ||= obj.arch
+    uuid.platform  ||= obj.platform
 
     print_status "#{cli.peerhost}:#{cli.peerport} Request received for #{req.relative_resource}... (UUID:#{uuid.to_s})"
 


### PR DESCRIPTION
This changeset adds support for embedding UUIDs into payloads and displaying the connected UUID in the `sessions -l -v` output. This PR handles most of the stagers and payloads that work over HTTP & HTTPS. This work is backwards-compatible with older stagers (64-bit reverse_http for example).

In addition, this PR adds two new datastore options for stagers and payloads using the HTTP/HTTPS transports:
- `PayloadUUIDSeed`: A human-readable string that is hashed and used to calculate a Payload UID
- `PayloadUUIDRaw`: An 8-byte raw Payload UID specified as a 16-byte hex string

A UUID is made up of 4 distinct fields:
- `puid`: The Payload UID is a possibly-random 8-byte prefix identifying a specific generated payload. This is randomly generated or derived from `PayloadUUIDSeed` or `PayloadUUIDRaw`
- `arch`: The Architecture ID corresponds to a table of constants that map to every architecture known within Metasploit. This isn't perfect due to weirdness within Metasploit (X64 isn't exactly X86_64)
- `platform`: The Platform ID corresponds to a table of constants that map to every platformknown within Metasploit. If the payload supports multiple platforms, the first one in the PlatformList will be stored in the UUID.
- `timestamp`: The Timestamp is a Unix time value (UTC) of when the payload was generated. Values prior to 2015-01-01 or too far into the future are treated as invalid and ignored.

These four values are then obfuscated using two random bytes via XOR. These two random bytes result in a fairly random 16-byte UUID value. For HTTP/HTTPS transports, these 16 bytes are further encoded as a 22-byte Base64URL string. 

Generated stagers and payloads now automatically embed a UUID if there is enough room. In the case of HTTP/HTTPS transports, the first 22 bytes of the URL (excluding non-Base64URL bytes) are treated as the UUID. If the UUID looks "invalid" (bad arch, platform, timestamp), only the Payload UID will be extracted, preserving backwards compatibility with existing payloads.

Stagers using HTTP/HTTPS transports will reuse the UUID during the switch from "init" to "connection" URLs, preserving the UUID between Metasploit instances and the staging process. The currently associated UUID can be seed with the `-v` flag to the `sessions -l` command.

There is still quite a bit of work left to do before UUIDs become practical, but this PR creates the initial path, and opens the door to smaller future PRs to add support to specific stagers and payloads. The end goal would be to enable universal handlers that can detect the architecture and platform on the fly and make it easy to track exactly what payload connected back to a shared listener.
