### PR TITLE
Update MDM dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
     metasploit-payloads (1.0.2)
-    metasploit_data_models (1.2.1)
+    metasploit_data_models (1.2.2)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       arel-helpers
@@ -139,7 +139,7 @@ GEM
     mini_portile (0.6.2)
     minitest (4.7.5)
     msgpack (0.6.0)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     multi_test (0.1.2)
     network_interface (0.0.1)
     nokogiri (1.6.6.2)
@@ -174,7 +174,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rb-readline-r7 (0.5.2.0)
-    recog (2.0.4)
+    recog (2.0.5)
       nokogiri
     redcarpet (3.2.3)
     rkelly-remix (0.0.6)


### PR DESCRIPTION
MSP-12813
## Verification
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY: all pass
- [x] `bundle show metasploit_data_models`
- [x] VERIFY: installed version is metasploit_data_models-1.2.2
