### PR TITLE
Add RPC API Documentation (All RPC Calls)

### DIFF
--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -12,10 +12,12 @@ module RPC
 
 class Client
 
-  # @return [String] A login token.
+  # @!attribute token
+  #   @return [String] A login token.
   attr_accessor :token
 
-  # @return [Hash] Login information.
+  # @!attribute info
+  #   @return [Hash] Login information.
   attr_accessor :info
 
 

--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -12,9 +12,18 @@ module RPC
 
 class Client
 
-  attr_accessor :token, :info
+  # @return [String] A login token.
+  attr_accessor :token
+
+  # @return [Hash] Login information.
+  attr_accessor :info
 
 
+  # Initializes the RPC client to connect to: https://127.0.0.1:3790 (TLS1)
+  #
+  # @param [Hash] info Information needed for the initialization.
+  # @option info [String] :token A token used by the client.
+  # @return [void]
   def initialize(info={})
     self.info = {
       :host => '127.0.0.1',
@@ -29,6 +38,12 @@ class Client
   end
 
 
+  # Logs in by calling the 'auth.login' API.
+  #
+  # @param [String] user Username.
+  # @param [String] pass Password.
+  # @raise RuntimeError Indicating a failed authentication.
+  # @return [TrueClass] Indicating a successful login.
   def login(user,pass)
     res = self.call("auth.login", user, pass)
     unless (res && res['result'] == "success")
@@ -38,8 +53,20 @@ class Client
     true
   end
 
-  # Prepend the authentication token as the first parameter
-  # of every call except auth.login. Requires the
+
+  # Calls an API.
+  #
+  # @param [String] meth The RPC API to call.
+  # @param [Array] args The arguments to pass.
+  # @raise [RuntimeError] Something is wrong while calling the remote API, including:
+  #                       * A missing token (your client needs to authenticate).
+  #                       * A unexpected response from the server, such as a timeout or unexpected HTTP code.
+  # @raise [Msf::RPC::ServerException] The RPC service returns an error.
+  # @return [Hash] The API response.
+  # @example
+  #  # This will return something like this:
+  #  # {"version"=>"4.11.0-dev", "ruby"=>"2.1.5 x86_64-darwin14.0 2014-11-13", "api"=>"1.0"}
+  #  rpc.call('core.version')
   def call(meth, *args)
     unless meth == "auth.login"
       unless self.token
@@ -84,6 +111,10 @@ class Client
     end
   end
 
+
+  # Closes the client.
+  #
+  # @return [void]
   def close
     if @cli && @cli.conn?
       @cli.close

--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -64,7 +64,10 @@ class Client
   #                       * A missing token (your client needs to authenticate).
   #                       * A unexpected response from the server, such as a timeout or unexpected HTTP code.
   # @raise [Msf::RPC::ServerException] The RPC service returns an error.
-  # @return [Hash] The API response.
+  # @return [Hash] The API response. It contains the following keys:
+  #  * 'version' [String] Framework version.
+  #  * 'ruby' [String] Ruby version.
+  #  * 'api' [String] API version.
   # @example
   #  # This will return something like this:
   #  # {"version"=>"4.11.0-dev", "ruby"=>"2.1.5 x86_64-darwin14.0 2014-11-13", "api"=>"1.0"}

--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -40,7 +40,8 @@ class Client
   end
 
 
-  # Logs in by calling the 'auth.login' API.
+  # Logs in by calling the 'auth.login' API. The authentication token will expire 5 minutes
+  # after the last request was made.
   #
   # @param [String] user Username.
   # @param [String] pass Password.

--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -57,7 +57,7 @@ class Client
   # Calls an API.
   #
   # @param [String] meth The RPC API to call.
-  # @param [Array] args The arguments to pass.
+  # @param [Array<string>] args The arguments to pass.
   # @raise [RuntimeError] Something is wrong while calling the remote API, including:
   #                       * A missing token (your client needs to authenticate).
   #                       * A unexpected response from the server, such as a timeout or unexpected HTTP code.

--- a/lib/msf/core/rpc/v10/constants.rb
+++ b/lib/msf/core/rpc/v10/constants.rb
@@ -8,6 +8,11 @@ API_VERSION = "1.0"
 class Exception < RuntimeError
   attr_accessor :code, :message
 
+  # Initializes Exception.
+  #
+  # @param [Fixnum] code An error code.
+  # @param [String] message An error message.
+  # @return [void]
   def initialize(code, message)
     self.code    = code
     self.message = message
@@ -18,6 +23,13 @@ end
 class ServerException < RuntimeError
   attr_accessor :code, :error_message, :error_class, :error_backtrace
 
+  # Initializes ServerException.
+  #
+  # @param [Fixnum] code An error code.
+  # @param [String] error_message An error message.
+  # @param [Exception] error_class An error class.
+  # @param [Array] error_backtrace A backtrace of the error.
+  # @return [void]
   def initialize(code, error_message, error_class, error_backtrace)
     self.code          = code
     self.error_message = error_message

--- a/lib/msf/core/rpc/v10/rpc_auth.rb
+++ b/lib/msf/core/rpc/v10/rpc_auth.rb
@@ -11,8 +11,20 @@ begin
 rescue ::LoadError
 end
 
+  # Handles client authentication.
+  #
+  # @param [String] user The username.
+  # @param [String] pass The password.
+  # @raise [Msf::RPC::Exception] Something is wrong while authenticating, you can possibly get:
+  #                              * 401 Failed authentication.
+  # @return [Hash] A hash indicating a successful login.
+  #  * 'result' [String] A successful message: 'success'.
+  #  * 'token' [String] A token for the authentication.
+  # @example Here's how you would use this from the client:
+  #  # This returns something like the following:
+  #  # {"result"=>"success", "token"=>"TEMPyp1N40NK8GM0Tx7A87E6Neak2tVJ"}
+  #  rpc.call('auth.login_noauth', 'username', 'password')
   def rpc_login_noauth(user,pass)
-
     if not (user.kind_of?(::String) and pass.kind_of?(::String))
       error(401, "Login Failed")
     end
@@ -42,6 +54,19 @@ end
     { "result" => "success", "token" => token }
   end
 
+
+  # Handles client deauthentication.
+  #
+  # @param [String] token The user's token to log off.
+  # @raise [Msf::RPC::Exception] An error indicating a failed deauthentication, including:
+  #                              * 500 Invalid authentication token.
+  #                              * 500 Permanent authentication token.
+  # @return [Hash] A hash indiciating the action was successful.
+  #  * 'result' [String] The successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  # This returns something like:
+  #  # {"result"=>"success"}
+  #  rpc.call('auth.logout', 'TEMPyp1N40NK8GM0Tx7A87E6Neak2tVJ')
   def rpc_logout(token)
     found = self.service.tokens[token]
     error("500", "Invalid Authentication Token") if not found
@@ -53,6 +78,15 @@ end
     { "result" => "success" }
   end
 
+
+  # Returns a list of authentication tokens.
+  #
+  # @return [Hash] A hash that contains a list of authentication tokens.
+  #  * 'tokens' [Array] An array of tokens.
+  # @example Here's how you would use this from the client:
+  #  # This returns something like:
+  #  # {"tokens"=>["TEMPf5I4Ec8cBEKVD8D7xtIbTXWoKapP", "TEMPtcVmMld8w74zo0CYeosM3iXW0nJz"]}
+  #  rpc.call('auth.token_list')
   def rpc_token_list
     res = self.service.tokens.keys
     begin
@@ -66,6 +100,14 @@ end
     { "tokens" => res }
   end
 
+
+  # Adds a new token to the database.
+  #
+  # @param [String] token A unique token.
+  # @return [Hash] A hash indicating the action was successful.
+  #  * 'result' [String] The successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  rpc.call('auth.token_add', 'UNIQUE_TOKEN')
   def rpc_token_add(token)
     db = false
     begin
@@ -85,6 +127,14 @@ end
     { "result" => "success" }
   end
 
+
+  # Generates a unique token, and automatically saved to the database.
+  #
+  # @return [Hash] A hash indicating the action was successful, also the new token.
+  #  * 'result' [String] The successful message: 'success'
+  #  * 'token' [String] A new token.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('auth.token_generate')
   def rpc_token_generate
     token = Rex::Text.rand_text_alphanumeric(32)
     db = false
@@ -106,6 +156,14 @@ end
     { "result" => "success", "token" => token }
   end
 
+
+  # Removes a token from the database.
+  #
+  # @param [String] token The token to delete.
+  # @return [Hash] A hash indicating the action was successful.
+  #  * 'result' [String] The successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  rpc.call('auth.token_remove', 'TEMPtcVmMld8w74zo0CYeosM3iXW0nJz')
   def rpc_token_remove(token)
     db = false
     begin

--- a/lib/msf/core/rpc/v10/rpc_auth.rb
+++ b/lib/msf/core/rpc/v10/rpc_auth.rb
@@ -11,7 +11,8 @@ begin
 rescue ::LoadError
 end
 
-  # Handles client authentication.
+  # Handles client authentication. The authentication token will expire 5 minutes after the
+  # last request was made.
   #
   # @param [String] user The username.
   # @param [String] pass The password.
@@ -79,7 +80,8 @@ end
   end
 
 
-  # Returns a list of authentication tokens.
+  # Returns a list of authentication tokens including the temporary ones, permanent, or the ones
+  # stored in the backend.
   #
   # @return [Hash] A hash that contains a list of authentication tokens. It contains the following key:
   #  * 'tokens' [Array<string>] An array of tokens.
@@ -128,10 +130,10 @@ end
   end
 
 
-  # Generates a unique token, and automatically saved to the database.
+  # Generates a random 32-byte authentication token, and automatically saved to the database.
   #
   # @return [Hash] A hash indicating the action was successful, also the new token.
-  #                It contains the following keys:
+  #  It contains the following keys:
   #  * 'result' [String] The successful message: 'success'
   #  * 'token' [String] A new token.
   # @example Here's how you would use this from the client:
@@ -158,8 +160,10 @@ end
   end
 
 
-  # Removes a token from the database.
+  # Removes a token from the database. Similar to what #rpc_logout does internally, except this
+  # can remove tokens stored in the database backend (Mdm).
   #
+  # @see #rpc_logout
   # @param [String] token The token to delete.
   # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'

--- a/lib/msf/core/rpc/v10/rpc_auth.rb
+++ b/lib/msf/core/rpc/v10/rpc_auth.rb
@@ -17,7 +17,7 @@ end
   # @param [String] pass The password.
   # @raise [Msf::RPC::Exception] Something is wrong while authenticating, you can possibly get:
   #                              * 401 Failed authentication.
-  # @return [Hash] A hash indicating a successful login.
+  # @return [Hash] A hash indicating a successful login, it contains the following keys:
   #  * 'result' [String] A successful message: 'success'.
   #  * 'token' [String] A token for the authentication.
   # @example Here's how you would use this from the client:
@@ -61,7 +61,7 @@ end
   # @raise [Msf::RPC::Exception] An error indicating a failed deauthentication, including:
   #                              * 500 Invalid authentication token.
   #                              * 500 Permanent authentication token.
-  # @return [Hash] A hash indiciating the action was successful.
+  # @return [Hash] A hash indiciating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'
   # @example Here's how you would use this from the client:
   #  # This returns something like:
@@ -81,7 +81,7 @@ end
 
   # Returns a list of authentication tokens.
   #
-  # @return [Hash] A hash that contains a list of authentication tokens.
+  # @return [Hash] A hash that contains a list of authentication tokens. It contains the following key:
   #  * 'tokens' [Array<string>] An array of tokens.
   # @example Here's how you would use this from the client:
   #  # This returns something like:
@@ -104,7 +104,7 @@ end
   # Adds a new token to the database.
   #
   # @param [String] token A unique token.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('auth.token_add', 'UNIQUE_TOKEN')
@@ -131,6 +131,7 @@ end
   # Generates a unique token, and automatically saved to the database.
   #
   # @return [Hash] A hash indicating the action was successful, also the new token.
+  #                It contains the following keys:
   #  * 'result' [String] The successful message: 'success'
   #  * 'token' [String] A new token.
   # @example Here's how you would use this from the client:
@@ -160,7 +161,7 @@ end
   # Removes a token from the database.
   #
   # @param [String] token The token to delete.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('auth.token_remove', 'TEMPtcVmMld8w74zo0CYeosM3iXW0nJz')

--- a/lib/msf/core/rpc/v10/rpc_auth.rb
+++ b/lib/msf/core/rpc/v10/rpc_auth.rb
@@ -82,7 +82,7 @@ end
   # Returns a list of authentication tokens.
   #
   # @return [Hash] A hash that contains a list of authentication tokens.
-  #  * 'tokens' [Array] An array of tokens.
+  #  * 'tokens' [Array<string>] An array of tokens.
   # @example Here's how you would use this from the client:
   #  # This returns something like:
   #  # {"tokens"=>["TEMPf5I4Ec8cBEKVD8D7xtIbTXWoKapP", "TEMPtcVmMld8w74zo0CYeosM3iXW0nJz"]}

--- a/lib/msf/core/rpc/v10/rpc_base.rb
+++ b/lib/msf/core/rpc/v10/rpc_base.rb
@@ -5,6 +5,9 @@ module RPC
 class RPC_Base
   attr_accessor :framework, :service, :tokens, :users
 
+  # Initializes framework, service, tokens, and users
+  #
+  # return [void]
   def initialize(service)
     self.service   = service
     self.framework = service.framework
@@ -12,6 +15,12 @@ class RPC_Base
     self.users     = service.users
   end
 
+  # Raises an Msf::RPC Exception.
+  #
+  # @param [Fixnum] code The error code to raise.
+  # @param [String] message The error message.
+  # @raise [Msf::RPC::Exception]
+  # @return [void]
   def error(code, message)
     raise Msf::RPC::Exception.new(code, message)
   end

--- a/lib/msf/core/rpc/v10/rpc_console.rb
+++ b/lib/msf/core/rpc/v10/rpc_console.rb
@@ -15,7 +15,7 @@ class RPC_Console < RPC_Base
     @console_driver = Msf::Ui::Web::Driver.new(:framework => framework)
   end
 
-  # Creates a new framework console.
+  # Creates a new framework console instance.
   #
   # @param [Hash] opts See Msf::Ui::Web::Driver#create_console
   # @return [Hash] Information about the new console. It contains the following keys:
@@ -58,7 +58,7 @@ class RPC_Console < RPC_Base
   end
 
 
-  # Deletes a framework console.
+  # Deletes a framework console instance.
   #
   # @param [Fixnum] cid Framework console ID.
   # @return [Hash] A result indicating whether the action was successful or not.
@@ -74,7 +74,7 @@ class RPC_Console < RPC_Base
   end
 
 
-  # Returns the framework console output.
+  # Returns the framework console output in raw form.
   #
   # @param [Fixnum] cid Framework console ID.
   # @return [Hash] There are two different hashes you might get:
@@ -143,15 +143,12 @@ class RPC_Console < RPC_Base
   end
 
 
-  # Kills a framework session.
+  # Kills a framework session that serves the same purpose as [CTRL]+[C] to abort an interactive session.
+  # You might also want to considering using the session API calls instead of this.
   #
   # @param [Fixnum] cid Framework console ID.
-  # @return [Hash] There are two different hashes you might get:
-  #
-  #  If the console ID is invalid, you will get a hash like the following:
-  #  * 'result' [String] A value that says 'failure'.
-  #  If the console ID is valid, you will get the following that indicates the action was successful.
-  #  * 'result' [String] A value that says 'success'.
+  # @return [Hash] A hash indicating whether the action was successful or not. It contains:
+  #  * 'result' [String] A message that says 'success' if the console ID is valid (and successfully killed, otherwise 'failed')
   # @example Here's how you would use this from the client:
   #  rpc.call('console.session_kill', 4)
   def rpc_session_kill(cid)
@@ -162,15 +159,11 @@ class RPC_Console < RPC_Base
   end
 
 
-  # Detaches a framework session.
+  # Detaches a framework session that serves the same purpos as [CTRL]+[Z] to background an interactive session.
   #
   # @param [Fixnum] cid Framework console ID.
-  # @return [Hash] There are two different hashes you might get:
-  #
-  #  If the console ID is invalid, you will get a hash like the following:
-  #  * 'result' [String] A value that says 'failure'.
-  #  If the console ID is valid, you will get the following that indicates the action was successful.
-  #  * 'result' [String] A value that says 'success'.
+  # @return [Hash] A hash indicating whether the action was successful or not. It contains:
+  #  * 'result' [String] A message that says 'success' if the console ID is valid (and successfully detached, otherwise 'failed')
   # @example Here's how you would use this from the client:
   #  rpc.call('console.session_detach', 4)
   def rpc_session_detach(cid)

--- a/lib/msf/core/rpc/v10/rpc_console.rb
+++ b/lib/msf/core/rpc/v10/rpc_console.rb
@@ -17,7 +17,7 @@ class RPC_Console < RPC_Base
 
   # Creates a new framework console.
   #
-  # @param [Hash] opts (Optional) See Msf::Ui::Web::Driver#create_console
+  # @param [Hash] opts See Msf::Ui::Web::Driver#create_console
   # @return [Hash] Information about the new console, such as:
   #  * 'id' [Fixnum] The console's ID.
   #  * 'prompt' [String] The framework prompt (example: 'msf > ')
@@ -38,7 +38,7 @@ class RPC_Console < RPC_Base
   # Returns a list of framework consoles.
   #
   # @return [Hash] Console information.
-  #  * 'consoles' [Array] consoles, each element is another hash that includes:
+  #  * 'consoles' [Array<Hash>] consoles, each element is another hash that includes:
   #    * 'id' [Fixnum] The console's ID
   #    * 'prompt' [String] The framework prompt (example: 'msf > ')
   #    * 'busy' [TrueClass] The console's busy state, or
@@ -151,6 +151,8 @@ class RPC_Console < RPC_Base
   #  * 'result' [String] A value that says 'failure'.
   #  If the console ID is valid, you will get the following that indicates the action was successful.
   #  * 'result' [String] A value that says 'success'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('console.session_kill', 4)
   def rpc_session_kill(cid)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]
