### PR TITLE
webcam_chat fails on Windows 7 targets and Kali Linux hosts

### DIFF
--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -166,9 +166,9 @@ def self.open_webrtc_browser(url='http://google.com/')
       app_data = ENV['APPDATA']
       paths << "#{app_data}\\Google\\Chrome\\Application\\chrome.exe"
 
-      paths.each do |p|
-        if File.exists?(p)
-          args = (p =~ /chrome\.exe/) ? "--allow-file-access-from-files" : ""
+      paths.each do |path|
+        if File.exists?(path)
+          args = (path =~ /chrome\.exe/) ? "--allow-file-access-from-files" : ""
           system("#{path} #{args} #{url}")
           found_browser = true
           break
@@ -188,13 +188,14 @@ def self.open_webrtc_browser(url='http://google.com/')
     end
   else
     if defined? ENV['PATH']
-      ['chrome', 'chromium', 'firefox', 'opera'].each do |browser|
+      ['firefox', 'google-chrome', 'chrome', 'chromium', 'firefox', 'opera'].each do |browser|
         ENV['PATH'].split(':').each do |path|
           browser_path = "#{path}/#{browser}"
           if File.exists?(browser_path)
             args = (browser_path =~ /Chrome/) ? "--allow-file-access-from-files" : ""
             system("#{browser_path} #{args} #{url} &")
             found_browser = true
+            break
           end
         end
       end

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -103,10 +103,12 @@ class Webcam
     case client.platform
     when /win/
       paths = [
-        "Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
-        "Program Files\\Google\\Chrome\\Application\\chrome.exe",
-        "Program Files (x86)\\Mozilla Firefox\\firefox.exe",
-        "Program Files\\Mozilla Firefox\\firefox.exe"
+        "%ProgramFiles(x86)%\\Google\\Chrome\\Application\\chrome.exe",
+        "%ProgramFiles%\\Google\\Chrome\\Application\\chrome.exe",
+        "%ProgramW6432%\\Google\\Chrome\\Application\\chrome.exe",
+        "%ProgramFiles(x86)%\\Mozilla Firefox\\firefox.exe",
+        "%ProgramFiles%\\Mozilla Firefox\\firefox.exe",
+        "%ProgramW6432%\\Mozilla Firefox\\firefox.exe"
       ]
 
       drive = session.sys.config.getenv("SYSTEMDRIVE")

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -103,7 +103,9 @@ class Webcam
     case client.platform
     when /win/
       paths = [
+        "Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
         "Program Files\\Google\\Chrome\\Application\\chrome.exe",
+        "Program Files (x86)\\Mozilla Firefox\\firefox.exe",
         "Program Files\\Mozilla Firefox\\firefox.exe"
       ]
 


### PR DESCRIPTION
I couldn't get a reliable webcam_chat working on a Windows 7 target with Chrome or Firefox, from a Kali Linux attacker with Chrome or Firefox. I did manage to find some spots where I could clean things up a little (a bad variable name, more options for browser names, and 32-bit installation paths), but it still wasn't working out for me.

This PR is more of an issue than anything, since it doesn't actually solve things. I no longer stack trace, which is nice, but while I pop up both browsers, the WebRTC stuff doesn't seem to be working right on Kali -- tried with several webcams and network configurations. Maybe there's a firewall rule I'm missing somewhere on one side or the other?

Anyway, I really like this meterpreter extension. I want it to work in this common case of Kali -> Win7, since it's so fun to demo. I'd /love/ to see it work on Android Chrome, since it'd be extra creepy, but that can wait.

Assigning to @wchen-r7 aspirationally, since he wrote it initially. Someday, I'll do some more troubleshooting.
