### PR TITLE
Various post-commit fixups

### DIFF
--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -16,13 +16,13 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'MS15-034 HTTP Protocol Stack Request Handling Denial-of-Service',
       'Description'    => %q{
-        This module will check if your hosts are vulnerable to CVE-2015-1635 (MS15-034). A
-        vulnerability in the HTTP Protocol stack (HTTP.sys) that could result in arbitrary code
+        This module will check if scanned hosts are vulnerable to CVE-2015-1635 (MS15-034), a
+        vulnerability in the HTTP protocol stack (HTTP.sys) that could result in arbitrary code
         execution. This module will try to cause a denial-of-service.
 
-        Please note that you must supply a valid file resource for the TARGETURI option.
-        By default, IIS may come with these settings that you could try: iisstart.htm,
-        welcome.png, iis-85.png, etc.
+        Please note that a valid file resource must be supplied for the TARGETURI option.
+        By default, IIS, by default, provides these resources: welcome.png, and iis-85.png.
+        Others may also exist, depending on configuration options.
       },
       'Author'         =>
         [

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
         execution. This module will try to cause a denial-of-service.
 
         Please note that a valid file resource must be supplied for the TARGETURI option.
-        By default, IIS, by default, provides these resources: welcome.png, and iis-85.png.
+        By default, IIS, provides 'welcome.png' and 'iis-85.png' as resources.
         Others may also exist, depending on configuration options.
       },
       'Author'         =>

--- a/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
+++ b/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'Apple OSX/iOS/Windows Safari Non-HTTPOnly Cookie Theft',
       'Description' => %q{
-        A vulnerability exists in versions of OSX/iOS/Windows Safari released
+        A vulnerability exists in versions of OSX, iOS, and Windows Safari released
         before April 8, 2015 that allows the non-HTTPOnly cookies of any
         domain to be stolen.
       },

--- a/modules/auxiliary/gather/java_rmi_registry.rb
+++ b/modules/auxiliary/gather/java_rmi_registry.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Auxiliary
       'Name'        => 'Java RMI Registry Interfaces Enumeration',
       'Description'    => %q{
         This module gathers information from an RMI endpoint running an RMI registry
-        interface. It enumerates the names bound in the a registry and looks up each
+        interface. It enumerates the names bound in a registry and looks up each
         remote reference.
       },
       'Author'      => ['juan vazquez'],

--- a/modules/auxiliary/gather/java_rmi_registry.rb
+++ b/modules/auxiliary/gather/java_rmi_registry.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Auxiliary
       'Name'        => 'Java RMI Registry Interfaces Enumeration',
       'Description'    => %q{
         This module gathers information from an RMI endpoint running an RMI registry
-        interface. It enumerates the names bound into a registry and lookups each
+        interface. It enumerates the names bound in the a registry and looks up each
         remote reference.
       },
       'Author'      => ['juan vazquez'],

--- a/modules/auxiliary/gather/ssllabs_scan.rb
+++ b/modules/auxiliary/gather/ssllabs_scan.rb
@@ -404,7 +404,8 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
         'Name'          => 'SSL Labs API Client',
         'Description'   => %q{
-          This module is a simple client for the SSL Labs APIs, designed for SSL/TLS assessment during a penetration testing.
+          This module is a simple client for the SSL Labs APIs, designed for
+          SSL/TLS assessment during a penetration test.
         },
         'License'       => MSF_LICENSE,
         'Author'         =>

