### PR TITLE
Remove comment about report_auth_info

### DIFF
--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -199,8 +199,6 @@ class Metasploit3 < Msf::Post
     end
     # report the goods!
     if config['admin_port'] == "<none>"
-      #if report_auth_info executes with admin_port equal to "<none>"
-      #the module will crash with an error.
       vprint_status("(No admin information found.)")
     else
       service_data = {


### PR DESCRIPTION
This module isn't using report_auth_info, so this comment is no longer needed.

No verification steps are provided because this is just a comment.