@@ -164,10 +166,12 @@ class RPC_Console < RPC_Base
   # @param [Fixnum] cid Framework console ID.
   # @return [Hash] There are two different hashes you might get:
   #
-  # If the console ID is invalid, you will get a hash like the following:
-  # * 'result' [String] A value that says 'failure'.
-  # If the console ID is valid, you will get the following that indicates the action was successful.
-  # * 'result' [String] A value that says 'success'.
+  #  If the console ID is invalid, you will get a hash like the following:
+  #  * 'result' [String] A value that says 'failure'.
+  #  If the console ID is valid, you will get the following that indicates the action was successful.
+  #  * 'result' [String] A value that says 'success'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('console.session_detach', 4)
   def rpc_session_detach(cid)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]

--- a/lib/msf/core/rpc/v10/rpc_console.rb
+++ b/lib/msf/core/rpc/v10/rpc_console.rb
@@ -18,7 +18,7 @@ class RPC_Console < RPC_Base
   # Creates a new framework console.
   #
   # @param [Hash] opts See Msf::Ui::Web::Driver#create_console
-  # @return [Hash] Information about the new console, such as:
+  # @return [Hash] Information about the new console. It contains the following keys:
   #  * 'id' [Fixnum] The console's ID.
   #  * 'prompt' [String] The framework prompt (example: 'msf > ')
   #  * 'busy' [TrueClass] The console's busy state, or
@@ -38,7 +38,7 @@ class RPC_Console < RPC_Base
   # Returns a list of framework consoles.
   #
   # @return [Hash] Console information.
-  #  * 'consoles' [Array<Hash>] consoles, each element is another hash that includes:
+  #  * 'consoles' [Array<Hash>] consoles, each element is a hash that includes:
   #    * 'id' [Fixnum] The console's ID
   #    * 'prompt' [String] The framework prompt (example: 'msf > ')
   #    * 'busy' [TrueClass] The console's busy state, or
@@ -62,7 +62,8 @@ class RPC_Console < RPC_Base
   #
   # @param [Fixnum] cid Framework console ID.
   # @return [Hash] A result indicating whether the action was successful or not.
-  #  * 'result' [String] Either 'success' or 'failure'.
+  #                It contains the following key:
+  #                * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('console.destroy', 1)
   def rpc_destroy(cid)

--- a/lib/msf/core/rpc/v10/rpc_console.rb
+++ b/lib/msf/core/rpc/v10/rpc_console.rb
@@ -7,11 +7,24 @@ module Msf
 module RPC
 class RPC_Console < RPC_Base
 
+  # Initializes the RPC console
+  #
+  # @return [Msf::Ui::Web::Driver]
   def initialize(*args)
     super
     @console_driver = Msf::Ui::Web::Driver.new(:framework => framework)
   end
 
+  # Creates a new framework console.
+  #
+  # @param [Hash] opts (Optional) See Msf::Ui::Web::Driver#create_console
+  # @return [Hash] Information about the new console, such as:
+  #  * 'id' [Fixnum] The console's ID.
+  #  * 'prompt' [String] The framework prompt (example: 'msf > ')
+  #  * 'busy' [TrueClass] The console's busy state, or
+  #  * 'busy' [FalseClass] The console's busy state.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('console.create')
   def rpc_create(opts={})
     cid = @console_driver.create_console(opts)
     {
@@ -21,6 +34,17 @@ class RPC_Console < RPC_Base
     }
   end
 
+
+  # Returns a list of framework consoles.
+  #
+  # @return [Hash] Console information.
+  #  * 'consoles' [Array] consoles, each element is another hash that includes:
+  #    * 'id' [Fixnum] The console's ID
+  #    * 'prompt' [String] The framework prompt (example: 'msf > ')
+  #    * 'busy' [TrueClass] The console's busy state, or
+  #    * 'busy' [FalseClass] The console's busy state.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('console.list')
   def rpc_list
     ret = []
     @console_driver.consoles.each_key do |cid|
@@ -33,6 +57,14 @@ class RPC_Console < RPC_Base
     {'consoles' => ret}
   end
 
+
+  # Deletes a framework console.
+  #
+  # @param [Fixnum] cid Framework console ID.
+  # @return [Hash] A result indicating whether the action was successful or not.
+  #  * 'result' [String] Either 'success' or 'failure'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('console.destroy', 1)
   def rpc_destroy(cid)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]
@@ -40,6 +72,21 @@ class RPC_Console < RPC_Base
     { 'result' => res ? 'success' : 'failure' }
   end
 
+
+  # Returns the framework console output.
+  #
+  # @param [Fixnum] cid Framework console ID.
+  # @return [Hash] There are two different hashes you might get:
+  #
+  #  If the console ID is invalid, you will get a hash like the following:
+  #  * 'result' [String] A value that says 'failure'.
+  #  If the console ID is valid, you will get a hash like the following:
+  #  * 'data' [String] The output the framework console produces (example: the banner)
+  #  * 'prompt' [String] The framework prompt (example: 'msf > ')
+  #  * 'busy' [TrueClass] The console's busy state, or
+  #  * 'busy' [FalseClass] The console's busy state.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('console.read', 1)
   def rpc_read(cid)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]
@@ -50,18 +97,60 @@ class RPC_Console < RPC_Base
     }
   end
 
+
+  # Sends an input (such as a command) to the framework console.
+  #
+  # @param [Fixnum] cid Framework console ID.
+  # @param [String] data User input.
+  # @return [Hash] There are two different hashes you might get:
+  #
+  #  If the console ID is invalid, you will get a hash like the following:
+  #  * 'result' [String] A value that says 'failure'.
+  #  If the console ID is invalid, you will get a hash like the following:
+  #  * 'wrote' [Fixnum] Number of bytes sent.
+  # @note Remember to add a newline (\\r\\n) at the end of input, otherwise
+  #       the console will not do anything. And you will need to use the
+  #       #rpc_read method to retrieve the output again.
+  # @example Here's how you would use this from the client:
+  #  # This will show the current module's options.
+  #  rpc.call('console.write', 4, "show options\r\n")
   def rpc_write(cid, data)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]
     { "wrote" => @console_driver.write_console(cid, data || '') }
   end
 
+
+  # Returns the tab-completed version of your input (such as a module path).
+  #
+  # @param [Fixnum] cid Framework console ID.
+  # @param [String] line Command.
+  # @return [Hash] There are two different hashes you might get:
+  #
+  #  If the console ID is invalid, you will get a hash like the following:
+  #  * 'result' [String] A value that says 'failure'.
+  #  If the console ID is valid, you will get a hash like the following:
+  #  * 'tabs' [String] The tab-completed version of the command.
+  # @example Here's how you would use this from the client:
+  #  # This will return:
+  #  # {"tabs"=>["use exploit/windows/smb/ms08_067_netapi"]}
+  #  rpc.call('console.tabs', 4, "use exploit/windows/smb/ms08_067_")
   def rpc_tabs(cid, line)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]
     { "tabs" => @console_driver.consoles[cid].tab_complete(line) }
   end
 
+
+  # Kills a framework session.
+  #
+  # @param [Fixnum] cid Framework console ID.
+  # @return [Hash] There are two different hashes you might get:
+  #
+  #  If the console ID is invalid, you will get a hash like the following:
+  #  * 'result' [String] A value that says 'failure'.
+  #  If the console ID is valid, you will get the following that indicates the action was successful.
+  #  * 'result' [String] A value that says 'success'.
   def rpc_session_kill(cid)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]
@@ -69,6 +158,16 @@ class RPC_Console < RPC_Base
     { 'result' => 'success' }
   end
 
+
+  # Detaches a framework session.
+  #
+  # @param [Fixnum] cid Framework console ID.
+  # @return [Hash] There are two different hashes you might get:
+  #
+  # If the console ID is invalid, you will get a hash like the following:
+  # * 'result' [String] A value that says 'failure'.
+  # If the console ID is valid, you will get the following that indicates the action was successful.
+  # * 'result' [String] A value that says 'success'.
   def rpc_session_detach(cid)
     cid = cid.to_s
     return { 'result' => 'failure' } if not @console_driver.consoles[cid]

--- a/lib/msf/core/rpc/v10/rpc_core.rb
+++ b/lib/msf/core/rpc/v10/rpc_core.rb
@@ -3,6 +3,14 @@ module Msf
 module RPC
 class RPC_Core < RPC_Base
 
+  # Returns the RPC versions.
+  #
+  # @return [Hash] A hash that includes the version information:
+  #  * 'version' [String] Framework version
+  #  * 'ruby'    [String] Ruby version
+  #  * 'api'     [String] API version
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.version')
   def rpc_version
     {
       "version" => ::Msf::Framework::Version,
@@ -11,40 +19,114 @@ class RPC_Core < RPC_Base
     }
   end
 
+
+  # Stops the RPC service.
+  #
+  # @return [void]
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.stop')
   def rpc_stop
     self.service.stop
   end
 
+
+  # Returns a global datstore option.
+  #
+  # @param [String] var The name of the global datastore.
+  # @return [Hash] The global datastore option. If the option is not set, then the value is empty.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.getg', 'GlobalSetting')
   def rpc_getg(var)
     val = framework.datastore[var]
     { var.to_s => val.to_s }
   end
 
+
+  # Sets a global datastore option.
+  #
+  # @param [String] var The hash key of the global datastore option.
+  # @param [String] val The value of the global datastore option.
+  # @return [Hash] A hash indicating the action was successful.
+  #  * 'result' [String] The successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.setg', 'MyGlobal', 'foobar')
   def rpc_setg(var, val)
     framework.datastore[var] = val
     { "result" => "success" }
   end
 
+
+  # Unsets a global datastore option.
+  #
+  # @param [String] var The global datastore option.
+  # @return [Hash] A hash indicating the action was successful.
+  #  * 'result' [String] The successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.unsetg', 'MyGlobal')
   def rpc_unsetg(var)
     framework.datastore.delete(var)
     { "result" => "success" }
   end
 
+
+  # Saves current framework settings.
+  #
+  # @return [Hash] A hash indicating the action was successful.
+  #  * 'result' [String] The successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.save')
   def rpc_save
     framework.save_config
     { "result" => "success" }
   end
 
