### PR TITLE
Using the new cred API for multiple auxiliary modules

### DIFF
--- a/modules/auxiliary/scanner/http/axis_local_file_include.rb
+++ b/modules/auxiliary/scanner/http/axis_local_file_include.rb
@@ -70,6 +70,32 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: (ssl ? 'https' : 'http'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def get_credentials(uri)
     lfi_payload = "?xsd=../conf/axis2.xml"
 
@@ -96,15 +122,7 @@ class Metasploit3 < Msf::Auxiliary
 
           print_good("#{target_url} - Apache Axis - Credentials Found Username: '#{username}' - Password: '#{password}'")
 
-          report_auth_info(
-            :host => rhost,
-            :port => rport,
-            :sname => (ssl ? 'https' : 'http'),
-            :user => username,
-            :pass => password,
-            :proof => "WEBAPP=\"Apache Axis\", VHOST=#{vhost}",
-            :active => true
-          )
+          report_cred(ip: rhost, port: rport, user: username, password: password)
 
         else
           print_error("#{target_url} - Apache Axis - Not Vulnerable")

--- a/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
+++ b/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
@@ -88,6 +88,32 @@ class Metasploit3 < Msf::Auxiliary
       end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'Cisco ASA ASDM',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   # Brute-force the login page
   def do_login(user, pass)
     vprint_status("#{peer} - Trying username:#{user.inspect} with password:#{pass.inspect}")
@@ -113,17 +139,7 @@ class Metasploit3 < Msf::Auxiliary
 
         print_good("#{peer} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
-        report_hash = {
-          :host   => rhost,
-          :port   => rport,
-          :sname  => 'Cisco ASA ASDM',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'
-        }
-
-        report_auth_info(report_hash)
+        report_cred(ip: rhost, port: rport, user: user, password: pass)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -114,6 +114,32 @@ class Metasploit3 < Msf::Auxiliary
       end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'Cisco IronPort Appliance',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -138,17 +164,7 @@ class Metasploit3 < Msf::Auxiliary
       if res and res.get_cookies.include?('authenticated=')
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
-        report_hash = {
-          :host   => rhost,
-          :port   => rport,
-          :sname  => 'Cisco IronPort Appliance',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'
-        }
-
-        report_auth_info(report_hash)
+        report_cred(ip: rhost, port: rport, user: user, password: pass)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -157,6 +157,33 @@ class Metasploit3 < Msf::Auxiliary
           )
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'Cisco SSL VPN',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+
   # Brute-force the login page
   def do_login(user, pass, group)
     vprint_status("#{peer} - Trying username:#{user.inspect} with password:#{pass.inspect} and group:#{group.inspect}")
@@ -197,18 +224,7 @@ class Metasploit3 < Msf::Auxiliary
 
         do_logout(resp.get_cookies)
 
-        report_hash = {
-          :host   => rhost,
-          :port   => rport,
-          :sname  => 'Cisco SSL VPN',
-          :user   => user,
-          :pass   => pass,
-          :group => group,
-          :active => true,
-          :type => 'password'
-        }
-
-        report_auth_info(report_hash)
+        report_cred(ip: rhost, port: rport, user: user, password: pass)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -225,6 +225,7 @@ class Metasploit3 < Msf::Auxiliary
         do_logout(resp.get_cookies)
 
         report_cred(ip: rhost, port: rport, user: user, password: pass)
+        report_note(ip: rhost, type: 'cisco.cred.group', data: group)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
@@ -82,6 +82,32 @@ class Metasploit3 < Msf::Auxiliary
     }
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: (ssl ? 'https' : 'http'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   # default to user=admin without password (default on most dlink routers)
   def do_login(user='admin', pass='')
     vprint_status("#{target_url} - Trying username:'#{user}' with password:'#{pass}'")
@@ -91,16 +117,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if result == :success
       print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
-
-      report_auth_info(
-        :host   => rhost,
-        :port   => rport,
-        :sname => (ssl ? 'https' : 'http'),
-        :user   => user,
-        :pass   => pass,
-        :proof  => "WEBAPP=\"D-Link Management Interface\", PROOF=#{response.to_s}",
-        :active => true
-      )
+      report_cred(ip: rhost, port: rport, user: user, password: pass)
 
       return :next_user
     else

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -101,21 +101,39 @@ class Metasploit3 < Msf::Auxiliary
     if result == :success
       print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
 
-      report_auth_info(
-        :host   => rhost,
-        :port   => rport,
-        :sname => (ssl ? 'https' : 'http'),
-        :user   => user,
-        :pass   => pass,
-        :proof  => "WEBAPP=\"D-Link Management Interface\", PROOF=#{response.to_s}",
-        :active => true
-      )
+      report_cred(ip: rhost, port: rport, user: user, password: pass)
 
       return :next_user
     else
       vprint_error("#{target_url} - Failed to login as '#{user}'")
       return
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: (ssl ? 'https' : 'http'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def do_http_login(user,pass)

--- a/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
@@ -83,6 +83,32 @@ class Metasploit3 < Msf::Auxiliary
     }
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: (ssl ? 'https' : 'http'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   # default to user=admin without password (default on most dlink routers)
   def do_login(user='admin', pass='')
     vprint_status("#{target_url} - Trying username:'#{user}' with password:'#{pass}'")
@@ -93,15 +119,7 @@ class Metasploit3 < Msf::Auxiliary
     if result == :success
       print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
 
-      report_auth_info(
-        :host   => rhost,
-        :port   => rport,
-        :sname => (ssl ? 'https' : 'http'),
-        :user   => user,
-        :pass   => pass,
-        :proof  => "WEBAPP=\"D-Link Management Interface\", PROOF=#{response.to_s}",
-        :active => true
-      )
+      report_cred(ip: rhost, port: rport, user: user, password: pass)
 
       return :next_user
     else

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -63,6 +63,32 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: (ssl ? 'https' : 'http'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run_host(ip)
     # Check if remote host is available or appears vulnerable
     unless check_host(ip) == Exploit::CheckCode::Appears

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -75,9 +75,7 @@ class Metasploit3 < Msf::Auxiliary
     credential_data = {
       origin_type: :service,
       module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
+      username: opts[:user]
     }.merge(service_data)
 
     login_data = {
@@ -129,11 +127,10 @@ class Metasploit3 < Msf::Auxiliary
     final_results.each do |user|
       print_good("Found User: #{user}")
 
-      report_auth_info(
-        :host => Rex::Socket.getaddress(datastore['RHOST']),
-        :port => datastore['RPORT'],
-        :user => user,
-        :type => "drupal_user"
+      report_cred(
+        ip: Rex::Socket.getaddress(datastore['RHOST']),
+        port: datastore['RPORT'],
+        user: user
       )
     end
 

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Auxiliary
     login_data = {
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      status: Metasploit::Model::Login::Status::UNTRIED,
     }.merge(service_data)
 
     create_credential_login(login_data)

--- a/modules/auxiliary/scanner/http/ektron_cms400net.rb
+++ b/modules/auxiliary/scanner/http/ektron_cms400net.rb
@@ -124,6 +124,32 @@ class Metasploit3 < Msf::Auxiliary
       end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: (ssl ? 'https' : 'http'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user=nil, pass=nil, viewstate_arg=viewstate, eventvalidation_arg=eventvalidation)
     vprint_status("#{target_url} - Trying: username:'#{user}' with password:'#{pass}'")
 
@@ -141,17 +167,7 @@ class Metasploit3 < Msf::Auxiliary
 
       if (res and res.code == 200 and res.body.to_s.match(/LoginSuceededPanel/i) != nil)
         print_good("#{target_url} [Ektron CMS400.NET] Successful login: '#{user}' : '#{pass}'")
-        report_auth_info(
-          :host         => rhost,
-          :port         => rport,
-          :sname => (ssl ? 'https' : 'http'),
-          :user         => user,
-          :pass         => pass,
-          :proof        => "WEBAPP=\"Ektron CMS400.NET\", VHOST=#{vhost}",
-          :source_type  => "user_supplied",
-          :duplicate_ok => true,
-          :active       => true
-        )
+        report_cred(ip: rhost, port: rport, user: user, password: pass)
 
       elsif(res and res.code == 200)
         vprint_error("#{target_url} [Ekton CMS400.NET] - Failed login as: '#{user}'")

--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -66,6 +66,32 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: (ssl ? 'https' : 'http'),
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -87,16 +113,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if res && res.code == 200 && res.body.include?("Home Page") && res.headers['Server'] && res.headers['Server'].include?("EtherPAD")
       print_good("#{peer} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
-      report_hash = {
-        :host   => rhost,
-        :port   => rport,
-        :sname  => 'EtherPAD Duo Portal',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'
-      }
-      report_auth_info(report_hash)
+      report_cred(ip: rhost, port: rport, user: user, password: pass)
       return :next_user
     else
       vprint_error("#{peer} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")

--- a/modules/auxiliary/scanner/http/infovista_enum.rb
+++ b/modules/auxiliary/scanner/http/infovista_enum.rb
@@ -79,6 +79,32 @@ class Metasploit3 < Msf::Auxiliary
     do_login(user, pass)
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'InfoVista VistaPortal',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -100,18 +126,7 @@ class Metasploit3 < Msf::Auxiliary
         vprint_error("#{rhost}:#{rport} - FAILED LOGIN - #{user.inspect}:#{pass.inspect} with code #{res.code}")
       else
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
-
-        report_hash = {
-          :host   => rhost,
-          :port   => rport,
-          :sname  => 'InfoVista VistaPortal',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'
-        }
-
-        report_auth_info(report_hash)
+        report_cred(ip: rhost, port: rport, user: user, password: pass)
         return :next_user
       end
 

--- a/modules/auxiliary/scanner/http/novell_mdm_creds.rb
+++ b/modules/auxiliary/scanner/http/novell_mdm_creds.rb
@@ -77,6 +77,31 @@ class Metasploit3 < Msf::Auxiliary
     return creds.split(":")
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'novellmdm',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run_host(ip)
     print_status("Verifying that Zenworks login page exists at #{ip}")
     uri = normalize_uri(target_uri.path)
@@ -97,14 +122,7 @@ class Metasploit3 < Msf::Auxiliary
         print_good("Got creds. Login:#{user} Password:#{pass}")
         print_good("Access the admin interface here: #{ip}:#{rport}#{target_uri.path}dashboard/")
 
-        report_auth_info(
-          :host => ip,
-          :port => rport,
-          :sname => "novellmdm",
-          :user => user,
-          :pass => pass,
-          :active => true
-        )
+        report_cred(ip: ip, port: rport, user: user, password: pass)
       else
         print_error("Zenworks MDM does not appear to be running at #{ip}")
         return :abort

--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -127,6 +127,31 @@ class Metasploit3 < Msf::Auxiliary
     return (res and res.body =~ /Logged in as (.+)/) ? false : true
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'splunk-web',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 
   #
   # Brute-force the login page
@@ -165,15 +190,8 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       print_good("SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
+      report_cred(ip: datastore['RHOST'], port: datastore['RPORT'], user:user, password: pass)
 
-      report_hash = {
-        :host   => datastore['RHOST'],
-        :port   => datastore['RPORT'],
-        :sname  => 'splunk-web',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'}
 
       report_auth_info(report_hash)
       return :next_user

--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -193,7 +193,6 @@ class Metasploit3 < Msf::Auxiliary
       report_cred(ip: datastore['RHOST'], port: datastore['RPORT'], user:user, password: pass)
 
 
-      report_auth_info(report_hash)
       return :next_user
 
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT

--- a/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
+++ b/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
@@ -130,6 +130,32 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'cctv_dvr',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user=nil, pass=nil)
     vprint_status("#{rhost} - Trying username:'#{user}' with password:'#{pass}'")
 
@@ -179,16 +205,7 @@ class Metasploit3 < Msf::Auxiliary
 
       # Report valid credentials under the CCTV DVR admin port (5920/TCP).
       # This is a proprietary protocol.
-      report_auth_info(
-        :host         => rhost,
-        :port         => rport,
-        :sname        => 'cctv_dvr',
-        :user         => user,
-        :pass         => pass,
-        :source_type  => "user_supplied",
-        :duplicate_ok => false,
-        :active       => true
-      )
+      report_cred(ip: rhost, port: rport, user:user, password: pass)
 
       @valid_hosts << rhost
       return :next_user

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -37,6 +37,31 @@ class Metasploit3 < Msf::Auxiliary
     register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'vmware',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 
   def run_host(ip)
     return unless is_vmware?
@@ -45,14 +70,7 @@ class Metasploit3 < Msf::Auxiliary
       case result
       when :success
         print_good "#{rhost}:#{rport} - Successful Login! (#{user}:#{pass})"
-        report_auth_info(
-          :host   => rhost,
-          :port   => rport,
-          :user   => user,
-          :pass   => pass,
-          :source_type => "user_supplied",
-          :active => true
-        )
+        report_cred(ip: rhost, port: rport, user: user, password: pass)
         return if datastore['STOP_ON_SUCCESS']
       when :fail
         print_error "#{rhost}:#{rport} - Login Failure (#{user}:#{pass})"

--- a/modules/auxiliary/voip/asterisk_login.rb
+++ b/modules/auxiliary/voip/asterisk_login.rb
@@ -51,6 +51,32 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: 'asterisk_manager',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run_host(ip)
     print_status("Initializing module...")
     begin
@@ -91,15 +117,7 @@ class Metasploit3 < Msf::Auxiliary
         send_manager(cmd)
         if /Response: Success/.match(@result)
           print_good("User: \"#{user}\" using pass: \"#{pass}\" - can login on #{rhost}:#{rport}!")
-          report_auth_info(
-            :host   => rhost,
-            :port   => rport,
-            :sname  => 'asterisk_manager',
-            :user   => user,
-            :pass   => pass,
-            :active => true,
-            :update => :unique_data
-          )
+          report_cred(ip: rhost, port: rport, user: user, password: pass)
           disconnect
           return :next_user
         else

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  FAKE_IP   = '192.168.12.123'
+  FAKE_PORT = 80
+  FAKE_USER = 'username'
+  FAKE_PASS = 'password'
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => "report_cred test",
+      'Description'    => %q{
+      	This module will test every auxiliary module's report_cred method
+      },
+      'Author'         => [ 'sinn3r' ],
+      'License'        => MSF_LICENSE
+    ))
+  end
+
+  def test_novell_mdm_creds
+    mod = framework.auxiliary.create('scanner/http/novell_mdm_creds')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_joomla_bruteforce_login
+    mod = framework.auxiliary.create('scanner/http/joomla_bruteforce_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_infovista_enum
+    mod = framework.auxiliary.create('scanner/http/infovista_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_etherpad_duo_login
+    mod = framework.auxiliary.create('scanner/http/etherpad_duo_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_ektron_cms400net
+    mod = framework.auxiliary.create('scanner/http/ektron_cms400net')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_drupal_views_user_enum
+    mod = framework.auxiliary.create('scanner/http/drupal_views_user_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_dolibarr_login
+    mod = framework.auxiliary.create('scanner/http/dolibarr_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_dlink_dir_session_cgi_http_login
+    mod = framework.auxiliary.create('scanner/http/dlink_dir_session_cgi_http_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_dlink_dir_615h_http_login
+    mod = framework.auxiliary.create('scanner/http/dlink_dir_615h_http_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_dlink_dir_300_615_http_login
+    mod = framework.auxiliary.create('scanner/http/dlink_dir_300_615_http_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_cisco_ssl_vpn
+    mod = framework.auxiliary.create('scanner/http/cisco_ssl_vpn')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_cisco_ironport_enum
+    mod = framework.auxiliary.create('scanner/http/cisco_ironport_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_cisco_asa_asdm
+    mod = framework.auxiliary.create('scanner/http/cisco_asa_asdm')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_axis_local_file_include
+    mod = framework.auxiliary.create('scanner/http/axis_local_file_include')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_splunk_web_login
+    mod = framework.auxiliary.create('scanner/http/splunk_web_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_cctv_dvr_login
+    mod = framework.auxiliary.create('scanner/misc/cctv_dvr_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_http_vcms_login
+    mod = framework.auxiliary.create('scanner/http/vcms_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_telnet_ruggedcom
+    mod = framework.auxiliary.create('scanner/telnet/telnet_ruggedcom')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: 'factory', password: FAKE_PASS)
+  end
+
+  def test_vmware_http_login
+    mod = framework.auxiliary.create('scanner/vmware/vmware_http_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_asterisk_login
+  	mod = framework.auxiliary.create('voip/asterisk_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def run
+    self.methods.each do |m|
+      next if m.to_s !~ /^test_.+/
+      print_status("Trying: ##{m.to_s}")
+      begin
+        self.send(m)
+        print_good("That didn't blow up. Good!")
+      rescue ::Exception => e
+        print_error("That blew up :-(")
+        print_line("#{e.class} #{e.message}\n#{e.backtrace*"\n"}")
+      ensure
+        print_line
+      end
+    end
+  end
+
+end

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def test_drupal_views_user_enum
     mod = framework.auxiliary.create('scanner/http/drupal_views_user_enum')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER)
   end
 
   def test_dolibarr_login


### PR DESCRIPTION
This is what I have for today, feel free to review/merge anytime. There will be more.

To test this:
- [x] Start msfconsole
- [x] Do: `loadpath [path to msf/test/modules/]`
- [x] Do: `use auxiliary/test/report_auth_info`
- [x] Do: `run`
- [x] You should not see any backtrace
