### PR TITLE
Sqlmap plugin json parse issue

### DIFF
--- a/lib/sqlmap/sqlmap_session.rb
+++ b/lib/sqlmap/sqlmap_session.rb
@@ -13,9 +13,13 @@ module Sqlmap
 
       args['headers'] = headers if headers
       args['vars_get'] = params if params
-      res = c.request_cgi(args)
-      res = c.send_recv(res)
-      return res
+      begin
+        res = c.request_cgi(args)
+        res = c.send_recv(res)
+        return res
+      rescue Rex::ConnectionRefused
+        return
+      end
     end
 
     def post(uri, headers = nil, data = nil, originator_args = nil)
@@ -26,12 +30,15 @@ module Sqlmap
       }
 
       args.merge!(originator_args) if originator_args
-
       args['headers'] = headers if headers
       args['data'] = data if data
-      res = c.request_cgi(args)
-      res = c.send_recv(res)
-      return res
+      begin
+        res = c.request_cgi(args)
+        res = c.send_recv(res)
+        return res
+      rescue Rex::ConnectionRefused
+        return
+      end
     end
   end
 end


### PR DESCRIPTION
As indicated in https://github.com/rapid7/metasploit-framework/issues/5222, the sqlmap plugin assumes that connection will succeed everytime. This PR make sure if connection is not established at runtime and a new task ID is not received, that the error is handled gracefully and proper error message displayed to the user.

This PR is not dependent on any prior PR.
