### PR TITLE
Update user info on migrate

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -319,25 +319,28 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     false
   end
 
+  def update_session_info
+    username = self.sys.config.getuid
+    sysinfo  = self.sys.config.sysinfo
+
+    safe_info = "#{username} @ #{sysinfo['Computer']}"
+    safe_info.force_encoding("ASCII-8BIT") if safe_info.respond_to?(:force_encoding)
+    # Should probably be using Rex::Text.ascii_safe_hex but leave
+    # this as is for now since "\xNN" is arguably uglier than "_"
+    # showing up in various places in the UI.
+    safe_info.gsub!(/[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]+/n,"_")
+    self.info = safe_info
+  end
+
   #
   # Populate the session information.
   #
   # Also reports a session_fingerprint note for host os normalization.
   #
-  def load_session_info()
+  def load_session_info
     begin
       ::Timeout.timeout(60) do
-        # Gather username/system information
-        username = self.sys.config.getuid
-        sysinfo  = self.sys.config.sysinfo
-
-        safe_info = "#{username} @ #{sysinfo['Computer']}"
-        safe_info.force_encoding("ASCII-8BIT") if safe_info.respond_to?(:force_encoding)
-        # Should probably be using Rex::Text.ascii_safe_hex but leave
-        # this as is for now since "\xNN" is arguably uglier than "_"
-        # showing up in various places in the UI.
-        safe_info.gsub!(/[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]+/n,"_")
-        self.info = safe_info
+        update_session_info
 
         hobj = nil
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -818,6 +818,9 @@ class Console::CommandDispatcher::Core
 
     print_status("Migration completed successfully.")
 
+    # Update session info (we may have a new username)
+    client.update_session_info
+
     unless existing_relays.empty?
       print_status("Recreating TCP relay(s)...")
       existing_relays.each do |r|


### PR DESCRIPTION
Updates session info after a successful migrate

Resolves #5465 

Example:

```
sf exploit(web_delivery) > sessions 

Active sessions
===============

  Id  Type                   Information                   Connection
  --  ----                   -----------                   ----------
  2   meterpreter x86/win32  TEST\Administrator @ USER-PC  192.168.5.101:8686 -> 192.168.5.102:49190 (192.168.5.102)

msf exploit(web_delivery) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > ps


Process list
============

 PID   Name                    Arch  Session  User                          Path
 ---   ----                    ----  -------  ----                          ----
 0     [System Process]                                                     
 4     System                  x86   0                                      
...
 4048  SearchFilterHost.exe    x86   0        NT AUTHORITY\SYSTEM           C:\Windows\system32\SearchFilterHost.exe


meterpreter > migrate 4048
[*] Migrating from 840 to 4048...
[*] Migration completed successfully.
meterpreter > background
[*] Backgrounding session 2...
msf exploit(web_delivery) > sessions

Active sessions
===============

  Id  Type                   Information                    Connection
  --  ----                   -----------                    ----------
  2   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ USER-PC  192.168.5.101:8686 -> 192.168.5.102:49190 (192.168.5.102)
```
