### PR TITLE
IRB Expression Evaluation From Options

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -94,6 +94,10 @@ class Core
   @@go_pro_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ])
 
+  @@irb_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner."                                   ],
+    "-e" => [ true,  "Expression to evaluate."                        ])
+
   # The list of data store elements that cannot be set when in defanged
   # mode.
   DefangedProhibitedDataStoreElements = [ "MsfModulePaths" ]
@@ -759,8 +763,8 @@ class Core
   def cmd_irb_help
     print_line "Usage: irb"
     print_line
-    print_line "Drop into an interactive Ruby environment"
-    print_line
+    print_line "Execute commands in a Ruby environment"
+    print @@irb_opts.usage()
   end
 
   #
@@ -768,6 +772,26 @@ class Core
   #
   def cmd_irb(*args)
     defanged?
+
+    expressions = []
+
+    # Parse the command options
+    @@irb_opts.parse(args) do |opt, idx, val|
+      case opt
+        when '-e'
+          expressions << val
+        when '-h'
+          cmd_irb_help
+          return false
+      end
+    end
+
+    if !expressions.empty?
+      expressions.each do |expression|
+        eval(expression, binding)
+      end
+      return
+    end
 
     print_status("Starting IRB shell...\n")
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -30,6 +30,10 @@ class Console::CommandDispatcher::Core
     self.bgjob_id   = 0
   end
 
+  @@irb_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner."                  ],
+    "-e" => [ true,  "Expression to evaluate."       ])
+
   @@load_opts = Rex::Parser::Arguments.new(
     "-l" => [ false, "List all available extensions" ],
     "-h" => [ false, "Help menu."                    ])
@@ -322,15 +326,43 @@ class Console::CommandDispatcher::Core
 
   alias cmd_interact_tabs cmd_close_tabs
 
+  def cmd_irb_help
+    print_line "Usage: irb"
+    print_line
+    print_line "Execute commands in a Ruby environment"
+    print @@irb_opts.usage()
+  end
+
   #
   # Runs the IRB scripting shell
   #
   def cmd_irb(*args)
-    print_status("Starting IRB shell")
-    print_status("The 'client' variable holds the meterpreter client\n")
+    expressions = []
+
+    # Parse the command options
+    @@irb_opts.parse(args) do |opt, idx, val|
+      case opt
+        when '-e'
+          expressions << val
+        when '-h'
+          cmd_irb_help
+          return
+      end
+    end
 
     session = client
     framework = client.framework
+
+    if !expressions.empty?
+      expressions.each do |expression|
+        eval(expression, binding)
+      end
+      return
+    end
+
+    print_status("Starting IRB shell")
+    print_status("The 'client' variable holds the meterpreter client\n")
+
     Rex::Ui::Text::IrbShell.new(binding).run
   end
 


### PR DESCRIPTION
This PR adds the -e option to both the framework and meterpreter `irb` commands. The -e flag can be specified to evaluate an arbitrary ruby expression without completely dropping into an IRB interpreter. This can then be used from the CLI interface or from resource files.

This is even more useful when used with the alias command. For example a new `mdm_ui_events` command could easily be created by a user with the following command:
`alias -f mdm_ui_events irb -e \'puts Mdm::Event.where(name: \"ui_command\").all.map{|x| [x.created_at.to_s, x.info[:command]].join(\",\") }.join(\"\\n\")\'`

Example usage from meterpreter:

```
meterpreter > irb -e "puts session.sys.config.sysinfo['OS']"
Windows 7 (Build 7601, Service Pack 1).
meterpreter > 
```

Example usage from the framework:

```
msf-git (S:1 J:0) exploit(handler) > irb -e 'puts "#{framework.sessions.length} session open"'
1 session open
```
