### PR TITLE
Urgent: Force :init_connect for stageless

### DIFF
--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -48,7 +48,8 @@ module Msf::Payload::TransportConfig
     # going up as part of the stage.
     uri = opts[:uri]
     unless uri
-      sum = uri_checksum_lookup(:connect)
+      type = opts[:stageless] == true ? :init_connect : :connect
+      sum = uri_checksum_lookup(type)
       uri = generate_uri_uuid(sum, opts[:uuid])
     end
 

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -45,6 +45,7 @@ module Metasploit4
 
   def generate_config(opts={})
     opts[:uuid] ||= generate_payload_uuid
+    opts[:stageless] = true
 
     # create the configuration block
     config_opts = {

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -45,6 +45,7 @@ module Metasploit4
 
   def generate_config(opts={})
     opts[:uuid] ||= generate_payload_uuid
+    opts[:stageless] = true
 
     # create the configuration block
     config_opts = {

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -45,6 +45,7 @@ module Metasploit4
 
   def generate_config(opts={})
     opts[:uuid] ||= generate_payload_uuid
+    opts[:stageless] = true
 
     # create the configuration block
     config_opts = {

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -45,6 +45,7 @@ module Metasploit4
 
   def generate_config(opts={})
     opts[:uuid] ||= generate_payload_uuid
+    opts[:stageless] = true
 
     # create the configuration block
     config_opts = {


### PR DESCRIPTION
Somewhere along the line we managed to regress the stageless code so that `reverse_http` and `reverse_https` payloads were not using `:init_connect` when the payloads were generated. This is bad because without it, the stageless binaries will all be using the same URI when talking to MSF and MSF will "combine" all the sessions into one. This means that commands may execute on any of the sessions.

Currently, when you run a stageless payload, you see the following in MSF:

```
msf exploit(handler) > 
[*] 10.1.10.35:49170 (UUID: 3608b1bf940885da/x86=1/windows=1/2015-06-27T08:15:10Z) Attaching orphaned/stageless session ...
[*] Meterpreter session 2 opened (10.1.10.40:8443 -> 10.1.10.35:49170) at 2015-06-27 18:18:28 +1000
```

Note that MSF believes that it's orphaned/staged and doesn't offer a new URI so that the stageless session can be uniquely identified. After running the same payload _again_, no new session is created. This is where the sessions are being merged.

This PR fixes this issue. x64 and x86 stageless Meterpreter payloads that use HTTP or HTTPS now correctly use the `:init_connect` URI type, resulting in MSF creating a new URI for the initial connection on the fly. The result is:

```
msf exploit(handler) >
[*] 10.1.10.35:49173 (UUID: a48d3799ae791c89/x86=1/windows=1/2015-06-27T08:20:40Z) Redirecting stageless connection ...
[*] 10.1.10.35:49174 (UUID: a48d3799ae791c89/x86=1/windows=1/2015-06-27T08:20:40Z) Attaching orphaned/stageless session ...
[*] Meterpreter session 1 opened (10.1.10.40:8443 -> 10.1.10.35:49174) at 2015-06-27 18:20:52 +1000
[*] 10.1.10.35:49176 (UUID: a48d3799ae791c89/x86=1/windows=1/2015-06-27T08:20:40Z) Redirecting stageless connection ...
[*] 10.1.10.35:49177 (UUID: a48d3799ae791c89/x86=1/windows=1/2015-06-27T08:20:40Z) Attaching orphaned/stageless session ...
[*] Meterpreter session 2 opened (10.1.10.40:8443 -> 10.1.10.35:49177) at 2015-06-27 18:20:58 +1000
```

Here we can see that each time the payload is run, MSF "redirects the stageless connection", which is where the new URI is generated. Immediately afterwards we see that the connection comes in on the `:connect` URI, resulting in a new session.

I'm not sure how we got here, but clearly this isn't good for stageless HTTP/HTTPS.
## Verification

Set up payloads and listeners for:
- [x] `windows/meterpreter_reverse_http`
- [x] `windows/meterpreter_reverse_https`
- [x] `windows/x64/meterpreter_reverse_http`
- [x] `windows/x64/meterpreter_reverse_https`

For each of these payloads, validate that:
- [x] when a new stageless connection comes in that MSF redirects the URI to the `:connect` URI.
- [x] when _another_ new stageless connection comes in, the same happens, and multiple sessions are created.

Cheers!