+
+  # Reloads framework modules. This will take some time to complete.
+  #
+  # @return [Hash] Module stats:
+  #  * 'exploits' [Fixnum] The number of exploits reloaded.
+  #  * 'auxiliary' [Fixnum] The number of auxiliary modules reloaded.
+  #  * 'post' [Fixnum] The number of post modules reloaded.
+  #  * 'encoders' [Fixnum] The number of encoders reloaded.
+  #  * 'nops' [Fixnum] The number of NOP modules reloaded.
+  #  * 'payloads' [Fixnum] The number of payloads reloaded.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.reload_modules')
   def rpc_reload_modules
     framework.modules.reload_modules
     rpc_module_stats()
   end
 
+
+  # Adds a new module path.
+  #
+  # @param [String] path The new path to load.
+  # @return [Hash] Module stats:
+  #  * 'exploits' [Fixnum] The number of exploits loaded.
+  #  * 'auxiliary' [Fixnum] The number of auxiliary modules loaded.
+  #  * 'post' [Fixnum] The number of post modules loaded.
+  #  * 'encoders' [Fixnum] The number of encoders loaded.
+  #  * 'nops' [Fixnum] The number of NOP modules loaded.
+  #  * 'payloads' [Fixnum] The number of payloads loaded.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.add_module_path', '/tmp/modules/')
   def rpc_add_module_path(path)
     framework.modules.add_module_path(path)
     rpc_module_stats()
   end
 
+
+  # Returns the module stats.
+  #
+  # @return [Hash] Module stats:
+  #  * 'exploits' [Fixnum] The number of exploits.
+  #  * 'auxiliary' [Fixnum] The number of auxiliary modules.
+  #  * 'post' [Fixnum] The number of post modules.
+  #  * 'encoders' [Fixnum] The number of encoders.
+  #  * 'nops' [Fixnum] The number of NOP modules.
+  #  * 'payloads' [Fixnum] The number of payloads.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.module_stats')
   def rpc_module_stats
     {
       'exploits'  => framework.stats.num_exploits,
@@ -56,6 +138,13 @@ class RPC_Core < RPC_Base
     }
   end
 
+  # Returns a list of framework threads.
+  #
+  # @return [Hash] A collection of threads such as: 'status', 'critical', 'name', 'started'
+  # @example Here's how you would use this from the cient:
+  #  # You will get something like this:
+  #  # {0=>{"status"=>"sleep", "critical"=>false, "name"=>"StreamServerListener", "started"=>"2015-04-21 15:25:49 -0500"}}
+  #  rpc.call('core.thread_list')
   def rpc_thread_list
     res = {}
     framework.threads.each_index do |i|
@@ -71,6 +160,13 @@ class RPC_Core < RPC_Base
     res
   end
 
+  # Kills a framework thread.
+  #
+  # @param [Fixnum] tid The thread ID to kill.
+  # @return [Hash] A hash indicating the action was successful.
+  #  * 'result' [String] A successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  rpc.call('core.thread_kill', 10)
   def rpc_thread_kill(tid)
     framework.threads.kill(tid.to_i) rescue nil
     { "result" => "success" }

--- a/lib/msf/core/rpc/v10/rpc_core.rb
+++ b/lib/msf/core/rpc/v10/rpc_core.rb
@@ -46,7 +46,7 @@ class RPC_Core < RPC_Base
   #
   # @param [String] var The hash key of the global datastore option.
   # @param [String] val The value of the global datastore option.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('core.setg', 'MyGlobal', 'foobar')
@@ -59,7 +59,7 @@ class RPC_Core < RPC_Base
   # Unsets a global datastore option.
   #
   # @param [String] var The global datastore option.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('core.unsetg', 'MyGlobal')
@@ -71,7 +71,7 @@ class RPC_Core < RPC_Base
 
   # Saves current framework settings.
   #
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] The successful message: 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('core.save')
@@ -83,7 +83,7 @@ class RPC_Core < RPC_Base
 
   # Reloads framework modules. This will take some time to complete.
   #
-  # @return [Hash] Module stats:
+  # @return [Hash] Module stats that contain the following keys:
   #  * 'exploits' [Fixnum] The number of exploits reloaded.
   #  * 'auxiliary' [Fixnum] The number of auxiliary modules reloaded.
   #  * 'post' [Fixnum] The number of post modules reloaded.
@@ -101,7 +101,7 @@ class RPC_Core < RPC_Base
   # Adds a new module path.
   #
   # @param [String] path The new path to load.
-  # @return [Hash] Module stats:
+  # @return [Hash] Module stats that contain the following keys:
   #  * 'exploits' [Fixnum] The number of exploits loaded.
   #  * 'auxiliary' [Fixnum] The number of auxiliary modules loaded.
   #  * 'post' [Fixnum] The number of post modules loaded.
@@ -118,7 +118,7 @@ class RPC_Core < RPC_Base
 
   # Returns the module stats.
   #
-  # @return [Hash] Module stats:
+  # @return [Hash] Module stats that contain the following keys:
   #  * 'exploits' [Fixnum] The number of exploits.
   #  * 'auxiliary' [Fixnum] The number of auxiliary modules.
   #  * 'post' [Fixnum] The number of post modules.
@@ -140,7 +140,12 @@ class RPC_Core < RPC_Base
 
   # Returns a list of framework threads.
   #
-  # @return [Hash] A collection of threads such as: 'status', 'critical', 'name', 'started'
+  # @return [Hash] A collection of threads. Each key is the thread ID, and the value is another hash
+  #                that contains the following:
+  #                * 'status' [String] Thread status.
+  #                * 'critical' [Boolean] Thread is critical.
+  #                * 'name' [String] Thread name.
+  #                * 'started' [String] Timestamp of when the thread started.
   # @example Here's how you would use this from the cient:
   #  # You will get something like this:
   #  # {0=>{"status"=>"sleep", "critical"=>false, "name"=>"StreamServerListener", "started"=>"2015-04-21 15:25:49 -0500"}}
@@ -163,7 +168,7 @@ class RPC_Core < RPC_Base
   # Kills a framework thread.
   #
   # @param [Fixnum] tid The thread ID to kill.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] A successful message: 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('core.thread_kill', 10)

--- a/lib/msf/core/rpc/v10/rpc_core.rb
+++ b/lib/msf/core/rpc/v10/rpc_core.rb
@@ -3,7 +3,7 @@ module Msf
 module RPC
 class RPC_Core < RPC_Base
 
-  # Returns the RPC versions.
+  # Returns the RPC service versions.
   #
   # @return [Hash] A hash that includes the version information:
   #  * 'version' [String] Framework version

--- a/lib/msf/core/rpc/v10/rpc_core.rb
+++ b/lib/msf/core/rpc/v10/rpc_core.rb
@@ -98,7 +98,10 @@ class RPC_Core < RPC_Base
   end
 
 
-  # Adds a new module path.
+  # Adds a new local file system path (local to the server) as a module path. The module must be
+  # accessible to the user running the Metasploit service, and contain a top-level directory for
+  # each module type such as: exploits, nop, encoder, payloads, auxiliary, post. Also note that
+  # this will not unload modules that were deleted from the file system that were previously loaded.
   #
   # @param [String] path The new path to load.
   # @return [Hash] Module stats that contain the following keys:

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -222,14 +222,14 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] Credentials with the following hash key:
   #  * 'creds' [Array<Hash>] An array of credentials. Each hash in the array will have the following:
-  #   * 'user' [String] Username.
-  #   * 'pass' [String] Password.
-  #   * 'updated_at' [Fixnum] Last updated at.
-  #   * 'type' [String] Password type.
-  #   * 'host' [String] Host.
-  #   * 'port' [Fixnum] Port.
-  #   * 'proto' [String] Protocol.
-  #   * 'sname' [String] Service name.
+  #    * 'user' [String] Username.
+  #    * 'pass' [String] Password.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'type' [String] Password type.
+  #    * 'host' [String] Host.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'sname' [String] Service name.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.creds', {})
   def rpc_creds(xopts)
@@ -277,7 +277,6 @@ public
   #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
   #  * 500 Database not loaded. Try: rpc.call('console.create')
   #  * 500 Invalid workspace.
-  #  You probably want to run: rpc.call('console.create').
   # @return [Hash] Host information that starts with the following hash key:
   #  * 'hosts' [Array<Hash>] An array of hosts. Each hash in the array will have the following:
   #    * 'created_at' [Fixnum] Creation date.
@@ -451,10 +450,10 @@ public
   # @raise [Msf::RPC::Exception] Database not loaded.
   # @return [Hash] A hash with the following key:
   #  * 'workspaces' [Array<Hash>] In each hash of the array, you will get these keys:
-  #   * 'id' [Fixnum] Workspace ID.
-  #   * 'name' [String] Workspace name.
-  #   * 'created_at' [Fixnum] Last created at.
-  #   * 'updated_at' [Fixnum] Last updated at.
+  #    * 'id' [Fixnum] Workspace ID.
+  #    * 'name' [String] Workspace name.
+  #    * 'created_at' [Fixnum] Last created at.
+  #    * 'updated_at' [Fixnum] Last updated at.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.workspaces')
   def rpc_workspaces
@@ -496,10 +495,10 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash with the following key:
   #  * 'workspace' [Array<Hash>] In each hash of the array, you will get these keys:
-  #   * 'name' [String] Workspace name.
-  #   * 'id' [Fixnum] Workspace ID.
-  #   * 'created_at' [Fixnum] Last created at.
-  #   * 'updated_at' [Fixnum] Last updated at.
+  #    * 'name' [String] Workspace name.
+  #    * 'id' [Fixnum] Workspace ID.
+  #    * 'created_at' [Fixnum] Last created at.
+  #    * 'updated_at' [Fixnum] Last updated at.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.get_workspace')
   def rpc_get_workspace(wspace)
@@ -606,18 +605,18 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following:
   #  * 'host' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'created_at' [Fixnum] Last created at.
-  #   * 'address' [String] Address.
-  #   * 'mac' [String] Mac address.
-  #   * 'name' [String] Host name.
-  #   * 'state' [String] Host state.
-  #   * 'os_name' [String] OS name.
-  #   * 'os_flavor' [String] OS flavor.
-  #   * 'os_sp' [String] OS service pack.
-  #   * 'os_lang' [String] OS language.
-  #   * 'updated_at' [Fixnum] Last updated at.
-  #   * 'purpose' [String] Purpose. Example: 'server'.
-  #   * 'info' [String] Additional information.
+  #    * 'created_at' [Fixnum] Last created at.
+  #    * 'address' [String] Address.
+  #    * 'mac' [String] Mac address.
+  #    * 'name' [String] Host name.
+  #    * 'state' [String] Host state.
+  #    * 'os_name' [String] OS name.
+  #    * 'os_flavor' [String] OS flavor.
+  #    * 'os_sp' [String] OS service pack.
+  #    * 'os_lang' [String] OS language.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'purpose' [String] Purpose. Example: 'server'.
+  #    * 'info' [String] Additional information.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.get_host', {:host => ip})
   def rpc_get_host(xopts)
@@ -722,13 +721,13 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following key:
   #  * 'service' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'host' [String] Host address.
-  #   * 'created_at' [Fixnum] Creation date.
-  #   * 'port' [Fixnum] Port.
-  #   * 'proto' [String] Protocol.
-  #   * 'state' [String] Service state.
-  #   * 'name' [String] Service name.
-  #   * 'info' [String] Additional information.
+  #    * 'host' [String] Host address.
+  #    * 'created_at' [Fixnum] Creation date.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'state' [String] Service state.
+  #    * 'name' [String] Service name.
+  #    * 'info' [String] Additional information.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.get_service', {:workspace=>'default', :proto=>'tcp', :port=>443})
   def rpc_get_service(xopts)
@@ -790,15 +789,15 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following:
   #  * 'note' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'host' [String] Host.
-  #   * 'port' [Fixnum] Port.
-  #   * 'proto' [String] Protocol.
-  #   * 'created_at' [Fixnum] Last created at.
-  #   * 'updated_at' [Fixnum] Last updated at.
-  #   * 'ntype' [String] Note type.
-  #   * 'data' [String] Note data.
-  #   * 'critical' [String] A boolean indicating criticality.
-  #   * 'seen' [String] A boolean indicating whether the note has been seen before.
+  #    * 'host' [String] Host.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'created_at' [Fixnum] Last created at.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'ntype' [String] Note type.
+  #    * 'data' [String] Note data.
+  #    * 'critical' [String] A boolean indicating criticality.
+  #    * 'seen' [String] A boolean indicating whether the note has been seen before.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.get_note', {:proto => 'tcp', :port => 80})
   def rpc_get_note(xopts)
@@ -866,12 +865,12 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the client connection:
   #  * 'client' [Array<Hash>] Each hash of the array contains the following:
-  #   * 'host' [String] Host IP.
-  #   * 'created_at' [Fixnum] Created date.
-  #   * 'updated_at' [Fixnum] Last updated at.
-  #   * 'ua_string' [String] User-Agent string.
-  #   * 'ua_name' [String] User-Agent name.
-  #   * 'ua_ver' [String] User-Agent version.
+  #    * 'host' [String] Host IP.
+  #    * 'created_at' [Fixnum] Created date.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'ua_string' [String] User-Agent string.
+  #    * 'ua_name' [String] User-Agent name.
+  #    * 'ua_ver' [String] User-Agent version.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.get_client', {:workspace=>'default', :ua_string=>user_agent, :host=>ip})
   def rpc_get_client(xopts)
@@ -977,11 +976,11 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following:
   #  * 'notes' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'time' [Fixnum] Creation date.
-  #   * 'host' [String] Host address.
-  #   * 'service' [String] Service name or port.
-  #   * 'type' [String] Host type.
-  #   * 'data' [String] Host data.
+  #    * 'time' [Fixnum] Creation date.
+  #    * 'host' [String] Host address.
+  #    * 'service' [String] Service name or port.
+  #    * 'type' [String] Host type.
+  #    * 'data' [String] Host data.
   # @example Here's how you would use this from the client:
   #  # This gives you all the notes.
   #  rpc.call('db.notes', {})
@@ -1051,10 +1050,10 @@ public
   # @return [Hash] A hash that contains the following:
   #  * 'result' [String] A message that says 'success'.
   #  * 'deleted' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'address' [String] Host address.
