### PR TITLE
Change ExcellentRanking to GoodRanking for MS14-064

### DIFF
--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 require 'msf/core/exploit/powershell'
 
 class Metasploit4 < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GoodRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::EXE


### PR DESCRIPTION
The ms14_064_ole_code_execution exploit's ranking is being lowered to GoodRanking because of these two reasons:
1. The vulnerable component isn't in Internet Explorer. And BES can't check it so the exploit still fires even if the target is patched. This is not the desired behavior.
2. Although rare, we've seen the exploit crashing IE, and since this is a memory curruption type of bug, it should not be in Excellent ranking anyway.

cc @void-in 
