### PR TITLE
Support randomizing scanner rhosts order

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -25,6 +25,7 @@ def initialize(info = {})
   deregister_options('RHOST')
 
   register_advanced_options([
+    OptBool.new('RandomizeHostOrder', [true, 'Randomize the order in which hosts are scanned', true]),
     OptBool.new('ShowProgress', [true, 'Display progress messages during a scan', true]),
     OptInt.new('ShowProgressPercent', [true, 'The interval in percent that progress should be shown', 10])
   ], Auxiliary::Scanner)
@@ -50,7 +51,7 @@ def run
   @show_progress = datastore['ShowProgress']
   @show_percent  = datastore['ShowProgressPercent'].to_i
 
-  ar             = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
+  ar             = Rex::Socket::RangeWalker.new(datastore['RHOSTS'], (datastore['RandomizeHostOrder'] ? 128 : 0))
   @range_count   = ar.length || 0
   @range_done    = 0
   @range_percent = 0
@@ -165,7 +166,7 @@ def run
 
     size = run_batch_size()
 
-    ar = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
+    ar = Rex::Socket::RangeWalker.new(datastore['RHOSTS'], (datastore['RandomizeHostOrder'] ? 128 : 0))
 
     while(true)
       nohosts = false


### PR DESCRIPTION
This pull request introduces a feature to allow the `Rex::Socket::RangeWalker` class to return hosts in a pseudo-random order with a specified chunk size. Currently this is only used in the scanner mixin and can be disabled with the new advanced option `RandomizeHostOrder` which defaults to true. When `RandomizeHostOrder` is set the scanner mixin will specify a shuffle size of 128 as to avoid excessive memory usage.

In the RangeWalker, if a shuffle_size is specified as 1 or less, the hosts are not randomized.

This also adds to the specs to ensure that the next method returns hosts both in order by default and in a random order when directed to.

To ensure that the rhost scan order is correct, set THREADS to 1.

To do:
- [ ] Ensure the spec passes and the spec code is up to par
- [ ] Run a scanner module against a range and notice the RHOSTs are randomized
- [ ] Set RandomizeHostOrder to false and rerun the module to enjoy current-style consecutive scanning

Example output:

```
msf-git (S:0 J:0) auxiliary(snmp_login) > set RHOSTS 192.168.1.1-5
RHOSTS => 192.168.1.1-5
msf-git (S:0 J:0) auxiliary(snmp_login) > set RandomizeHostOrder true
RandomizeHostOrder => true
rmsf-git (S:0 J:0) auxiliary(snmp_login) > run

[-] [2015.05.21-12:07:24] :161SNMP - 192.168.1.3:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:07:28] :161SNMP - 192.168.1.4:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:07:33] :161SNMP - 192.168.1.5:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:07:37] :161SNMP - 192.168.1.1:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:07:42] :161SNMP - 192.168.1.2:161 - LOGIN FAILED: test: (Incorrect: )
[*] [2015.05.21-12:07:42] Scanned 5 of 5 hosts (100% complete)
[*] Auxiliary module execution completed
msf-git (S:0 J:0) auxiliary(snmp_login) > set RandomizeHostOrder false
RandomizeHostOrder => false
msf-git (S:0 J:0) auxiliary(snmp_login) > run

[-] [2015.05.21-12:07:52] :161SNMP - 192.168.1.1:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:07:57] :161SNMP - 192.168.1.2:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:08:01] :161SNMP - 192.168.1.3:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:08:06] :161SNMP - 192.168.1.4:161 - LOGIN FAILED: test: (Incorrect: )
[-] [2015.05.21-12:08:10] :161SNMP - 192.168.1.5:161 - LOGIN FAILED: test: (Incorrect: )
[*] [2015.05.21-12:08:10] Scanned 5 of 5 hosts (100% complete)
[*] Auxiliary module execution completed
msf-git (S:0 J:0) auxiliary(snmp_login) > 
```
