### PR TITLE
Fix a typo in author's name

### DIFF
--- a/modules/exploits/windows/local/lenovo_systemupdate.rb
+++ b/modules/exploits/windows/local/lenovo_systemupdate.rb
@@ -26,7 +26,7 @@ class Metasploit3 < Msf::Exploit::Local
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Micahel Milvich', # vulnerability discovery, advisory
+          'Michael Milvich', # vulnerability discovery, advisory
           'Sofiane Talmat',  # vulnerability discovery, advisory
           'h0ng10'           # Metasploit module
         ],

--- a/modules/exploits/windows/local/lenovo_systemupdate.rb
+++ b/modules/exploits/windows/local/lenovo_systemupdate.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Local
   def get_security_token(lenovo_directory)
     unless client.railgun.get_dll('tvsutil')
       client.railgun.add_dll('tvsutil', "#{lenovo_directory}\\tvsutil.dll")
-      client.railgun.add_function('tvsutil', 'GetSystemInfoData', 'DWORD', [['PWCHAR', 'systeminfo', 'out']], windows_name = nil, calling_conv = 'cdecl')
+      client.railgun.add_function('tvsutil', 'GetSystemInfoData', 'DWORD', [['PWCHAR', 'systeminfo', 'out']], nil, 'cdecl')
     end
 
     dll_response = client.railgun.tvsutil.GetSystemInfoData(256)


### PR DESCRIPTION
# Verification
- [x] Read the [advisory](http://www.ioactive.com/pdfs/Lenovo_System_Update_Multiple_Privilege_Escalations.pdf) 
- [x] **verify** "Michael" is spelled the same there and in the module.
