### PR TITLE
Make 'ls' and 'download' easier to use, add glob and recursive options

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -991,7 +991,7 @@ def stdapi_fs_ls(request, response):
 	path = packet_get_tlv(request, TLV_TYPE_DIRECTORY_PATH)['value']
 	path = os.path.abspath(unicode(path))
 	glob = '*'
-	if '*' in path:
+	if any((c in ['*','[','?']) for c in path):
 		glob = os.path.basename(path)
 		path = os.path.dirname(path)
 	for file_name in filter(lambda f: fnmatch.fnmatch(f, glob), os.listdir(path)):

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -990,9 +990,11 @@ def stdapi_fs_getwd(request, response):
 def stdapi_fs_ls(request, response):
 	path = packet_get_tlv(request, TLV_TYPE_DIRECTORY_PATH)['value']
 	path = os.path.abspath(unicode(path))
-	dir_contents = os.listdir(path)
-	dir_contents.sort()
-	for file_name in dir_contents:
+	glob = '*'
+	if '*' in path:
+		glob = os.path.basename(path)
+		path = os.path.dirname(path)
+	for file_name in filter(lambda f: fnmatch.fnmatch(f, glob), os.listdir(path)):
 		file_path = os.path.join(path, file_name)
 		response += tlv_pack(TLV_TYPE_FILE_NAME, file_name)
 		response += tlv_pack(TLV_TYPE_FILE_PATH, file_path)

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -52,9 +52,10 @@ class Dir < Rex::Post::Dir
   #
   # Enumerates all of the files/folders in a given directory.
   #
-  def Dir.entries(name = getwd)
+  def Dir.entries(name = getwd, glob = nil)
     request = Packet.create_request('stdapi_fs_ls')
     files   = []
+    name = name + ::File::SEPARATOR + glob if glob
 
     request.add_tlv(TLV_TYPE_DIRECTORY_PATH, client.unicode_filter_decode(name))
 
@@ -194,9 +195,9 @@ class Dir < Rex::Post::Dir
   # Downloads the contents of a remote directory a
   # local directory, optionally in a recursive fashion.
   #
-  def Dir.download(dst, src, recursive = false, force = true, &stat)
+  def Dir.download(dst, src, recursive = false, force = true, glob = nil, &stat)
 
-    self.entries(src).each { |src_sub|
+    self.entries(src, glob).each { |src_sub|
       dst_item = dst + ::File::SEPARATOR + client.unicode_filter_encode(src_sub)
       src_item = src + client.fs.file.separator + client.unicode_filter_encode(src_sub)
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -231,7 +231,7 @@ class Dir < Rex::Post::Dir
         end
 
         stat.call('mirroring', src_item, dst_item) if (stat)
-        download(dst_item, src_item, recursive, force, &stat)
+        download(dst_item, src_item, recursive, force, glob, &stat)
         stat.call('mirrored', src_item, dst_item) if (stat)
       end
     }

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -210,8 +210,8 @@ class Dir < Rex::Post::Dir
       if (src_stat.file?)
         stat.call('downloading', src_item, dst_item) if (stat)
         begin
-          client.fs.file.download(dst_item, src_item)
-          stat.call('downloaded', src_item, dst_item) if (stat)
+          result = client.fs.file.download_file(dst_item, src_item)
+          stat.call(result, src_item, dst_item) if (stat)
         rescue ::Rex::Post::Meterpreter::RequestError => e
           if force
             stat.call('failed', src_item, dst_item) if (stat)

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -285,10 +285,8 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       end
 
       stat.call('downloading', src, dest) if (stat)
-
-      download_file(dest, src)
-
-      stat.call('downloaded', src, dest) if (stat)
+      result = download_file(dest, src)
+      stat.call(result, src, dest) if (stat)
     }
   end
 
@@ -297,6 +295,17 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   #
   def File.download_file(dest_file, src_file)
     src_fd = client.fs.file.new(src_file, "rb")
+
+    # Check for changes
+    src_stat = client.fs.filestat.new(src_file)
+    if ::File.exists?(dest_file)
+      dst_stat = ::File.stat(dest_file)
+      if src_stat.size == dst_stat.size and src_stat.mtime == dst_stat.mtime
+        return 'skipped'
+      end
+    end
+
+    # Make the destination path if necessary
     dir = ::File.dirname(dest_file)
     ::FileUtils.mkdir_p(dir) if dir and not ::File.directory?(dir)
 
