### PR TITLE
Update database.yml.example to ref MSF-DEV

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -3,8 +3,7 @@
 # these days. (No SQLite, no MySQL).
 #
 # To set up a metasploit database, follow the directions hosted at:
-# https://fedoraproject.org/wiki/Metasploit_Postgres_Setup (Works on
-# essentially any Linux distro, not just Fedora)
+# http://r-7.co/MSF-DEV#set-up-postgresql
 development: &pgsql
   adapter: postgresql
   database: metasploit_framework_development


### PR DESCRIPTION
We no longer rely on the Fedora Project's documentation for setting up a PostgreSQL database. The comment doc here should reflect this change.
## Verification
- [x] See the http://r-7.co/MSF-DEV#set-up-postgresql link
- [x] Validate that it actually goes to where it claims.

Also, TIL that you can use anchors within a bit.ly link. Neat.
