### PR TITLE
Fix #5531, the ```stage_payload``` method does not take arguments.

### DIFF
--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -138,7 +138,8 @@ module Msf::Payload::Stager
     if stage_assembly and !stage_assembly.empty?
       raw = build(stage_assembly, stage_offsets)
     else
-      raw = stage_payload(opts).dup
+      # Options get ignored by the stage_payload method
+      raw = stage_payload
     end
 
     # Substitute variables in the stage


### PR DESCRIPTION
The msfconsole `generate` command exercises an otherwise unused code path that incorrectly passes arguments to the `stage_payload` method. This PR fixes #5531.
