### PR TITLE
Fix missing . in SRV query

### DIFF
--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -330,7 +330,7 @@ class Metasploit3 < Msf::Auxiliary
     i, a = 0, []
     # Most common SRV Records
     srvrcd = [
-      "_gc._tcp.","_kerberos._tcp.", "_kerberos._udp.","_ldap._tcp","_test._tcp.",
+      "_gc._tcp.","_kerberos._tcp.", "_kerberos._udp.","_ldap._tcp.","_test._tcp.",
       "_sips._tcp.","_sip._udp.","_sip._tcp.","_aix._tcp.","_aix._tcp.","_finger._tcp.",
       "_ftp._tcp.","_http._tcp.","_nntp._tcp.","_telnet._tcp.","_whois._tcp.","_h323cs._tcp.",
       "_h323cs._udp.","_h323be._tcp.","_h323be._udp.","_h323ls._tcp.","_h323ls._udp.",


### PR DESCRIPTION
This update adds a missing . to the end of the
_ldap._tcp SRV record so that it properly forms
the DNS query.

Output before:
[_] [2015.04.24-11:14:08] Using DNS Server: 192.168.1.241
[*] [2015.04.24-11:14:08] Enumerating SRV records for testbox.lab
[_] Auxiliary module execution completed

Output after:
[_] [2015.04.24-11:13:36] Using DNS Server: 192.168.1.241
[*] [2015.04.24-11:13:36] Enumerating SRV records for testbox.lab
[*] [2015.04.24-11:13:36] SRV Record: _ldap._tcp.testbox.lab Host: 127.0.0.1. Port: 389 Priority: 0
[_] Auxiliary module execution completed
