### PR TITLE
add Git information disclosure scanner

### DIFF
--- a/modules/auxiliary/scanner/http/git_scanner.rb
+++ b/modules/auxiliary/scanner/http/git_scanner.rb
@@ -1,0 +1,131 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  # Exploit mixins should be called first
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::WmapScanServer
+  # Scanner mixin should be near last
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name'        => 'HTTP Git Scanner',
+      'Description' => 'Detect git directories and files and analize its content.',
+      'Author'       => ['t0nyhj'],
+      'License'     => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        OptString.new('PATH', [ true,  "The test path to .git directory", '/'])#,
+        #OptBool.new('GET_SOURCE', [ false, "Attempt to obtain file source code", true ]),
+        #OptBool.new('SHOW_SOURCE', [ false, "Show source code", true ])
+
+      ], self.class)
+
+    register_advanced_options(
+      [
+        OptInt.new('ErrorCode', [ true, "Error code for non existent directory", 404]),
+        OptPath.new('HTTP404Sigs',   [ false, "Path of 404 signatures to use",
+            File.join(Msf::Config.data_directory, "wmap", "wmap_404s.txt")
+          ]
+        ),
+        OptBool.new('NoDetailMessages', [ false, "Do not display detailed test messages", true ])
+
+      ], self.class)
+  end
+
+  def run_host(target_host)
+    conn = true
+    ecode = nil
+    emesg = nil
+
+    word1 = 'core'
+    word2 = 'remote'
+    word3 = 'branch'
+
+    tpath = normalize_uri(datastore['PATH'])
+    if tpath[-1,1] != '/'
+      tpath += '/'
+    end
+
+    ecode = datastore['ErrorCode'].to_i
+    vhost = datastore['VHOST'] || wmap_target_host
+
+    #
+    # Detect error code
+    #
+    begin
+      randdir = Rex::Text.rand_text_alpha(5).chomp + '/'
+      res = send_request_cgi({
+        'uri'  		=>  tpath+randdir,
+        'method'   	=> 'GET',
+        'ctype'		=> 'text/html'
+      }, 20)
+
+      return if not res
+
+      tcode = res.code.to_i
+
+
+      # Look for a string we can signature on as well
+      if(tcode >= 200 and tcode <= 299)
+
+        File.open(datastore['HTTP404Sigs'], 'rb').each do |str|
+          if(res.body.index(str))
+            emesg = str
+            break
+          end
+        end
+
+        if(not emesg)
+          #print_status("Using first 256 bytes of the response as 404 string")
+          emesg = res.body[0,256]
+        else
+          #print_status("Using custom 404 string of '#{emesg}'")
+        end
+      else
+        ecode = tcode
+        #print_status("Using code '#{ecode}' as not found.")
+      end
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      conn = false
+    rescue ::Timeout::Error, ::Errno::EPIPE
+    end
+
+    return if not conn
+
+    dm = datastore['NoDetailMessages']
+
+    begin
+      turl = tpath+'.git/config'#'.svn/entries'
+
+      res = send_request_cgi({
+        'uri'          => turl,
+        'method'       => 'GET',
+        'version' => '1.0',
+      }, 10)
+
+      if(not res or ((res.code.to_i == ecode) or (emesg and res.body.index(emesg))))
+        if dm == false
+          print_status("[#{target_host}] NOT Found. #{tpath} #{res.code}")
+        end
+      else
+        if (res.body.include?(word1) or res.body.include?(word2) or res.body.include?(word3))
+          print_good("[#{target_host}:#{rport}] Git Config file found.")
+        end
+      end
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    rescue ::Timeout::Error, ::Errno::EPIPE
+    end
+  end
+end


### PR DESCRIPTION
Scan git information disclosure vuls.
## Verification

![image](https://cloud.githubusercontent.com/assets/10477178/8350308/d9e9ef12-1b56-11e5-8317-1e14453bf2c1.png)
## Example Output

<pre><code>
msf > use auxiliary/scanner/http/git_scanner
msf auxiliary(git_scanner) > set rhosts 180.150.151.130/24
rhosts => 180.150.151.130/24
msf auxiliary(git_scanner) > set threads 100
threads => 100
msf auxiliary(git_scanner) > run

[*] Scanned  30 of 256 hosts (11% complete)
[*] Scanned  55 of 256 hosts (21% complete)
[*] Scanned 108 of 256 hosts (42% complete)
[*] Scanned 114 of 256 hosts (44% complete)
[+] [180.150.151.158:80] Git Config file found.
[+] [180.150.151.128:80] Git Config file found.
[+] [180.150.151.130:80] Git Config file found.
[+] [180.150.151.131:80] Git Config file found.
[*] Scanned 136 of 256 hosts (53% complete)
[*] Scanned 154 of 256 hosts (60% complete)
[*] Scanned 191 of 256 hosts (74% complete)
[*] Scanned 210 of 256 hosts (82% complete)
[*] Scanned 240 of 256 hosts (93% complete)
[*] Scanned 256 of 256 hosts (100% complete)
[*] Auxiliary module execution completed
</code></pre>


than you can use the tool [https://github.com/lijiejie/GitHack] to get the source code. 
good luck. :-)
