### PR TITLE
Fix -i in connect command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -629,6 +629,8 @@ class Core
       n2c.kill
     end
 
+    c2n.join
+    n2c.join
 
     sock.close rescue nil
     infile.close if infile


### PR DESCRIPTION
Fix #5074 - missing thread joins resulted in the socket being closed prematurely

```
msf > cat /tmp/r
[*] exec: cat /tmp/r

HEAD / HTTP/1.0

msf > connect -i /tmp/r google.ca 80
[*] Connected to google.ca:80
HTTP/1.0 302 Found
Cache-Control: private
Content-Type: text/html; charset=UTF-8
Location: http://www.google.ca/?gfe_rd=cr&ei=pusiVemTHIeN8Qea0oHABA
Content-Length: 258
Date: Mon, 06 Apr 2015 20:25:10 GMT
Server: GFE/2.0
Alternate-Protocol: 80:quic,p=0.5

msf > connect localhost 22
[*] Connected to localhost:22
SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2
hi there
Protocol mismatch.
msf > connect -z localhost 22
[*] Connected to localhost:22
msf > 
```
