### PR TITLE
Update Payload Cached Sizes fails in PSH Script

### DIFF
--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -37,7 +37,7 @@ module Powershell
 
       begin
         # Open code file for reading
-        fd = ::File.new(code, 'rb')
+        fd = ::File.new(code || '', 'rb')
         while (line = fd.gets)
           @code << line
         end


### PR DESCRIPTION
When attempting to update cached payload sizes which utilize the
Rex::Powershell functionality, the BRE block which appropriates
initial code is called with the 'code' variable being a nil which
results in:

```
lib/rex/powershell/script.rb:40:in `initialize': no implicit
conversion of nil into String (TypeError)
```

This throws a conditional into the File.open call which presents an
empty string instead of a nil. This still results in the rescue
block having to catch the exception, but manages to keep the
payload size updating script happy and retains consistent
behavior.
