### PR TITLE
Instantiate the module that created our session to get its name if we don't have cache yet

### DIFF
--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -125,6 +125,11 @@ module Msf::DBManager::Session
         mod_fullname = session.via_exploit
       end
       mod_detail = ::Mdm::Module::Detail.find_by_fullname(mod_fullname)
+      if mod_detail.nil?
+        # Then the cache isn't built yet, take the hit for instantiating the
+        # module
+        mod_detail = framework.modules.create(mod_fullname)
+      end
       mod_name = mod_detail.name
 
       vuln_info = {


### PR DESCRIPTION
Fixes #5086 
# Verification
- [x] set up an exploit and make sure it will get you a session. I used multi/misc/java_rmi_server.
- [x] `save`
- [x] `exit`
- [x] `rake db:drop db:create db:migrate`
- [x] Run the module right away to make sure we beat the cache rebuild: `msfconsole -x 'run -z'`
- [x] `vulns`
  - [x] **Verify** you have a vuln
