### PR TITLE
UPnP vs HNAP 

### DIFF
--- a/modules/exploits/linux/http/dlink_hnap_header_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_hnap_header_exec_noauth.rb
@@ -13,9 +13,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'D-Link Devices UPnP SOAPAction-Header Command Execution',
+      'Name'        => 'D-Link Devices HNAP SOAPAction-Header Command Execution',
       'Description' => %q{
-        Different D-Link Routers are vulnerable to OS command injection in the UPnP SOAP
+        Different D-Link Routers are vulnerable to OS command injection in the HNAP SOAP
         interface. Since it is a blind OS command injection vulnerability, there is no
         output for the executed command. This module has been tested on a DIR-645 device.
         The following devices are also reported as affected: DAP-1522 revB, DAP-1650 revB,


### PR DESCRIPTION
the vulnerability is not in UPnP, it is in the HNAP (Home Network Administration Protocol) implementation from Dlink

thx to Craig for pointing me to this
