### PR TITLE
Add Support For RFB Version 4 (Newer VNC Servers)

### DIFF
--- a/lib/rex/proto/rfb/client.rb
+++ b/lib/rex/proto/rfb/client.rb
@@ -24,7 +24,7 @@ class Client
     @opts = opts
 
     @banner = nil
-    @majver = MajorVersion
+    @majver = MajorVersions
     @minver = -1
     @auth_types = []
   end
@@ -50,7 +50,7 @@ class Client
 
     if @banner =~ /RFB ([0-9]{3})\.([0-9]{3})/
       maj = $1.to_i
-      if maj != MajorVersion
+      unless MajorVersions.include?(maj)
         @error = "Invalid major version number: #{maj}"
         return false
       end
@@ -61,8 +61,15 @@ class Client
 
     @minver = $2.to_i
 
-    our_ver = "RFB %03d.%03d\n" % [MajorVersion, @minver]
-    @sock.put(our_ver)
+		# Forces client version 3 to be used. This adds support
+		# 	version 4 servers.
+		# It may be necessary to hardcode a miniver as well
+		# to do: add support for Version 4. Version 4 client
+		#   adds additional information to the packet regarding
+		#		supported authentication types.
+    our_ver = "RFB %03d.%03d\n" % [3, @minver]
+    puts our_ver
+		@sock.put(our_ver)
 
     true
   end

--- a/lib/rex/proto/rfb/client.rb
+++ b/lib/rex/proto/rfb/client.rb
@@ -62,14 +62,13 @@ class Client
     @minver = $2.to_i
 
 		# Forces client version 3 to be used. This adds support
-		# 	version 4 servers.
+		# 	for version 4 servers.
 		# It may be necessary to hardcode a miniver as well
 		# to do: add support for Version 4. Version 4 client
 		#   adds additional information to the packet regarding
 		#		supported authentication types.
     our_ver = "RFB %03d.%03d\n" % [3, @minver]
-    puts our_ver
-		@sock.put(our_ver)
+    @sock.put(our_ver)
 
     true
   end

--- a/lib/rex/proto/rfb/constants.rb
+++ b/lib/rex/proto/rfb/constants.rb
@@ -19,7 +19,9 @@ module RFB
 DefaultPort = 5900
 
 # Version information
-MajorVersion = 3
+# Created array and added support for version 4. aux/scanner/vnc/vnc_login
+#   was confirmed to work with version 004.001
+MajorVersions = [3,4]
 # NOTE: We will emulate whatever minor version the server reports.
 
 # Security types

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       'Description' => %q{
           This module will test a VNC server on a range of machines and
         report successful logins. Currently it supports RFB protocol
-        version 3.3, 3.7, and 3.8 using the VNC challenge response
+        version 3.3, 3.7, 3.8 and 4.001 using the VNC challenge response
         authentication method.
       },
       'Author'      =>


### PR DESCRIPTION
I created an array for versions instead of a single variable for the RFB major version in the rex rfb constants file. I modified the rex rfb client file to support the array. Metasploit will respond to RFB server versions 3 and 4 with a client response of 3 with a modification on line 70 of the rex rfb client file. I verified this on version RFB 4.001 (VNC Server 5.2.3 x64) with the auxiliary/scanner/vnc/vnc_login module. 
