### PR TITLE
Post enum_system changes to case statements instead of if/elsif.

### DIFF
--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -11,8 +11,8 @@ class Metasploit3 < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::System
 
-  def initialize(info={})
-    super( update_info( info,
+  def initialize(info = {})
+    super(update_info(info,
         'Name'          => 'Linux Gather System and User Information',
         'Description'   => %q{
           This module gathers system information. We collect
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Post
         'Platform'      => ['linux'],
         'SessionTypes'  => ['shell', 'meterpreter']
       ))
-
   end
 
   def run
@@ -60,7 +59,7 @@ class Metasploit3 < Msf::Post
     mount = execute("/bin/mount -l")
     crons = get_crons(users, user)
     diskspace = execute("/bin/df -ahT")
-    disks = (mount + "\n\/" + diskspace)
+    disks = (mount + "\n\n" + diskspace)
     logfiles = execute("find /var/log -type f -perm -4 2> /dev/null")
     uidgid = execute("find / -xdev -type f -perm +6000 -perm -1 2> /dev/null")
 
@@ -74,11 +73,10 @@ class Metasploit3 < Msf::Post
     save("Setuid/setgid files", uidgid)
   end
 
-
-  def save(msg, data, ctype="text/plain")
+  def save(msg, data, ctype = 'text/plain')
     ltype = "linux.enum.system"
     loot = store_loot(ltype, ctype, session, data, nil, msg)
-    print_status("#{msg} stored in #{loot.to_s}")
+    print_status("#{msg} stored in #{loot}")
   end
 
   def get_host
@@ -148,8 +146,8 @@ class Metasploit3 < Msf::Post
   end
 
   def get_crons(users, user)
-    if user == "root" && users != nil
-      users = users.chomp.split()
+    if user == "root" && !users.nil?
+      users = users.chomp.split
       users.each do |u|
         if u == "root"
           vprint_status("Enumerating as root")
@@ -164,10 +162,9 @@ class Metasploit3 < Msf::Post
       vprint_status("Enumerating as #{user}")
       cron_data = "***** Listing cron jobs for #{user} *****\n\n"
       cron_data += execute("crontab -l")
+
+      # Save cron data to loot
+      return cron_data
     end
-
-    # Save cron data to loot
-    return cron_data
   end
-
 end

--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -11,7 +11,6 @@ class Metasploit3 < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::System
 
-
   def initialize(info={})
     super( update_info( info,
         'Name'          => 'Linux Gather System and User Information',
@@ -53,13 +52,15 @@ class Metasploit3 < Msf::Post
     users = execute("/bin/cat /etc/passwd | cut -d : -f 1")
     user = execute("/usr/bin/whoami")
 
+    print_good("\tModule running as \"#{user}\" user")
+
     installed_pkg = get_packages(distro[:distro])
     installed_svc = get_services(distro[:distro])
 
     mount = execute("/bin/mount -l")
     crons = get_crons(users, user)
     diskspace = execute("/bin/df -ahT")
-    disks = (mount +"\n\/"+ diskspace)
+    disks = (mount + "\n\/" + diskspace)
     logfiles = execute("find /var/log -type f -perm -4 2> /dev/null")
     uidgid = execute("find / -xdev -type f -perm +6000 -perm -1 2> /dev/null")
 
@@ -71,7 +72,6 @@ class Metasploit3 < Msf::Post
     save("Disk info", disks)
     save("Logfiles", logfiles)
     save("Setuid/setgid files", uidgid)
-
   end
 
 
@@ -107,16 +107,17 @@ class Metasploit3 < Msf::Post
   end
 
   def get_packages(distro)
-    packages_installed = nil
-    if distro =~ /fedora|redhat|suse|mandrake|oracle|amazon/
+    packages_installed = ""
+    case distro
+    when /fedora|redhat|suse|mandrake|oracle|amazon/
       packages_installed = execute("rpm -qa")
-    elsif distro =~ /slackware/
-      packages_installed = execute("ls /var/log/packages")
-    elsif distro =~ /ubuntu|debian/
-      packages_installed = execute("dpkg -l")
-    elsif distro =~ /gentoo/
+    when /slackware/
+      packages_installed = execute("/bin/ls /var/log/packages")
+    when /ubuntu|debian/
+      packages_installed = execute("/usr/bin/dpkg -l")
+    when /gentoo/
       packages_installed = execute("equery list")
-    elsif distro =~ /arch/
+    when /arch/
       packages_installed = execute("/usr/bin/pacman -Q")
     else
       print_error("Could not determine package manager to get list of installed packages")
@@ -126,46 +127,47 @@ class Metasploit3 < Msf::Post
 
   def get_services(distro)
     services_installed = ""
-    if distro =~ /fedora|redhat|suse|mandrake|oracle|amazon/
+    case distro
+    when /fedora|redhat|suse|mandrake|oracle|amazon/
       services_installed = execute("/sbin/chkconfig --list")
-    elsif distro =~ /slackware/
+    when /slackware/
       services_installed << "\nEnabled:\n*************************\n"
       services_installed << execute("ls -F /etc/rc.d | /bin/grep \'*$\'")
       services_installed << "\n\nDisabled:\n*************************\n"
       services_installed << execute("ls -F /etc/rc.d | /bin/grep \'[a-z0-9A-z]$\'")
-    elsif distro =~ /ubuntu|debian/
-      services_installed = execute("/usr/bin/service --status-all")
-    elsif distro =~ /gentoo/
+    when /ubuntu|debian/
+      services_installed = execute("/usr/sbin/service --status-all")
+    when /gentoo/
       services_installed = execute("/bin/rc-status --all")
-    elsif distro =~ /arch/
-      services_installed = execute("/bin/egrep '^DAEMONS' /etc/rc.conf")
+    when /arch/
+      services_installed = execute("/bin/grep '^DAEMONS' /etc/rc.conf")
     else
-      print_error("Could not determine the Linux Distribution to get list of configured services")
+      print_error("Could not determine the Linux Distribuition to get list of configured services")
     end
     return services_installed
   end
 
   def get_crons(users, user)
-    if user == "root" and users != nil
+    if user == "root" && users != nil
       users = users.chomp.split()
       users.each do |u|
         if u == "root"
           vprint_status("Enumerating as root")
           cron_data = ""
-          users.each do |u|
-            cron_data += "*****Listing cron jobs for #{u}*****\n"
-            cron_data += execute("crontab -u #{u} -l") + "\n\n"
+          users.each do |usr|
+            cron_data += "*****Listing cron jobs for #{usr}*****\n"
+            cron_data += execute("crontab -u #{usr} -l") + "\n\n"
           end
         end
       end
     else
-      vprint_status("Enumerating as #{user}")
+      vprint_status("Enumerating as \"#{user}\"")
       cron_data = "***** Listing cron jobs for #{user} *****\n\n"
       cron_data += execute("crontab -l")
     end
 
     # Save cron data to loot
     return cron_data
-
   end
+
 end

--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -140,9 +140,9 @@ class Metasploit3 < Msf::Post
     when /gentoo/
       services_installed = execute("/bin/rc-status --all")
     when /arch/
-      services_installed = execute("/bin/grep '^DAEMONS' /etc/rc.conf")
+      services_installed = execute("/bin/egrep '^DAEMONS' /etc/rc.conf")
     else
-      print_error("Could not determine the Linux Distribuition to get list of configured services")
+      print_error("Could not determine the Linux Distribution to get list of configured services")
     end
     return services_installed
   end
@@ -161,7 +161,7 @@ class Metasploit3 < Msf::Post
         end
       end
     else
-      vprint_status("Enumerating as \"#{user}\"")
+      vprint_status("Enumerating as #{user}")
       cron_data = "***** Listing cron jobs for #{user} *****\n\n"
       cron_data += execute("crontab -l")
     end


### PR DESCRIPTION
Today I used the post module (post/linux/gather/enum_system.rb) to make a list of configs and made a few changes. Example, altered the conditions if/elsif to use case statements. What do you think?

```
msf post(enum_system) > run

[+] Info:
[+]     Kali GNU/Linux 1.1.0  
[+]     Linux kali 3.18.0-kali3-686-pae #1 SMP Debian 3.18.6-1~kali2 (2015-03-02) i686 GNU/Linux
[+]     Module running as "root" user
[*] Linux version stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_776805.txt
[*] User accounts stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_355048.txt
[*] Installed Packages stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_974282.txt
[*] Running Services stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_094769.txt
[*] Cron jobs stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_109197.txt
[*] Disk info stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_003158.txt
[*] Logfiles stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_763104.txt
[*] Setuid/setgid files stored in /home/espreto/.msf4/loot/20150414200509_default_192.168.1.40_linux.enum.syste_601568.txt
[*] Post module execution completed
msf post(enum_system) >
```
