### PR TITLE
Resolve #5013 - Prevent OSX Python Meterpreter Crashing

### DIFF
--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -749,7 +749,7 @@ class PythonMeterpreter(object):
 		resp = struct.pack('>I', len(resp) + 4) + resp
 		return resp
 
-if not hasattr(os, 'fork') or (hasattr(os, 'fork') and os.fork() == 0):
+if not hasattr(os, 'fork') or has_osxsc or (hasattr(os, 'fork') and os.fork() == 0):
 	if hasattr(os, 'setsid'):
 		try:
 			os.setsid()


### PR DESCRIPTION
This removes forking which causes the SystemConfigurator wrapper to crash.

Ideally SC should be fixed, but as a temporary workaround we can remove forking when running on OSX.
