### PR TITLE
Case insensitive plugin unload

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2346,7 +2346,7 @@ class Core
     # Walk the plugins array
     framework.plugins.each { |plugin|
       # Unload the plugin if it matches the name we're searching for
-      if (plugin.name == args[0])
+      if (plugin.name.downcase == args[0].downcase)
         print("Unloading plugin #{args[0]}...")
         framework.plugins.unload(plugin)
         print_line("unloaded.")

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -4,20 +4,21 @@ require 'rex/parser/nessus_xml'
 
 module Msf
 
-  PLUGIN_NAME        = 'Nessus'
-  PLUGIN_DESCRIPTION = 'Nessus Bridge for Metasploit'
-
   class Plugin::Nessus < Msf::Plugin
 
     def name
-      PLUGIN_NAME
+      'Nessus'
     end
-      
+
+    def desc
+        "Nessus Bridge for Metasploit"
+    end
+
     class ConsoleCommandDispatcher
       include Msf::Ui::Console::CommandDispatcher
       
       def name
-        PLUGIN_NAME
+        "Nessus"
       end
 
       def xindex
@@ -1668,7 +1669,7 @@ module Msf
     def initialize(framework, opts)
       super
       add_console_dispatcher(ConsoleCommandDispatcher)
-      print_status(PLUGIN_DESCRIPTION)
+      print_status("Nessus Bridge for Metasploit")
       print_status("Type %bldnessus_help%clr for a command listing")
     end
 

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -7,7 +7,7 @@ module Msf
   class Plugin::Nessus < Msf::Plugin
 
     def name
-      'Nessus'
+      "Nessus"
     end
 
     def desc

--- a/plugins/sqlmap.rb
+++ b/plugins/sqlmap.rb
@@ -281,11 +281,11 @@ module Msf
     end
 
     def name
-      'Sqlmap'
+      "Sqlmap"
     end
 
     def desc
-      'Use Sqlmap, yo!'
+      "sqlmap plugin for Metasploit"
     end
   end
 end

--- a/plugins/sqlmap.rb
+++ b/plugins/sqlmap.rb
@@ -281,11 +281,11 @@ module Msf
     end
 
     def name
-      "Sqlmap"
+      'Sqlmap'
     end
 
     def desc
-      "sqlmap plugin for Metasploit"
+      'Use Sqlmap, yo!'
     end
   end
 end


### PR DESCRIPTION
Fix https://github.com/rapid7/metasploit-framework/issues/5221.

Before patch

``` ruby
msf > load nessus
[*] Nessus Bridge for Metasploit
[*] Type nessus_help for a command listing
[*] Successfully loaded plugin: Nessus
msf > unload nessus
msf > show plugins

Plugins
=======

   Name    Description
   ----    -----------
   Nessus

msf > unload Nessus
Unloading plugin Nessus...unloaded.
msf > show plugins
msf > load nessus
/opt/void-in/metasploit-framework/plugins/nessus.rb:7: warning: already initialized constant Msf::PLUGIN_NAME
/opt/void-in/metasploit-framework/plugins/nessus.rb:7: warning: previous definition of PLUGIN_NAME was here
/opt/void-in/metasploit-framework/plugins/nessus.rb:8: warning: already initialized constant Msf::PLUGIN_DESCRIPTION
/opt/void-in/metasploit-framework/plugins/nessus.rb:8: warning: previous definition of PLUGIN_DESCRIPTION was here
[*] Nessus Bridge for Metasploit
[*] Type nessus_help for a command listing
[*] Successfully loaded plugin: Nessus
```

After patch

``` ruby
msf > load nessus
[*] Nessus Bridge for Metasploit
[*] Type nessus_help for a command listing
[*] Successfully loaded plugin: Nessus
msf > show plugins

Plugins
=======

   Name    Description
   ----    -----------
   Nessus  Nessus Bridge for Metasploit

msf > unload nessus
Unloading plugin nessus...unloaded.
msf > show plugins
msf > load nessus
[*] Nessus Bridge for Metasploit
[*] Type nessus_help for a command listing
[*] Successfully loaded plugin: Nessus
msf >
```
