### PR TITLE
New post module to Load Powershell scripts into Powershell Session

### DIFF
--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -151,7 +151,7 @@ module Powershell
       scriptbybase = ps_script.rig.generate(4)
       scriptbybasefull = ps_script.rig.generate(4)
 
-      if (encoded_expression.size > 14999 && compress_script(encoded_expression).size > 14999)
+      if (encoded_expression.size > 14999)
         print_error("Script size: #{encoded_expression.size} This script requres a stager")
         arr = encoded_expression.chars.each_slice(14999).map(&:join)
         print_good("Loading " + arr.count.to_s + " chunks into the stager.")
@@ -170,11 +170,6 @@ module Powershell
         end
         linkvars.slice!(0..2)
         session.shell_command("$#{script_var} = #{linkvars}")
-      elsif (compress_script(encoded_expression).size < 15000 and encoded_expression.size > 14999)
-        # Attempt to compress the PSH script into available space
-        encoded_expression = compress_script(encoded_expression)
-        print_good("Compressed script size: #{encoded_expression.size}")
-        session.shell_command("$#{script_var} = \"#{encoded_expression}\"")
       else
         print_good("Script size: #{encoded_expression.size}")
         session.shell_command("$#{script_var} = \"#{encoded_expression}\"")

--- a/modules/post/windows/manage/exec_powershell.rb
+++ b/modules/post/windows/manage/exec_powershell.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Post
 
     register_options(
       [
-        OptString.new( 'SCRIPT',  [true, 'Path to the PS script or command string to execute' ]),
+        OptString.new( 'SCRIPT',  [true, 'Path to the local PS script or command string to execute' ]),
       ], self.class)
 
     register_advanced_options(
@@ -40,22 +40,18 @@ class Metasploit3 < Msf::Post
 
   end
 
-
-
   def run
 
     # Make sure we meet the requirements before running the script, note no need to return
     # unless error
     raise "Powershell not available" if ! have_powershell?
 
-                # Preprocess the Powershell::Script object with substitions from Exploit::Powershell
-                script = make_subs(read_script(datstore['SCRIPT']),process_subs(datstore['SUBSTITUTIONS']))
+    # Preprocess the Powershell::Script object with substitions from Exploit::Powershell
+    script = make_subs(read_script(datstore['SCRIPT']),process_subs(datstore['SUBSTITUTIONS']))
 
-                # Execute in session
+    # Execute in session
     print_status psh_exec(script)
     print_good('Finished!')
   end
-
-
 
 end

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Post
 
     register_options(
       [
-        OptPath.new( 'SCRIPT',  [true, 'Path to the PS script', ::File.join(Msf::Config.install_root, "scripts", "ps", "msflag.ps1") ]),
+        OptPath.new( 'SCRIPT',  [true, 'Path to the local PS script', ::File.join(Msf::Config.install_root, "scripts", "ps", "msflag.ps1") ]),
       ], self.class)
 
     register_advanced_options(

--- a/modules/post/windows/manage/powershell/load_script.rb
+++ b/modules/post/windows/manage/powershell/load_script.rb
@@ -28,8 +28,8 @@ class Metasploit3 < Msf::Post
 
     register_options(
       [
-        OptPath.new( 'SCRIPT',  [false, 'Path to the PS script', ::File.join(Msf::Config.install_root, "scripts", "ps", "msflag.ps1") ]),
-        OptPath.new( 'FOLDER',  [false, 'Path to a folder of PS scripts'])
+        OptPath.new( 'SCRIPT',  [false, 'Path to the local PS script', ::File.join(Msf::Config.install_root, "scripts", "ps", "msflag.ps1") ]),
+        OptPath.new( 'FOLDER',  [false, 'Path to a local folder of PS scripts'])
       ], self.class)
 
   end


### PR DESCRIPTION
This new post module takes any powershell session type and allows a user to import-modules into the powershell session and use them locally. To implement this I have had to create a stager approach that has been added to the powershell mixin module. Anything over 20000 bytes gets staged and uploaded. This module only works for powershell sessions as stated in the module. 

Additionally, @sempervictus made some changes to the powershell coding and wanted to merge into this PR. 
