### PR TITLE
HTML Title Grabber

### DIFF
--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'HTTP HTML Title tag content grabber',
+      'Name'        => 'HTTP HTML Title Tag Content Grabber',
       'Description' => %q{
         Generates a GET request to the webservers provided and returns the server header,
         HTML title attribute and location header (if set). Useful for rapidly identifying

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -30,6 +30,15 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('VHOST')
   end
 
+  def run
+
+    if datastore['STORE_NOTES']==false && datastore['SHOW_ERRORS']==false && datastore['SHOW_TITLES']==false
+        print_error("Notes storage is false, errors have been turned off and titles are not being shown on the console. There isn't much point in running this module.")
+    else
+        super
+    end
+  end
+
   def run_host(target_host)
     begin
       res = send_request_cgi('uri'          => '/',

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'msf/core'
-require 'cgi'
 
 class Metasploit3 < Msf::Auxiliary
   # Exploit mixins should be called first
@@ -86,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
         # Last bit of logic to capture the title
         rx[:title].strip!
         if rx[:title] != ''
-          rx_title = CGI.unescapeHTML(rx[:title])
+          rx_title = Rex::Text.html_decode(rx[:title])
           print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
           if datastore['STORE_NOTES'] == true
             notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header }

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -45,8 +45,10 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(target_host)
     begin
         # Send a normal GET request
-        res = send_request_cgi('uri'          => '/',
-                               'method'       => 'GET')
+        res = send_request_cgi(
+          'uri' => '/',
+          'method' => 'GET'
+        )
 
         # If no response, quit now
         if res.nil?

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -40,12 +40,18 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(target_host)
     begin
-      res = send_request_cgi('uri'          => '/',
-                             'method'       => 'GET')
+        # Send a normal GET request
+        res = send_request_cgi('uri'          => '/',
+                               'method'       => 'GET')
 
-      if res.nil?
-        print_error("No response from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
-      else
+        # If no response, quit now
+        if res.nil?
+          print_error("[#{target_host}:#{rport}] No response") if datastore['SHOW_ERRORS'] == true
+          return
+        end
+
+        # Retrieve the headers to capture the Location and Server header
+        # Note that they are case-insensitive but stored in a hash
         server_header = nil
         location_header = nil
         if !res.headers.nil?
@@ -54,34 +60,38 @@ class Metasploit3 < Msf::Auxiliary
             server_header  = val if key.downcase == 'server'
           end
         else
-          print_error("No headers from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+          print_error("[#{target_host}:#{rport}] No HTTP headers") if datastore['SHOW_ERRORS'] == true
         end
 
-        if !res.body.nil?
-          # Very basic, just match the first title tag we come to.
-          rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
-          if rx
-            rx[:title].strip!
-            if rx[:title] != ''
-              rx_title = CGI.unescapeHTML(rx[:title])
-              print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
-              if datastore['STORE_NOTES'] == true
-                notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header }
-                report_note(host: target_host, type: "http.title", data: notedata)
-              end
-            else
-              print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
-            end
-          else
-            print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+        # If the body is blank, just stop now as there is no chance of a title
+        if res.body.nil?
+          print_error("[#{target_host}:#{rport}] No webpage body") if datastore['SHOW_ERRORS'] == true
+          return
+        end
+
+        # Very basic, just match the first title tag we come to. If the match fails,
+        # there is no chance that we will have a title
+        rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
+        unless rx
+          print_error("[#{target_host}:#{rport}] No webpage title") if datastore['SHOW_ERRORS'] == true
+          return
+        end
+
+        # Last bit of logic to capture the title
+        rx[:title].strip!
+        if rx[:title] != ''
+          rx_title = CGI.unescapeHTML(rx[:title])
+          print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
+          if datastore['STORE_NOTES'] == true
+            notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header }
+            report_note(host: target_host, type: "http.title", data: notedata)
           end
         else
-          print_error("No webpage body from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+          print_error("[#{target_host}:#{rport}] No webpage title") if datastore['SHOW_ERRORS'] == true
         end
       end
 
       rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       rescue ::Timeout::Error, ::Errno::EPIPE
-    end
   end
 end

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -15,8 +15,12 @@ class Metasploit3 < Msf::Auxiliary
   def initialize
     super(
       'Name'        => 'HTTP HTML <title> tag content grabber',
-      'Description' => 'Generates a GET request to the webservers provided and returns the server header, HTML title attribute and location header (if set). Useful for rapidly identifying all webservers on a network and identifying interesting hosts en mass.',
-      'Author'       => ['Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>'],
+      'Description' => %q{
+        Generates a GET request to the webservers provided and returns the server header,
+        HTML title attribute and location header (if set). Useful for rapidly identifying
+        interesting web applications en mass.
+      },
+      'Author'       => 'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>',
       'License'     => MSF_LICENSE,
     )
 

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -51,13 +51,18 @@ class Metasploit3 < Msf::Auxiliary
 
         if !res.body.nil?
           # Very basic, just match the first title tag we come to.
-          rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s.strip)
-          if rx && rx[:title] != ''
-            rx_title = CGI.unescapeHTML(rx[:title])
-            print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
-            if datastore['STORE_NOTES'] == true
-              notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header }
-              report_note(host: target_host, type: "http.title", data: notedata)
+          rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
+          if rx
+            rx[:title].strip!
+            if rx[:title] != ''
+              rx_title = CGI.unescapeHTML(rx[:title])
+              print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
+              if datastore['STORE_NOTES'] == true
+                notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header }
+                report_note(host: target_host, type: "http.title", data: notedata)
+              end
+            else
+              print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
             end
           else
             print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -10,7 +10,6 @@ class Metasploit3 < Msf::Auxiliary
 
   # Exploit mixins should be called first
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Auxiliary::WmapScanServer
   # Scanner mixin should be near last
   include Msf::Auxiliary::Scanner
 

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -31,11 +31,10 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-
-    if datastore['STORE_NOTES']==false && datastore['SHOW_ERRORS']==false && datastore['SHOW_TITLES']==false
-        print_error("Notes storage is false, errors have been turned off and titles are not being shown on the console. There isn't much point in running this module.")
+    if datastore['STORE_NOTES'] == false && datastore['SHOW_ERRORS'] == false && datastore['SHOW_TITLES'] == false
+      print_error("Notes storage is false, errors have been turned off and titles are not being shown on the console. There isn't much point in running this module.")
     else
-        super
+      super
     end
   end
 

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -1,0 +1,83 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'cgi'
+
+class Metasploit3 < Msf::Auxiliary
+
+  # Exploit mixins should be called first
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::WmapScanServer
+  # Scanner mixin should be near last
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'HTTP HTML <title> tag content grabber',
+      'Description' => 'Generates a GET request to the webservers provided and returns the server header, HTML title attribute and location header (if set). Useful for rapidly identifying all webservers on a network and identifying interesting hosts en mass.',
+      'Author'       => ['Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>'],
+      'License'     => MSF_LICENSE,
+    )
+
+    register_options(
+      [
+        OptBool.new('STORE_NOTES', [ true, 'Store the captured information in notes. Use "notes -t http.title" to view', true ]),
+        OptBool.new('SHOW_ERRORS', [ true, 'Show error messages relating to grabbing titles on the console', true ]),
+        OptBool.new('SHOW_TITLES', [ true, 'Show the titles on the console as they are grabbed', true ]),
+    ], self.class)
+
+    deregister_options('VHOST')
+  end
+
+  def run_host(target_host)
+    begin
+      res = send_request_cgi({
+        'uri'          => '/',
+        'method'       => 'GET',
+      })
+
+      if res.nil?
+        print_error("No response from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+      else 
+        server_header = nil
+        location_header = nil
+        if not res.headers.nil?
+          res.headers.each do |key,val|
+             location_header = val if key.downcase == 'location' 
+             server_header  = val if key.downcase == 'server' 
+          end
+        else
+          print_error("No headers from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+        end
+
+        if not res.body.nil?
+	        # Very basic, just match the first title tag we come to.
+	        rx = /<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*<\/title>/im.match(res.body.to_s)
+            if rx 
+                rx[:title].strip!
+                if not rx[:title] == ''
+			        rx_title = CGI.unescapeHTML(rx[:title])
+			        print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
+			        if datastore['STORE_NOTES'] == true then
+			            notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header}
+			            report_note(:host => target_host, :type => "http.title", :data => notedata) 
+			        end
+                else
+                    print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+                end
+            else
+                print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+            end
+        else
+            print_error("No webpage body from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+        end
+      end
+
+      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      rescue ::Timeout::Error, ::Errno::EPIPE
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -45,8 +45,8 @@ class Metasploit3 < Msf::Auxiliary
     begin
         # Send a normal GET request
         res = send_request_cgi(
-          'uri': '/',
-          'method': 'GET'
+          uri: '/',
+          method: 'GET'
         )
 
         # If no response, quit now

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -7,7 +7,6 @@ require 'msf/core'
 require 'cgi'
 
 class Metasploit3 < Msf::Auxiliary
-
   # Exploit mixins should be called first
   include Msf::Exploit::Remote::HttpClient
   # Scanner mixin should be near last
@@ -25,53 +24,46 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptBool.new('STORE_NOTES', [ true, 'Store the captured information in notes. Use "notes -t http.title" to view', true ]),
         OptBool.new('SHOW_ERRORS', [ true, 'Show error messages relating to grabbing titles on the console', true ]),
-        OptBool.new('SHOW_TITLES', [ true, 'Show the titles on the console as they are grabbed', true ]),
-    ], self.class)
+        OptBool.new('SHOW_TITLES', [ true, 'Show the titles on the console as they are grabbed', true ])
+      ], self.class)
 
     deregister_options('VHOST')
   end
 
   def run_host(target_host)
     begin
