### PR TITLE
Fix #5616, Save username before stop_on_success breaking the loop

### DIFF
--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -220,8 +220,8 @@ module Metasploit
 
               if result.success?
                 consecutive_error_count = 0
-                break if stop_on_success
                 successful_users << credential.public
+                break if stop_on_success
               else
                 if result.status == Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
                   consecutive_error_count += 1


### PR DESCRIPTION
Fix #5616 

This patch is based on code review, plus it's a one-line fix so I don't really have any verification steps to give.

The problem we're trying to address here is that when the scan! method receives a good result, it wants to save that username. However, if the stop_on_success option is set, it will break out of the loop before it can save the username. It really should be the other way around.
- [x] So to review this pull request, I suggest think about if this logic makes sense to you.
