### PR TITLE
Include interactive channel logging

### DIFF
--- a/lib/rex/post/meterpreter/ui/console.rb
+++ b/lib/rex/post/meterpreter/ui/console.rb
@@ -83,6 +83,7 @@ class Console
     channel.extend(InteractiveChannel) unless (channel.kind_of?(InteractiveChannel) == true)
     channel.on_command_proc = self.on_command_proc if self.on_command_proc
     channel.on_print_proc   = self.on_print_proc if self.on_print_proc
+    channel.on_log_proc = method(:log_output) if self.respond_to?(:log_output, true)
 
     channel.interact(input, output)
     channel.reset_ui

--- a/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
+++ b/lib/rex/post/meterpreter/ui/console/interactive_channel.rb
@@ -81,6 +81,7 @@ module Console::InteractiveChannel
     data = self.lsock.sysread(16384)
 
     self.on_print_proc.call(data.strip) if self.on_print_proc
+    self.on_log_proc.call(data.strip) if self.on_log_proc
     user_output.print(data)
   end
 
@@ -90,6 +91,8 @@ module Console::InteractiveChannel
   def _remote_fd(stream)
     self.lsock
   end
+
+  attr_accessor :on_log_proc
 
 end
 


### PR DESCRIPTION
to log shell activities etc:

looks like:

```
[*] Logging started: 2015-06-21 17:03:36 +0100

load stdapiload privmeterpreter > getuidServer username: User-PC\User
meterpreter > shellProcess 1508 created.
Channel 1 created.
Microsoft Windows [Version 6.1.7600]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\>whoami
user-pc\user

C:\>exitmeterpreter > sysinfoComputer        : USER-PC
OS              : Windows 7 (Build 7600).
Architecture    : x86
System Language : en_GB
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
```
