### PR TITLE
Add TIMEOUT config param

### DIFF
--- a/modules/exploits/multi/http/drupal_drupageddon.rb
+++ b/modules/exploits/multi/http/drupal_drupageddon.rb
@@ -42,7 +42,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
     [
-      OptString.new('TARGETURI', [ true, "The target URI of the Drupal installation", '/'])
+      OptString.new('TARGETURI', [ true, "The target URI of the Drupal installation", '/']),
+      OptInt.new('TIMEOUT', [ true, "The timeout waiting for the server response", 20])
     ], self.class)
 
     register_advanced_options(
@@ -58,6 +59,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def admin_role
     datastore['ADMIN_ROLE']
+  end
+
+  def timeout
+    datastore['TIMEOUT']
   end
 
   def iter
@@ -146,7 +151,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'vars_get' => {
         'q' => 'user/login'
       }
-    })
+    }, timeout)
 
     unless res and res.body
       fail_with(Failure::Unknown, "No response or response body, bailing.")
@@ -174,7 +179,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'vars_get' => {
         'q' => 'user/login'
       }
-    })
+    }, timeout)
 
     unless res and res.body
       fail_with(Failure::Unknown, "No response or response body, bailing.")
@@ -195,7 +200,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'vars_get' => {
         'q' => 'user/login'
       }
-    })
+    }, timeout)
 
     unless res and res.code == 302
       fail_with(Failure::Unknown, "No response or response body, bailing.")
@@ -212,7 +217,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'q' => 'admin/modules'
       },
       'cookie' => cookie
-    })
+    }, timeout)
 
     form_build_id, form_token = extract_form_ids(res.body)
 
@@ -245,7 +250,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'q' => 'admin/modules/list/confirm'
       },
       'cookie' => cookie
-    })
+    }, timeout)
 
     unless res and res.body
       fail_with(Failure::Unknown, "No response or response body, bailing.")
@@ -262,7 +267,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'q' => 'admin/people/permissions'
       },
       'cookie' => cookie
-    })
+    }, timeout)
 
 
     unless res and res.body
@@ -306,7 +311,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'q' => 'admin/people/permissions'
       },
       'cookie' => cookie
-    })
+    }, timeout)
 
     unless res and res.body
       fail_with(Failure::Unknown, "No response or response body, bailing.")
@@ -320,7 +325,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'q' => 'node/add/article'
       },
       'cookie' => cookie
-    })
+    }, timeout)
 
     unless res and res.body
       fail_with(Failure::Unknown, "No response or response body, bailing.")
@@ -343,7 +348,7 @@ class Metasploit3 < Msf::Exploit::Remote
     post_data = data.to_s
 
     print_status("#{peer} - Calling preview page. Exploit should trigger...")
-    send_request_cgi(
+    send_request_cgi({
       'method'   => 'POST',
       'uri'      => uri_path,
       'ctype'    => "multipart/form-data; boundary=#{data.bound}",
@@ -352,6 +357,6 @@ class Metasploit3 < Msf::Exploit::Remote
         'q' => 'node/add/article'
       },
       'cookie' => cookie
-    )
+    }, timeout)
   end
 end


### PR DESCRIPTION
Modified "drupalgedon" module to add TIMEOUT like parameter. I am testing servers Drupal 7.31 and they response very slow and the value 20 by default for timeout is not enough.
