### PR TITLE
Remove stray comma causing help to be incorrect

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -81,7 +81,7 @@ class Console::CommandDispatcher::Core
       c["migrate"] = "Migrate the server to another process"
 
       # UUID functionality isn't yet available on other platforms
-      c["uuid"] = "Get the UUID for the current session",
+      c["uuid"] = "Get the UUID for the current session"
 
       # Yet to implement transport hopping for other meterpreters.
       # Works for posix and native windows though.


### PR DESCRIPTION
This comma was causing meterpreter's help to come out like this:

```
meterpreter > help

Core Commands
=============

    Command                   Description
    -------                   -----------
... snip ...
    transport                 Change the current transport mechanism
    use                       Deprecated alias for 'load'
    uuid                      ["Get the UUID for the current session", "Change the current transport mechanism"]
    write                     Writes data to a channel
```

Removing it changes the help so that it does this instead:

```
meterpreter > help

Core Commands
=============

    Command                   Description
    -------                   -----------
... snip ...
    transport                 Change the current transport mechanism
    use                       Deprecated alias for 'load'
    uuid                      Get the UUID for the current session
    write                     Writes data to a channel
```
## Verification
- [ ] Help doesn't look stupid any more

Thanks to @mubix for reporting.
