### PR TITLE
Testing merged meterpreter/java payloads gem 'metasploit-payloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (= 0.4.0)
       metasploit-model (~> 0.29.0)
-      meterpreter_bins (= 0.0.22)
+      metasploit-payloads (= 0.0.1)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -123,6 +123,7 @@ GEM
     metasploit-model (0.29.2)
       activesupport
       railties (< 4.0.0)
+    metasploit-payloads (0.0.1)
     metasploit_data_models (0.24.0)
       activerecord (>= 3.2.13, < 4.0.0)
       activesupport
@@ -132,7 +133,6 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.22)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.2)

--- a/lib/msf/core/payload/java.rb
+++ b/lib/msf/core/payload/java.rb
@@ -17,9 +17,7 @@ module Msf::Payload::Java
   def generate_stage
     stage = ''
     @stage_class_files.each do |path|
-      fd = File.open(File.join( Msf::Config.data_directory, "java", path ), "rb")
-      data = fd.read(fd.stat.size)
-      fd.close
+      data = MetasploitPayloads.read("java", path)
       stage << ([data.length].pack("N") + data)
     end
     stage << [0].pack("N")
@@ -37,7 +35,7 @@ module Msf::Payload::Java
   #
   # Used by stagers to create a jar file as a {Rex::Zip::Jar}.  Stagers
   # define a list of class files in @class_files which are pulled from
-  # {Msf::Config.data_directory}.  The configuration file is created by
+  # {MetasploitPayloads.data_directory}.  The configuration file is created by
   # the payload's #config method.
   #
   # @option opts :main_class [String] the name of the Main-Class
@@ -58,7 +56,7 @@ module Msf::Payload::Java
     jar = Rex::Zip::Jar.new
     jar.add_sub("metasploit") if opts[:random]
     jar.add_file("metasploit.dat", config)
-    jar.add_files(paths, File.join(Msf::Config.data_directory, "java"))
+    jar.add_files(paths, File.join(MetasploitPayloads.data_directory, "java"))
     jar.build_manifest(:main_class => main_class)
 
     jar
@@ -103,7 +101,7 @@ module Msf::Payload::Java
     zip.add_file('WEB-INF/', '')
     zip.add_file('WEB-INF/web.xml', web_xml)
     zip.add_file("WEB-INF/classes/", "")
-    zip.add_files(paths, File.join(Msf::Config.data_directory, "java"), "WEB-INF/classes/")
+    zip.add_files(paths, File.join(MetasploitPayloads.data_directory, "java"), "WEB-INF/classes/")
     zip.add_file("WEB-INF/classes/metasploit.dat", config)
 
     zip

--- a/lib/msf/core/payload/windows/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/stageless_meterpreter.rb
@@ -52,7 +52,7 @@ module Payload::Windows::StagelessMeterpreter
   end
 
   def generate_stageless_x86(url = nil)
