### PR TITLE
Set RHOSTS directly, fixes #5258

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -2018,19 +2018,10 @@ class Db
       mydatastore = self.framework.datastore
     end
 
-    if rhosts.length > 5
-      # Lots of hosts makes 'show options' wrap which is difficult to
-      # read, store to a temp file
-      rhosts_file = Rex::Quickfile.new("msf-db-rhosts-")
-      mydatastore['RHOSTS'] = 'file:'+rhosts_file.path
-      # create the output file and assign it to the RHOSTS variable
-      rhosts_file.write(rhosts.join("\n")+"\n")
-      rhosts_file.close
-    else
-      # For short lists, just set it directly
-      mydatastore['RHOSTS'] = rhosts.join(" ")
-    end
+    # Set the list of hosts directly
+    mydatastore['RHOSTS'] = rhosts.join(" ")
 
+    # TODO: Handle large hosts lists better
     print_line "RHOSTS => #{mydatastore['RHOSTS']}"
     print_line
   end


### PR DESCRIPTION
This change is necessary after #4989 in order for the -R option of the db commands to work properly. This moves away from using temporary files and instead sets the value directly. 
