### PR TITLE
Update the gemspecs for recog 2.0 / mdm 1.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       packetfu (= 1.1.9)
       railties
       rb-readline-r7
-      recog (~> 1.0)
+      recog (~> 2.0)
       robots
       rubyzip (~> 1.1)
       sqlite3
@@ -24,7 +24,7 @@ PATH
       activerecord (>= 4.0.9, < 4.1.0)
       metasploit-credential (~> 1.0)
       metasploit-framework (= 4.11.0.pre.dev)
-      metasploit_data_models (~> 1.0)
+      metasploit_data_models (~> 1.2)
       pg (>= 0.11)
     metasploit-framework-pcap (4.11.0.pre.dev)
       metasploit-framework (= 4.11.0.pre.dev)
@@ -124,7 +124,7 @@ GEM
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
     metasploit-payloads (0.0.7)
-    metasploit_data_models (1.0.1)
+    metasploit_data_models (1.2.0)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       arel-helpers
@@ -133,12 +133,12 @@ GEM
       pg
       postgres_ext
       railties (>= 4.0.9, < 4.1.0)
-      recog (~> 1.0)
+      recog (~> 2.0)
     method_source (0.8.2)
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (4.7.5)
-    msgpack (0.5.11)
+    msgpack (0.6.0)
     multi_json (1.11.0)
     multi_test (0.1.2)
     network_interface (0.0.1)
@@ -146,7 +146,7 @@ GEM
       mini_portile (~> 0.6.0)
     packetfu (1.1.9)
     pcaprub (0.12.0)
-    pg (0.18.1)
+    pg (0.18.2)
     pg_array_parser (0.0.9)
     postgres_ext (2.4.1)
       activerecord (>= 4.0.0)
@@ -156,7 +156,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.5.2)
+    rack (1.5.3)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.0.13)
@@ -174,7 +174,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rb-readline-r7 (0.5.2.0)
-    recog (1.0.29)
+    recog (2.0.2)
       nokogiri
     redcarpet (3.2.3)
     rkelly-remix (0.0.6)
@@ -222,7 +222,7 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.7.3)
-    tzinfo (0.3.43)
+    tzinfo (0.3.44)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # Metasploit::Credential database models
   spec.add_runtime_dependency 'metasploit-credential', '~> 1.0'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models', '~> 1.0'
+  spec.add_runtime_dependency 'metasploit_data_models', '~> 1.2'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code
   spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
   # Needed for module caching in Mdm::ModuleDetails

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
   spec.add_runtime_dependency 'railties'
   # required for OS fingerprinting
-  spec.add_runtime_dependency 'recog', '~> 1.0'
+  spec.add_runtime_dependency 'recog', '~> 2.0'
 
   # rb-readline doesn't work with Ruby Installer due to error with Fiddle:
   #   NoMethodError undefined method `dlopen' for Fiddle:Module


### PR DESCRIPTION
MSP-12735
# Pre-verification steps
## metasploit_data_models
- [x] Merge https://github.com/rapid7/metasploit_data_models/pull/126
## metasploit-framework
- [ ] `bundle install` to update `Gemfile.lock` to released version of metasploit_data_models.
# Verification Steps
- [ ] `rake spec`
- [ ] VERIFY no failures
