### PR TITLE
Per-env eager load settings for Rails 4

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,15 @@ module Metasploit
 
       config.paths['log']             = "#{Msf::Config.log_directory}/#{Rails.env}.log"
       config.paths['config/database'] = [Metasploit::Framework::Database.configurations_pathname.try(:to_path)]
+
+      case Rails.env
+      when "development"
+        config.eager_load = false
+      when "test"
+        config.eager_load = false
+      when "production"
+        config.eager_load = true
+      end
     end
   end
 end


### PR DESCRIPTION
 #5234
 MSP-12612
## Verification steps
#### Production (default)
- [x] `./msfconsole`
- [x] `irb`
- [x] Verify: `Rails.application.config.eager_load == true`
- [x] exit IRB and msfconsole
#### Test
- [x] `./msfconsole -E test`
- [x] `irb`
- [x] Verify: `Rails.application.config.eager_load == false`
- [x] exit IRB and msfconsole
#### Development
- [x] `./msfconsole -E development`
- [x] `irb`
- [x] Verify: `Rails.application.config.eager_load == false`
- [x] exit IRB and msfconsole
