### PR TITLE
Minor description fixups

### DIFF
--- a/modules/exploits/multi/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/multi/browser/adobe_flash_pixel_bender_bof.rb
@@ -17,11 +17,12 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits a buffer overflow vulnerability in Adobe Flash Player. The
         vulnerability occurs in the flash.Display.Shader class, when setting specially
         crafted data as its bytecode, as exploited in the wild in April 2014. This module
-        has been tested successfully on:
-        * Windows 7 SP1, IE 8 to IE 11 with Flash 13.0.0.182.
-        * Windows 7 SP1, Firefox 38.0.5, Flash 11.7.700.275 and Adobe Flash 13.0.0.182
-        * Windows 8.1, Firefox 38.0.5 and Adobe Flash 13.0.0.182.
-        * Linux Mint "Rebecca" (32 bits), Firefox 33.0 and Adobe Flash 11.2.202.350
+        has been tested successfully on the following operating systems and Flash versions:
+
+        Windows 7 SP1, IE 8 to IE 11 with Flash 13.0.0.182,
+        Windows 7 SP1, Firefox 38.0.5, Flash 11.7.700.275 and Adobe Flash 13.0.0.182,
+        Windows 8.1, Firefox 38.0.5 and Adobe Flash 13.0.0.182,
+        Linux Mint "Rebecca" (32 bit), Firefox 33.0 and Adobe Flash 11.2.202.350
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
@@ -16,10 +16,10 @@ class Metasploit3 < Msf::Exploit::Remote
       info,
       'Name'           => 'Wordpress Front-end Editor File Upload',
       'Description'    => %q{
-          The Wordpress Front-end Editor plugin contains an authenticated file upload
-          vulnerability. We can upload arbitrary files to the upload folder, because
-          the plugin also uses it's own file upload mechanism instead of the wordpress
-          api it's possible to upload any file type.
+          The WordPress Front-end Editor plugin contains an authenticated file upload
+          vulnerability. An attacker can upload arbitrary files to the upload folder because
+          the plugin uses its own file upload mechanism instead of the WordPress API, which
+          incorrectly allows uploads of any file type.
       },
       'Author'         =>
         [


### PR DESCRIPTION
Edited modules/exploits/multi/browser/adobe_flash_pixel_bender_bof.rb first landed in #5524, adobe_flash_pixel_bender_bof in flash renderer . Removed ASCII bullets since those rarely render correctly.

Edited modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb first landed in #5252, @espreto's module for WordPress Front-end Editor File Upload Vuln . Fixed up some language usage, camel-cased "WordPress."
## Validation
- [x] Agree with the edits.
