### PR TITLE
Update nessus_xmlrpc_logic to use the new creds API

### DIFF
--- a/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
@@ -99,17 +99,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if res.code == 200
       if res.body =~ /<status>OK<\/status>/
-        print_good("SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
-
-        report_hash = {
-          :host   => datastore['RHOST'],
-          :port   => datastore['RPORT'],
-          :sname  => 'nessus-xmlrpc',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'}
-
+        print_good("SUCCESSFUL LOGIN. '#{user}':'#{pass}'")
         report_cred(
           ip: datastore['RHOST'],
           port: datastore['RPORT'],
@@ -120,7 +110,7 @@ class Metasploit3 < Msf::Auxiliary
         return :next_user
       end
     end
-    vprint_error("FAILED LOGIN. '#{user}' : '#{pass}'")
+    vprint_error("FAILED LOGIN. '#{user}':'#{pass}'")
     return :skip_pass
   end
 
@@ -143,7 +133,7 @@ class Metasploit3 < Msf::Auxiliary
 
     login_data = {
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
     }.merge(service_data)
 
     create_credential_login(login_data)

--- a/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
@@ -110,11 +110,43 @@ class Metasploit3 < Msf::Auxiliary
           :active => true,
           :type => 'password'}
 
-        report_auth_info(report_hash)
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'nessus-xmlrpc',
+          user: user,
+          password: pass
+        )
         return :next_user
       end
     end
     vprint_error("FAILED LOGIN. '#{user}' : '#{pass}'")
     return :skip_pass
   end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
 end


### PR DESCRIPTION
This PR updates the modules/auxiliary/scanner/nessus/nessus_xmlrpc_login module to use the new creds API.

Nessus version 5 or later are using REST API and not XMLRPC. This module is to keep it for legacy Nessus installations. The following procedure was used for testing the module changes:
- Start msfconsole
- Do: irb
- Run the following commands<br/>
  mod = framework.auxiliary.create('scanner/nessus/nessus_xmlrpc_login')
  <br/>
  mod.report_cred(ip: '1.1.1.1', port: '8834', user: 'admin', password: 'mypassword', service_name: 'nessus-xmlrpc')
- Exit the irb through exit command
- Run creds command. You should see:

``` ruby
Credentials
===========

host     service                   public  private     realm  private_type
----     -------                   ------  -------     -----  ------------
1.1.1.1  8834/tcp (nessus-xmlrpc)  admin   mypassword         Password
```
