### PR TITLE
Clean-up and enhance ftp_version

### DIFF
--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -27,13 +27,14 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(_target_host)
     begin
       if connect(true, false) && banner && banner =~ /^220[ -]/
-        recog_banner = banner.gsub(/^220[ -](.*)\r\n/) { "#{Regexp.last_match(1)}\r\n" }
+        recog_banner = banner.gsub(/^220[ -](.*)\r\n/) { "#{Regexp.last_match(1)}\r\n" }.strip
         sanitized_banner = Rex::Text.to_hex_ascii(recog_banner)
-        unless info = Recog::Nizer.match('ftp.banner', recog_banner)
+        if info = Recog::Nizer.match('ftp.banner', recog_banner)
+          print_status("#{peer} FTP Banner: '#{sanitized_banner}'")
+        else
           info = sanitized_banner
           print_warning("#{peer} -- no Recog match: #{sanitized_banner}")
         end
-        print_status("#{peer} FTP Banner: '#{sanitized_banner}'")
         report_service(host: rhost, port: rport, name: 'ftp', info: info.to_s)
       end
     rescue ::Interrupt

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -26,18 +26,15 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(_target_host)
     begin
-      if connect(true, false) && banner
-        if /^220 (?<recog_banner>.*)$/ =~ banner
-          recog_banner.strip!
-          sanitized_banner = Rex::Text.to_hex_ascii(recog_banner)
-          unless info = Recog::Nizer.match('ftp.banner', recog_banner)
-            info = sanitized_banner
-            print_warning("#{peer} -- no Recog match: #{sanitized_banner}")
-          end
-          print_status("#{peer} FTP Banner: '#{sanitized_banner}'")
-          report_service(host: rhost, port: rport, name: 'ftp', info: info.to_s)
-        else
+      if connect(true, false) && banner && banner =~ /^220[ -]/
+        recog_banner = banner.gsub(/^220[ -](.*)\r\n/) { "#{Regexp.last_match(1)}\r\n" }
+        sanitized_banner = Rex::Text.to_hex_ascii(recog_banner)
+        unless info = Recog::Nizer.match('ftp.banner', recog_banner)
+          info = sanitized_banner
+          print_warning("#{peer} -- no Recog match: #{sanitized_banner}")
         end
+        print_status("#{peer} FTP Banner: '#{sanitized_banner}'")
+        report_service(host: rhost, port: rport, name: 'ftp', info: info.to_s)
       end
     rescue ::Interrupt
       raise $ERROR_INFO

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(_target_host)
     begin
-      if connect(true, false)
+      if connect(true, false) && banner
         banner_sanitized = Rex::Text.to_hex_ascii(banner)
         print_status("#{rhost}:#{rport} FTP Banner: '#{banner_sanitized}'")
         report_service(host: rhost, port: rport, name: 'ftp', info: banner_sanitized)

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -6,7 +6,6 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Exploit::Remote::Ftp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
@@ -18,31 +17,20 @@ class Metasploit3 < Msf::Auxiliary
       'Author'      => 'hdm',
       'License'     => MSF_LICENSE
     )
-
-    register_options(
-      [
-        Opt::RPORT(21),
-      ], self.class)
   end
 
-  def run_host(target_host)
-
+  def run_host(_target_host)
     begin
-
-    res = connect(true, false)
-
-    if(banner)
-      banner_sanitized = Rex::Text.to_hex_ascii(self.banner.to_s)
-      print_status("#{rhost}:#{rport} FTP Banner: '#{banner_sanitized}'")
-      report_service(:host => rhost, :port => rport, :name => "ftp", :info => banner_sanitized)
-    end
-
-    disconnect
-
+      if connect(true, false)
+        banner_sanitized = Rex::Text.to_hex_ascii(banner)
+        print_status("#{rhost}:#{rport} FTP Banner: '#{banner_sanitized}'")
+        report_service(host: rhost, port: rport, name: 'ftp', info: banner_sanitized)
+      end
     rescue ::Interrupt
