### PR TITLE
Add the POSIX binaries to the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,10 @@ external/source/exploits/**/Debug
 external/source/exploits/**/Release
 
 # Avoid checking in Meterpreter binaries. These are supplied upstream by
-# the meterpreter_bins gem.
+# the metasploit-payloads gem.
 data/meterpreter/*.dll
+data/meterpreter/*.bin
+data/meterpreter/*.lso
 
 # Avoid checking in Meterpreter libs that are built from
 # private source. If you're interested in this functionality,


### PR DESCRIPTION
Now that the POSIX bins are in the metasploit-payloads gem, we can make sure that we don't accidentally include them in future commits by adding them to `.gitignore`.
