### PR TITLE
fixes Issue #5272 on report_vuln

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -46,7 +46,7 @@ module Msf::DBManager::Vuln
 
   def find_vuln_by_refs(refs, host, service=nil)
     ref_ids = refs.find_all { |ref| ref.name.starts_with? 'CVE-'}
-    host.vulns.joins(:refs).where(service_id: service.try(:id), refs: { id: ref_ids}).first
+    host.vulns.includes(:refs).where(service_id: service.try(:id), refs: { id: ref_ids}).first
   end
 
   def get_vuln(wspace, host, service, name, data='')


### PR DESCRIPTION
use includes instead of joins so that refs on
the vuln are not marked as readonly

fixes https://github.com/rapid7/metasploit-framework/issues/5272

VERIFICATION STEPS
- [x] ./msfconsole -qx 'use auxiliary/scanner/http/ssl_version; set rhosts www.google.com; run'
- [x] VERIFY no ActiveRecord::ReadOnlyRecord errors
