### PR TITLE
Update to redcarpet 3.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
       json (~> 1.4)
     recog (1.0.27)
       nokogiri
-    redcarpet (3.1.2)
+    redcarpet (3.2.3)
     rkelly-remix (0.0.6)
     robots (0.10.1)
     rspec (2.99.0)


### PR DESCRIPTION
MSP-12565

Version 3.2.3 [fixes](https://github.com/vmg/redcarpet/commit/a6c759d7e7cbdd8cb8a1876f97a38b1befe221d5) a XSS via parse_line ([OSVDB-120415](http://osvdb.org/show/osvdb/120415)).
# Verification Steps
- [x] `bundle`
- [x] `rake yard` (wait a long time)
- [x] VERIFY docs are generated without redcarpet crashing.
# Post-merge Steps
- [x] Notify @limhoff-r7 or @trosen-r7 so they can ackknowledge the alert resolved on Gemnasium.
