### PR TITLE
Backport an upstream fix for a nil header

### DIFF
--- a/lib/rbmysql/protocol.rb
+++ b/lib/rbmysql/protocol.rb
@@ -234,6 +234,7 @@ class RbMysql
       begin
         Timeout.timeout @read_timeout do
           header = @sock.read(4)
+          raise EOFError unless header && header.length == 4
           len1, len2, seq = header.unpack("CvC")
           len = (len2 << 8) + len1
           # Ignore the sequence number -- protocol differences between 4.x and 5.x


### PR DESCRIPTION
https://github.com/tmtm/ruby-mysql/commit/353d5951da1089432eac063b793b6561361be78a
https://github.com/tmtm/ruby-mysql/commit/7c984ea66e9cca61b1e6e99647138c99f44a5ba5

Fixes #5207.
