### PR TITLE
Change 2 reference links to use HTTPS

### DIFF
--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -100,13 +100,13 @@ class Msf::Module::SiteReference < Msf::Module::Reference
     elsif (in_ctx_id == 'CVE')
       self.site = "http://cvedetails.com/cve/#{in_ctx_val}/"
     elsif (in_ctx_id == 'CWE')
-      self.site = "http://cwe.mitre.org/data/definitions/#{in_ctx_val}.html"
+      self.site = "https://cwe.mitre.org/data/definitions/#{in_ctx_val}.html"
     elsif (in_ctx_id == 'BID')
       self.site = "http://www.securityfocus.com/bid/#{in_ctx_val}"
     elsif (in_ctx_id == 'MSB')
       self.site = "http://technet.microsoft.com/en-us/security/bulletin/#{in_ctx_val}"
     elsif (in_ctx_id == 'EDB')
-      self.site = "http://www.exploit-db.com/exploits/#{in_ctx_val}"
+      self.site = "https://www.exploit-db.com/exploits/#{in_ctx_val}"
     elsif (in_ctx_id == 'US-CERT-VU')
       self.site = "http://www.kb.cert.org/vuls/id/#{in_ctx_val}"
     elsif (in_ctx_id == 'ZDI')


### PR DESCRIPTION
This commit changes reference links for CWE and the Exploit-DB from the 'info' command to use HTTPS instead of HTTP.  Here are two links showing that both support HTTPS:

https://cwe.mitre.org/data/definitions/94.html
https://www.exploit-db.com/exploits/34066
