### PR TITLE
Fix WinRM_Login Stacktrace

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -224,7 +224,7 @@ module Metasploit
           configure_http_client(cli)
 
           if realm
-            cli.set_config('domain' => credential.realm)
+            cli.set_config('domain' => realm)
           end
 
           begin


### PR DESCRIPTION
## Verification
- [x] Run WinRM_login with valid credentials and watch it stacktrace

Apply this PR
- [x] Run WinRM_login and succeed!

```
20150415-15:44 - 192.168.153.137 auxiliary(winrm_login) > run

[-] [2015.04.15-15:44:03] Auxiliary failed: NameError undefined local variable or method `credential' for #<Metasploit::Framework::LoginScanner::WinRM:0x00000006f14f68>
[-] [2015.04.15-15:44:03] Call stack:
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/http.rb:227:in `send_request'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/http.rb:266:in `attempt_login'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:216:in `block in scan!'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:148:in `block in each_credential'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/metasploit/framework/credential_collection.rb:121:in `each'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:135:in `each_credential'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/metasploit/framework/login_scanner/base.rb:198:in `scan!'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/modules/auxiliary/scanner/winrm/winrm_login.rb:68:in `run_host'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:116:in `block (2 levels) in run'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `call'
[-] [2015.04.15-15:44:03]   /usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
[*] Auxiliary module execution completed
```
