### PR TITLE
explicitly require bind_tcp/reverse_tcp in new powershell session payloads

### DIFF
--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/handler/bind_tcp'
 require 'msf/core/payload/windows/exec'
 require 'msf/base/sessions/powershell'
 ###

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
 require 'msf/core/payload/windows/exec'
 require 'msf/base/sessions/powershell'
 ###


### PR DESCRIPTION
This fixes a transient error was noted when running the weekly release documentation builder scripts:

metasploit-framework/modules/payloads/singles/windows/powershell_bind_tcp.rb:37:in
   `initialize': uninitialized constant Msf::Handler::BindTcp (NameError)

cc @cdoughty-r7
