### PR TITLE
fix deletekey API usage from the meterpreter CLI

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
@@ -163,7 +163,11 @@ class RegistryKey
   # Returns the path to the key.
   #
   def to_s
-    return self.root_key.to_s + "\\" + self.base_key
+    if self.base_key.nil?
+      self.root_key.to_s + "\\"
+    else
+      self.root_key.to_s + "\\" + self.base_key
+    end
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -641,11 +641,11 @@ class Console::CommandDispatcher::Stdapi::Sys
         when "deletekey"
           open_key = nil
           if not rem
-            open_key = client.sys.registry.open_key(root_key, base_key, KEY_WRITE + wowflag)
+            open_key = client.sys.registry.open_key(root_key, nil, KEY_WRITE + wowflag)
           else
             remote_key = client.sys.registry.open_remote_key(rem, root_key)
             if remote_key
-              open_key = remote_key.open_key(base_key, KEY_WRITE + wowflag)
+              open_key = remote_key.open_key(nil, KEY_WRITE + wowflag)
             end
           end
           open_key.delete_key(base_key)


### PR DESCRIPTION
There is an old-looking bug where the deletekey command opens the key it tries
to delete, then deletes the same key name again. Basically, it uses the wrong
level of indirection. This fixes #5099 
# Verification Steps
- [x] Start a meterpreter windows session
- [x] create and verify a test key, e.g. 'reg createkey -k HKCU\Monkey'
- [x] delete and verify the test key, e.g. 'reg deletekey -k HKCU\Monkey'

```
meterpreter > reg createkey -k HKCU\\Monkey
Successfully created key: HKCU\Monkey
meterpreter > reg deletekey -k HKCU\\Monkey
Successfully deleted key: HKCU\Monkey
```
