### PR TITLE
Set postgres version for Travis to 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,6 @@ branches:
   except:
     - gh-pages
     - metakitty
+
+addons:
+  postgresql: '9.3'


### PR DESCRIPTION
This explicitly sets Travis to use postgres 9.3 versus default 9.1. This will make that environment consistent with what is running on Jenkins.
-  [x] Travis passes
