### PR TITLE
Refactor db_nmap and fix the save option

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -14,10 +14,6 @@ class Db
   require 'tempfile'
 
   include Msf::Ui::Console::CommandDispatcher
-
-  # TODO: Not thrilled about including this entire module for just store_local.
-  include Msf::Auxiliary::Report
-
   include Metasploit::Credential::Creation
 
   #
@@ -1752,15 +1748,14 @@ class Db
     return unless active?
   ::ActiveRecord::Base.connection_pool.with_connection {
     if (args.length == 0)
-      print_status("Usage: db_nmap [nmap options]")
+      print_status("Usage: db_nmap [--save | [--help | -h]] [nmap options]")
       return
     end
-    save = false
     arguments = []
     while (arg = args.shift)
       case arg
-      when 'save'
-        save = active?
+      when '--save'
+        save = true
       when '--help', '-h'
         cmd_db_nmap_help
         return
@@ -1778,55 +1773,47 @@ class Db
       return
     end
 
-    fd = Tempfile.new('dbnmap')
-    fd.binmode
-
-    fo = Tempfile.new('dbnmap')
-    fo.binmode
-
-    # When executing native Nmap in Cygwin, expand the Cygwin path to a Win32 path
-    if(Rex::Compat.is_cygwin and nmap =~ /cygdrive/)
-      # Custom function needed because cygpath breaks on 8.3 dirs
-      tout = Rex::Compat.cygwin_to_win32(fd.path)
-      fout = Rex::Compat.cygwin_to_win32(fo.path)
-      arguments.push('-oX', tout)
-      arguments.push('-oN', fout)
-    else
-      arguments.push('-oX', fd.path)
-      arguments.push('-oN', fo.path)
-    end
+    fd = Rex::Quickfile.new(['msf-db-nmap-', '.xml'], Msf::Config.local_directory)
 
     begin
-      nmap_pipe = ::Open3::popen3([nmap, 'nmap'], *arguments)
-      temp_nmap_threads = []
-      temp_nmap_threads << framework.threads.spawn("db_nmap-Stdout", false, nmap_pipe[1]) do |np_1|
-        np_1.each_line do |nmap_out|
-          next if nmap_out.strip.empty?
-          print_status("Nmap: #{nmap_out.strip}")
-        end
+      # When executing native Nmap in Cygwin, expand the Cygwin path to a Win32 path
+      if(Rex::Compat.is_cygwin and nmap =~ /cygdrive/)
+        # Custom function needed because cygpath breaks on 8.3 dirs
+        tout = Rex::Compat.cygwin_to_win32(fd.path)
+        arguments.push('-oX', tout)
+      else
+        arguments.push('-oX', fd.path)
       end
 
-      temp_nmap_threads << framework.threads.spawn("db_nmap-Stderr", false, nmap_pipe[2]) do |np_2|
-        np_2.each_line do |nmap_err|
-          next if nmap_err.strip.empty?
-          print_status("Nmap: '#{nmap_err.strip}'")
+      begin
+        nmap_pipe = ::Open3::popen3([nmap, 'nmap'], *arguments)
+        temp_nmap_threads = []
+        temp_nmap_threads << framework.threads.spawn("db_nmap-Stdout", false, nmap_pipe[1]) do |np_1|
+          np_1.each_line do |nmap_out|
+            next if nmap_out.strip.empty?
+            print_status("Nmap: #{nmap_out.strip}")
+          end
         end
+
+        temp_nmap_threads << framework.threads.spawn("db_nmap-Stderr", false, nmap_pipe[2]) do |np_2|
+          np_2.each_line do |nmap_err|
+            next if nmap_err.strip.empty?
+            print_status("Nmap: '#{nmap_err.strip}'")
+          end
+        end
+
+        temp_nmap_threads.map {|t| t.join rescue nil}
+        nmap_pipe.each {|p| p.close rescue nil}
+      rescue ::IOError
       end
 
-      temp_nmap_threads.map {|t| t.join rescue nil}
-      nmap_pipe.each {|p| p.close rescue nil}
-    rescue ::IOError
-    end
+      framework.db.import_nmap_xml_file(:filename => fd.path)
 
-    fo.close(true)
-    framework.db.import_nmap_xml_file(:filename => fd.path)
-
-    if save
-      fd.rewind
-      saved_path = report_store_local("nmap.scan.xml", "text/xml", fd.read, "nmap_#{Time.now.utc.to_i}")
-      print_status("Saved NMAP XML results to #{saved_path}")
+      print_status("Saved NMAP XML results to #{fd.path}") if save
+    ensure
+      fd.close
+      fd.unlink unless save
     end
-    fd.close(true)
   }
   end
 
@@ -1867,13 +1854,6 @@ class Db
     end
 
     tabs
-  end
-
-  #
-  # Store some locally-generated data as a file, similiar to store_loot.
-  #
-  def report_store_local(ltype=nil, ctype=nil, data=nil, filename=nil)
-    store_local(ltype,ctype,data,filename)
   end
 
   #

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -61,7 +61,6 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
   it { is_expected.to respond_to :each_host_range_chunk }
   it { is_expected.to respond_to :make_sortable }
   it { is_expected.to respond_to :name }
-  it { is_expected.to respond_to :report_store_local }
   it { is_expected.to respond_to :set_rhosts_from_addrs }
 
   describe "#cmd_creds" do


### PR DESCRIPTION
Fixes #4999 and refactors `db_nmap`.

**PROTIP:** Use https://github.com/rapid7/metasploit-framework/pull/5487/files?w= to negate the whitespace changes.
