### PR TITLE
Fix #4866, msfvenom not properly handling platform & arch

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -144,8 +144,10 @@ module Msf
       if arch.blank?
         @arch = mod.arch.first
         cli_print "No Arch selected, selecting Arch: #{arch} from the payload"
+        datastore['ARCH'] = arch if mod.kind_of?(Msf::Payload::Generic)
         return mod.arch.first
       elsif mod.arch.include? arch
+        datastore['ARCH'] = arch if mod.kind_of?(Msf::Payload::Generic)
         return arch
       else
         return nil
@@ -157,7 +159,10 @@ module Msf
     # @param mod [Msf::Payload] The module class to choose a platform for
     # @return [Msf::Module::PlatformList] The selected platform list
     def choose_platform(mod)
+      # By default, platform_list will at least return Msf::Module::Platform
+      # if there is absolutely no pre-configured platform info at all
       chosen_platform = platform_list
+
       if chosen_platform.platforms.empty?
         chosen_platform = mod.platform
         cli_print "No platform was selected, choosing #{chosen_platform.platforms.first} from the payload"
@@ -165,6 +170,17 @@ module Msf
       elsif (chosen_platform & mod.platform).empty?
         chosen_platform = Msf::Module::PlatformList.new
       end
+
+      begin
+        platform_object = Msf::Module::Platform.find_platform(platform)
+      rescue ArgumentError
+        platform_object = nil
+      end
+
+      if mod.kind_of?(Msf::Payload::Generic) && mod.send(:module_info)['Platform'].empty? && platform_object
+        datastore['PLATFORM'] = platform
+      end
+
       chosen_platform
     end
 


### PR DESCRIPTION
This fixes #4866, an issue with msfvenom not properly handling special cases with generic payloads. So the story behind this fix is that we have these two problems:
## Root Cause

Problem 1: The current payload selection design relies on the payload module in order to set the platform and arch. Almost all MSF payloads contain a default platform and arch, however, the bind and reverse generic payloads don't.

Problem 2: By default, Msf::Payload::Generic also explicitly sets the PLATFORM and ARCH datastore options to nil. So there is no way the payload generator can figure out what platform and arch to use.

As a result of these problems, msfvenom will actually end up getting a Msf::Module::Platform as the default platform, which doesn't actually represent any valid platform we can use (such as Msf::Module::Platform::Windows). And the first item of ARCH_ALL for the arch.

In addition, msfvenom has these two arguments that the user can use: --platform and --arch. In most cases, these arguments are used more like checks than actually setting anything. Because remember: Framework's payload selector retreives the platform & arch from the module (trusted), not the user input (untrusted). But from the user's perspective it's impossible to know this.

After experimenting different ways to fix this, I came up with this patch. It feels sort of more like a hack than a real fix, but as far as I can tell, this is the best you can get unless you want to redesign generic payload selection.

This patch should not affect payload generation for exploits or other parts of the Framework, because Msf::PayloadGenerator is currently exclusive for msfvenom.
## Bug Verification

Here, test msfvenom without the patch.
- [x] Do: `./msfvenom -p generic/shell_reverse_tcp -f raw`
- [x] You should see that:
  - "No platform was selected, choosing Msf::Module::Platform from the payload"
  - "No Arch selected, selecting Arch: x86 from the payload"
  - No payload generated
- [x] Do: `./msfvenom -p generic/shell_reverse_tcp --platform windows -f raw`
- [x] You should see that:
  - "A platform could not be determined by the generic payload"
  - No payload generated
## Patch Verification
- [x] Do: `./msfvenom -p generic/shell_reverse_tcp --platform windows -f raw`
- [x] It should generate a payload
- [x] Do: `./msfvenom -p generic/shell_reverse_tcp --platform windows --arch x86 -f exe -o /tmp/test.exe`
- [x] Do: `file /tmp/test.exe`
- [x] It should say it's a PE32 file for Windows. The exact message might be a little different depending on the OS you're on, but you should get the point.
- [x] Do: `./msfvenom -p generic/shell_reverse_tcp --platform windows --arch x86_64 -f exe -o /tmp/test.exe`
- [x] Do: `file /tmp/test.exe` again
- [x] It should say it's a PE32+ file for Windows. The exact message might be a little different depending on the OS you're on, but you should get the point.
- [x] Do: `./msfvenom -p generic/shell_reverse_tcp --platform windows --arch x64 -f raw`
- [x] It should say "The selected arch is incompatible with the payload". This is because based on the ARCH_ALL list (see msf/lib/rex/constants.rb), there's no such thing as a x64, so it's the expected behavior.
