### PR TITLE
undef payload_exe for ams_hndlrsvc #5304

### DIFF
--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -53,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
     execute_cmdstager({ :temp => '.' })
-    @payload_exe = payload_exe
+    @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")
     execute_command(@payload_exe)


### PR DESCRIPTION
Applying similar changes that were made to ams_xfr (see https://github.com/rapid7/metasploit-framework/pull/4993)