-  #   * 'port' [Fixnum] Port.
-  #   * 'proto' [String] Protocol.
-  #   * 'name' [String] Vulnerability name.
+  #    * 'address' [String] Host address.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'name' [String] Vulnerability name.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.del_vuln', {:host=>ip, :port=>445, :proto=>'tcp'})
   def rpc_del_vuln(xopts)
@@ -1144,10 +1143,10 @@ public
   # @return [Hash] A hash that contains the following:
   #  * 'result' [String] A message that says 'success'.
   #  * 'deleted' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'address' [String] Host address.
-  #   * 'port' [Fixnum] Port.
-  #   * 'proto'[String] Protocol.
-  #   * 'ntype' [String] Note type.
+  #    * 'address' [String] Host address.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'ntype' [String] Note type.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.del_note', {:workspace=>'default', :host=>ip, :port=>443, :proto=>'tcp'})
   def rpc_del_note(xopts)
@@ -1235,10 +1234,10 @@ public
   # @return [Hash] A hash that contains the following:
   #  * 'result' [String] A message that says 'success' or 'failed'.
   #  * 'deleted' [Array<Hash>] If result says success, then you will get this key.
-  #                            Each hash in the array contains the following:
-  #   * 'address' [String] Host address.
-  #   * 'port' [Fixnum] Port.
-  #   * 'proto' [String] Protocol.
+  #    Each hash in the array contains:
+  #    * 'address' [String] Host address.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.del_service', {:host=>ip})
   def rpc_del_service(xopts)
@@ -1310,8 +1309,8 @@ public
   #  * 500 Database not loaded. Try: rpc.call('console.create')
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following:
-  #  'result' [String] A message that says 'success'.
-  #  'deleted' [Array] All the deleted hosts.
+  #  * 'result' [String] A message that says 'success'.
+  #  * 'deleted' [Array<String>] All the deleted hosts.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.del_host', {:host=>ip})
   def rpc_del_host(xopts)
@@ -1358,7 +1357,7 @@ public
   #  * 500 Database not loaded. Try: rpc.call('console.create')
   #  * 500 Invalid workspace.
   # @return [Hash] A hash indicating whether the action was successful or not. It contains:
-  #  'result' [String] A message that says either 'success' or 'failed'.
+  #  * 'result' [String] A message that says either 'success' or 'failed'.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.report_vuln', {:host=>ip, :name=>'file upload'})
   def rpc_report_vuln(xopts)
@@ -1385,13 +1384,13 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following:
   #  * 'events' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'host' [String] Host address.
-  #   * 'created_at' [Fixnum] Creation date.
-  #   * 'updated_at' [Fixnum] Last updated at.
-  #   * 'name' [String] Event name.
-  #   * 'critical' [Boolean] Criticality.
-  #   * 'username' [String] Username.
-  #   * 'info' [String] Additional information.
+  #    * 'host' [String] Host address.
+  #    * 'created_at' [Fixnum] Creation date.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'name' [String] Event name.
+  #    * 'critical' [Boolean] Criticality.
+  #    * 'username' [String] Username.
+  #    * 'info' [String] Additional information.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.events', {})
   def rpc_events(xopts)
@@ -1489,15 +1488,15 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following:
   #  * 'loots' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'host' [String] Host address.
-  #   * 'service' [String] Service name or port.
-  #   * 'ltype' [String] Loot type.
-  #   * 'ctype' [String] Content type.
-  #   * 'data' [String] Looted data.
-  #   * 'created_at' [Fixnum] Creation date.
-  #   * 'updated_at' [Fixnum] Last updated at.
-  #   * 'name' [String] Name.
-  #   * 'info' [String] Additional information.
+  #    * 'host' [String] Host address.
+  #    * 'service' [String] Service name or port.
+  #    * 'ltype' [String] Loot type.
+  #    * 'ctype' [String] Content type.
+  #    * 'data' [String] Looted data.
+  #    * 'created_at' [Fixnum] Creation date.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'name' [String] Name.
+  #    * 'info' [String] Additional information.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.loots', {})
   def rpc_loots(xopts)
@@ -1593,14 +1592,14 @@ public
   #  * 500 Invalid workspace.
   # @return [Hash] A hash that contains the following:
   #  * 'vuln' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'host' [String] Host address.
-  #   * 'port' [Fixnum] Port.
-  #   * 'proto' [String] Protocol.
-  #   * 'created_at' [Fixnum] Creation date.
-  #   * 'updated_at' [Fixnum] Last updated at.
-  #   * 'name' [String] Vulnerability name.
-  #   * 'info' [String] Additional information.
-  #   * 'refs' [Array<String>] Reference names.
+  #    * 'host' [String] Host address.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'created_at' [Fixnum] Creation date.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'name' [String] Vulnerability name.
+  #    * 'info' [String] Additional information.
+  #    * 'refs' [Array<String>] Reference names.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.get_vuln', {:proto=>'tcp'})
   def rpc_get_vuln(xopts)
@@ -1719,8 +1718,8 @@ public
   # @return [Hash] A hash that contains the following:
   #  * 'result' [String] A message that says 'success'.
   #  * 'deleted' [Array<Hash>] Each hash in the array contains the following:
-  #   * 'address' [String] Host address.
-  #   * 'ua_string' [String] User-Agent string.
+  #    * 'address' [String] Host address.
+  #    * 'ua_string' [String] User-Agent string.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.del_client', {})
   def rpc_del_client(xopts)
@@ -1871,7 +1870,9 @@ public
   # Disconnects the database.
   #
   # @return [Hash] A hash that indicates whether the action was successful or not. It contains:
-  #  'result' [String] A message that says either 'success' or 'failed'.
+  #  * 'result' [String] A message that says either 'success' or 'failed'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.disconnect')
   def rpc_disconnect
     if (self.framework.db)
       self.framework.db.disconnect()

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -140,7 +140,7 @@ public
   # Creates a credential.
   #
   # @param [Hash] xopts Credential options. (See #create_credential Documentation)
-  # @return [Hash] Credential data.
+  # @return [Hash] Credential data. It contains the following keys:
   #  * :username [String] Username saved.
   #  * :private [String] Password saved.
   #  * :private_type [String] Password type.
@@ -211,6 +211,23 @@ public
     invalidate_login(opts)
   end
 
+
+  # Returns login credentials from a specific workspace.
+  #
+  # @param [Hash] xopts Options.
+  # @option xopts [String] :workspace Name of the workspace.
+  # @return [Hash] Credentials with the following hash key:
+  #  * 'creds' [Array<Hash>] An array of credentials. Each hash in the array will have the following:
+  #                          * 'user' [String] Username.
+  #                          * 'pass' [String] Password.
+  #                          * 'updated_at' [Fixnum] Last updated at.
+  #                          * 'type' [String] Password type.
+  #                          * 'host' [String] Host.
+  #                          * 'port' [Fixnum] Port.
+  #                          * 'proto' [String] Protocol.
+  #                          * 'sname' [String] Service name.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.creds', {})
   def rpc_creds(xopts)
     ::ActiveRecord::Base.connection_pool.with_connection {
       ret = {}
@@ -247,6 +264,27 @@ public
     }
   end
 
