### PR TITLE
Bump recog to 2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rb-readline-r7 (0.5.2.0)
-    recog (2.0.5)
+    recog (2.0.6)
       nokogiri
     redcarpet (3.2.3)
     rkelly-remix (0.0.6)


### PR DESCRIPTION
This adds Windows 10 SMB support along with SSH and FTP fingerprints.
