### PR TITLE
Configure transport from stager mixin (fix RC4 stagers)

### DIFF
--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -31,8 +31,16 @@ module Msf::Payload::Stager
   # Override this in stages/stagers to use specific transports
   #
   def transport_config(opts={})
-    transport_name = "transport_config_#{self.refname =~ /reverse_/ ? 'reverse' : 'bind'}" +
-      "_#{self.refname =~ /_tcp/ ? 'tcp' : 'http'}"
+    direction = self.refname =~ /reverse_/ ? 'reverse' : 'bind'
+    transport = case self.refname
+    when /_tcp/
+      'tcp'
+    when /_https/
+      'https'
+    else
+      'http'
+    end
+    transport_name = "transport_config_#{direction}_#{transport}"
     send(transport_name.to_sym,opts)
   end 
 

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 require 'msf/core'
 require 'msf/core/option_container'
+require 'msf/core/payload/transport_config'
 
 ###
 #
@@ -8,6 +9,8 @@ require 'msf/core/option_container'
 #
 ###
 module Msf::Payload::Stager
+
+  include Msf::Payload::TransportConfig
 
   def initialize(info={})
     super
@@ -21,6 +24,17 @@ module Msf::Payload::Stager
       ], Msf::Payload::Stager)
 
   end
+
+  #
+  # Perform attempt at detecting the appropriate transport config.
+  # Call the determined config with passed options.
+  # Override this in stages/stagers to use specific transports
+  #
+  def transport_config(opts={})
+    transport_name = "transport_config_#{self.refname =~ /reverse_/ ? 'reverse' : 'bind'}" +
+      "_#{self.refname =~ /_tcp/ ? 'tcp' : 'http'}"
+    send(transport_name.to_sym,opts)
+  end 
 
   #
   # Sets the payload type to a stager.


### PR DESCRIPTION
Transport configuration for basic session types can be performed
by the stager mixin.

Add a default transport_config method to Msf::Payload::Stager by
mixing in Msf::Payload::TransportConfig and attempting to guess
the default transport and direction types from the currently loaded
module's (MSF module) refname.

Users with custom payloads will no longer need to update them with
transport_config methods unless they use a non standard transport,
direction, or other innovation which affects the default approach.

Testing:
  Tested with payloads lacking transport_config methods or access
to the TransportConfig module (Ruby) namespace. This also resolves
problems with the RC4 payloads in upstream as they can't currently
generate stagers for meterpreter.
