### PR TITLE
Fix regression in SNMP LoginScanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -114,7 +114,7 @@ module Metasploit
 
         end
 
-        # Sets the connection timeout approrpiately for SNMP
+        # Sets the connection timeout appropriately for SNMP
         # if the user did not set it.
         def set_sane_defaults
           self.connection_timeout = 2 if self.connection_timeout.nil?

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -12,6 +12,8 @@ module Metasploit
         include Metasploit::Framework::LoginScanner::Base
 
         DEFAULT_PORT         = 161
+        DEFAULT_RETRIES      = 0
+        DEFAULT_VERSION      = 'all'
         LIKELY_PORTS         = [ 161, 162 ]
         LIKELY_SERVICE_NAMES = [ 'snmp' ]
         PRIVATE_TYPES        = [ :password ]
@@ -117,6 +119,8 @@ module Metasploit
         def set_sane_defaults
           self.connection_timeout = 2 if self.connection_timeout.nil?
           self.port = DEFAULT_PORT if self.port.nil?
+          self.retries = DEFAULT_RETRIES if self.retries.nil?
+          self.version = DEFAULT_VERSION if self.version.nil?
         end
 
         # This method takes an snmp client and tests whether

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -11,6 +11,7 @@ module Metasploit
       class SNMP
         include Metasploit::Framework::LoginScanner::Base
 
+        DEFAULT_TIMEOUT      = 2
         DEFAULT_PORT         = 161
         DEFAULT_RETRIES      = 0
         DEFAULT_VERSION      = 'all'
@@ -117,7 +118,7 @@ module Metasploit
         # Sets the connection timeout appropriately for SNMP
         # if the user did not set it.
         def set_sane_defaults
-          self.connection_timeout = 2 if self.connection_timeout.nil?
+          self.connection_timeout = DEFAULT_TIMEOUT if self.connection_timeout.nil?
           self.port = DEFAULT_PORT if self.port.nil?
           self.retries = DEFAULT_RETRIES if self.retries.nil?
           self.version = DEFAULT_VERSION if self.version.nil?


### PR DESCRIPTION
From #4722.

This fix sets default values for `retries` and `version`. The defaults are present in the `snmp_login` module but missing in the `LoginScanner`.

MSP-12668
