### PR TITLE
User Hunter Plugin

### DIFF
--- a/plugins/user_hunter.rb
+++ b/plugins/user_hunter.rb
@@ -2,6 +2,10 @@
 # $Id$
 # $Revision$
 #
+# Find specific users based on enumeration
+#
+# Joshua D. Abraham <jabra[at]praetorian.com>
+#
 module Msf
 
 class Plugin::UserHunter < Msf::Plugin

--- a/plugins/user_hunter.rb
+++ b/plugins/user_hunter.rb
@@ -15,8 +15,7 @@ class Plugin::UserHunter < Msf::Plugin
 
     def commands
       {
-        'smb_hunt'        => "Search the database for specific user found via
-smb enumeration"
+        'smb_hunt'        => "Search the database for specific user(s) found via smb enumeration"
       }
     end
 
@@ -66,12 +65,14 @@ smb enumeration"
       end
 
       if(opt_userfile)
-        ::File.open(opt_userfile, "rb") do |fd|
-          fd.each_line do |line|
-            line.strip!
-            next if line.empty?
-            next if line =~ /^#/
-            opt_users << line
+        if ::File.readable?(opt_userfile)
+          ::File.open(opt_userfile, "rb") do |fd|
+            fd.each_line do |line|
+              line.strip!
+              next if line.empty?
+              next if line =~ /^#/
+              opt_users << line
+            end
           end
         end
       end

--- a/plugins/user_hunter.rb
+++ b/plugins/user_hunter.rb
@@ -15,12 +15,12 @@ class Plugin::UserHunter < Msf::Plugin
 
     def commands
       {
-        'smb_hunt'        => "Search the database for specific user(s) found via smb enumeration"
+        'user_hunt_smb'        => "Search the database for specific user(s) found via smb enumeration"
       }
     end
 
     def cmd_print_usage(opts)
-      print_line("Usage: smb_hunt [options] <username> [username] .. [username]")
+      print_line("Usage: user_hunt_smb [options] <username> [username] .. [username]")
       print_line(opts.usage)
       return
     end
@@ -34,7 +34,7 @@ class Plugin::UserHunter < Msf::Plugin
       true
     end
 
-    def cmd_smb_hunt(*args)
+    def cmd_user_hunt_smb(*args)
       return if not cmd_verify_db
 
       opts = Rex::Parser::Arguments.new(

--- a/plugins/user_hunter.rb
+++ b/plugins/user_hunter.rb
@@ -1,0 +1,112 @@
+#
+# $Id$
+# $Revision$
+#
+module Msf
+
+class Plugin::UserHunter < Msf::Plugin
+
+  class SMBCommandDispatcher
+    include Msf::Ui::Console::CommandDispatcher
+
+    def name
+      "User Hunter"
+    end
+
+    def commands
+      {
+        'smb_hunt'        => "Search the database for specific user found via
+smb enumeration"
+      }
+    end
+
+    def cmd_print_usage(opts)
+      print_line("Usage: smb_hunt [options] <username> [username] .. [username]")
+      print_line(opts.usage)
+      return
+    end
+
+    def cmd_verify_db
+      if ! (framework.db and framework.db.usable and framework.db.active)
+        print_error("No database has been configured, please use db_create/db_connect first")
+        return false
+      end
+
+      true
+    end
+
+    def cmd_smb_hunt(*args)
+      return if not cmd_verify_db
+
+      opts = Rex::Parser::Arguments.new(
+        "-h"   => [ false,  "This help menu"],
+        "-v"   => [ false,  "Verbose flag"],
+        "-f"   => [ true,   "A file containing a list of users to search for (one per line)"]
+      )
+
+      opt_userfile  = nil
+      opt_users     = []
+      opt_verbose   = false
+
+      if(args.length == 0 or args[0].empty? or args[0] == "-h")
+        cmd_print_usage(opts)
+      end
+
+      opts.parse(args) do |opt, idx, val|
+        case opt
+        when "-h"
+          cmd_print_usage(opts)
+        when "-f"
+          opt_userfile = val
+        when "-v"
+          opt_verbose = true
+        else
+          opt_users << val
+        end
+      end
+
+      if(opt_userfile)
+        ::File.open(opt_userfile, "rb") do |fd|
+          fd.each_line do |line|
+            line.strip!
+            next if line.empty?
+            next if line =~ /^#/
+            opt_users << line
+          end
+        end
+      end
+
+      opt_users.uniq!
+
+      framework.db.notes.each do |sid|
+        if sid[:ntype] ==  'smb_loggedin_users'
+          if opt_verbose
+            print_status(">> Checking users from #{sid.host.address}")
+          end
+          if opt_users.include?(sid[:data][:user].to_s)
+            print_good(">> FOUND USER: #{sid.host.address} - #{sid[:data][:user]}")
+          end
+        end
+      end
+    end
+  end
+
+
+  def initialize(framework, opts)
+    super
+    add_console_dispatcher(SMBCommandDispatcher)
+  end
+
+  def cleanup
+    remove_console_dispatcher('User Hunter')
+  end
+
+  def name
+    "user_hunter"
+  end
+
+  def desc
+    "Search for specific users"
+  end
+end
+end


### PR DESCRIPTION
Plugin to compare a list of known users with those that have been found via smb_enumuser_domain. Any users that are identified will be returned in the console

example usage: 

```
 msf> load user_hunter
   [*] Successfully loaded plugin: user_hunter
   msf > user_hunt_smb 
   Usage: user_hunt_smb [options] <username> [username] .. [username]

   OPTIONS:

    -f <opt>  A file containing a list of users to search for (one per line)
    -h        This help menu
    -v        Verbose flag

   msf > user_hunt_smb -f /tmp/da.txt
   [+] >> FOUND USER: 192.168.1.50- ACME\joe-admin
```
