### PR TITLE
Properly store quake service info

### DIFF
--- a/modules/auxiliary/scanner/quake/server_info.rb
+++ b/modules/auxiliary/scanner/quake/server_info.rb
@@ -55,10 +55,13 @@ class Metasploit3 < Msf::Auxiliary
       stuff = decode_info(response)
     when 'status'
       stuff = decode_status(response)
+    else
+      stuff = {}
     end
 
     if datastore['VERBOSE']
-      stuff.inspect
+      # get everything
+      stuff
     else
       # try to get the host name, game name and version
       stuff.select { |k, _| %w(hostname sv_hostname gamename com_gamename version).include?(k) }
@@ -68,9 +71,9 @@ class Metasploit3 < Msf::Auxiliary
   def scanner_process(response, src_host, src_port)
     stuff = decode_stuff(response)
     return unless stuff
-    @results[src_host] ||= []
+    @results[src_host] ||= {}
     print_good("#{src_host}:#{src_port} found '#{stuff}'")
-    @results[src_host] << stuff
+    @results[src_host].merge!(stuff)
   end
 
   def scanner_postscan(_batch)
@@ -81,7 +84,7 @@ class Metasploit3 < Msf::Auxiliary
         proto: 'udp',
         port: rport,
         name: 'Quake',
-        info: stuff
+        info: stuff.inspect
       )
     end
   end


### PR DESCRIPTION
This feels like a regression because I swear this worked and was tested, but the referenced module was improperly calling `report_service` which throws an error that isn't obvious, and no services are asserted as a result:

```
msf auxiliary(server_info) > run

[+] 10.4.25.3:27960 found '{"sv_hostname"=>"noname", "version"=>"ioq3 1.36+svn2202-1/Ubuntu linux-x86_64 Dec 12 2011", "com_gamename"=>"Quake3Arena", "gamename"=>"baseq3"}'
[*] Error: 10.4.25.3-10.4.25.3: can't cast Array to text
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(server_info) > services

Services
========

host  port  proto  name  state  info
----  ----  -----  ----  -----  ----

```

After, with and without verbose:

```
runmsf auxiliary(server_info) > run

[+] 10.4.25.3:27960 found '{"sv_hostname"=>"noname", "version"=>"ioq3 1.36+svn2202-1/Ubuntu linux-x86_64 Dec 12 2011", "com_gamename"=>"Quake3Arena", "gamename"=>"baseq3"}'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(server_info) > services

Services
========

host       port   proto  name   state  info
----       ----   -----  ----   -----  ----
10.4.25.3  27960  udp    quake  open   {"sv_hostname"=>"noname", "version"=>"ioq3 1.36+svn2202-1/Ubuntu linux-x86_64 Dec 12 2011", "com_gamename"=>"Quake3Arena", "gamename"=>"baseq3"}
msf auxiliary(server_info) > set VERBOSE true
VERBOSE => true
msf auxiliary(server_info) > run

[*] Sending probes to 10.4.25.3->10.4.25.3 (1 hosts)
[+] 10.4.25.3:27960 found '{"capturelimit"=>"8", "g_maxGameClients"=>"0", "sv_floodProtect"=>"1", "sv_maxPing"=>"0", "sv_minPing"=>"0", "sv_dlRate"=>"100", "sv_maxRate"=>"10000", "sv_minRate"=>"0", "sv_maxclients"=>"8", "sv_hostname"=>"noname", "timelimit"=>"25", "fraglimit"=>"30", "dmflags"=>"0", "version"=>"ioq3 1.36+svn2202-1/Ubuntu linux-x86_64 Dec 12 2011", "com_gamename"=>"Quake3Arena", "com_protocol"=>"71", "g_gametype"=>"0", "mapname"=>"q3dm2", "sv_privateClients"=>"0", "sv_allowDownload"=>"0", "bot_minplayers"=>"0", "gamename"=>"baseq3", "g_needpass"=>"0"}'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(server_info) > services 

Services
========

host       port   proto  name   state  info
----       ----   -----  ----   -----  ----
10.4.25.3  27960  udp    quake  open   {"capturelimit"=>"8", "g_maxGameClients"=>"0", "sv_floodProtect"=>"1", "sv_maxPing"=>"0", "sv_minPing"=>"0", "sv_dlRate"=>"100", "sv_maxRate"=>"10000", "sv_minRate"=>"0", "sv_maxclients"=>"8", "sv_hostname"=>"noname", "timelimit"=>"25", "fraglimit"=>"30", "dmflags"=>"0", "version"=>"ioq3 1.36+svn2202-1/Ubuntu linux-x86_64 Dec 12 2011", "com_gamename"=>"Quake3Arena", "com_protocol"=>"71", "g_gametype"=>"0", "mapname"=>"q3dm2", "sv_privateClients"=>"0", "sv_allowDownload"=>"0", "bot_minplayers"=>"0", "gamename"=>"baseq3", "g_needpass"=>"0"}
```
