### PR TITLE
Implements msfvenom --smallest

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -375,7 +375,7 @@ module Msf
           e.datastore.import_options_from_hash(datastore)
           encoders << e if e
         end
-        encoders.sort_by { |my_encoder| my_encoder.rank }.reverse
+        encoders.select{ |my_encoder| my_encoder.rank != ManualRanking }.sort_by { |my_encoder| my_encoder.rank }.reverse
       else
         encoders
       end

--- a/modules/encoders/cmd/echo.rb
+++ b/modules/encoders/cmd/echo.rb
@@ -34,12 +34,12 @@ class Metasploit3 < Msf::Encoder
     end
 
     if state.badchars.include?("-")
-      raise RuntimeError
+      raise EncodingError
     else
       # Without an escape character we can't escape anything, so echo
       # won't work.
       if state.badchars.include?("\\")
-        raise RuntimeError
+        raise EncodingError
       else
         buf = encode_block_bash_echo(state,buf)
       end
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Encoder
       if state.badchars.include?("`")
         # Last ditch effort, dollar paren
         if state.badchars.include?("$") or state.badchars.include?("(")
-          raise RuntimeError
+          raise EncodingError
         else
           buf = "$(/bin/echo -ne #{hex})"
         end

--- a/modules/encoders/cmd/generic_sh.rb
+++ b/modules/encoders/cmd/generic_sh.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Encoder
     state.badchars.unpack('C*') { |c| qot.delete(c.chr) }
 
     # Throw an error if we ran out of quotes
-    raise RuntimeError if qot.length == 0
+    raise EncodingError if qot.length == 0
 
     sep = qot[0].chr
 
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Encoder
       if (state.badchars.match(/\(|\)/))
 
         # No paranthesis...
-        raise RuntimeError
+        raise EncodingError
       end
 
       cmd << "system\\(pack\\(qq#{sep}H\\*#{sep},qq#{sep}#{hex}#{sep}\\)\\)"
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Encoder
       if (state.badchars.match(/\(|\)/))
         if (state.badchars.include?(" "))
           # No spaces allowed, no paranthesis, give up...
-          raise RuntimeError
+          raise EncodingError
         end
 
         cmd << "'system pack qq#{sep}H*#{sep},qq#{sep}#{hex}#{sep}'"
@@ -124,7 +124,7 @@ class Metasploit3 < Msf::Encoder
       if (state.badchars.include?("`"))
         # Last ditch effort, dollar paren
         if (state.badchars.include?("$") or state.badchars.include?("("))
-          raise RuntimeError
+          raise EncodingError
         else
           buf = "$(/bin/echo -ne #{hex})"
         end

--- a/modules/encoders/cmd/perl.rb
+++ b/modules/encoders/cmd/perl.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Encoder
     end
 
     if state.badchars.include?("-")
-      raise RuntimeError
+      raise EncodingError
     else
       buf = encode_block_perl(state,buf)
     end
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Encoder
     # Convert spaces to IFS...
     if state.badchars.include?(" ")
       if state.badchars.match(/[${IFS}]/n)
-        raise RuntimeError
+        raise EncodingError
       end
       cmd.gsub!(/\s/, '${IFS}')
     end
@@ -118,7 +118,7 @@ class Metasploit3 < Msf::Encoder
     state.badchars.unpack('C*') { |c| qot.delete(c.chr) }
 
     # Throw an error if we ran out of quotes
-    raise RuntimeError if qot.length == 0
+    raise EncodingError if qot.length == 0
 
     sep = qot[0].chr
     # Use an explicit length for the H specifier instead of just "H*"

--- a/modules/encoders/cmd/printf_php_mq.rb
+++ b/modules/encoders/cmd/printf_php_mq.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Encoder
       (state.badchars.include?("|")) or
       # We must have at least ONE of these two..
       (state.badchars.include?("x") and state.badchars.include?("0"))
-      raise RuntimeError
+      raise EncodingError
     end
 
     # Now we build a string of the original payload with bad characters

--- a/modules/encoders/mipsbe/byte_xori.rb
+++ b/modules/encoders/mipsbe/byte_xori.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Encoder::Xor
     # add 4 number of passes  for the space reserved for the key, at the end of the decoder stub
     # (see commented source)
     number_of_passes=state.buf.length+4
-    raise InvalidPayloadSizeException.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
+    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
 
     # 16-bits not (again, see also commented source)
     reg_14 = (number_of_passes+1)^0xFFFF

