### PR TITLE
Detect more Readmes

### DIFF
--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -107,18 +107,15 @@ module Msf::HTTP::Wordpress::Version
       fail("Unknown readme type #{type}")
     end
 
-    readme_url = normalize_uri(target_uri.path, wp_content_dir, folder, name, 'readme.txt')
-    res = send_request_cgi(
-      'uri'    => readme_url,
-      'method' => 'GET'
-    )
-    
-    if res.nil? || res.code != 200
-      readme_url = normalize_uri(target_uri.path, wp_content_dir, folder, name, 'Readme.txt')
+    readmes = ['readme.txt', 'Readme.txt', 'README.txt']
+
+    readmes.each do |r|
+      readme_url = normalize_uri(target_uri.path, wp_content_dir, folder, name, 'readme.txt')
       res = send_request_cgi(
         'uri'    => readme_url,
         'method' => 'GET'
       )
+      break if res && res.code == 200
     end
 
     if res.nil? || res.code != 200

--- a/lib/msf/http/wordpress/version.rb
+++ b/lib/msf/http/wordpress/version.rb
@@ -109,8 +109,10 @@ module Msf::HTTP::Wordpress::Version
 
     readmes = ['readme.txt', 'Readme.txt', 'README.txt']
 
-    readmes.each do |r|
-      readme_url = normalize_uri(target_uri.path, wp_content_dir, folder, name, 'readme.txt')
+    res = nil
+    readmes.each do |readme_name|
+      readme_url = normalize_uri(target_uri.path, wp_content_dir, folder, name, readme_name)
+      vprint_status("#{peer} - Checking #{readme_url}")
       res = send_request_cgi(
         'uri'    => readme_url,
         'method' => 'GET'


### PR DESCRIPTION
This code checks for more Readme files when using the wordpress mixin.

Tested with
`./msfconsole -x "use exploit/unix/webapp/wp_worktheflow_upload; set RHOST 10.211.55.4; set VERBOSE true; check; exit"`

```
RHOST => 10.211.55.4
VERBOSE => true
[*] 10.211.55.4:80 - Checking /wp-content/plugins/work-the-flow-file-upload/readme.txt
[*] 10.211.55.4:80 - Checking /wp-content/plugins/work-the-flow-file-upload/Readme.txt
[*] 10.211.55.4:80 - Checking /wp-content/plugins/work-the-flow-file-upload/README.txt
[*] 10.211.55.4:80 - Found version 2.5.2 of the plugin
[*] 10.211.55.4:80 - The target is not exploitable.
```
