### PR TITLE
Pre-release fixups

### DIFF
--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -13,9 +13,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-                      'Name'           => 'GoAhead Embedded Web Server Directory Traversal',
+                      'Name'           => 'Embedthis GoAhead Embedded Web Server Directory Traversal',
       'Description'    => %q{
-        This module exploits a directory traversal vulnerability in the EmbedThis GoAhead Web Server v3.4.1,
+        This module exploits a directory traversal vulnerability in the Embedthis GoAhead Web Server v3.4.1,
         allowing to read arbitrary files with the web server privileges.
       },
       'References'     =>

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -18,7 +18,7 @@ class Metasploit4 < Msf::Exploit::Local
       'Name'           => 'Apple OS X Rootpipe Privilege Escalation',
       'Description'    => %q{
         This module exploits a hidden backdoor API in Apple's Admin framework on
-        Mac OS X to escalate privileges to root, dupped "Rootpipe."
+        Mac OS X to escalate privileges to root, dubbed "Rootpipe."
 
         This module was tested on Yosemite 10.10.2 and should work on previous versions.
 

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -15,12 +15,12 @@ class Metasploit4 < Msf::Exploit::Local
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Mac OS X "Rootpipe" Privilege Escalation',
+      'Name'           => 'Apple OS X Rootpipe Privilege Escalation',
       'Description'    => %q{
         This module exploits a hidden backdoor API in Apple's Admin framework on
-        Mac OS X to escalate privileges to root. Dubbed "Rootpipe."
+        Mac OS X to escalate privileges to root, dupped "Rootpipe."
 
-        Tested on Yosemite 10.10.2 and should work on previous versions.
+        This module was tested on Yosemite 10.10.2 and should work on previous versions.
 
         The patch for this issue was not backported to older releases.
 


### PR DESCRIPTION
Just some minor title changes, really.

commit 49f480af8b9d27e676c02006ae8873a119e1aae6
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Mon Apr 13 10:42:13 2015 -0500

```
Fix funny punctuation on rootpipe exploit title

See #5119
```

commit 0b439671efd6dabcf1a69fd0b089c28badf5ccff
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Mon Apr 13 10:37:39 2015 -0500

```
Fix vendor caps

Trusting the github repo README at

https://github.com/embedthis/goahead

See #5101
```
