### PR TITLE
Inconstancy - If datastore['VERBOSE'] vs vprint

### DIFF
--- a/lib/msf/core/exploit/dhcp.rb
+++ b/lib/msf/core/exploit/dhcp.rb
@@ -36,14 +36,14 @@ module Exploit::DHCPServer
 
   def start_service(hash = {}, context = {})
     @dhcp = Rex::Proto::DHCP::Server.new(hash, context)
-    print_status("Starting DHCP server") if datastore['VERBOSE']
+    vprint_status("Starting DHCP server")
     @dhcp.start
     add_socket(@dhcp.sock)
     @dhcp
   end
 
   def stop_service
-    print_status("Stopping DHCP server") if datastore['VERBOSE']
+    vprint_status("Stopping DHCP server")
     @dhcp.stop
   end
 

--- a/lib/msf/core/exploit/tftp.rb
+++ b/lib/msf/core/exploit/tftp.rb
@@ -20,14 +20,14 @@ module Exploit::TFTPServer
   def start_service(tag, exe)
     @tftp = Rex::Proto::TFTP::Server.new
     @tftp.register_file(tag, exe)
-    print_status("Starting TFTP server to host \"#{tag}\" (#{exe.length} bytes)") if datastore['VERBOSE']
+    vprint_status("Starting TFTP server to host \"#{tag}\" (#{exe.length} bytes)")
     @tftp.start
     add_socket(@tftp.sock)
     @tftp
   end
 
   def stop_service
-    print_status("Stopping TFTP server") if datastore['VERBOSE']
+    vprint_status("Stopping TFTP server")
     @tftp.stop
   end
 

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
     open_pcap
     print_status("Sending file...") unless verbose
     while (loop > 0 or infinity) do
-      vprint_status("Sending file (loop : #{count = count + 1})")
+      vprint_status("Sending file (loop: #{count = count + 1})")
       inject_pcap(filename, file_filter, pkt_delay )
       loop -= 1 unless infinity
       Kernel.select(nil, nil, nil, (delay * 1.0)/1000) if loop > 0 or infinity

--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -102,7 +102,7 @@ class Metasploit4 < Msf::Exploit::Remote
     return Exploit::CheckCode::Appears if res.body =~ /SVNTag=JBoss_4_/
     return Exploit::CheckCode::Appears if res.body =~ /SVNTag=JBoss_5_/
 
-    if res.body =~ /ServletException/	# Simple check, if we caused an exception.
+    if res.body =~ /ServletException/   # Simple check, if we caused an exception.
       vprint_status('Target seems vulnerable, but the used JBoss version is not supported by this exploit')
       return Exploit::CheckCode::Appears
     end
@@ -302,13 +302,13 @@ EOT
       elsif res.code < 200 || res.code >= 300
         msg = "http request failed to #{uri} [#{res.code}]"
       elsif res.code == 200
-        print_status("Successfully called '#{uri}'") if datastore['VERBOSE']
+        vprint_status("Successfully called '#{uri}'")
         return res
       end
 
       if attempt < num_attempts - 1
         msg << ', retrying in 5 seconds...'
-        print_status(msg) if datastore['VERBOSE']
+        vprint_status(msg)
         select(nil, nil, nil, 5)
       else
         print_error(msg)

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -78,15 +78,15 @@ class Metasploit3 < Msf::Post
       lplat = [Msf::Platform::Windows]
       larch = [ARCH_X86]
       psh_arch = 'x86'
-      print_status("Platform: Windows") if datastore['VERBOSE']
+      vprint_status("Platform: Windows")
     when /osx/i
       platform = 'python'
       payload_name = 'python/meterpreter/reverse_tcp'
-      print_status("Platform: OS X") if datastore['VERBOSE']
+      vprint_status("Platform: OS X")
     when /solaris/i
       platform = 'python'
       payload_name = 'python/meterpreter/reverse_tcp'
-      print_status("Platform: Solaris") if datastore['VERBOSE']
+      vprint_status("Platform: Solaris")
     else
       # Find the best fit, be specific with uname to avoid matching hostname or something else
       target_info = cmd_exec('uname -mo')
