### PR TITLE
Improves detection of the MS15-034

### DIFF
--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -64,6 +64,11 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  # Needed to allow the vulnerable uri to be shared between the #check and #dos
+  def target_uri
+    @target_uri ||= super
+  end
+
   def get_file_size(ip)
     @file_size ||= lambda {
       file_size = -1

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -121,23 +121,19 @@ class Metasploit3 < Msf::Auxiliary
     return uris unless res
 
     site_uri = URI.parse(full_uri)
+    page     = Nokogiri::HTML(res.body.encode('UTF-8', invalid: :replace, undef: :replace))
 
-    Nokogiri::HTML(res.body).xpath('//link|//script|//style|//img').each do |tag|
+    page.xpath('//link|//script|//style|//img').each do |tag|
       %w(href src).each do |attribute|
-        begin
-          attr_value = tag[attribute]
+        attr_value = tag[attribute]
 
-          next unless attr_value && !attr_value.empty?
+        next unless attr_value && !attr_value.empty?
 
-          uri = site_uri.merge(URI.encode(attr_value.strip))
+        uri = site_uri.merge(URI.encode(attr_value.strip))
 
-          next unless uri.host == vhost || uri.host == rhost
+        next unless uri.host == vhost || uri.host == rhost
 
-          uris << uri.path if uri.path =~ /\.[a-z]{2,}$/i # Only keep path with a file
-        rescue => e
-          vprint_error("#{peer} - #{e}")
-          next
-        end
+        uris << uri.path if uri.path =~ /\.[a-z]{2,}$/i # Only keep path with a file
       end
     end
 

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
     if check_host(ip) == Exploit::CheckCode::Vulnerable
       dos_host(ip)
     else
-      print_status("#{ip}:#{rport} - Probably not vulnerable, will not dos it.")
+      print_status("#{peer} - Probably not vulnerable, will not dos it.")
     end
   end
 
@@ -76,17 +76,17 @@ class Metasploit3 < Msf::Auxiliary
       res = send_request_raw('uri' => uri)
 
       unless res
-        vprint_error("#{ip}:#{rport} - Connection timed out")
+        vprint_error("#{peer} - Connection timed out")
         return file_size
       end
 
       if res.code == 404
-        vprint_error("#{ip}:#{rport} - You got a 404. URI must be a valid resource.")
+        vprint_error("#{peer} - You got a 404. URI must be a valid resource.")
         return file_size
       end
 
       file_size = res.body.length
-      vprint_status("#{ip}:#{rport} - File length: #{file_size} bytes")
+      vprint_status("#{peer} - File length: #{file_size} bytes")
 
       return file_size
     }.call
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Auxiliary
     rescue ::Errno::EPIPE, ::Timeout::Error
       # Same exceptions the HttpClient mixin catches
     end
-    print_status("#{ip}:#{rport} - DOS request sent")
+    print_status("#{peer} - DOS request sent")
   end
 
   def potential_static_files_uris

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -160,7 +160,7 @@ class Metasploit3 < Msf::Auxiliary
       vmessage = "#{peer} - Checking #{uri} [#{res.code}]"
 
       if res && res.body.include?('Requested Range Not Satisfiable')
-        print_status("#{peer} - #{uri} is vulnerable")
+        vprint_status("#{vmessage} - Vulnerable")
 
         target_uri.path = uri # Needed for the DoS attack
 

--- a/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
+++ b/modules/auxiliary/dos/http/ms15_034_ulonglongadd.rb
@@ -155,7 +155,7 @@ class Metasploit3 < Msf::Auxiliary
       vmessage = "#{peer} - Checking #{uri} [#{res.code}]"
 
       if res && res.body.include?('Requested Range Not Satisfiable')
-        print_status("#{vmessage} - Vulnerable")
+        print_status("#{peer} - #{uri} is vulnerable")
 
         target_uri.path = uri # Needed for the DoS attack
 


### PR DESCRIPTION
Currently only the /welcome.png is checked, however in practise, this file is barely there.

Furthermore, some scanners like Nessus often fail to properly detect the issue, and when it's detected, the vulnerable file is not provided.

I've improved the detection based on a script I created at work: https://github.com/RandomStorm/scripts/blob/master/ms15-034-checker.rb

The idea is to extract all potential static files from the index page and test them rather than just check the /welcome.png.

Output examples:

Vulnerable:
w/o Verbose:

```
msf auxiliary(ms15_034_ulonglongadd) > check

[*] X.X.X.X:80 - Checking /static/banner.jpg [416] - Vulnerable
[+] X.X.X.X:80 - The target is vulnerable.
[*] Checked 1 of 1 hosts (100% complete)
```

with verbose:

```
msf auxiliary(ms15_034_ulonglongadd) > check

[*] X.X.X.X:80 - Checking /welcome.png [404] - Unknown
[*] X.X.X.X:80 - Checking /static/banner.jpg [416] - Vulnerable
[+] X.X.X.X:80 - The target is vulnerable.
[*] Checked 1 of 1 hosts (100% complete)
```

Not vulnerable:
w/o verbose:

```
msf auxiliary(ms15_034_ulonglongadd) > check
[*] 192.168.1.24:80 - The target is not exploitable.
[*] Checked 1 of 1 hosts (100% complete)
```

with verbose:

```
msf auxiliary(ms15_034_ulonglongadd) > check

[*] 192.168.1.24:80 - Checking /welcome.png [400] - Safe
[*] 192.168.1.24:80 - The target is not exploitable.
[*] Checked 1 of 1 hosts (100% complete)
```

Unknown (Debian Server):
w/o verbose:

```
msf auxiliary(ms15_034_ulonglongadd) > check
[*] 192.168.1.103:80 - Cannot reliably check exploitability.
[*] Checked 1 of 1 hosts (100% complete)
```

with verbose

```
msf auxiliary(ms15_034_ulonglongadd) > check

[*] 192.168.1.103:80 - Checking /wordpress-4.2/welcome.png [404] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/xmlrpc.php [405] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/wp-content/themes/twentyfifteen/genericons/genericons.css [200] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/wp-content/themes/twentyfifteen/style.css [200] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/wp-includes/js/jquery/jquery.js [200] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/wp-includes/js/jquery/jquery-migrate.min.js [200] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/wp-includes/wlwmanifest.xml [200] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/wp-content/themes/twentyfifteen/js/skip-link-focus-fix.js [200] - Unknown
[*] 192.168.1.103:80 - Checking /wordpress-4.2/wp-content/themes/twentyfifteen/js/functions.js [200] - Unknown
[*] 192.168.1.103:80 - Cannot reliably check exploitability.
[*] Checked 1 of 1 hosts (100% complete)
```

Some questions/remarks:
- https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/exploit/http/client.rb#L400 rhost shouldn't be replaced by vhost ? givent that if not supplied, the vhost is set to rhost
- Is there a VHOSTS option ? As there is a RHOSTS, it would seem logical to also have the plural form of VHOST, useful especially in scanner mode
