### PR TITLE
serialize arrays before storing in Mdm:WebPage attributes

### DIFF
--- a/lib/msf/core/db_manager/web.rb
+++ b/lib/msf/core/db_manager/web.rb
@@ -138,8 +138,8 @@ module Msf::DBManager::Web
     page = ::Mdm::WebPage.where(web_site_id: site[:id], path: path, query: query).first_or_initialize
     page.code     = code
     page.body     = body
-    page.headers  = headers
-    page.cookie   = opts[:cookie] if opts[:cookie]
+    page.headers  = headers.to_s
+    page.cookie   = opts[:cookie].to_s if opts[:cookie]
     page.auth     = opts[:auth]   if opts[:auth]
     page.mtime    = opts[:mtime]  if opts[:mtime]
     page.ctype    = opts[:ctype]  if opts[:ctype]


### PR DESCRIPTION
The current MDM schema no longer appears to allow storing ruby Arrays for the header or cookie fields for a WebPage. It is not clear why this worked prior to the Rails 4 merge (maybe schema validation was simply more liberal), but that is what causes things to fail now.

This fixes #5515.
# Validation
- [ ] Run ./msfconsole -qx 'use auxiliary/scanner/http/crawler; set RHOST www.rapid7.com; run; exit'
- [ ] Verify that this is able to crawl the website without throwing an exceptions
