### PR TITLE
Fix grammar in comments

### DIFF
--- a/lib/msf/core/auxiliary.rb
+++ b/lib/msf/core/auxiliary.rb
@@ -6,7 +6,7 @@ module Msf
 ###
 #
 # The auxiliary class acts as a base class for all modules that perform
-# reconnaisance, retrieve data, brute force logins, or any other action
+# reconnaissance, retrieve data, brute force logins, or any other action
 # that doesn't fit our concept of an 'exploit' (involving payloads and
 # targets and whatnot).
 #

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -548,7 +548,7 @@ module Auxiliary::AuthBrute
   end
 
   # Provides a consistant way to display messages about AuthBrute-mixed modules.
-  # Acceptable opts are fairly self-explanitory, but :level can be tricky.
+  # Acceptable opts are fairly self-explanatory, but :level can be tricky.
   #
   # It can be one of status, good, error, or line (and corresponds to the usual
   # print_status, print_good, etc. methods).

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -243,7 +243,7 @@ module Auxiliary::Cisco
           store_cred(cred)
 
 #
-# Various authentication secretss
+# Various authentication secrets
 #
         when /^\s*username ([^\s]+) privilege (\d+) (secret|password) (\d+) ([^\s]+)/i
           user  = $1

--- a/lib/msf/core/auxiliary/login.rb
+++ b/lib/msf/core/auxiliary/login.rb
@@ -16,7 +16,7 @@ module Auxiliary::Login
   EOL  = CR + LF
 
   #
-  # Creates an instance of a login negoation module.
+  # Creates an instance of a login negotiation module.
   #
   def initialize(info = {})
     super

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -425,7 +425,7 @@ module Auxiliary::Report
       fname = ctype || "local_#{Time.now.utc.to_i}"
     end
 
-    # Split by path seperator
+    # Split by path separator
     fname = ::File.split(fname).last
 
     case ctype # Probably could use more cases

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -85,7 +85,7 @@ class DataStore < Hash
   def import_options_from_s(option_str, delim = nil)
     hash = {}
 
-    # Figure out the deliminter, default to space.
+    # Figure out the delimeter, default to space.
     if (delim.nil?)
       delim = /\s/
 
@@ -94,7 +94,7 @@ class DataStore < Hash
       end
     end
 
