### PR TITLE
Fix #5565, Fix os.js service pack detection

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -1027,7 +1027,7 @@ os_detect.getVersion = function(){
 			}
 			switch (navigator.appMinorVersion){
 				case ";SP2;":
-					ua_version += ";SP2";
+					os_sp = "SP2";
 					break;
 			}
 		}


### PR DESCRIPTION
Fix #5565

Service pack information should not be in ua_version, instead it should be os_sp.

Verification
- [ ] Set up Win XP SP2 with IE6
- [ ] Copy and paste os.js in a html file
- [ ] Add these two lines to the html file:

``` javascript
var osInfo = os_detect.getVersion();
alert(osInfo.ua_version);
```
- [ ] Start a web server to host the file: `ruby -run -e httpd . -p 8181`
- [ ] Browse to the html file w/ IE6
- [ ] It should say "6.0"
