### PR TITLE
Update splunk_web_login to use the new creds API

### DIFF
--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -16,9 +16,9 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'Splunk Web Interface Login Utility',
       'Description'    => %{
-        This module simply attempts to login to a Splunk web interface. Some Splunk 
-        applications still have the default credential 'admin:changeme' written on 
-        the login page.  If this default credential is found, the module will also 
+        This module simply attempts to login to a Splunk web interface. Some Splunk
+        applications still have the default credential 'admin:changeme' written on
+        the login page.  If this default credential is found, the module will also
         store that information, and then move on to trying more passwords.
       },
       'Author'         =>

--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -159,15 +159,6 @@ class Metasploit3 < Msf::Auxiliary
 
       print_good("SUCCESSFUL LOGIN. '#{user}':'#{pass}'")
 
-      report_hash = {
-        :host   => datastore['RHOST'],
-        :port   => datastore['RPORT'],
-        :sname  => 'splunk-web',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'}
-
       report_cred(
         ip: datastore['RHOST'],
         port: datastore['RPORT'],
@@ -202,7 +193,7 @@ class Metasploit3 < Msf::Auxiliary
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 
     create_credential_login(login_data)


### PR DESCRIPTION
This PR updates the modules/auxiliary/scanner/http/splunk_web_login module to use the new creds API.
To verify:
- Download splunk from http://download.splunk.com/products/splunk/releases/6.2.3/splunk/windows/splunk-6.2.3-264376-x64-release.msi. This is the latest version available at the moment for Windows.
- Install splunk. By default the web daemon runs on port 8000.
- Make sure port 8000 is remotely accessible
- First time, the login is admin:change. Change the default credentials when prompted after first login.
- On the Metasploit machine, run msfconsole
- Do: use auxiliary/scanner/http/splunk_web_login
- Do Configure the RHOSTS option: set RHOSTS <splunk IP>
- Adjust any other settings if required
- Do: run
- If credentials are successfully brute-forced, run creds. You should see:

``` ruby
Credentials
===========

host          service                public  private   realm  private_type
----          -------                ------  -------   -----  ------------
1.1.1.1       8000/tcp (splunk-web)  admin   password         Password
```

Note that the statement "free version of Splunk actually does not require any authentication, in that case the module will abort trying" is not true. The new splunk software require authentication always. 
