### PR TITLE
Remove the extra target_uri

### DIFF
--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -48,9 +48,6 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('VHOST')
   end
 
-  def target_uri
-    @target_uri ||= super
-  end
 
   def potential_static_files_uris
     uri = normalize_uri(target_uri.path)


### PR DESCRIPTION
In this module, you should only see one `def target_uri`. I added an extra one.
