### PR TITLE
Fix false positive in POODLE scanner

### DIFF
--- a/modules/auxiliary/scanner/http/ssl_version.rb
+++ b/modules/auxiliary/scanner/http/ssl_version.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
         vprint_status("#{peer} connected and fingerprinted: #{fp}")
         # TODO: Interrogate the connection itself to see what version
         # was used. Where that actually lives is eluding me. :/
-        if datastore['SSLVersion'] == 'SSL3'
+        if datastore['SSL'] && datastore['SSLVersion'] == 'SSL3'
           print_good("#{peer} accepts SSLv3")
           report_poodle_vuln(ip)
         end

--- a/modules/auxiliary/scanner/http/ssl_version.rb
+++ b/modules/auxiliary/scanner/http/ssl_version.rb
@@ -52,7 +52,6 @@ class Metasploit3 < Msf::Auxiliary
   # Fingerprint a single host
   def run_host(ip)
     begin
-      connect
       res = send_request_raw({ 'uri' => '/', 'method' => 'GET' })
       fp = http_fingerprint(:response => res)
       if fp
@@ -67,9 +66,6 @@ class Metasploit3 < Msf::Auxiliary
     rescue ::OpenSSL::SSL::SSLError => e
       ssl_version = e.message.match(/ state=([^\s]+)/)[1]
       vprint_status("#{peer} does not accept #{ssl_version}")
-    rescue ::Timeout::Error, ::Errno::EPIPE
-    ensure
-      disconnect
     end
   end
 


### PR DESCRIPTION
If `SSL` is `false` somehow.

Fixes #5248.
