### PR TITLE
Fix #5103, Revert unwanted URI encoding

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -81,6 +81,7 @@ class Metasploit4 < Msf::Auxiliary
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },
+        'encode_params' => false,
         'vars_get' => {
           'sap-client'    => datastore['CLIENT'],
           'sap-language'  => 'EN'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -123,6 +123,7 @@ class Metasploit4 < Msf::Auxiliary
       'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{client}",
       'ctype' => 'text/xml; charset=UTF-8',
       'authorization' => basic_auth(username, password),
+      'encode_params' => false,
       'headers' =>
         {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -102,6 +102,7 @@ class Metasploit4 < Msf::Auxiliary
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },
+        'encode_params' => false,
         'vars_get' => {
           'sap-client'    => datastore['CLIENT'],
           'sap-language'  => 'EN'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -103,6 +103,7 @@ class Metasploit4 < Msf::Auxiliary
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },
+        'encode_params' => false,
         'vars_get' => {
           'sap-client'    => datastore['CLIENT'],
           'sap-language'  => 'EN'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -71,6 +71,7 @@ class Metasploit4 < Msf::Auxiliary
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
         },
+        'encode_params' => false,
         'vars_get' => {
           'sap-client'    => client,
           'sap-language'  => 'EN'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -89,6 +89,7 @@ class Metasploit4 < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'ctype' => 'text/xml; charset=UTF-8',
+        'encode_params' => false,
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -75,6 +75,7 @@ class Metasploit4 < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
+        'encode_params' => false,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers'  => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -78,6 +78,7 @@ class Metasploit4 < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
+        'encode_params' => false,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -78,6 +78,7 @@ class Metasploit4 < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
+        'encode_params' => false,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -94,6 +94,7 @@ class Metasploit4 < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
+        'encode_params' => false,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -69,6 +69,7 @@ class Metasploit4 < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
+        'encode_params' => false,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -105,6 +105,7 @@ class Metasploit3 < Msf::Exploit::Remote
       res = send_request_cgi({
         'uri'       => '/admin/system.html',
         'cookie'    => "usercookie=#{user}; passcookie=#{pass};",
+        'encode_params' => false,
         'vars_get'  => {
           'step'    => '2',
           'device'  => "lo#{cmd}"

--- a/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
@@ -102,6 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
       login = send_request_cgi({
         'uri' => normalize_uri(target_uri.path, '/index.php'),
         'method' => 'POST',
+        'encode_params' => false,
         'vars_post' => post,
         'vars_get' => {
           'c' => 'login',

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -97,6 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
       res = send_request_cgi({
         'uri'           => '/index.cgi',
         'authorization' => basic_auth(user, pass),
+        'encode_params' => false,
         'vars_get'      => {
           'nlines'  => lines,
           'action'  => 'See logs',

--- a/modules/exploits/multi/http/hyperic_hq_script_console.rb
+++ b/modules/exploits/multi/http/hyperic_hq_script_console.rb
@@ -66,6 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'       => normalize_uri(@uri.path, 'j_spring_security_check'),
       'method'    => 'POST',
       'cookie'    => @cookie,
+      'encode_params' => false,
       'vars_post' => {
         'j_username' => Rex::Text.uri_encode(user, 'hex-normal'),
         'j_password' => Rex::Text.uri_encode(pass, 'hex-normal'),
@@ -86,6 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => normalize_uri(@uri.path, 'mastheadAttach.do'),
       'cookie' => @cookie,
+      'encode_params' => false,
       'vars_get' => {
         'typeId' => '10003'
       }
@@ -144,6 +146,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'    => 'POST',
       'uri'       => normalize_uri(@uri.path, 'hqu/gconsole/console/execute.hqu?org.apache.catalina.filters.CSRF_NONCE=')+@nonce,
       'cookie'    => @cookie,
+      'encode_params' => false,
       'vars_post' => {
         'code' => java # java_craft_runtime_exec(cmd)
       }

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -184,6 +184,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'     => normalize_uri(base, 'setup/setup-/../../plugin-admin.jsp'),
       'method'  => 'POST',
       'data'    => data,
+      'encode_params' => false,
       'headers' => {
         'Content-Type'   => 'multipart/form-data; boundary=' + boundary,
         'Content-Length' => data.length,
@@ -202,6 +203,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("Deleting plugin #{plugin_name} from the server")
       res = send_request_cgi({
         'uri'     => normalize_uri(base, 'setup/setup-/../../plugin-admin.jsp'),
+        'encode_params' => false,
         'headers' => {
           'Cookie' => "JSESSIONID=#{rand_text_numeric(13)}",
         },

--- a/modules/exploits/windows/http/adobe_robohelper_authbypass.rb
+++ b/modules/exploits/windows/http/adobe_robohelper_authbypass.rb
@@ -71,6 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri'		=> '/robohelp/server',
         'version'	=> '1.1',
         'method'	=> 'POST',
+        'encode_params' => false,
         'data'		=> file,
         'headers'	=> {
           'Content-Type'		=> 'multipart/form-data; boundary=---------------------------' + uid,

--- a/modules/exploits/windows/http/desktopcentral_file_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_file_upload.rb
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'    => 'POST',
       'data'      => contents,
       'ctype'     => 'text/html',
+      'encode_params' => false,
       'vars_get'  => {
         'computerName'  => 'DesktopCentral',
         'domainName'    => 'webapps',

--- a/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
@@ -85,6 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
     send_request_cgi({
       'uri'		  => '/OvCgi/ovalarm.exe',
       'method'	  => "GET",
+      'encode_params' => false,
       'headers'  => {
         'Accept-Language' => sploit
       },

--- a/modules/exploits/windows/http/sybase_easerver.rb
+++ b/modules/exploits/windows/http/sybase_easerver.rb
@@ -70,6 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri'       => normalize_uri(datastore['DIR'], 'Login.jsp'),
       'method'    => 'GET',
+      'encode_params' => false,
       'headers'   => {
         'Accept' => '*/*',
       },

--- a/modules/exploits/windows/http/zenworks_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_uploadservlet.rb
@@ -73,6 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'headers'   => {
         'Content-Type' => 'application/octet-stream',
       },
+      'encode_params' => false,
       'vars_get'  => {
         'filename' => "../../webapps/#{app_base}.war"
       }
@@ -82,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     select(nil, nil, nil, 20)
 
-    if (res.code == 200)
+    if (res && res.code == 200)
       print_status("Triggering payload at '/#{app_base}/#{jsp_name}.jsp' ...")
         send_request_raw(
           {


### PR DESCRIPTION
Fix #5103. By default, Httpclient will encode the URI but we don't necessarily want that. These modules originally didn't use URI encoding when they were written so we should just keep them that way.

@FireFart Can you please take this?
