### PR TITLE
Fix #5315 - Allow HTTP method and URL to be configurable for jenkins_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -17,7 +17,9 @@ module Metasploit
           self.uri = "/j_acegi_security_check" if self.uri.nil?
           self.method = "POST" if self.method.nil?
 
-          self.uri = normalize_uri(self.uri)
+          if self.uri[0] != '/'
+            self.uri = "/#{self.uri}"
+          end
 
           super
         end

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -37,15 +37,15 @@ module Metasploit
             configure_http_client(cli)
             cli.connect
             req = cli.request_cgi({
-              'method'=>'POST',
-              'uri'=>'/j_acegi_security_check',
+              'method'=> method,
+              'uri'=> uri,
               'vars_post'=> {
                 'j_username' => credential.public,
-                'j_password'=>credential.private
+                'j_password'=> credential.private
                 }
             })
             res = cli.send_recv(req)
-            if res && !res.headers['location'].include?('loginError')
+            if res && res.headers['location'] && !res.headers['location'].include?('loginError')
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -17,6 +17,8 @@ module Metasploit
           self.uri = "/j_acegi_security_check" if self.uri.nil?
           self.method = "POST" if self.method.nil?
 
+          self.uri = normalize_uri(self.uri)
+
           super
         end
 

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -23,6 +23,8 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
+        OptString.new('LOGIN_URL', [true, 'The URL that handles the login process', '/j_acegi_security_check']),
+        OptEnum.new('HTTP_METHOD', [true, 'The HTTP method to use for the login', 'POST', ['GET', 'POST']]),
         Opt::RPORT(8080)
       ], self.class)
 
@@ -44,6 +46,8 @@ class Metasploit3 < Msf::Auxiliary
 
     scanner = Metasploit::Framework::LoginScanner::Jenkins.new(
       configure_http_login_scanner(
+        uri: datastore['LOGIN_URL'],
+        method: datastore['HTTP_METHOD'],
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],


### PR DESCRIPTION
Fix #5315

This patch allows the HTTP method and URL to be configurable for jenkins_login by the user.
## To verify
- [ ] Create a fake HTTP server: `ruby -run -e httpd . -p 8181`
- [ ] Start msfconsole
- [ ] `use auxilliary/scanner/http/jenkins_login`
- [ ] `set rhosts [The fake HTTP server's IP]`
- [ ] `set rport 8181`
- [ ] `set username user`
- [ ] `set password pass`
- [ ] `run`
- [ ] On msfconsole, you should see: `LOGIN FAILED: username:password (Incorrect)`
- [ ] On the fake HTTP server, you should see this request in the log:

```
[11/May/2015:10:18:01 CDT] "POST /j_acegi_security_check/j_acegi_security_check HTTP/1.1" 404 318
```
- [ ] Back to msfconsole, this time do: `set method GET`
- [ ] Also do: `set login_url something`
- [ ] In the web server's log, you should see something like this:

```
 [11/May/2015:10:41:54 CDT] "GET /something HTTP/1.1" 404 282
```
