### PR TITLE
Fix #3816 by deleting print_debug

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -92,11 +92,7 @@ module Exploit::Remote::HttpServer
   def print_error(msg='')
     (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
   end
-  # :category: print_* overrides
-  # Prepends client and module name if inside a thread with a #cli
-  def print_debug(msg='')
-    (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
-  end
+
   #
   # :category: print_* overrides
   # Prepends client and module name if inside a thread with a #cli
@@ -122,11 +118,6 @@ module Exploit::Remote::HttpServer
   # :category: print_* overrides
   # Prepends client and module name if inside a thread with a #cli
   def vprint_error(msg='')
-    (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
-  end
-  # :category: print_* overrides
-  # Prepends client and module name if inside a thread with a #cli
-  def vprint_debug(msg='')
     (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
   end
   # :category: print_* overrides

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -219,7 +219,7 @@ module Msf
 
       @requirements.each do |k, v|
         expected = k != :vuln_test ? v : 'true'
-        vprint_debug("Comparing requirement: #{k}=#{expected} vs #{k}=#{profile[k.to_sym]}")
+        vprint_status("Comparing requirement: #{k}=#{expected} vs #{k}=#{profile[k.to_sym]}")
 
         if k == :activex
           bad_reqs << k if has_bad_activex?(profile[k.to_sym])
@@ -334,7 +334,7 @@ module Msf
       when :script
         # Gathers target data from a POST request
         parsed_body = CGI::parse(Rex::Text.decode_base64(request.body) || '')
-        vprint_debug("Received sniffed browser data over POST: \n#{parsed_body}.")
+        vprint_status("Received sniffed browser data over POST: \n#{parsed_body}.")
         parsed_body.each { |k, v| update_profile(target_info, k.to_sym, v.first) }
       when :headers
         # Gathers target data from headers

--- a/lib/msf/core/module/ui/message/verbose.rb
+++ b/lib/msf/core/module/ui/message/verbose.rb
@@ -1,9 +1,4 @@
 module Msf::Module::UI::Message::Verbose
-  # Verbose version of #print_debug
-  def vprint_debug(msg)
-    print_debug(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
-  end
-
   # Verbose version of #print_error
   def vprint_error(msg)
     print_error(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']

--- a/lib/msf/core/plugin.rb
+++ b/lib/msf/core/plugin.rb
@@ -120,13 +120,6 @@ class Plugin
   end
 
   #
-  # Prints a 'debug' message.
-  #
-  def print_debug(msg='')
-    output.print_debug(msg) if (output)
-  end
-
-  #
   # Prints a status line.
   #
   def print_status(msg='')

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -331,7 +331,6 @@ protected
     begin
       client.sys.config.getprivs()
       root_key, base_key = session.sys.registry.splitkey(key)
-      #print_debug("Loading file #{file}")
       begin
         loadres = session.sys.registry.load_key(root_key, base_key, file)
       rescue Rex::Post::Meterpreter::RequestError => e
@@ -349,7 +348,6 @@ protected
           #print_error("An unknown error has occurred: #{loadres.to_s}")
           return false
         else
-          #print_debug("Registry Hive Loaded Successfully: #{key}")
           return true
         end
       end
@@ -377,7 +375,6 @@ protected
           #print_error("An unknown error has occurred: #{unloadres.to_s}")
           return false
         else
-          #print_debug("Registry Hive Unloaded Successfully: #{key}")
           return true
         end
       end

--- a/lib/msf/http/typo3/login.rb
+++ b/lib/msf/http/typo3/login.rb
@@ -32,10 +32,10 @@ module Msf::HTTP::Typo3::Login
     end
     n = n_match[1]
 
-    vprint_debug("e: #{e}")
-    vprint_debug("n: #{n}")
+    vprint_status("e: #{e}")
+    vprint_status("n: #{n}")
     rsa_enc = typo3_helper_login_rsa(e, n, pass)
-    vprint_debug("RSA Hash: #{rsa_enc}")
+    vprint_status("RSA Hash: #{rsa_enc}")
     # make login request
     vars_post = {
       'n' => '',
@@ -58,10 +58,10 @@ module Msf::HTTP::Typo3::Login
     })
     if res_login
       if res_login.body =~ /<!-- ###LOGIN_ERROR### begin -->(.*)<!-- ###LOGIN_ERROR### end -->/im
-        vprint_debug(strip_tags($1))
+        vprint_status(strip_tags($1))
         return nil
       elsif res_login.body =~ /<p class="t3-error-text">(.*?)<\/p>/im
-        vprint_debug(strip_tags($1))
+        vprint_status(strip_tags($1))
         return nil
       else
         cookies = res_login.get_cookies

--- a/lib/rex/io/bidirectional_pipe.rb
+++ b/lib/rex/io/bidirectional_pipe.rb
@@ -87,10 +87,6 @@ class BidirectionalPipe < Rex::Ui::Text::Input
     print_line('[+] ' + msg)
   end
 
-  def print_debug(msg='')
-    print_line('[!] ' + msg)
-  end
-
   def flush
   end
 

--- a/lib/rex/ui/output.rb
+++ b/lib/rex/ui/output.rb
@@ -30,9 +30,6 @@ class Output
   def print_good(msg='')
   end
 
-  def print_debug(msg='')
-  end
-
   #
   # Prints a status line.
   #

--- a/lib/rex/ui/subscriber.rb
+++ b/lib/rex/ui/subscriber.rb
@@ -57,16 +57,6 @@ module Subscriber
     end
 
     #
-    # Wraps user_output.print_debug
-    #
-    def print_debug(msg='')
-      if (user_output)
-        print_blank_line if user_output.prompting?
-        user_output.print_debug(msg)
-      end
-    end
-
-    #
     # Wraps user_output.print_warning
     #
     def print_warning(msg='')

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -55,10 +55,6 @@ class Output < Rex::Ui::Output
     print_line("%bld%grn[+]%clr #{msg}")
   end
 
-  def print_debug(msg = '')
-    print_line("%bld%cya[!]%clr #{msg}")
-  end
-
   def print_status(msg = '')
     print_line("%bld%blu[*]%clr #{msg}")
   end

--- a/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
     }
 
     space_to_fill = size_bytes - empty_xml.size
-    vprint_debug("#{peer} - max XML space to fill: #{space_to_fill} bytes")
+    vprint_status("#{peer} - max XML space to fill: #{space_to_fill} bytes")
 
     payload = "&#{entity};" * (space_to_fill / 6)
     entity_value_length = space_to_fill - payload.length

--- a/modules/auxiliary/gather/doliwamp_traversal_creds.rb
+++ b/modules/auxiliary/gather/doliwamp_traversal_creds.rb
@@ -101,7 +101,6 @@ class Metasploit3 < Msf::Auxiliary
   # Verify if session cookie is valid and return user's ID
   #
   def get_user_id
-    # print_debug("#{peer} - Trying to hijack session '#{@cookie}'")
     res = send_request_cgi({
       'uri'       => normalize_uri(target_uri.path, 'user/fiche.php'),
       'cookie'    => @cookie
@@ -121,7 +120,6 @@ class Metasploit3 < Msf::Auxiliary
   # Construct cookie using token
   #
   def create_cookie(token)
-    # print_debug("#{peer} - Creating a cookie with token '#{token}'")
     res = send_request_cgi({
       'uri'       => normalize_uri(target_uri.path, 'user/fiche.php'),
       'cookie'    => "DOLSESSID_#{Rex::Text.rand_text_alphanumeric(10)}=#{token}"

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(8080),
-        OptBool.new('DEBUG', [ false, 'Enable requests debugging output', false ]),
         OptBool.new('MULTIPORTS', [ false, 'Multiple ports will be used : 80, 1080, 3128, 8080, 8123', false ]),
         OptBool.new('RANDOMIZE_PORTS', [ false, 'Randomize the order the ports are probed', false ]),
         OptBool.new('VERIFY_CONNECT', [ false, 'Enable test for CONNECT method', false ]),
@@ -193,10 +192,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check_host(target_host,target_port,site,user_agent)
-
-    if datastore['DEBUG']
-      print_status("Checking #{target_host}:#{target_port} [#{site}]")
-    end
+    vprint_status("Checking #{target_host}:#{target_port} [#{site}]")
 
     is_valid,retcode,retvia,retsrv = send_request(site,user_agent)
 

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -56,7 +56,6 @@ class Metasploit3 < Msf::Auxiliary
 
       if not res.body.include?("llow:")
         vprint_status("[#{target_host}] #{tpath}robots.txt - Doesn't contain \"llow:\"")
-        print_status(res.body.inspect) if datastore['DEBUG']
         return
       end
 

--- a/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
+++ b/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
@@ -93,11 +93,11 @@ class Metasploit3 < Msf::Auxiliary
         end
       else
         state = Msf::ServiceState::Closed
-        print_status("#{peer} #{external_addr} - #{int}/#{protocol} #{state} because of successful mapping with matched ports") if (datastore['DEBUG'])
+        vprint_status("#{peer} #{external_addr} - #{int}/#{protocol} #{state} because of successful mapping with matched ports")
       end
     else
       state = Msf::ServiceState::Closed
-      print_status("#{peer} #{external_addr} - #{int}/#{protocol} #{state} because of code #{result} response") if (datastore['DEBUG'])
+      vprint_status("#{peer} #{external_addr} - #{int}/#{protocol} #{state} because of code #{result} response")
     end
 
     report_service(

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -43,7 +43,6 @@ class Metasploit3 < Msf::Auxiliary
     val_actual = resp[idx,4].unpack("V")[0]
     idx += 4
     value	= resp[idx,val_actual*2]
-    #print_debug "resp[0x#{idx.to_s(16)},#{val_actual*2}] : " + value
     idx += val_actual * 2
 
     idx += val_actual % 2 * 2 # alignment
@@ -54,15 +53,12 @@ class Metasploit3 < Msf::Auxiliary
   def parse_net_wksta_enum_users_info(resp)
     accounts = [ Hash.new() ]
 
-    #print_debug resp[0,20].unpack("H*")
     idx = 20
     count = resp[idx,4].unpack("V")[0] # wkssvc_NetWkstaEnumUsersInfo -> Info -> PtrCt0 -> User() -> Ptr -> Max Count
     idx += 4
-    #print_debug "Max Count  : " + count.to_s
 
     1.upto(count) do
       # wkssvc_NetWkstaEnumUsersInfo -> Info -> PtrCt0 -> User() -> Ptr -> Ref ID
-      # print_debug "Ref ID#{account.to_s}: " + resp[idx,4].unpack("H*").to_s
       idx += 4 # ref id name
       idx += 4 # ref id logon domain
       idx += 4 # ref id other domains

--- a/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
@@ -173,7 +173,7 @@ class Metasploit3 < Msf::Auxiliary
     while (attempt_num <= retry_num) && (ret.nil? || ret == :connection_error)
       if attempt_num > 0
         Rex.sleep(2 ** attempt_num)
-        print_debug "#{peer(ip)} Retrying '#{user}' due to connection error"
+        vprint_status("#{peer(ip)} Retrying '#{user}' due to connection error")
       end
 
       ret = check_user(ip, user, rport)

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -148,7 +148,7 @@ class Metasploit3 < Msf::Auxiliary
     while attempt_num <= retry_num and (ret.nil? or ret == :connection_error)
       if attempt_num > 0
         Rex.sleep(2 ** attempt_num)
-        print_debug "#{peer(ip)} Retrying '#{user}' due to connection error"
+        vprint_status("#{peer(ip)} Retrying '#{user}' due to connection error")
       end
 
       ret = check_user(ip, user, rport)
@@ -161,12 +161,12 @@ class Metasploit3 < Msf::Auxiliary
   def show_result(attempt_result, user, ip)
     case attempt_result
     when :success
-      print_good "#{peer(ip)} User '#{user}' found"
+      print_good("#{peer(ip)} User '#{user}' found")
       do_report(ip, user, rport)
     when :connection_error
-      print_error "#{peer(ip)} User '#{user}' on could not connect"
+      print_error("#{peer(ip)} User '#{user}' on could not connect")
     when :fail
-      print_debug "#{peer(ip)} User '#{user}' not found"
+      print_error("#{peer(ip)} User '#{user}' not found")
     end
   end
 

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -693,12 +693,12 @@ class Metasploit3 < Msf::Auxiliary
       ssl_type = ssl_unpacked[0]
       ssl_version = ssl_unpacked[1]
       ssl_len = ssl_unpacked[2]
-      vprint_debug("SSL record ##{ssl_record_counter}:")
-      vprint_debug("\tType:    #{ssl_type}")
-      vprint_debug("\tVersion: 0x#{ssl_version}")
-      vprint_debug("\tLength:  #{ssl_len}")
+      vprint_status("SSL record ##{ssl_record_counter}:")
+      vprint_status("\tType:    #{ssl_type}")
+      vprint_status("\tVersion: 0x#{ssl_version}")
+      vprint_status("\tLength:  #{ssl_len}")
       if ssl_type != HANDSHAKE_RECORD_TYPE
-        vprint_debug("\tWrong Record Type! (#{ssl_type})")
+        vprint_status("\tWrong Record Type! (#{ssl_type})")
       else
         ssl_data = remaining_data[5, ssl_len]
         handshakes = parse_handshakes(ssl_data)
@@ -729,24 +729,24 @@ class Metasploit3 < Msf::Auxiliary
       hs_len = hs_unpacked[2]
       hs_data = remaining_data[4, hs_len]
       handshake_count += 1
-      vprint_debug("\tHandshake ##{handshake_count}:")
-      vprint_debug("\t\tLength: #{hs_len}")
+      vprint_status("\tHandshake ##{handshake_count}:")
+      vprint_status("\t\tLength: #{hs_len}")
 
       handshake_parsed = nil
       case hs_type
         when HANDSHAKE_SERVER_HELLO_TYPE
-          vprint_debug("\t\tType:   Server Hello (#{hs_type})")
+          vprint_status("\t\tType:   Server Hello (#{hs_type})")
           handshake_parsed = parse_server_hello(hs_data)
         when HANDSHAKE_CERTIFICATE_TYPE
-          vprint_debug("\t\tType:   Certificate Data (#{hs_type})")
+          vprint_status("\t\tType:   Certificate Data (#{hs_type})")
           handshake_parsed = parse_certificate_data(hs_data)
         when HANDSHAKE_KEY_EXCHANGE_TYPE
-          vprint_debug("\t\tType:   Server Key Exchange (#{hs_type})")
+          vprint_status("\t\tType:   Server Key Exchange (#{hs_type})")
           # handshake_parsed = parse_server_key_exchange(hs_data)
         when HANDSHAKE_SERVER_HELLO_DONE_TYPE
-          vprint_debug("\t\tType:   Server Hello Done (#{hs_type})")
+          vprint_status("\t\tType:   Server Hello Done (#{hs_type})")
         else
-          vprint_debug("\t\tType:   Handshake type #{hs_type} not implemented")
+          vprint_status("\t\tType:   Handshake type #{hs_type} not implemented")
       end
 
       handshakes << {
@@ -763,13 +763,13 @@ class Metasploit3 < Msf::Auxiliary
   # Parse Server Hello message
   def parse_server_hello(data)
     version = data.unpack('H4')[0]
-    vprint_debug("\t\tServer Hello Version:           0x#{version}")
+    vprint_status("\t\tServer Hello Version:           0x#{version}")
     random = data[2,32].unpack('H*')[0]
-    vprint_debug("\t\tServer Hello random data:       #{random}")
+    vprint_status("\t\tServer Hello random data:       #{random}")
     session_id_length = data[34,1].unpack('C')[0]
-    vprint_debug("\t\tServer Hello Session ID length: #{session_id_length}")
+    vprint_status("\t\tServer Hello Session ID length: #{session_id_length}")
     session_id = data[35,session_id_length].unpack('H*')[0]
-    vprint_debug("\t\tServer Hello Session ID:        #{session_id}")
+    vprint_status("\t\tServer Hello Session ID:        #{session_id}")
     # TODO Read the rest of the server hello (respect message length)
 
     # TODO: return hash with data
@@ -782,8 +782,8 @@ class Metasploit3 < Msf::Auxiliary
     unpacked = data.unpack('Cn')
     cert_len_padding = unpacked[0]
     cert_len = unpacked[1]
-    vprint_debug("\t\tCertificates length: #{cert_len}")
-    vprint_debug("\t\tData length: #{data.length}")
+    vprint_status("\t\tCertificates length: #{cert_len}")
+    vprint_status("\t\tData length: #{data.length}")
     # contains multiple certs
     already_read = 3
     cert_counter = 0
@@ -793,14 +793,14 @@ class Metasploit3 < Msf::Auxiliary
       single_cert_unpacked = data[already_read, 3].unpack('Cn')
       single_cert_len_padding = single_cert_unpacked[0]
       single_cert_len =  single_cert_unpacked[1]
-      vprint_debug("\t\tCertificate ##{cert_counter}:")
-      vprint_debug("\t\t\tCertificate ##{cert_counter}: Length: #{single_cert_len}")
+      vprint_status("\t\tCertificate ##{cert_counter}:")
+      vprint_status("\t\t\tCertificate ##{cert_counter}: Length: #{single_cert_len}")
       certificate_data = data[(already_read + 3), single_cert_len]
       cert = OpenSSL::X509::Certificate.new(certificate_data)
       # First received certificate is the one from the server
       @cert = cert if @cert.nil?
-      #vprint_debug("Got certificate: #{cert.to_text}")
-      vprint_debug("\t\t\tCertificate ##{cert_counter}: #{cert.inspect}")
+      #vprint_status("Got certificate: #{cert.to_text}")
+      vprint_status("\t\t\tCertificate ##{cert_counter}: #{cert.inspect}")
       already_read = already_read + single_cert_len + 3
     end
 

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Auxiliary
       OptRegexp.new('EXCLUDE', [false,
         'Only attempt to use exploits whose name DOES NOT match this regex'
       ]),
-      OptBool.new('DEBUG', [false,
+      OptBool.new('DEBUG_AUTOPWN', [false,
         'Do not obfuscate the javascript and print various bits of useful info to the browser',
         false
       ]),
@@ -232,7 +232,7 @@ class Metasploit3 < Msf::Auxiliary
     ENDJS
     )
 
-    if (datastore['DEBUG'])
+    if (datastore['DEBUG_AUTOPWN'])
       print_status("NOTE: Debug Mode; javascript will not be obfuscated")
     else
       pre = Time.now
@@ -349,7 +349,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # For testing, set the exploit uri to the name of the exploit so it's
     # easy to tell what is happening from the browser.
-    if (datastore['DEBUG'])
+    if (datastore['DEBUG_AUTOPWN'])
       @exploits[name].datastore['URIPATH'] = name
     else
       # randomize it manually since if a saved value exists in the user's
@@ -1056,7 +1056,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def js_debug(msg)
-    if datastore['DEBUG']
+    if datastore['DEBUG_AUTOPWN']
       return "document.body.innerHTML += #{msg};"
     end
     return ""

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -836,7 +836,7 @@ class Metasploit3 < Msf::Auxiliary
     #
 
     #js = ::Rex::Exploitation::JSObfu.new(js)
-    #js.obfuscate unless datastore["DEBUG"]
+    #js.obfuscate unless datastore["DEBUG_AUTOPWN"]
 
     response.body = "#{js}"
     print_status("Responding with #{sploit_cnt} exploits")

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -233,7 +233,7 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     if (datastore['DEBUG'])
-      print_debug("NOTE: Debug Mode; javascript will not be obfuscated")
+      print_status("NOTE: Debug Mode; javascript will not be obfuscated")
     else
       pre = Time.now
 

--- a/modules/auxiliary/spoof/llmnr/llmnr_response.rb
+++ b/modules/auxiliary/spoof/llmnr/llmnr_response.rb
@@ -47,10 +47,6 @@ attr_accessor :sock, :thread
       OptInt.new('TTL', [ false, "Time To Live for the spoofed response", 300]),
     ])
 
-    register_advanced_options([
-      OptBool.new('Debug', [ false, "Determines whether incoming packet parsing is displayed", false])
-    ])
-
     deregister_options('RHOST', 'PCAPFILE', 'SNAPLEN', 'FILTER')
     self.thread = nil
     self.sock = nil

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -46,10 +46,6 @@ class Metasploit3 < Msf::Auxiliary
       OptRegexp.new('REGEX', [ true, "Regex applied to the NB Name to determine if spoofed reply is sent", '.*']),
     ])
 
-    register_advanced_options([
-      OptBool.new('DEBUG', [ false, "Determines whether incoming packet parsing is displayed", false])
-    ])
-
     deregister_options('RHOST', 'PCAPFILE', 'SNAPLEN', 'FILTER')
     self.thread = nil
     self.sock = nil
@@ -90,20 +86,18 @@ class Metasploit3 < Msf::Auxiliary
 
     vprint_good("#{rhost.ljust 16} nbns - #{nbnsq_decodedname} matches regex, responding with #{spoof}")
 
-    if datastore['DEBUG']
-      print_status("transid:        #{nbnsq_transid.unpack('H4')}")
-      print_status("tlags:          #{nbnsq_flags.unpack('B16')}")
-      print_status("questions:      #{nbnsq_questions.unpack('n')}")
-      print_status("answerrr:       #{nbnsq_answerrr.unpack('n')}")
-      print_status("authorityrr:    #{nbnsq_authorityrr.unpack('n')}")
-      print_status("additionalrr:   #{nbnsq_additionalrr.unpack('n')}")
-      print_status("name:           #{nbnsq_name} #{nbnsq_name.unpack('H34')}")
-      print_status("full name:      #{nbnsq_name.slice(1..-2)}")
-      print_status("decoded:        #{decoded}")
-      print_status("decoded name:   #{nbnsq_decodedname}")
-      print_status("type:           #{nbnsq_type.unpack('n')}")
-      print_status("class:          #{nbnsq_class.unpack('n')}")
-    end
+    vprint_status("transid:        #{nbnsq_transid.unpack('H4')}")
+    vprint_status("tlags:          #{nbnsq_flags.unpack('B16')}")
+    vprint_status("questions:      #{nbnsq_questions.unpack('n')}")
+    vprint_status("answerrr:       #{nbnsq_answerrr.unpack('n')}")
+    vprint_status("authorityrr:    #{nbnsq_authorityrr.unpack('n')}")
+    vprint_status("additionalrr:   #{nbnsq_additionalrr.unpack('n')}")
+    vprint_status("name:           #{nbnsq_name} #{nbnsq_name.unpack('H34')}")
+    vprint_status("full name:      #{nbnsq_name.slice(1..-2)}")
+    vprint_status("decoded:        #{decoded}")
+    vprint_status("decoded name:   #{nbnsq_decodedname}")
+    vprint_status("type:           #{nbnsq_type.unpack('n')}")
+    vprint_status("class:          #{nbnsq_class.unpack('n')}")
 
     # time to build a response packet - Oh YEAH!
     response = nbnsq_transid +

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
         send_response(cli, apk_bytes, magic_headers)
       end
     elsif req.uri =~ /_poll/
-      vprint_debug "Polling #{req.qstring['id']}: #{@served_payloads[req.qstring['id']]}"
+      vprint_status("Polling #{req.qstring['id']}: #{@served_payloads[req.qstring['id']]}")
       send_response(cli, @served_payloads[req.qstring['id']].to_s, 'Content-type' => 'text/plain')
     elsif req.uri =~ /launch$/
       send_response_html(cli, launch_html)

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -349,7 +349,7 @@ int main(int argc,char *argv[], char ** envp)
     rm_f executable_path
     write_file(executable_path, elf)
     output = cmd_exec("chmod +x #{executable_path}; #{executable_path}")
-    output.each_line { |line| print_debug line.chomp }
+    output.each_line { |line| vprint_status(line.chomp) }
 
     stime = Time.now.to_f
     print_status "Starting the payload handler..."

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -57,7 +57,7 @@ class Metasploit4 < Msf::Exploit::Local
       OptString.new("WritableDir", [ true, "A directory where we can write files (must not be mounted noexec)", "/tmp" ]),
       OptInt.new("Count", [true, "Number of attempts to win the race condition", 500 ]),
       OptInt.new("ListenerTimeout", [true, "Number of seconds to wait for the exploit", 60]),
-      OptBool.new("DEBUG", [ true, "Make the exploit executable be verbose about what it's doing", false ])
+      OptBool.new("DEBUG_EXPLOIT", [ true, "Make the exploit executable be verbose about what it's doing", false ])
     ])
   end
 
@@ -327,7 +327,7 @@ int main(int argc,char *argv[], char ** envp)
     main.gsub!(/shellcode_size = 0/, "shellcode_size = #{payload.encoded.length}")
     main.gsub!(/cmd_path = ""/, "cmd_path = \"#{executable_path}\"")
     main.gsub!(/COUNT/, datastore["Count"].to_s)
-    main.gsub!(/#define dprintf/, "#define dprintf printf") if datastore['DEBUG']
+    main.gsub!(/#define dprintf/, "#define dprintf printf") if datastore['DEBUG_EXPLOIT']
 
     cpu = nil
     if target['Arch'] == ARCH_X86

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -66,7 +66,7 @@ class Metasploit4 < Msf::Exploit::Local
         OptString.new("WritableDir", [ true, "A directory where we can write files (must not be mounted noexec)", "/tmp" ]),
     ])
     register_options([
-        OptBool.new("DEBUG", [ true, "Make the exploit executable be verbose about what it's doing", false ]),
+        OptBool.new("DEBUG_EXPLOIT", [ true, "Make the exploit executable be verbose about what it's doing", false ]),
     ])
   end
 
@@ -85,7 +85,7 @@ class Metasploit4 < Msf::Exploit::Local
       #endif
     |
     current_task_struct_h(sc)
-    if datastore["DEBUG"]
+    if datastore["DEBUG_EXPLOIT"]
       cparser.parse "#define DEBUG\n"
     end
 

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -446,7 +446,7 @@ int main(int argc, char **argv) {
     rm_f executable_path
     write_file(executable_path, elf)
     output = cmd_exec("chmod +x #{executable_path}; #{executable_path}")
-    output.each_line { |line| print_debug line.chomp }
+    output.each_line { |line| vprint_status(line.chomp) }
 
   end
 

--- a/modules/exploits/linux/misc/sercomm_exec.rb
+++ b/modules/exploits/linux/misc/sercomm_exec.rb
@@ -195,8 +195,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts)
-    vprint_debug(cmd)
-
     # Get the length of the command, for the backdoor's command injection
     cmd_length = cmd.length
 

--- a/modules/exploits/linux/smtp/exim_gethostbyname_bof.rb
+++ b/modules/exploits/linux/smtp/exim_gethostbyname_bof.rb
@@ -97,7 +97,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     rescue
       peer = "#{rhost}:#{rport}"
-      vprint_debug("#{peer} - Caught #{$!.class}: #{$!.message}")
+      vprint_status("#{peer} - Caught #{$!.class}: #{$!.message}")
 
     ensure
       smtp_disconnect
@@ -160,14 +160,14 @@ class Metasploit4 < Msf::Exploit::Remote
     16.times do
       done = catch(:another_heap_shift) do
         heap_shift = MIN_HEAP_SHIFT + (rand(1024) & ~15)
-        print_debug("#{{ heap_shift: heap_shift }}")
+        vprint_status("#{{ heap_shift: heap_shift }}")
 
         # write the malloc_chunk header at increasing offsets (8-byte step),
         # until we overwrite the "503 sender not yet given" error message
 
         128.step(256, 8) do |write_offset|
           error = try_information_leak(heap_shift, write_offset)
-          print_debug("#{{ write_offset: write_offset, error: error }}")
+          vprint_status("#{{ write_offset: write_offset, error: error }}")
           throw(:another_heap_shift) if not error
           next if error == "503 sender not yet given"
 
@@ -179,7 +179,7 @@ class Metasploit4 < Msf::Exploit::Remote
             error[i] = try_information_leak(heap_shift, write_offset + i*8)
             throw(:another_heap_shift) if not error[i]
           end
-          print_debug("#{{ error: error }}")
+          vprint_status("#{{ error: error }}")
 
           _leaked_arch = leaked_arch
           if (error[0] == error[1]) and (error[0].empty? or (error[0].unpack('C')[0] & 7) == 0) and # fd_nextsize
@@ -197,7 +197,7 @@ class Metasploit4 < Msf::Exploit::Remote
           else
             throw(:another_heap_shift)
           end
-          print_debug("#{{ leaked_arch: leaked_arch }}")
+          vprint_status("#{{ leaked_arch: leaked_arch }}")
           fail_with(Failure::BadConfig, "arch changed") if _leaked_arch and _leaked_arch != leaked_arch
 
           # try different large-bins: most of them should be empty,
@@ -211,7 +211,7 @@ class Metasploit4 < Msf::Exploit::Remote
             next if (error.unpack('C')[0] & (leaked_arch == ARCH_X86 ? 7 : 15)) != 0 # MALLOC_ALIGN_MASK
             count[error] += 1
           end
-          print_debug("#{{ count: count }}")
+          vprint_status("#{{ count: count }}")
           throw(:another_heap_shift) if count.empty?
 
           # convert count to a nested array of [key, value] arrays and sort it
@@ -345,7 +345,7 @@ class Metasploit4 < Msf::Exploit::Remote
     encoded = payload.raw.gsub(/[\"\\]/, '\\\\\\&').gsub(/[\$\{\}\\]/, '\\\\\\&')
     # setsid because of Exim's "killpg(pid, SIGKILL);" after "alarm(60);"
     command = '${run{/usr/bin/env setsid /bin/sh -c "' + encoded + '"}}'
-    print_debug(command)
+    vprint_status("Command: #{command}")
 
     # don't try to execute commands directly, try a very simple ACL first,
     # to distinguish between exploitation-problems and shellcode-problems
@@ -407,9 +407,9 @@ class Metasploit4 < Msf::Exploit::Remote
             # (we don't control what's stored at heap_addr)
 
             rand_offset = rand(max_rand_offset)
-            print_debug("#{{ helo: helo_len, step: step_len, addr: heap_addr.to_s(16), offset: rand_offset }}")
+            vprint_status("#{{ helo: helo_len, step: step_len, addr: heap_addr.to_s(16), offset: rand_offset }}")
             reply = try_code_execution(helo_len, acldrop, heap_addr + rand_offset)
-            print_debug("#{{ reply: reply }}") if reply
+            vprint_status("#{{ reply: reply }}") if reply
 
             if reply and
                reply[:code] == "550" and
@@ -419,7 +419,7 @@ class Metasploit4 < Msf::Exploit::Remote
               print_good("Please wait for reply...")
               # execute command this time, not acldrop
               reply = try_code_execution(helo_len, command, heap_addr + rand_offset)
-              print_debug("#{{ reply: reply }}")
+              vprint_status("#{{ reply: reply }}")
               return handler
             end
 

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('CONTENT', [ false, "Content to display inside the HTML <body>.", '' ] ),
-        OptBool.new('DEBUG', [false, "Display some alert()'s for debugging the payload.", false])
+        OptBool.new('DEBUG_JS', [false, "Display some alert()'s for debugging the payload.", false])
       ], Auxiliary::Timed)
 
   end
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # @return [String] containing javascript that will alert a debug string
   #   if the DEBUG is set to true
   def js_debug(str, quote="'")
-    if datastore['DEBUG'] then "alert(#{quote}#{str}#{quote})" else '' end
+    if datastore['DEBUG_JS'] then "alert(#{quote}#{str}#{quote})" else '' end
   end
 
   # @return [String] HTML that is sent in the first response to the client

--- a/modules/exploits/multi/browser/java_storeimagearray.rb
+++ b/modules/exploits/multi/browser/java_storeimagearray.rb
@@ -97,10 +97,10 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def on_request_uri( cli, request )
-    print_debug("Requesting: #{request.uri}")
+    vprint_status("Requesting: #{request.uri}")
     if request.uri !~ /\.jar$/i
       if not request.uri =~ /\/$/
-        print_status("Sending redirect...")
+        vprint_status("Sending redirect...")
         send_redirect(cli, "#{get_resource}/", '')
         return
       end

--- a/modules/exploits/multi/http/drupal_drupageddon.rb
+++ b/modules/exploits/multi/http/drupal_drupageddon.rb
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
     md5_base64 = phpass_encode64(md5, md5.length)
     md5_stripped = md5_base64[0...22]
     pass = "$P\\$" + iter_char + salt + md5_stripped
-    vprint_debug("#{peer} - password hash: #{pass}")
+    vprint_status("#{peer} - password hash: #{pass}")
 
     return pass
   end
@@ -129,8 +129,8 @@ class Metasploit3 < Msf::Exploit::Remote
     form_build_id = $1 if content =~ /name="form_build_id" value="(.+?)"/
     form_token = $1 if content =~ /name="form_token" value="(.+?)"/
 
-    vprint_debug("#{peer} - form_build_id: #{form_build_id}")
-    vprint_debug("#{peer} - form_token: #{form_token}")
+    vprint_status("#{peer} - form_build_id: #{form_build_id}")
+    vprint_status("#{peer} - form_token: #{form_token}")
 
     return form_build_id, form_token
   end
@@ -202,7 +202,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     cookie = res.get_cookies
-    vprint_debug("#{peer} - cookie: #{cookie}")
+    vprint_status("#{peer} - cookie: #{cookie}")
 
     # call admin interface to extract CSRF token and enabled modules
     print_status("#{peer} - Trying to parse enabled modules")
@@ -280,7 +280,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # get administrator role id
     id = $1 if res.body =~ /for="edit-([0-9]+)-administer-content-types">#{admin_role}:/
-    vprint_debug("#{peer} - admin role id: #{id}")
+    vprint_status("#{peer} - admin role id: #{id}")
 
     unless id
       fail_with(Failure::Unknown, "Could not parse out administrator ID")

--- a/modules/exploits/multi/http/jboss_seam_upload_exec.rb
+++ b/modules/exploits/multi/http/jboss_seam_upload_exec.rb
@@ -80,21 +80,21 @@ class Metasploit3 < Msf::Exploit::Remote
             'data' => "actionOutcome=/success.xhtml?user%3d%23{expressions.getClass().forName('java.lang.Runtime').getDeclaredMethod('getRuntime')}"
         }, timeout=datastore['TIMEOUT'])
         if (res and res.code == 302 and res.headers['Location'])
-            vprint_debug("Server sent a 302 with location")
-            if (res.headers['Location'] =~ %r(public\+static\+java\.lang\.Runtime\+java.lang.Runtime.getRuntime\%28\%29))
-                report_vuln({
-                    :host => rhost,
-                    :port => rport,
-                    :name => "#{self.name} - #{uri}",
-                    :refs => self.references,
-                    :info => "Module #{self.fullname} found vulnerable JBoss Seam 2 resource."
-                })
-                return Exploit::CheckCode::Vulnerable
-            else
-                return Exploit::CheckCode::Safe
-            end
+          vprint_status("Server sent a 302 with location")
+          if (res.headers['Location'] =~ %r(public\+static\+java\.lang\.Runtime\+java.lang.Runtime.getRuntime\%28\%29))
+            report_vuln({
+              :host => rhost,
+              :port => rport,
+              :name => "#{self.name} - #{uri}",
+              :refs => self.references,
+              :info => "Module #{self.fullname} found vulnerable JBoss Seam 2 resource."
+            })
+            return Exploit::CheckCode::Vulnerable
+          else
+            return Exploit::CheckCode::Safe
+          end
         else
-            return Exploit::CheckCode::Unknown
+          return Exploit::CheckCode::Unknown
         end
 
         # If we reach this point, we didn't find the service
@@ -205,8 +205,6 @@ EOJSP
 
 
     def get_full_path(filename)
-        #vprint_debug("Trying to find full path for #{filename}")
-
         uri = target_uri.path
         res = send_request_cgi(
         {
@@ -220,7 +218,6 @@ EOJSP
             # the user argument should be set to the result of our call - which
             # will be the full path of our file
             matches = /.*user=(.+)\&.*/.match(res.headers['Location'])
-            #vprint_debug("Location is " + res.headers['Location'])
             if (matches and matches.captures)
                 return Rex::Text::uri_decode(matches.captures[0])
             else
@@ -241,16 +238,16 @@ EOJSP
 
         append = 'false'
         while (data.length > chunk_size)
-            status = upload_file_chunk(@payload_exe, append, data[0, chunk_size])
-            if status
-                vprint_debug("Uploaded chunk")
-            else
-                vprint_error("Failed to upload chunk")
-                break
-            end
-            data = data[chunk_size, data.length - chunk_size]
-            # first chunk is an overwrite, afterwards, we need to append
-            append = 'true'
+          status = upload_file_chunk(@payload_exe, append, data[0, chunk_size])
+          if status
+            vprint_status("Uploaded chunk")
+          else
+            vprint_error("Failed to upload chunk")
+            break
+          end
+          data = data[chunk_size, data.length - chunk_size]
+          # first chunk is an overwrite, afterwards, we need to append
+          append = 'true'
         end
         status = upload_file_chunk(@payload_exe, 'true', data)
         if status
@@ -290,7 +287,7 @@ EOJSP
                 return
             end
 
-            vprint_debug("Sending in chunks of #{chunk_size}")
+            vprint_status("Sending in chunks of #{chunk_size}")
 
             case target['Platform']
             when 'java'

--- a/modules/exploits/unix/webapp/projectsend_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectsend_upload_exec.rb
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_warning("#{peer} - File upload may have failed")
       return fname
     else
-      vprint_debug("#{peer} - Received response: #{res.code} - #{res.body}")
+      vprint_status("#{peer} - Received response: #{res.code} - #{res.body}")
       fail_with(Failure::Unknown, "#{peer} - Something went wrong")
     end
   end

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -235,10 +235,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code != 502
       print_error("Eek! We weren't expecting a response, but we got one")
-      if datastore['DEBUG']
-        print_line()
-        print_error(res.to_s)
-      end
     end
 
     handler

--- a/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
@@ -157,10 +157,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code != 502
       print_error("Eek! We weren't expecting a response, but we got one")
-      if datastore['DEBUG']
-        print_error('')
-        print_error(res.to_s)
-      end
     end
 
     handler

--- a/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
@@ -157,10 +157,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code != 502
       print_error("Eek! We weren't expecting a response, but we got one")
-      if datastore['DEBUG']
-        print_error('')
-        print_error(res.to_s)
-      end
     end
 
     handler

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -91,10 +91,6 @@ class Metasploit3 < Msf::Exploit::Remote
       # nothing
     end
 
-    if (datastore['DEBUG'])
-      print_status("Headers:\n" + headers.inspect)
-      print_status("Body:\n" + body.inspect)
-    end
     disconnect
     [headers, body]
   end

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -116,7 +116,6 @@ class Metasploit3 < Msf::Exploit::Local
 
     print_status("Creating task: #{taskname}")
     cmdline = "schtasks.exe /create /tn #{taskname} /tr \"#{cmd}\" /sc monthly /f"
-#		print_debug("Will Execute:\n\t#{cmdline}")
     exec_schtasks(cmdline, "create the task")
 
     #

--- a/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
+++ b/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
@@ -59,9 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # We create the filepath for the upload, for execution it should be \windows\system32\wbem\mof\<file with extension mof!
     file = "..\\..\\" << remote_filepath << remote_filename << "\x00"
-    #print_debug("File to upload: #{file}")
     pkt_size = local_filedata.size() + file.size() + (0x108 - file.size()) + 4
-    #print_debug(pkt_size)
 
     # Magic_code  + packing + size
     pkt = magic_code << "AAAAAAAAAAAA" << [pkt_size].pack('L')

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -27,11 +27,6 @@ class Metasploit3 < Msf::Post
       'SessionTypes' => ['meterpreter'],
       'References'   => [['URL', 'http://lab.mediaservice.net/code/cachedump.rb']]
     ))
-
-    register_options(
-    [
-      OptBool.new('DEBUG', [true, 'Debugging output', false])
-    ], self.class)
   end
 
 
@@ -44,7 +39,7 @@ class Metasploit3 < Msf::Post
   def capture_nlkm(lsakey)
     nlkm = registry_getvaldata("HKLM\\SECURITY\\Policy\\Secrets\\NL$KM\\CurrVal", "")
 
-    print_status("Encrypted NL$KM: #{nlkm.unpack("H*")[0]}") if( datastore['DEBUG'] )
+    vprint_status("Encrypted NL$KM: #{nlkm.unpack("H*")[0]}")
 
     if lsa_vista_style?
       nlkm_dec = decrypt_lsa_data(nlkm, lsakey)
@@ -306,7 +301,7 @@ class Metasploit3 < Msf::Post
 
       print_status('Obtaining boot key...')
       bootkey = capture_boot_key
-      print_status("Boot key: #{bootkey.unpack("H*")[0]}") if( datastore['DEBUG'] )
+      vprint_status("Boot key: #{bootkey.unpack("H*")[0]}")
 
       print_status('Obtaining Lsa key...')
       lsakey = capture_lsa_key(bootkey)
@@ -315,11 +310,11 @@ class Metasploit3 < Msf::Post
         return
       end
 
-      print_status("Lsa Key: #{lsakey.unpack("H*")[0]}") if( datastore['DEBUG'] )
+      vprint_status("Lsa Key: #{lsakey.unpack("H*")[0]}")
 
       print_status("Obtaining LK$KM...")
       nlkm = capture_nlkm(lsakey)
-      print_status("NL$KM: #{nlkm.unpack("H*")[0]}") if( datastore['DEBUG'] )
+      vprint_status("NL$KM: #{nlkm.unpack("H*")[0]}")
 
       print_status("Dumping cached credentials...")
       ok = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SECURITY\\Cache", KEY_READ)
@@ -340,9 +335,9 @@ class Metasploit3 < Msf::Post
         cache = parse_cache_entry(nl)
 
         if ( cache.userNameLength > 0 )
-          print_status("Reg entry: #{nl.unpack("H*")[0]}") if( datastore['DEBUG'] )
-          print_status("Encrypted data: #{cache.enc_data.unpack("H*")[0]}") if( datastore['DEBUG'] )
-          print_status("Ch:  #{cache.ch.unpack("H*")[0]}") if( datastore['DEBUG'] )
+          vprint_status("Reg entry: #{nl.unpack("H*")[0]}")
+          vprint_status("Encrypted data: #{cache.enc_data.unpack("H*")[0]}")
+          vprint_status("Ch:  #{cache.ch.unpack("H*")[0]}")
 
           if lsa_vista_style?
             dec_data = decrypt_hash_vista(cache.enc_data, nlkm, cache.ch)
@@ -350,7 +345,7 @@ class Metasploit3 < Msf::Post
             dec_data = decrypt_hash(cache.enc_data, nlkm, cache.ch)
           end
 
-          print_status("Decrypted data: #{dec_data.unpack("H*")[0]}") if( datastore['DEBUG'] )
+          vprint_status("Decrypted data: #{dec_data.unpack("H*")[0]}")
 
           john << parse_decrypted_cache(dec_data, cache)
 

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -185,7 +185,7 @@ class Metasploit3 < Msf::Post
     :source_type => "exploit",
     :user => user_name,
     :pass => password)
-    print_debug "Should have reported..."
+    vprint_status("Should have reported...")
 
     # Set savedpwds to 1 on return
     return 1

--- a/modules/post/windows/gather/file_from_raw_ntfs.rb
+++ b/modules/post/windows/gather/file_from_raw_ntfs.rb
@@ -86,12 +86,12 @@ class Metasploit3 < Msf::Post
   end
 
   def read(size)
-    vprint_debug("Reading #{size} bytes")
+    vprint_status("Reading #{size} bytes")
     client.railgun.kernel32.ReadFile(@handle, size, size, 4, nil)['lpBuffer']
   end
 
   def seek(offset)
-    vprint_debug("Seeking to offset #{offset}")
+    vprint_status("Seeking to offset #{offset}")
     high_offset = offset >> 32
     low_offset = offset & (2**33 - 1)
     client.railgun.kernel32.SetFilePointer(@handle, low_offset, high_offset, 0)

--- a/spec/support/shared/examples/msf/module/ui/message/verbose.rb
+++ b/spec/support/shared/examples/msf/module/ui/message/verbose.rb
@@ -1,5 +1,4 @@
 shared_examples_for 'Msf::Module::UI::Message::Verbose' do
-  it { is_expected.to respond_to :vprint_debug }
   it { is_expected.to respond_to :vprint_error }
   it { is_expected.to respond_to :vprint_good }
   it { is_expected.to respond_to :vprint_status }

--- a/test/modules/auxiliary/test/check.rb
+++ b/test/modules/auxiliary/test/check.rb
@@ -34,12 +34,12 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check
-    print_debug "Check is successful"
+    vprint_status("Check is successful")
     return Msf::Exploit::CheckCode::Vulnerable
   end
 
   def run
-    print_debug "Run is successful."
+    vprint_status("Run is successful.")
   end
 
 end

--- a/test/modules/auxiliary/test/space-check.rb
+++ b/test/modules/auxiliary/test/space-check.rb
@@ -34,12 +34,12 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check
-    print_debug "Check is successful"
+    vprint_status("Check is successful")
     return Msf::Exploit::CheckCode::Vulnerable
   end
 
   def run
-    print_debug "Run is successful."
+    vprint_status("Run is successful.")
   end
 
 end

--- a/test/modules/exploits/test/browserexploitserver.rb
+++ b/test/modules/exploits/test/browserexploitserver.rb
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def on_request_exploit(cli, request, target_info)
-    print_debug("Target selected: #{get_target.name}")
+    vprint_status("Target selected: #{get_target.name}")
     print_line(Rex::Text.to_hex_dump([rop_junk].pack("V*")))
     print_line(Rex::Text.to_hex_dump([rop_nop].pack("V*")))
     p = get_payload(cli, target_info)

--- a/test/modules/exploits/test/check.rb
+++ b/test/modules/exploits/test/check.rb
@@ -32,12 +32,12 @@ class Metasploit3 < Msf::Exploit
   end
 
   def check
-    print_debug "Check is successful"
+    vprint_status("Check is successful")
     return Msf::Exploit::CheckCode::Vulnerable
   end
 
   def exploit
-    print_debug "Exploit is successful."
+    vprint_status("Exploit is successful.")
   end
 
 end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -614,7 +614,7 @@ class Msftidy
   #
   # @see https://github.com/rapid7/metasploit-framework/issues/3816
   def check_datastore_debug
-    if @source =~ /Opt.*\.new\('(?i)DEBUG(?-i)'/
+    if @source =~ /Opt.*\.new\(["'](?i)DEBUG(?-i)["']/
       error('Please don\'t register a DEBUG datastore option, it has an special meaning and is used for development')
     end
   end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -601,6 +601,15 @@ class Msftidy
     end
   end
 
+  # Check for (v)print_debug usage, since it doesn't exist anymore
+  #
+  # @see https://github.com/rapid7/metasploit-framework/issues/3816
+  def check_print_debug
+    if @source =~ /print_debug/
+      error('Please don\'t use (v)print_debug, use vprint_(status|good|error|warning) instead')
+    end
+  end
+
   private
 
   def load_file(file)
@@ -650,6 +659,7 @@ def run_checks(full_filepath)
   tidy.check_sock_get
   tidy.check_udp_sock_get
   tidy.check_invalid_url_scheme
+  tidy.check_print_debug
   return tidy
 end
 

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -613,9 +613,18 @@ class Msftidy
   # Check for modules registering the DEBUG datastore option
   #
   # @see https://github.com/rapid7/metasploit-framework/issues/3816
-  def check_datastore_debug
+  def check_register_datastore_debug
     if @source =~ /Opt.*\.new\(["'](?i)DEBUG(?-i)["']/
       error('Please don\'t register a DEBUG datastore option, it has an special meaning and is used for development')
+    end
+  end
+
+  # Check for modules using the DEBUG datastore option
+  #
+  # @see https://github.com/rapid7/metasploit-framework/issues/3816
+  def check_use_datastore_debug
+    if @source =~ /datastore\[["'](?i)DEBUG(?-i)["']\]/
+      error('Please don\'t use the DEBUG datastore option in production, it has an special meaning and is used for development')
     end
   end
 
@@ -669,7 +678,8 @@ def run_checks(full_filepath)
   tidy.check_udp_sock_get
   tidy.check_invalid_url_scheme
   tidy.check_print_debug
-  tidy.check_datastore_debug
+  tidy.check_register_datastore_debug
+  tidy.check_use_datastore_debug
   return tidy
 end
 

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -610,6 +610,15 @@ class Msftidy
     end
   end
 
+  # Check for modules registering the DEBUG datastore option
+  #
+  # @see https://github.com/rapid7/metasploit-framework/issues/3816
+  def check_datastore_debug
+    if @source =~ /Opt.*\.new\('(?i)DEBUG(?-i)'/
+      error('Please don\'t register a DEBUG datastore option, it has an special meaning and is used for development')
+    end
+  end
+
   private
 
   def load_file(file)
@@ -660,6 +669,7 @@ def run_checks(full_filepath)
   tidy.check_udp_sock_get
   tidy.check_invalid_url_scheme
   tidy.check_print_debug
+  tidy.check_datastore_debug
   return tidy
 end
 


### PR DESCRIPTION
Like explained on #3816, this PR:
- Delete (v)print_debug method
- Take care of (v)print_debug uses
- Adds a msftidy check to detect modules trying to use the (v)print_debug method
- Adds a msftidy check to detect modules registering a 'DEBUG' option in production
- Adds a msftidy check to detect modules using the 'DEBUG' option in production
- Take care of modules using the 'DEBUG' option in production
## Verification
- [x] Verify which there aren't modules registering the 'DEBUG' datastore option
- [x] Verify which there aren't modules using the 'DEBUG' datastore option
- [x] Verify which there aren't modules using the (v)print_debug methods
- [x] **IMPORTANT** PRO people should verify and take care of any (v)print_debug usage before this is landed
