### PR TITLE
Switch the go_pro advice to something less faily

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3188,7 +3188,7 @@ class Core
       if is_metasploit_service_running
         launch_metasploit_browser
       else
-        print_error "Metasploit services aren't running. Type 'service metasploit start' and try again."
+        print_error "Metasploit services aren't running yet. Type 'service metasploit restart,' or try again in a moment."
       end
     end
     return true


### PR DESCRIPTION
As described on #5018, on Kali 1.1.0a and thereabouts, if you type `service metasploit start` twice in quick succession, you end up horking up the startup process. `service metasploit restart`, turns out, tends to be more reliable.

All this fix does is alert the user to a better mechanism to solve this.

Note, this doesn't fix completely #5018. It's merely a documentation change. A proper fix will need to happen in release engineering and the init scripts responsible for wrapping the service.

@kgray-r7 should confirm that this procedure is, in fact, better.
## Verification
- [ ] On a fresh boot of Kali linux, latest, type `msfconsole`
- [ ] Be convinced that `go_pro` sounds like fun.
- [ ] Notice the error message, since you haven't started the metasploit services yet.
- [ ] Follow the instructions and use `service metasploit restart` instead of `start`.
- [ ] In five seconds, do it again.
- [ ] In five-ish minutes -- plenty of time to start -- do it a third time.
## Expected results:
- [ ] The first attempt should fail
- [ ] The second attempt should fail
- [ ] The third attempt should succeed.
