### PR TITLE
Add browser_autopwn info to firefox_proxy_prototype

### DIFF
--- a/modules/exploits/multi/browser/firefox_proxy_prototype.rb
+++ b/modules/exploits/multi/browser/firefox_proxy_prototype.rb
@@ -13,6 +13,14 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Remote::FirefoxPrivilegeEscalation
 
+  autopwn_info({
+    :ua_name    => HttpClients::FF,
+    :ua_minver  => "31.0",
+    :ua_maxver  => "34.0",
+    :javascript => true,
+    :rank       => ManualRanking
+  })
+
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Firefox Proxy Prototype Privileged Javascript Injection',


### PR DESCRIPTION
Resolve https://github.com/rapid7/metasploit-framework/issues/5079

Error was due to missing browser_autopwn info.
