### PR TITLE
Resolve #5343, Print payload size

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -276,12 +276,15 @@ module Msf
     # @return [String] A string containing the bytes of the payload in the format selected
     def generate_payload
       if platform == "java" or arch == "java" or payload.start_with? "java/"
-        generate_java_payload
+        p = generate_java_payload
+        cli_print "Payload size: #{p.length} bytes"
+        p
       else
         raw_payload = generate_raw_payload
         raw_payload = add_shellcode(raw_payload)
         encoded_payload = encode_payload(raw_payload)
         encoded_payload = prepend_nops(encoded_payload)
+        cli_print "Payload size: #{encoded_payload.length} bytes"
         format_payload(encoded_payload)
       end
     end

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -606,7 +606,7 @@ describe Msf::PayloadGenerator do
       }
 
       it 'calls generate_java_payload' do
-        payload_generator.should_receive(:generate_java_payload)
+        payload_generator.should_receive(:generate_java_payload).and_call_original
         payload_generator.generate_payload
       end
     end


### PR DESCRIPTION
Resolve #5343. Prints payload size
## Testing:
- [ ] Do: `./msfvenom -p windows/meterpreter/reverse_tcp -f raw |wc -c`
- [ ] Both should say the payload size
- [ ] Do: `./msfvenom -p windows/meterpreter/reverse_tcp -f js_le |wc -c`
- [ ] Payload size should be smaller than whatever wc says
- [ ] Do: `./msfvenom -p java/meterpreter/reverse_tcp -f raw -o /tmp/test.jar`
- [ ] The payload size should be the same as the jar file
