### PR TITLE
Fix #5130, Correct use of fail_with in wp_worktheflow_upload.rb

### DIFF
--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
         fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
       end
     else
-      fail_with('ERROR')
+      fail_with(Failure::Unknown, 'ERROR')
     end
 
     print_status("#{peer} - Calling payload...")


### PR DESCRIPTION
The fail_with method requires two arguments, but there's only one.
## Verification
- [x] Please see: https://github.com/rapid7/metasploit-framework/blob/c2a252face46e541c6608f56abf1945cc91231e8/lib/msf/core/exploit.rb#L1221