-      raise $!
+      raise $ERROR_INFO
     rescue ::Rex::ConnectionError, ::IOError
+    ensure
+      disconnect
     end
-
   end
 end

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -29,10 +29,11 @@ class Metasploit3 < Msf::Auxiliary
       if connect(true, false) && banner && banner =~ /^220[ -]/
         recog_banner = banner.gsub(/^220[ -](.*)\r\n/) { "#{Regexp.last_match(1)}\r\n" }.strip
         sanitized_banner = Rex::Text.to_hex_ascii(recog_banner)
-        if info = Recog::Nizer.match('ftp.banner', recog_banner)
+        info = { "banner" => recog_banner }
+        if recog_match = Recog::Nizer.match('ftp.banner', recog_banner)
+          info.merge!(recog_match)
           print_status("#{peer} FTP Banner: '#{sanitized_banner}'")
         else
-          info = sanitized_banner
           print_warning("#{peer} -- no Recog match: #{sanitized_banner}")
         end
         report_service(host: rhost, port: rport, name: 'ftp', info: info.to_s)


### PR DESCRIPTION
This:
- Addresses some minor style issues
- Adds support for recog matching against the FTP banners
- Adds support for multi-line FTP banners (https://github.com/rapid7/recog/issues/69)

Testing:

Before:

```
msf auxiliary(ftp_version) > run

[*] 192.168.32.160:21 FTP Banner: '220--------------------------------------------------------------------------------\x0d\x0a220-This is the "Banner" message for the Mac OS X Server's FTP server process.\x0d\x0a220-\x0d\x0a220-              FTP clients will receive this message immediately\x0d\x0a220-              before being prompted for a name and password.\x0d\x0a220-\x0d\x0a220-PLEASE NOTE:\x0d\x0a220-\x0d\x0a220-       Some FTP clients will exhibit problems if you make this file too long.\x0d\x0a220-\x0d\x0a220-\x0d\x0a220-To customize this message for your system:\x0d\x0a220-\x0d\x0a220-  -  Launch the TextEdit application.\x0d\x0a220-  -  Select "Open" from the "File" menu.\x0d\x0a220-  -  Type "/Library/FTPServer/Messages/banner.txt" into the "Go to" textbox.\x0d\x0a220-  -  Click the "Open" button.\x0d\x0a220--------------------------------------------------------------------------------\x0d\x0a220-\x0d\x0a220 test-apps FTP server (Version:  Mac OS X Server) ready.\x0d\x0a'
[*] Scanned 1 of 3 hosts (33% complete)
[*] 192.168.32.104:21 FTP Banner: '220 example.com FTP server (Version 4.2 Mon Dec 3 12:04:40 CST 2012) ready.\x0d\x0a'
[*] Scanned 2 of 3 hosts (66% complete)
[*] 192.168.32.200:21 FTP Banner: '220 example.com FTP server (BSDI Version 7.00LS) ready.\x0d\x0a'
[*] Scanned 3 of 3 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ftp_version) > services 

Services
========

host            port  proto  name  state  info
----            ----  -----  ----  -----  ----
192.168.32.104  21    tcp    ftp   open   220 example.com FTP server (Version 4.2 Mon Dec 3 12:04:40 CST 2012) ready.\x0d\x0a
192.168.32.160  21    tcp    ftp   open   220--------------------------------------------------------------------------------\x0d\x0a220-This is the "Banner" message for the Mac OS X Server's FTP server process.\x0d\x0a220-\x0d\x0a220-              FTP clients will receive this message immediately\x0d\x0a220-              before being prompted for a name and password.\x0d\x0a220-\x0d\x0a220-PLEASE NOTE:\x0d\x0a220-\x0d\x0a220-       Some FTP clients will exhibit problems if you make this file too long.\x0d\x0a220-\x0d\x0a220-\x0d\x0a220-To customize this message for your system:\x0d\x0a220-\x0d\x0a220-  -  Launch the TextEdit application.\x0d\x0a220-  -  Select "Open" from the "File" menu.\x0d\x0a220-  -  Type "/Library/FTPServer/Messages/banner.txt" into the "Go to" textbox.\x0d\x0a220-  -  Click the "Open" button.\x0d\x0a220--------------------------------------------------------------------------------\x0d\x0a220-\x0d\x0a220 test-apps FTP server (Version:  Mac OS X Server) ready.\x0d\x0a
192.168.32.200  21    tcp    ftp   open   220 example.com FTP server (BSDI Version 7.00LS) ready.\x0d\x0a

```

After:

```
msf auxiliary(ftp_version) > run

[*] 192.168.32.160:21 FTP Banner: '-------------------------------------------------------------------------------\x0d\x0aThis is the "Banner" message for the Mac OS X Server's FTP server process.\x0d\x0a\x0d\x0a              FTP clients will receive this message immediately\x0d\x0a              before being prompted for a name and password.\x0d\x0a\x0d\x0aPLEASE NOTE:\x0d\x0a\x0d\x0a       Some FTP clients will exhibit problems if you make this file too long.\x0d\x0a\x0d\x0a\x0d\x0aTo customize this message for your system:\x0d\x0a\x0d\x0a  -  Launch the TextEdit application.\x0d\x0a  -  Select "Open" from the "File" menu.\x0d\x0a  -  Type "/Library/FTPServer/Messages/banner.txt" into the "Go to" textbox.\x0d\x0a  -  Click the "Open" button.\x0d\x0a-------------------------------------------------------------------------------\x0d\x0a\x0d\x0amarketing-apps FTP server (Version:  Mac OS X Server) ready.'
[*] Scanned 1 of 3 hosts (33% complete)
[*] 192.168.32.104:21 FTP Banner: 'aix7-1-d.vuln.yyz.rapid7.com FTP server (Version 4.2 Mon Dec 3 12:04:40 CST 2012) ready.'
[*] Scanned 2 of 3 hosts (66% complete)
[!] 192.168.32.200:21 -- no Recog match: kanoodle-bigip-2.com FTP server (BSDI Version 7.00LS) ready.
[*] Scanned 3 of 3 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ftp_version) > services 

Services
========

host            port  proto  name  state  info
----            ----  -----  ----  -----  ----
192.168.32.104  21    tcp    ftp   open   {"banner"=>"example.com FTP server (Version 4.2 Mon Dec 3 12:04:40 CST 2012) ready.", "matched"=>"Generic/unknown FTP Server found on HP-UX and AIX systems", "host.name"=>"example.com"}
192.168.32.160  21    tcp    ftp   open   {"banner"=>"-------------------------------------------------------------------------------\r\nThis is the \"Banner\" message for the Mac OS X Server's FTP server process.\r\n\r\n              FTP clients will receive this message immediately\r\n              before being prompted for a name and password.\r\n\r\nPLEASE NOTE:\r\n\r\n       Some FTP clients will exhibit problems if you make this file too long.\r\n\r\n\r\nTo customize this message for your system:\r\n\r\n  -  Launch the TextEdit application.\r\n  -  Select \"Open\" from the \"File\" menu.\r\n  -  Type \"/Library/FTPServer/Messages/banner.txt\" into the \"Go to\" textbox.\r\n  -  Click the \"Open\" button.\r\n-------------------------------------------------------------------------------\r\n\r\ntest-apps FTP server (Version:  Mac OS X Server) ready.", "matched"=>"FTPD on Mac OS X Server", "service.vendor"=>"Apple", "service.product"=>"FTP", "os.vendor"=>"Apple", "os.family"=>"Mac OS X", "os.device"=>"General", "os.product"=>"Mac OS X Server", "host.name"=>"test-apps", "os.version"=>""}
192.168.32.200  21    tcp    ftp   open   {"banner"=>"example.com FTP server (BSDI Version 7.00LS) ready."}
```
