### PR TITLE
Import Rex::Ui::Text::Table functionality

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -30,6 +30,19 @@ class Console::CommandDispatcher::Stdapi::Fs
   @@upload_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner." ],
     "-r" => [ false, "Upload recursively." ])
+  #
+  # Options for the ls command
+  #
+  @@ls_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner." ],
+    "-S" => [ true, "Search string." ],
+    "-t" => [ false, "Sort by time" ],
+    "-t" => [ false, "Sort by time" ],
+    "-s" => [ false, "Sort by size" ],
+    "-r" => [ false, "Reverse sort order" ],
+    "-x" => [ false, "Show short file names" ],
+    "-l" => [ false, "List in long format (default)" ],
+    "-R" => [ false, "Recursively list subdirectories encountered" ])
 
   #
   # List of supported commands.
@@ -223,22 +236,34 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   alias :cmd_del :cmd_rm
 
-        #
-        # Move source to destination
-        #
-        def cmd_mv(*args)
-                if (args.length < 2)
-                        print_line("Usage: mv oldfile newfile")
-                        return true
-                end
+  #
+  # Move source to destination
+  #
+  def cmd_mv(*args)
+    if (args.length < 2)
+      print_line("Usage: mv oldfile newfile")
+      return true
+    end
+    client.fs.file.mv(args[0],args[1])
+    return true
+  end
 
-                client.fs.file.mv(args[0],args[1])
-
-                return true
-        end
-
-        alias :cmd_move :cmd_mv
+  alias :cmd_move :cmd_mv
   alias :cmd_rename :cmd_mv
+
+  #
+  # Move source to destination
+  #
+  def cmd_cp(*args)
+    if (args.length < 2)
+      print_line("Usage: cp oldfile newfile")
+      return true
+    end
+    client.fs.file.cp(args[0],args[1])
+    return true
+  end
+
+  alias :cmd_copy :cmd_cp
 
 
   def cmd_download_help
@@ -387,7 +412,15 @@ class Console::CommandDispatcher::Stdapi::Fs
 
   alias cmd_getlwd cmd_lpwd
 
-  def list_path(path, columns, sort, order, short, recursive = false, depth = 0)
+
+  def cmd_ls_help
+    print_line "Usage: ls [options]"
+    print_line
+    print_line "Lists contents of directory or file info, searchable"
+    print_line @@ls_opts.usage
+  end
+
+  def list_path(path, columns, sort, order, short, recursive = false, depth = 0, search_term = nil)
 
     # avoid infinite recursion
     if depth > 100
@@ -398,7 +431,8 @@ class Console::CommandDispatcher::Stdapi::Fs
       'Header'  => "Listing: #{path}",
       'SortIndex' => columns.index(sort),
       'SortOrder' => order,
-      'Columns' => columns)
+      'Columns' => columns,
+      'SearchTerm' => search_term)
 
     items = 0
 
@@ -419,8 +453,10 @@ class Console::CommandDispatcher::Stdapi::Fs
       row.insert(4, p['FileShortName'] || '') if short
 
       if fname != '.' && fname != '..'
-        tbl << row
-        items += 1
+        if row.join(' ') =~ /#{search_term}/
+          tbl << row
+          items += 1
+        end
 
         if recursive && ffstat && ffstat.directory?
           if client.fs.file.is_glob?(path)
@@ -430,7 +466,7 @@ class Console::CommandDispatcher::Stdapi::Fs
             child_path = path + ::File::SEPARATOR + fname
           end
           begin
-            list_path(child_path, columns, sort, order, short, recursive, depth + 1)
+            list_path(child_path, columns, sort, order, short, recursive, depth + 1, search_term)
           rescue RequestError
           end
         end
@@ -448,39 +484,48 @@ class Console::CommandDispatcher::Stdapi::Fs
   # Lists files
   #
   def cmd_ls(*args)
+    # Set defaults
+    path = client.fs.dir.getwd
+    search_term = nil
+    sort = 'Name'
+    short = nil
+    order = :forward
+    recursive = nil
 
