### PR TITLE
Fix a stack trace with ipmi_dumphashes when no database was configured.

### DIFF
--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -270,7 +270,7 @@ class Metasploit3 < Msf::Auxiliary
     }.merge(service_data)
 
     cl = create_credential_login(login_data)
-    cl.core_id
+    cl ? cl.core_id : nil
   end
 
   def report_cracked_cred(user, password, core_id)


### PR DESCRIPTION
The ipmi_dumphashes module is triggering a stack trace when no database is connected and a valid hash is found. This looks like a regression introduced during the credential refactor.

The error in the console looks like:

```
Auxiliary failed: NoMethodError undefined method `core_id'
```
