### PR TITLE
Change writing style of symantec_web_gateway_login

### DIFF
--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -32,33 +32,32 @@ class Metasploit3 < Msf::Auxiliary
   end
 
 
-  # Initializes CredentialCollection and SymantecWebGateway
-  def init(ip)
-    @cred_collection = Metasploit::Framework::CredentialCollection.new(
-      blank_passwords: datastore['BLANK_PASSWORDS'],
-      pass_file:       datastore['PASS_FILE'],
-      password:        datastore['PASSWORD'],
-      user_file:       datastore['USER_FILE'],
-      userpass_file:   datastore['USERPASS_FILE'],
-      username:        datastore['USERNAME'],
-      user_as_pass:    datastore['USER_AS_PASS']
-    )
-
-    @scanner = Metasploit::Framework::LoginScanner::SymantecWebGateway.new(
-      configure_http_login_scanner(
-        host: ip,
-        port: datastore['RPORT'],
-        cred_details:       @cred_collection,
-        stop_on_success:    datastore['STOP_ON_SUCCESS'],
-        bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5
+  def scanner(ip)
+    @scanner ||= lambda {
+      cred_collection = Metasploit::Framework::CredentialCollection.new(
+        blank_passwords: datastore['BLANK_PASSWORDS'],
+        pass_file:       datastore['PASS_FILE'],
+        password:        datastore['PASSWORD'],
+        user_file:       datastore['USER_FILE'],
+        userpass_file:   datastore['USERPASS_FILE'],
+        username:        datastore['USERNAME'],
+        user_as_pass:    datastore['USER_AS_PASS']
       )
-    )
-  end
+
+      return Metasploit::Framework::LoginScanner::SymantecWebGateway.new(
+        configure_http_login_scanner(
+          host: ip,
+          port: datastore['RPORT'],
+          cred_details:       cred_collection,
+          stop_on_success:    datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
+          connection_timeout: 5
+        ))
+    }.call
+end
 
 
-  # Reports a good login credential
-  def do_report(ip, port, result)
+  def report_good_cred(ip, port, result)
     service_data = {
       address: ip,
       port: port,
@@ -86,39 +85,34 @@ class Metasploit3 < Msf::Auxiliary
   end
 
 
+  def report_bad_cred(ip, rport, result)
+    invalidate_login(
+      address: ip,
+      port: rport,
+      protocol: 'tcp',
+      public: result.credential.public,
+      private: result.credential.private,
+      realm_key: result.credential.realm_key,
+      realm_value: result.credential.realm,
+      status: result.status,
+      proof: result.proof
+    )
+  end
+
+
   # Attempts to login
   def bruteforce(ip)
-    @scanner.scan! do |result|
+    scanner(ip).scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
         print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}'"
-        do_report(ip, rport, result)
+        report_good_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute :level => :verror, :ip => ip, :msg => result.proof
-        invalidate_login(
-            address: ip,
-            port: rport,
-            protocol: 'tcp',
-            public: result.credential.public,
-            private: result.credential.private,
-            realm_key: result.credential.realm_key,
-            realm_value: result.credential.realm,
-            status: result.status,
-            proof: result.proof
-        )
+        report_bad_cred(ip, rport, result)
       when Metasploit::Model::Login::Status::INCORRECT
         vprint_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
-        invalidate_login(
-            address: ip,
-            port: rport,
-            protocol: 'tcp',
-            public: result.credential.public,
-            private: result.credential.private,
-            realm_key: result.credential.realm_key,
-            realm_value: result.credential.realm,
-            status: result.status,
-            proof: result.proof
-        )
+        report_bad_cred(ip, rport, result)
       end
     end
   end
@@ -126,8 +120,7 @@ class Metasploit3 < Msf::Auxiliary
 
   # Start here
   def run_host(ip)
-    init(ip)
-    unless @scanner.check_setup
+    unless scanner(ip).check_setup
       print_brute :level => :error, :ip => ip, :msg => 'Target is not Symantec Web Gateway'
       return
     end


### PR DESCRIPTION
This update is just for matching whatever I'm saying here:
https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module

The module should not behave any different than before.
## Setup Preparation
- [ ] You can download Symantec Web Gateway here (it's a VM): http://www.symantec.com/web-gateway/

The download requires you to create an account (which will ask your contact information and all that). If you don't want to go through this and you can reach me in person, you can just use my box. I have version 5.2.1.80, which should be pretty current.
## Verification
- [ ] Make sure Travis is green
- [ ] Try a good credential against Symantec Web Gateway like the following demo (you should get a successful login):

```
$ msfconsole
msf > use auxiliary/scanner/http/symantec_web_gateway_login
msf auxiliary(symantec_web_gateway_login) > set rhosts 192.168.1.162
rhosts => 192.168.1.162
msf auxiliary(symantec_web_gateway_login) > set username sinn3r
username => sinn3r
msf auxiliary(symantec_web_gateway_login) > set password GoodPassword
password => GoodPassword
msf auxiliary(symantec_web_gateway_login) > run

[+] 192.168.1.162:443 SYMANTEC_WEB_GATEWAY - Success: 'sinn3r:GoodPassword'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(symantec_web_gateway_login) >
```
- [ ] Try a bad credential against Symantec Web Gateway like the following demo (you should get a failed login):

```
msf auxiliary(symantec_web_gateway_login) > set password BadPassword
password => BadPassword
msf auxiliary(symantec_web_gateway_login) > run

[-] 192.168.1.162:443 SYMANTEC_WEB_GATEWAY - Failed: 'sinn3r:BadPassword'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(symantec_web_gateway_login) >
```
