### PR TITLE
Improvements to Msf::ModuleSet for #4943

### DIFF
--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -315,14 +315,7 @@ class Msf::ModuleSet < Hash
   # @return [Array<Array<String, Class>>] Array of arrays where the inner array is a pair of the module reference name
   #   and the module class.
   def rank_modules
-    self.mod_ranked = self.sort { |a_pair, b_pair|
-      a_rank = module_rank(*a_pair)
-      b_rank = module_rank(*b_pair)
-
-      # Compare their relevant rankings.  Since we want highest to lowest,
-      # we compare b_rank to a_rank in terms of higher/lower precedence
-      b_rank <=> a_rank
-    }
+    self.mod_ranked = self.sort_by { |pair| module_rank(*pair) }.reverse!
   end
 
   # Retrieves the rank from a loaded, not-yet-loaded, or unloadable Metasploit Module.

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -57,6 +57,8 @@ class Msf::ModuleSet < Hash
     # Notify any general subscribers of the creation event
     if instance
       self.framework.events.on_module_created(instance)
+    else
+      self.delete(reference_name)
     end
 
     return instance

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -114,9 +114,7 @@ class Msf::ModuleSet < Hash
   def each_module_ranked(opts = {}, &block)
     demand_load_modules
 
-    self.mod_ranked = rank_modules
-
-    each_module_list(mod_ranked, opts, &block)
+    each_module_list(rank_modules, opts, &block)
   end
 
   # Forces all modules in this set to be loaded.
@@ -140,7 +138,6 @@ class Msf::ModuleSet < Hash
     self.architectures_by_module     = {}
     self.platforms_by_module = {}
     self.mod_sorted        = nil
-    self.mod_ranked        = nil
     self.mod_extensions    = []
 
     #
@@ -294,11 +291,6 @@ class Msf::ModuleSet < Hash
   #
   #   @return [Hash{Class => Array<String>}] Maps module class to Array of platform Strings.
   attr_accessor :platforms_by_module
-  # @!attribute [rw] mod_ranked
-  #   Array of module names and module classes ordered by their Rank with the higher Ranks first.
-  #
-  #   @return (see #rank_modules)
-  attr_accessor :mod_ranked
   # @!attribute [rw] mod_sorted
   #   Array of module names and module classes ordered by their names.
   #
@@ -317,7 +309,7 @@ class Msf::ModuleSet < Hash
   # @return [Array<Array<String, Class>>] Array of arrays where the inner array is a pair of the module reference name
   #   and the module class.
   def rank_modules
-    self.mod_ranked = self.sort_by { |pair| module_rank(*pair) }.reverse!
+    self.sort_by { |pair| module_rank(*pair) }.reverse!
   end
 
   # Retrieves the rank from a loaded, not-yet-loaded, or unloadable Metasploit Module.


### PR DESCRIPTION
This implements a few improvements to how module ranking works in Msf:ModuleSet
- if a module cannot be instantiated, delete it from the ModuleSet
- Use a more optimal module rank sort_by so we're not repeatedly instantiating module instances while sorting
- Removes unused mod_ranked attribute
#5156 may have fixed the bulk of the issues from #4943, but this incorporates most of the rest of the proposed fixes from @limhoff-r7
# Verification steps
- [x] Issues reported under #4943 do not recur
- [x] Specs pass
- [x] No errors from msfencode, msfconsole generating payloads, etc.
