### PR TITLE
Fix logins where SYSTEM doesnt have SYSDBA privileges

### DIFF
--- a/lib/msf/core/exploit/oracle.rb
+++ b/lib/msf/core/exploit/oracle.rb
@@ -52,18 +52,29 @@ module Exploit::ORACLE
   end
 
   def connect
+    handle = nil
+
     if(not @oci8_loaded)
       raise RuntimeError, "Could not load the Oracle driver (oci8): #{@oci8_error}"
     end
 
     # Create a Connection to the Database
     if datastore['DBUSER'] == 'SYS' || datastore['DBUSER'] == 'SYSTEM'
-      handle = OCI8.new(
-        datastore['DBUSER'],
-        datastore['DBPASS'],
-        "//#{datastore['RHOST']}:#{datastore['RPORT']}/#{datastore['SID']}",
-        :SYSDBA
-      )
+      begin
+        handle = OCI8.new(
+          datastore['DBUSER'],
+          datastore['DBPASS'],
+          "//#{datastore['RHOST']}:#{datastore['RPORT']}/#{datastore['SID']}",
+          :SYSDBA
+        )
+      rescue ::OCIError
+        # Try again without a request for SYSDBA
+        handle = OCI8.new(
+          datastore['DBUSER'],
+          datastore['DBPASS'],
+          "//#{datastore['RHOST']}:#{datastore['RPORT']}/#{datastore['SID']}"
+        )
+      end
     else
       handle = OCI8.new(
         datastore['DBUSER'],
@@ -71,7 +82,7 @@ module Exploit::ORACLE
         "//#{datastore['RHOST']}:#{datastore['RPORT']}/#{datastore['SID']}"
       )
     end
-
+    handle
   end
 
   def disconnect


### PR DESCRIPTION
This solves an issue where trying to login with the username of SYSTEM fails in some environments.

Without this patch, the following exception occurs:

```
[-] ORA-01031: insufficient privileges
```
