### PR TITLE
Adds signature checking to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - rake --version
   # Fail build if msftidy is not successful
+  - bash ./tools/dev/import-dev-keys.sh
   - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
   - ls -la ./.git/hooks
   - ./.git/hooks/post-merge

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 bundler_args: --without coverage development pcap
 cache: bundler
 env:
-  global:
-    - TRAVIS_CI_TEST_ENVIRONMENT="true"
   matrix:
     - RAKE_TASKS="cucumber cucumber:boot"
     - RAKE_TASKS=spec SPEC_OPTS="--tag content"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_install:
   - bash ./tools/dev/import-dev-keys.sh
   - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
   - ls -la ./.git/hooks
+  # What does travis actually see?
+  - git log --show-signature -5
   - ./.git/hooks/post-merge
 before_script:
   - cp config/database.yml.travis config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - RAKE_TASKS="cucumber cucumber:boot"
   - RAKE_TASKS=spec SPEC_OPTS="--tag content"
   - RAKE_TASKS=spec SPEC_OPTS="--tag ~content"
+  - TRAVIS_CI_TEST_ENVIRONMENT=1
 
 language: ruby
 matrix:
@@ -15,7 +16,7 @@ before_install:
   - bash ./tools/dev/import-dev-keys.sh
   - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
   - ls -la ./.git/hooks
-  # What does travis actually see?
+  # Note which commit we're really on
   - git log --format=full --show-signature -2
   - ./.git/hooks/post-merge
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 bundler_args: --without coverage development pcap
 cache: bundler
 env:
-  - RAKE_TASKS="cucumber cucumber:boot"
-  - RAKE_TASKS=spec SPEC_OPTS="--tag content"
-  - RAKE_TASKS=spec SPEC_OPTS="--tag ~content"
-  - TRAVIS_CI_TEST_ENVIRONMENT=1
+  global:
+    - TRAVIS_CI_TEST_ENVIRONMENT="true"
+  matrix:
+    - RAKE_TASKS="cucumber cucumber:boot"
+    - RAKE_TASKS=spec SPEC_OPTS="--tag content"
+    - RAKE_TASKS=spec SPEC_OPTS="--tag ~content"
 
 language: ruby
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
   - ls -la ./.git/hooks
   # What does travis actually see?
-  - git log --show-signature -5
+  - git log --format=full --show-signature -2
   - ./.git/hooks/post-merge
 before_script:
   - cp config/database.yml.travis config/database.yml

--- a/tools/dev/import-dev-keys.sh
+++ b/tools/dev/import-dev-keys.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Requires bash version 3 or so for regular expression pattern match
+
+COMMITTER_KEYS_URL='https://raw.githubusercontent.com/wiki/rapid7/metasploit-framework/Committer-Keys.md'
+KEYBASE_KEY_URLS=$(
+ \curl -sSL $COMMITTER_KEYS_URL |
+ \awk '$4 ~/https:\/\/keybase.io\//' |
+ \sed 's#.*\(https://keybase.io/[^)]*\).*#\1/key.asc#'
+)
+
+for key in $KEYBASE_KEY_URLS; do
+  echo Importing $key...
+  \curl -sSL $key | gpg --quiet --no-auto-check-trustdb --import -
+done
+
+# Exceptions -- keys that do show up in the logs, but aren't (yet) in Keybase:
+# This should cover every key since May of 2014.
+
+# Currently, one lone missing key:
+#
+# gpg: Signature made Mon 16 Feb 2015 02:09:53 PM CST using RSA key ID D5D50A02
+# gpg: Can't check signature: public key not found
+# 14da69c - Land #4757, adds RC for auto payload gen (3 months ago) <kernelsmith@github> []
+#
+# https://github.com/rapid7/metasploit-framework/commit/14da69c is
+# harmless, though. It's only an RC script, not run by default, and it
+# automates setting up a payload handler.
+
+
+echo Processing exceptions...
+
+MIT_KEYIDS="
+Brandont       0xA3EE1B07
+Ccatalan       0xC3953653
+Farias         0x01DF79A1
+Firefart       0x66BC32C7
+HDM            0xFA604913
+Jvennix        0x3E85A2B0
+Kernelsmith    0x3D609E33
+Lsanchez       0xFB80E8DD
+OJ             0x1FAA5749
+Sgonzalez      0xCA93BCE5
+Shuckins       0x8C03C944
+TheLightCosine 0x3A913DB2
+Wvu            0xC1629024
+"
+
+MIT_KEY_URL_BASE="https://pgp.mit.edu/pks/lookup?op=get&search="
+
+for key in $MIT_KEYIDS; do
+  if [[ $key =~ ^0x ]]
+  then
+    \curl -sSL $MIT_KEY_URL_BASE$key | gpg --quiet --no-auto-check-trustdb --import -
+  else
+    echo Importing key for $key...
+  fi
+done
+

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -26,6 +26,16 @@ def merge_error_message
   puts "-" * 72
 end
 
