### PR TITLE
Update ca_arcserve_rpc_authbypass to use the new cred API

### DIFF
--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -130,15 +130,6 @@ class Metasploit3 < Msf::Exploit::Remote
       pass = resp[pass_index+1].gsub(/\"/, "")
     end
 
-    # report the auth
-    report_cred(
-      ip: datastore['RHOST'],
-      port: 445,
-      service_name: 'smb',
-      user: user,
-      password: pass
-    )
-
     srvc = {
         :host   => datastore['RHOST'],
         :port   => datastore['RPORT'],
@@ -153,6 +144,15 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_good("Collected credentials User: '#{user}' Password: '#{pass}'")
+
+    # report the auth
+    report_cred(
+      ip: datastore['RHOST'],
+      port: 445,
+      service_name: 'smb',
+      user: user,
+      password: pass
+    )
 
     # try psexec on the remote host
     psexec = framework.exploits.create("windows/smb/psexec")

--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -70,9 +70,8 @@ class Metasploit3 < Msf::Exploit::Remote
     credential_data = {
       module_fullname: fullname,
       post_reference_name: self.refname,
-      session_id: session_db_id,
-      origin_type: :session,
       private_data: opts[:password],
+      origin_type: :service,
       private_type: :password,
       username: opts[:user]
     }.merge(service_data)

--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -58,6 +58,33 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class )
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      post_reference_name: self.refname,
+      session_id: session_db_id,
+      origin_type: :session,
+      private_data: opts[:password],
+      private_type: :password,
+      username: opts[:user]
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def exploit
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
 
@@ -105,16 +132,13 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # report the auth
-    auth = {
-        :host   => datastore['RHOST'],
-        :port   => 445,
-        :sname  => 'smb',
-        :proto  => 'tcp',
-        :user   => user,
-        :pass   => pass,
-        :active => true
-      }
-    report_auth_info(auth)
+    report_cred(
+      ip: datastore['RHOST'],
+      port: 445,
+      service_name: 'smb',
+      user: user,
+      password: pass
+    )
 
     srvc = {
         :host   => datastore['RHOST'],


### PR DESCRIPTION
This patch updates the ca_arcserve_rpc_authbypass module to use the new credential API.

I can't actually find the vulnerable software, so please test the exploit this way:
- [x] Start msfconsole
- [x] Do: `workspace -a ca_cred_test`
- [x] Under the msf prompt, do: `irb`
- [x] Enter the following code:

```
mod = framework.exploits.create('windows/http/ca_arcserve_rpc_authbypass')
mod.report_cred(ip: '192.168.1.123', port: 445, service_name: 'smb', user: 'fakeuser', password: 'fakepass')
```

Note: The way report_cred is called above is exactly how the exploit calls report_cred
- [x] Exit irb. And then do: `creds`
- [x] You should see the fake cred created by calling the exploit's report_cred method:

```
msf auxiliary(test) > creds
Credentials
===========

host           service        public    private   realm  private_type
----           -------        ------    -------   -----  ------------
192.168.1.123  445/tcp (smb)  fakeuser  fakepass         Password
```
