### PR TITLE
Fixes #5375 - Provide more context and references about how to fix deprecated report_auth_info 

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -179,7 +179,13 @@ module Auxiliary::Report
   # @option opts [String] :pass The private part of the credential (e.g. password)
   def report_auth_info(opts={})
     print_warning("*** #{self.fullname} is still calling the deprecated report_auth_info method! This needs to be updated!")
-    return if not db
+    print_warning('*** For detailed information about LoginScanners and the Credentials objects see:')
+    print_warning('     https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners')
+    print_warning('     https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module')
+    print_warning('*** For examples of modules converted to just report credentials without report_auth_info, see:')
+    print_warning('     https://github.com/rapid7/metasploit-framework/pull/5376')
+    print_warning('     https://github.com/rapid7/metasploit-framework/pull/5377')
+    return unless db
     raise ArgumentError.new("Missing required option :host") if opts[:host].nil?
     raise ArgumentError.new("Missing required option :port") if (opts[:port].nil? and opts[:service].nil?)
 


### PR DESCRIPTION
This pull request fixes https://github.com/rapid7/metasploit-framework/issues/5375.

While discussing https://github.com/rapid7/metasploit-framework/issues/5269 we decided to provide more context on the warning message show when modules try to use `report_auth_info```, which is currently deprecated. 

This pull request adds the next information to the warning message:
- References to the wiki pages describing `LoginScanner` and `Credential` objects.
- Referentes to pull requests converting modules which just use `report_auth_info` (but aren't `LoginScanner`)
## Verification
- [ ] Add the next module to `~/.msf4/modules/auxiliary/test/report_auth_deprecated.rb`

``` ruby
##
# This module requires Metasploit: http://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

require 'msf/core'

class Metasploit3 < Msf::Auxiliary

  include Msf::Exploit::Remote::Tcp
  include Msf::Auxiliary::Report

  def initialize
    super(
      'Name'        => 'report_auth_info deprecated test',
      'Description' => %q{ test },
      'Author'      => [ 'juan vazquez' ],
      'License'     => MSF_LICENSE
    )
  end

  def run
    report_auth_info(
      :host => rhost,
      :port => rport,
      :sname => "Test Server",
      :user => 'test',
      :pass => 'password'
    )
  end
end
```
- [ ] Run the msfconsole
- [ ] Use the auxiliary/test/report_auth_deprecated and configure its `RHOST` and `RPORT`:

```
msf > use auxiliary/test/report_auth_deprecated
msf auxiliary(report_auth_deprecated) > show options

Module options (auxiliary/test/report_auth_deprecated):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST                   yes       The target address
   RPORT                   yes       The target port

msf auxiliary(report_auth_deprecated) > set rhost 172.16.158.123
rhost => 172.16.158.123
msf auxiliary(report_auth_deprecated) > set rport 9191
rport => 9191
```
- [ ] Runt he module and **VERIFY** (1) the new warning message is shown and (2) the creds are reported anyway.

```
msf auxiliary(report_auth_deprecated) > run

[!] *** auxiliary/test/report_auth_deprecated is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] Auxiliary module execution completed
msf auxiliary(report_auth_deprecated) > creds
Credentials
===========
host            service                 public         private                                                                                                                                  realm       private_type
----            -------                 ------         -------                                                                                                                                  -----       ------------
172.16.158.123  9191/tcp (Test Server)  test           password                                                                                                                                             Password
```