@@ -312,6 +321,10 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
       src_fd.close
       dst_fd.close
     end
+
+    # Clone the times from the remote file
+    ::File.utime(src_stat.atime, src_stat.mtime, dest_file)
+    return 'download'
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -265,6 +265,10 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     stat.call('uploaded', src_file, dest_file) if (stat)
   end
 
+  def File.is_glob?(name)
+    /\*|\[|\?/ === name
+  end
+
   #
   # Download one or more files from the remote computer to the local
   # directory supplied in destination.

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -300,7 +300,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     src_stat = client.fs.filestat.new(src_file)
     if ::File.exists?(dest_file)
       dst_stat = ::File.stat(dest_file)
-      if src_stat.size == dst_stat.size and src_stat.mtime == dst_stat.mtime
+      if src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime
         return 'skipped'
       end
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -412,8 +412,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     order = args.include?('-r') ? :reverse : :forward
     args.delete('-r')
 
-    recursive = args.include?('-R')
-    args.delete('-R')
+    recursive = args.delete('-R')
 
     args.delete('-l')
 
@@ -434,7 +433,11 @@ class Console::CommandDispatcher::Stdapi::Fs
     columns = [ 'Mode', 'Size', 'Type', 'Last modified', 'Name' ]
     columns.insert(4, 'Short Name') if short
 
-    stat = client.fs.file.stat(/\*|\[|\?/ === path.to_s ? Pathname.new(path).dirname : path)
+    stat_path = path
+    if /\*|\[|\?/ === path.to_s
+      stat_path = ::File.dirname(path)
+    end
+    stat = client.fs.file.stat(stat_path)
     if stat.directory?
       list_path(path, columns, sort, order, short, recursive)
     else

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -99,7 +99,7 @@ class Console::CommandDispatcher::Stdapi::Fs
   #
   # Search for files.
   #
-  def cmd_search( *args )
+  def cmd_search(*args)
 
     root    = nil
     glob    = nil
@@ -115,37 +115,37 @@ class Console::CommandDispatcher::Stdapi::Fs
     opts.parse(args) { | opt, idx, val |
       case opt
         when "-h"
-          print_line( "Usage: search [-d dir] [-r recurse] -f pattern" )
-          print_line( "Search for files." )
-          print_line( opts.usage )
+          print_line "Usage: search [-d dir] [-r recurse] -f pattern"
+          print_line "Search for files."
+          print_line opts.usage
           return
         when "-d"
           root = val
         when "-f"
           glob = val
         when "-r"
-          recurse = false if( val =~ /^(f|n|0)/i )
+          recurse = false if val =~ /^(f|n|0)/i
       end
     }
 
-    if( not glob )
-      print_error( "You must specify a valid file glob to search for, e.g. >search -f *.doc" )
+    if not glob
+      print_error "You must specify a valid file glob to search for, e.g. >search -f *.doc"
       return
     end
 
-    files = client.fs.file.search( root, glob, recurse )
+    files = client.fs.file.search(root, glob, recurse)
 
-    if( not files.empty? )
-      print_line( "Found #{files.length} result#{ files.length > 1 ? 's' : '' }..." )
+    if not files.empty?
+      print_line "Found #{files.length} result#{ files.length > 1 ? 's' : '' }..."
       files.each do | file |
-        if( file['size'] > 0 )
-          print( "    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']} (#{file['size']} bytes)\n" )
+        if file['size'] > 0
+          print "    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']} (#{file['size']} bytes)\n"
         else
-          print( "    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']}\n" )
+          print "    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']}\n"
         end
       end
     else
-      print_line( "No files matching your search were found." )
+      print_line "No files matching your search were found."
     end
 
   end
@@ -343,7 +343,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       end
     }
 
-    return true
+    true
   end
 
   #
@@ -430,8 +430,8 @@ class Console::CommandDispatcher::Stdapi::Fs
       end
     end
 
-    if (items > 0)
-      print("\n" + tbl.to_s + "\n")
+    if items > 0
+      print_line(tbl.to_s)
     else
       print_line("No entries exist in #{path}")
     end
@@ -463,13 +463,13 @@ class Console::CommandDispatcher::Stdapi::Fs
 
     # Check for cries of help
     if args.length > 1 || args.any? { |a| a[0] == '-' }
-      print_line('Usage: ls [dir] [-x] [-S] [-t] [-r]')
-      print_line('   -x Show short file names')
-      print_line('   -S Sort by size')
-      print_line('   -t Sort by time modified')
-      print_line('   -r Reverse sort order')
-      print_line('   -l List in long format (default)')
-      print_line('   -R Recursively list subdirectories encountered.')
+      print_line 'Usage: ls [dir] [-x] [-S] [-t] [-r]'
+      print_line '   -x Show short file names'
+      print_line '   -S Sort by size'
+      print_line '   -t Sort by time modified'
+      print_line '   -r Reverse sort order'
+      print_line '   -l List in long format (default)'
+      print_line '   -R Recursively list subdirectories encountered.'
       return true
     end
 
@@ -479,14 +479,22 @@ class Console::CommandDispatcher::Stdapi::Fs
     columns.insert(4, 'Short Name') if short
 
     stat_path = path
-    if client.fs.file.is_glob?(path)
+
+    # Check session capabilities
+    is_glob = client.fs.file.is_glob?(path)
+    if is_glob
+      if !client.commands.include?('stdapi_fs_search')
+        print_line 'File globbing not supported with this session'
+        return
+      end
       stat_path = ::File.dirname(path)
     end
+
     stat = client.fs.file.stat(stat_path)
     if stat.directory?
       list_path(path, columns, sort, order, short, recursive)
     else
-      print_line("#{stat.prettymode}  #{stat.size}  #{stat.ftype[0,3]}  #{stat.mtime}  #{path}")
+      print_line "#{stat.prettymode}  #{stat.size}  #{stat.ftype[0,3]}  #{stat.mtime}  #{path}"
     end
 
     return true

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -317,6 +317,7 @@ class Console::CommandDispatcher::Stdapi::Fs
             dest_path = src_path.tr(src_separator, ::File::SEPARATOR)
 
             client.fs.file.download(dest_path, src_path) do |step, src, dst|
+              puts step
               print_status("#{step.ljust(11)}: #{src} -> #{dst}")
               client.framework.events.on_session_download(client, src, dest) if msf_loaded?
             end
@@ -336,7 +337,7 @@ class Console::CommandDispatcher::Stdapi::Fs
           end
         elsif (stat.file?)
           client.fs.file.download(dest, src) do |step, src, dst|
-            print_status("#step.ljust(11)}: #{src} -> #{dst}")
+            print_status("#{step.ljust(11)}: #{src} -> #{dst}")
             client.framework.events.on_session_download(client, src, dest) if msf_loaded?
           end
         end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -386,7 +386,13 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   alias cmd_getlwd cmd_lpwd
 
-  def list_path(path, columns, sort, order, short, recursive = false)
+  def list_path(path, columns, sort, order, short, recursive = false, depth = 0)
+
+    # avoid infinite recursion
+    if depth > 100
+      return
+    end
+
     tbl = Rex::Ui::Text::Table.new(
       'Header'  => "Listing: #{path}",
       'SortIndex' => columns.index(sort),
@@ -423,7 +429,7 @@ class Console::CommandDispatcher::Stdapi::Fs
             child_path = path + ::File::SEPARATOR + fname
           end
           begin
-            list_path(child_path, columns, sort, order, short, recursive)
+            list_path(child_path, columns, sort, order, short, recursive, depth + 1)
           rescue RequestError
           end
         end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -434,7 +434,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     columns = [ 'Mode', 'Size', 'Type', 'Last modified', 'Name' ]
     columns.insert(4, 'Short Name') if short
 
-    stat = client.fs.file.stat(path.to_s.include?('*') ? Pathname.new(path).dirname : path)
+    stat = client.fs.file.stat(/\*|\[|\?/ === path.to_s ? Pathname.new(path).dirname : path)
     if stat.directory?
       list_path(path, columns, sort, order, short, recursive)
     else

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -115,9 +115,9 @@ class Console::CommandDispatcher::Stdapi::Fs
     opts.parse(args) { | opt, idx, val |
       case opt
         when "-h"
-          print_line "Usage: search [-d dir] [-r recurse] -f pattern"
-          print_line "Search for files."
-          print_line opts.usage
+          print_line("Usage: search [-d dir] [-r recurse] -f pattern")
+          print_line("Search for files.")
+          print_line(opts.usage)
           return
         when "-d"
           root = val
@@ -129,23 +129,23 @@ class Console::CommandDispatcher::Stdapi::Fs
     }
 
     if not glob
-      print_error "You must specify a valid file glob to search for, e.g. >search -f *.doc"
+      print_error("You must specify a valid file glob to search for, e.g. >search -f *.doc")
       return
     end
 
     files = client.fs.file.search(root, glob, recurse)
 
     if not files.empty?
-      print_line "Found #{files.length} result#{ files.length > 1 ? 's' : '' }..."
+      print_line("Found #{files.length} result#{ files.length > 1 ? 's' : '' }...")
       files.each do | file |
         if file['size'] > 0
-          print "    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']} (#{file['size']} bytes)\n"
+          print("    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']} (#{file['size']} bytes)\n")
         else
-          print "    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']}\n"
+          print("    #{file['path']}#{ file['path'].empty? ? '' : '\\' }#{file['name']}\n")
         end
       end
     else
-      print_line "No files matching your search were found."
+      print_line("No files matching your search were found.")
     end
 
   end
@@ -242,9 +242,9 @@ class Console::CommandDispatcher::Stdapi::Fs
 
 
   def cmd_download_help
-    print_line "Usage: download [options] src1 src2 src3 ... destination"
+    print_line("Usage: download [options] src1 src2 src3 ... destination")
     print_line
-    print_line "Downloads remote files and directories to the local machine."
+    print_line("Downloads remote files and directories to the local machine.")
     print_line @@download_opts.usage
   end
 
@@ -501,7 +501,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     if stat.directory?
       list_path(path, columns, sort, order, short, recursive)
     else
-      print_line "#{stat.prettymode}  #{stat.size}  #{stat.ftype[0,3]}  #{stat.mtime}  #{path}"
+      print_line("#{stat.prettymode}  #{stat.size}  #{stat.ftype[0,3]}  #{stat.mtime}  #{path}")
     end
 
     return true
@@ -552,9 +552,9 @@ class Console::CommandDispatcher::Stdapi::Fs
   end
 
   def cmd_upload_help
-    print_line "Usage: upload [options] src1 src2 src3 ... destination"
+    print_line("Usage: upload [options] src1 src2 src3 ... destination")
     print_line
-    print_line "Uploads local files and directories to the remote machine."
+    print_line("Uploads local files and directories to the remote machine.")
     print_line @@upload_opts.usage
   end
 


### PR DESCRIPTION
This PR adds a couple of common features to 'ls' and 'download' from a meterpreter prompt. For the 'ls' command, it adds '-R', which does a recursive walk through subdirectories just like unix ls. The second is initial support for globing / pattern matching. This relies on the underlying meterpreter also having support for glob matching, which the Windows C meterpreter already does.

For the 'download' command, this also adds file globbing for matching on patterns to. It also adds a couple of options. If a recursive pattern match is specified, the search API is used if available to find the files. Also, the remote file timestamp is preserved locally. This info along with the size is used to determine if a file should be downloaded or not. This allows a sort of directory mirroring (though it could still probably be improved if search could stat at the same time).

This also adds support to python meterpreter for globbing on ls. It allows 'ls -l' to be accepted without any errors. I have a patch to posix meterpreter to add support, but its underlying libc doesn't have 'glob', so some work need to go toward updating that or extracting a glob into it first.
# Verification
- [x] 'ls -R' works on any meterpreter (support is in MSF, not the meterpreters themselves)
- [x] 'ls -l' is accepted (this is the default format style anyway)
- [x] 'ls *.pattern' matches as expected with python meterpreter
- [x] 'ls *.pattern' matches as expected with windows meterpreter
- [x] 'download _pattern_' downloads files matching the pattern
- [x] 'download -r _pattern_' mirrors files matching the pattern
- [x] unadorned ls invocations work as expected
