### PR TITLE
Import Powershell libraries and sample post module

### DIFF
--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -18,7 +18,7 @@ module Powershell
     # eval %Q|def_delegators :@code, :#{::String.instance_methods[0..(String.instance_methods.index(:class)-1)].join(', :')}|
     def_delegators :@code, :each_line, :strip, :chars, :intern, :chr, :casecmp, :ascii_only?, :<, :tr_s,
                    :!=, :capitalize!, :ljust, :to_r, :sum, :private_methods, :gsub, :dump, :match, :to_sym,
-                   :enum_for, :display, :tr_s!, :freeze, :gsub, :split, :rindex, :<<, :<=>, :+, :lstrip!,
+                   :enum_for, :display, :tr_s!, :freeze, :gsub!, :split, :rindex, :<<, :<=>, :+, :lstrip!,
                    :encoding, :start_with?, :swapcase, :lstrip!, :encoding, :start_with?, :swapcase,
                    :each_byte, :lstrip, :codepoints, :insert, :getbyte, :swapcase!, :delete, :rjust, :>=,
                    :!, :count, :slice, :clone, :chop!, :prepend, :succ!, :upcase, :include?, :frozen?,


### PR DESCRIPTION
Sync critical functionality from Rex and Msf namespaces dealing
with encoding and processing of powershell script for exploit
or post namespaces.

Import Post module. Primarily adds a psh_exec method which will be
replaced in the next PR with @benpturner's work integrated into
the Post module namespace.

Provide a sample metasploit windows post module to show the
execution pipeline - entire subs process can be removed and the
module reduced to a psh_exec(datastore['SCRIPT']).

This commit is designed to provide sync between the SVIT fork and
upstream. Pending commits to be based on this work will provide
access to .NET compiler in the Post namespace to be used for
dynamic persistent payload creation on target and the import of
@benpturner's work.
