### PR TITLE
Render markdown in module descriptions

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -39,26 +39,21 @@ class ReadableText < Rex::Ui::Text::Output::Stdio
 
   def self.md_parse(text)
 
-    lines = text.split("\n")
+    lines = text.lines()
     lines.map! do |line|
-      if /^\s*#+\s*(.*)$/.match(line) # THIS REGEX LOOKS FOR '#' CHARACTER AND CAPTURES REST OF LINE
+      case line
+      when /^\s*#+\s*(.*)$/ # this regex looks for '#' character and captures rest of line
         line = format_text(/^\s*#+\s*(.*)$/.match(line)[1], :bold)
-      elsif /^\s*$/.match(line) # THIS REGEX HELPS US IGNORE A LINE THAT IS COMPLETELY WHITESPACE
+      when /^\s*$/ # this regex helps us ignore a line that is completely whitespace
         line = ""
-      elsif /\*+(.[^\*+]+[^\*+])\*+/.match(line) # THIS REGEX HELPS US TO DETECT WORDS THAT ARE SURROUNDED BY ASTERISKS
+      when /\*+(.[^\*+]+[^\*+])\*+/ # this regex helps us to detect words that are surrounded by asterisks
         line.gsub(/\*+(.[^\*+]+[^\*+])\*+/) { |match| "%bld" + match.gsub('*', '') + "%clr" }
-      else
-        line = line = format_text(line, :plain)
       end
     end
 
 
     lines.join("\n")
   end
-
- TextStyle = Struct.new(:format, :str)
-
-
 
   def self.format_title(txt)
     return format_text(txt, :underline)

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -6,7 +6,7 @@ module Serializer
 # is meant to be displayed on a console or some other non-GUI
 # medium.
 class ReadableText < Rex::Ui::Text::Output::Stdio
-  extend Rex::Ui::Text::Color
+
   #Default number of characters to wrap at.
   DefaultColumnWrap = 70
   #Default number of characters to indent.
@@ -14,6 +14,20 @@ class ReadableText < Rex::Ui::Text::Output::Stdio
 
   def self.format_text(txt, fmt)
     return "#{fmt}#{txt}%clr"
+  end
+
+  def self.md_parse(text)
+    lines = text.split("\n")
+    lines.map! do |line|
+      if /^\s*#+\s*(.*)$/.match(line) # THIS REGEX LOOKS FOR '#' CHARACTER AND CAPTURES REST OF LINE
+        line = format_text(/^\s*#+\s*(.*)$/.match(line)[1], STYLES[:bold])
+      elsif /^\s*$/.match(line) # THIS REGEX HELPS US IGNORE A LINE THAT IS COMPLETELY WHITESPACE
+        line = ""
+      else
+        line = line = format_text(line, STYLES[:plain])
+      end
+    end
+    lines.join("\n")
   end
 STYLES = {
   :bold => '%bld',
@@ -230,7 +244,7 @@ STYLES = {
 
     # Description
     output << format_title("Description:\n")
-    output << word_wrap(Rex::Text.compress(mod.description))
+    output << word_wrap(Rex::Text.compress(md_parse(mod.description)))
     output << "\n"
 
     # References

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -5,7 +5,7 @@ module Serializer
 # This class formats information in a plain-text format that
 # is meant to be displayed on a console or some other non-GUI
 # medium.
-class ReadableText < Rex::Ui::Text::Output::Stdio
+class ReadableText
 
   #Default number of characters to wrap at.
   DefaultColumnWrap = 70
@@ -46,8 +46,8 @@ class ReadableText < Rex::Ui::Text::Output::Stdio
         line = format_text(/^\s*#+\s*(.*)$/.match(line)[1], :bold)
       when /^\s*$/ # this regex helps us ignore a line that is completely whitespace
         line = ""
-      when /\*+(.[^\*+]+[^\*+])\*+/ # this regex helps us to detect words that are surrounded by asterisks
-        line.gsub(/\*+(.[^\*+]+[^\*+])\*+/) { |match| "%bld" + match.gsub('*', '') + "%clr" }
+      when /\*+([^\*]+)\*+/ # this regex helps us to detect words that are surrounded by asterisks
+        line.gsub(/\*+([^\*]+)\*+/, "%bld\\1%clr");
       end
     end
 

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -13,44 +13,56 @@ class ReadableText < Rex::Ui::Text::Output::Stdio
   DefaultIndent     = 2
 
   def self.format_text(txt, fmt)
-    return "#{fmt}#{txt}%clr"
+    styles = {
+        :bold => '%bld',
+        :cyan =>'%cya',
+        :red => '%red',
+        :green => '%grn',
+        :blue => '%blu',
+        :yellow => '%yel',
+        :white => '%whi',
+        :magenta => '%mag',
+        :black => '%blk',
+        :dark_red => '%dred',
+        :dark_green => '%dgrn',
+        :dark_blue => '%dblu',
+        :dark_yellow => '%dyel',
+        :dark_cyan => '%dcya',
+        :dark_white => '%dwhi',
+        :dark_magenta => '%dmag',
+        :underline => '%und',
+        :plain => '%clr'
+    }
+
+    return "#{styles[fmt]}#{txt}%clr"
   end
 
   def self.md_parse(text)
+
     lines = text.split("\n")
     lines.map! do |line|
       if /^\s*#+\s*(.*)$/.match(line) # THIS REGEX LOOKS FOR '#' CHARACTER AND CAPTURES REST OF LINE
-        line = format_text(/^\s*#+\s*(.*)$/.match(line)[1], STYLES[:bold])
+        line = format_text(/^\s*#+\s*(.*)$/.match(line)[1], :bold)
       elsif /^\s*$/.match(line) # THIS REGEX HELPS US IGNORE A LINE THAT IS COMPLETELY WHITESPACE
         line = ""
+      elsif /\*+(.[^\*+]+[^\*+])\*+/.match(line) # THIS REGEX HELPS US TO DETECT WORDS THAT ARE SURROUNDED BY ASTERISKS
+        parts = /\*+(.[^\*+]+[^\*+])\*+/.match(line)
+        line.gsub!(parts[0], format_text(parts[1], :bold))
       else
-        line = line = format_text(line, STYLES[:plain])
+        line = line = format_text(line, :plain)
       end
     end
+
+
     lines.join("\n")
   end
-STYLES = {
-  :bold => '%bld',
-  :cyan =>'%cya',
-  :red => '%red',
-  :green => '%grn',
-  :blue => '%blu',
-  :yellow => '%yel',
-  :white => '%whi',
-  :magenta => '%mag',
-  :black => '%blk',
-  :dark_red => '%dred',
-  :dark_green => '%dgrn',
-  :dark_blue => '%dblu',
-  :dark_yellow => '%dyel',
-  :dark_cyan => '%dcya',
-  :dark_white => '%dwhi',
-  :dark_magenta => '%dmag',
-  :underline => '%und',
-  :plain => '%clr'
-}
+
+ TextStyle = Struct.new(:format, :str)
+
+
+
   def self.format_title(txt)
-    return format_text(txt, STYLES[:underline])
+    return format_text(txt, :underline)
   end
 
   # Returns a formatted string that contains information about
@@ -206,7 +218,7 @@ STYLES = {
     output << "       Name: #{mod.name}\n"
     output << "     Module: #{mod.fullname}\n"
     output << "   Platform: #{mod.platform_to_s}\n"
-    output << " Privileged: " + (mod.privileged? ? format_text("yes", STYLES[:green]): format_text("no", STYLES[:red])) + "\n"
+    output << " Privileged: " + (mod.privileged? ? format_text("yes", :green): format_text("no", :red)) + "\n"
     output << "    License: #{mod.license}\n"
     output << "       Rank: #{mod.rank_to_s.capitalize}\n"
     output << "  Disclosed: #{mod.disclosure_date}\n" if mod.disclosure_date
@@ -357,7 +369,7 @@ STYLES = {
     output << "     Module: #{mod.fullname}\n"
     output << "   Platform: #{mod.platform_to_s}\n"
     output << "       Arch: #{mod.arch_to_s}\n"
-    output << "Needs Admin: " + (mod.privileged? ? format_text("yes", STYLES[:green]) : format_text("no", STYLES[:red])) + "\n"
+    output << "Needs Admin: " + (mod.privileged? ? format_text("yes", :green) : format_text("no", :red)) + "\n"
     output << " Total size: #{mod.size}\n"
     output << "       Rank: #{mod.rank_to_s.capitalize}\n"
     output << "\n"
@@ -449,7 +461,7 @@ STYLES = {
       next if (opt.evasion?)
       next if (missing && opt.valid?(val))
 
-      tbl << [ name, opt.display_value(val), opt.required? ? format_text("yes", STYLES[:green]) : format_text("no", STYLES[:red]), opt.desc ]
+      tbl << [ name, opt.display_value(val), opt.required? ? format_text("yes", :green) : format_text("no", :red), opt.desc ]
     }
 
     return tbl.to_s

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -5,15 +5,12 @@ module Serializer
 # This class formats information in a plain-text format that
 # is meant to be displayed on a console or some other non-GUI
 # medium.
-class ReadableText
+class ReadableText < Rex::Ui::Text::Output::Stdio
   extend Rex::Ui::Text::Color
   #Default number of characters to wrap at.
   DefaultColumnWrap = 70
   #Default number of characters to indent.
   DefaultIndent     = 2
-  def self.supports_color?
-    return true
-  end
 
   def self.format_text(txt, fmt)
     return "#{fmt}#{txt}%clr"
@@ -21,6 +18,7 @@ class ReadableText
 STYLES = {
   :bold => '%bld',
   :cyan =>'%cya',
+  :red => '%red',
   :green => '%grn',
   :blue => '%blu',
   :yellow => '%yel',
@@ -194,7 +192,7 @@ STYLES = {
     output << "       Name: #{mod.name}\n"
     output << "     Module: #{mod.fullname}\n"
     output << "   Platform: #{mod.platform_to_s}\n"
-    output << " Privileged: " + (mod.privileged? ? "Yes" : "No") + "\n"
+    output << " Privileged: " + (mod.privileged? ? format_text("yes", STYLES[:green]): format_text("no", STYLES[:red])) + "\n"
     output << "    License: #{mod.license}\n"
     output << "       Rank: #{mod.rank_to_s.capitalize}\n"
     output << "  Disclosed: #{mod.disclosure_date}\n" if mod.disclosure_date
@@ -345,7 +343,7 @@ STYLES = {
     output << "     Module: #{mod.fullname}\n"
     output << "   Platform: #{mod.platform_to_s}\n"
     output << "       Arch: #{mod.arch_to_s}\n"
-    output << "Needs Admin: " + (mod.privileged? ? "Yes" : "No") + "\n"
+    output << "Needs Admin: " + (mod.privileged? ? format_text("yes", STYLES[:green]) : format_text("no", STYLES[:red])) + "\n"
     output << " Total size: #{mod.size}\n"
     output << "       Rank: #{mod.rank_to_s.capitalize}\n"
     output << "\n"
@@ -437,7 +435,7 @@ STYLES = {
       next if (opt.evasion?)
       next if (missing && opt.valid?(val))
 
-      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
+      tbl << [ name, opt.display_value(val), opt.required? ? format_text("yes", STYLES[:green]) : format_text("no", STYLES[:red]), opt.desc ]
     }
 
     return tbl.to_s

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -6,11 +6,40 @@ module Serializer
 # is meant to be displayed on a console or some other non-GUI
 # medium.
 class ReadableText
-
+  extend Rex::Ui::Text::Color
   #Default number of characters to wrap at.
   DefaultColumnWrap = 70
   #Default number of characters to indent.
   DefaultIndent     = 2
+  def self.supports_color?
+    return true
+  end
+
+  def self.format_text(txt, fmt)
+    return "#{fmt}#{txt}%clr"
+  end
+STYLES = {
+  :bold => '%bld',
+  :cyan =>'%cya',
+  :green => '%grn',
+  :blue => '%blu',
+  :yellow => '%yel',
+  :white => '%whi',
+  :magenta => '%mag',
+  :black => '%blk',
+  :dark_red => '%dred',
+  :dark_green => '%dgrn',
+  :dark_blue => '%dblu',
+  :dark_yellow => '%dyel',
+  :dark_cyan => '%dcya',
+  :dark_white => '%dwhi',
+  :dark_magenta => '%dmag',
+  :underline => '%und',
+  :plain => '%clr'
+}
+  def self.format_title(txt)
+    return format_text(txt, STYLES[:underline])
+  end
 
   # Returns a formatted string that contains information about
   # the supplied module instance.
@@ -172,26 +201,26 @@ class ReadableText
     output << "\n"
 
     # Authors
-    output << "Provided by:\n"
+    output << format_title("Provided by:\n")
     mod.each_author { |author|
       output << indent + author.to_s + "\n"
     }
     output << "\n"
 
     # Targets
-    output << "Available targets:\n"
+    output << format_title("Available targets:\n")
     output << dump_exploit_targets(mod, indent)
 
     # Options
     if (mod.options.has_options?)
-      output << "Basic options:\n"
+      output << format_title("Basic options:\n")
       output << dump_options(mod, indent)
       output << "\n"
     end
 
     # Payload information
     if (mod.payload_info.length)
-      output << "Payload information:\n"
+      output << format_title("Payload information:\n")
       if (mod.payload_space)
         output << indent + "Space: " + mod.payload_space.to_s + "\n"
       end
@@ -202,7 +231,7 @@ class ReadableText
     end
 
     # Description
-    output << "Description:\n"
+    output << format_title("Description:\n")
     output << word_wrap(Rex::Text.compress(mod.description))
     output << "\n"
 
@@ -228,7 +257,7 @@ class ReadableText
     output << "\n"
 
     # Authors
-    output << "Provided by:\n"
+    output << format_title("Provided by:\n")
     mod.each_author { |author|
       output << indent + author.to_s + "\n"
     }
@@ -236,19 +265,19 @@ class ReadableText
 
     # Actions
     if mod.action
-      output << "Available actions:\n"
+      output << format_title("Available actions:\n")
       output << dump_module_actions(mod, indent)
     end
 
     # Options
     if (mod.options.has_options?)
-      output << "Basic options:\n"
+      output << format_title("Basic options:\n")
       output << dump_options(mod, indent)
       output << "\n"
     end
 
     # Description
-    output << "Description:\n"
+    output << format_title("Description:\n")
     output << word_wrap(Rex::Text.compress(mod.description))
     output << "\n"
 
@@ -274,7 +303,7 @@ class ReadableText
     output << "\n"
 
     # Authors
-    output << "Provided by:\n"
+    output << format_title("Provided by:\n")
     mod.each_author { |author|
       output << indent + author.to_s + "\n"
     }
@@ -282,19 +311,19 @@ class ReadableText
 
     # Actions
     if mod.action
-      output << "Available actions:\n"
+      output << format_title("Available actions:\n")
       output << dump_module_actions(mod, indent)
     end
 
     # Options
     if (mod.options.has_options?)
-      output << "Basic options:\n"
+      output << format_title("Basic options:\n")
       output << dump_options(mod, indent)
       output << "\n"
     end
 
     # Description
-    output << "Description:\n"
+    output << format_title("Description:\n")
     output << word_wrap(Rex::Text.compress(mod.description))
     output << "\n"
 
@@ -322,7 +351,7 @@ class ReadableText
     output << "\n"
 
     # Authors
-    output << "Provided by:\n"
+    output << format_title("Provided by:\n")
     mod.each_author { |author|
       output << indent + author.to_s + "\n"
     }
@@ -330,13 +359,13 @@ class ReadableText
 
     # Options
     if (mod.options.has_options?)
-      output << "Basic options:\n"
+      output << format_title("Basic options:\n")
       output << dump_options(mod)
       output << "\n"
     end
 
     # Description
-    output << "Description:\n"
+    output << format_title("Description:\n")
     output << word_wrap(Rex::Text.compress(mod.description))
     output << "\n\n"
 
@@ -359,14 +388,14 @@ class ReadableText
     output << "\n"
 
     # Authors
-    output << "Provided by:\n"
+    output << format_title("Provided by:\n")
     mod.each_author { |author|
       output << indent + author.to_s + "\n"
     }
     output << "\n"
 
     # Description
-    output << "Description:\n"
+    output << format_title("Description:\n")
     output << word_wrap(Rex::Text.compress(mod.description))
     output << "\n"
 
@@ -476,7 +505,7 @@ class ReadableText
     output = ''
 
     if (mod.respond_to? :references and mod.references and mod.references.length > 0)
-      output << "References:\n"
+      output << format_title("References:\n")
       mod.references.each { |ref|
         output << indent + ref.to_s + "\n"
       }

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -46,8 +46,7 @@ class ReadableText < Rex::Ui::Text::Output::Stdio
       elsif /^\s*$/.match(line) # THIS REGEX HELPS US IGNORE A LINE THAT IS COMPLETELY WHITESPACE
         line = ""
       elsif /\*+(.[^\*+]+[^\*+])\*+/.match(line) # THIS REGEX HELPS US TO DETECT WORDS THAT ARE SURROUNDED BY ASTERISKS
-        parts = /\*+(.[^\*+]+[^\*+])\*+/.match(line)
-        line.gsub!(parts[0], format_text(parts[1], :bold))
+        line.gsub(/\*+(.[^\*+]+[^\*+])\*+/) { |match| "%bld" + match.gsub('*', '') + "%clr" }
       else
         line = line = format_text(line, :plain)
       end

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -13,12 +13,40 @@ describe Msf::Serializer::ReadableText do
     expect(res).to eq '%bldtest%clr'
 
   end
-  it "should format text underlie" do
+  it "should format text underline" do
     res = subject.format_text("test", :underline)
     expect(res).to eq '%undtest%clr'
 
   end
 
+  it "should parse titles" do
+    res = subject.md_parse("#test")
+    expect(res).to eq '%bldtest%clr'
+  end
+  it "should parse titles ignoring title depth" do
+    res = subject.md_parse("###test")
+    expect(res).to eq '%bldtest%clr'
+  end
+
+  it "should parse titles even with arbitrary spaces" do
+    res = subject.md_parse("#               test")
+    expect(res).to eq '%bldtest%clr'
+  end
+  it "should format text underline and not ignore spaces" do
+    res = subject.format_text("    test", :underline)
+    expect(res).to eq '%und    test%clr'
+
+  end
+
+  it "should parse text as bold when surrounded by asterisks" do
+    res = subject.md_parse("*test*")
+    expect(res).to eq '%bldtest%clr'
+  end
+
+  it "should parse multiple bold segments in a single line" do
+    res = subject.md_parse("*one* and *two*")
+    expect(res).to eq "%bldone%clr and %bldtwo%clr"
+  end
 
 end
 

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'msf/base/serializer/readable_text'
+# require 'rex/post/meterpreter/extensions/stdapi/net/interface'
+# require 'rex/post/meterpreter/extensions/stdapi/net/route'
+
+describe Msf::Serializer::ReadableText do
+
+  let (:subject) {
+    described_class
+  }
+  it "should format text bold" do
+     res = subject.format_text("test", :bold)
+    expect(res).to eq '%bldtest%clr'
+
+  end
+  it "should format text underlie" do
+    res = subject.format_text("test", :underline)
+    expect(res).to eq '%undtest%clr'
+
+  end
+
+
+end
+

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 require 'msf/base/serializer/readable_text'
-# require 'rex/post/meterpreter/extensions/stdapi/net/interface'
-# require 'rex/post/meterpreter/extensions/stdapi/net/route'
 
 describe Msf::Serializer::ReadableText do
 

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -7,8 +7,7 @@ describe Msf::Serializer::ReadableText do
 
 
   context '.format_text' do
-
-
+    
 
     it "should format text bold" do
        res = serializer.format_text("test", :bold)

--- a/spec/lib/msf/base/serializer/readable_text_spec.rb
+++ b/spec/lib/msf/base/serializer/readable_text_spec.rb
@@ -3,48 +3,54 @@ require 'msf/base/serializer/readable_text'
 
 describe Msf::Serializer::ReadableText do
 
-  let (:subject) {
-    described_class
-  }
-  it "should format text bold" do
-     res = subject.format_text("test", :bold)
-    expect(res).to eq '%bldtest%clr'
+  subject(:serializer) { described_class }
 
-  end
-  it "should format text underline" do
-    res = subject.format_text("test", :underline)
-    expect(res).to eq '%undtest%clr'
 
-  end
+  context '.format_text' do
 
-  it "should parse titles" do
-    res = subject.md_parse("#test")
-    expect(res).to eq '%bldtest%clr'
-  end
-  it "should parse titles ignoring title depth" do
-    res = subject.md_parse("###test")
-    expect(res).to eq '%bldtest%clr'
-  end
 
-  it "should parse titles even with arbitrary spaces" do
-    res = subject.md_parse("#               test")
-    expect(res).to eq '%bldtest%clr'
-  end
-  it "should format text underline and not ignore spaces" do
-    res = subject.format_text("    test", :underline)
-    expect(res).to eq '%und    test%clr'
 
-  end
+    it "should format text bold" do
+       res = serializer.format_text("test", :bold)
+      expect(res).to eq '%bldtest%clr'
 
-  it "should parse text as bold when surrounded by asterisks" do
-    res = subject.md_parse("*test*")
-    expect(res).to eq '%bldtest%clr'
-  end
+    end
+    it "should format text underline" do
+      res = serializer.format_text("test", :underline)
+      expect(res).to eq '%undtest%clr'
 
-  it "should parse multiple bold segments in a single line" do
-    res = subject.md_parse("*one* and *two*")
-    expect(res).to eq "%bldone%clr and %bldtwo%clr"
+    end
   end
+  context '.md_parse' do
 
+    it "should parse titles" do
+      res = serializer.md_parse("#test")
+      expect(res).to eq '%bldtest%clr'
+    end
+    it "should parse titles ignoring title depth" do
+      res = serializer.md_parse("###test")
+      expect(res).to eq '%bldtest%clr'
+    end
+
+    it "should parse titles even with arbitrary spaces" do
+      res = serializer.md_parse("#               test")
+      expect(res).to eq '%bldtest%clr'
+    end
+    it "should format text underline and not ignore spaces" do
+      res = serializer.format_text("    test", :underline)
+      expect(res).to eq '%und    test%clr'
+
+    end
+
+    it "should parse text as bold when surrounded by asterisks" do
+      res = serializer.md_parse("*test*")
+      expect(res).to eq '%bldtest%clr'
+    end
+
+    it "should parse multiple bold segments in a single line" do
+      res = serializer.md_parse("*one* and *two*")
+      expect(res).to eq "%bldone%clr and %bldtwo%clr"
+    end
+  end
 end
 


### PR DESCRIPTION
This pull request renders markdown in module descriptions in the console. Titles, bolding and underline are rendered. Also, "Yes" and "No" are colorized "green" and "red" respectively.
# Validation Steps
- [ ] rake spec
- [ ] all should pass
