### PR TITLE
Add missing Rank

### DIFF
--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -7,6 +7,7 @@ require 'msf/core'
 require 'digest/md5'
 
 class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
 

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -7,6 +7,7 @@ require 'msf/core'
 require 'msf/core/exploit/android'
 
 class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::Remote::BrowserAutopwn


### PR DESCRIPTION
While still working on my stuff over here, I have to enumerate all BES modules and check the `Rank`, but these modules don't have that. Probably forgotten.

No verification steps here, should be very easy.
