### PR TITLE
Remove unneccesary match_set in MatchResult.create

### DIFF
--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -95,7 +95,6 @@ module Msf::DBManager::Session
       if session.exploit.user_data_is_match?
         MetasploitDataModels::AutomaticExploitation::MatchResult.create!(
           match: session.exploit.user_data[:match],
-          match_set: session.exploit.user_data[:match_set],
           run: session.exploit.user_data[:run],
           state: 'succeeded',
         )


### PR DESCRIPTION
PR fixes UknownAttribute error for match_set in Rails 4. Rails 3 ignored the extra match_set attribute

MSP-12516
## Validation
- [ ] `SPEC=spec/lib/msf/db_manager_spec.rb rake spec`
- [ ] All should pass
