### PR TITLE
Fix up the core_machine_id call to handle weirdness better

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -320,7 +320,9 @@ class ClientCore < Extension
 
     # Normalise the format of the incoming machine id so that it's consistent
     # regardless of case and leading/trailing spaces. This means that the
-    # individual meterpreters don't have to care
+    # individual meterpreters don't have to care.
+
+    # Note that the machine ID may be blank or nil and that is OK
     Rex::Text.md5(mid.to_s.downcase.strip)
   end
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -321,8 +321,7 @@ class ClientCore < Extension
     # Normalise the format of the incoming machine id so that it's consistent
     # regardless of case and leading/trailing spaces. This means that the
     # individual meterpreters don't have to care
-    mid.downcase!.strip! if mid
-    return Rex::Text.md5(mid)
+    Rex::Text.md5(mid.to_s.downcase.strip)
   end
 
   def transport_remove(opts={})


### PR DESCRIPTION
This change fixes a few corner cases where the `core_machine_id` call will throw a stack trace. It is reproducable with Wine, but may impact real machines as well.

The stack trace it fixes only shows up in the framework.log, but looks like:

```
[06/23/2015 10:47:38] [d(0)] core: Session 1 did not respond to validation request NoMethodError: undefined method `strip!' for nil:NilClass
```

The impact of this bug will be a prematurely closed session.
