### PR TITLE
MSP-12649 remove early require of rex in msfcli

### DIFF
--- a/msfcli
+++ b/msfcli
@@ -19,8 +19,6 @@ while File.symlink?(msfbase)
 end
 
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
-require 'rex'
-
 
 class Msfcli
   #


### PR DESCRIPTION
This is causing startup issues in some environments where not all the rex dependencies are loading. Remove it for now, removal of msfcli is close at hand anyway.

```
$ sudo msfcli exploit/unix/webapp/wp_nmediawebsite_file_upload S
[!] ************************************************************************
[!] * The utility msfcli is deprecated! *
[!] * It will be removed on or about 2015-06-18 *
[!] * Please use msfconsole -r or -x instead *
[!] * Details: https://github.com/rapid7/metasploit-framework/pull/3802 *
[!] ************************************************************************
/opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file – nokogiri (LoadError)
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/apps/pro/msf3/lib/rex/proto/http/response.rb:4:in `<top (required)>'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/apps/pro/msf3/lib/rex/proto/http.rb:4:in `<top (required)>'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/apps/pro/msf3/lib/rex/proto.rb:2:in `<top (required)>'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/apps/pro/msf3/lib/rex.rb:79:in `<top (required)>'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/ruby/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
from /opt/metasploit/apps/pro/msf3/msfcli:22:in `<main>'
```