-    dll, offset = load_rdi_dll(MeterpreterBinaries.path('metsrv', 'x86.dll'))
+    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x86.dll'))
 
     conf = {
       :rdi_offset => offset,
@@ -94,7 +94,7 @@ module Payload::Windows::StagelessMeterpreter
     unless datastore['EXTENSIONS'].nil?
       datastore['EXTENSIONS'].split(',').each do |e|
         e = e.strip.downcase
-        ext, o = load_rdi_dll(MeterpreterBinaries.path("ext_server_#{e}", 'x86.dll'))
+        ext, o = load_rdi_dll(MetasploitPayloads.meterpreter_path("ext_server_#{e}", 'x86.dll'))
 
         # append the size, offset to RDI and the payload itself
         dll << [ext.length].pack('V') + ext

--- a/lib/msf/core/payload/windows/x64/stageless_meterpreter.rb
+++ b/lib/msf/core/payload/windows/x64/stageless_meterpreter.rb
@@ -52,7 +52,7 @@ module Payload::Windows::StagelessMeterpreter_x64
   end
 
   def generate_stageless_x64(url = nil)
-    dll, offset = load_rdi_dll(MeterpreterBinaries.path('metsrv', 'x64.dll'))
+    dll, offset = load_rdi_dll(MetasploitPayloads.meterpreter_path('metsrv', 'x64.dll'))
 
     conf = {
       :rdi_offset => offset,
@@ -94,7 +94,7 @@ module Payload::Windows::StagelessMeterpreter_x64
     unless datastore['EXTENSIONS'].nil?
       datastore['EXTENSIONS'].split(',').each do |e|
         e = e.strip.downcase
-        ext, o = load_rdi_dll(MeterpreterBinaries.path("ext_server_#{e}", 'x64.dll'))
+        ext, o = load_rdi_dll(MetasploitPayloads.meterpreter_path("ext_server_#{e}", 'x64.dll'))
 
         # append the size, offset to RDI and the payload itself
         dll << [ext.length].pack('V') + ext

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1135,7 +1135,7 @@ require 'msf/core/exe/segment_appender'
     paths = [
       [ "metasploit", "Payload.class" ],
     ]
-    zip.add_files(paths, File.join(Msf::Config.data_directory, "java"))
+    zip.add_files(paths, File.join(MetasploitPayloads.data_directory, "java"))
     zip.build_manifest :main_class => "metasploit.Payload"
     config = "Spawn=#{spawn}\r\nExecutable=#{exe_name}\r\n"
     zip.add_file("metasploit.dat", config)

--- a/lib/rex/post/meterpreter.rb
+++ b/lib/rex/post/meterpreter.rb
@@ -1,5 +1,5 @@
 # -*- coding: binary -*-
 
-require 'meterpreter_bins'
+require 'metasploit-payloads'
 require 'rex/post/meterpreter/client'
 require 'rex/post/meterpreter/ui/console'

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -221,7 +221,7 @@ class ClientCore < Extension
       # Get us to the installation root and then into data/meterpreter, where
       # the file is expected to be
       modname = "ext_server_#{mod.downcase}"
-      path = MeterpreterBinaries.path(modname, client.binary_suffix)
+      path = MetasploitPayloads.meterpreter_path(modname, client.binary_suffix)
 
       if opts['ExtensionPath']
         path = ::File.expand_path(opts['ExtensionPath'])
@@ -595,7 +595,7 @@ class ClientCore < Extension
     # Create the migrate stager
     migrate_stager = c.new()
 
-    dll = MeterpreterBinaries.path('metsrv',binary_suffix)
+    dll = MetasploitPayloads.meterpreter_path('metsrv', binary_suffix)
     if dll.nil?
       raise RuntimeError, "metsrv.#{binary_suffix} not found", caller
     end
@@ -626,12 +626,7 @@ class ClientCore < Extension
   end
 
   def generate_linux_stub
-    file = ::File.join(Msf::Config.data_directory, "meterpreter", "msflinker_linux_x86.bin")
-    blob = ::File.open(file, "rb") {|f|
-      f.read(f.stat.size)
-    }
-
-    blob
+    MetasploitPayloads.read('meterpreter', 'msflinker_linux_x86.bin')
   end
 
   def elf_ep(payload)

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -45,7 +45,7 @@ class Priv < Extension
 
     elevator_name = Rex::Text.rand_text_alpha_lower( 6 )
 
-    elevator_path = MeterpreterBinaries.path('elevator', client.binary_suffix)
+    elevator_path = MetasploitPayloads.meterpreter_path('elevator', client.binary_suffix)
     if elevator_path.nil?
       raise RuntimeError, "elevator.#{binary_suffix} not found", caller
     end

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -157,7 +157,7 @@ class UI < Rex::Post::UI
 
     # include the x64 screenshot dll if the host OS is x64
     if( client.sys.config.sysinfo['Architecture'] =~ /^\S*x64\S*/ )
-      screenshot_path = MeterpreterBinaries.path('screenshot','x64.dll')
+      screenshot_path = MetasploitPayloads.meterpreter_path('screenshot','x64.dll')
       if screenshot_path.nil?
         raise RuntimeError, "screenshot.x64.dll not found", caller
       end
@@ -172,7 +172,7 @@ class UI < Rex::Post::UI
     end
 
     # but always include the x86 screenshot dll as we can use it for wow64 processes if we are on x64
-    screenshot_path = MeterpreterBinaries.path('screenshot','x86.dll')
+    screenshot_path = MetasploitPayloads.meterpreter_path('screenshot','x86.dll')
     if screenshot_path.nil?
       raise RuntimeError, "screenshot.x86.dll not found", caller
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -620,8 +620,8 @@ class Console::CommandDispatcher::Core
       case opt
       when "-l"
         exts = SortedSet.new
-        msf_path = MeterpreterBinaries.metasploit_data_dir
-        gem_path = MeterpreterBinaries.local_dir
+        msf_path = MetasploitPayloads.msf_meterpreter_dir
+        gem_path = MetasploitPayloads.local_meterpreter_dir
         [msf_path, gem_path].each do |path|
           ::Dir.entries(path).each { |f|
             if (::File.file?(::File.join(path, f)) && f =~ /ext_server_(.*)\.#{client.binary_suffix}/ )
@@ -668,8 +668,8 @@ class Console::CommandDispatcher::Core
 
   def cmd_load_tabs(str, words)
     tabs = SortedSet.new
-    msf_path = MeterpreterBinaries.metasploit_data_dir
-    gem_path = MeterpreterBinaries.local_dir
+    msf_path = MetasploitPayloads.msf_meterpreter_dir
+    gem_path = MetasploitPayloads.local_meterpreter_dir
     [msf_path, gem_path].each do |path|
     ::Dir.entries(path).each { |f|
       if (::File.file?(::File.join(path, f)) && f =~ /ext_server_(.*)\.#{client.binary_suffix}/ )

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.29.0'
   # Needed for Meterpreter on Windows, soon others.
-  spec.add_runtime_dependency 'meterpreter_bins', '0.0.22'
+  spec.add_runtime_dependency 'metasploit-payloads', '0.0.1'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       # We need this class as a wrapper to run in a thread.  For some reason
       # the Payload class is giving illegal access exceptions without it.
-      path = File.join(Msf::Config.data_directory, "java", "metasploit", "PayloadServlet.class")
+      path = File.join(MetasploitPayloads.data_directory, "java", "metasploit", "PayloadServlet.class")
       fd = File.open(path, "rb")
       servlet = fd.read(fd.stat.size)
       fd.close

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ["metasploit", "JMXPayloadMBean.class"],
         ["metasploit", "JMXPayload.class"],
       ]
-      jar.add_files(paths, [ Msf::Config.data_directory, "java" ])
+      jar.add_files(paths, [ MetasploitPayloads.data_directory, "java" ])
 
       send_response(cli, jar.pack,
         {

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -179,7 +179,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [ "metasploit", "RMILoader.class" ],
         [ "metasploit", "RMIPayload.class" ],
       ]
-      jar.add_files(paths, [ Msf::Config.data_directory, "java" ])
+      jar.add_files(paths, [ MetasploitPayloads.data_directory, "java" ])
 
       send_response(cli, jar.pack,
       {

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -53,10 +53,8 @@ module Metasploit3
           jar.add_file(full, '')
         end
       end
-      fd = File.open(File.join( Msf::Config.data_directory, "java", path ), "rb")
-      data = fd.read(fd.stat.size)
+      data = MetasploitPayloads.read('java', path)
       jar.add_file(path.join("/"), data)
-      fd.close
     end
     jar.build_manifest(:main_class => "metasploit.Payload")
     jar.add_file("metasploit.dat", config)

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -29,10 +29,7 @@ module Metasploit3
   end
 
   def generate
-    file = File.join(Msf::Config.data_directory, "meterpreter", "meterpreter.php")
-    met = File.open(file, "rb") {|f|
-      f.read(f.stat.size)
-    }
+    met = MetasploitPayloads.read('meterpreter', 'meterpreter.php')
     met.gsub!("127.0.0.1", datastore['LHOST']) if datastore['LHOST']
     met.gsub!("4444", datastore['LPORT'].to_s) if datastore['LPORT']
 

--- a/modules/payloads/stages/java/meterpreter.rb
+++ b/modules/payloads/stages/java/meterpreter.rb
@@ -54,8 +54,7 @@ module Metasploit3
   # used as the final stage; calls super to get the intermediate stager.
   #
   def generate_stage
-    file = File.join(Msf::Config.data_directory, "meterpreter", "meterpreter.jar")
-    met = File.open(file, "rb") {|f| f.read(f.stat.size) }
+    met = MetasploitPayloads.read('meterpreter', 'meterpreter.jar')
 
     # All of the dendencies to create a jar loader, followed by the length
     # of the jar and the jar itself.

--- a/modules/payloads/stages/linux/x86/meterpreter.rb
+++ b/modules/payloads/stages/linux/x86/meterpreter.rb
@@ -97,13 +97,6 @@ module Metasploit3
   end
 
   def generate_stage
-    #file = File.join(Msf::Config.data_directory, "msflinker_linux_x86.elf")
-    file = File.join(Msf::Config.data_directory, "meterpreter", "msflinker_linux_x86.bin")
-
-    met = File.open(file, "rb") {|f|
-      f.read(f.stat.size)
-    }
-
-    return met
+    MetasploitPayloads.read('meterpreter', 'msflinker_linux_x86.bin')
   end
 end

--- a/modules/payloads/stages/php/meterpreter.rb
+++ b/modules/payloads/stages/php/meterpreter.rb
@@ -24,13 +24,6 @@ module Metasploit3
   end
 
   def generate_stage
-    file = File.join(Msf::Config.data_directory, "meterpreter", "meterpreter.php")
-
-    met = File.open(file, "rb") {|f|
-      f.read(f.stat.size)
-    }
-    #met.gsub!(/#.*?$/, '')
-    #met = Rex::Text.compress(met)
-    met
+    MetasploitPayloads.read('meterpreter', 'meterpreter.php')
   end
 end

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -27,11 +27,7 @@ module Metasploit3
   end
 
   def generate_stage
-    file = ::File.join(Msf::Config.data_directory, "meterpreter", "meterpreter.py")
-
-    met = ::File.open(file, "rb") {|f|
-      f.read(f.stat.size)
-    }
+    met = MetasploitPayloads.read('meterpreter', 'meterpreter.py')
 
     if datastore['PythonMeterpreterDebug']
       met = met.sub("DEBUGGING = False", "DEBUGGING = True")

--- a/modules/payloads/stages/windows/meterpreter.rb
+++ b/modules/payloads/stages/windows/meterpreter.rb
@@ -39,7 +39,7 @@ module Metasploit3
   end
 
   def library_path
-    MeterpreterBinaries.path('metsrv','x86.dll')
+    MetasploitPayloads.meterpreter_path('metsrv','x86.dll')
   end
 
 end

--- a/modules/payloads/stages/windows/patchupmeterpreter.rb
+++ b/modules/payloads/stages/windows/patchupmeterpreter.rb
@@ -41,7 +41,7 @@ module Metasploit3
   end
 
   def library_path
-    MeterpreterBinaries.path('metsrv','x86.dll')
+    MetasploitPayloads.meterpreter_path('metsrv','x86.dll')
   end
 
 end

--- a/modules/payloads/stages/windows/x64/meterpreter.rb
+++ b/modules/payloads/stages/windows/x64/meterpreter.rb
@@ -34,7 +34,7 @@ module Metasploit3
   end
 
   def library_path
-    MeterpreterBinaries.path('metsrv','x64.dll')
+    MetasploitPayloads.meterpreter_path('metsrv','x64.dll')
   end
 
 end

--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -92,7 +92,7 @@ if client.platform =~ /win32|win64/
     to ||= from
     print_status(" >> Uploading #{from}...")
     fd = client.fs.file.new(tempdir + "\\" + to, "wb")
-    path = (from == 'metsrv.x86.dll') ? MeterpreterBinaries.path('metsrv','x86.dll') : File.join(based, from)
+    path = (from == 'metsrv.x86.dll') ? MetasploitPayloads.meterpreter_path('metsrv','x86.dll') : File.join(based, from)
     fd.write(::File.read(path, ::File.size(path)))
     fd.close
   end

--- a/spec/lib/rex/post/meterpreter_spec.rb
+++ b/spec/lib/rex/post/meterpreter_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'rex/post/meterpreter'
 
-describe MeterpreterBinaries do
+describe MetasploitPayloads do
   it 'is available' do
-    expect(described_class).to eq(MeterpreterBinaries)
+    expect(described_class).to eq(MetasploitPayloads)
   end
 end


### PR DESCRIPTION
This is the first test PR for addressing issue https://github.com/rapid7/meterpreter/issues/110 , which is to enable merging the meterpreter sources and building and publishing a cohesive gem that works for all of them. The 0.0.1 version of the gem was largely built with from Jenkins using the docker image found here: https://registry.hub.docker.com/u/rapid7/build/tags/manage/. The scripts used to merge the repos and to build the docker image are here: https://github.com/bcook-r7/mmerge

Rather than exactly merging everything into rapid7/meterpreter and disrupting development, this PR adds a new gem called metasploit-payloads, creates a new repo https://github.com/rapid7/metasploit-payloads and a modified API to allow addressing more files outside of the meterpreter directory, e.g. the java payloads. This is planning for future expansion for other sorts of binary payloads that may need to be built on a regular basis. See https://github.com/rapid7/meterpreter/issues/110#issuecomment-86628988 for more discussion.

One open question is whether to keep the old behavior of using data/meterpreter if it exists over the gem files, or maybe cause the search to look adjacent to the metasploit-framework -> metasploit-payloads directory if it exists. I'm thinking of awkward scenarios that might occur in testing that already somewhat affect windows/linux builds (remembering to copy to the right place after building, forgetting to remove copied files, etc.)

I want to leave this PR just a bit to see how its received and what adjustments need to be made before we switch over. Ideally, the switch would occur within the next 2 weeks.
