### PR TITLE
MSP-9532: Increase REXML expansion text limit

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -129,6 +129,8 @@ module Msf::DBManager::Import
       end
     end
 
+    # Override REXML's expansion text limit to 50k (default: 10240 bytes)
+    REXML::Security.entity_expansion_text_limit = 51200
 
     if block
       import(args.merge(:data => data)) { |type,data| yield type,data }


### PR DESCRIPTION
PR fixes db_manager #import_file to handle larger xml, which in some cases would have thrown a "RuntimeError entity expansion has grown too large" and halt the import.

Background: As of ruby 1.9.3p392 and ruby 2.0.0, a they added restrictions to REXML::Text.unnormalize to allow only 10240 bytes (10k) entity substitutions per node. This was prevent DoS where the REXML parser can be coerced in to allocating extremely large string objects which can consume all of the memory on a machine.

https://www.ruby-lang.org/en/news/2013/02/22/rexml-dos-2013-02-22/

The max text memory allocation is 98 megabytes. "The REXML already defaults to only allow 10000 entity substitutions per document, so the maximum amount of text that can be generated by entity substitution will be around 98 megabytes.”

PR Increases to reasonable size to handle larger xml file expansion on import (~50k per node --> ~512M max allocation).
## Verification (for Pro only)
- [x] Create a new workspace.
- [x] Click "Import" button in Discovery section
- [x] Choose a file to import: 'pro/ui/features/legacy/data/main_import_file.zip'
- [x] Click 'Import Data'
- [x] Task log should show that it successfully imported everything.
