### PR TITLE
Small rework of the spinners, clear the line when done

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -19,11 +19,21 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
     return if Rex::Compat.is_cygwin
     return if $msf_spinner_thread
     $msf_spinner_thread = Thread.new do
-      $stderr.print "[*] Starting the Metasploit Framework console..."
+      base_line = "[*] Starting the Metasploit Framework console..."
+      cycle = 0
       loop do
         %q{/-\|}.each_char do |c|
-          $stderr.print c
-          $stderr.print "\b"
+          status = "#{base_line}#{c}\r"
+          cycle += 1
+          off    = cycle % base_line.length
+          case status[off, 1]
+          when /[a-z]/
+            status[off, 1] = status[off, 1].upcase
+          when /[A-Z]/
+            status[off, 1] = status[off, 1].downcase
+          end
+          $stderr.print status
+          ::IO.select(nil, nil, nil, 0.10)
         end
       end
     end

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -547,7 +547,7 @@ class Driver < Msf::Ui::Driver
 
     if $msf_spinner_thread
       $msf_spinner_thread.kill
-      $stderr.print "\n"
+      $stderr.print "\r" + (" " * 60) + "\n"
     end
 
     run_single("banner") unless opts['DisableBanner']


### PR DESCRIPTION
This solves two small bugs when the "spinner":
- The lack of a sleep caused the spinner thread to use more CPU than necessary
- The status line wasn't cleared once loading was complete

This also adds a subtle progress bar into the status line (hard to notice during fast loads, though)
