### PR TITLE
Avoid generating labels with '..' in them with metasm

### DIFF
--- a/lib/metasm/metasm/main.rb
+++ b/lib/metasm/metasm/main.rb
@@ -306,8 +306,8 @@ class ExeFormat
   # creates a new label, that is guaranteed to never be returned again as long as this object (ExeFormat) exists
   def new_label(base = '')
     base = base.dup.tr('^a-zA-Z0-9_', '_')
-    # use %x instead of to_s(16) for negative values
-    base = (base << '_uuid' << ('%08x' % base.object_id)).freeze if base.empty? or @unique_labels_cache[base]
+    # use %x with absolute value to avoid negative number formatting
+    base = (base << '_uuid' << ('%08x' % base.object_id.abs)).freeze if base.empty? or @unique_labels_cache[base]
     @unique_labels_cache[base] = true
     base
   end


### PR DESCRIPTION
Metasm generates labels for the assembler using "%x" % string.object_id. If the pointer for string.object_id begins with the most significant digit set, it looks like a sign-extended 2's complement number (negative), and gets formatted by ruby as '..f1412300' or similar. On 32-bit platforms, there is rather high chance of randomly ending up with a label like 'goto_test_uuid..f1234560:', which is a parse error.

This patch simply takes the absolute value of the object_id to avoid negative interpretations.  This fixes hiesenbugs using metasm's C compiler on 32-bit platforms.

This fixes a few long-standing bugs in Pro using dynamic stagers on 32-bit Linux platforms where virtual addresses with the significant bit set are relatively common.
