### PR TITLE
Resolve #5219, user-configurable HTTP timeout

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -53,7 +53,7 @@ module Exploit::Remote::HttpClient
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
-        OptInt.new('HttpTimeout', [false, 'HTTP connection and receive timeout', 20])
+        OptInt.new('HttpRequestTimeout', [false, 'HTTP connection and receive timeout', 20])
       ], self.class
     )
 
@@ -308,7 +308,7 @@ module Exploit::Remote::HttpClient
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
   #
   def send_request_raw(opts={}, timeout = 20)
-    actual_timeout = datastore['HttpTimeout'] || opts[:timeout] || timeout
+    actual_timeout = datastore['HttpRequestTimeout'] || opts[:timeout] || timeout
     begin
       c = connect(opts)
       r = c.request_raw(opts)
@@ -325,7 +325,7 @@ module Exploit::Remote::HttpClient
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_cgi.
   #
   def send_request_cgi(opts={}, timeout = 20)
-    actual_timeout = datastore['HttpTimeout'] || opts[:timeout] || timeout
+    actual_timeout = datastore['HttpRequestTimeout'] || opts[:timeout] || timeout
     begin
       c = connect(opts)
       r = c.request_cgi(opts)
@@ -344,7 +344,7 @@ module Exploit::Remote::HttpClient
   #   will contain the full URI.
   #
   def send_request_cgi!(opts={}, timeout = 20, redirect_depth = 1)
-    actual_timeout = datastore['HttpTimeout'] || opts[:timeout] || timeout
+    actual_timeout = datastore['HttpRequestTimeout'] || opts[:timeout] || timeout
     res = send_request_cgi(opts, actual_timeout)
     return res unless res && res.redirect? && redirect_depth > 0
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -52,7 +52,8 @@ module Exploit::Remote::HttpClient
         OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
-        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION'])
+        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
+        OptInt.new('HttpTimeout', [false, 'HTTP connection and receive timeout', 20])
       ], self.class
     )
 
@@ -307,10 +308,11 @@ module Exploit::Remote::HttpClient
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
   #
   def send_request_raw(opts={}, timeout = 20)
+    actual_timeout = datastore['HttpTimeout'] || opts[:timeout] || timeout
     begin
       c = connect(opts)
       r = c.request_raw(opts)
-      c.send_recv(r, opts[:timeout] ? opts[:timeout] : timeout)
+      c.send_recv(r, actual_timeout)
     rescue ::Errno::EPIPE, ::Timeout::Error
       nil
     end
@@ -323,10 +325,11 @@ module Exploit::Remote::HttpClient
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_cgi.
   #
   def send_request_cgi(opts={}, timeout = 20)
+    actual_timeout = datastore['HttpTimeout'] || opts[:timeout] || timeout
     begin
       c = connect(opts)
       r = c.request_cgi(opts)
-      c.send_recv(r, opts[:timeout] ? opts[:timeout] : timeout)
+      c.send_recv(r, actual_timeout)
     rescue ::Errno::EPIPE, ::Timeout::Error
       nil
     end
@@ -341,7 +344,8 @@ module Exploit::Remote::HttpClient
   #   will contain the full URI.
   #
   def send_request_cgi!(opts={}, timeout = 20, redirect_depth = 1)
-    res = send_request_cgi(opts, timeout)
+    actual_timeout = datastore['HttpTimeout'] || opts[:timeout] || timeout
+    res = send_request_cgi(opts, actual_timeout)
     return res unless res && res.redirect? && redirect_depth > 0
 
     redirect_depth -= 1
@@ -360,7 +364,7 @@ module Exploit::Remote::HttpClient
       opts['ssl'] = false
     end
 
-    send_request_cgi!(opts, timeout, redirect_depth)
+    send_request_cgi!(opts, actual_timeout, redirect_depth)
   end
 
   #


### PR DESCRIPTION
Resolve #5219 

This patch allows HTTP timeout to be user-configurable (for the HttpClient).
## Verification
- [ ] Set up a web server
- [ ] Block the web server's port with a firewall
- [ ] Save this test script: https://gist.github.com/wchen-r7/9dbb3532f1a9838b5749
- [ ] Start msfconsole
- [ ] Load the test module
- [ ] `set rhost [server ip]`
- [ ] `set HttpTimeout 3`
- [ ] You should see that the tested methods (send_request_raw, send_request_cgi, send_request_cgi!) all timeout after 3 seconds, like the following:

```
msf auxiliary(test) > set rhost 192.168.1.109
rhost => 192.168.1.109
msf auxiliary(test) > set HttpTimeout 3
HttpTimeout => 3
msf auxiliary(test) > run

[*] Current timeout setting is: 3 seconds
[*] Sending a request using send_request_raw
[*] Timedout!
[*] Time spent: 3.061901

[*] Sending a request using send_request_cgi
[*] Timeout!
[*] Time spent: 3.053522

[*] Sending a request using send_request_cgi!
[*] Timeout!
[*] Time spent: 3.060696
[*] Auxiliary module execution completed
msf auxiliary(test) > 
```