-    # Check sort column
-    sort = args.include?('-S') ? 'Size' : 'Name'
-    sort = args.include?('-t') ? 'Last modified' : sort
-    args.delete('-S')
-    args.delete('-t')
-
-    # Check whether to include the short name option
-    short = args.include?('-x')
-    args.delete('-x')
-
-    # Check sort order
-    order = args.include?('-r') ? :reverse : :forward
-    args.delete('-r')
-
-    # Check for recursive mode
-    recursive = !args.delete('-R').nil?
-
-    args.delete('-l')
-
-    # Check for cries of help
-    if args.length > 1 || args.any? { |a| a[0] == '-' }
-      print_line('Usage: ls [dir] [-x] [-S] [-t] [-r]')
-      print_line('   -x Show short file names')
-      print_line('   -S Sort by size')
-      print_line('   -t Sort by time modified')
-      print_line('   -r Reverse sort order')
-      print_line('   -l List in long format (default)')
-      print_line('   -R Recursively list subdirectories encountered.')
-      return true
-    end
-
-    path = args[0] || client.fs.dir.getwd
+    # Parse the args
+    @@ls_opts.parse(args) { |opt, idx, val|
+      case opt
+      # Sort options
+      when '-s'
+        sort = 'Size'
+      when '-t'
+        sort = 'Last modified'
+      # Output options
+      when '-x'
+        short = true
+      when '-l'
+        short = nil
+      when '-r'
+        order = :reverse
+      when '-R'
+        recursive = true
+      # Search
+      when '-S'
+        search_term = val
+        if search_term.nil?
+          print_error("Enter a search term")
+          return true
+        else
+          search_term = /#{search_term}/nmi
+        end
+      # Help and path
+      when "-h"
+        cmd_ls_help
+        return 0
+      when nil
+        path = val
+      end
+    }
 
     columns = [ 'Mode', 'Size', 'Type', 'Last modified', 'Name' ]
     columns.insert(4, 'Short Name') if short
@@ -499,7 +544,7 @@ class Console::CommandDispatcher::Stdapi::Fs
 
     stat = client.fs.file.stat(stat_path)
     if stat.directory?
-      list_path(path, columns, sort, order, short, recursive)
+      list_path(path, columns, sort, order, short, recursive, 0, search_term)
     else
       print_line("#{stat.prettymode}  #{stat.size}  #{stat.ftype[0,3]}  #{stat.mtime}  #{path}")
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -21,61 +21,61 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Options used by the 'execute' command.
   #
   @@execute_opts = Rex::Parser::Arguments.new(
-    "-a" => [ true,  "The arguments to pass to the command."                   ],
-    "-c" => [ false, "Channelized I/O (required for interaction)."             ],
-    "-f" => [ true,  "The executable command to run."                          ],
-    "-h" => [ false, "Help menu."                                              ],
-    "-H" => [ false, "Create the process hidden from view."                    ],
-    "-i" => [ false, "Interact with the process after creating it."            ],
-    "-m" => [ false, "Execute from memory."                                    ],
-    "-d" => [ true,  "The 'dummy' executable to launch when using -m."         ],
+    "-a" => [ true,  "The arguments to pass to the command."		   ],
+    "-c" => [ false, "Channelized I/O (required for interaction)."		   ],
+    "-f" => [ true,  "The executable command to run."			   ],
+    "-h" => [ false, "Help menu."						   ],
+    "-H" => [ false, "Create the process hidden from view."			   ],
+    "-i" => [ false, "Interact with the process after creating it."		   ],
+    "-m" => [ false, "Execute from memory."					   ],
+    "-d" => [ true,  "The 'dummy' executable to launch when using -m."	   ],
     "-t" => [ false, "Execute process with currently impersonated thread token"],
-    "-k" => [ false, "Execute process on the meterpreters current desktop"     ],
+    "-k" => [ false, "Execute process on the meterpreters current desktop"	   ],
     "-s" => [ true,  "Execute process in a given session as the session user"  ])
 
   #
   # Options used by the 'reboot' command.
   #
   @@reboot_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help menu."                                              ],
-    "-f" => [ true,  "Force a reboot, valid values [1|2]"                      ])
+    "-h" => [ false, "Help menu."						   ],
+    "-f" => [ true,  "Force a reboot, valid values [1|2]"			   ])
 
   #
   # Options used by the 'shutdown' command.
   #
   @@shutdown_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help menu."                                              ],
