### PR TITLE
Add workspace to prompt format options

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -178,6 +178,9 @@ module Shell
           input.prompt.gsub!(/%J/, framework.jobs.length.to_s)
           input.prompt.gsub!(/%L/, Rex::Socket.source_address("50.50.50.50"))
           input.prompt.gsub!(/%D/, ::Dir.getwd)
+          if framework.db && framework.db.workspace
+            input.prompt.gsub!(/%W/, framework.db.workspace.name)
+          end
           self.init_prompt = input.prompt
         end
 


### PR DESCRIPTION
# Verification
- [x] `setg Prompt %red%T %grn%J %blu%S %yel%W%clr`
- [x] **Verify** see your workspace in the prompt in yellow
- [x] `workspace -a foo`
- [x] **Verify** see `foo` in the prompt in yellow
- [x] `workspace -d foo`
- [x] **Verify** see `default` in the prompt in yellow
