### PR TITLE
Fixup record_mic to not fail with longer time durations

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -82,7 +82,7 @@ class Webcam
   def record_mic(duration)
     request = Packet.create_request('webcam_audio_record')
     request.add_tlv(TLV_TYPE_AUDIO_DURATION, duration)
-    response = client.send_request(request)
+    response = client.send_request(request, duration + 1)
     response.get_tlv( TLV_TYPE_AUDIO_DATA ).value
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -82,7 +82,8 @@ class Webcam
   def record_mic(duration)
     request = Packet.create_request('webcam_audio_record')
     request.add_tlv(TLV_TYPE_AUDIO_DURATION, duration)
-    response = client.send_request(request, duration + 1)
+    # Wait for a response proportional to the record duration
+    response = client.send_request(request, duration * 2)
     response.get_tlv( TLV_TYPE_AUDIO_DATA ).value
   end
 


### PR DESCRIPTION
# Problem

The record_mic api is currently synchronous and gets the response at the end of recording. Thus, we should configure the packet receiver to wait at least as many seconds as was specified to record in the first place. This has a companion PR in https://github.com/rapid7/meterpreter/pull/168 that fixes memory allocations between subsequent requests.
# Validation steps
- [ ] Optionally build and install meterpreter from PR 168 (it makes fiddling with durations easier)
- [ ] Start a meterpreter session and run 'record_mic -d 20'
- [ ] Observe that the request completes and does not timeout waiting for a response