+def signed_error_message
+  msg = []
+  msg << "[*] This merge was not signed with a known key"
+  msg << "[*] Please fix this if you intend to publish this"
+  msg << "[*] merge commit to the rapid7 master branch"
+  puts "-" * 72
+  puts msg.join("\n")
+  puts "-" * 72
+end
+
 valid = true # Presume validity
 files_to_check = []
 
@@ -48,6 +58,8 @@ else
   changed_files = %x[git diff --cached --name-only]
 end
 
+signature_check = %x{git log --show-signature -1}
+
 changed_files.each_line do |fname|
   fname.strip!
   next unless File.exist?(fname)
@@ -57,9 +69,9 @@ changed_files.each_line do |fname|
 end
 
 if files_to_check.empty?
-  puts "--- No Metasploit modules to check ---"
+  puts "[*] No Metasploit modules to check"
 else
-  puts "--- Checking new and changed module syntax with tools/msftidy.rb ---"
+  puts "[*] Checking new and changed module syntax with tools/msftidy.rb"
   files_to_check.each do |fname|
     cmd = "ruby ./tools/msftidy.rb  #{fname}"
     msftidy_output= %x[ #{cmd} ]
@@ -82,5 +94,13 @@ unless valid
     puts "-" * 72
     exit(0x01)
   end
+end
 
+if base_caller == :post_merge
+  if signature_check.include? "gpg: Good signature from"
+    puts "[+] Signature check passed."
+  else
+    puts signed_error_message
+    exit(0x11)
+  end
 end

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -58,13 +58,7 @@ else
   changed_files = %x[git diff --cached --name-only]
 end
 
-# Travis's merges always include one extra merge, so we
-# need to step back one if we're on Travis.
-if ENV['TRAVIS_CI_TEST_ENVIRONMENT']
-  signature_check = %x{git log --show-signature HEAD~ -1}
-else
-  signature_check = %x{git log --show-signature -1}
-end
+signature_check = %x{git log --show-signature -1}
 
 changed_files.each_line do |fname|
   fname.strip!

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -103,10 +103,13 @@ unless valid
 end
 
 if base_caller == :post_merge
-  if signature_check =~ /\ngpg: Good signature from /m
+  if signature_check =~ /^commit .*\ngpg: Good signature from .*\nMerge: /m
     puts "[+] Merge commit signature check passed."
   else
-    puts signed_error_message
-    exit(0x11)
+    unless signature_check =~ /^commit .*\nMerge: /m
+      puts signature_check
+      puts signed_error_message
+      exit(0x11)
+    end
   end
 end

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -103,6 +103,7 @@ unless valid
 end
 
 if base_caller == :post_merge
+  puts signature_check.inspect # Sanity check
   if signature_check =~ /^commit .*\ngpg: Good signature from .*\nMerge: /m
     puts "[+] Merge commit signature check passed."
   else


### PR DESCRIPTION
I will update this PR with a reasonable description and verfication steps once I see that the Travis check doesn't throw errors or do anything unexpected.

Preemptively marking as Delayed.

Squashed commit of the following:

commit b58a38e22f5e0591103036614ab6431351119ee3
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue May 12 15:05:16 2015 -0500

```
Actually import developer keys
```

commit 37fa8bd5829b0894351a854b128a29accc367204
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue May 12 14:55:49 2015 -0500

```
Rename the key importer bash script
```

commit 59347e531b582f069fb197bcced36676eadcdeda
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue May 12 14:52:33 2015 -0500

```
Normalize output on the file check
```

commit cc6a6b21bb723ce58d1972bfb9303d66f55a0a47
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue May 12 14:50:46 2015 -0500

```
Add a success message for signature checking
```

commit a39c84fc0ae0d84e1b69a7523332e3dbc3342a98
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue May 12 14:48:25 2015 -0500

```
Include typo, oops
```

commit c23bebb03e108eb3ea10e4a59e874a688cb3f5c5
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue May 12 14:45:48 2015 -0500

```
Add a signature check to the post-merge hook
```

commit 97755f4b8d3f2cdfa6e9eb0e95ef5fc86d6967a6
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue May 12 14:17:13 2015 -0500

```
Beef up the keybase importer with missing keys

This is important to assure that older commits are on the up-and-up, or
commits from committers who, for whatever reason, haven't made their
git signing key their default keybase.io key.
```

commit 87b81244ec194b09a59bc41c7d3385e198e21333
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Mon Mar 23 16:08:30 2015 -0500

```
Update import-keybase.sh
```

commit 0c75eec8e88f26e1c55aa3e6a3006c1851304964
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue Mar 17 12:11:44 2015 -0500

```
Update the tool

Longer description, if needed, wrapped at 72 characters.

[See #XXXX]
```

commit 0136155c9840e2a2721f5b81f11dc549cee51a9c
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Tue Mar 10 16:28:10 2015 -0500

```
Experimental tool to import keys from Keybase

This isn't verifying anything, just adds keys. It's on you to trust them
or not.
```
