### PR TITLE
Fix #4602 - remove bins from bundle install

### DIFF
--- a/features/commands/help.feature
+++ b/features/commands/help.feature
@@ -1,7 +1,7 @@
 Feature: Help command
 
   Background:
-    Given I run `./msfconsole --defer-module-loads -x help -x exit`
+    Given I run `../../msfconsole --defer-module-loads -x help -x exit`
 
   Scenario: The 'help' command's output
     Then the output should contain:

--- a/features/commands/help.feature
+++ b/features/commands/help.feature
@@ -1,7 +1,7 @@
 Feature: Help command
 
   Background:
-    Given I run `msfconsole --defer-module-loads -x help -x exit`
+    Given I run `./msfconsole --defer-module-loads -x help -x exit`
 
   Scenario: The 'help' command's output
     Then the output should contain:

--- a/features/modules/exploit/smb/ms08_067_netapi.feature
+++ b/features/modules/exploit/smb/ms08_067_netapi.feature
@@ -5,7 +5,7 @@ Feature: MS08-067 netapi
     Given a directory named "home"
     And I cd to "home"
     And a mocked home directory
-    Given I run `msfconsole` interactively
+    Given I run `./msfconsole` interactively
     And I wait for stdout to contain "Free Metasploit Pro trial: http://r-7.co/trymsp"
 
   Scenario: The MS08-067 Module should have the following options

--- a/features/msfconsole/database_yml.feature
+++ b/features/msfconsole/database_yml.feature
@@ -1,11 +1,11 @@
 @boot
-Feature: `./msfconsole` `database.yml`
+Feature: `msfconsole` `database.yml`
 
-  In order to connect to the database in `./msfconsole`
-  As a user calling `./msfconsole` from a terminal
+  In order to connect to the database in `msfconsole`
+  As a user calling `msfconsole` from a terminal
   I want to be able to set the path of the `database.yml` in one of 4 locations (in order of precedence):
 
-  1. An explicit argument to the `-y` flag to `./msfconsole`
+  1. An explicit argument to the `-y` flag to `msfconsole`
   2. The MSF_DATABASE_CONFIG environment variable
   3. The user's `~/.msf4/database.yml`
   4. `config/database.yml` in the metasploit-framework checkout location.
@@ -48,7 +48,7 @@ Feature: `./msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit --yaml command_line.yml`
+    When I run `../../msfconsole -q --defer-module-loads --environment test --execute-command exit --yaml command_line.yml`
     Then the output should contain "command_line_metasploit_framework_test"
 
   Scenario: Without --yaml, MSF_DATABASE_CONFIG wins
@@ -82,7 +82,7 @@ Feature: `./msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit`
+    When I run `../../msfconsole -q --defer-module-loads --environment test --execute-command exit`
     Then the output should contain "environment_metasploit_framework_test"
 
   Scenario: Without --yaml or MSF_DATABASE_CONFIG, ~/.msf4/database.yml wins
@@ -109,7 +109,7 @@ Feature: `./msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit`
+    When I run `../../msfconsole -q --defer-module-loads --environment test --execute-command exit`
     Then the output should contain "user_metasploit_framework_test"
 
   Scenario: Without --yaml, MSF_DATABASE_CONFIG or ~/.msf4/database.yml, project "database.yml" wins
@@ -127,7 +127,7 @@ Feature: `./msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit`
+    When I run `../msfconsole -q --defer-module-loads --environment test --execute-command exit`
     Then the output should contain "project_metasploit_framework_test"
 
 
@@ -140,14 +140,14 @@ Feature: `./msfconsole` `database.yml`
     And a mocked home directory
     And I cd to "../.."
     And the project "database.yml" does not exist
-    When I run `./msfconsole --defer-module-loads --environment test --execute-command db_status --execute-command exit`
+    When I run `../msfconsole -q --defer-module-loads --environment test --execute-command db_status --execute-command exit`
     Then the output should not contain "command_line_metasploit_framework_test"
     And the output should not contain "environment_metasploit_framework_test"
     And the output should not contain "user_metasploit_framework_test"
     And the output should not contain "project_metasploit_framework_test"
     And the output should contain "[*] postgresql selected, no connection"
 
-  Scenario: Starting `./msfconsole` with a valid database.yml
-    When I run `./msfconsole --defer-module-loads --execute-command db_status --execute-command exit`
+  Scenario: Starting `msfconsole` with a valid database.yml
+    When I run `../../msfconsole -q --defer-module-loads --execute-command db_status --execute-command exit`
     Then the output should contain "[*] postgresql connected to metasploit_framework_test"
 

--- a/features/msfconsole/database_yml.feature
+++ b/features/msfconsole/database_yml.feature
@@ -1,11 +1,11 @@
 @boot
-Feature: `msfconsole` `database.yml`
+Feature: `./msfconsole` `database.yml`
 
