### PR TITLE
hack android-specific commands back to life

### DIFF
--- a/lib/msf/base/sessions/meterpreter_android.rb
+++ b/lib/msf/base/sessions/meterpreter_android.rb
@@ -19,6 +19,13 @@ class Meterpreter_Java_Android < Msf::Sessions::Meterpreter_Java_Java
     self.platform = 'java/android'
   end
 
+  def load_android
+    original = console.disable_output
+    console.disable_output = true
+    console.run_single('load android')
+    console.disable_output = original
+  end
+
 end
 
 end

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -65,6 +65,12 @@ module MeterpreterOptions
         end
       end
 
+      if session.platform =~ /android/i
+        if datastore['AutoLoadAndroid']
+          session.load_android
+        end
+      end
+
       [ 'InitialAutoRunScript', 'AutoRunScript' ].each do |key|
         if (datastore[key].empty? == false)
           args = Shellwords.shellwords( datastore[key] )


### PR DESCRIPTION
This fixes #5557 by reactivating the hack that allows msfconsole to pretend that we loaded an android extension. We need to follow this up with a refactor of the android_ commands back into stdapi and implement enumextcmd so that commands can be introspected at runtime instead.
# Verification steps
- [x] Setup an android meterpreter session
- [x] run 'help' and check that commands like 'check_root' exist and run