@@ -96,16 +96,16 @@ class Metasploit3 < Msf::Post
         payload_name = 'linux/x86/meterpreter/reverse_tcp'
         lplat = [Msf::Platform::Linux]
         larch = [ARCH_X86]
-        print_status("Platform: Linux") if datastore['VERBOSE']
+        vprint_status("Platform: Linux")
       elsif cmd_exec('python -V') =~ /Python (2|3)\.(\d)/
         # Generic fallback for OSX, Solaris, Linux/ARM
         platform = 'python'
         payload_name = 'python/meterpreter/reverse_tcp'
-        print_status("Platform: Python [fallback]") if datastore['VERBOSE']
+        vprint_status("Platform: Python [fallback]")
       end
     end
     payload_name = datastore['PAYLOAD_OVERWRITE'] if datastore['PAYLOAD_OVERWRITE']
-    print_status("Upgrade payload: #{payload_name}") if datastore['VERBOSE']
+    vprint_status("Upgrade payload: #{payload_name}")
 
     if platform.blank?
       print_error("Shells on the the target platform, #{session.platform}, cannot be upgraded to Meterpreter at this time.")
@@ -129,26 +129,26 @@ class Metasploit3 < Msf::Post
     case platform
     when 'win'
       if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
-        print_status("Transfer method: Powershell") if datastore['VERBOSE']
+        vprint_status("Transfer method: Powershell")
         psh_opts = { :prepend_sleep => 1, :encode_inner_payload => true, :persist => false }
         cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))
       else
         print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'
-        print_status("Transfer method: VBS [fallback]") if datastore['VERBOSE']
+        vprint_status("Transfer method: VBS [fallback]")
         exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
         aborted = transmit_payload(exe)
       end
     when 'python'
-      print_status("Transfer method: Python") if datastore['VERBOSE']
+      vprint_status("Transfer method: Python")
       cmd_exec("python -c \"#{payload_data}\"")
     else
-      print_status("Transfer method: Bourne shell [fallback]") if datastore['VERBOSE']
+      vprint_status("Transfer method: Bourne shell [fallback]")
       exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
       aborted = transmit_payload(exe)
     end
 
     if datastore['HANDLER']
-      print_status("Cleaning up handler") if datastore['VERBOSE']
+      vprint_status("Cleaning up handler")
       cleanup_handler(listener_job_id, aborted)
     end
     return nil
@@ -188,7 +188,7 @@ class Metasploit3 < Msf::Post
     total_bytes = 0
     cmds.each { |cmd| total_bytes += cmd.length }
 
-    print_status("Starting transfer...") if datastore['VERBOSE']
+    vprint_status("Starting transfer...")
     begin
       #
       # Run the commands one at a time
@@ -230,7 +230,7 @@ class Metasploit3 < Msf::Post
     framework.threads.spawn('ShellToMeterpreterUpgradeCleanup', false) {
       if !aborted
         timer = 0
-        print_status("Waiting up to #{HANDLE_TIMEOUT} seconds for the session to come back") if datastore['VERBOSE']
+        vprint_status("Waiting up to #{HANDLE_TIMEOUT} seconds for the session to come back")
         while !framework.jobs[listener_job_id].nil? && timer < HANDLE_TIMEOUT
           sleep(1)
           timer += 1

--- a/modules/post/windows/gather/credentials/spark_im.rb
+++ b/modules/post/windows/gather/credentials/spark_im.rb
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Post
           end
 
           hash = pass.split("password").join.chomp
-          print_status("Spark password hash: #{hash}") if datastore['VERBOSE']
+          vprint_status("Spark password hash: #{hash}")
 
           # call method to decrypt hash
           decrypt(hash)


### PR DESCRIPTION
@void-in pointed out in #5554 (https://github.com/rapid7/metasploit-framework/pull/5554#discussion_r32699037)
`vprint_status` rather than `print_status("...") if datastore['VERBOSE']`

The one with the most mistakes in was my own #5530 _(fixing my mistake!)_.

_....lazy bash fu_

```
root@kali ~/metasploit-framework$ grep -Ri "VERBOSE"  | grep -i " print_"
```