--- a/modules/encoders/mipsbe/longxor.rb
+++ b/modules/encoders/mipsbe/longxor.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Encoder::Xor
 
     # add one xor operation for the key (see comment below)
     number_of_passes=state.buf.length/4+1
-    raise InvalidPayloadSizeException.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 10240
-    raise InvalidPayloadSizeException.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
+    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 10240
+    raise EncodingError.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
 
     # 16-bits not (again, see below)
     reg_14 = (number_of_passes+1)^0xFFFF

--- a/modules/encoders/mipsle/byte_xori.rb
+++ b/modules/encoders/mipsle/byte_xori.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Encoder::Xor
     # add 4 number of passes  for the space reserved for the key, at the end of the decoder stub
     # (see commented source)
     number_of_passes=state.buf.length+4
-    raise InvalidPayloadSizeException.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
+    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 32766
 
     # 16-bits not (again, see also commented source)
     reg_14 = (number_of_passes+1)^0xFFFF

--- a/modules/encoders/mipsle/longxor.rb
+++ b/modules/encoders/mipsle/longxor.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Encoder::Xor
 
     # add one xor operation for the key (see comment below)
     number_of_passes=state.buf.length/4+1
-    raise InvalidPayloadSizeException.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 10240
-    raise InvalidPayloadSizeException.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
+    raise EncodingError.new("The payload being encoded is too long (#{state.buf.length} bytes)") if number_of_passes > 10240
+    raise EncodingError.new("The payload is not padded to 4-bytes (#{state.buf.length} bytes)") if state.buf.length%4 != 0
 
     # 16-bits not (again, see below)
     reg_14 = (number_of_passes+1)^0xFFFF

--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Encoder
     # Have to have these for the decoder stub, so if they're not available,
     # there's nothing we can do here.
     ["(",")",".","_","c","h","r","e","v","a","l","b","s","6","4","d","o"].each do |c|
-      raise EncodeError if state.badchars.include?(c)
+      raise BadcharError if state.badchars.include?(c)
     end
 
     # PHP escapes quotes by default with magic_quotes_gpc, so we use some

--- a/modules/encoders/x86/add_sub.rb
+++ b/modules/encoders/x86/add_sub.rb
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Encoder
     @inst = {}
     @set = add_or_sub(@avchars)
     if @set == 0 then
-      raise RuntimeError, "Bad character list includes essential characters."
+      raise EncodingError, "Bad character list includes essential characters."
       exit
     elsif @set == 1 then #add
       @inst["opcode"] = 0x05
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Encoder
     @inst["push_esp"] = 0x54
     @inst["pop_esp"] = 0x5c
     if state.buf.size%4 != 0 then
-      raise RuntimeError, "Shellcode size must be divisible by 4, try nop padding."
+      raise EncodingError, "Shellcode size must be divisible by 4, try nop padding."
       exit
     end
     #init

--- a/modules/encoders/x86/alpha_mixed.rb
+++ b/modules/encoders/x86/alpha_mixed.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
       else
         res = Rex::Arch::X86.geteip_fpu(state.badchars)
         if (not res)
-          raise RuntimeError, "Unable to generate geteip code"
+          raise EncodingError, "Unable to generate geteip code"
         end
       buf, reg, off = res
       end

--- a/modules/encoders/x86/alpha_upper.rb
+++ b/modules/encoders/x86/alpha_upper.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
       else
         res = Rex::Arch::X86.geteip_fpu(state.badchars)
         if (not res)
-          raise RuntimeError, "Unable to generate geteip code"
+          raise EncodingError, "Unable to generate geteip code"
         end
       buf, reg, off = res
       end

--- a/modules/encoders/x86/avoid_utf8_tolower.rb
+++ b/modules/encoders/x86/avoid_utf8_tolower.rb
@@ -90,20 +90,6 @@ require 'msf/core'
 #
 class Metasploit3 < Msf::Encoder
 
-  #
-  # In some cases, payloads can be an invalid size that is incompatible with
-  # this encoder
-  #
-  class InvalidPayloadSizeException < ::Exception
-    def initialize(msg)
-      @msg = msg
-    end
-
-    def to_s
-      @msg
-    end
-  end
-
   # This encoder has a manual ranking because it should only be used in cases
   # where information has been explicitly supplied, like the BufferOffset.
   Rank = ManualRanking
@@ -136,7 +122,7 @@ class Metasploit3 < Msf::Encoder
 
     # Check to make sure that the length is a valid size
     if is_badchar(state, len)
