### PR TITLE
Patch for 5378

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1270,8 +1270,8 @@ class Db
       end
     end
     if search_term
-      note_list.delete_if do |n|
-        !n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
+      note_list = note_list.select do |n|
+        n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
       end
     end
 


### PR DESCRIPTION
The notes -S command was not working properly due to using delete_if with ActiveRecord::Associations::CollectionProxy. This PR changes the use of delete_if with select as suggested by @hmoore-r7. 

Before (as reported by HD)

``` ruby
msf exploit(handler) > notes -S 8472389472343298473247239472347234
[*] Time: 2015-05-14 04:06:49 UTC Note: host=192.168.0.6 type=host.os.session_fingerprint data={:name=>"Z420", :os=>"Windows 8 (Build 9200).", :arch=>"x64 (Current Process is WOW64)"}
[*] Time: 2015-05-12 15:58:40 UTC Note: host=192.168.0.3 type=host.os.session_fingerprint data={:name=>"smash", :os=>"Windows XP (Build 2600, Service Pack 3).", :arch=>"x64 (Current Process is WOW64)"}
```

Now with a valid search:

``` ruby
msf > search -S WORKGROUP
[*] Time: 2014-12-17 05:38:24 UTC Note: host=1.1.1.1 service=smb port=445 protocol=tcp type=smb.fingerprint data={:native_os=>"Windows Server 2008 R2 Standard 7600", :native_lm=>"Windows Server 2008 R2 Standard 6.1", :os_edition=>"Standard", :os_build=>"7600", :SMBName=>"XXXX", :SMBDomain=>"WORKGROUP"}
```

Now with an invalid search:

``` ruby
msf > search -S 53535345363
msf >
```
