### PR TITLE
Fix the disclosure date in WP RevSlider module

### DIFF
--- a/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
+++ b/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
       'Targets'        => [['ThemePunch Revolution Slider (revslider) 3.0.95', {}]],
-      'DisclosureDate' => 'Nov 26 2015',
+      'DisclosureDate' => 'Nov 26 2014',
       'DefaultTarget'  => 0)
     )
   end


### PR DESCRIPTION
This module has a disclosure date in the future, looks like a typo.
