### PR TITLE
Bug/5266/snmp issues

### DIFF
--- a/lib/metasploit/framework/credential.rb
+++ b/lib/metasploit/framework/credential.rb
@@ -75,8 +75,10 @@ module Metasploit
       def to_s
         if realm && realm_key == Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
           "#{self.realm}\\#{self.public}:#{self.private}"
-        else
+        elsif self.private
           "#{self.public}:#{self.private}#{at_realm}"
+        else
+          self.public
         end
       end
 

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -566,7 +566,6 @@ module Auxiliary::AuthBrute
     else
       level = opts[:level].to_s.strip
     end
-
     host_ip = opts[:ip] || opts[:rhost] || opts[:host] || (rhost rescue nil) || datastore['RHOST']
     host_port = opts[:port] || opts[:rport] || (rport rescue nil) || datastore['RPORT']
     msg = opts[:msg] || opts[:message] || opts[:legacy_msg]

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -12,10 +12,19 @@ module Auxiliary::Report
 
   optionally_include_metasploit_credential_creation
 
+  def db_warning_given?
+    if @warning_issued
+      true
+    else
+      @warning_issued = true
+      false
+    end
+  end
+
   def create_cracked_credential(opts={})
     if active_db?
       super(opts)
-    else
+    elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
     end
   end
@@ -23,7 +32,7 @@ module Auxiliary::Report
   def create_credential(opts={})
     if active_db?
       super(opts)
-    else
+    elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
     end
   end
@@ -31,7 +40,7 @@ module Auxiliary::Report
   def create_credential_login(opts={})
     if active_db?
       super(opts)
-    else
+    elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
     end
   end
@@ -39,7 +48,7 @@ module Auxiliary::Report
   def invalidate_login(opts={})
     if active_db?
       super(opts)
-    else
+    elsif !db_warning_given?
       vprint_warning('No active DB -- Credential data will not be saved!')
     end
   end

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
           print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential} (Access level: #{result.access_level})"
         else
           invalidate_login(credential_data)
-          vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+          vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
         end
       end
     end

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
           print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential} (Access level: #{result.access_level})"
         else
           invalidate_login(credential_data)
-          vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+          print_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
         end
       end
     end


### PR DESCRIPTION
This PR addresses a few of the bugs reported in https://github.com/rapid7/metasploit-framework/issues/5266

VERIFICATION STEPS
- [x] run msfconsole without a db
- [x] `use auxiliary/scanner/snmp/snmp_login`
- [x] create a PASS_FILE with several community strings to try. make sure the first one isn't valid
- [x] target an SNMP host
- [x] `set VERBOSE true`
- [x] `run`
- [x] VERIFY their is no longer trailing `:` after the community string in the messages
- [x] VERIFY you only see `[!] No active DB -- Credential data will not be saved!` once
- [x] VERIFY you don't get a trailing `:` after `Incorrect` on the failure messages
- [x] VERIFY the ip address is not missing from the front of the failure messages
