### PR TITLE
Network Resiliency Emulator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ PATH
       rubyzip (~> 1.1)
       sqlite3
       tzinfo
+      vagrant-wrapper
     metasploit-framework-db (4.11.0.pre.dev)
       activerecord (>= 4.0.9, < 4.1.0)
       metasploit-credential (~> 1.0)
@@ -223,6 +224,7 @@ GEM
     tilt (1.4.1)
     timecop (0.7.3)
     tzinfo (0.3.44)
+    vagrant-wrapper (2.0.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -92,4 +92,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sqlite3'
   # required for Time::TZInfo in ActiveSupport
   spec.add_runtime_dependency 'tzinfo'
+  # required for netem_proxy
+  spec.add_runtime_dependency 'vagrant-wrapper'
 end

--- a/modules/auxiliary/server/netem_proxy.rb
+++ b/modules/auxiliary/server/netem_proxy.rb
@@ -1,0 +1,168 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'vagrant-wrapper'
+
+class Metasploit3 < Msf::Auxiliary
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Emulate network conditions via a proxy router',
+      'Description'    => %q{
+          This module will enable a local proxy router that can emulate bad
+          network conditions. Traffic forwarded through the router to or from
+          the local host can emulate network bandwidth, latency and packet loss
+          conditions.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => ['bcook'],
+    ))
+
+    name = 'metasploit_netem_router'
+
+    register_options(
+      [
+        OptInt.new("PacketDelay",     [false, 'Packet delay in ms', 0]),
+        OptString.new("DataRate",     [false, 'Data rate in Mbps (0 is unlimited)', 0.0]),
+        OptInt.new("PacketLoss",      [false, 'Packet loss percentage', 0.0]),
+        OptInt.new("PacketDup",       [false, 'Packet dup percentage', 0.0]),
+        OptInt.new("PacketCorrupt",   [false, 'Packet corruption percentage', 0.0]),
+
+        OptString.new('VagrantName',  [true,  'Vagrant image name', name]),
+        OptString.new('VagrantBox',   [true,  'Vagrant box for the router VM', 'ubuntu/trusty64']),
+        OptString.new('VagrantNet',   [true,  'Vagrant private network', '192.168.13.2']),
+        OptBool.new('VagrantDestroy', [true,  'Destroy image on stop', false]),
+
+        OptString.new('SRVHOST',      [false, 'The address to listen on', '']),
+        OptPort.new('SRVPORT',        [true,  'The port to listen on', 4445]),
+        OptEnum.new('SRVPROTO',       [true,  'The protocol to use', 'tcp', ['udp', 'tcp']]),
+        OptString.new('LHOST',        [true,  'The address to forward to', '192.168.13.1']),
+        OptPort.new('LPORT',          [true,  'The port to forward to', 4444]),
+      ], self.class)
+
+  end
+
+  def vagrant_image_name
+    "Vagrant image #{datastore['VagrantName']} (#{datastore['VagrantBox']})"
+  end
+
+  def vagrant_create_environment
+    @vagrant_dir = File.join(Dir.tmpdir, datastore['VagrantName'])
+    @vagrant_file = File.join(@vagrant_dir, 'Vagrantfile')
+    @vagrant_destroy = datastore['VagrantDestroy']
+    ENV['VAGRANT_CWD'] = @vagrant_dir
+  end
+
+  def gen_linux_routing_cmds(pub_intf, priv_intf)
+    routing_cmds = []
+
+    [pub_intf, priv_intf].each do |intf|
+      routing_cmds << "sysctl -w net.ipv4.conf.#{intf}.forwarding=1"
+      routing_cmds << "sysctl -w net.ipv6.conf.#{intf}.forwarding=1"
+    end
+
+    routing_cmds << "iptables -t nat -F"
+    routing_cmds << "iptables -t nat -A PREROUTING -i #{pub_intf} -p #{datastore['SRVPROTO']}" +
+                    " --dport #{datastore['SRVPORT']} -j DNAT" +
+                    " --to-destination #{datastore['LHOST']}:#{datastore['LPORT']}"
+    routing_cmds << "iptables -t nat -A POSTROUTING -j MASQUERADE"
+
+    tc_opts = []
+    tc_opts << "delay #{datastore['PacketDelay']}ms" if datastore['PacketDelay'] > 0
+    tc_opts << "loss #{datastore['PacketLoss']}%" if datastore['PacketLoss'] > 0.0
+    tc_opts << "duplicate #{datastore['PacketDup']}%" if datastore['PacketDup'] > 0.0
+    tc_opts << "corrupt #{datastore['PacketCorrupt']}%" if datastore['PacketCorrupt'] > 0.0
+
+    routing_cmds << "tc qdisc delete dev #{priv_intf} root"
+    if !tc_opts.empty?
+      tc_opt = tc_opts.join(" ")
+      routing_cmds << "tc qdisc add dev #{priv_intf} root netem #{tc_opt}"
+    end
+
+    kbps = datastore['DataRate'] * 1000
+    if kbps > 0.0
+      #routing_cmds << "tc class add dev #{priv_intf} parent 1:1 handle 10 htb rate #{kbps}Kbps"
+    end
+
+    routing_cmds
+  end
+
+  def vagrant_write_config
+
+    port_forward = [':forwarded_port']
+    port_forward << "guest: #{datastore['SRVPORT']}"
+    port_forward << "host: #{datastore['SRVPORT']}"
+    port_forward << "proto: \"#{datastore['SRVPROTO']}\""
+    if datastore['SRVHOST'] != ""
+      port_forward << "host_ip: datastore['SRVHOST']"
+    end
+
+    provision_cmds = []
+    gen_linux_routing_cmds('eth0', 'eth1').each do |cmd|
+      provision_cmds << "os.vm.provision \"shell\", inline: \"#{cmd}\""
+    end
+
+    vagrant_tpl = %Q{
+VAGRANTFILE_API_VERSION = "2"
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.define "#{datastore['VagrantName']}" do |os|
+    os.vm.box = "#{datastore['VagrantBox']}"
+    os.vm.network #{port_forward.join(', ')}
+    os.vm.network :private_network, ip: "#{datastore['VagrantNet']}"
+    #{provision_cmds.join("\n    ")}
+  end
+end
+    }
+
+    Dir.mkdir(@vagrant_dir, 0700) if !Dir.exist?(@vagrant_dir)
+    File.open(@vagrant_file, 'w') { |file| file.write(vagrant_tpl) }
+  end
+
+  def cleanup_vm(obj)
+    # Cleanup the VM
+    if @vagrant_destroy
+      print_status("Destroying #{vagrant_image_name}")
+      @vagrant.get_output('destroy -f')
+    else
+      print_status("Suspending #{vagrant_image_name}")
+      @vagrant.get_output('suspend')
+    end
+  end
+
+  def monitor_vm(obj)
+    # Sleep while waiting for the job to be killed
+    while true
+      sleep 10
+    end
+  end
+
+  def run
+    # Handle check for vagrant
+    begin
+      @vagrant = VagrantWrapper.new('> 1.5')
+    rescue ::Exception => e
+      print_error(e.message)
+      print_status(VagrantWrapper::install_instructions)
+      return
+    end
+
+    # Spinup the VM
+    vagrant_create_environment
+    vagrant_write_config
+
+    print_status("Starting #{vagrant_image_name}")
+    @vagrant.get_output('up')
+    @vagrant.get_output('provision')
+    print_status("Vagrant router image started")
+
+    framework.jobs.start_bg_job(
+      "Auxiliary: #{self.refname}",
+      self,
+      Proc.new { |ctx_| self.monitor_vm(ctx_) },
+      Proc.new { |ctx_| self.cleanup_vm(ctx_) }
+    )
+  end
+end