+
+  # Returns information about hosts.
+  #
+  # @param [Hash] xopts Options.
+  # @option xopts [String] :workspace Name of the workspace.
+  # @return [Hash] Host information that starts with the following hash key:
+  #  * 'hosts' [Array<Hash>] An array of hosts. Each hash in the array will have the following:
+  #                          * 'created_at' [Fixnum] Creation date.
+  #                          * 'address' [String] IP address.
+  #                          * 'mac' [String] MAC address.
+  #                          * 'name' [String] Computer name.
+  #                          * 'state' [String] Host's state.
+  #                          * 'os_name' [String] Name of the operating system.
+  #                          * 'os_flavor' [String] OS flavor.
+  #                          * 'os_sp' [String] Service pack.
+  #                          * 'os_lang' [String] OS language.
+  #                          * 'updated_at' [Fixnum] Last updated at.
+  #                          * 'purpose' [String] Host purpose (example: server)
+  #                          * 'info' [String] Additional information about the host.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.hosts', {})
   def rpc_hosts(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -141,14 +141,14 @@ public
   #
   # @param [Hash] xopts Credential options. (See #create_credential Documentation)
   # @return [Hash] Credential data. It contains the following keys:
-  #  * :username [String] Username saved.
-  #  * :private [String] Password saved.
-  #  * :private_type [String] Password type.
-  #  * :realm_value [String] Realm.
-  #  * :realm_key [String] Realm key.
-  #  * :host [String] Host (Only avilable if there's a :last_attempted_at and :status)
-  #  * :sname [String] Service name (only available if there's a :last_attempted_at and :status)
-  #  * :status [Status] Login status (only available if there's a :last_attempted_at and :status)
+  #  * 'username' [String] Username saved.
+  #  * 'private' [String] Password saved.
+  #  * 'private_type' [String] Password type.
+  #  * 'realm_value' [String] Realm.
+  #  * 'realm_key' [String] Realm key.
+  #  * 'host' [String] Host (Only avilable if there's a :last_attempted_at and :status)
+  #  * 'sname' [String] Service name (only available if there's a :last_attempted_at and :status)
+  #  * 'status' [Status] Login status (only available if there's a :last_attempted_at and :status)
   # @see https://github.com/rapid7/metasploit-credential/blob/master/lib/metasploit/credential/creation.rb#L107 #create_credential Documentation.
   # @example Here's how you would use this from the client:
   #  opts = {
@@ -216,16 +216,20 @@ public
   #
   # @param [Hash] xopts Options:
   # @option xopts [String] :workspace Name of the workspace.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
   # @return [Hash] Credentials with the following hash key:
   #  * 'creds' [Array<Hash>] An array of credentials. Each hash in the array will have the following:
-  #                          * 'user' [String] Username.
-  #                          * 'pass' [String] Password.
-  #                          * 'updated_at' [Fixnum] Last updated at.
-  #                          * 'type' [String] Password type.
-  #                          * 'host' [String] Host.
-  #                          * 'port' [Fixnum] Port.
-  #                          * 'proto' [String] Protocol.
-  #                          * 'sname' [String] Service name.
+  #   * 'user' [String] Username.
+  #   * 'pass' [String] Password.
+  #   * 'updated_at' [Fixnum] Last updated at.
+  #   * 'type' [String] Password type.
+  #   * 'host' [String] Host.
+  #   * 'port' [Fixnum] Port.
+  #   * 'proto' [String] Protocol.
+  #   * 'sname' [String] Service name.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.creds', {})
   def rpc_creds(xopts)
@@ -269,6 +273,11 @@ public
   #
   # @param [Hash] xopts Options:
   # @option xopts [String] :workspace Name of the workspace.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  #  You probably want to run: rpc.call('console.create').
   # @return [Hash] Host information that starts with the following hash key:
   #  * 'hosts' [Array<Hash>] An array of hosts. Each hash in the array will have the following:
   #    * 'created_at' [Fixnum] Creation date.
@@ -329,8 +338,12 @@ public
   # @option xopts [String] :address Address.
   # @option xopts [String] :ports Port range.
   # @option xopts [String] :names Names (Use ',' as the separator).
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
   # @return [Hash] A hash with the following keys:
-  #  * :services [Array<Hash>] In each hash of the array, you will get these keys:
+  #  * 'services' [Array<Hash>] In each hash of the array, you will get these keys:
   #    * 'host' [String] Host.
   #    * 'created_at' [Fixnum] Last created at.
   #    * 'updated_at' [Fixnum] Last updated at.
@@ -340,7 +353,7 @@ public
   #    * 'name' [String] Service name.
   #    * 'info' [String] Additional information about the service.
   # @example Here's how you would use this from the client:
-  #  rpc.call('db.services')
+  #  rpc.call('db.services', {})
   def rpc_services( xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -384,6 +397,10 @@ public
   # @option xopts [String] :proto Protocol.
   # @option xopts [String] :address Address.
   # @option xopts [String] :ports Port range.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
   # @return [Hash] A hash with the following key:
   #  * 'vulns' [Array<Hash>] In each hash of the array, you will get these keys:
   #    * 'port' [Fixnum] Port.
@@ -459,7 +476,7 @@ public
 
   # Returns the current workspace.
   #
-  # @raise [Msf::RPC::Exception] Database not loaded.
+  # @raise [Msf::RPC::Exception] Database not loaded. Try: rpc.call('console.create')
   # @return [Hash] A hash with the following keys:
   #  * 'workspace' [String] Workspace name.
   #  * 'workspace_id' [Fixnum] Workspace ID.
@@ -505,8 +522,7 @@ public
   # Sets a workspace.
   #
   # @param [String] wspace Workspace name.
-  # @raise [Msf::RPC::Exception] You might get one of the following errors:
-  #  * 500 Database not loaded.
+  # @raise [Msf::RPC::Exception] 500 Database not loaded.
   # @return [Hash] A hash indicating whether the action was successful or not. You will get:
   #  * 'result' [String] A message that says either 'success' or 'failed'
   # @example Here's how you would use this from the client:
@@ -524,6 +540,18 @@ public
   }
   end
 
+
+  # Deletes a workspace.
+  #
+  # @param [String] wspace Workspace name.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 404 Workspace not found.
+  # @return [Hash] A hash indicating the action was successful. It contains the following:
+  #  * 'result' [String] A message that says 'success'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.wspace', 'temp_workspace')
   def rpc_del_workspace(wspace)
   ::ActiveRecord::Base.connection_pool.with_connection {
     db_check
@@ -544,6 +572,18 @@ public
   }
   end
 
+
+  # Adds a new workspace.
+  #
+  # @param [String] wspace Workspace name.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash indicating whether the action was successful or not. You get:
+  #  * 'result' [String] A message that says either 'success' or 'failed'.
+  # @example Here's how you would use this from the client:
+  #  * rpc.call('db.add_workspace', 'my_new_workspace')
   def rpc_add_workspace(wspace)
   ::ActiveRecord::Base.connection_pool.with_connection {
     db_check
@@ -553,6 +593,33 @@ public
   }
   end
 
+
+  # Returns information about a host.
+  #
+  # @param [Hash] xopts Options (:addr, :address, :host are the same thing, and you only need one):
+  # @option xopts [String] :addr Host address.
+  # @option xopts [String] :address Same as :addr.
+  # @option xopts [String] :host Same as :address.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash that contains the following:
+  #  * 'host' [Array<Hash>] Each hash in the array contains the following:
+  #   * 'created_at' [Fixnum] Last created at.
+  #   * 'address' [String] Address.
+  #   * 'mac' [String] Mac address.
+  #   * 'name' [String] Host name.
+  #   * 'state' [String] Host state.
+  #   * 'os_name' [String] OS name.
+  #   * 'os_flavor' [String] OS flavor.
+  #   * 'os_sp' [String] OS service pack.
+  #   * 'os_lang' [String] OS language.
+  #   * 'updated_at' [Fixnum] Last updated at.
+  #   * 'purpose' [String] Purpose. Example: 'server'.
+  #   * 'info' [String] Additional information.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.get_host', {:host => ip})
   def rpc_get_host(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -581,6 +648,30 @@ public
   }
   end
 
+
+  # Reports a new host to the database.
+  #
+  # @param [Hash] xopts Information about the host.
+  # @option xopts [String] :host IP address. You msut supply this.
+  # @option xopts [String] :state One of the Msf::HostState constants. (See Most::HostState Documentation)
+  # @option xopts [String] :os_name Something like "Windows", "Linux", or "Mac OS X".
+  # @option xopts [String] :os_flavor Something like "Enterprise", "Pro", or "Home".
+  # @option xopts [String] :os_sp Something like "SP2".
+  # @option xopts [String] :os_lang Something like "English", "French", or "en-US".
+  # @option xopts [String] :arch one of the ARCH_* constants. (see ARCH Documentation)
+  # @option xopts [String] :mac Mac address.
+  # @option xopts [String] :scope Interface identifier for link-local IPv6.
+  # @option xopts [String] :virtual_host The name of the VM host software, eg "VMWare", "QEMU", "Xen", etc.
+  # @see https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/host_state.rb Most::HostState Documentation.
+  # @see https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/constants.rb#L66 ARCH Documentation.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash indicating whether the action was successful or not. It contains the following:
+  #  * 'result' [String] A message that says either 'success' or 'failed'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.report_host', {:host => ip})
   def rpc_report_host(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -591,6 +682,23 @@ public
   }
   end
 
+
+  # Reports a service to the database.
+  #
+  # @param [Hash] xopts Information about the service.
+  # @option xopts [String] :host Required. The host where this service is running.
+  # @option xopts [String] :port Required. The port where this service listens.
+  # @option xopts [String] :proto Required. The transport layer protocol (e.g. tcp, udp).
+  # @option xopts [String] :name The application layer protocol (e.g. ssh, mssql, smb).
+  # @option xopts [String] :sname An alias for the above
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash indicating whether the action was successful or not. It contains:
+  #  * 'result' [String] A message that says either 'success' or 'failed'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.report_service', {:host=>ip, :port=>8181, :proto=>'tcp', :name=>'http'})
   def rpc_report_service(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -1262,6 +1370,17 @@ public
 
   end
 
+
+  # Returns the database status.
+  #
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  # @return [Hash] A hash that contains the following keys:
+  #  * 'driver' [String] Name of the database driver.
+  #  * 'db' [String] Name of the database.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.status')
   def rpc_status
     if (not self.framework.db.driver)
       return {:driver => 'None' }
@@ -1283,6 +1402,11 @@ public
     {:driver => 'None' }
   end
 
+
+  # Disconnects the database.
+  #
+  # @return [Hash] A hash that indicates whether the action was successful or not. It contains:
+  #  'result' [String] A message that says either 'success' or 'failed'.
   def rpc_disconnect
     if (self.framework.db)
       self.framework.db.disconnect()

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -754,6 +754,30 @@ public
   }
   end
 
+
+  # Returns a note.
+  #
+  # @param [Hash] xopts Options.
+  # @option xopts [String] :proto Protocol.
+  # @option xopts [Fixnum] :port Port.
+  # @option xopts [String] :ntype Note type.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash that contains the following:
+  #  * 'note' [Array<Hash>] Each hash in the array contains the following:
+  #   * 'host' [String] Host.
+  #   * 'port' [Fixnum] Port.
+  #   * 'proto' [String] Protocol.
+  #   * 'created_at' [Fixnum] Last created at.
+  #   * 'updated_at' [Fixnum] Last updated at.
+  #   * 'ntype' [String] Note type.
+  #   * 'data' [String] Note data.
+  #   * 'critical' [String] A boolean indicating criticality.
+  #   * 'seen' [String] A boolean indicating whether the note has been seen before.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.get_note', {:proto => 'tcp', :port => 80})
   def rpc_get_note(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -806,6 +830,27 @@ public
   }
   end
 
+
+  # Returns information about a client connection.
+  #
+  # @param [Hash] xopts Options:
+  # @option xopts [String] :workspace Workspace name.
+  # @option xopts [String] :ua_string User agent string.
+  # @option xopts [String] :host Host IP.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash that contains the client connection:
+  #  * 'client' [Array<Hash>] Each hash of the array contains the following:
+  #   * 'host' [String] Host IP.
+  #   * 'created_at' [Fixnum] Created date.
+  #   * 'updated_at' [Fixnum] Last updated at.
+  #   * 'ua_string' [String] User-Agent string.
+  #   * 'ua_name' [String] User-Agent name.
+  #   * 'ua_ver' [String] User-Agent version.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.get_client', {:workspace=>'default', :ua_string=>user_agent, :host=>ip})
   def rpc_get_client(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -827,6 +872,24 @@ public
   }
   end
 
+
+  # Reports a client connection.
+  #
+  # @param [Hash] xopts Information about the client.
+  # @option xopts [String] :ua_string Required. User-Agent string.
+  # @option xopts [String] :host Required. Host IP.
+  # @option xopts [String] :ua_name One of the Msf::HttpClients constants. (See Msf::HttpClient Documentation.)
+  # @option xopts [String] :ua_ver Detected version of the given client.
+  # @option xopts [String] An id or Campaign object.
+  # @see https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/constants.rb#L52 Msf::HttpClient Documentation.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash indicating whether the action was successful or not. It contains:
+  #  * 'result' [String] A message that says either 'success' or 'failed'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.report_client', {:workspace=>'default', :ua_string=>user_agent, :host=>ip})
   def rpc_report_client(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -836,7 +899,29 @@ public
   }
   end
 
-  #DOC NOTE: :data and :ntype are REQUIRED
+
+  # Reports a note.
+  #
+  # @param [Hash] xopts Information about the note.
+  # @option xopts [String] :type Required. The type of note, e.g. smb_peer_os.
+  # @option xopts [String] :workspace The workspace to associate with this note.
+  # @option xopts [String] :host An IP address or a Host object to associate with this note.
+  # @option xopts [String] :service A Service object to associate with this note.
+  # @option xopts [String] :data Whatever it is you're making a note of.
+  # @option xopts [Fixnum] :port Along with +:host+ and +:proto+, a service to associate with this note.
+  # @option xopts [String] :proto Along with +:host+ and +:port+, a service to associate with this note.
+  # @option xopts [Hash] A hash that contains the following information.
+  #  * :unique [Boolean] Allow only a single Note per +:host+/+:type+ pair.
+  #  * :unique_data [Boolean] Like +:uniqe+, but also compare +:data+.
+  #  * :insert [Boolean] Always insert a new Note even if one with identical values exists.
+  # @raise [Msf::RPC::ServerException] You might get one of these errors:
+  #  * 500 ActiveRecord::ConnectionNotEstablished. Try: rpc.call('console.create').
+  #  * 500 Database not loaded. Try: rpc.call('console.create')
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash indicating whether the action was successful or not. It contains:
+  #  * 'result' [String] A message that says either 'success' or 'failed'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.report_note', {:type=>'http_data', :host=>'192.168.1.123', :data=>'data'})
   def rpc_report_note(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -106,11 +106,64 @@ private
 
 public
 
+
+  # Creates a credential.
+  #
+  # @note Despite the fact the method name for this is called "rpc_create_cracked_credential", it
+  #       does not actually call the create_cracked_credential API in metasploit-credential. Instead,
+  #       it calls create_credential.
+  # @todo This method needs to call create_cracked_credential, not create_credential.
+  # @param [Hash] xopts Credential options. (See #create_credential Documentation)
+  # @return [Metasploit::Credential::Core]
+  # @see https://github.com/rapid7/metasploit-credential/blob/master/lib/metasploit/credential/creation.rb#L107 #create_credential Documentation.
+  # @see #rpc_create_credential
+  # @example Here's how you would use this from the client:
+  #  opts = {
+  #   origin_type: :service,
+  #   address: '192.168.1.100',
+  #   port: 445,
+  #   service_name: 'smb',
+  #   protocol: 'tcp',
+  #   module_fullname: 'auxiliary/scanner/smb/smb_login',
+  #   workspace_id: myworkspace_id,
+  #   private_data: 'password1',
+  #   private_type: :password,
+  #   username: 'Administrator'
+  #  }
+  #  rpc.call('db.create_cracked_credential', opts)
   def rpc_create_cracked_credential(xopts)
     opts = fix_cred_options(xopts)
     create_credential(opts)
   end
 
+
+  # Creates a credential.
+  #
+  # @param [Hash] xopts Credential options. (See #create_credential Documentation)
+  # @return [Hash] Credential data.
+  #  * :username [String] Username saved.
+  #  * :private [String] Password saved.
+  #  * :private_type [String] Password type.
+  #  * :realm_value [String] Realm.
+  #  * :realm_key [String] Realm key.
+  #  * :host [String] Host (Only avilable if there's a :last_attempted_at and :status)
+  #  * :sname [String] Service name (only available if there's a :last_attempted_at and :status)
+  #  * :status [Status] Login status (only available if there's a :last_attempted_at and :status)
+  # @see https://github.com/rapid7/metasploit-credential/blob/master/lib/metasploit/credential/creation.rb#L107 #create_credential Documentation.
+  # @example Here's how you would use this from the client:
+  #  opts = {
+  #   origin_type: :service,
+  #   address: '192.168.1.100',
+  #   port: 445,
+  #   service_name: 'smb',
+  #   protocol: 'tcp',
+  #   module_fullname: 'auxiliary/scanner/smb/smb_login',
+  #   workspace_id: myworkspace_id,
+  #   private_data: 'password1',
+  #   private_type: :password,
+  #   username: 'Administrator'
+  #  }
+  #  rpc.call('db.create_cracked_credential', opts)
   def rpc_create_credential(xopts)
     opts = fix_cred_options(xopts)
     core = create_credential(opts)
@@ -135,6 +188,24 @@ public
     ret
   end
 
+
+  # Sets the status of a login credential to a failure.
+  #
+  # @param [Hash] xopts Credential data (See #invalidate_login Documentation)
+  # @raise [Msf::RPC::Exception] If there's an option missing.
+  # @return [void]
+  # @see https://github.com/rapid7/metasploit-credential/blob/master/lib/metasploit/credential/creation.rb#L492 #invalidate_login Documentation
+  # @see https://github.com/rapid7/metasploit-model/blob/master/lib/metasploit/model/login/status.rb Status symbols.
+  # @example Here's how you would use this from the client:
+  #  opts = {
+  #    address: '192.168.1.100',
+  #    port: 445,
+  #    protocol: 'tcp',
+  #    public: 'admin',
+  #    private: 'password1',
+  #    status: 'Incorrect'
+  #  }
+  #  rpc.call('db.invalidate_login', opts)
   def rpc_invalidate_login(xopts)
     opts = fix_cred_options(xopts)
     invalidate_login(opts)

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -214,7 +214,7 @@ public
 
   # Returns login credentials from a specific workspace.
   #
-  # @param [Hash] xopts Options.
+  # @param [Hash] xopts Options:
   # @option xopts [String] :workspace Name of the workspace.
   # @return [Hash] Credentials with the following hash key:
   #  * 'creds' [Array<Hash>] An array of credentials. Each hash in the array will have the following:
@@ -267,22 +267,22 @@ public
 
   # Returns information about hosts.
   #
-  # @param [Hash] xopts Options.
+  # @param [Hash] xopts Options:
   # @option xopts [String] :workspace Name of the workspace.
   # @return [Hash] Host information that starts with the following hash key:
   #  * 'hosts' [Array<Hash>] An array of hosts. Each hash in the array will have the following:
-  #                          * 'created_at' [Fixnum] Creation date.
-  #                          * 'address' [String] IP address.
-  #                          * 'mac' [String] MAC address.
-  #                          * 'name' [String] Computer name.
-  #                          * 'state' [String] Host's state.
-  #                          * 'os_name' [String] Name of the operating system.
-  #                          * 'os_flavor' [String] OS flavor.
-  #                          * 'os_sp' [String] Service pack.
-  #                          * 'os_lang' [String] OS language.
-  #                          * 'updated_at' [Fixnum] Last updated at.
-  #                          * 'purpose' [String] Host purpose (example: server)
-  #                          * 'info' [String] Additional information about the host.
+  #    * 'created_at' [Fixnum] Creation date.
+  #    * 'address' [String] IP address.
+  #    * 'mac' [String] MAC address.
+  #    * 'name' [String] Computer name.
+  #    * 'state' [String] Host's state.
+  #    * 'os_name' [String] Name of the operating system.
+  #    * 'os_flavor' [String] OS flavor.
+  #    * 'os_sp' [String] Service pack.
+  #    * 'os_lang' [String] OS language.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'purpose' [String] Host purpose (example: server)
+  #    * 'info' [String] Additional information about the host.
   # @example Here's how you would use this from the client:
   #  rpc.call('db.hosts', {})
   def rpc_hosts(xopts)
@@ -318,6 +318,29 @@ public
   }
   end
 
+
+  # Returns information about services.
+  #
+  # @param [Hash] xopts Options:
+  # @option xopts [String] :workspace Name of workspace.
+  # @option xopts [Fixnum] :limit Limit.
+  # @option xopts [Fixnum] :offset Offset.
+  # @option xopts [String] :proto Protocol.
+  # @option xopts [String] :address Address.
+  # @option xopts [String] :ports Port range.
+  # @option xopts [String] :names Names (Use ',' as the separator).
+  # @return [Hash] A hash with the following keys:
+  #  * :services [Array<Hash>] In each hash of the array, you will get these keys:
+  #    * 'host' [String] Host.
+  #    * 'created_at' [Fixnum] Last created at.
+  #    * 'updated_at' [Fixnum] Last updated at.
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'state' [String] Service state.
+  #    * 'name' [String] Service name.
+  #    * 'info' [String] Additional information about the service.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.services')
   def rpc_services( xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -351,6 +374,26 @@ public
   }
   end
 
+
+  # Returns information about reported vulnerabilities.
+  #
+  # @param [Hash] xopts Options:
+  # @option xopts [String] :workspace Name of workspace.
+  # @option xopts [Fixnum] :limit Limit.
+  # @option xopts [Fixnum] :offset Offset.
+  # @option xopts [String] :proto Protocol.
+  # @option xopts [String] :address Address.
+  # @option xopts [String] :ports Port range.
+  # @return [Hash] A hash with the following key:
+  #  * 'vulns' [Array<Hash>] In each hash of the array, you will get these keys:
+  #    * 'port' [Fixnum] Port.
+  #    * 'proto' [String] Protocol.
+  #    * 'time' [Fixnum] Time reported.
+  #    * 'host' [String] Vulnerable host.
+  #    * 'name' [String] Exploit that was used.
+  #    * 'refs' [String] Vulnerability references.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.vulns', {})
   def rpc_vulns(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -385,6 +428,18 @@ public
   }
   end
 
+
+  # Returns information about workspaces.
+  #
+  # @raise [Msf::RPC::Exception] Database not loaded.
+  # @return [Hash] A hash with the following key:
+  #  * 'workspaces' [Array<Hash>] In each hash of the array, you will get these keys:
+  #   * 'id' [Fixnum] Workspace ID.
+  #   * 'name' [String] Workspace name.
+  #   * 'created_at' [Fixnum] Last created at.
+  #   * 'updated_at' [Fixnum] Last updated at.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.workspaces')
   def rpc_workspaces
     db_check
 
@@ -401,11 +456,35 @@ public
     res
   end
 
+
+  # Returns the current workspace.
+  #
+  # @raise [Msf::RPC::Exception] Database not loaded.
+  # @return [Hash] A hash with the following keys:
+  #  * 'workspace' [String] Workspace name.
+  #  * 'workspace_id' [Fixnum] Workspace ID.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.current_workspace')
   def rpc_current_workspace
     db_check
     { "workspace" => self.framework.db.workspace.name, "workspace_id" => self.framework.db.workspace.id }
   end
 
+
+  # Returns the current workspace.
+  #
+  # @param [String] wspace workspace name.
+  # @raise [Msf::RPC::Exception] You might get one of the following errors:
+  #  * 500 Database not loaded.
+  #  * 500 Invalid workspace.
+  # @return [Hash] A hash with the following key:
+  #  * 'workspace' [Array<Hash>] In each hash of the array, you will get these keys:
+  #   * 'name' [String] Workspace name.
+  #   * 'id' [Fixnum] Workspace ID.
+  #   * 'created_at' [Fixnum] Last created at.
+  #   * 'updated_at' [Fixnum] Last updated at.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('db.get_workspace')
   def rpc_get_workspace(wspace)
     db_check
     wspace = find_workspace(wspace)
@@ -422,6 +501,17 @@ public
     ret
   end
 
+
+  # Sets a workspace.
+  #
+  # @param [String] wspace Workspace name.
+  # @raise [Msf::RPC::Exception] You might get one of the following errors:
+  #  * 500 Database not loaded.
+  # @return [Hash] A hash indicating whether the action was successful or not. You will get:
+  #  * 'result' [String] A message that says either 'success' or 'failed'
+  # @example Here's how you would use this from the client:
+  #  # This will set the current workspace to 'default'
+  #  rpc.call('db.set_workspace', 'default')
   def rpc_set_workspace(wspace)
   ::ActiveRecord::Base.connection_pool.with_connection {
     db_check

--- a/lib/msf/core/rpc/v10/rpc_job.rb
+++ b/lib/msf/core/rpc/v10/rpc_job.rb
@@ -3,6 +3,13 @@ module Msf
 module RPC
 class RPC_Job < RPC_Base
 
+  # Returns a list of jobs.
+  #
+  # @return [Hash] A list of jobs (IDs and names)
+  # @example Here's how you would use this from the client:
+  #  # This will return ('0' is the job ID):
+  #  # {"0"=>"Exploit: windows/browser/ms14_064_ole_code_execution"
+  #  rpc.call('job.list')
   def rpc_list
     res = {}
     self.framework.jobs.each do |j|
@@ -11,6 +18,14 @@ class RPC_Job < RPC_Base
     res
   end
 
+  # Returns a job.
+  #
+  # @param [Fixnum] jid Job ID.
+  # @raise [Msf::RPC::Exception] A 500 response indicating an invalid job ID was given.
+  # @return [Hash] A hash indicating the action was successful.
+  #  * 'result' [String] A successful message: 'success'
+  # @example Here's how you would use this from the client:
+  #  rpc.call('job.stop', 0)
   def rpc_stop(jid)
     obj = self.framework.jobs[jid.to_s]
     error(500, "Invalid Job") if not obj
@@ -18,6 +33,17 @@ class RPC_Job < RPC_Base
     { "result" => "success" }
   end
 
+  # Returns information about a job.
+  #
+  # @param [Fixnum] jid Job ID.
+  # @raise [Msf::RPC::Exception] A 500 response indicating an invalid job ID was given.
+  # @return [Hash] A hash that contains information about the job, such as the following (and maybe more)
+  #  * 'jid' [Fixnum] The Job ID.
+  #  * 'name' [String] The name of the job.
+  #  * 'start_time' [Fixnum] The start time.
+  #  * 'datastore' [Hash] Datastore options for the module.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('job.info', 0)
   def rpc_info(jid)
     obj = self.framework.jobs[jid.to_s]
     error(500, "Invalid Job") if not obj

--- a/lib/msf/core/rpc/v10/rpc_job.rb
+++ b/lib/msf/core/rpc/v10/rpc_job.rb
@@ -5,7 +5,8 @@ class RPC_Job < RPC_Base
 
   # Returns a list of jobs.
   #
-  # @return [Hash] A list of jobs (IDs and names)
+  # @return [Hash] A list of jobs (IDs and names).
+  #                Each key is the job ID, and each value is the job name.
   # @example Here's how you would use this from the client:
   #  # This will return ('0' is the job ID):
   #  # {"0"=>"Exploit: windows/browser/ms14_064_ole_code_execution"
@@ -22,7 +23,7 @@ class RPC_Job < RPC_Base
   #
   # @param [Fixnum] jid Job ID.
   # @raise [Msf::RPC::Exception] A 500 response indicating an invalid job ID was given.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] A successful message: 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('job.stop', 0)
@@ -37,7 +38,7 @@ class RPC_Job < RPC_Base
   #
   # @param [Fixnum] jid Job ID.
   # @raise [Msf::RPC::Exception] A 500 response indicating an invalid job ID was given.
-  # @return [Hash] A hash that contains information about the job, such as the following (and maybe more)
+  # @return [Hash] A hash that contains information about the job, such as the following (and maybe more):
   #  * 'jid' [Fixnum] The Job ID.
   #  * 'name' [String] The name of the job.
   #  * 'start_time' [Fixnum] The start time.

--- a/lib/msf/core/rpc/v10/rpc_job.rb
+++ b/lib/msf/core/rpc/v10/rpc_job.rb
@@ -18,7 +18,7 @@ class RPC_Job < RPC_Base
     res
   end
 
-  # Returns a job.
+  # Stops a job.
   #
   # @param [Fixnum] jid Job ID.
   # @raise [Msf::RPC::Exception] A 500 response indicating an invalid job ID was given.

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -4,30 +4,86 @@ module Msf
 module RPC
 class RPC_Module < RPC_Base
 
+  # Returns a list of exploit names.
+  #
+  # @return [Hash] A list of exploit names.
+  #  * 'modules' [Array] Exploit names, for example: ['windows/wins/ms04_045_wins']
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.exploits')
   def rpc_exploits
     { "modules" => self.framework.exploits.keys }
   end
 
+
+  # Returns a list of auxiliary module names.
+  #
+  # @return [Hash] A list of auxiliary module names.
+  #  * 'modules' [Array] Auxiliary module names, for example: ['vsploit/pii/web_pii']
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.auxiliary')
   def rpc_auxiliary
     { "modules" => self.framework.auxiliary.keys }
   end
 
+
+  # Returns a list of payload module names.
+  #
+  # @return [Hash] A list of payload module names.
+  #  * 'modules' [Array] Payload module names, for example: ['windows/x64/shell_reverse_tcp']
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.payloads')
   def rpc_payloads
     { "modules" => self.framework.payloads.keys }
   end
 
+
+  # Returns a list of encoder module names.
+  #
+  # @return [Hash] A list of encoder module names.
+  #  * 'modules' [Array] Encoder module names, for example: ['x86/unicode_upper']
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.encoders')
   def rpc_encoders
     { "modules" => self.framework.encoders.keys }
   end
 
+
+  # Returns a list of NOP module names.
+  #
+  # @return [Hash] A list of NOP module names.
+  #  * 'modules' [Array] NOP module names, for example: ['x86/single_byte']
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.nops')
   def rpc_nops
     { "modules" => self.framework.nops.keys }
   end
 
+
+  # Returns a list of post module names.
+  #
+  # @return [Hash] A list of post module names.
+  #  * 'modules' [Array] Post module names, for example: ['windows/wlan/wlan_profile']
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.post')
   def rpc_post
     { "modules" => self.framework.post.keys }
   end
 
+
+  # Returns the metadata of the module.
+  #
+  # @param [String] mtype Module type. Supported types include (case-sensitive):
+  #                       * exploit
+  #                       * auxiliary
+  #                       * post
+  #                       * nop
+  #                       * payload
+  # @param [String] mname Module name. For example: 'windows/wlan/wlan_profile'.
+  # @raise [Msf::RPC::Exception] Module not found (either the wrong type or name).
+  # @return [Hash] The module's metadata.
+  # @example Here's how you would use this from the client:
+  #  # This gives us the metadata of ms08_067_netapi
+  #  rpc.call('module.info', 'exploit', 'windows/smb/ms08_067_netapi')
   def rpc_info(mtype, mname)
     m = _find_module(mtype,mname)
     res = {}
@@ -74,6 +130,14 @@ class RPC_Module < RPC_Base
   end
 
 
+  # Returns the compatible payloads for a specific exploit.
+  #
+  # @param [String] mname Exploit module name. For example: 'windows/smb/ms08_067_netapi'.
+  # @raise [Msf::RPC::Exception] Module not found (wrong name).
+  # @return [Hash] The exploit's compatible payloads.
+  #  * 'payloads' [Array<string>] A list of payloads. For example: ['generic/custom']
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.compatible_payloads', 'windows/smb/ms08_067_netapi')
   def rpc_compatible_payloads(mname)
     m   = _find_module('exploit',mname)
     res = {}
@@ -85,6 +149,15 @@ class RPC_Module < RPC_Base
     res
   end
 
+
+  # Returns the compatible sessions for a specific post module.
+  #
+  # @param [String] mname Post module name. For example: 'windows/wlan/wlan_profile'.
+  # @raise [Msf::RPC::Exception] Module not found (wrong name).
+  # @return [Hash] The post module's compatible sessions.
+  #  * 'sessions' [Array<Fixnum>] A list of session IDs.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.compatible_sessions', 'windows/wlan/wlan_profile')
   def rpc_compatible_sessions(mname)
     m   = _find_module('post',mname)
     res = {}
@@ -93,6 +166,17 @@ class RPC_Module < RPC_Base
     res
   end
 
+
+  # Returns the compatible target-specific payloads for an exploit.
+  #
+  # @param [String] mname Exploit module name. For example: 'windows/smb/ms08_067_netapi'
+  # @param [Fixnum] target A specific target the exploit module provides.
+  # @raise [Msf::RPC::Exception] Module not found (wrong name).
+  # @return [Hash] The exploit's target-specific payloads.
+  #  * 'payloads' [Array<string>] A list of payloads.
+  # @example Here's how you would use this from the client:
+  #  # Find all the compatible payloads for target 1 (Windows 2000 Universal)
+  #  rpc.call('module.target_compatible_payloads', 'windows/smb/ms08_067_netapi', 1)
   def rpc_target_compatible_payloads(mname, target)
     m   = _find_module('exploit',mname)
     res = {}
@@ -105,6 +189,21 @@ class RPC_Module < RPC_Base
     res
   end
 
+
+  # Returns the module's datastore options.
+  #
+  # @param [String] mtype Module type. Supported types include (case-sensitive):
+  #                       * exploit
+  #                       * auxiliary
+  #                       * post
+  #                       * nop
+  #                       * payload
+  # @param [String] mname Module name. For example: 'windows/wlan/wlan_profile'.
+  # @raise [Msf::RPC::Exception] Module not found (either wrong type or name).
+  # @return [Hash] The module's datastore options. This will actually give you each option's
+  #                data type, requirement state, basic/advanced type, description, default value, etc.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.options', 'exploit', 'windows/smb/ms08_067_netapi')
   def rpc_options(mtype, mname)
     m = _find_module(mtype,mname)
     res = {}
@@ -131,6 +230,24 @@ class RPC_Module < RPC_Base
     res
   end
 
+
+  # Executes a module.
+  #
+  # @param [String] mtype Module type. Supported types include (case-sensitive):
+  #                       * exploit
+  #                       * auxiliary
+  #                       * post
+  #                       * payload
+  # @param [String] mname Module name. For example: 'windows/smb/ms08_067_netapi'.
+  # @param [Hash] opts Options for the module (such as datastore options).
+  # @raise [Msf::RPC::Exception] Module not found (either wrong type or name).
+  # @return [Hash]
+  #  * 'job_id' [Fixnum] Job ID.
+  #  * 'uuid' [String] UUID.
+  # @example Here's how you would use this from the client:
+  #  # Starts a windows/meterpreter/reverse_tcp on port 6669
+  #  opts = {'LHOST' => '0.0.0.0', 'LPORT'=>6669, 'PAYLOAD'=>'windows/meterpreter/reverse_tcp'}
+  #  rpc.call('module.execute', 'exploit', 'multi/handler', opts)
   def rpc_execute(mtype, mname, opts)
     mod = _find_module(mtype,mname)
     case mtype
@@ -146,11 +263,43 @@ class RPC_Module < RPC_Base
 
   end
 
+
+  # Returns a list of encoding formats.
+  #
+  # @return [Array] Encoding foramts.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('module.encode_formats')
   def rpc_encode_formats
     # Supported formats
     Msf::Simple::Buffer.transform_formats + Msf::Util::EXE.to_executable_fmt_formats
   end
 
+
+  # Encoders data with an encoder.
+  #
+  # @param [String] data Data to encode.
+  # @param [encoder] encoder Encoder module name. For example: 'x86/single_byte'.
+  # @param [Hash] options Encoding options, such as:
+  #  * 'format' [String] Encoding format.
+  #  * 'badchars' [String] Bad characters.
+  #  * 'platform' [String] Platform.
+  #  * 'arch' [String] Architecture.
+  #  * 'ecount' [Fixnum] Number of times to encode.
+  #  * 'inject' [TrueClass] To enable injection.
+  #  * 'template' [String] The template file (an executable).
+  #  * 'template_path' [String] Template path.
+  #  * 'addshellcode' [String] Custom shellcode.
+  # @raise [Msf::RPC::Exception] Invalid format (Error 500).
+  # @raise [Msf::RPC::Exception] Failure to encode (Error 500).
+  # @return The encoded data
+  #  * 'encoded' [String] The encoded data in the format you specify.
+  # @example Here's how you would use this from the client:
+  #  # This will encode 'AAAA' with shikata_ga_nai, and prints the following:
+  #  # unsigned char buf[] =
+  #  # "\xba\x9e\xb5\x91\x66\xdb\xd2\xd9\x74\x24\xf4\x5f\x29\xc9\xb1"
+  #  # "\x01\x31\x57\x15\x03\x57\x15\x83\xc7\x04\xe2\x6b\xf4\xd0\x27";
+  #  result = rpc.call('module.encode', 'AAAA', 'x86/shikata_ga_nai', {'format'=>'c'})
+  #  puts result['encoded']
   def rpc_encode(data, encoder, options)
     # Load supported formats
     supported_formats = Msf::Simple::Buffer.transform_formats + Msf::Util::EXE.to_executable_fmt_formats

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -7,7 +7,7 @@ class RPC_Module < RPC_Base
   # Returns a list of exploit names.
   #
   # @return [Hash] A list of exploit names.
-  #  * 'modules' [Array] Exploit names, for example: ['windows/wins/ms04_045_wins']
+  #  * 'modules' [Array<string>] Exploit names, for example: ['windows/wins/ms04_045_wins']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.exploits')
   def rpc_exploits
@@ -18,7 +18,7 @@ class RPC_Module < RPC_Base
   # Returns a list of auxiliary module names.
   #
   # @return [Hash] A list of auxiliary module names.
-  #  * 'modules' [Array] Auxiliary module names, for example: ['vsploit/pii/web_pii']
+  #  * 'modules' [Array<string>] Auxiliary module names, for example: ['vsploit/pii/web_pii']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.auxiliary')
   def rpc_auxiliary
@@ -29,7 +29,7 @@ class RPC_Module < RPC_Base
   # Returns a list of payload module names.
   #
   # @return [Hash] A list of payload module names.
-  #  * 'modules' [Array] Payload module names, for example: ['windows/x64/shell_reverse_tcp']
+  #  * 'modules' [Array<string>] Payload module names, for example: ['windows/x64/shell_reverse_tcp']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.payloads')
   def rpc_payloads
@@ -40,7 +40,7 @@ class RPC_Module < RPC_Base
   # Returns a list of encoder module names.
   #
   # @return [Hash] A list of encoder module names.
-  #  * 'modules' [Array] Encoder module names, for example: ['x86/unicode_upper']
+  #  * 'modules' [Array<string>] Encoder module names, for example: ['x86/unicode_upper']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.encoders')
   def rpc_encoders
@@ -51,7 +51,7 @@ class RPC_Module < RPC_Base
   # Returns a list of NOP module names.
   #
   # @return [Hash] A list of NOP module names.
-  #  * 'modules' [Array] NOP module names, for example: ['x86/single_byte']
+  #  * 'modules' [Array<string>] NOP module names, for example: ['x86/single_byte']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.nops')
   def rpc_nops
@@ -62,7 +62,7 @@ class RPC_Module < RPC_Base
   # Returns a list of post module names.
   #
   # @return [Hash] A list of post module names.
-  #  * 'modules' [Array] Post module names, for example: ['windows/wlan/wlan_profile']
+  #  * 'modules' [Array<string>] Post module names, for example: ['windows/wlan/wlan_profile']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.post')
   def rpc_post
@@ -280,17 +280,18 @@ class RPC_Module < RPC_Base
   # @param [String] data Data to encode.
   # @param [encoder] encoder Encoder module name. For example: 'x86/single_byte'.
   # @param [Hash] options Encoding options, such as:
-  #  * 'format' [String] Encoding format.
-  #  * 'badchars' [String] Bad characters.
-  #  * 'platform' [String] Platform.
-  #  * 'arch' [String] Architecture.
-  #  * 'ecount' [Fixnum] Number of times to encode.
-  #  * 'inject' [TrueClass] To enable injection.
-  #  * 'template' [String] The template file (an executable).
-  #  * 'template_path' [String] Template path.
-  #  * 'addshellcode' [String] Custom shellcode.
-  # @raise [Msf::RPC::Exception] Invalid format (Error 500).
-  # @raise [Msf::RPC::Exception] Failure to encode (Error 500).
+  # @option options [String] 'format' Encoding format.
+  # @option options [String] 'badchars' Bad characters.
+  # @option options [String] 'platform' Platform.
+  # @option options [String] 'arch' Architecture.
+  # @option options [Fixnum] 'ecount' Number of times to encode.
+  # @option options [TrueClass] 'inject' To enable injection.
+  # @option options [String] 'template' The template file (an executable).
+  # @option options [String] 'template_path' Template path.
+  # @option options [String] 'addshellcode' Custom shellcode.
+  # @raise [Msf::RPC::Exception] Error could be one of these:
+  #                              * 500 Invalid format
+  #                              * 500 Failure to encode
   # @return The encoded data
   #  * 'encoded' [String] The encoded data in the format you specify.
   # @example Here's how you would use this from the client:

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -4,7 +4,7 @@ module Msf
 module RPC
 class RPC_Module < RPC_Base
 
-  # Returns a list of exploit names.
+  # Returns a list of exploit names. The 'exploit/' prefix will not be included.
   #
   # @return [Hash] A list of exploit names. It contains the following key:
   #  * 'modules' [Array<string>] Exploit names, for example: ['windows/wins/ms04_045_wins']
@@ -15,7 +15,7 @@ class RPC_Module < RPC_Base
   end
 
 
-  # Returns a list of auxiliary module names.
+  # Returns a list of auxiliary module names. The 'auxiliary/' prefix will not be included.
   #
   # @return [Hash] A list of auxiliary module names. It contains the following key:
   #  * 'modules' [Array<string>] Auxiliary module names, for example: ['vsploit/pii/web_pii']
@@ -26,7 +26,7 @@ class RPC_Module < RPC_Base
   end
 
 
-  # Returns a list of payload module names.
+  # Returns a list of payload module names. The 'payload/' prefix will not be included.
   #
   # @return [Hash] A list of payload module names. It contains the following key:
   #  * 'modules' [Array<string>] Payload module names, for example: ['windows/x64/shell_reverse_tcp']
@@ -37,7 +37,7 @@ class RPC_Module < RPC_Base
   end
 
 
-  # Returns a list of encoder module names.
+  # Returns a list of encoder module names. The 'encoder/' prefix will not be included.
   #
   # @return [Hash] A list of encoder module names. It contains the following key:
   #  * 'modules' [Array<string>] Encoder module names, for example: ['x86/unicode_upper']
@@ -48,7 +48,7 @@ class RPC_Module < RPC_Base
   end
 
 
-  # Returns a list of NOP module names.
+  # Returns a list of NOP module names. The 'nop/' prefix will not be included.
   #
   # @return [Hash] A list of NOP module names. It contains the following key:
   #  * 'modules' [Array<string>] NOP module names, for example: ['x86/single_byte']
@@ -59,7 +59,7 @@ class RPC_Module < RPC_Base
   end
 
 
-  # Returns a list of post module names.
+  # Returns a list of post module names. The 'post/' prefix will not be included.
   #
   # @return [Hash] A list of post module names. It contains the following key:
   #  * 'modules' [Array<string>] Post module names, for example: ['windows/wlan/wlan_profile']
@@ -270,7 +270,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of encoding formats.
   #
-  # @return [Array] Encoding foramts.
+  # @return [Array<String>] Encoding foramts.
   # @example Here's how you would use this from the client:
   #  rpc.call('module.encode_formats')
   def rpc_encode_formats

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -6,7 +6,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of exploit names.
   #
-  # @return [Hash] A list of exploit names.
+  # @return [Hash] A list of exploit names. It contains the following key:
   #  * 'modules' [Array<string>] Exploit names, for example: ['windows/wins/ms04_045_wins']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.exploits')
@@ -17,7 +17,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of auxiliary module names.
   #
-  # @return [Hash] A list of auxiliary module names.
+  # @return [Hash] A list of auxiliary module names. It contains the following key:
   #  * 'modules' [Array<string>] Auxiliary module names, for example: ['vsploit/pii/web_pii']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.auxiliary')
@@ -28,7 +28,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of payload module names.
   #
-  # @return [Hash] A list of payload module names.
+  # @return [Hash] A list of payload module names. It contains the following key:
   #  * 'modules' [Array<string>] Payload module names, for example: ['windows/x64/shell_reverse_tcp']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.payloads')
@@ -39,7 +39,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of encoder module names.
   #
-  # @return [Hash] A list of encoder module names.
+  # @return [Hash] A list of encoder module names. It contains the following key:
   #  * 'modules' [Array<string>] Encoder module names, for example: ['x86/unicode_upper']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.encoders')
@@ -50,7 +50,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of NOP module names.
   #
-  # @return [Hash] A list of NOP module names.
+  # @return [Hash] A list of NOP module names. It contains the following key:
   #  * 'modules' [Array<string>] NOP module names, for example: ['x86/single_byte']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.nops')
@@ -61,7 +61,7 @@ class RPC_Module < RPC_Base
 
   # Returns a list of post module names.
   #
-  # @return [Hash] A list of post module names.
+  # @return [Hash] A list of post module names. It contains the following key:
   #  * 'modules' [Array<string>] Post module names, for example: ['windows/wlan/wlan_profile']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.post')
@@ -80,7 +80,7 @@ class RPC_Module < RPC_Base
   #                       * payload
   # @param [String] mname Module name. For example: 'windows/wlan/wlan_profile'.
   # @raise [Msf::RPC::Exception] Module not found (either the wrong type or name).
-  # @return [Hash] The module's metadata.
+  # @return [Hash] The module's metadata. The exact keys you will get depends on the module.
   # @example Here's how you would use this from the client:
   #  # This gives us the metadata of ms08_067_netapi
   #  rpc.call('module.info', 'exploit', 'windows/smb/ms08_067_netapi')
@@ -134,7 +134,7 @@ class RPC_Module < RPC_Base
   #
   # @param [String] mname Exploit module name. For example: 'windows/smb/ms08_067_netapi'.
   # @raise [Msf::RPC::Exception] Module not found (wrong name).
-  # @return [Hash] The exploit's compatible payloads.
+  # @return [Hash] The exploit's compatible payloads. It contains the following key:
   #  * 'payloads' [Array<string>] A list of payloads. For example: ['generic/custom']
   # @example Here's how you would use this from the client:
   #  rpc.call('module.compatible_payloads', 'windows/smb/ms08_067_netapi')
@@ -154,7 +154,7 @@ class RPC_Module < RPC_Base
   #
   # @param [String] mname Post module name. For example: 'windows/wlan/wlan_profile'.
   # @raise [Msf::RPC::Exception] Module not found (wrong name).
-  # @return [Hash] The post module's compatible sessions.
+  # @return [Hash] The post module's compatible sessions. It contains the following key:
   #  * 'sessions' [Array<Fixnum>] A list of session IDs.
   # @example Here's how you would use this from the client:
   #  rpc.call('module.compatible_sessions', 'windows/wlan/wlan_profile')
@@ -172,7 +172,7 @@ class RPC_Module < RPC_Base
   # @param [String] mname Exploit module name. For example: 'windows/smb/ms08_067_netapi'
   # @param [Fixnum] target A specific target the exploit module provides.
   # @raise [Msf::RPC::Exception] Module not found (wrong name).
-  # @return [Hash] The exploit's target-specific payloads.
+  # @return [Hash] The exploit's target-specific payloads. It contains the following key:
   #  * 'payloads' [Array<string>] A list of payloads.
   # @example Here's how you would use this from the client:
   #  # Find all the compatible payloads for target 1 (Windows 2000 Universal)
@@ -241,7 +241,7 @@ class RPC_Module < RPC_Base
   # @param [String] mname Module name. For example: 'windows/smb/ms08_067_netapi'.
   # @param [Hash] opts Options for the module (such as datastore options).
   # @raise [Msf::RPC::Exception] Module not found (either wrong type or name).
-  # @return [Hash]
+  # @return [Hash] It contains the following keys:
   #  * 'job_id' [Fixnum] Job ID.
   #  * 'uuid' [String] UUID.
   # @example Here's how you would use this from the client:
@@ -292,7 +292,7 @@ class RPC_Module < RPC_Base
   # @raise [Msf::RPC::Exception] Error could be one of these:
   #                              * 500 Invalid format
   #                              * 500 Failure to encode
-  # @return The encoded data
+  # @return The encoded data. It contains the following key:
   #  * 'encoded' [String] The encoded data in the format you specify.
   # @example Here's how you would use this from the client:
   #  # This will encode 'AAAA' with shikata_ga_nai, and prints the following:

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -241,6 +241,10 @@ class RPC_Module < RPC_Base
   # @param [String] mname Module name. For example: 'windows/smb/ms08_067_netapi'.
   # @param [Hash] opts Options for the module (such as datastore options).
   # @raise [Msf::RPC::Exception] Module not found (either wrong type or name).
+  # @note If you get exploit sessions via the RPC service, know that only the RPC clients
+  #       have access to those sessions. Framework msfconsole will not be able to use or
+  #       even see these sessions, because it belongs to a different framework instance.
+  #       However, this restriction does not apply to the database.
   # @return [Hash] It contains the following keys:
   #  * 'job_id' [Fixnum] Job ID.
   #  * 'uuid' [String] UUID.

--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -3,8 +3,19 @@ module Msf
 module RPC
 class RPC_Plugin < RPC_Base
 
+  # Loads a framework plugin.
+  #
+  # @param [String] path The plugin filename (without the extension). It will try to find your plugin
+  #                 in either one of these directories:
+  #                 * msf/plugins/
+  #                 * ~/.msf4/plugins/
+  # @param [Hash] xopts Options to pass to the plugin.
+  # @return [Hash] A hash indicating whether the action was successful or not.
+  #  * 'result' [String] A value that either says 'success' or 'failure'.
+  # @example Here's how you would use this from the client:
+  #  # Load the nexpose plugin
+  #  rpc.call('plugin.load', 'nexpose')
   def rpc_load(path, xopts = {})
-
     opts  = {}
 
     xopts.each do |k,v|
@@ -35,6 +46,14 @@ class RPC_Plugin < RPC_Base
 
   end
 
+
+  # Unloads a framework plugin.
+  #
+  # @param [String] name The plugin filename (without the extension). For example: 'nexpose'.
+  # @return [Hash] A hash indicating whether the action was successful or not.
+  #  * 'result' [String] A value that either says 'success' or 'failure'.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('plugin.unload', 'nexpose')
   def rpc_unload(name)
     self.framework.plugins.each { |plugin|
       # Unload the plugin if it matches the name we're searching for
@@ -47,6 +66,13 @@ class RPC_Plugin < RPC_Base
 
   end
 
+
+  # Returns a list of plugins loaded by framework.
+  #
+  # @return [Hash] All the plugins loaded.
+  #  * 'plugins' [Array<string>] A list of plugin names.
+  # @example Here's how you would use this from the client:
+  #  rpc.call('plugin.loaded')
   def rpc_loaded
     ret = {}
     ret[:plugins] = []

--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -11,7 +11,8 @@ class RPC_Plugin < RPC_Base
   #                 * ~/.msf4/plugins/
   # @param [Hash] xopts Options to pass to the plugin.
   # @return [Hash] A hash indicating whether the action was successful or not.
-  #  * 'result' [String] A value that either says 'success' or 'failure'.
+  #                It contains the following key:
+  #                * 'result' [String] A value that either says 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  # Load the nexpose plugin
   #  rpc.call('plugin.load', 'nexpose')
@@ -51,7 +52,8 @@ class RPC_Plugin < RPC_Base
   #
   # @param [String] name The plugin filename (without the extension). For example: 'nexpose'.
   # @return [Hash] A hash indicating whether the action was successful or not.
-  #  * 'result' [String] A value that either says 'success' or 'failure'.
+  #                It contains the following key:
+  #                * 'result' [String] A value that either says 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('plugin.unload', 'nexpose')
   def rpc_unload(name)
@@ -69,8 +71,8 @@ class RPC_Plugin < RPC_Base
 
   # Returns a list of plugins loaded by framework.
   #
-  # @return [Hash] All the plugins loaded.
-  #  * 'plugins' [Array<string>] A list of plugin names.
+  # @return [Hash] All the plugins loaded. It contains the following key:
+  #                * 'plugins' [Array<string>] A list of plugin names.
   # @example Here's how you would use this from the client:
   #  rpc.call('plugin.loaded')
   def rpc_loaded

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -6,7 +6,7 @@ module Msf
 module RPC
 class RPC_Session < RPC_Base
 
-  # Returns a list of sessions.
+  # Returns a list of sessions that belong to the framework instance used by the RPC service.
   #
   # @return [Hash] Information about sessions. Each key is the session ID, and each value is a hash
   #                that contains the following:

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -9,7 +9,7 @@ class RPC_Session < RPC_Base
   # Returns a list of sessions.
   #
   # @return [Hash] Information about sessions. Each key is the session ID, and each value is a hash
-  #                that contains the following
+  #                that contains the following:
   #                * 'type' [String] Payload type. Example: meterpreter.
   #                * 'tunnel_local' [String] Tunnel (where the malicious traffic comes from).
   #                * 'tunnel_peer' [String] Tunnel (local).
@@ -60,7 +60,7 @@ class RPC_Session < RPC_Base
   #
   # @param [Fixnum] sid Session ID.
   # @raise [Msf::RPC::Exception] Unknown session ID.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] A message that says 'success'.
   def rpc_stop( sid)
 
@@ -87,7 +87,7 @@ class RPC_Session < RPC_Base
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
   #                              * 500 Session is disconnected.
-  # @return [Hash]
+  # @return [Hash] It contains the following keys:
   #  * 'seq' [String] Sequence.
   #  * 'data' [String] Read data.
   # @example Here's how you would use this from the client:
@@ -134,7 +134,8 @@ class RPC_Session < RPC_Base
   # @param [Fixnum] sid Session ID.
   # @param [String] lhost Local host.
   # @param [Fixnum] lport Local port.
-  # @return [Hash] A hash indicating the actioin was successful.
+  # @return [Hash] A hash indicating the actioin was successful. It contains the following key:
+  #  'result' [String] A message that says 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('session.shell_upgrade', 2, payload_lhost, payload_lport)
   def rpc_shell_upgrade( sid, lhost, lport)
@@ -152,7 +153,7 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash]
+  # @return [Hash] It contains the following key: 
   #  * 'data' [String] Data read.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.meterpreter_read', 2)
@@ -176,7 +177,7 @@ class RPC_Session < RPC_Base
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
   #                              * 500 Session is disconnected.
-  # @return [Hash]
+  # @return [Hash] It contains the following key:
   #  * 'seq' [String] Sequence.
   #  * 'data' [String] Read data.
   # @example Here's how you would use this from the client:
@@ -200,7 +201,7 @@ class RPC_Session < RPC_Base
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
   #                              * 500 Session is disconnected.
-  # @return [Hash]
+  # @return [Hash] It contains the following key:
   #  * 'write_count' [String] Number of bytes written.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_put', 2, "DATA")
@@ -220,7 +221,7 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash]
+  # @return [Hash] It contains the following key:
   #  * 'seq' [String] Sequence.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_last', 2)
@@ -237,6 +238,7 @@ class RPC_Session < RPC_Base
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
   # @return [Hash] A hash indicating whether the action was successful or not.
+  #                It contains the following key:
   #  * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_clear', 2)
@@ -259,7 +261,7 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash] A hash indicating the action was successful or not.
+  # @return [Hash] A hash indicating the action was successful or not. It contains the following key:
   #  * 'result' [String] Either 'success' or 'failure'.
   # @see #rpc_meterpreter_run_single
   # @example Here's how you would use this from the client:
@@ -291,6 +293,7 @@ class RPC_Session < RPC_Base
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
   # @return [Hash] A hash indicating the action was successful or not.
+  #                It contains the following key:
   #  * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.meterpreter_session_detach', 3)
@@ -313,6 +316,7 @@ class RPC_Session < RPC_Base
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
   # @return [Hash] A hash indicating the action was successful or not.
+  #                It contains the following key:
   #  * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.meterpreter_session_kill', 3)
@@ -335,7 +339,7 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash] The tab-completed result.
+  # @return [Hash] The tab-completed result. It contains the following key:
   #  * 'tabs' [String] The tab-completed version of your input.
   # @example Here's how you would use this from the client:
   #  # This returns:
@@ -355,7 +359,7 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] 'success' 
   # @example Here's how you would use this from the client:
   #  rpc.call('session.meterpreter_run_single', 3, 'getpid')
@@ -378,7 +382,7 @@ class RPC_Session < RPC_Base
   # @see Msf::RPC::RPC_Module#rpc_execute You should use Msf::RPC::RPC_Module#rpc_execute instead.
   # @param [Fixnum] sid Session ID.
   # @param [String] data Meterpreter script name.
-  # @return [Hash] A hash indicating the action was successful.
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] 'success' 
   # @example Here's how you would use this from the client:
   #  rpc.call('session.meterpreter_script', 3, 'checkvm')
