### PR TITLE
Remove msfencode from the gemspec

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
       'msfconsole',
       'msfd',
       'msfelfscan',
-      'msfencode',
       'msfmachscan',
       'msfpescan',
       'msfrop',


### PR DESCRIPTION
What it says on the tin. Missed in 5a6a16c4ec84b09cacf51abb1b1eaf5ccfb8955c.
