### PR TITLE
Track and display the last checkin time for Meterpreter sessions

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -536,6 +536,7 @@ class ReadableText
       ]
 
     columns << 'Via' if verbose
+    columns << 'CheckIn' if verbose
     columns << 'PayloadId' if verbose
 
     tbl = Rex::Ui::Text::Table.new(
@@ -554,11 +555,16 @@ class ReadableText
 
       row = [ session.sid.to_s, session.type.to_s, sinfo, session.tunnel_to_s + " (#{session.session_host})" ]
       if session.respond_to? :platform
-        row[1] += " " + session.platform
+        row[1] << (" " + session.platform)
       end
 
       if verbose
         row << session.via_exploit.to_s
+        if session.respond_to?(:last_checkin) && session.last_checkin
+          row << "#{(Time.now.to_i - session.last_checkin.to_i)}s"
+        else
+          row << ''
+        end
         row << session.payload_uuid.to_s
       end
 

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -464,6 +464,10 @@ class Client
   # A list of the commands
   #
   attr_reader :commands
+  #
+  # The timestamp of the last received response
+  #
+  attr_accessor :last_checkin
 
 protected
   attr_accessor :parser, :ext_aliases # :nodoc:


### PR DESCRIPTION
This adds support for tracking and displaying the last check-in time for Meterpreter sessions.
This field will be blank for non-Meterpreter and recently initialized sessions.
To see the last check-in time, run `sessions -l -v`:

```
msf exploit(handler) > sessions  -l -v

Active sessions
===============

  Id  Type                   Information            Connection                                          Via                    CheckIn  PayloadId
  --  ----                   -----------            ----------                                          ---                    -------  ---------
  1   meterpreter x86/win32  z420\Developer @ Z420  192.168.0.3:4444 -> 192.168.0.6:2453 (192.168.0.6)  exploit/multi/handler  2s       2a7354ab5a3ce8b7/x86=1/windows=1/2015-05-03T15:38:40Z
```
