### PR TITLE
Resolve #5330, change print_error to print_warning for report_auth_info

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -169,7 +169,7 @@ module Auxiliary::Report
   # @option opts [String] :user The username for the cred
   # @option opts [String] :pass The private part of the credential (e.g. password)
   def report_auth_info(opts={})
-    print_error "*** #{self.fullname} is still calling the deprecated report_auth_info method! This needs to be updated!"
+    print_warning "*** #{self.fullname} is still calling the deprecated report_auth_info method! This needs to be updated!"
     return if not db
     raise ArgumentError.new("Missing required option :host") if opts[:host].nil?
     raise ArgumentError.new("Missing required option :port") if (opts[:port].nil? and opts[:service].nil?)


### PR DESCRIPTION
Resolve #5330 for more consistent deprecation style.

To make sure it's printing a warning:
- [ ] Save this test module to a location loadable by msf: https://gist.github.com/wchen-r7/28e18f2d0a250e0cfcd2
- [ ] Start msfconsole
- [ ] Load the module
- [ ] `run` (no options need to be configured)
- [ ] You should see something like this:

```
msf auxiliary(test) > run

[!] *** auxiliary/admin/http/test is still calling the deprecated report_auth_info method! This needs to be updated!
```
