### PR TITLE
Remove references to Iconv gem, since it's deprecated

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -4,17 +4,7 @@ require 'digest/sha1'
 require 'stringio'
 require 'cgi'
 require 'rex/powershell'
-
-%W{ iconv zlib }.each do |libname|
-  begin
-    old_verbose = $VERBOSE
-    $VERBOSE = nil
-    require libname
-  rescue ::LoadError
-  ensure
-    $VERBOSE = old_verbose
-  end
-end
+require 'zlib'
 
 module Rex
 

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -365,21 +365,25 @@ module Text
     return str
   end
 
+  # Converts US-ASCII to UTF-8, skipping over any characters which don't
+  # convert cleanly. This is a convenience method that wraps
+  # String#encode with non-raising default paramaters.
   #
-  # Converts US-ASCII and ISO-8859-1 to UTF-8, skipping over
-  # any characters which don't convert cleanly.
-  #
+  # @param str [String] An encodable ASCII string
+  # @return [String] a UTF-8 equivalent
+  # @note This method will discard invalid characters
   def self.to_utf8(str)
       str.encode('utf-8', { :invalid => :replace, :undef => :replace, :replace => '' })
   end
 
-  #
-  # Converts ASCII to EBCDIC
-  #
   class IllegalSequence < ArgumentError; end
 
-  # A native implementation of the EBCDIC->ASCII table, since it's not available
-  # in String#encode
+  # A native implementation of the ASCII to EBCDIC conversion table, since
+  # EBCDIC isn't available to String#encode as of Ruby 2.1
+  #
+  # @param str [String] An encodable ASCII string
+  # @return [String] an EBCDIC encoded string
+  # @note This method will raise in the event of invalid characters
   def self.to_ebcdic(str)
     new_str = []
     str.each_byte do |x|
@@ -392,8 +396,12 @@ module Text
     new_str.join
   end
 
-  # A native implementation of the EBCDIC->ASCII table, since it's not available
-  # in String#encode
+  # A native implementation of the EBCIDC to ASCII conversion table, since
+  # EBCDIC isn't available to String#encode as of Ruby 2.1
+  #
+  # @param str [String] an EBCDIC encoded string
+  # @return [String] An encodable ASCII string
+  # @note This method will raise in the event of invalid characters
   def self.from_ebcdic(str)
     new_str = []
     str.each_byte do |x|

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -366,20 +366,11 @@ module Text
   end
 
   #
-  # Converts ISO-8859-1 to UTF-8
+  # Converts US-ASCII and ISO-8859-1 to UTF-8, skipping over
+  # any characters which don't convert cleanly.
   #
   def self.to_utf8(str)
-
-    if str.respond_to?(:encode)
-      # Skip over any bytes that fail to convert to UTF-8
-      return str.encode('utf-8', { :invalid => :replace, :undef => :replace, :replace => '' })
-    end
-
-    begin
-      Iconv.iconv("utf-8","iso-8859-1", str).join(" ")
-    rescue
-      raise ::RuntimeError, "Your installation does not support iconv (needed for utf8 conversion)"
-    end
+      str.encode('utf-8', { :invalid => :replace, :undef => :replace, :replace => '' })
   end
 
   #

--- a/spec/lib/rex/text_spec.rb
+++ b/spec/lib/rex/text_spec.rb
@@ -4,6 +4,31 @@ require 'rex/text'
 describe Rex::Text do
   context "Class methods" do
 
+    context ".to_ebcdic" do
+      it "should convert ASCII to EBCDIC (both US standards)" do
+        described_class.to_ebcdic("Hello, World!").should eq("\xc8\x85\x93\x93\x96\x6b\x40\xe6\x96\x99\x93\x84\x5a")
+      end
+      it "should raise on non-convertable characters" do
+        lambda {described_class.to_ebcdic("\xff\xfe")}.should raise_exception(described_class::IllegalSequence)
+      end
+    end
+
+    context ".from_ebcdic" do
+      it "should convert EBCDIC to ASCII (both US standards)" do
+        described_class.from_ebcdic("\xc8\x85\x93\x93\x96\x6b\x40\xe6\x96\x99\x93\x84\x5a").should eq("Hello, World!")
+      end
+      it "should raise on non-convertable characters" do
+        lambda {described_class.from_ebcdic("\xff\xfe")}.should raise_exception(described_class::IllegalSequence)
+      end
+    end
+
+    context ".to_utf8" do
+      it "should convert a string to UTF-8, skipping badchars" do
+        described_class.to_utf8("Hello, world!").should eq("Hello, world!")
+        described_class.to_utf8("Oh no, \xff\xfe can't convert!").should eq("Oh no,  can't convert!")
+      end
+    end
+
     context ".to_octal" do
       it "should convert all chars 00 through ff" do
         described_class.to_octal("\x7f"*100).should eq("\\177"*100)


### PR DESCRIPTION
See #4525 for some background on this. Iconv is no longer supported, and people are supposed to use `String#encode` instead. The bummer is, there's no encoder for EBCDIC.

The only other place Iconv was used was an ASCII to UTF-8 "converter," which seems weird to me since ASCII is a subset of the UTF-8 character set. About the only thing `Rex::Text.to_utf8" did was to ensure that invalid characters would just be silently dropped, so the rspec tests reflect that.
## Verification
- [x] See that Travis-CI passes, as there are new rspec tests to ensure it all still works. `rake spec` is all green (and a little yellow) for me.
### Bonus verification
- [ ] See that the DB2 scanners and version checkers still work, since the DRDA libraries are the only things that use this at the moment. However, I believe that the rspec tests are adequate enough and you shouldn't need to go as far as functional testing to validate this PR.

Anyone who lands this should include a comment of "Fixes #4525" on the merge commit.
