### PR TITLE
Correct service name for mssql for scanner detection

### DIFF
--- a/lib/metasploit/framework/login_scanner/mssql.rb
+++ b/lib/metasploit/framework/login_scanner/mssql.rb
@@ -21,7 +21,7 @@ module Metasploit
         # Lifted from lib/msf/core/exploit/mssql.rb
         LIKELY_PORTS         = [ 1433, 1434, 1435, 14330, 2533, 9152, 2638 ]
         # Lifted from lib/msf/core/exploit/mssql.rb
-        LIKELY_SERVICE_NAMES = [ 'ms-sql-s', 'ms-sql2000', 'sybase' ]
+        LIKELY_SERVICE_NAMES = [ 'ms-sql-s', 'ms-sql2000', 'sybase', 'mssql' ]
         PRIVATE_TYPES        = [ :password, :ntlm_hash ]
         REALM_KEY           = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
 


### PR DESCRIPTION
This PR solves a bug that is experienced in **pro**. To start verifying this PR, pull master on pro, and pull the topic branch in framework.
# Verification Steps
- [ ] Scan a host that has an MSSQL service
- [ ] Select the scanned host and go to the config page for the bruteforce wizard
- [ ] In the services screen, as you select and deselect "MSSQL", make sure that the target count (at the top of the page) increments and decrements.

MSP-12826
