### PR TITLE
Remove ff 31-34 exploit from autopwn, requires interaction.

### DIFF
--- a/modules/exploits/multi/browser/firefox_proxy_prototype.rb
+++ b/modules/exploits/multi/browser/firefox_proxy_prototype.rb
@@ -10,16 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
-  include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Remote::FirefoxPrivilegeEscalation
-
-  autopwn_info({
-    :ua_name    => HttpClients::FF,
-    :ua_minver  => "31.0",
-    :ua_maxver  => "34.0",
-    :javascript => true,
-    :rank       => ManualRanking
-  })
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
I left the `include` in by mistake when creating the original module. This exploit requires a click from the user and should not be included in `browser_autopwn`.
