### PR TITLE
Use the correct help output for the ps command

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -436,12 +436,7 @@ class Console::CommandDispatcher::Stdapi::Sys
             return true
           end
         when '-h'
-          print_line "Usage: ps [ options ]"
-          print_line
-          print_line "OPTIONS:"
-          print_line " -S       Search string to filter by"
-          print_line " -h 		This help menu"
-          print_line
+          cmd_ps_help
           return 0
       when "-A"
         print_line "Filtering on arch..."
@@ -491,7 +486,6 @@ class Console::CommandDispatcher::Stdapi::Sys
       'SearchTerm' => search_term)
 
     processes.each { |ent|
-
       session = ent['session'] == 0xFFFFFFFF ? '' : ent['session'].to_s
       arch    = ent['arch']
 
@@ -503,8 +497,6 @@ class Console::CommandDispatcher::Stdapi::Sys
       row = [ ent['pid'].to_s, ent['name'], arch, session, ent['user'], ent['path'] ]
 
       tbl << row #if (search_term.nil? or row.join(' ').to_s.match(search_term))
-
-
     }
 
     if (processes.length == 0)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -429,15 +429,15 @@ class Console::CommandDispatcher::Stdapi::Sys
     # Parse opts
     @@ps_opts.parse(args) { |opt, idx, val|
       case opt
-        when '-S'
-          search_term = val
-          if search_term.nil?
-            print_error("Enter a search term")
-            return true
-          end
-        when '-h'
-          cmd_ps_help
-          return 0
+      when '-S'
+        search_term = val
+        if search_term.nil?
+          print_error("Enter a search term")
+          return true
+        end
+      when '-h'
+        cmd_ps_help
+        return true
       when "-A"
         print_line "Filtering on arch..."
         searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
@@ -510,6 +510,8 @@ class Console::CommandDispatcher::Stdapi::Sys
   end
 
   def cmd_ps_help
+    print_line "Usage: ps [ options ]"
+    print_line
     print_line "Use the command with no arguments to see all running processes."
     print_line "The following options can be used to filter those results:"
 


### PR DESCRIPTION
We somehow are using the wrong method for displaying the help output for the ps command in a meterpreter session.
# Validation steps:
- [x] It should not look like this:

```
meterpreter > ps -h
Usage: ps [ options ]

OPTIONS:
 -S       Search string to filter by
 -h         This help menu
```
- [x] It should not not look like this:

```
meterpreter > ps -h
Usage: ps [ options ]

Use the command with no arguments to see all running processes.
The following options can be used to filter those results:

OPTIONS:

    -A <opt>  Filters processes on architecture (x86 or x86_64)
    -S <opt>  String to search for (converts to regex)
    -U <opt>  Filters processes on the user using the supplied RegEx
    -h        Help menu.
    -s        Show only SYSTEM processes
```