--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -13,10 +13,11 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-                      'Name'           => 'Embedthis GoAhead Embedded Web Server Directory Traversal',
+      'Name'           => 'Embedthis GoAhead Embedded Web Server Directory Traversal',
       'Description'    => %q{
-        This module exploits a directory traversal vulnerability in the Embedthis GoAhead Web Server v3.4.1,
-        allowing to read arbitrary files with the web server privileges.
+        This module exploits a directory traversal vulnerability in the Embedthis
+        GoAhead Web Server v3.4.1, allowing to read arbitrary files with the web
+        server privileges.
       },
       'References'     =>
         [

--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -16,8 +16,8 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'Embedthis GoAhead Embedded Web Server Directory Traversal',
       'Description'    => %q{
         This module exploits a directory traversal vulnerability in the Embedthis
-        GoAhead Web Server v3.4.1, allowing to read arbitrary files with the web
-        server privileges.
+        GoAhead Web Server v3.4.1, allowing an attacker to read arbitrary files
+        with the web server privileges.
       },
       'References'     =>
         [

--- a/modules/auxiliary/scanner/http/owa_iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/owa_iis_internal_ip.rb
@@ -14,8 +14,8 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'           => 'Outlook Web App (OWA) / Client Access Server (CAS) IIS HTTP Internal IP Disclosure',
       'Description'    => %q{
-        This module tests vulnerable IIS HTTP header file paths on Microsoft Exchange OWA 2003,
-        CAS 2007, 2010, 2013 servers.
+        This module tests vulnerable IIS HTTP header file paths on Microsoft
+        Exchange OWA 2003 and CAS 2007, 2010, and 2013 servers.
       },
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/owa_iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/owa_iis_internal_ip.rb
@@ -14,7 +14,8 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'           => 'Outlook Web App (OWA) / Client Access Server (CAS) IIS HTTP Internal IP Disclosure',
       'Description'    => %q{
-        This module tests vulnerable IIS HTTP header file paths on Microsoft Exchange OWA 2003, CAS 2007, 2010, 2013 servers.
+        This module tests vulnerable IIS HTTP header file paths on Microsoft Exchange OWA 2003,
+        CAS 2007, 2010, 2013 servers.
       },
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/wp_mobileedition_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_mobileedition_file_read.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Auxiliary
       'Description'    => %q{
         This module exploits a directory traversal vulnerability in WordPress Plugin
         "WP Mobile Edition" version 2.2.7, allowing to read arbitrary files with the
-        web server privileges. Stay tuned to the correct value in TARGETURI.
+        web server privileges.
       },
       'References'     =>
         [

--- a/modules/exploits/linux/http/multi_ncc_ping_exec.rb
+++ b/modules/exploits/linux/http/multi_ncc_ping_exec.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a remote command injection vulnerability on several routers. The
         vulnerability exists in the ncc service, while handling ping commands. This module has
-        been tested on a DIR-626L emulated environment only. Several D-Link and TRENDnet devices
+        been tested on a DIR-626L emulated environment. Several D-Link and TRENDnet devices
         are reported as affected, including: D-Link DIR-626L (Rev A) v1.04b04, D-Link DIR-636L
         (Rev A) v1.04, D-Link DIR-808L (Rev A) v1.03b05, D-Link DIR-810L (Rev A) v1.01b04, D-Link
         DIR-810L (Rev B) v2.02b01, D-Link DIR-820L (Rev A) v1.02B10, D-Link DIR-820L (Rev A)

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -17,9 +17,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Wordpress SlideShow Gallery Authenticated File Upload',
       'Description'    => %q{
           The Wordpress SlideShow Gallery plugin contains an authenticated file upload
-          vulnerability. We can upload arbitrary files to the upload folder, because
-          the plugin also uses it's own file upload mechanism instead of the wordpress
-          api it's possible to upload any file type.
+          vulnerability. An attacker can upload arbitrary files to the upload folder.
+          Since the plugin uses its own file upload mechanism instead of the WordPress
+          API, it's possible to upload any file type.
       },
       'Author'         =>
         [

--- a/modules/exploits/windows/local/run_as.rb
+++ b/modules/exploits/windows/local/run_as.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Local
         [
           [ 'URL', 'https://msdn.microsoft.com/en-us/library/windows/desktop/ms682431' ]
         ],
-      'DisclosureDate' => 'Jan 01 1999' # Not valid but required by msftidy
+      'DisclosureDate' => 'Jan 01 1999' # Same as psexec -- a placeholder date for non-vuln 'exploits'
     ))
 
     register_options(


### PR DESCRIPTION
Edited modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb first landed
in #5150, @wchen-r7's DOS module for CVE-2015-1635 HTTP.sys

Edited modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
first landed in #5192, @joevennix's module for Safari CVE-2015-1126

Edited modules/auxiliary/gather/java_rmi_registry.rb first landed in

Edited modules/auxiliary/gather/ssllabs_scan.rb first landed in #5016,
add SSL Labs scanner

Edited modules/auxiliary/scanner/http/goahead_traversal.rb first landed
in #5101, Add Directory Traversal for GoAhead Web Server

Edited modules/auxiliary/scanner/http/owa_iis_internal_ip.rb first
landed in #5158, OWA internal IP disclosure scanner

Edited modules/auxiliary/scanner/http/wp_mobileedition_file_read.rb
first landed in #5159, WordPress Mobile Edition Plugin File Read Vuln

Edited modules/exploits/linux/http/multi_ncc_ping_exec.rb first landed
in #4924, @m-1-k-3's DLink CVE-2015-1187 exploit

Edited modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb first
landed in #5131, WordPress Slideshow Upload

Edited modules/exploits/windows/local/run_as.rb first landed in #4649,
improve post/windows/manage/run_as and as an exploit

(These results courtesy of a delightful git alias, here:

```
  cleanup-prs = !"for i in `git status | grep modules | sed
s/#.*modules/modules/`; do echo -n \"Edited $i first landed in \" && git
log --oneline --first-parent $i | tail -1 | sed 's/.*Land //' && echo
''; done"

```

So that's kind of fun.