-    "-f" => [ true,  "Force a shutdown, valid values [1|2]"                    ])
+    "-h" => [ false, "Help menu."						   ],
+    "-f" => [ true,  "Force a shutdown, valid values [1|2]"			   ])
 
   #
   # Options used by the 'reg' command.
   #
   @@reg_opts = Rex::Parser::Arguments.new(
-    "-d" => [ true,  "The data to store in the registry value."                ],
-    "-h" => [ false, "Help menu."                                              ],
-    "-k" => [ true,  "The registry key path (E.g. HKLM\\Software\\Foo)."       ],
-    "-t" => [ true,  "The registry value type (E.g. REG_SZ)."                  ],
-    "-v" => [ true,  "The registry value name (E.g. Stuff)."                   ],
+    "-d" => [ true,  "The data to store in the registry value."		   ],
+    "-h" => [ false, "Help menu."						   ],
+    "-k" => [ true,  "The registry key path (E.g. HKLM\\Software\\Foo)."	   ],
+    "-t" => [ true,  "The registry value type (E.g. REG_SZ)."		   ],
+    "-v" => [ true,  "The registry value name (E.g. Stuff)."		   ],
     "-r" => [ true,  "The remote machine name to connect to (with current process credentials" ],
-    "-w" => [ false, "Set KEY_WOW64 flag, valid values [32|64]."               ])
+    "-w" => [ false, "Set KEY_WOW64 flag, valid values [32|64]."		   ])
 
   #
   # Options for the 'ps' command.
   #
   @@ps_opts = Rex::Parser::Arguments.new(
+    "-S" => [ true,  "String to search for (converts to regex)"                ],
     "-h" => [ false, "Help menu."                                              ],
-    "-S" => [ true,  "Filters processes on the process name using the supplied RegEx"],
-    "-A" => [ true,  "Filters processes on architecture (x86 or x86_64)"       ],
-    "-s" => [ false, "Show only SYSTEM processes"                              ],
+    "-A" => [ true,  "Filters processes on architecture (x86 or x86_64)"	   ],
+    "-s" => [ false, "Show only SYSTEM processes"				   ],
     "-U" => [ true,  "Filters processes on the user using the supplied RegEx"  ])
 
   #
   # Options for the 'suspend' command.
   #
   @@suspend_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help menu."                                              ],
+    "-h" => [ false, "Help menu."						   ],
     "-c" => [ false, "Continues suspending or resuming even if an error is encountered"],
-    "-r" => [ false, "Resumes the target processes instead of suspending"      ])
+    "-r" => [ false, "Resumes the target processes instead of suspending"	   ])
 
   #
   # List of supported commands.
@@ -93,7 +93,7 @@ class Console::CommandDispatcher::Stdapi::Sys
       "kill"        => "Terminate a process",
       "ps"          => "List running processes",
       "reboot"      => "Reboots the remote computer",
-      "reg"         => "Modify and interact with the remote registry",
+      "reg"	      => "Modify and interact with the remote registry",
       "rev2self"    => "Calls RevertToSelf() on the remote machine",
       "shell"       => "Drop into a system command shell",
       "shutdown"    => "Shuts down the remote computer",
@@ -105,7 +105,7 @@ class Console::CommandDispatcher::Stdapi::Sys
       "clearev"     => [ "stdapi_sys_eventlog_open", "stdapi_sys_eventlog_clear" ],
       "drop_token"  => [ "stdapi_sys_config_drop_token" ],
       "execute"     => [ "stdapi_sys_process_execute" ],
-      "getpid"      => [ "stdapi_sys_process_getpid"  ],
+      "getpid"      => [ "stdapi_sys_process_getpid"	],
       "getprivs"    => [ "stdapi_sys_config_getprivs" ],
       "getuid"      => [ "stdapi_sys_config_getuid" ],
       "getsid"      => [ "stdapi_sys_config_getsid" ],
@@ -113,7 +113,7 @@ class Console::CommandDispatcher::Stdapi::Sys
       "kill"        => [ "stdapi_sys_process_kill" ],
       "ps"          => [ "stdapi_sys_process_get_processes" ],
       "reboot"      => [ "stdapi_sys_power_exitwindows" ],