--- a/modules/auxiliary/server/netem_proxy.rb
+++ b/modules/auxiliary/server/netem_proxy.rb
@@ -11,13 +11,13 @@ class Metasploit3 < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'        => 'Emulate network conditions via a proxy router',
+        'Name'        => 'Emulate Network Conditions with a Router Proxy',
         'Description' =>
         %q(
-            This module will enable a local proxy router that can emulate bad
+            This module configures a local router proxy that can emulate bad
             network conditions. Traffic forwarded through the router to or from
-            the local host can emulate network bandwidth, latency and packet loss
-            conditions.
+            the local host can emulate network outages, corruption, latency,
+            and packet loss. Vagrant 1.5 or later is required to use this module.
           ),
         'License'     => MSF_LICENSE,
         'Author'      => ['bcook']
@@ -122,7 +122,7 @@ end
     }
 
     Dir.mkdir(@vagrant_dir, 0700) unless Dir.exist?(@vagrant_dir)
-    File.open(@vagrant_file, 'w') { |file| file.write(vagrant_tpl) }
+    File.open(@vagrant_file, 'wb') { |file| file.write(vagrant_tpl) }
   end
 
   def cleanup_vm(_obj)


### PR DESCRIPTION
# Description

This module instantiates a simulated network link for the purpose of emulating bad network conditions. It works by instantiating a Linux VM using Vagrant, configuring port forwarding and NAT such that traffic to a local IP/port gets munged and connected to another local port. It is primarily focused on local testing of session resiliency.
# Verification Steps