-      raise InvalidPayloadSizeException.new("The payload being encoded is of an incompatible size (#{len} bytes)")
+      raise EncodingError.new("The payload being encoded is of an incompatible size (#{len} bytes)")
     end
 
     decoder =

--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -161,11 +161,11 @@ class Metasploit3 < Msf::Encoder
 
     # determine if we have any invalid characters that we rely on.
     unless all_bytes_valid
-      raise RuntimeError, "Bad character set contains characters that are required for this encoder to function."
+      raise EncodingError, "Bad character set contains characters that are required for this encoder to function."
     end
 
     unless @asm['PUSH'][@base_reg]
-      raise RuntimeError, "Invalid base register"
+      raise EncodingError, "Invalid base register"
     end
 
     # get the offset from the specified base register, or default to zero if not specifed
@@ -176,7 +176,7 @@ class Metasploit3 < Msf::Encoder
 
     # if we can't then we bomb, because we know we need to clear out EAX at least once
     unless @clear1
-      raise RuntimeError, "Unable to find AND-able chars resulting 0 in the valid character set."
+      raise EncodingError, "Unable to find AND-able chars resulting 0 in the valid character set."
     end
 
     protect_payload = (datastore['OverwriteProtect'] || "").downcase == "true"
@@ -288,7 +288,7 @@ class Metasploit3 < Msf::Encoder
     # Write out a stubbed placeholder for the offset instruction based on
     # the base register, we'll update this later on when we know how big our payload is.
     encoded, _ = sub_3(0, 0)
-    raise RuntimeError, "Couldn't offset base register." if encoded.nil?
+    raise EncodingError, "Couldn't offset base register." if encoded.nil?
     data << create_sub(encoded)
 
     # finally push the value of EAX back into ESP
@@ -312,7 +312,7 @@ class Metasploit3 < Msf::Encoder
       end
 
       # if we're still nil here, then we have an issue
-      raise RuntimeError, "Couldn't encode payload" if encoded.nil?
+      raise EncodingError, "Couldn't encode payload" if encoded.nil?
 
       data << create_sub(encoded)
     end
@@ -324,7 +324,7 @@ class Metasploit3 < Msf::Encoder
     encoded, _ = sub_3(total_offset, 0)
 
     # if we're still nil here, then we have an issue
-    raise RuntimeError, "Couldn't encode protection" if encoded.nil?
+    raise EncodingError, "Couldn't encode protection" if encoded.nil?
     patch = create_sub(encoded)
 
     # patch in the correct offset back at the start of our payload

--- a/modules/encoders/x86/shikata_ga_nai.rb
+++ b/modules/encoders/x86/shikata_ga_nai.rb
@@ -281,7 +281,7 @@ protected
     begin
       # Generate a permutation saving the ECX, ESP, and user defined registers
       loop_inst.generate(block_generator_register_blacklist, nil, state.badchars)
-    rescue RuntimeError => e
+    rescue EncodingError => e
       raise EncodingError
     end
   end

--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
     reg    = datastore['BufferRegister']
     offset = datastore['BufferOffset'].to_i || 0
     if (not reg)
-      raise RuntimeError, "Need BufferRegister"
+      raise EncodingError, "Need BufferRegister"
     end
     Rex::Encoder::Alpha2::UnicodeMixed::gen_decoder(reg, offset)
   end

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
     reg    = datastore['BufferRegister']
     offset = datastore['BufferOffset'].to_i || 0
     if (not reg)
-      raise RuntimeError, "Need BufferRegister"
+      raise EncodingError, "Need BufferRegister"
     end
     Rex::Encoder::Alpha2::UnicodeUpper::gen_decoder(reg, offset)
   end

--- a/msfvenom
+++ b/msfvenom
@@ -133,6 +133,10 @@ require 'msf/core/payload_generator'
       opts[:var_name] = x
     end
 
+    opt.on('--smallest', 'Generate the smallest possible payload') do
+      opts[:smallest] = true
+    end
+
     opt.on_tail('-h', '--help', 'Show this message') do
       raise UsageError, "#{opt}"
     end


### PR DESCRIPTION
This mode tries to generate the smallest possible output given a set of options. This overrides both the space and encoded space parameters in order to set the payload to its smallest representation. In order to make this work, two other bugs had to be fixed:
- Many encoders were raising non-EncodingError exceptions, which breaks encoder selection in a few places, including the payload generator class. A couple encoders were using invalid exceptions entirely.
- Automatic encoder selection in the payload generator now skips Manual ranked module unless those modules were explicitly requested. Without this change, modules that simply didn't work could be chosen (eicar, etc).

This builds on PR #5370
