### PR TITLE
Update pcanywhere_login to use the new cred API

### DIFF
--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
         report successful logins.
       },
       'Author'      => ['theLightCosine'],
-      'References'     =>
+      'References'  =>
         [
           [ 'CVE', '1999-0502'] # Weak password
         ],
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Auxiliary
           port: datastore['RPORT'],
           service_name: 'pcanywhere',
           user: user,
-          password: pass,
+          password: pass
         )
         return if datastore['STOP_ON_SUCCESS']
         print_status('Waiting to Re-Negotiate Connection (this may take a minute)...')
@@ -90,7 +90,8 @@ class Metasploit3 < Msf::Auxiliary
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL
     }.merge(service_data)
 
     create_credential_login(login_data)


### PR DESCRIPTION
This PR updates the modules/auxiliary/scanner/pcanywhere/pcanywhere_login module to use the new credential API.

pcanywhere is a proprietary software from Symentec that is why I couldn't find a working download. Tested as follow:
- Start msfconsole
- Do: workspace -a pcanywhere_cred_test
- Under the msf prompt, do: irb
- Enter the following code:
  mod = framework.auxiliary.create('scanner/pcanywhere/pcanywhere_login')
  mod.report_cred(ip: '1.2.3.4', port: 5631, service_name: 'pcanywhere', user: 'fakeuser', password: 'fakepassword')
- Exit irb
- Run creds command on the msfconsole

You should see the following:

``` ruby
Credentials
===========

host     service                public        private       realm  private_type
----     -------                ------        -------       -----  ------------
1.1.1.1  6531/tcp (pcanywhere)  fakeusername  fakepassword         Password
```