Network failure modes that this module can configure include:
- [ ] Periodic Network Outages
- [ ] Packet Delay
- [ ] Packet Corruption
- [ ] Packet Duplication
- [ ] Packet Loss

The VM is also configurable to allow:
- [ ] Configurable VM networking setup (can set IP/ports)
- [ ] Configurable VM shutdown action (can choose to suspend, destroy or leave running)

To test this module, you must have Vagrant 1.5 or newer installed, along with a working back end. I tested with Virtualbox, though others may work with some extra configuration. The default Vagrant box is configurable, though the network setup commands may require tweaking with different boxes. It might be interesting to create classes for different types of VMs, abstracting the configuration details.

On shutdown, you can choose to either have the module suspend the VM, destroy it, or leave it alone, in which case it will continue running after Metasploit framework has exited. The configuration file is written under /tmp/#{VagrantName} if you want to copy it or reuse it.

The default network diagram looks like this, with traffic sent to local port 4445 being forwarded to local service port 4444:

```
192.168.13.1:4445  -> Router -> 192.168.13.1:4444
```

To use this configuration for emulating a network to a session, configure the listener on port 4444 and the payload to connect to port 4445. Here is a sample scenario configuring periodic network outages and packet delays.

```
msf > use auxiliary/server/netem_proxy 
msf auxiliary(netem_proxy) > show options 

Module options (auxiliary/server/netem_proxy):

   Name                   Current Setting          Required  Description
   ----                   ---------------          --------  -----------
   LHOST                  192.168.13.1             yes       The address to forward to
   LPORT                  4444                     yes       The port to forward to
   NetworkOutageDuration  30                       no        Length in seconds of network outages
   NetworkOutageInterval  0                        no        Period in seconds to simulate network outages
   PacketCorruptPercent   0                        no        Packet corruption percentage
   PacketDelayMs          0                        no        Packet delay in ms
   PacketDupPercent       0                        no        Packet dup percentage
   PacketLossPercent      0                        no        Packet loss percentage
   SRVHOST                                         no        The address to listen on
   SRVPORT                4445                     yes       The port to listen on
   SRVPROTO               tcp                      yes       The protocol to use (accepted: udp, tcp)
   VagrantBox             ubuntu/trusty64          yes       Vagrant box for the router VM
   VagrantCleanup         suspend                  yes       Cleanup method (accepted: suspend, destroy, none)
   VagrantName            metasploit_netem_router  yes       Vagrant image name
   VagrantNet             192.168.13.2             yes       Vagrant private network

msf auxiliary(netem_proxy) > set PacketDelayMs 100
PacketDelayMs => 100
msf auxiliary(netem_proxy) > set PacketLossPercent 1
PacketLossPercent => 1
msf auxiliary(netem_proxy) > set NetworkOutageInterval 30
NetworkOutageInterval => 30
msf auxiliary(netem_proxy) > run

[*] Starting Vagrant image metasploit_netem_router (ubuntu/trusty64)
[*] Vagrant router image started
[*] Auxiliary module execution completed
msf auxiliary(netem_proxy) > jobs 

Jobs
====

  Id  Name
  --  ----
  0   Auxiliary: server/netem_proxy

msf auxiliary(netem_proxy) > use exploit/multi/handler 
msf exploit(handler) > set payload linux/x86
[*] Starting network outage on Vagrant image metasploit_netem_router (ubuntu/trusty64)
/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.13.1
lhost => 192.168.13.1
msf exploit(handler) > run

[*] Started reverse handler on 192.168.13.1:4444 
[*] Starting the payload handler...
^C[-] Exploit failed: Interrupt 
msf exploit(handler) > exit

[*] Suspending Vagrant image metasploit_netem_router (ubuntu/trusty64)
```