-    # Split on the deliminter
+    # Split on the delimeter
     option_str.split(delim).each { |opt|
       var, val = opt.split('=')
 

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -104,7 +104,7 @@ class Msf::DBManager
   attr_accessor :usable
 
   #
-  # iniitialize
+  # initialize
   #
 
   def initialize(framework, opts = {})

--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -95,7 +95,7 @@ module Msf::DBManager::Cred
     ret = {}
 
     # Check to see if the creds already exist. We look also for a downcased username with the
-    # same password because we can fairly safely assume they are not in fact two seperate creds.
+    # same password because we can fairly safely assume they are not in fact two separate creds.
     # this allows us to hedge against duplication of creds in the DB.
 
     if duplicate_ok

--- a/lib/msf/core/db_manager/import/libpcap.rb
+++ b/lib/msf/core/db_manager/import/libpcap.rb
@@ -8,7 +8,7 @@ module Msf::DBManager::Import::Libpcap
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
     # seen_hosts is only used for determining when to yield an address. Once we get
     # some packet analysis going, the values will have all sorts of info. The plan
-    # is to ru through all the packets as a first pass and report host and service,
+    # is to run through all the packets as a first pass and report host and service,
     # then, once we have everything parsed, we can reconstruct sessions and ngrep
     # out things like authentication sequences, examine ttl's and window sizes, all
     # kinds of crazy awesome stuff like that.

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -64,7 +64,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
       end
 
       # Only report loot if we actually have it.
-      # TODO: Copypasta. Seperate this out.
+      # TODO: Copypasta. Separate this out.
       if ::File.exists? loot_info[:orig_path]
         loot_dir = ::File.join(basedir,"loot")
         loot_file = ::File.split(loot_info[:orig_path]).last
@@ -114,7 +114,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
       task_info[:orig_path].gsub!(/^\./,tmp) if task_info[:orig_path]
 
       # Only report a task if we actually have it.
-      # TODO: Copypasta. Seperate this out.
+      # TODO: Copypasta. Separate this out.
       if ::File.exists? task_info[:orig_path]
         tasks_dir = ::File.join(basedir,"tasks")
         task_file = ::File.split(task_info[:orig_path]).last
@@ -168,7 +168,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     # Grab the list of unique basedirs over all entries.
     @import_filedata[:zip_tmp_subdirs] = @import_filedata[:zip_entry_names].map {|x| ::File.split(x)}.map {|x| x[0]}.uniq.reject {|x| x == "."}
 
-    # mkdir all of the base directores we just pulled out, if they don't
+    # mkdir all of the base directories we just pulled out, if they don't
     # already exist
     @import_filedata[:zip_tmp_subdirs].each {|sub|
       tmp_subdirs = ::File.join(@import_filedata[:zip_tmp],sub)

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -49,7 +49,7 @@ module Msf::DBManager::Session
   #   Creates an Mdm::Session from Mdm::Host.
   #
   #   @param opts [Hash{Symbol => Object}] options
-  #   @option opts [DateTime, Time] :closed_at The date and time the sesion was
+  #   @option opts [DateTime, Time] :closed_at The date and time the session was
   #     closed.
   #   @option opts [String] :close_reason Reason the session was closed.
   #   @option opts [Hash] :datastore {Msf::DataStore#to_h}.

--- a/lib/msf/core/db_manager/wmap.rb
+++ b/lib/msf/core/db_manager/wmap.rb
@@ -43,8 +43,8 @@ module Msf::DBManager::WMAP
   }
   end
 
-  # This method iterates the requests table identifiying possible targets
-  # This method wiil be remove on second phase of db merging.
+  # This method iterates the requests table identifying possible targets
+  # This method will be removed on second phase of db merging.
   def each_distinct_target(&block)
     request_distinct_targets.each do |target|
       block.call(target)
@@ -111,7 +111,7 @@ module Msf::DBManager::WMAP
   end
 
   # This method returns a list of all possible targets available in requests
-  # This method wiil be remove on second phase of db merging.
+  # This method will be removed on second phase of db merging.
   def request_distinct_targets
   ::ActiveRecord::Base.connection_pool.with_connection {
     ::Mdm::WmapRequest.select('DISTINCT host,address,port,ssl')

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -182,7 +182,7 @@ class EncodedPayload
           next
         end
 
-        # If the caller explictly requires register preservation, make sure
+        # If the caller explicitly requires register preservation, make sure
         # that the module in question can handle it. This is mostly used by
         # the stage encoder path.
         if (reqs['ForceSaveRegisters'] and

--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -99,7 +99,7 @@ class Encoder < Module
     #
     NonAlpha = "non_alpha"
     #
-    # tolower safe ascii - not 'A' - 'Z' (more flexable than nonalpha)
+    # tolower safe ascii - not 'A' - 'Z' (more flexible than nonalpha)
     #
     NonUpper = "non_upper"
     #

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -866,7 +866,7 @@ class Exploit < Msf::Module
 
   #
   # Minimum number of nops to use as a hint to the framework.
-  # Nil snigifies that the framework should decide.
+  # Nil signifies that the framework should decide.
   #
   def payload_min_nops(explicit_target = nil)
     explicit_target ||= target

--- a/lib/msf/core/exploit/afp.rb
+++ b/lib/msf/core/exploit/afp.rb
@@ -228,14 +228,14 @@ module Exploit::Remote::AFP
     parsed_data[:machine_type] = read_pascal_string(body, machine_type_offset)
     parsed_data[:versions] = read_array(body, afp_versions_offset)
     parsed_data[:uams] = read_array(body, uam_count_offset)
-    # skiped icon
+    # skipped icon
     parsed_data[:server_flags] = parse_flags(server_flags)
     parsed_data[:signature] = body.unpack("@#{server_signature_offset}H32").first
 
     network_addresses = read_array(body, network_addresses_offset, true)
     parsed_data[:network_addresses] = parse_network_addresses(network_addresses)
-    # skiped directory names
-    #Error catching for offset issues on this field. Need better error ahndling all through here
+    # skipped directory names
+    #Error catching for offset issues on this field. Need better error handling all through here
     begin
       parsed_data[:utf8_server_name] = read_utf8_pascal_string(body, utf8_servername_offset)
     rescue
@@ -289,7 +289,7 @@ module Exploit::Remote::AFP
         parsed_addreses << IPAddr.ntop(address[1..4]).to_s
       when 2 # Four-byte IP address followed by a two-byte port number
         parsed_addreses <<  "#{IPAddr.ntop(address[1..4])}:#{address[5..6].unpack("n").first}"
-      when 3 # DDP address (depricated)
+      when 3 # DDP address (deprecated)
         next
       when 4 # DNS name (maximum of 254 bytes)
         parsed_addreses << address[1..address.length - 1]

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -5,7 +5,7 @@ module Msf
 #
 # This module provides methods for sending and receiving
 # raw packets. It should be preferred over the soon-to-be
-# deprecated Rex::Socket::Ip and Msf::Exploite::Remote::Ip
+# deprecated Rex::Socket::Ip and Msf::Exploit::Remote::Ip
 # mixins.
 #
 # Please see the pcaprub documentation for more information
@@ -379,7 +379,7 @@ module Msf
         self.arp_cache = {}
       end
 
-      # For compatabilty with Msf::Exploit::Remote::Ip
+      # For compatibilty with Msf::Exploit::Remote::Ip
       def rhost
         datastore['RHOST']
       end
@@ -450,7 +450,7 @@ module Msf
         end
       end
 
-      # This function is usefull only on windows where pcaprub use the GUID
+      # This function is useful only on windows where pcaprub use the GUID
       def get_interface_guid(dev)
         check_pcaprub_loaded
         if RUBY_PLATFORM == "i386-mingw32"
@@ -473,7 +473,7 @@ module Msf
         dev   = get_interface_guid(dev)
         addrs = NetworkInterface.addresses(dev)
         raise RuntimeError, "Interface #{dev} does not exist" if !addrs
-        raise RuntimeError, "Can not get mac address for interface #{dev}" if !addrs[NetworkInterface::AF_LINK][0]['addr']
+        raise RuntimeError, "Cannot get mac address for interface #{dev}" if !addrs[NetworkInterface::AF_LINK][0]['addr']
         addrs[NetworkInterface::AF_LINK][0]['addr']
       end
 
@@ -491,7 +491,7 @@ module Msf
         addrs = NetworkInterface.addresses(dev)
         raise RuntimeError, "Interface #{dev} does not exist" if !addrs
         raise RuntimeError, "Interface #{dev} does not have an ipv4 address at position #{num}" if addrs[NetworkInterface::AF_INET].length < num + 1
-        raise RuntimeError, "Can not get the IPv4 address for interface #{dev}" if !addrs[NetworkInterface::AF_INET][num]['addr']
+        raise RuntimeError, "Cannot get the IPv4 address for interface #{dev}" if !addrs[NetworkInterface::AF_INET][num]['addr']
         addrs[NetworkInterface::AF_INET][num]['addr']
       end
 
@@ -501,7 +501,7 @@ module Msf
         addrs = NetworkInterface.addresses(dev)
         raise RuntimeError, "Interface #{dev} does not exist" if !addrs
         raise RuntimeError, "Interface #{dev} does not have an ipv4 address at position #{num}" if addrs[NetworkInterface::AF_INET].length < num + 1
-        raise RuntimeError, "Can not get IPv4 netmask for interface #{dev}" if !addrs[NetworkInterface::AF_INET][num]['netmask']
+        raise RuntimeError, "Cannot get IPv4 netmask for interface #{dev}" if !addrs[NetworkInterface::AF_INET][num]['netmask']
         addrs[NetworkInterface::AF_INET][num]['netmask']
       end
 
@@ -511,7 +511,7 @@ module Msf
         addrs = NetworkInterface.addresses(dev)
         raise RuntimeError, "Interface #{dev} do not exists" if !addrs
         raise RuntimeError, "Interface #{dev} do not have an ipv4 address at position #{num}" if addrs[NetworkInterface::AF_INET].length < num + 1
-        raise RuntimeError, "Can not get IPv4 broadcast address for interface #{dev}" if !addrs[NetworkInterface::AF_INET][num]['broadcast']
+        raise RuntimeError, "Cannot get IPv4 broadcast address for interface #{dev}" if !addrs[NetworkInterface::AF_INET][num]['broadcast']
         addrs[NetworkInterface::AF_INET][num]['broadcast']
       end
 
@@ -532,7 +532,7 @@ module Msf
         addrs = NetworkInterface.addresses(dev)
         raise RuntimeError, "Interface #{dev} do not exists" if !addrs
         raise RuntimeError, "Interface #{dev} do not have an ipv6 address at position #{num}" if addrs[NetworkInterface::AF_INET6].length < num + 1
-        raise RuntimeError, "Can not get ipv6 address for interface #{dev}" if !addrs[NetworkInterface::AF_INET6][num]['addr']
+        raise RuntimeError, "Cannot get ipv6 address for interface #{dev}" if !addrs[NetworkInterface::AF_INET6][num]['addr']
         addrs[NetworkInterface::AF_INET6][num]['addr'].gsub(/%(.)*$/, '')
       end
 
@@ -543,7 +543,7 @@ module Msf
         addrs = NetworkInterface.addresses(dev)
         raise RuntimeError, "Interface #{dev} do not exists" if !addrs
         raise RuntimeError, "Interface #{dev} do not have an ipv6 address at position #{num}" if addrs[NetworkInterface::AF_INET6].length < num + 1
-        raise RuntimeError, "Can not get ipv6 netmask address for interface #{dev}" if !addrs[NetworkInterface::AF_INET6][num]['netmask']
+        raise RuntimeError, "Cannot get ipv6 netmask address for interface #{dev}" if !addrs[NetworkInterface::AF_INET6][num]['netmask']
         addrs[NetworkInterface::AF_INET6][num]['netmask']
       end
 

--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -108,7 +108,7 @@ module Exploit::CmdStager
   # @option opts :decoder [Symbol] The decoder stub to use.
   # @param pl [String] String containing the payload to execute
   # @return [Array] The list of commands to execute
-  # @raise [ArgumentError] raised if the cmd stub can not be generated
+  # @raise [ArgumentError] raised if the cmd stub cannot be generated
   def generate_cmdstager(opts = {}, pl = nil)
     select_cmdstager(opts)
 
@@ -138,12 +138,12 @@ module Exploit::CmdStager
 
   # Selects the correct cmd stager and decoder stub to use
   #
-  # @param opts [Hash] Hash containing the options to select te correct cmd
+  # @param opts [Hash] Hash containing the options to select the correct cmd
   #   stager and decoder.
   # @option opts :flavor [Symbol] The cmd stager to use.
   # @option opts :decoder [Symbol] The decoder stub to use.
   # @return [void]
-  # @raise [ArgumentError] raised if a cmd stager can not be selected or it
+  # @raise [ArgumentError] raised if a cmd stager cannot be selected or it
   #   isn't compatible with the target platform.
   def select_cmdstager(opts = {})
     self.flavor = select_flavor(opts)
@@ -188,11 +188,11 @@ module Exploit::CmdStager
   # user through datastore options, (3) select the default decoder for the
   # current cmd stager flavor if available.
   #
-  # @param opts [Hash] Hash containing the options to select te correct
+  # @param opts [Hash] Hash containing the options to select the correct
   #   decoder.
   # @option opts :decoder [String] The decoder stub to use.
   # @return [String] The decoder.
-  # @return [nil] if a decoder can not be selected.
+  # @return [nil] if a decoder cannot be selected.
   def select_decoder(opts = {})
     return opts[:decoder] if opts.include?(:decoder)
     return datastore['CMDSTAGER::DECODER'] unless datastore['CMDSTAGER::DECODER'].blank?
@@ -203,11 +203,11 @@ module Exploit::CmdStager
   # flavor provided in options, (2) use the flavor provided by the user
   # through datastore options, (3) guess the flavor using the target platform.
   #
-  # @param opts [Hash] Hash containing the options to select te correct cmd
+  # @param opts [Hash] Hash containing the options to select the correct cmd
   #   stager
   # @option opts :flavor [Symbol] The cmd stager flavor to use.
   # @return [Symbol] The flavor to use.
-  # @return [nil] if a flavor can not be selected.
+  # @return [nil] if a flavor cannot be selected.
   def select_flavor(opts = {})
     return opts[:flavor].to_sym if opts.include?(:flavor)
     unless datastore['CMDSTAGER::FLAVOR'].blank? or datastore['CMDSTAGER::FLAVOR'] == 'auto'
@@ -220,7 +220,7 @@ module Exploit::CmdStager
   # target or platform.
   #
   # @return [Symbol] The cmd stager flavor to use.
-  # @return [nil] if the cmd stager flavor can not be guessed.
+  # @return [nil] if the cmd stager flavor cannot be guessed.
   def guess_flavor
     # First try to guess a compatible flavor based on the module & target information.
     unless target_flavor.nil?
@@ -252,7 +252,7 @@ module Exploit::CmdStager
   end
 
   # Returns all the compatible stager flavors specified by the module and each
-  # of it's targets.
+  # of its targets.
   #
   # @return [Array] the list of all compatible cmd stager flavors.
   def module_flavors

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -54,7 +54,7 @@ module Exploit::FileDropper
         # We need to be platform-independent here. Since we can't be
         # certain that {#target} is accurate because exploits with
         # automatic targets frequently change it, we just go ahead and
-        # run both a windows and a unixy command in the same line. One
+        # run both a windows and a unix command in the same line. One
         # of them will definitely fail and the other will probably
         # succeed. Doing it this way saves us an extra round-trip.
         # Trick shared by @mihi42

--- a/lib/msf/core/exploit/fmtstr.rb
+++ b/lib/msf/core/exploit/fmtstr.rb
@@ -238,7 +238,7 @@ module Exploit::FormatString
     # no need to advance :)
     return "" if prec == 0
 
-    # asumming %x max normal length is 8...
+    # assuming %x max normal length is 8...
     if prec >= 8
       return "%0" + prec.to_s + "x"
     end

--- a/lib/msf/core/exploit/ftp.rb
+++ b/lib/msf/core/exploit/ftp.rb
@@ -211,7 +211,7 @@ module Exploit::Remote::Ftp
 
     # dispatch to the proper method
     if (type == "get")
-      # failed listings jsut disconnect..
+      # failed listings just disconnect..
       begin
         data = self.datasocket.get_once(-1, ftp_timeout)
       rescue ::EOFError

--- a/lib/msf/core/exploit/gdb.rb
+++ b/lib/msf/core/exploit/gdb.rb
@@ -24,7 +24,7 @@ module Exploit::Remote::Gdb
   # thrown when a checksum is invalid
   class BadChecksumError < RuntimeError; end
 
-  # Default list of supported GDB features to send the to the target
+  # Default list of supported GDB features to send them to the target
   GDB_FEATURES = 'qSupported:multiprocess+;qRelocInsn+;qvCont+;'
 
   # Maps index of register in GDB that holds $PC to architecture

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -453,7 +453,7 @@ module Exploit::Remote::HttpServer
   # Returns the last-used resource path
   #
   def get_resource
-    # We don't want modules modifying their service_path inadvertantly, so
+    # We don't want modules modifying their service_path inadvertently, so
     # give them a dup.  Can be nil during module setup.
     @service_path ? @service_path.dup : nil
   end

--- a/lib/msf/core/exploit/java.rb
+++ b/lib/msf/core/exploit/java.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 ###
 #
-# This mixn provides methods for interacting with a JDK installation to perform
+# This mixin provides methods for interacting with a JDK installation to perform
 # functions such as dynamic compilation and jar signing.
 #
 # Dependencies:
@@ -108,7 +108,7 @@ module Exploit::Java
     if classnames.class == [].class && codez.class == [].class
       # default compile class
       begin
-      # Sames as java_compiler_klass.CompileFromMemory(	String[] classnames,
+      # Same as java_compiler_klass.CompileFromMemory(	String[] classnames,
       #						String[] codez, String[] compilerOptions)
         success = java_compiler_klass._invoke('CompileFromMemory',
           # Signature explained: [ means array, Lpath.to.object; means object

--- a/lib/msf/core/exploit/mssql_sqli.rb
+++ b/lib/msf/core/exploit/mssql_sqli.rb
@@ -134,7 +134,7 @@ module Exploit::Remote::MSSQL_SQLI
   end
 
   #
-  # Issue a SQL query using the the SQL injection point
+  # Issue a SQL query using the SQL injection point
   #
   def mssql_query(sqla, doprint=false)
 

--- a/lib/msf/core/exploit/ndmp.rb
+++ b/lib/msf/core/exploit/ndmp.rb
@@ -92,7 +92,7 @@ module Exploit::Remote::NDMP
       self.recv_buff << ( sock.get_once( 4 - self.recv_buff.length, 5) || '' )
     end
 
-    # If we did not recieve a full length value, return early
+    # If we did not receive a full length value, return early
     if (self.recv_buff.length < 4)
       return false
     end

--- a/lib/msf/core/exploit/ntlm.rb
+++ b/lib/msf/core/exploit/ntlm.rb
@@ -10,7 +10,7 @@ module Msf
 ###
 #
 # This mixins will only provide the options name and description when a protocol want to use ntlm features from lib/rex/proto/ntlm .
-# Unfortunatly other mixin's still have to make direct call from lib/rex/proto/ntlm
+# Unfortunately other mixin's still have to make direct call from lib/rex/proto/ntlm
 # cause some protocol like SMB are implemented in lib/rex/proto/ while others like mssql are implemented in lib/msf/core/exploit
 #
 ###

--- a/lib/msf/core/exploit/oracle.rb
+++ b/lib/msf/core/exploit/oracle.rb
@@ -100,7 +100,7 @@ module Exploit::ORACLE
     # The Handling is a little different for certain types of query
     # Mainly Select needs a fetch statement to get the data
     # Also return types are a little different (some return rows changed so we can used that)
-    # The case statement could probaby be collapsed a bit but leaving it as is for the moment
+    # The case statement could probably be collapsed a bit but leaving it as is for the moment
     # in case it's useful later...
 
     # Select Queries

--- a/lib/msf/core/exploit/pdf.rb
+++ b/lib/msf/core/exploit/pdf.rb
@@ -218,7 +218,7 @@ module Exploit::PDF
   end
 
   ##
-  #Controller funtion, should be entrypoint for pdf exploits
+  #Controller function, should be entrypoint for pdf exploits
   ##
   def create_pdf(js)
     strFilter = ""

--- a/lib/msf/core/exploit/pdf_parse.rb
+++ b/lib/msf/core/exploit/pdf_parse.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 ###
 #
-# This module provides methods for parseing and interacting
+# This module provides methods for parsing and interacting
 # with the PDF format.
 #
 ###

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -621,7 +621,7 @@ module Msf
     private
 
 
-    # Sends a 404 respons. If a custom 404 is configured, then it will redirect to that instead.
+    # Sends a 404 response. If a custom 404 is configured, then it will redirect to that instead.
     def send_not_found(cli)
       custom_404_url = get_custom_404_url
       if custom_404_url.blank?

--- a/lib/msf/core/exploit/smb/server/share.rb
+++ b/lib/msf/core/exploit/smb/server/share.rb
@@ -240,7 +240,7 @@ module Msf
         datastore['SRVHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['SRVHOST']
       end
 
-      # New connection handler, executed when there is a new conneciton.
+      # New connection handler, executed when there is a new connection.
       #
       # @param c [Socket] The client establishing the connection.
       # @return [Hash] The hash with the client data initialized.

--- a/lib/msf/core/exploit/tincd.rb
+++ b/lib/msf/core/exploit/tincd.rb
@@ -64,7 +64,7 @@ module Exploit::Remote::TincdExploitClient
 
   #
   # The main method that will be called that will call other methods to send first message
-  # and continously read from socket and ensures TCP disconnect at the end
+  # and continuously read from socket and ensures TCP disconnect at the end
   #
   def send_recv(packet_payload)
     @packet_payload = packet_payload
@@ -95,7 +95,7 @@ module Exploit::Remote::TincdExploitClient
 
   #
   # Reading of certificate files and parsing them, generation of random keys
-  # and intialization of OFB mode blowfish cipher
+  # and initialization of OFB mode blowfish cipher
   #
   def init_ciphers(server_file, client_file)
     server_public_key_cipher = OpenSSL::PKey::RSA.new(File.read(server_file))
@@ -315,7 +315,7 @@ module Exploit::Remote::TincdExploitClient
   end
 
   #
-  # Ack state to signalise challenge/response was successfull
+  # Ack state to signalize challenge/response was successful
   #
   def ack
     vprint_status('Sending ack (signalise server that we accept challenge' +
@@ -325,7 +325,7 @@ module Exploit::Remote::TincdExploitClient
   end
 
   #
-  # Sending a packet inside the VPN connection after successfull protocol setup
+  # Sending a packet inside the VPN connection after successful protocol setup
   #
   def send_packet
     vprint_status('Protocol finished setup. Going to send packet.')

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -172,7 +172,7 @@ class Framework
   attr_reader   :datastore
   #
   # The framework instance's aux manager.  The aux manager is responsible
-  # for collecting and catalogging all aux information that comes in from
+  # for collecting and cataloging all aux information that comes in from
   # aux modules.
   #
   attr_reader   :auxmgr

--- a/lib/msf/core/handler/find_tty.rb
+++ b/lib/msf/core/handler/find_tty.rb
@@ -6,7 +6,7 @@ module Handler
 
 ###
 #
-# This handler expects a interactive TTY on the supplied socket/io object
+# This handler expects an interactive TTY on the supplied socket/io object
 #
 ###
 module FindTty

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -7,7 +7,7 @@ module Msf
 #
 # The module base class is responsible for providing the common interface
 # that is used to interact with modules at the most basic levels, such as
-# by inspecting a given module's attributes (name, dsecription, version,
+# by inspecting a given module's attributes (name, description, version,
 # authors, etc) and by managing the module's data store.
 #
 ###

--- a/lib/msf/core/module/full_name.rb
+++ b/lib/msf/core/module/full_name.rb
@@ -12,7 +12,7 @@ module Msf::Module::FullName
 
 
     # @attribute refname
-    #   The module's name that is assigned it it by the framework
+    #   The module's name that is assigned to it by the framework
     #   or derived from the path that the module is loaded from.
     attr_accessor :refname
 

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -10,7 +10,7 @@ require 'abbrev'
 class Msf::Module::Platform
 
   Rank  = 0
-  # actually, having a argument of '' is what to do for wanting 'all'
+  # actually, having an argument of '' is what to do for wanting 'all'
   Short = "all"
 
   class << self
@@ -18,7 +18,7 @@ class Msf::Module::Platform
   end
 
   #
-  # Returns the "real" name of the module instance, accouting for potentially
+  # Returns the "real" name of the module instance, accounting for potentially
   # aliased class names.
   #
   def self.realname

--- a/lib/msf/core/module/platform_list.rb
+++ b/lib/msf/core/module/platform_list.rb
@@ -2,7 +2,7 @@
 # -*- coding: binary -*-
 
 #
-# This is a helper to a easy way to specify support platforms.  It will take a
+# This is a helper to an easy way to specify support platforms.  It will take a
 # list of strings or Msf::Module::Platform objects and build them into a list
 # of Msf::Module::Platform objects.  It also supports ranges based on relative
 # ranks...

--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -140,7 +140,7 @@ module Msf
     # providers it wishes to monitor.  This can be used to allow modules
     # to automatically execute or perform other tasks when certain
     # events occur.  For instance, when a new host is detected, other
-    # aux modules may wish to run such that they can collect more
+    # auxiliary modules may wish to run such that they can collect more
     # information about the host that was detected.
     #
     # @param klass [Class<Msf::Module>] The module class

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -578,7 +578,7 @@ class Msf::Modules::Loader::Base
     raise ::NotImplementedError
   end
 
-  # Restores the namespace module to it's original name under it's original parent Module if there was a previous
+  # Restores the namespace module to its original name under its original parent Module if there was a previous
   # namespace module.
   #
   # @param [Module] parent_module The .parent of namespace_module before it was removed from the constant tree.

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -698,7 +698,7 @@ class OptionContainer < Hash
   end
 
   #
-  # Make sures that each of the options has a value of a compatible
+  # Make sure that each of the options has a value of a compatible
   # format and that all the required options are set.
   #
   def validate(datastore)

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -264,7 +264,7 @@ class Payload < Msf::Module
   # payload's convention.
   #
   def compatible_convention?(conv)
-    # If we ourself don't have a convention or our convention is equal to
+    # If we don't have a convention or our convention is equal to
     # the one supplied, then we know we are compatible.
     if ((self.convention == nil) or
         (self.convention == conv))
@@ -324,7 +324,7 @@ class Payload < Msf::Module
   # RHOST is substituted with the RHOST value from the datastore which will
   # have been populated by the framework.
   #
-  # Supprted packing types:
+  # Supported packing types:
   #
   # - ADDR  (foo.com, 1.2.3.4)
   # - ADDR6 (foo.com, fe80::1234:5678:8910:1234)

--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -56,7 +56,7 @@ module Msf::Payload::Dalvik
     #
     # If you plan to publish your application(s) on Google Play, note
     # that a validity period ending after 22 October 2033 is a
-    # requirement. You can not upload an application if it is signed
+    # requirement. You cannot upload an application if it is signed
     # with a key whose validity expires before that date.
     # """
     cert.not_after = cert.not_before + 3600*24*365*20 # 20 years

--- a/lib/msf/core/payload/uuid_options.rb
+++ b/lib/msf/core/payload/uuid_options.rb
@@ -22,7 +22,7 @@ module Msf::Payload::UUIDOptions
 
   #
   # Generates a URI with a given checksum and optionally with an embedded UUID if
-  # the desired length can accomodate it.
+  # the desired length can accommodate it.
   #
   # @param mode [Symbol] The type of checksum to generate (:connect, :init_native, :init_python, :init_java)
   # @param len [Fixnum] The length of the URI not including the leading slash, optionally nil for random

--- a/lib/msf/core/payload/windows/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/stageless_meterpreter.rb
@@ -76,7 +76,7 @@ module Payload::Windows::StagelessMeterpreter
 
     # the URL might not be given, as it might be patched in some other way
     if url
-      # Patch the URL using the patcher as this upports both ASCII and WCHAR.
+      # Patch the URL using the patcher as this supports both ASCII and WCHAR.
       unless Rex::Payloads::Meterpreter::Patch.patch_string!(dll, "https://#{'X' * 512}", "s#{url}\x00")
         # If the patching failed this could mean that we are somehow
         # working with outdated binaries, so try to patch with the

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -23,7 +23,7 @@ module Msf
   class PayloadGenerator
 
     # @!attribute  add_code
-    #   @return [String] The path to a shellcode file to execute in a seperate thread
+    #   @return [String] The path to a shellcode file to execute in a separate thread
     attr_accessor :add_code
     # @!attribute  arch
     #   @return [String] The CPU architecture to build the payload for
@@ -117,10 +117,10 @@ module Msf
     end
 
     # This method takes the shellcode generated so far and adds shellcode from
-    # a supplied file. The added shellcode is executed in a seperate thread
+    # a supplied file. The added shellcode is executed in a separate thread
     # from the main payload.
     # @param shellcode [String] The shellcode to add to
-    # @return [String] the combined shellcode which executes the added code in a seperate thread
+    # @return [String] the combined shellcode which executes the added code in a separate thread
     def add_shellcode(shellcode)
       if add_code.present? and platform_list.platforms.include? Msf::Module::Platform::Windows and arch == "x86"
         cli_print "Adding shellcode from #{add_code} to the payload"
@@ -314,7 +314,7 @@ module Msf
     def get_encoders
       encoders = []
       if encoder.present?
-        # Allow comma seperated list of encoders so users can choose several
+        # Allow comma separated list of encoders so users can choose several
         encoder.split(',').each do |chosen_encoder|
           e = framework.encoders.create(chosen_encoder)
           e.datastore.import_options_from_hash(datastore)

--- a/lib/msf/core/plugin.rb
+++ b/lib/msf/core/plugin.rb
@@ -10,7 +10,7 @@ module Msf
 # to augment the feature set of the framework by being able to load and unload
 # them during the course of a framework's lifetime.  For instance, a plugin
 # could be loaded to alter the default behavior of new sessions, such as by
-# scripting meterpreter sessions that are created.  The possiblities are
+# scripting meterpreter sessions that are created.  The possibilities are
 # endless!
 #
 # All plugins must exist under the Msf::Plugin namespace.  Plugins are

--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -53,7 +53,7 @@ class Msf::Post < Msf::Module
   end
 
   # This method returns the ID of the {Mdm::Session} that the post module
-  # is currently running agaist.
+  # is currently running against.
   #
   # @return [NilClass] if there is no database record for the session
   # @return [Fixnum] if there is a database record to get the id for

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -84,7 +84,7 @@ module Msf::Post::Common
     case session.type
     when /meterpreter/
       #
-      # The meterpreter API requires arguments to come seperately from the
+      # The meterpreter API requires arguments to come separately from the
       # executable path. This has no effect on Windows where the two are just
       # blithely concatenated and passed to CreateProcess or its brethren. On
       # POSIX, this allows the server to execve just the executable when a

--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -212,7 +212,7 @@ module Accounts
 
       case error
       when client.railgun.const('ERROR_INVALID_PARAMETER')
-        # Unless the railgun call is broken, this means revesion is wrong
+        # Unless the railgun call is broken, this means revision is wrong
         return { :type => :invalid }
       when client.railgun.const('ERROR_NONE_MAPPED')
         # There were no accounts associated with this SID

--- a/lib/msf/core/post/windows/cli_parse.rb
+++ b/lib/msf/core/post/windows/cli_parse.rb
@@ -86,7 +86,7 @@ module CliParse
         # NOTE:  this will NOT pickup the (NOT_STOPPABLE, NOT_PAUSABLE), see next, but it
         # 	 will pickup when there's multiple dependencies
         arr = line.scan(/\w+/)
-        val = arr.join(',') # join with commas, tho there is probably only one item in arr
+        val = arr.join(',') # join with commas, though there is probably only one item in arr
         hashish[lastkey] << ",#{val}" # append to old val with preceding ','
         # if that's confusing, maybe:  hashish[lastkey] = "#{hashish[lastkey]},#{val}"
         tip = false

--- a/lib/msf/core/post/windows/mssql.rb
+++ b/lib/msf/core/post/windows/mssql.rb
@@ -155,7 +155,7 @@ module Msf
             return false unless username
 
             session.core.use('incognito') unless session.incognito
-            vprint_status("Attemping to impersonate user: #{username}")
+            vprint_status("Attempting to impersonate user: #{username}")
             res = session.incognito.incognito_impersonate_token(username)
 
             if res =~ /Successfully/i

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -346,7 +346,7 @@ protected
           #print_error("The file you specified is currently locked by another process: #{file}")
           return false
         when /stdapi_registry_load_key: Operation failed:/
-          #print_error("An unknown error has occured: #{loadres.to_s}")
+          #print_error("An unknown error has occurred: #{loadres.to_s}")
           return false
         else
           #print_debug("Registry Hive Loaded Successfully: #{key}")
@@ -374,7 +374,7 @@ protected
           #print_error("The KEY you provided does not appear to match a loaded Registry Hive: #{key}")
           return false
         when /stdapi_registry_unload_key: Operation failed:/
-          #print_error("An unknown error has occured: #{unloadres.to_s}")
+          #print_error("An unknown error has occurred: #{unloadres.to_s}")
           return false
         else
           #print_debug("Registry Hive Unloaded Successfully: #{key}")

--- a/lib/msf/core/post/windows/runas.rb
+++ b/lib/msf/core/post/windows/runas.rb
@@ -126,7 +126,7 @@ module Msf::Post::Windows::Runas
   # @param domain [String] The target user domain
   # @param user [String] The target user
   # @param password [String] The target user password
-  # @param application_name [String] Thn executableived :CloseHandle
+  # @param application_name [String] The executable to run :CloseHandle
   # with unexpected arguments
   #          expected: ("testPhToken")
   #                        got: (n be run, can be

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -128,7 +128,7 @@ module Msf::PostMixin
   # Checks the session's type against this module's
   # <tt>module_info["SessionTypes"]</tt> as well as examining platform
   # compatibility.  +sess_or_sid+ can be a Session object, Fixnum, or
-  # String.  In the latter cases it sould be a key in
+  # String.  In the latter cases it should be a key in
   # +framework.sessions+.
   #
   # @note Because it errs on the side of compatibility, a true return

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -21,7 +21,7 @@ private
   def fix_cred_options(opts)
     new_opts = fix_options(opts)
 
-    # Convert some of are data back to symbols
+    # Convert some of the raw data back to symbols
     if new_opts[:origin_type]
       new_opts[:origin_type] = new_opts[:origin_type].to_sym
     end

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -84,7 +84,7 @@ module Session
     #self.routes = []
   end
 
-  # Direct descendents
+  # Direct descendants
   require 'msf/core/session/interactive'
   require 'msf/core/session/basic'
   require 'msf/core/session/comm'

--- a/lib/msf/core/session/comm.rb
+++ b/lib/msf/core/session/comm.rb
@@ -16,7 +16,7 @@ module Comm
 
   #
   # Session-based comm classes implement an instance specific method for
-  # creating network-based connections rather than the typicall class
+  # creating network-based connections rather than the typical class
   # specific methods.
   #
   def create(param)


### PR DESCRIPTION
From @void-in, a slew of comment grammar fixes. There are also a few word changes in some `raise` methods. Will review this and land momentarily.
