### PR TITLE
Extra space in message "Local IP:"

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -229,7 +229,7 @@ module Exploit::Remote::HttpServer
     print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{uopts['Path']}")
 
     if (opts['ServerHost'] == '0.0.0.0')
-      print_status(" Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
+      print_status("Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
     end
 
     add_resource(uopts)


### PR DESCRIPTION
While working on my stuff over here, I tried to regex the output `/^Local IP: /` and it actually failed. There is actually an extra space in there. It doesn't look like you actually need this extra space.
