### PR TITLE
Bump the Session Verify default timeout to 30 seconds based on feedback

### DIFF
--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -13,7 +13,7 @@ module MeterpreterOptions
       [
         OptBool.new('AutoLoadStdapi', [true, "Automatically load the Stdapi extension", true]),
         OptBool.new('AutoVerifySession', [true, "Automatically verify and drop invalid sessions", true]),
-        OptInt.new('AutoVerifySessionTimeout', [false, "Timeout period to wait for session validation to occur, in seconds", 10]),
+        OptInt.new('AutoVerifySessionTimeout', [false, "Timeout period to wait for session validation to occur, in seconds", 30]),
         OptString.new('InitialAutoRunScript', [false, "An initial script to run on session creation (before AutoRunScript)", '']),
         OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", '']),
         OptBool.new('AutoSystemInfo', [true, "Automatically capture system information on initialization.", true]),


### PR DESCRIPTION
This change modifies the default timeout from 10 seconds to 30 seconds as a result of community feedback. Slow and lossy network connections could hit the 10 second timeout in many cases.
