### PR TITLE
Fix a few double spaces

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -47,7 +47,7 @@ module Exploit::Remote::HttpClient
           Rex::Proto::Http::Client::DefaultUserAgent
           ]),
         OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for  authentication', '']),
+        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', '']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
         Traq 2.0 to 2.3. It's in the admincp/common.php script.
 
         This function is called in each script located in the /admicp/ directory to
-        make sure the user has admin rights. This is a broken authorization schema 
+        make sure the user has admin rights. This is a broken authorization schema
         because the header() function doesn't stop the execution flow.
         This can be exploited by malicious users to execute admin functionality,
         e.g. execution of arbitrary PHP code leveraging of plugins.php functionality.

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -17,12 +17,11 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits an arbitrary command execution vulnerability in
         Traq 2.0 to 2.3. It's in the admincp/common.php script.
 
-        This function is called in each script located into /admicp/ directory to
+        This function is called in each script located in the /admicp/ directory to
         make sure the user has admin rights, but this is a broken authorization
-        schema due to the header() function doesn't stop the execution flow. This
-        can be exploited by malicious users to execute admin functionality resulting
-        for  e.g.  in execution of arbitrary PHP code leveraging of plugins.php
-        functionality.
+        schema due to the header() function doesn't stop the execution flow.
+        This can be exploited by malicious users to execute admin functionality.
+        e.g. execution of arbitrary PHP code leveraging of plugins.php functionality.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -18,9 +18,9 @@ class Metasploit3 < Msf::Exploit::Remote
         Traq 2.0 to 2.3. It's in the admincp/common.php script.
 
         This function is called in each script located in the /admicp/ directory to
-        make sure the user has admin rights, but this is a broken authorization
-        schema due to the header() function doesn't stop the execution flow.
-        This can be exploited by malicious users to execute admin functionality.
+        make sure the user has admin rights. This is a broken authorization schema 
+        because the header() function doesn't stop the execution flow.
+        This can be exploited by malicious users to execute admin functionality,
         e.g. execution of arbitrary PHP code leveraging of plugins.php functionality.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/http/xampp_webdav_upload_php.rb
+++ b/modules/exploits/windows/http/xampp_webdav_upload_php.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         OptString.new('PATH', [ true,  "The path to attempt to upload", '/webdav/']),
         OptString.new('FILENAME', [ false ,  "The filename to give the payload. (Leave Blank for Random)"]),
         OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', 'wampp']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for  authentication', 'xampp'])
+        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', 'xampp'])
       ], self.class)
   end
 

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         # The USERNAME and PASSWORD are registered again to make them more obvious they're
         # configurable.
         OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for  authentication', '']),
+        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', '']),
         OptString.new('PATH', [ true,  "The path to attempt to upload", '/metasploit%RAND%.asp'])
       ], self.class)
   end


### PR DESCRIPTION
Fix a few double spaces
e.g.

```
Module options (exploit/windows/iis/iis_webdav_upload_asp):

   Name      Current Setting        Required  Description
   ----      ---------------        --------  -----------
   PASSWORD                         no        The HTTP password to specify for  authentication
```

Also reworded a exploit info as it didn't make much sense to me
