### PR TITLE
HTTP Title Grabber (Notes bugfix)

### DIFF
--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -45,8 +45,8 @@ class Metasploit3 < Msf::Auxiliary
     begin
         # Send a normal GET request
         res = send_request_cgi(
-          'uri': '/',
-          'method': 'GET'
+          uri: '/',
+          method: 'GET'
         )
 
         # If no response, quit now
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Auxiliary
           print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
           if datastore['STORE_NOTES'] == true
             notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header }
-            report_note(host: target_host, type: "http.title", data: notedata)
+            report_note(host: target_host, port: rport, type: "http.title", data: notedata, unique: :unique_data)
           end
         else
           print_error("[#{target_host}:#{rport}] No webpage title") if datastore['SHOW_ERRORS'] == true


### PR DESCRIPTION
This is a really small bugfix for the title module.
Apparently, the 'notes' module defaults to unique insertion mode, which gives rise to the problem of overlapping hosts. For example, if you ran the title grabber on 127.0.0.1: 80 and then reran it on 127.0.0.1:443 and the titles were different, the port 443 note would overwrite the port 80 note. 

This simple change just adds unique: :unique_data to ensure that titles from multiple servers on the same IP are preserved.
