### PR TITLE
Update vmware_http_login to use the new creds API

### DIFF
--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -144,7 +144,7 @@ class Metasploit3 < Msf::Auxiliary
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 
     create_credential_login(login_data)


### PR DESCRIPTION
This PR updates the modules/auxiliary/scanner/vmware/vmware_http_login module to use the new creds API.
To verify:
- Create a new workspace: workspace -a vmware_creds_test
- Do: use auxiliary/scanner/vmware/vmware_http_login
- Do: set RHOSTS <ESX or ESXi server IP>
- Do: set USERNAME <username>
- Do: set PASSWORD <password>
- Do: set STOP_ON_SUCCESS true
- Do: run
- If credentials are successfully guessed, run the creds command. You should see:

``` ruby
Credentials
===========

host          service               public  private     realm  private_type
----          -------               ------  -------     -----  ------------
1.1.1.1      443/tcp (VMware-Web)   root     mypassword        Password
```

Tested on VMware ESXi 5.5.0 build-2068190