@@ -393,7 +397,7 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash] A hash that contains the separator.
+  # @return [Hash] A hash that contains the separator. It contains the following key:
   #  * 'separator' [String] The separator used by the meterpreter.
   # @example Here's how you would use this from the client:
   #  # This returns:
@@ -409,7 +413,7 @@ class RPC_Session < RPC_Base
   # Returns all the compatible post modules for this session.
   #
   # @param [Fixnum] sid Session ID.
-  # @return [Hash] Post modules.
+  # @return [Hash] Post modules. It contains the following key:
   #  * 'modules' [Array<string>] An array of post module names. Example: ['post/windows/wlan/wlan_profile']
   # @example Here's how you would use this from the client:
   #  rpc.call('session.compatible_modules', 3)

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -73,7 +73,7 @@ class RPC_Session < RPC_Base
   end
 
 
-  # Reads a shell session (such as a command output).
+  # Reads the output of a shell session (such as a command output).
   #
   # @note Shell read is now a positon-aware reader of the shell's associated
   #       ring buffer. For more direct control of the pointer into a ring
@@ -107,7 +107,8 @@ class RPC_Session < RPC_Base
   end
 
 
-  # Writes to a shell session (such as a command).
+  # Writes to a shell session (such as a command). Note that you will to manually add a newline at the
+  # enf of your input so the system will process it.
   # You may want to use #rpc_shell_read to retrieve the output.
   #
   # @note shell_write is a wrapper of #rpc_ring_put.
