### PR TITLE
Fix #5318 - retrieve domain from env var instead of net.exe

### DIFF
--- a/modules/post/windows/gather/enum_domain_group_users.rb
+++ b/modules/post/windows/gather/enum_domain_group_users.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Post
 
     # Parse Returned data
     members = get_members(usr_res.split("\n"))
-    domain = client.sys.config.getenv("USERDOMAIN")
+    domain = get_env("USERDOMAIN")
 
     # Show results if we have any, Error if we don't
     if ! members.empty?

--- a/modules/post/windows/gather/enum_domain_group_users.rb
+++ b/modules/post/windows/gather/enum_domain_group_users.rb
@@ -38,15 +38,13 @@ class Metasploit3 < Msf::Post
     cur_domain, cur_user = client.sys.config.getuid.split("\\")
     ltype = "domain.group.members"
     ctype = "text/plain"
-    domain = ""
 
     # Get Data
     usr_res = run_cmd("net groups \"#{datastore['GROUP']}\" /domain")
-    dom_res = run_cmd("net config workstation")
 
     # Parse Returned data
     members = get_members(usr_res.split("\n"))
-    domain = get_domain(dom_res.split("\n"))
+    domain = client.sys.config.getenv("USERDOMAIN")
 
     # Show results if we have any, Error if we don't
     if ! members.empty?
@@ -93,16 +91,6 @@ class Metasploit3 < Msf::Post
     return members
   end
 
-  def get_domain(results)
-    domain = ''
-
-    results.each do |line|
-      if line =~ /Workstation domain \s+(.*)/ then domain = $1.strip end
-    end
-
-    return domain
-  end
-
   def is_member(cur_dom, cur_user, dom, users)
 
     member = false
@@ -115,6 +103,7 @@ class Metasploit3 < Msf::Post
 
     return member
   end
+
   def run_cmd(cmd)
     process = session.sys.process.execute(cmd, nil, {'Hidden' => true, 'Channelized' => true})
     res = ""


### PR DESCRIPTION
Fix for #5318 

The previous method of extracting the domain (`net config workstation`) doesn't work when running as SYSTEM. The USERDOMAIN env var seems to be reliable enough to use instead.

```
meterpreter > getuid
Server username: OWNME\Administrator
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > use post/windows/gather/enum_domain_group_users
msf post(enum_domain_group_users) > set GROUP domain admins
GROUP => domain admins
msf post(enum_domain_group_users) > run -j -o SESSION=1
[*] Post module running as background job
msf post(enum_domain_group_users) >
[*] Running module against W7-2
[*] Found users in domain admins
[*]     OWNME\Administrator
[*]     OWNME\andy
[*]     OWNME\Dean
[*]     OWNME\owen
[*]     OWNME\splunkadmin
[*]     OWNME\svc
[*]     OWNME\veritas
[*] Current sessions running as OWNME\Administrator is a member of domain admins!!
[*] User list stored in /home/rw/.msf4/loot/20150508141519_default_192.168.73.45_domain.group.mem_983388.txt
```

```
meterpreter > getsystem
...got system (via technique 1).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > background
[*] Backgrounding session 1...
msf post(enum_domain_group_users) > run -j -o SESSION=1
[*] Post module running as background job
msf post(enum_domain_group_users) >
[*] Running module against W7-2
[*] Found users in domain admins
[*]     OWNME\Administrator
[*]     OWNME\andy
[*]     OWNME\Dean
[*]     OWNME\owen
[*]     OWNME\splunkadmin
[*]     OWNME\svc
[*]     OWNME\veritas
[-] Current session running as NT AUTHORITY\SYSTEM is not a member of domain admins
[*] User list stored in /home/rw/.msf4/loot/20150508141546_default_192.168.73.45_domain.group.mem_576735.txt
```
