### PR TITLE
Update wordpress_login_enum to use the new cred API

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -125,7 +125,7 @@ class Metasploit3 < Msf::Auxiliary
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 
     create_credential_login(login_data)


### PR DESCRIPTION
This patch updates the wordpress_login_enum module to use the new credential API.
- [x] Get a LAMP box
- [x] Install [Wordpress](https://wordpress.org/download/release-archive/)
- [x] Configure Wordpress, make sure you know the user/pass
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/http/wordpress_login_enum`
- [x] Do: `set rhosts [Target IP]`
- [x] Do: `set username [username]`
- [x] Do: `set password [password]`
- [x] Do: `run`
- [x] You should get a valid cred
- [x] Do: `creds` in the console
- [x] You should see the cred there too