@@ -135,7 +136,7 @@ class RPC_Session < RPC_Base
   # @param [String] lhost Local host.
   # @param [Fixnum] lport Local port.
   # @return [Hash] A hash indicating the actioin was successful. It contains the following key:
-  #  'result' [String] A message that says 'success'
+  #  * 'result' [String] A message that says 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('session.shell_upgrade', 2, payload_lhost, payload_lport)
   def rpc_shell_upgrade( sid, lhost, lport)
@@ -149,6 +150,9 @@ class RPC_Session < RPC_Base
 
   # Reads the output from a meterpreter session (such as a command output).
   #
+  # @note Multiple concurrent callers writing and reading the same Meterperter session can lead to
+  #  a conflict, where one caller gets the others output and vice versa. Concurrent access to a
+  #  Meterpreter session is best handled by post modules.
   # @param [Fixnum] sid Session ID.
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
@@ -215,7 +219,7 @@ class RPC_Session < RPC_Base
     end
   end
 
-  # Returns the last sequence.
+  # Returns the last sequence (last issued ReadPointer) for a shell session.
   #
   # @param [Fixnum] sid Session ID.
   # @raise [Msf::RPC::Exception] An error that could be one of these:
@@ -231,14 +235,13 @@ class RPC_Session < RPC_Base
   end
 
 
-  # Clears the session.
+  # Clears a shell session. This may be useful to reclaim memory for idle background sessions.
   #
   # @param [Fixnum] sid Session ID.
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash] A hash indicating whether the action was successful or not.
-  #                It contains the following key:
+  # @return [Hash] A hash indicating whether the action was successful or not. It contains:
   #  * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_clear', 2)
@@ -256,6 +259,9 @@ class RPC_Session < RPC_Base
   # Sends an input to a meterpreter prompt.
   # You may want to use #rpc_meterpreter_read to retrieve the output.
   #
+  # @note Multiple concurrent callers writing and reading the same Meterperter session can lead to
+  #  a conflict, where one caller gets the others output and vice versa. Concurrent access to a
+  #  Meterpreter session is best handled by post modules.
   # @param [Fixnum] sid Session ID.
   # @param [String] data Input to the meterpreter prompt.
   # @raise [Msf::RPC::Exception] An error that could be one of these:
@@ -286,14 +292,13 @@ class RPC_Session < RPC_Base
   end
 
 
-  # Detaches from a meterpreter session.
+  # Detaches from a meterpreter session. Serves the same purpose as [CTRL]+[Z].
   #
   # @param [Fixnum] sid Session ID.
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Session ID is unknown.
   #                              * 500 Invalid session type.
-  # @return [Hash] A hash indicating the action was successful or not.
-  #                It contains the following key:
+  # @return [Hash] A hash indicating the action was successful or not. It contains:
   #  * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.meterpreter_session_detach', 3)
@@ -309,7 +314,7 @@ class RPC_Session < RPC_Base
   end
 
 
-  # Kills a meterpreter session.
+  # Kills a meterpreter session. Serves the same purpose as [CTRL]+[C]
   #
   # @param [Fixnum] sid Session ID.
   # @raise [Msf::RPC::Exception] An error that could be one of these:


### PR DESCRIPTION
This is for https://github.com/rapid7/metasploit-framework/issues/5209. It documents all the RPC API calls.
## Recommended Verification
- [x] cd to /msf/lib/msf/core/rpc/v10
- [x] Do: `yard doc *.rb`
- [x] It will generate the documentation. You should not see any errors, like this:

```
$ yard doc *.rb
Files:          12
Modules:         2 (    2 undocumented)
Classes:        13 (   13 undocumented)
Constants:       1 (    1 undocumented)
Methods:       178 (   13 undocumented)
 85.05% documented
```
- [ ] Open doc/index.html.
- [ ] Each method that begins with `def rpc_` should have a description.
- [ ] Each method that begins with `def rpc_` should have documentation about arguments.
- [ ] Each method that begins with `def rpc_` should have documentation about their return value.
- [ ] Each method that begins with `def rpc` should have a code example.
