### PR TITLE
Adding an OSVDB number to the Netgear module

### DIFF
--- a/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
@@ -31,6 +31,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'  =>
         [
           [ 'BID', '72640' ],
+          [ 'OSVDB', '118316' ],
           [ 'URL', 'https://github.com/darkarnium/secpub/tree/master/NetGear/SOAPWNDR' ]
         ],
       'Author'      =>


### PR DESCRIPTION
## Verification
- [x] Look up 72640 on OSVDB.
- [x] Get confused as to why that's not talking about Netgear stuff.
- [x] Realize that it's a BID, not an OSVDB number.
- [x] Look it up on OSVDB and find [118316](http://osvdb.org/show/osvdb/118316).
- [x] See that OSVDB in this PR.
