### PR TITLE
Missing `require 'metasploit/credential'`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.14.4)
+    metasploit-credential (0.14.3)
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.29.0)
       metasploit_data_models (~> 0.23.0)
@@ -120,7 +120,7 @@ GEM
       railties (< 4.0.0)
       rubyntlm
       rubyzip (~> 1.1)
-    metasploit-model (0.29.2)
+    metasploit-model (0.29.0)
       activesupport
       railties (< 4.0.0)
     metasploit_data_models (0.23.2)
@@ -175,7 +175,7 @@ GEM
     rb-readline-r7 (0.5.2.0)
     rdoc (3.12.2)
       json (~> 1.4)
-    recog (1.0.26)
+    recog (1.0.24)
       nokogiri
     redcarpet (3.1.2)
     rkelly-remix (0.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.14.3)
+    metasploit-credential (0.14.4)
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.29.0)
       metasploit_data_models (~> 0.23.0)
@@ -120,7 +120,7 @@ GEM
       railties (< 4.0.0)
       rubyntlm
       rubyzip (~> 1.1)
-    metasploit-model (0.29.0)
+    metasploit-model (0.29.2)
       activesupport
       railties (< 4.0.0)
     metasploit_data_models (0.23.2)
@@ -175,7 +175,7 @@ GEM
     rb-readline-r7 (0.5.2.0)
     rdoc (3.12.2)
       json (~> 1.4)
-    recog (1.0.24)
+    recog (1.0.26)
       nokogiri
     redcarpet (3.1.2)
     rkelly-remix (0.0.6)

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -59,14 +59,15 @@ module Metasploit
         end
       end
 
-      # Tries to `require 'metasploit/credential/creation'` and include it in the `including_module`.
+      # Tries to `require 'metasploit/credential'` and include `Metasploit::Credential::Creation` in the
+      # `including_module`.
       #
       # @param including_module [Module] `Class` or `Module` that wants to `include Metasploit::Credential::Creation`.
       # @return [void]
       def self.optionally_include_metasploit_credential_creation(including_module)
         optionally(
-            'metasploit/credential/creation',
-            "metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for #{including_module.name}",
+            'metasploit/credential',
+            "metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for #{including_module.name}"
         ) do
           including_module.send(:include, Metasploit::Credential::Creation)
         end


### PR DESCRIPTION
MSP-12529

While working on the Rails 4 upgrade it was discovered that metasploit-framework when trying to optionally `include Metasploit::Credential::Creation`, tries to optionally require 'metasploit/credential/creation', but does require the top-level require for the metasploit-credential gem, 'metasploit/credential', which is required by gem convention.  With metasploit-credential 0.14.4 this causes metasploit-framework to have a NameError because the 'metasploit/credential/creation' file no longer uses nested Modules to prevent partial definition of the outer Metasploit::Credential module:
1. `git clone git@github.com:limhoff-r7/metasploit-framework.git`
2. `cd metasploit-framework`
3. `git checkout 7442aa14392baa9bee801e31205fc59b8b56f465` (commit using metasploit-credential v0.14.4 without fix)
4. `bundle`
5. `rake db:drop db:create db:migrate`

Expected:
Migrations run

Actual:

```
rake aborted!
NameError: uninitialized constant Metasploit::Credential
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@metasploit-framework/gems/metasploit-credential-0.14.4/lib/metasploit/credential/creation.rb:4:in `<top (required)>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/metasploit/framework/require.rb:22:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/metasploit/framework/require.rb:22:in `optionally'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/metasploit/framework/require.rb:67:in `optionally_include_metasploit_credential_creation'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/metasploit/framework/require.rb:114:in `optionally_include_metasploit_credential_creation'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core/db_manager.rb:61:in `<class:DBManager>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core/db_manager.rb:23:in `<top (required)>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core/framework.rb:74:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core/framework.rb:74:in `<class:Framework>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core/framework.rb:25:in `<module:Msf>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core/framework.rb:17:in `<top (required)>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core.rb:44:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/msf/core.rb:44:in `<top (required)>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/metasploit/framework.rb:26:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/lib/metasploit/framework.rb:26:in `<top (required)>'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:85:in `require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:85:in `rescue in block in require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:68:in `block in require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:61:in `each'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:61:in `require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler.rb:133:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/config/application.rb:10:in `<top (required)>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/Rakefile:2:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/Rakefile:2:in `<top (required)>'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@metasploit-framework/bin/ruby_executable_hooks:15:in `eval'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@metasploit-framework/bin/ruby_executable_hooks:15:in `<main>'
LoadError: cannot load such file -- metasploit-framework
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:76:in `require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:72:in `each'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:72:in `block in require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:61:in `each'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler/runtime.rb:61:in `require'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@global/gems/bundler-1.7.6/lib/bundler.rb:133:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/config/application.rb:10:in `<top (required)>'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/Rakefile:2:in `require'
/Users/luke.imhoff/git/limhoff-r7/metasploit-framework/Rakefile:2:in `<top (required)>'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@metasploit-framework/bin/ruby_executable_hooks:15:in `eval'
/Users/luke.imhoff/.rvm/gems/ruby-2.1.5@metasploit-framework/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```

Commit https://github.com/rapid7/metasploit-framework/commit/8b56286e66f3980601243261d6d58b92fd8aa613 shows the fix against metasploit-credential 0.14.4 and commit https://github.com/rapid7/metasploit-framework/commit/eb9b5d9a35a1ed6822f2fefa809d4b350eed2b41 goes back to the original Gemfile.lock with metasploit-credential 0.14.3, proving the fix works for both versions of metasploit-credential.
# Verification Steps
- [x] VERIFY no changes to Gemfile.lock in this PR.
## Fix is needed with metasploit-credential v0.14.4
- [x] `git checkout 7442aa14392baa9bee801e31205fc59b8b56f465`
- [x] `bundle`
- [x] VERIFY `Gemfile.lock` contains metasploit-credential 0.14.4
- [x] `rake db:drop db:create db:migrate`
- [x] VERIFY migrations raise `NameError`
## Fix works with metasploit-credential v0.14.4
- [x] `git checkout 8b56286e66f3980601243261d6d58b92fd8aa613`
- [x] `bundle`
- [x] VERIFY `Gemfile.lock` contains metasploit-credential 0.14.4
- [x] `rake db:drop db:create db:migrate`
- [x] VERIFY migrations run
## Fix works with metasploit-credential v0.14.3
- [x] `git checkout eb9b5d9a35a1ed6822f2fefa809d4b350eed2b41` (this should be the HEAD of this PR)
- [x] `bundle`
- [x] VERIFY `Gemfile.lock` contains metasploit-credential 0.14.3
- [x] `rake db:drop db:create db:migrate`
- [x] VERIFY migrations run
