### PR TITLE
Cleanup and enhance ssh_version

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -5,12 +5,15 @@
 
 require 'msf/core'
 
-
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+
+  # the default timeout (in seconds) to wait, in total, for both a successful
+  # connection to a given endpoint and for the initial protocol response
+  # from the supposed SSH endpoint to be returned
+  DEFAULT_TIMEOUT = 30
 
   def initialize
     super(
@@ -18,54 +21,58 @@ class Metasploit3 < Msf::Auxiliary
       'Description' => 'Detect SSH Version.',
       'References'  =>
         [
-          [ 'URL', 'http://en.wikipedia.org/wiki/SecureShell' ],
+          [ 'URL', 'http://en.wikipedia.org/wiki/SecureShell' ]
         ],
       'Author'      => [ 'Daniel van Eeden <metasploit[at]myname.nl>' ],
       'License'     => MSF_LICENSE
     )
 
     register_options(
-    [
-      Opt::RPORT(22),
-      OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', 30])
-    ], self.class)
+      [
+        Opt::RPORT(22),
+        OptInt.new('TIMEOUT', [true, 'Timeout for the SSH probe', DEFAULT_TIMEOUT])
+      ],
+      self.class
+    )
   end
 
-  def to
-    return 30 if datastore['TIMEOUT'].to_i.zero?
-    datastore['TIMEOUT'].to_i
+  def timeout
+    datastore['TIMEOUT'] <= 0 ? DEFAULT_TIMEOUT : datastore['TIMEOUT']
   end
 
   def run_host(target_host)
     begin
-      ::Timeout.timeout(to) do
-
+      ::Timeout.timeout(timeout) do
         connect
 
-        resp = sock.get_once(-1, 5)
+        resp = sock.get_once(-1, timeout)
 
-        if (resp and resp =~ /SSH/)
-          ver,msg = (resp.split(/[\r\n]+/))
-          # Check to see if this is Kippo, which sends a premature
-          # key init exchange right on top of the SSH version without
-          # waiting for the required client identification string.
-          if msg and msg.size >= 5
-            extra = msg.unpack("NCCA*") # sz, pad_sz, code, data
-            if (extra.last.size+2 == extra[0]) and extra[2] == 20
-              ver << " (Kippo Honeypot)"
+        if resp
+          if resp =~ /^SSH/
+            ver, msg = resp.split(/[\r\n]+/)
+            # Check to see if this is Kippo, which sends a premature
+            # key init exchange right on top of the SSH version without
+            # waiting for the required client identification string.
+            if msg && msg.size >= 5
+              extra = msg.unpack("NCCA*") # sz, pad_sz, code, data
+              if (extra.last.size + 2 == extra[0]) && extra[2] == 20
+                ver << " (Kippo Honeypot)"
+              end
             end
+            print_status("#{target_host}:#{rport}, SSH server version: #{ver}")
+            report_service(host: rhost, port: rport, name: 'ssh', proto: 'tcp', info: ver)
+          else
+            vprint_warning("#{target_host}:#{rport} was not SSH --"  \
+                          " #{resp.size} bytes beginning with #{resp[0, 12]}")
           end
-          print_status("#{target_host}:#{rport}, SSH server version: #{ver}")
-          report_service(:host => rhost, :port => rport, :name => "ssh", :proto => "tcp", :info => ver)
         else
-          print_error("#{target_host}:#{rport}, SSH server version detection failed!")
+          vprint_warning("#{target_host}:#{rport} no response")
         end
-
-        disconnect
       end
-
     rescue Timeout::Error
-      print_error("#{target_host}:#{rport}, Server timed out after #{to} seconds. Skipping.")
+      vprint_warning("#{target_host}:#{rport} timed out after #{timeout} seconds. Skipping.")
+    ensure
+      disconnect
     end
   end
 end

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'recog'
 
 class Metasploit3 < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
@@ -36,9 +37,14 @@ class Metasploit3 < Msf::Auxiliary
     )
   end
 
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
   def timeout
     datastore['TIMEOUT'] <= 0 ? DEFAULT_TIMEOUT : datastore['TIMEOUT']
   end
+
 
   def run_host(target_host)
     begin
@@ -48,19 +54,25 @@ class Metasploit3 < Msf::Auxiliary
         resp = sock.get_once(-1, timeout)
 
         if resp
-          if resp =~ /^SSH/
-            ver, msg = resp.split(/[\r\n]+/)
+          ident, first_message = resp.split(/[\r\n]+/)
+          if /^SSH-\d+\.\d+-(?<banner>.*)$/ =~ ident
+            if recog_match = Recog::Nizer.match('ssh.banner', banner)
+              info = recog_match.to_s
+            else
+              info = 'UNKNOWN'
+              print_warning("#{peer} unknown SSH banner: #{banner}")
+            end
             # Check to see if this is Kippo, which sends a premature
             # key init exchange right on top of the SSH version without
             # waiting for the required client identification string.
-            if msg && msg.size >= 5
-              extra = msg.unpack("NCCA*") # sz, pad_sz, code, data
+            if first_message && first_message.size >= 5
+              extra = first_message.unpack("NCCA*") # sz, pad_sz, code, data
               if (extra.last.size + 2 == extra[0]) && extra[2] == 20
-                ver << " (Kippo Honeypot)"
+                info << " (Kippo Honeypot)"
               end
             end
-            print_status("#{target_host}:#{rport}, SSH server version: #{ver}")
-            report_service(host: rhost, port: rport, name: 'ssh', proto: 'tcp', info: ver)
+            print_status("#{target_host}:#{rport}, SSH server version: #{ident}")
+            report_service(host: rhost, port: rport, name: 'ssh', proto: 'tcp', info: info)
           else
             vprint_warning("#{target_host}:#{rport} was not SSH --"  \
                           " #{resp.size} bytes beginning with #{resp[0, 12]}")

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -71,18 +71,18 @@ class Metasploit3 < Msf::Auxiliary
                 info << " (Kippo Honeypot)"
               end
             end
-            print_status("#{target_host}:#{rport}, SSH server version: #{ident}")
+            print_status("#{peer}, SSH server version: #{ident}")
             report_service(host: rhost, port: rport, name: 'ssh', proto: 'tcp', info: info)
           else
-            vprint_warning("#{target_host}:#{rport} was not SSH --"  \
+            vprint_warning("#{peer} was not SSH --"  \
                           " #{resp.size} bytes beginning with #{resp[0, 12]}")
           end
         else
-          vprint_warning("#{target_host}:#{rport} no response")
+          vprint_warning("#{peer} no response")
         end
       end
     rescue Timeout::Error
-      vprint_warning("#{target_host}:#{rport} timed out after #{timeout} seconds. Skipping.")
+      vprint_warning("#{peer} timed out after #{timeout} seconds. Skipping.")
     ensure
       disconnect
     end


### PR DESCRIPTION
I was working on https://github.com/rapid7/recog/pull/68 and was looking for some alternative ways to test my work by testing my changes against larger SSH "banner" data sets.  I took `ssh_version` for a spin but found several things, primarily logging, to be in need of improvement when run against larger networks.  So I made those changes.

Then I realized that this would be a great place to wedge Recog since it is already shipped/used with Metasploit and the additional fingerprint information may be useful for someone running this module.

FWIW, I am also using this PR as a test/playground to see if there are easy wins for Recog in some of the existing Metasploit modules, primarily auxiliary.

/CC @hmoore-r7 
