### PR TITLE
Correct a bad spelling in ms15_034_ulonglongadd.rb

### DIFF
--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Auxiliary
       'Description'    => %q{
         This module will check if your hosts are vulnerable to CVE-2015-1635 (MS15-034). A
         vulnerability in the HTTP Protocol stack (HTTP.sys) that could result in arbitrary code
-        execution. This module will try to cause a denail-of-service.
+        execution. This module will try to cause a denial-of-service.
 
         Please note that you must supply a valid file resource for the TARGETURI option.
         By default, IIS may come with these settings that you could try: iisstart.htm,


### PR DESCRIPTION
I made a typo: "denail of service", and @dmiller-nmap found it.
