### PR TITLE
fix timestomp arg parsing

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/timestomp.rb
@@ -52,12 +52,21 @@ class Console::CommandDispatcher::Priv::Timestomp
   #
   def cmd_timestomp(*args)
     if (args.length < 2)
-      print_line("\nUsage: timestomp file_path OPTIONS\n" +
+      print_line("\nUsage: timestomp OPTIONS file_path\n" +
         @@timestomp_opts.usage)
       return
     end
 
-    file_path = args.shift
+    file_path = nil
+    args.each { |a| file_path = a unless a[0] == "-" }
+
+    if file_path.nil?
+      print_line("\nNo filepath specified.")
+      return
+    end
+
+    args.delete(file_path)
+
     modified  = nil
     accessed  = nil
     creation  = nil


### PR DESCRIPTION
Fix #5106 

Arg/opt order doesn't matter now.

```
meterpreter > ls test2.txt
100666/rw-rw-rw-  7  fil  2015-04-10 00:41:56 -0400  test2.txt
meterpreter > timestomp test2.txt -v
Modified      : 2015-04-10 01:41:56 -0400
Accessed      : 2015-04-10 01:41:56 -0400
Created       : 2015-04-10 01:41:56 -0400
Entry Modified: 2015-04-10 01:41:56 -0400
meterpreter > timestomp -v test2.txt
Modified      : 2015-04-10 01:41:56 -0400
Accessed      : 2015-04-10 01:41:56 -0400
Created       : 2015-04-10 01:41:56 -0400
Entry Modified: 2015-04-10 01:41:56 -0400
meterpreter >
```
