### PR TITLE
Fix #5461, actually stop a job from the RPC service

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_job.rb
+++ b/lib/msf/core/rpc/v10/rpc_job.rb
@@ -28,9 +28,10 @@ class RPC_Job < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('job.stop', 0)
   def rpc_stop(jid)
-    obj = self.framework.jobs[jid.to_s]
+    jid = jid.to_s
+    obj = self.framework.jobs[jid]
     error(500, "Invalid Job") if not obj
-    obj.stop
+    self.framework.jobs.stop_job(jid)
     { "result" => "success" }
   end
 


### PR DESCRIPTION
Fix #5461. The RPC service is incorrectly stopping a job, this patch should fix that.
- [x] Start the RPC service: `ruby msfrpcd -U user -P pass -f`
- [x] Start a RCP client: `ruby msfrpc -U user -P pass -a [RPC server's IP]`
- [x] In the client, do: `rpc.call('module.execute', 'exploit', 'multi/handler', {'LHOST'=>'0.0.0.0', 'LPORT'=>4444, 'PAYLOAD'=>'windows/meterpreter/reverse_tcp'})`
- [x] Do: `rpc.call('job.list')`
- [x] It should list the multi/handler job (let's assume the job ID is 0)
- [x] In a different terminal, do: `netstat -antp tcp |grep 4444`
- [x] You should see port 444 listening
- [x] Do: `rpc.call('job.stop', 0)`
- [x] Do: `rpc.call('job.list')`
- [x] The job should be gone
- [x] Do: `netstat -antp tcp |grep 4444`
- [x] Port 4444 is also no longer listening