-      res = send_request_cgi({
-        'uri'          => '/',
-        'method'       => 'GET',
-      })
+      res = send_request_cgi('uri'          => '/',
+                             'method'       => 'GET')
 
       if res.nil?
         print_error("No response from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
-      else 
+      else
         server_header = nil
         location_header = nil
-        if not res.headers.nil?
-          res.headers.each do |key,val|
-             location_header = val if key.downcase == 'location' 
-             server_header  = val if key.downcase == 'server' 
+        if !res.headers.nil?
+          res.headers.each do |key, val|
+            location_header = val if key.downcase == 'location'
+            server_header  = val if key.downcase == 'server'
           end
         else
           print_error("No headers from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
         end
 
-        if not res.body.nil?
-	        # Very basic, just match the first title tag we come to.
-	        rx = /<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*<\/title>/im.match(res.body.to_s)
-            if rx 
-                rx[:title].strip!
-                if not rx[:title] == ''
-			        rx_title = CGI.unescapeHTML(rx[:title])
-			        print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
-			        if datastore['STORE_NOTES'] == true then
-			            notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header}
-			            report_note(:host => target_host, :type => "http.title", :data => notedata) 
-			        end
-                else
-                    print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
-                end
-            else
-                print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+        if !res.body.nil?
+          # Very basic, just match the first title tag we come to.
+          rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s.strip)
+          if rx && rx[:title] != ''
+            rx_title = CGI.unescapeHTML(rx[:title])
+            print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
+            if datastore['STORE_NOTES'] == true
+              notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header }
+              report_note(host: target_host, type: "http.title", data: notedata)
             end
