### PR TITLE
Fix uninitialized constant COMPAT_OLD_DHGEX

### DIFF
--- a/lib/net/ssh/transport/constants.rb
+++ b/lib/net/ssh/transport/constants.rb
@@ -27,5 +27,11 @@ module Net; module SSH; module Transport
     KEXDH_INIT                = 30
     KEXDH_REPLY               = 31
 
+        #--
+        # Compatibility flags
+        #++
+
+        COMPAT_OLD_DHGEX          = 0x1
+
   end
 end; end; end

--- a/lib/net/ssh/transport/constants.rb
+++ b/lib/net/ssh/transport/constants.rb
@@ -27,11 +27,11 @@ module Net; module SSH; module Transport
     KEXDH_INIT                = 30
     KEXDH_REPLY               = 31
 
-        #--
-        # Compatibility flags
-        #++
+    #--
+    # Compatibility flags
+    #++
 
-        COMPAT_OLD_DHGEX          = 0x1
+    COMPAT_OLD_DHGEX          = 0x1
 
   end
 end; end; end


### PR DESCRIPTION
Needed in `lib/net/ssh/transport/session.rb`. Removed in 1664a4b5e83959d189df16673c2fa0c85e0493b1.

Fixes #5085.
