### PR TITLE
Fix #5137 - Correct use of fail_with for wp_nmediawebsite_file_upload.rb

### DIFF
--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
         begin
           new_php_pagename = JSON.parse(res.body)["filename"]
         rescue JSON::ParserError
-          new_php_pagename = ''
+          fail_with(Failure::Unknown, 'Unable to parse JSON data for the filename')
         end
         print_good("#{peer} - Our payload is at: #{new_php_pagename}. Calling payload...")
         register_files_for_cleanup(new_php_pagename)
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
         fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
       end
     else
-      fail_with('ERROR')
+      fail_with(Failure::Unknown,'ERROR')
     end
 
     print_status("#{peer} - Calling payload...")


### PR DESCRIPTION
Bug fix for #5137

This PR fixes a bug for how fail_with is used in the wp_nmediawebsite_file_upload.rb module. The method requires two arguments, and the reason argument is missing.

I also decided to call fail_with if the JSON data fails to parse, because there's no need to continue.
## Verification
- [x] Please see: https://github.com/rapid7/metasploit-framework/blob/c2a252face46e541c6608f56abf1945cc91231e8/lib/msf/core/exploit.rb#L1221
