### PR TITLE
Remove check for UUID in the valid session check

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -307,7 +307,9 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
     begin
       self.machine_id = self.core.machine_id(timeout)
-      self.payload_uuid ||= self.core.uuid(timeout)
+      # This is causing breakages thanks to Meterpeter not doing what it should
+      # be doing with the uuid.
+      #self.payload_uuid ||= self.core.uuid(timeout)
 
       return true
     rescue ::Rex::Post::Meterpreter::RequestError


### PR DESCRIPTION
Meterpreter's current UUID functionality is broken, because it assumes that the content is a string. This is blatantly wrong because the UUID is just a series of bytes. If the bytes happen to contain a NULL, then Meterpreter returns a UUID that isn't long enough. MSF will fail to convert these bytes into a valid UUID, resulting in the session validity check failing.

Removing this line, in the short term, resolves this issue. I'm working on a proper fix so that meterpreter does what it should do properly, at which point this line will make a new appearance.

So sorry :(
