### PR TITLE
Ensure that local variable `upload_path` is defined

### DIFF
--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -345,10 +345,7 @@ class Metasploit3 < Msf::Exploit::Remote
     upload_path = normalize_uri(target_uri.path.to_s, "html", "upload")
     vprint_status("#{peer} - Uploading #{war.length} bytes as #{@app_base}.war ...")
     res = send_war_payload(upload_path, war)
-    return parse_upload_response(res)
-  end
 
-  def parse_upload_response(res)
     unless res
       vprint_error("#{peer} - Upload failed on #{upload_path} [No Response]")
       return false


### PR DESCRIPTION
Merge `upload_payload` and `parse_upload_response` so that the `upload_path` variable is defined for use in error messages in the event of failure.

If the WAR upload request fails the upload response parsing code bombs out due to an undefined variable. To reproduce start a fake Tomcat server:

```
$ mkdir -p /tmp/tomcat/manager
$ touch /tmp/tomcat/manager/html
$ cd /tmp/tomcat/ 
$ python -m SimpleHTTPServer
Serving HTTP on 0.0.0.0 port 8000 ...
```

Run the exploit:

```
msf > use exploit/multi/http/tomcat_mgr_upload  
msf exploit(tomcat_mgr_upload) > set RHOST 127.1.1.1
RHOST => 127.1.1.1
msf exploit(tomcat_mgr_upload) > set RPORT 8000
RPORT => 8000
msf exploit(tomcat_mgr_upload) > set FingerprintCheck false
FingerprintCheck => false
msf exploit(tomcat_mgr_upload) > exploit
[*] Started reverse handler on 127.0.0.1:4444 
[*] 127.1.1.1:8000 - Retrieving session ID and CSRF token...
[*] 127.1.1.1:8000 - Uploading and deploying oe1yNfhtJ3cdvYL0...
[-] Exploit failed: NameError undefined local variable or method `upload_path' for #<Msf::Modules::Mod6578706c...
```
