### PR TITLE
Update owa_login to use new cred API

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -341,6 +341,7 @@ class Metasploit3 < Msf::Auxiliary
 
     login_data = {
       core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -206,15 +206,6 @@ class Metasploit3 < Msf::Auxiliary
       # Check if the password needs to be changed.
       if res.headers['location'] =~ /expiredpassword/
         print_good("#{msg} SUCCESSFUL LOGIN. #{elapsed_time} '#{user}' : '#{pass}': NOTE password change required")
-        report_hash = {
-          :host   => datastore['RHOST'],
-          :port   => datastore['RPORT'],
-          :sname  => 'owa',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'}
-
         report_cred(
           ip: datastore['RHOST'],
           port: datastore['RPORT'],
@@ -276,16 +267,6 @@ class Metasploit3 < Msf::Auxiliary
 
     if res.body =~ login_check
       print_good("#{msg} SUCCESSFUL LOGIN. #{elapsed_time} '#{user}' : '#{pass}'")
-
-      report_hash = {
-        :host   => datastore['RHOST'],
-        :port   => datastore['RPORT'],
-        :sname  => 'owa',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'}
-
       report_cred(
         ip: datastore['RHOST'],
         port: datastore['RPORT'],
@@ -360,7 +341,7 @@ class Metasploit3 < Msf::Auxiliary
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 
     create_credential_login(login_data)

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -76,7 +76,6 @@ class Metasploit3 < Msf::Auxiliary
       }
     )
 
-
     register_options(
       [
         OptInt.new('RPORT', [ true, "The target port", 443]),
@@ -128,7 +127,15 @@ class Metasploit3 < Msf::Auxiliary
       each_user_pass do |user, pass|
         next if (user.blank? or pass.blank?)
         vprint_status("#{msg} Trying #{user} : #{pass}")
-        try_user_pass({"user" => user, "domain"=>domain, "pass"=>pass, "auth_path"=>auth_path, "inbox_path"=>inbox_path, "login_check"=>login_check, "vhost"=>vhost})
+        try_user_pass({
+          user: user,
+          domain: domain,
+          pass: pass,
+          auth_path: auth_path,
+          inbox_path: inbox_path,
+          login_check: login_check,
+          vhost: vhost
+        })
       end
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED
       print_error("#{msg} HTTP Connection Error, Aborting")
@@ -136,13 +143,13 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def try_user_pass(opts)
-    user = opts["user"]
-    pass = opts["pass"]
-    auth_path = opts["auth_path"]
-    inbox_path = opts["inbox_path"]
-    login_check = opts["login_check"]
-    vhost = opts["vhost"]
-    domain = opts["domain"]
+    user = opts[:user]
+    pass = opts[:pass]
+    auth_path = opts[:auth_path]
+    inbox_path = opts[:inbox_path]
+    login_check = opts[:login_check]
+    vhost = opts[:vhost]
+    domain = opts[:domain]
 
     user = domain + '\\' + user if domain
 
@@ -208,7 +215,13 @@ class Metasploit3 < Msf::Auxiliary
           :active => true,
           :type => 'password'}
 
-        report_auth_info(report_hash)
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'owa',
+          user: user,
+          password: pass
+        )
         return :next_user
       end
 
@@ -273,7 +286,13 @@ class Metasploit3 < Msf::Auxiliary
         :active => true,
         :type => 'password'}
 
-      report_auth_info(report_hash)
+      report_cred(
+        ip: datastore['RHOST'],
+        port: datastore['RPORT'],
+        service_name: 'owa',
+        user: user,
+        password: pass
+      )
       return :next_user
     else
       vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (response body did not match)")
@@ -282,14 +301,14 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def get_ad_domain
-    urls = ["aspnet_client",
-      "Autodiscover",
-      "ecp",
-      "EWS",
-      "Microsoft-Server-ActiveSync",
-      "OAB",
-      "PowerShell",
-      "Rpc"]
+    urls = ['aspnet_client',
+      'Autodiscover',
+      'ecp',
+      'EWS',
+      'Microsoft-Server-ActiveSync',
+      'OAB',
+      'PowerShell',
+      'Rpc']
 
     domain = nil
 
@@ -299,7 +318,7 @@ class Metasploit3 < Msf::Auxiliary
           'encode'   => true,
           'uri'      => "/#{url}",
           'method'   => 'GET',
-          'headers'  =>  {"Authorization" => "NTLM TlRMTVNTUAABAAAAB4IIogAAAAAAAAAAAAAAAAAAAAAGAbEdAAAADw=="}
+          'headers'  =>  {'Authorization' => 'NTLM TlRMTVNTUAABAAAAB4IIogAAAAAAAAAAAAAAAAAAAAAGAbEdAAAADw=='}
         })
       rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
         vprint_error("#{msg} HTTP Connection Failed")
@@ -314,12 +333,37 @@ class Metasploit3 < Msf::Auxiliary
       if res && res.code == 401 && res.headers.has_key?('WWW-Authenticate') && res.headers['WWW-Authenticate'].match(/^NTLM/i)
         hash = res['WWW-Authenticate'].split('NTLM ')[1]
         domain = Rex::Proto::NTLM::Message.parse(Rex::Text.decode_base64(hash))[:target_name].value().gsub(/\0/,'')
-        print_good("Found target domain: " + domain)
+        print_good("Found target domain: #{domain}")
         return domain
       end
     end
 
     return domain
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def msg


### PR DESCRIPTION
This PR updates the modules/auxiliary/scanner/http/owa_login to use the new credentials API.
- Start msfconsole
- Do: use auxiliary/scanner/http/owa_login
- Do: Configure RHOST
- Do: Configure USER_FILE
- Do: Configure: PASS_FILE
- Do: run
- Run creds command on the msf prompt. You should see:

``` ruby
Credentials
===========

host         service        public                         private             realm  private_type
----         -------        ------                         -------             -----  ------------
1.1.1.1      443/tcp (owa)  local\test@test.com            mypassword                 Password
```

Tested successfully on Exchange 2013 OWA
