### PR TITLE
Fix #5391 incomplete cmd stager documentation

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -127,8 +127,8 @@ module Exploit::CmdStager
 
   # Show the progress of the upload while cmd staging
   #
-  # @param total [Float] The total number of bytes to send
-  # @param sent [Float] The number of bytes sent
+  # @param total [Float] The total number of bytes to send.
+  # @param sent [Float] The number of bytes sent.
   # @return [void]
   def progress(total, sent)
     done = (sent.to_f / total.to_f) * 100
@@ -308,9 +308,10 @@ module Exploit::CmdStager
   def execute_cmdstager_end(opts)
   end
 
-  # Code to execute each command from the. This method is designed to be
-  # overriden by a module using this mixin.
+  # Code called to execute each command via an arbitrary module-defined vector.
+  # This method needs to be overriden by modules using this mixin.
   #
+  # @param cmd [String] The command to execute.
   # @param opts [Hash] Hash of configuration options.
   def execute_command(cmd, opts)
     raise NotImplementedError


### PR DESCRIPTION
This PR fixes #5391 by updating the documentation to the `execute_command` function by making the comments complete sentences.