+          else
+            print_error("No webpage title from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+          end
         else
-            print_error("No webpage body from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
+          print_error("No webpage body from #{target_host}:#{rport}") if datastore['SHOW_ERRORS'] == true
         end
       end
 

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'HTTP HTML <title> tag content grabber',
+      'Name'        => 'HTTP HTML Title tag content grabber',
       'Description' => %q{
         Generates a GET request to the webservers provided and returns the server header,
         HTML title attribute and location header (if set). Useful for rapidly identifying
@@ -45,8 +45,8 @@ class Metasploit3 < Msf::Auxiliary
     begin
         # Send a normal GET request
         res = send_request_cgi(
-          'uri' => '/',
-          'method' => 'GET'
+          'uri': '/',
+          'method': 'GET'
         )
 
         # If no response, quit now


### PR DESCRIPTION
# Overview

On most penetration tests (particularly internal tests on large networks), it is useful to be able to connect to a large number of webservers, obtain basic page information (server header and title) so that any interesting or anomalous servers can be easily identified.

This can be achieved using some third party tools, and to an extent can be achieved using scraper. However, this PR is for an auxiliary module which will connect to 'RHOSTS:RPORT', perform a non-greedy match for the first `<title>` tag (which will return the first title that appears on the page), the return HTTP code, the Location header (if present) and the Server header (if present).  It will optionally present this on the console if `SHOW_TITLES` is set and write to notes (http.title) if `STORE_NOTES` is set. It can be made as quiet as possible to allow background execution without filling up the console with output. The benefit of using notes can be easily seen using commands such as

`notes -t http.title -S ':port=>443, :server=>"Apache.*?"' -R` 

and then launching another module specifically aimed at mod_ssl etc.

Note that this is first and foremost a title grabber, not a fingerprinting module. Therefore, no output will be generated if a title cannot be obtained, even if the web server is still alive. It should be used to identify interesting hosts based on HTML title, not to identify webservers which are responding to HTTP.
# Output Format
## Console

If `SHOW_TITLES` is set, the code will generate console output in the format shown in the example below:

`[*] [46.228.47.114:80] [C:200] [R:] [S:ATS] TITLE`

| Format | Example | Description |
| --- | --- | --- |
| C | [C:200] | The HTTP status code from the server |
| R | [R:http://www.mwrinfosecurity.com/] | The contents of the Location header, if present. This is useful to see at a glance if a GET request redirects you to another URL. |
| S | [S:ATS] | The contents of the Server header, if present. |
| (Rest of string) | TITLE | The unescaped contents of the first HTML TITLE tag |
## Notes

If `STORE_NOTES` is set, the code will inject a note into the notes database to cover each of the HTML titles that are obtained, as shown in the example below:

`[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.237 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}`

The format is relatively self-explanatory. 
# Verification
- [x] Able to grab HTML titles on tcp/80 when provided with domain names

`msf  auxiliary(title) > show options`

```
Module options (auxiliary/scanner/http/title):

   Name         Current Setting                                         Required  Description
   ----         ---------------                                         --------  -----------
   Proxies                                                              no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       www.mwrinfosecurity.com www.yahoo.com www.google.co.uk  yes       The target address range or CIDR identifier
   RPORT        80                                                      yes       The target port
   SHOW_ERRORS  true                                                    yes       Show error messages relating to grabbing titles on the console
   SHOW_TITLES  true                                                    yes       Show the titles on the console as they are grabbed
   STORE_NOTES  true                                                    yes       Store the captured information in notes. Use "notes -t http.title" to view
   THREADS      3                                                       yes       The number of concurrent threads
```

`msf  auxiliary(title) > exploit`

```
[*] [5.79.13.16:80] [C:301] [R:http://www.mwrinfosecurity.com/] [S:Apache] 301 Moved Permanently
[*] [46.228.47.114:80] [C:404] [R:] [S:ATS] Yahoo
[*] [46.228.47.115:80] [C:404] [R:] [S:ATS] Yahoo
[*] Scanned  3 of 20 hosts (15% complete)
[*] Scanned  4 of 20 hosts (20% complete)
[*] [193.0.255.241:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.222:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.249:80] [C:200] [R:] [S:gws] Google
[*] Scanned  6 of 20 hosts (30% complete)
[*] [193.0.255.236:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.221:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.237:80] [C:200] [R:] [S:gws] Google
[*] Scanned  8 of 20 hosts (40% complete)
[*] Scanned 10 of 20 hosts (50% complete)
[*] [193.0.255.234:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.230:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.245:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.251:80] [C:200] [R:] [S:gws] Google
[*] Scanned 14 of 20 hosts (70% complete)
[*] [193.0.255.226:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.211:80] [C:200] [R:] [S:gws] Google
[*] [193.0.255.215:80] [C:200] [R:] [S:gws] Google
[*] Scanned 15 of 20 hosts (75% complete)
[*] Scanned 16 of 20 hosts (80% complete)
[*] [193.0.255.219:80] [C:200] [R:] [S:gws] Google
[*] Scanned 19 of 20 hosts (95% complete)
[*] [193.0.255.207:80] [C:200] [R:] [S:gws] Google
[*] Scanned 20 of 20 hosts (100% complete)
[*] Auxiliary module execution completed
```
- [x] Notes from the above correctly stored in the database

`msf  auxiliary(title) > notes -t http.title`

```
[*] Time: 2015-05-11 17:25:21 UTC Note: host=5.79.13.16 type=http.title data={:code=>301, :port=>80, :server=>"Apache", :title=>"301 Moved Permanently", :redirect=>"http://www.mwrinfosecurity.com/"}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.241 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.249 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.236 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.237 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.234 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.230 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.245 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.251 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.226 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.215 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.219 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.207 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=46.228.47.114 type=http.title data={:code=>404, :port=>80, :server=>"ATS", :title=>"Yahoo", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.222 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.221 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:22 UTC Note: host=193.0.255.211 type=http.title data={:code=>200, :port=>80, :server=>"gws", :title=>"Google", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=46.228.47.115 type=http.title data={:code=>404, :port=>80, :server=>"ATS", :title=>"Yahoo", :redirect=>nil}
```
- [x] Able to grab HTML titles on tcp/443 when provided with IP addresses

`msf  auxiliary(title) > show options`

```
Module options (auxiliary/scanner/http/title):

   Name         Current Setting           Required  Description
   ----         ---------------           --------  -----------
   Proxies                                no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       193.0.255.236 5.79.13.16  yes       The target address range or CIDR identifier
   RPORT        443                       yes       The target port
   SHOW_ERRORS  true                      yes       Show error messages relating to grabbing titles on the console
   SHOW_TITLES  true                      yes       Show the titles on the console as they are grabbed
   STORE_NOTES  true                      yes       Store the captured information in notes. Use "notes -t http.title" to view
   THREADS      3                         yes       The number of concurrent threads
```

`msf  auxiliary(title) > exploit`

```
[*] [5.79.13.16:443] [C:200] [R:] [S:Apache] MWR InfoSecurity
[*] [193.0.255.236:443] [C:200] [R:] [S:gws] Google
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
- [x] Notes stored correctly

`msf  auxiliary(title) > notes -t http.title -S ':port=>443'`

```
[*] Time: 2015-05-11 17:25:21 UTC Note: host=5.79.13.16 type=http.title data={:code=>200, :port=>443, :server=>"Apache", :title=>"MWR InfoSecurity", :redirect=>nil}
[*] Time: 2015-05-11 17:25:21 UTC Note: host=193.0.255.236 type=http.title data={:code=>200, :port=>443, :server=>"gws", :title=>"Google", :redirect=>nil}
```
# Support

Thanks to @Meatballs1 and @hmoore-r7 for your support :smile: 
