### PR TITLE
Sorting and adding a couple more -r7 to mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,41 +1,45 @@
 bcook-r7 <bcook-r7@github>         Brent Cook <bcook@rapid7.com>
 bturner-r7 <bturner-r7@github>     Brandon Turner <brandon_turner@rapid7.com>
+ccatalan-r7 <ccatalan-r7@github>   Christian Catalan <ccatalan@rapid7.com>
 cdoughty-r7 <cdoughty-r7@github>   Chris Doughty <chris_doughty@rapid7.com>
 dheiland-r7 <dheiland-r7@github>   Deral Heiland <dh@layereddefense.com>
-dmaloney-r7 <dmaloney-r7@github>   David Maloney <David_Maloney@rapid7.com>
 dmaloney-r7 <dmaloney-r7@github>   David Maloney <DMaloney@rapid7.com>
+dmaloney-r7 <dmaloney-r7@github>   David Maloney <David_Maloney@rapid7.com>
 dmaloney-r7 <dmaloney-r7@github>   dmaloney-r7 <DMaloney@rapid7.com>
 ecarey-r7 <ecarey-r7@github>       Erran Carey <e@ipwnstuff.com>
 farias-r7 <farias-r7@github>       Fernando Arias <fernando_arias@rapid7.com>
 hmoore-r7 <hmoore-r7@github>       HD Moore <hd_moore@rapid7.com>
 hmoore-r7 <hmoore-r7@github>       HD Moore <hdm@digitaloffense.net>
 jhart-r7 <jhart-r7@github>         Jon Hart <jon_hart@rapid7.com>
-jlee-r7 <jlee-r7@github>           egypt <egypt@metasploit.com> # aka egypt
-jlee-r7 <jlee-r7@github>           James Lee <egypt@metasploit.com> # aka egypt
 jlee-r7 <jlee-r7@github>           James Lee <James_Lee@rapid7.com>
+jlee-r7 <jlee-r7@github>           James Lee <egypt@metasploit.com> # aka egypt
+jlee-r7 <jlee-r7@github>           egypt <egypt@metasploit.com> # aka egypt
 jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan.vazquez@metasploit.com>
 jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan_vazquez@rapid7.com>
 kgray-r7 <kgray-r7@github>         Kyle Gray <kyle_gray@rapid7.com>
 limhoff-r7 <limhoff-r7@github>     Luke Imhoff <luke_imhoff@rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>   darkbushido <lance.sanchez@gmail.com>
 lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance.sanchez+github@gmail.com>
 lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance.sanchez@rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance@aus-mac-1041.aus.rapid7.com>
 lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance@AUS-MAC-1041.local>
+lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance@aus-mac-1041.aus.rapid7.com>
+lsanchez-r7 <lsanchez-r7@github>   darkbushido <lance.sanchez@gmail.com>
 mbuck-r7 <mbuck-r7@github>         Matt Buck <Matthew_Buck@rapid7.com>
 mbuck-r7 <mbuck-r7@github>         Matt Buck <techpeace@gmail.com>
 mschloesser-r7 <mschloesser-r7@github> Mark Schloesser <mark_schloesser@rapid7.com>
 mschloesser-r7 <mschloesser-r7@github> mschloesser-r7 <mark_schloesser@rapid7.com>
 parzamendi-r7 <parzamendi-r7@github> parzamendi-r7 <peter_arzamendi@rapid7.com>
+pdeardorff-r7 <pdeardorff-r7@github> Paul Deardorff <Paul_Deardorff@rapid7.com>
+pdeardorff-r7 <pdeardorff-r7@github> pdeardorff-r7 <paul_deardorff@rapid7.com>
+sgonzalez-r7 <sgonzalez-r7@github> Sonny Gonzalez <sonny_gonzalez@rapid7.com>
 shuckins-r7 <shuckins-r7@github>   Samuel Huckins <samuel_huckins@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <tod_beardsley@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@metasploit.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@packetfu.com>
-trosen-r7 <trosen-r7@github>       Trevor Rosen <trevor@catapult-creative.com>
 trosen-r7 <trosen-r7@github>       Trevor Rosen <Trevor_Rosen@rapid7.com>
+trosen-r7 <trosen-r7@github>       Trevor Rosen <trevor@catapult-creative.com>
+wchen-r7 <wchen-r7@github>         Wei Chen <Wei_Chen@rapid7.com>
 wchen-r7 <wchen-r7@github>         sinn3r <msfsinn3r@gmail.com> # aka sinn3r
 wchen-r7 <wchen-r7@github>         sinn3r <wei_chen@rapid7.com>
-wchen-r7 <wchen-r7@github>         Wei Chen <Wei_Chen@rapid7.com>
 wvu-r7 <wvu-r7@github>             William Vu <William_Vu@rapid7.com>
 wvu-r7 <wvu-r7@github>             William Vu <wvu@metasploit.com>
 wvu-r7 <wvu-r7@github>             William Vu <wvu@nmt.edu>


### PR DESCRIPTION
This adds a few more recent additions to the Rapid7 committters list to the .mailmap file, to make sorting and blaming commits by employees vs open source folk a little more accurate.
