### PR TITLE
Clean the code of the module couchdb_enum.

### DIFF
--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -14,9 +14,15 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'CouchDB Enum Utility',
       'Description'    => %q{
-        Send a "send_request_cgi()" to enumerate databases and your values on CouchDB (Without authentication by default)
+        This module enumerates databases and your values on CouchDB
+        (without authentication by default). It uses the REST API
+        in order to make it.
       },
-      'Author'         => [ 'espreto <robertoespreto[at]gmail.com>' ],
+      'References'    =>
+        [
+          ['URL', 'https://wiki.apache.org/couchdb/HTTP_database_API']
+        ],
+      'Author'         => [ 'Roberto Soares Espreto <robertoespreto[at]gmail.com>' ],
       'License'        => MSF_LICENSE
       ))
 
@@ -24,60 +30,45 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(5984),
         OptString.new('TARGETURI', [true, 'Path to list all the databases', '/_all_dbs']),
-        OptEnum.new('HTTP_METHOD', [true, 'HTTP Method, default GET', 'GET', ['GET', 'POST', 'PUT', 'DELETE'] ]),
         OptString.new('USERNAME', [false, 'The username to login as']),
         OptString.new('PASSWORD', [false, 'The password to login with'])
       ], self.class)
-    end
+  end
 
   def run
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
-    uri = normalize_uri(target_uri.path)
-    res = send_request_cgi({
-      'uri'      => uri,
-      'method'   => datastore['HTTP_METHOD'],
-      'authorization' => basic_auth(username, password),
-      'headers'  => {
-        'Cookie'   => 'Whatever?'
-      }
-    })
-
-    if res.nil?
-      print_error("No response for #{target_host}")
-      return nil
-    end
-
     begin
+      res = send_request_cgi({
+        'uri'           => normalize_uri(target_uri.path),
+        'method'        => 'GET',
+        'authorization' => basic_auth(username, password)
+      })
+
       temp = JSON.parse(res.body)
-    rescue JSON::ParserError
-      print_error("Unable to parse JSON")
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, JSON::ParserError => e
+      print_error("#{peer} - The following Error was encountered: #{e.class}")
       return
     end
 
-    results = JSON.pretty_generate(temp)
+    if res.code == 200 && res.headers['Server'] =~ /CouchDB/
 
-    if (res.code == 200)
-      print_good("#{target_host}:#{rport} -> #{res.code}")
-      print_good("Response Headers:\n\n #{res.headers}")
-      print_good("Response Body:\n\n #{results}\n")
-    elsif (res.code == 403) # Forbidden
-      print_error("Received #{res.code} - Forbidden to #{target_host}:#{rport}")
-      print_error("Response from server:\n\n #{results}\n")
-    elsif (res.code == 404) # Not Found
-      print_error("Received #{res.code} - Not Found to #{target_host}:#{rport}")
-      print_error("Response from server:\n\n #{results}\n")
-    else
-      print_status("Received #{res.code}")
-      print_line("#{results}")
-    end
+      print_status('Enumerating...')
+      results = JSON.pretty_generate(temp)
+      print_good("Found:\n\n#{results}\n")
 
-    if res and res.code == 200 and res.headers['Content-Type'] and res.body.length > 0
-      path = store_loot("couchdb.enum.file", "text/plain", rhost, res.body, "CouchDB Enum Results")
-      print_status("Results saved to #{path}")
+      path = store_loot(
+        'couchdb.enum',
+        'text/plain',
+        rhost,
+        results,
+        'CouchDB Enum'
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
     else
-      print_error("Failed to save the result")
+      print_error("#{peer} - Unable to enum, received \"#{res.code}\"")
     end
   end
 end


### PR DESCRIPTION
I rewrote some parts of the module that develops a while back for enumeration of CouchDB databases. I think it's better than it was before. Please suggestions.
### Before

```
msf auxiliary(couchdb_enum) > run

[+] 192.168.1.40:5984 -> 200
[+] Response Headers:

 Server: CouchDB/1.2.0 (Erlang OTP/R15B01)
Date: Wed, 15 Apr 2015 06:11:47 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 59
Cache-Control: must-revalidate


[+] Response Body:

 [
  "_replicator",
  "_users",
  "database_hackers",
  "database_msf"
]

[*] Results saved to /home/espreto/.msf4/loot/20150415031219_default_192.168.1.40_couchdb.enum.fil_116909.txt
[*] Auxiliary module execution completed
msf auxiliary(couchdb_enum) > set TARGETURI /database_msf
TARGETURI => /database_msf
msf auxiliary(couchdb_enum) > run

[+] 192.168.1.40:5984 -> 200
[+] Response Headers:

 Server: CouchDB/1.2.0 (Erlang OTP/R15B01)
Date: Wed, 15 Apr 2015 06:12:08 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 231
Cache-Control: must-revalidate


[+] Response Body:

 {
  "db_name": "database_msf",
  "doc_count": 0,
  "doc_del_count": 0,
  "update_seq": 0,
  "purge_seq": 0,
  "compact_running": false,
  "disk_size": 79,
  "data_size": 0,
  "instance_start_time": "1429077149813920",
  "disk_format_version": 6,
  "committed_update_seq": 0
}

[*] Results saved to /home/espreto/.msf4/loot/20150415031240_default_192.168.1.40_couchdb.enum.fil_507576.txt
[*] Auxiliary module execution completed
msf auxiliary(couchdb_enum) >
```
### After

```
msf auxiliary(couchdb_enum) > set RHOST 192.168.1.40
RHOST => 192.168.1.40
msf auxiliary(couchdb_enum) > run

[*] Enumerating...
[+] Found:

[
  "_replicator",
  "_users",
  "database_hackers",
  "database_msf"
]

[+] 192.168.1.40:5984 - File saved in: /home/espreto/.msf4/loot/20150415025544_default_192.168.1.40_couchdb.enum_456115.txt
[*] Auxiliary module execution completed
msf auxiliary(couchdb_enum) > set TARGETURI /database_msf
TARGETURI => /database_msf
msf auxiliary(couchdb_enum) > run

[*] Enumerating...
[+] Found:

{
  "db_name": "database_msf",
  "doc_count": 0,
  "doc_del_count": 0,
  "update_seq": 0,
  "purge_seq": 0,
  "compact_running": false,
  "disk_size": 79,
  "data_size": 0,
  "instance_start_time": "1429077149813920",
  "disk_format_version": 6,
  "committed_update_seq": 0
}

[+] 192.168.1.40:5984 - File saved in: /home/espreto/.msf4/loot/20150415025602_default_192.168.1.40_couchdb.enum_975484.txt
[*] Auxiliary module execution completed
msf auxiliary(couchdb_enum) > 
msf auxiliary(couchdb_enum) >
```

Best regards,
