### PR TITLE
Nessus plugin check_export_status repeat probes if status not ready

### DIFF
--- a/lib/nessus/nessus-xmlrpc.rb
+++ b/lib/nessus/nessus-xmlrpc.rb
@@ -181,12 +181,7 @@ module Nessus
       request = Net::HTTP::Get.new("/scans/#{scan_id}/export/#{file_id}/status")
       request.add_field("X-Cookie", @token)
       res = @connection.request(request)
-      if res.code == "200"
-        return "ready"
-      else
-        res = JSON.parse(res.body)
-        return res
-      end
+      return res.code, JSON.parse(res.body)
     end
 
     def policy_delete(policy_id)

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -1261,7 +1261,7 @@ module Msf
         case args.length
         when 2
           scan_id = args[0]
-          format = args[1].downcase
+          format = args[1]
         else
           print_status("Usage: ")
           print_status("nessus_scan_export <scan ID> <export format>")
@@ -1269,7 +1269,7 @@ module Msf
           print_status("Use nessus_scan_list to list all available scans with their corresponding scan IDs")
           return
         end
-        if format.in?(['nessus','html','pdf','csv','db'])
+        if format.downcase.in?(['nessus','html','pdf','csv','db'])
           export = @n.scan_export(scan_id, format)
           if export["file"]
             file_id = export["file"]

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -4,20 +4,21 @@ require 'rex/parser/nessus_xml'
 
 module Msf
 
-  PLUGIN_NAME        = 'Nessus'
-  PLUGIN_DESCRIPTION = 'Nessus Bridge for Metasploit'
-
   class Plugin::Nessus < Msf::Plugin
 
     def name
-      PLUGIN_NAME
+      "Nessus"
+    end
+
+    def desc
+        "Nessus Bridge for Metasploit"
     end
       
     class ConsoleCommandDispatcher
       include Msf::Ui::Console::CommandDispatcher
       
       def name
-        PLUGIN_NAME
+        "Nessus"
       end
 
       def xindex
@@ -450,7 +451,7 @@ module Msf
           print_status("Returns a list of information about the scan or policy templates..")
           return
         end
-        if type.in?(['scan', 'policy'])
+        if type.downcase.in?(['scan', 'policy'])
           list=@n.list_template(type)
         else
           print_error("Only scan and policy are valid templates")
@@ -1183,7 +1184,7 @@ module Msf
         when 2
           scan_id = args[0]
           category = args[1]
-          if category.in?(['info', 'hosts', 'vulnerabilities', 'history'])
+          if category.downcase.in?(['info', 'hosts', 'vulnerabilities', 'history'])
             category = args[1]
           else
             print_error("Invalid category. The available categories are info, hosts, vulnerabilities, and history")
@@ -1274,9 +1275,13 @@ module Msf
             file_id = export["file"]
             print_good("The export file ID for scan ID #{scan_id} is #{file_id}")
             print_status("Checking export status...")
-            status = @n.scan_export_status(scan_id, file_id)
-            if status == "ready"
-              print_good("The status of scan ID #{scan_id} export is ready")
+            code, body = @n.scan_export_status(scan_id, file_id)
+            if code == "200"
+              if body =~ /ready/
+                print_good("The status of scan ID #{scan_id} export is ready")
+              else
+                print_status("Scan result not ready for download. Please check again after a few seconds")
+              end
             else
               print_error("There was some problem in exporting the scan. The error message is #{status}")
             end
@@ -1301,16 +1306,30 @@ module Msf
         when 2
           scan_id = args[0]
           file_id = args[1]
-          status = @n.scan_export_status(scan_id, file_id)
-          if status == "ready"
-            print_status("The status of scan ID #{scan_id} export is ready")
-          else
-            print_error("There was some problem in exporting the scan. The error message is #{status}")
-          end
+          check_export_status(scan_id, file_id)
         else
           print_status("Usage: ")
           print_status("nessus_scan_export_status <scan ID> <file ID>")
           print_status("Use nessus_scan_export <scan ID> <format> to export a scan and get its file ID")
+        end
+      end
+
+      def check_export_status(scan_id, file_id, attempt = 0)
+        code, body = @n.scan_export_status(scan_id, file_id)
+        if code == "200"
+          if body.to_s =~ /ready/
+            print_status("The status of scan ID #{scan_id} export is ready")
+          else
+            if attempt < 3
+              print_status("Scan result not ready for download. Checking again...")
+              select(nil, nil, nil, 1)
+              attempt = attempt + 1
+              print_error("Current value of attempt is #{attempt}")
+              check_export_status(scan_id, file_id, attempt)
+            end
+          end
+        else
+          print_error("There was some problem in exporting the scan. The error message is #{body}")
         end
       end
 
@@ -1668,7 +1687,7 @@ module Msf
     def initialize(framework, opts)
       super
       add_console_dispatcher(ConsoleCommandDispatcher)
-      print_status(PLUGIN_DESCRIPTION)
+      print_status("Nessus Bridge for Metasploit")
       print_status("Type %bldnessus_help%clr for a command listing")
     end
 


### PR DESCRIPTION
Fix for https://github.com/rapid7/metasploit-framework/issues/5217. Before this patch, the return status code of 200 was assumed to indicate the status of the scan report is ready. However, if the server is slow or the report size is too large, the response code is 200 but the status of export function is still not ready. This fix call the status_export API thrice with one second delay. The probe is restricted to check the API three times max to prevent the console from waiting forever. 

plugings/nessus.rb file was edited in https://github.com/rapid7/metasploit-framework/pull/5223 as well. These editions are done on top of that. First land PR https://github.com/rapid7/metasploit-framework/pull/5223 (assuming no issues) then this.
