### PR TITLE
Improve developer experience for fail_with

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1218,10 +1218,31 @@ class Exploit < Msf::Module
   # Failure tracking
   ##
 
+  # Raises a Msf::Exploit::Failed exception. It overrides the fail_with method
+  # in lib/msf/core/module.rb
+  #
+  # @param reason [String] A constant from Msf::Module::Failure.
+  #                        If the reason does not come from there, then it will default to
+  #                        Msf::Module::Failure::Unknown.
+  # @param mssg [String] (Optional) A message about the failure.
+  # @raise [Msf::Exploit::Failed] A custom Msf::Exploit::Failed exception.
+  # @return [void]
+  # @see Msf::Module::Failure
+  # @see Msf::Module#fail_with
+  # @example
+  #   fail_with(Msf::Module::Failure::NoAccess, 'Unable to login to upload payload')
   def fail_with(reason,msg=nil)
-    self.fail_reason = reason
+    # The reason being registered here will be used later on, so it's important we don't actually
+    # provide a made-up one.
+    allowed_values = Msf::Module::Failure.constants.collect {|e| Msf::Module::Failure.const_get(e)}
+    if allowed_values.include?(reason)
+      self.fail_reason = reason
+    else
+      self.fail_reason = Msf::Module::Failure::Unknown
+    end
+
     self.fail_detail = msg
-    raise Msf::Exploit::Failed, (msg || "No reason given")
+    raise Msf::Exploit::Failed, (msg || "No failure message given")
   end
 
   def report_failure

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -276,7 +276,18 @@ class Module
   end
 
   #
-  # Support fail_with for all module types, allow specific classes to override
+  # Raises a RuntimeError failure message. This is meant to be used for all non-exploits,
+  # and allows specific classes to override.
+  #
+  # @param reason [String] A reason about the failure.
+  # @param msg [String] (Optional) A message about the failure.
+  # @raise [RuntimeError]
+  # @return [void]
+  # @note If you are writing an exploit, you don't use this API. Instead, please refer to the
+  #       API documentation from lib/msf/core/exploit.rb.
+  # @see Msf::Exploit#fail_with
+  # @example
+  #   fail_with('No Access', 'Unable to login')
   #
   def fail_with(reason, msg=nil)
     raise RuntimeError, "#{reason.to_s}: #{msg}"


### PR DESCRIPTION
So after looking at #5171 I realized maybe there's some confusion about fail_with. @FireFart did a great job catching them all though.

The fail_with for an exploit is used differently than a non-exploit, so it would be nice to document about this. Also, be strict about the reason for the exploit one, because this can affect other components of Metasploit because we actually use that data.
- [x] Under the msf directory, do: `yard doc`
- [x] You should see the new doc generated in the "doc" directory
- [x] Open msf/doc/Msf/Exploit.html
- [x] You should see the new documentation for fail_with for exploit.rb.
- [x] The two "See Also" links should work too.
- [x] Find msf/doc/Msf/Module.html
- [x] You should see the new documentation for fail_with for module.rb
- [x] The "See Also" link to exploit.rb should work too
- [x] Save the following template as an exploit somewhere in the exploit directory:

``` ruby
##
# This module requires Metasploit: http://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

require 'msf/core'

class Metasploit3 < Msf::Exploit::Remote
  Rank = NormalRanking

  def initialize(info={})
    super(update_info(info,
      'Name'           => "Test fail_with",
      'Description'    => %q{ Test fail_with },
      'License'        => MSF_LICENSE,
      'Author'         => [ 'Name' ],
      'Platform'       => 'win',
      'Targets'        => [ [ 'Anything', {} ] ],
      'Privileged'     => false,
      'DefaultOptions' => {'DisablePayloadHandler'=>true},
      'DisclosureDate' => "Nov 01 2015",
      'DefaultTarget'  => 0))
  end

  def exploit
    #
    # This is what you should see:
    # [-] Exploit aborted due to failure: unknown: ohoh, bad reason!
    #
    # fail_with("Bad Reason", 'ohoh, bad reason!')


    #
    # This is what you should see:
    # [-] Exploit aborted due to failure: bad-config: bad-config
    #
    # fail_with(Failure::BadConfig, 'bad-config')
  end

end
```
- [x] Start msfconsole
- [x] Do: `use [the test module's path]`
- [x] Uncomment the first fail_with
- [x] Do: `rerun`
- [x] You should see this message: "[-] Exploit aborted due to failure: unknown: ohoh, bad reason!"
- [x] Comment the first fail_with back
- [x] Uncomment the second fail_with
- [x] Do: `rerun`
- [x] You should see this message: "[-] Exploit aborted due to failure: bad-config: bad-config"
