### PR TITLE
Warn the user about probably missing SSL option

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -61,6 +61,11 @@ module Auxiliary
     # Verify the options
     mod.options.validate(mod.datastore)
 
+    warnings = mod.options.check_warnings(mod.datastore)
+    warnings.each do |w|
+      mod.print_warning(w)
+    end
+
     # Initialize user interaction
     if ! opts['Quiet']
       mod.init_ui(opts['LocalInput'] || mod.user_input, opts['LocalOutput'] || mod.user_output)
@@ -112,6 +117,11 @@ module Auxiliary
     # Validate the option container state so that options will
     # be normalized
     mod.validate
+
+    warnings = mod.options.check_warnings(mod.datastore)
+    warnings.each do |w|
+      mod.print_warning(w)
+    end
 
     mod.setup
 
@@ -182,4 +192,3 @@ end
 
 end
 end
-

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -75,6 +75,11 @@ module Exploit
       # Verify the options
       exploit.options.validate(exploit.datastore)
 
+      warnings = exploit.options.check_warnings(exploit.datastore)
+      warnings.each do |w|
+        exploit.print_warning(w)
+      end
+
       # Start it up
       driver = ExploitDriver.new(exploit.framework)
 
@@ -182,6 +187,11 @@ module Exploit
     # be normalized
     mod.validate
 
+    warnings = mod.options.check_warnings(mod.datastore)
+    warnings.each do |w|
+      mod.print_warning(w)
+    end
+
     mod.setup
 
     # Run check
@@ -199,4 +209,3 @@ end
 
 end
 end
-

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -94,6 +94,11 @@ class ExploitDriver
     # are ready to operate as they should.
     exploit.options.validate(exploit.datastore)
 
+    warnings = exploit.options.check_warnings(exploit.datastore)
+    warnings.each do |w|
+      exploit.print_warning(w)
+    end
+
     # Validate the payload's options.  The payload's datastore is
     # most likely shared against the exploit's datastore, but in case it
     # isn't.
@@ -329,4 +334,3 @@ protected
 end
 
 end
-

--- a/lib/msf/core/module/options.rb
+++ b/lib/msf/core/module/options.rb
@@ -21,6 +21,10 @@ module Msf::Module::Options
     self.options.validate(self.datastore)
   end
 
+  def check_warnings
+    self.options.check_warnings(self.datastore)
+  end
+
   protected
 
   #

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -725,6 +725,12 @@ class OptionContainer < Hash
         "One or more options failed to validate", caller
     end
 
+    # message about missing SSL
+    if datastore.include?('RPORT') && [443, 8443].include?(datastore['RPORT']) &&
+      datastore.include?('SSL') && datastore['SSL'] == false
+      puts('If you are testing a SSL enabled port be sure to execute \'set SSL true\'')
+    end
+
     return true
   end
 
@@ -835,4 +841,3 @@ end
 end
 
 end
-

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -725,13 +725,19 @@ class OptionContainer < Hash
         "One or more options failed to validate", caller
     end
 
+    return true
+  end
+
+  def check_warnings(datastore)
+    warnings = []
+
     # message about missing SSL
     if datastore.include?('RPORT') && [443, 8443].include?(datastore['RPORT']) &&
       datastore.include?('SSL') && datastore['SSL'] == false
-      puts('If you are testing a SSL enabled port be sure to execute \'set SSL true\'')
+      warnings.push('If you are testing a SSL enabled port be sure to execute \'set SSL true\'')
     end
 
-    return true
+    return warnings
   end
 
   #


### PR DESCRIPTION
This PR checks if the user selected a default SSL port and did not set the SSL datastore option. Currently I am doing a simple `puts` because `print_warning` is not available here.

Any advice on how to output a message to the user here?

Testcase:
`./msfconsole -x 'use auxiliary/dos/http/ms15_034_ulonglongadd; set RPORT 443; set RHOSTS 10.211.55.1; run; exit'`

Output:

```
RPORT => 443
RHOSTS => 10.211.55.1
If you are testing a SSL enabled port be sure to execute 'set SSL true'
^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
```