-      "reg"         => [
+      "reg"	      => [
         "stdapi_registry_load_key",
         "stdapi_registry_unload_key",
         "stdapi_registry_open_key",
@@ -169,7 +169,7 @@ class Console::CommandDispatcher::Stdapi::Sys
     interact    = false
     desktop     = false
     channelized = nil
-    hidden      = nil
+    hidden	    = nil
     from_mem    = false
     dummy_exec  = "cmd"
     cmd_args    = nil
@@ -422,23 +422,27 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Lists running processes.
   #
   def cmd_ps(*args)
+    # Init vars
     processes = client.sys.process.get_processes
-    @@ps_opts.parse(args) do |opt, idx, val|
+    search_term = nil
+
+    # Parse opts
+    @@ps_opts.parse(args) { |opt, idx, val|
       case opt
-      when "-h"
-        cmd_ps_help
-        return true
-      when "-S"
-        print_line "Filtering on process name..."
-        searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
-        processes.each do |proc|
-          if val.nil? or val.empty?
-            print_line "You must supply a search term!"
-            return false
+        when '-S'
+          search_term = val
+          if search_term.nil?
+            print_error("Enter a search term")
+            return true
           end
-          searched_procs << proc  if proc["name"].match(/#{val}/)
-        end
-        processes = searched_procs
+        when '-h'
+          print_line "Usage: ps [ options ]"
+          print_line
+          print_line "OPTIONS:"
+          print_line " -S       Search string to filter by"
+          print_line " -h 		This help menu"
+          print_line
+          return 0
       when "-A"
         print_line "Filtering on arch..."
         searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
@@ -448,14 +452,14 @@ class Console::CommandDispatcher::Stdapi::Sys
             print_line "You must select either x86 or x86_64"
             return false
           end
-          searched_procs << proc  if proc["arch"] == val
+          searched_procs << proc	if proc["arch"] == val
         end
         processes = searched_procs
       when "-s"
         print_line "Filtering on SYSTEM processes..."
         searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
         processes.each do |proc|
-          searched_procs << proc  if proc["user"] == "NT AUTHORITY\\SYSTEM"
+          searched_procs << proc	if proc["user"] == "NT AUTHORITY\\SYSTEM"
         end
         processes = searched_procs
       when "-U"
@@ -466,16 +470,48 @@ class Console::CommandDispatcher::Stdapi::Sys
             print_line "You must supply a search term!"
             return false
           end
-          searched_procs << proc  if proc["user"].match(/#{val}/)
+          searched_procs << proc	if proc["user"].match(/#{val}/)
         end
         processes = searched_procs
       end
-    end
+    }
+
+    tbl = Rex::Ui::Text::Table.new(
+      'Header'  => "Process list",
+      'Indent'  => 1,
+      'Columns' =>
+        [
+          "PID",
+          "Name",
+          "Arch",
+          "Session",
+          "User",
+          "Path"
+        ],
+      'SearchTerm' => search_term)
+
+    processes.each { |ent|
+
+      session = ent['session'] == 0xFFFFFFFF ? '' : ent['session'].to_s
+      arch    = ent['arch']
+
+      # for display and consistency with payload naming we switch the internal 'x86_64' value to display 'x64'
+      if( arch == ARCH_X86_64 )
+        arch = "x64"
+      end
+
+      row = [ ent['pid'].to_s, ent['name'], arch, session, ent['user'], ent['path'] ]
+
+      tbl << row #if (search_term.nil? or row.join(' ').to_s.match(search_term))
+
+
+    }
+
     if (processes.length == 0)
       print_line("No running processes were found.")
     else
       print_line
-      print_line(processes.to_table("Indent" => 1).to_s)
+      print("\n" + tbl.to_s + "\n")
       print_line
     end
     return true
@@ -529,12 +565,12 @@ class Console::CommandDispatcher::Stdapi::Sys
     end
 
     # Initiailze vars
-    key     = nil
-    value   = nil
-    data    = nil
-    type    = nil
+    key	= nil
+    value	= nil
+    data	= nil
+    type	= nil
     wowflag = 0x0000
-    rem     = nil
+    rem	= nil
 
     @@reg_opts.parse(args) { |opt, idx, val|
       case opt
@@ -544,13 +580,13 @@ class Console::CommandDispatcher::Stdapi::Sys
             "Interact with the target machine's registry.\n" +
             @@reg_opts.usage +
             "COMMANDS:\n\n" +
-            "    enumkey    Enumerate the supplied registry key [-k <key>]\n" +
-            "    createkey  Create the supplied registry key  [-k <key>]\n" +
-            "    deletekey  Delete the supplied registry key  [-k <key>]\n" +
+            "    enumkey	Enumerate the supplied registry key [-k <key>]\n" +
+            "    createkey	Create the supplied registry key  [-k <key>]\n" +
+            "    deletekey	Delete the supplied registry key  [-k <key>]\n" +
             "    queryclass Queries the class of the supplied key [-k <key>]\n" +
-            "    setval     Set a registry value [-k <key> -v <val> -d <data>]\n" +
-            "    deleteval  Delete the supplied registry value [-k <key> -v <val>]\n" +
-            "    queryval   Queries the data contents of a value [-k <key> -v <val>]\n\n")
+            "    setval	Set a registry value [-k <key> -v <val> -d <data>]\n" +
+            "    deleteval	Delete the supplied registry value [-k <key> -v <val>]\n" +
+            "    queryval	Queries the data contents of a value [-k <key> -v <val>]\n\n")
           return false
         when "-k"
           key   = val
@@ -672,7 +708,7 @@ class Console::CommandDispatcher::Stdapi::Sys
 
           open_key.set_value(value, client.sys.registry.type2str(type), data)
 
-          print_line("Successful set #{value}.")
+          print_line("Successfully set #{value} of #{type}.")
 
         when "deleteval"
           if (value == nil)
@@ -859,11 +895,11 @@ class Console::CommandDispatcher::Stdapi::Sys
     args.uniq!
     diff = args - valid_pids.map {|e| e.to_s}
     if not diff.empty? # then we had an invalid pid
-      print_error("The following pids are not valid:  #{diff.join(", ").to_s}.")
+      print_error("The following pids are not valid:	#{diff.join(", ").to_s}.")
       if continue
         print_status("Continuing.  Invalid args have been removed from the list.")
       else
-        print_error("Quitting.  Use -c to continue using only the valid pids.")
+        print_error("Quitting.	Use -c to continue using only the valid pids.")
         return false
       end
     end
@@ -912,4 +948,3 @@ end
 end
 end
 end
-

--- a/lib/rex/ui/text/table.rb
+++ b/lib/rex/ui/text/table.rb
@@ -72,6 +72,7 @@ class Table
     self.prefix   = opts['Prefix']  || ''
     self.postfix  = opts['Postfix'] || ''
     self.colprops = []
+    self.scterm  = opts['SearchTerm'] ? /#{opts['SearchTerm']}/mi : /./
 
     self.sort_index  = opts['SortIndex'] || 0
     self.sort_order  = opts['SortOrder'] || :forward
@@ -113,7 +114,7 @@ class Table
       if (is_hr(row))
         str << hr_to_s
       else
-        str << row_to_s(row)
+        str << row_to_s(row) if row_to_s(row).match(self.scterm)
       end
     }
 
@@ -129,7 +130,7 @@ class Table
     str = ''
     str << ( columns.join(",") + "\n" )
     rows.each { |row|
-      next if is_hr(row)
+      next if is_hr(row) or !(row_to_s(row).match(self.scterm))
       str << ( row.map{|x|
         x = x.to_s
 
@@ -175,7 +176,10 @@ class Table
       raise RuntimeError, 'Invalid number of columns!'
     end
     fields.each_with_index { |field, idx|
+      # Remove whitespace and ensure String format
+      field = field.to_s.strip
       if (colprops[idx]['MaxWidth'] < field.to_s.length)
+        old = colprops[idx]['MaxWidth']
         colprops[idx]['MaxWidth'] = field.to_s.length
       end
     }
@@ -217,6 +221,51 @@ class Table
   #
   # Returns new sub-table with headers and rows maching column names submitted
   #
+  #
+  # Flips table 90 degrees left
+  #
+  def drop_left
+    tbl = self.class.new(
+      'Columns' => Array.new(self.rows.count+1,'  '),
+      'Header' => self.header,
+      'Indent' => self.indent)
+    (self.columns.count+1).times do |ti|
+      row = self.rows.map {|r| r[ti]}.unshift(self.columns[ti]).flatten
+      # insert our col|row break. kind of hackish
+      row[1] = "| #{row[1]}" unless row.all? {|e| e.nil? || e.empty?}
+      tbl << row
+    end
+    return tbl
+  end
+
+  #
+  # Build table from CSV dump
+  #
+  def self.new_from_csv(csv)
+    # Read in or keep data, get CSV or die
+    if csv.is_a?(String)
+      csv = File.file?(csv) ? CSV.read(csv) : CSV.parse(csv)
+    end
+    # Adjust for skew
+    if csv.first == ["Keys", "Values"]
+      csv.shift # drop marker
+      cols = []
+      rows = []
+      csv.each do |row|
+        cols << row.shift
+        rows << row
+      end
+      tbl = self.new('Columns' => cols)
+      rows.in_groups_of(cols.count) {|r| tbl << r.flatten}
+    else
+      tbl = self.new('Columns' => csv.shift)
+      while !csv.empty? do
+        tbl << csv.shift
+      end
+    end
+    return tbl
+  end
+
   def [](*col_names)
     tbl = self.class.new('Indent' => self.indent,
                          'Header' => self.header,
@@ -245,7 +294,7 @@ class Table
   attr_accessor :columns, :rows, :colprops # :nodoc:
   attr_accessor :width, :indent, :cellpad # :nodoc:
   attr_accessor :prefix, :postfix # :nodoc:
-  attr_accessor :sort_index, :sort_order # :nodoc:
+  attr_accessor :sort_index, :sort_order, :scterm # :nodoc:
 
 protected
 
@@ -274,14 +323,17 @@ protected
     last_idx = nil
     columns.each_with_index { |col,idx|
       if (last_col)
-        nameline << pad(' ', last_col, last_idx)
-
-        remainder = colprops[last_idx]['MaxWidth'] - last_col.length
-        if (remainder < 0)
-          remainder = 0
-        end
+        # This produces clean to_s output without truncation
+        # Preserves full string in cells for to_csv output
+        padding = pad(' ', last_col, last_idx)
+        nameline << padding
+        remainder = padding.length - cellpad
+      if (remainder < 0)
+        remainder = 0
+      end
         barline << (' ' * (cellpad + remainder))
       end
+
       nameline << col
       barline << ('-' * col.length)
 
@@ -307,13 +359,13 @@ protected
     last_cell = nil
     last_idx = nil
     row.each_with_index { |cell, idx|
-      if (idx != 0)
+      if (last_cell)
         line << pad(' ', last_cell.to_s, last_idx)
       end
       # line << pad(' ', cell.to_s, idx)
       # Limit wide cells
       if colprops[idx]['MaxChar']
-        last_cell = cell.to_s[0..colprops[idx]['MaxChar'].to_i]
+        last_cell = cell.to_s[0..colprops[idx]['MaxChar'].to_i]# - 1]
         line << last_cell
       else
         line << cell.to_s
@@ -330,13 +382,17 @@ protected
   # some text and a column index.
   #
   def pad(chr, buf, colidx, use_cell_pad = true) # :nodoc:
-    remainder = colprops[colidx]['MaxWidth'] - buf.length
-    val       = chr * remainder;
+    # Ensure we pad the minimum required amount
+    max = colprops[colidx]['MaxChar'] || colprops[colidx]['MaxWidth']
+    max = colprops[colidx]['MaxWidth'] if max.to_i > colprops[colidx]['MaxWidth'].to_i
+    remainder = max - buf.length
+    remainder = 0 if remainder < 0
+    val       = chr * remainder
 
     if (use_cell_pad)
       val << ' ' * cellpad
     end
-
+    
     return val
   end
 


### PR DESCRIPTION
Squash historical commits and merge/updates:

---

Allow passing MaxChar to Rex::Ui::Text::Table cols

Passing MaxChar allows setting the maximum number of characters
printed within a specific column during the row_to_s method.
This does not affect CSV output nor truncate the actual data.
Meant for tidying up long console ouput.

Example: cleaned up 'cmd_creds' to show proof and not maul tables
with unix session data.

---

Add MaxChar to tbl.row.cell.to_s

ColProps will now take a 'col_name' => { 'MaxChar' => 64 } which
only affects row.to_s.
cmd_creds without -S will now limit pass and proof to 64 char.

---

Create Rex Tables from CSV

---

Rex::Text::Ui::Table.new[find_by_colnames]

Add :[] to ...Ui::Table allowing user to pass multiple colnames.
Returns a new table with only those columns and their rows.

Useful when using Rex to filter output, prep CSV, etc.

Testing:

```
t = Rex::Ui::Text::Table.new('Columns' => ['a','b','c'])
t << ['x','y','z']
t << ['p','q','r']
t['a','c']

=> a  c
-  -
p  r
x  z
```

---

Allow Internal Filtering by SearchTerm

Allow passing 'SearchTerm' into Rex::Ui::Text::Table creation to
filter all output by regex match to the string passed.
Provides base functionality for higher level subscribers such as
cmd_ls in meterpreter sessions for filtering output

---

Import fs.rb

Merge forked changes to cmd_ls allowing for the use of string
matching on listing output via Rex::Ui::Text::Table's SearchTerm
facility.

Example:

```
meterpreter > ls chef -R -S wget
No entries exist in chef/backup/chef/handlers
No entries exist in chef/backup/chef/ohai_plugins
No entries exist in chef/backup/chef
No entries exist in chef/backup
No entries exist in chef/cache/cookbooks/avast/attributes
No entries exist in chef/cache/cookbooks/avast/recipes
No entries exist in chef/cache/cookbooks/avast
No entries exist in chef/cache/cookbooks/chef-client/attributes
No entries exist in chef/cache/cookbooks/chef-client/libraries
No entries exist in chef/cache/cookbooks/chef-client/recipes
No entries exist in chef/cache/cookbooks/chef-client
No entries exist in chef/cache/cookbooks/chef_handler/attributes
No entries exist in chef/cache/cookbooks/chef_handler/libraries
No entries exist in chef/cache/cookbooks/chef_handler/providers
No entries exist in chef/cache/cookbooks/chef_handler/recipes
No entries exist in chef/cache/cookbooks/chef_handler/resources
No entries exist in chef/cache/cookbooks/chef_handler
No entries exist in chef/cache/cookbooks/cron/providers
No entries exist in chef/cache/cookbooks/cron/recipes
No entries exist in chef/cache/cookbooks/cron/resources
No entries exist in chef/cache/cookbooks/cron
No entries exist in chef/cache/cookbooks/logrotate/attributes
No entries exist in chef/cache/cookbooks/logrotate/definitions
No entries exist in chef/cache/cookbooks/logrotate/libraries
No entries exist in chef/cache/cookbooks/logrotate/recipes
No entries exist in chef/cache/cookbooks/logrotate
No entries exist in chef/cache/cookbooks/ohai/attributes
No entries exist in chef/cache/cookbooks/ohai/files/default/plugins
No entries exist in chef/cache/cookbooks/ohai/files/default
No entries exist in chef/cache/cookbooks/ohai/files
No entries exist in chef/cache/cookbooks/ohai/recipes
No entries exist in chef/cache/cookbooks/ohai
No entries exist in chef/cache/cookbooks/svit-windows/attributes
No entries exist in chef/cache/cookbooks/svit-windows/recipes
No entries exist in chef/cache/cookbooks/svit-windows/templates/default/plugins
No entries exist in chef/cache/cookbooks/svit-windows/templates/default
No entries exist in chef/cache/cookbooks/svit-windows/templates
No entries exist in chef/cache/cookbooks/svit-windows
No entries exist in chef/cache/cookbooks/windows/attributes
No entries exist in chef/cache/cookbooks/windows/files/default/handlers
No entries exist in chef/cache/cookbooks/windows/files/default
No entries exist in chef/cache/cookbooks/windows/files
No entries exist in chef/cache/cookbooks/windows/libraries
No entries exist in chef/cache/cookbooks/windows/providers
No entries exist in chef/cache/cookbooks/windows/recipes
No entries exist in chef/cache/cookbooks/windows/resources
No entries exist in chef/cache/cookbooks/windows
No entries exist in chef/cache/cookbooks
No entries exist in chef/cache
No entries exist in chef/handlers
No entries exist in chef/log
No entries exist in chef/ohai_plugins
No entries exist in chef/run
Listing: chef
=============

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  161   fil   2014-07-21 11:08:26 -0400  wget.ps1
100666/rw-rw-rw-  1285  fil   2014-07-21 11:08:26 -0400  wget.vbs

meterpreter >
```

---

Import sys.rb

Merge forked changes to cmd_ps allowing for the use of string
matching on listing output via Rex::Ui::Text::Table's SearchTerm
facility

Example:

```
meterpreter > ps -S x64.*Auth.*Sys

Process list
============

 PID   Name                       Arch  Session  User                          Path
 ---   ----                       ----  -------  ----                          ----
 400   smss.exe                   x64   0        NT AUTHORITY\SYSTEM           C:\Windows\System32\smss.exe
...
```
