### PR TITLE
Add AutoVerifySessionTimeout Meterpreter advanced option

### DIFF
--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -13,6 +13,7 @@ module MeterpreterOptions
       [
         OptBool.new('AutoLoadStdapi', [true, "Automatically load the Stdapi extension", true]),
         OptBool.new('AutoVerifySession', [true, "Automatically verify and drop invalid sessions", true]),
+        OptInt.new('AutoVerifySessionTimeout', [false, "Timeout period to wait for session validation to occur, in seconds", 10]),
         OptString.new('InitialAutoRunScript', [false, "An initial script to run on session creation (before AutoRunScript)", '']),
         OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", '']),
         OptBool.new('AutoSystemInfo', [true, "Automatically capture system information on initialization.", true]),
@@ -43,7 +44,7 @@ module MeterpreterOptions
     valid = true
 
     if datastore['AutoVerifySession'] == true
-      if not session.is_valid_session?
+      if not session.is_valid_session?(datastore['AutoVerifySessionTimeout'].to_i)
         print_error("Meterpreter session #{session.sid} is not valid and will be closed")
         valid = false
       end


### PR DESCRIPTION
With the addition of the `AutoVerifySession` setting in MSF users can control whether they want session validation to be enabled or not. This means that MSF will make sure the shell is responsive within a "reasonable" period of time, and if not, shut down the session. This prevents users from having "dead shells" and not knowing what to do with them.

This PR adds another setting called `AutoVerifySessionTimeout`, which allows the user to control the period of time that those validation messages have before the session is marked as invalid, and then closed. The original value, hidden behind the scenes in code, was `10` seconds. This is left as the default value. Users can modify this value in environments where latency is higher, forcing the framework to give the shell a better opportunity to get established before marking it as invalid.

This PR should fix #5534.
## Verification
- [x] `use multi/handler`
- [x] `set payload` to any Meterpreter payload
- [x] Make sure that the `AutoVerifySessionTimeout` value is present in the advanced options
- [x] Create a Meterpreter session using the default value
- [x] Modify the value, and create a new session

It'd be nice to simulate a high latency environment somewhere prior to landing this so you can see it fail in one case, modify the timeout, and see it work in the second case. @sweetsoftware it'd be nice if you could also have a look at this branch to see if it helps your situation. Thanks!
