### PR TITLE
Update kloxo_sqli to use the new cred API

### DIFF
--- a/modules/exploits/linux/http/kloxo_sqli.rb
+++ b/modules/exploits/linux/http/kloxo_sqli.rb
@@ -73,6 +73,32 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      post_reference_name: self.refname,
+      private_data: opts[:password],
+      origin_type: :service,
+      private_type: :password,
+      username: opts[:user]
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def check
     return Exploit::CheckCode::Safe unless webcommand_exists?
     return Exploit::CheckCode::Safe if exploit_sqli(1, bad_char(0))
@@ -94,13 +120,12 @@ class Metasploit3 < Msf::Exploit::Remote
     @session = send_login
     fail_with(Failure::NoAccess, "#{peer} - Login with admin/#{@password} failed...") if @session.nil?
 
-    report_auth_info(
-      :host => rhost,
-      :port => rport,
-      :user => 'admin',
-      :pass => @password,
-      :type => 'password',
-      :sname => (ssl ? 'https' : 'http')
+    report_cred(
+      ip: rhost,
+      port: rport,
+      user: 'admin',
+      service_name: 'http',
+      password: @password
     )
 
     print_status("#{peer} - Retrieving the server name...")

--- a/modules/exploits/linux/http/kloxo_sqli.rb
+++ b/modules/exploits/linux/http/kloxo_sqli.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 
     create_credential_login(login_data)


### PR DESCRIPTION
This patch updates the linux/http/kloxo_sqli exploit to use the new credential API.

I don't have the vulnerable application for testing, but here's a way you can verify it.
- [x] Start msfconsole
- [x] Do: `workspace -a kloxo`
- [x] Do: `irb`
- [x] Do the following:

```
mod = framework.exploits.create('linux/http/kloxo_sqli')
od.report_cred(ip: '192.168.1.123', port: 80, user: 'admin', service_name: 'http', password: 'mypass')
```

The credential data reported should mimic what the exploit does.
- [x] Do: `creds`
- [x] You should see the cred in there
