### PR TITLE
Minor cleanups on recent modules

### DIFF
--- a/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
+++ b/modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'MS15-034 HTTP Protocol Stack Request Handling HTTP.SYS Memory Information Disclosure',
       'Description' => %q{
-        Dumps memory contents using a crafted Range header. Affects only
+        This module dumps memory contents using a crafted Range header, and affects only
         Windows 8.1, Server 2012, and Server 2012R2. Note that if the target
         is running in VMware Workstation, this module has a high likelihood
         of resulting in BSOD; however, VMware ESX and non-virtualized hosts

--- a/modules/exploits/multi/browser/adobe_flash_shader_drawing_fill.rb
+++ b/modules/exploits/multi/browser/adobe_flash_shader_drawing_fill.rb
@@ -16,9 +16,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'         => %q{
         This module exploits a memory corruption happening when applying a Shader as a drawing fill
         as exploited in the wild on June 2015. This module has been tested successfully on:
-        Windows 7 SP1 (32-bit), IE11 and Adobe Flash 17.0.0.188.
-        Windows 7 SP1 (32-bit), Firefox 38.0.5 and Adobe Flash 17.0.0.188.
-        Windows 8.1, Firefox 38.0.5 and Adobe Flash 17.0.0.188.
+
+        Windows 7 SP1 (32-bit), IE11 and Adobe Flash 17.0.0.188,
+        Windows 7 SP1 (32-bit), Firefox 38.0.5 and Adobe Flash 17.0.0.188,
+        Windows 8.1, Firefox 38.0.5 and Adobe Flash 17.0.0.188, and
         Linux Mint "Rebecca" (32 bits), Firefox 33.0 and Adobe Flash 11.2.202.460.
       },
       'License'             => MSF_LICENSE,

--- a/modules/exploits/multi/browser/adobe_flash_shader_job_overflow.rb
+++ b/modules/exploits/multi/browser/adobe_flash_shader_job_overflow.rb
@@ -20,10 +20,11 @@ class Metasploit3 < Msf::Exploit::Remote
         of the ShaderJob after starting the job it's possible to create a buffer overflow condition
         where the size of the destination buffer and the length of the copy are controlled. This
         module has been tested successfully on:
-        * Windows 7 SP1 (32-bit), IE11 and Adobe Flash 17.0.0.169.
-        * Windows 7 SP1 (32-bit), Firefox 38.0.5 and Adobe Flash 17.0.0.169.
-        * Windows 8.1, Firefox 38.0.5 and Adobe Flash 17.0.0.169.
-        * Linux Mint "Rebecca" (32 bits), Firefox 33.0 and Adobe Flash 11.2.202.457.
+
+        Windows 7 SP1 (32-bit), IE11 and Adobe Flash 17.0.0.169,
+        Windows 7 SP1 (32-bit), Firefox 38.0.5 and Adobe Flash 17.0.0.169,
+        Windows 8.1, Firefox 38.0.5 and Adobe Flash 17.0.0.169, and
+        Linux Mint "Rebecca" (32 bits), Firefox 33.0 and Adobe Flash 11.2.202.457.
       },
       'License'             => MSF_LICENSE,
       'Author'              =>

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => "report_cred test",
+      'Name'           => "report_cred Test",
       'Description'    => %q{
-      	This module will test every auxiliary module's report_cred method
+        This module will test every auxiliary module's report_cred method
       },
       'Author'         => [ 'sinn3r' ],
       'License'        => MSF_LICENSE
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def test_asterisk_login
-  	mod = framework.auxiliary.create('voip/asterisk_login')
+    mod = framework.auxiliary.create('voip/asterisk_login')
     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
   end
 


### PR DESCRIPTION
Edited modules/auxiliary/scanner/http/ms15_034_http_sys_memory_dump.rb
first landed in #5577, MS15-034 HTTP.SYS Information Disclosure

Edited modules/exploits/multi/browser/adobe_flash_shader_drawing_fill.rb
first landed in #5605, CVE-2015-3105 flash exploit

Edited modules/exploits/multi/browser/adobe_flash_shader_job_overflow.rb
first landed in #5559, Adobe Flash Player ShaderJob Buffer Overflow

Edited modules/auxiliary/test/report_auth_info.rb first landed in #5540,
@wchen-r7's changes for multiple auxiliary modules to use the new cred
API
