### PR TITLE
Fix loop spinning in HttpClient

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -586,6 +586,8 @@ class Client
         begin
 
           buff = conn.get_once(-1, 1)
+          return resp if buff.nil? or buff.empty?
+
           rv   = resp.parse( buff || '' )
 
         # Handle unexpected disconnects

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -579,6 +579,7 @@ class Client
 
       rv = nil
       while (
+               not conn.closed? and
                rv != Packet::ParseCode::Completed and
                rv != Packet::ParseCode::Error
               )
@@ -586,8 +587,6 @@ class Client
         begin
 
           buff = conn.get_once(-1, 1)
-          return resp if buff.to_s.length == 0
-
           rv   = resp.parse( buff || '' )
 
         # Handle unexpected disconnects

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -586,7 +586,7 @@ class Client
         begin
 
           buff = conn.get_once(-1, 1)
-          return resp if buff.nil? or buff.empty?
+          return resp if buff.to_s.length == 0
 
           rv   = resp.parse( buff || '' )
 


### PR DESCRIPTION
Problem: when running modules that use the HttpClient mixin, some web servers will cause the mixin's read_response() to spin, and jack the CPU to 100% which freezes the console. This happens with the Skype web server at the very least, and probably others.

Scenario: set RHOSTS to an IP with a Skype web server running, run `auxiliary/scanner/http/http_version` or `auxiliary/scanner/http/tomcat_mgr_login` and watch the console freeze. I assume any module that uses the HttpClient mixin is affected.

Proposed fix: break out of the loop when the read buffer is empty instead of smashing the CPU waiting for more data that will never come.

Alternative fix: a `sleep 0.1` at the end of the loop stops the spinning and is less heavy-handed, but seems a bit hacky.

I'm not 100% convinced these fixes are any good, btw, so comments welcome.
