### PR TITLE
Fix IPv6 issues in staged and stageless

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -91,7 +91,7 @@ module ReverseHttp
   def payload_uri(req)
     if req and req.headers and req.headers['Host'] and not datastore['OverrideRequestHost']
       callback_host = req.headers['Host']
-    elsif ipv6?
+    elsif Rex::Socket.is_ipv6?(datastore['LHOST'])
       callback_host = "[#{datastore['LHOST']}]:#{datastore['LPORT']}"
     else
       callback_host = "#{datastore['LHOST']}:#{datastore['LPORT']}"

--- a/lib/msf/core/handler/reverse_http/stageless.rb
+++ b/lib/msf/core/handler/reverse_http/stageless.rb
@@ -35,7 +35,9 @@ module Handler::ReverseHttp::Stageless
       raise ArgumentError, "Stageless generation requires an ssl argument"
     end
 
-    url = "http#{opts[:ssl] ? "s" : ""}://#{datastore['LHOST']}:#{datastore['LPORT']}"
+    host = datastore['LHOST']
+    host = "[#{host}]" if Rex::Socket.is_ipv6?(host)
+    url = "http#{opts[:ssl] ? "s" : ""}://#{host}:#{datastore['LPORT']}"
     url << "#{generate_uri_uuid_mode(:connect)}/"
 
     # invoke the given function to generate the architecture specific payload


### PR DESCRIPTION
While mucking around with an MSF install sitting behind Nginx, I found:
- Stageless HTTP payloads weren't adding brackets around IPv6 hosts.
- Staged HTTP handler was using an undefined function to check for IPv6 addresses when host header overriding was disabled.

This small patch makes sure that stageless IPv6 HTTP hosts have brackets in place correctly. It also fixes the issue where a missing `ipv6?` function in the staged handler was causing issues when `OverideRequestHost` is set to `true`
## Crash Fix Verification
- [ ] Put a proxy like nginx in place which forwards all https requests on port `A` to port `B`
- [ ] Create meterpreter payload with `reverse_https` with `LPORT` set to  `A`
- [ ] Create associated listener for `reverse_https` with `LPORT` set to `A`, `ReverseListenerBindPort` set to `B` and `OverrideRequestHost` set to `true`
- [ ] Run the payload, everything should work.

Before this fix, the setting above would throw an exception in MSF:

```
msf exploit(handler) > [*] xxx.xxx.xxx.xxx:40354 Request received for /8V4janjAoWipZahk_EPa9Q0yz3Tr75EjYw8uhQ1EjYu4S14LX22knZj2
dkuNuHXiKVojYhtPEIdlKfWO8S84Ig7gum1LtyeGYZVrbGin6YNI4rpwZMpZ6-LJOYlvUGAFi34fy4pZjI3MZA1OyWORaBpZRdm6ocLSV5-dDI4r1pDr1n9KQXKfTnB
wTh1uJGTS4kWxYd5eKGH9osR6_eyYqXmiFDrHI4DP_... (UUID:f15e236a78c0a168/x86=1/windows=1/2015-04-09T12:41:27Z)
[-] Exception handling request: undefined method `ipv6?' for #<#<Class:0x00000008a38bf0>:0x00000006ee2680>
```
### IPv6 usage verification
- [ ] Create a stageless HTTPS payload which makes use of an IPv6 address.
- [ ] Payload should work correctly.
