### PR TITLE
Fixes #5269: Report ipmi_dumphashes credentials with create_credential_login

### DIFF
--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -260,7 +260,7 @@ class Metasploit3 < Msf::Auxiliary
       origin_type: :service,
       private_data: hash,
       private_type: :nonreplayable_hash,
-      jtr_format: 'rakp_hmac_sha1_hash',
+      jtr_format: 'rakp',
       username: user,
     }.merge(service_data)
 

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -180,7 +180,7 @@ class Metasploit3 < Msf::Auxiliary
 
       # Write the rakp hash to the database
       hash = "#{rhost} #{username}:$rakp$#{sha1_salt}$#{sha1_hash}"
-      report_hash(username, hash)
+      core_id = report_hash(username, hash)
       # Write the vulnerability to the database
       unless reported_vuln
         report_vuln(
@@ -205,7 +205,7 @@ class Metasploit3 < Msf::Auxiliary
         print_good("#{rhost}:#{rport} - IPMI - Hash for user '#{username}' matches password '#{pass}'")
 
         # Report the clear-text credential to the database
-        report_cracked_cred(username, pass)
+        report_cracked_cred(username, pass, core_id)
         break
       end
     end
@@ -269,24 +269,18 @@ class Metasploit3 < Msf::Auxiliary
       status: Metasploit::Model::Login::Status::UNTRIED
     }.merge(service_data)
 
-    create_credential_login(login_data)
+    cl = create_credential_login(login_data)
+    cl.core_id
   end
 
-  def report_cracked_cred(user, password)
-    credential_data = {
-      module_fullname: self.fullname,
-      origin_type: :service,
-      private_data: password,
-      private_type: :password,
+  def report_cracked_cred(user, password, core_id)
+    cred_data = {
+      core_id: core_id,
       username: user,
-    }.merge(service_data)
+      password: password
+    }
 
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }.merge(service_data)
-
-    create_credential_login(login_data)
+    create_cracked_credential(cred_data)
   end
 
   #

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -180,7 +180,7 @@ class Metasploit3 < Msf::Auxiliary
 
       # Write the rakp hash to the database
       hash = "#{rhost} #{username}:$rakp$#{sha1_salt}$#{sha1_hash}"
-      report_hash(user, hash)
+      report_hash(username, hash)
       # Write the vulnerability to the database
       unless reported_vuln
         report_vuln(


### PR DESCRIPTION
Report ipmi_dumphashes credentials with create_credential_login instead of report_auth_info

See #5269 
## Verification
- [ ] Find an IPMI target
- [ ] Run the ipmi_dumphashes module
- [ ] VERIFY which it finds hashes and is able to crack some of them
- [ ] Run the creds command
- [ ] Verify which both hashes and plaintext credentials (if cracked) are stored successfully.

Since I hadn't an IPMI target I just faked the calls to `report_hash` and `report_cracked_cred`. Here are the results in the database:

```
msf auxiliary(ipmi_dumphashes) > run

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ipmi_dumphashes) > creds
Credentials
===========

host          service         public  private                             realm  private_type
----          -------         ------  -------                             -----  ------------
172.16.158.1  623/udp (ipmi)  ADMIN   172.16.158.1 ADMIN:$rakp$gzaw$oDWz         Nonreplayable hash
172.16.158.1  623/udp (ipmi)  ADMIN   ADMIN                                      Password
```
