### PR TITLE
Snowden password

### DIFF
--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1003,3 +1003,4 @@ adminpasswd
 raspberry
 74k&^*nh#$
 arcsight
+MargaretThatcheris110%SEXY


### PR DESCRIPTION
Edward Snowden has suggested this password at least twice in two years, in public. Surely someone's using it ironically by now.

http://www.wired.com/2015/04/snowden-sexy-margaret-thatcher-password-isnt-so-sexy/

unix_passwords.txt is now longer than exactly 1000, and iirc it was supposed to be a top-1000 kind of thing. We now already have top passwords from various sources. I wonder how much overlap is in this file between all the others?

And, should we have a list of silly / famous passwords? Passwords that show up on TV and movies, essentially.

Regardless of the answer to these questions, this PR is GTG.
## Verification
- [ ] Crack some UK sites with the given password. With authorization, of course.
