### PR TITLE
cleanup HTTP and HTTPS listeners when all sessions are closed

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -165,7 +165,9 @@ module ReverseHttp
   def stop_handler
     if self.service
       self.service.remove_resource("/")
-      Rex::ServiceManager.stop_service(self.service) if self.sessions == 0
+      if self.service.resources.empty? && self.sessions == 0
+        Rex::ServiceManager.stop_service(self.service)
+      end
     end
   end
 

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -79,7 +79,7 @@ module PacketDispatcher
 
   def shutdown_passive_dispatcher
     return if not self.passive_service
-    self.passive_service.remove_resource("/" + self.conn_id  + "/")
+    self.passive_service.remove_resource(self.conn_id  + "/")
 
     # If there are no more resources registered on the service, stop it entirely
     if self.passive_service.resources.empty?

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -81,6 +81,11 @@ module PacketDispatcher
     return if not self.passive_service
     self.passive_service.remove_resource("/" + self.conn_id  + "/")
 
+    # If there are no more resources registered on the service, stop it entirely
+    if self.passive_service.resources.empty?
+      Rex::ServiceManager.stop_service(self.passive_service)
+    end
+
     self.alive      = false
     self.send_queue = []
     self.recv_queue = []


### PR DESCRIPTION
Rather than listening forever after a session shuts down, close the session if there are no other URI's registered on the listener. This allows reconfiguring the listener without restarting framework, but should be safe for situations where multiple modules share the same listener.
# Verification
- [x] setup a reverse http / https meterpreter session
- [x] stop the session
- [x] verify that the listener is no longer listening (can't start meterpreter a second time)
- [x] make changes to the session config, run the handler again
- [x] verify a new reverse http / https meterpreter session establishes once more