-  In order to connect to the database in `msfconsole`
-  As a user calling `msfconsole` from a terminal
+  In order to connect to the database in `./msfconsole`
+  As a user calling `./msfconsole` from a terminal
   I want to be able to set the path of the `database.yml` in one of 4 locations (in order of precedence):
 
-  1. An explicit argument to the `-y` flag to `msfconsole`
+  1. An explicit argument to the `-y` flag to `./msfconsole`
   2. The MSF_DATABASE_CONFIG environment variable
   3. The user's `~/.msf4/database.yml`
   4. `config/database.yml` in the metasploit-framework checkout location.
@@ -48,7 +48,7 @@ Feature: `msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `msfconsole --defer-module-loads --environment test --execute-command exit --yaml command_line.yml`
+    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit --yaml command_line.yml`
     Then the output should contain "command_line_metasploit_framework_test"
 
   Scenario: Without --yaml, MSF_DATABASE_CONFIG wins
@@ -82,7 +82,7 @@ Feature: `msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `msfconsole --defer-module-loads --environment test --execute-command exit`
+    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit`
     Then the output should contain "environment_metasploit_framework_test"
 
   Scenario: Without --yaml or MSF_DATABASE_CONFIG, ~/.msf4/database.yml wins
@@ -109,7 +109,7 @@ Feature: `msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `msfconsole --defer-module-loads --environment test --execute-command exit`
+    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit`
     Then the output should contain "user_metasploit_framework_test"
 
   Scenario: Without --yaml, MSF_DATABASE_CONFIG or ~/.msf4/database.yml, project "database.yml" wins
@@ -127,7 +127,7 @@ Feature: `msfconsole` `database.yml`
         database: project_metasploit_framework_test
         username: project_metasploit_framework_test
       """
-    When I run `msfconsole --defer-module-loads --environment test --execute-command exit`
+    When I run `./msfconsole --defer-module-loads --environment test --execute-command exit`
     Then the output should contain "project_metasploit_framework_test"
 
 
@@ -140,14 +140,14 @@ Feature: `msfconsole` `database.yml`
     And a mocked home directory
     And I cd to "../.."
     And the project "database.yml" does not exist
-    When I run `msfconsole --defer-module-loads --environment test --execute-command db_status --execute-command exit`
+    When I run `./msfconsole --defer-module-loads --environment test --execute-command db_status --execute-command exit`
     Then the output should not contain "command_line_metasploit_framework_test"
     And the output should not contain "environment_metasploit_framework_test"
     And the output should not contain "user_metasploit_framework_test"
     And the output should not contain "project_metasploit_framework_test"
     And the output should contain "[*] postgresql selected, no connection"
 
-  Scenario: Starting `msfconsole` with a valid database.yml
-    When I run `msfconsole --defer-module-loads --execute-command db_status --execute-command exit`
+  Scenario: Starting `./msfconsole` with a valid database.yml
+    When I run `./msfconsole --defer-module-loads --execute-command db_status --execute-command exit`
     Then the output should contain "[*] postgresql connected to metasploit_framework_test"
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -27,8 +27,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/).reject { |file|
     file =~ /^config/
   }
-=begin
   spec.bindir = '.'
+
+=begin  
   spec.executables   = [
       'msfbinscan',
       'msfcli',
@@ -46,6 +47,7 @@ Gem::Specification.new do |spec|
       'msfvenom'
   ]
 =end
+
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/).reject { |file|
     file =~ /^config/
   }
+=begin
   spec.bindir = '.'
   spec.executables   = [
       'msfbinscan',
@@ -44,6 +45,7 @@ Gem::Specification.new do |spec|
       'msfupdate',
       'msfvenom'
   ]
+=end
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/).reject { |file|
     file =~ /^config/
   }
-  spec.bindir = '.'
 
 =begin  
+  spec.bindir = '.'
   spec.executables   = [
       'msfbinscan',
       'msfcli',

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -28,26 +28,6 @@ Gem::Specification.new do |spec|
     file =~ /^config/
   }
 
-=begin  
-  spec.bindir = '.'
-  spec.executables   = [
-      'msfbinscan',
-      'msfcli',
-      'msfconsole',
-      'msfd',
-      'msfelfscan',
-      'msfencode',
-      'msfmachscan',
-      'msfpayload',
-      'msfpescan',
-      'msfrop',
-      'msfrpc',
-      'msfrpcd',
-      'msfupdate',
-      'msfvenom'
-  ]
-=end
-
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Based on discussions in #4602, it seems the most straight-forward solution is still to remove the bins from the metasploit-framework gemspec, and to update anything that depends on them.

This is just a rebase of #4729 with the path for cucumber adjusted to not require msfconsole to be in the path. This will need some testing through a full build to ensure no test harnesses rely on it first.
