### PR TITLE
Favor cmd_exec on linux gather modules

### DIFF
--- a/modules/post/linux/gather/enum_configs.rb
+++ b/modules/post/linux/gather/enum_configs.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Post
     when /meterpreter/
       host = sysinfo["Computer"]
     when /shell/
-      host = session.shell_command_token("hostname").chomp
+      host = cmd_exec("hostname").chomp
     end
 
     return host

--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Post
     when /meterpreter/
       host = sysinfo["Computer"]
     when /shell/
-      host = session.shell_command_token("hostname").chomp
+      host = cmd_exec("hostname").chomp
     end
 
     print_status("Running module against #{host}")

--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Post
     when /meterpreter/
       host = sysinfo["Computer"]
     when /shell/
-      host = session.shell_command_token("hostname").chomp
+      host = cmd_exec("hostname").chomp
     end
 
     return host

--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -79,28 +79,9 @@ class Metasploit3 < Msf::Post
     print_status("#{msg} stored in #{loot}")
   end
 
-  def get_host
-    case session.type
-    when /meterpreter/
-      host = sysinfo["Computer"]
-    when /shell/
-      host = session.shell_command_token("hostname").chomp
-    end
-
-    print_status("Running module against #{host}")
-
-    host
-  end
-
   def execute(cmd)
     vprint_status("Execute: #{cmd}")
     output = cmd_exec(cmd)
-    output
-  end
-
-  def cat_file(filename)
-    vprint_status("Download: #{filename}")
-    output = read_file(filename)
     output
   end
 

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -66,17 +66,6 @@ class Metasploit3 < Msf::Post
     print_status("#{msg} stored in #{loot.to_s}")
   end
 
-  def get_host
-    case session.type
-    when /meterpreter/
-      host = sysinfo['Computer']
-    when /shell/
-      host = session.shell_command_token('hostname').chomp
-    end
-    print_status("Running module against #{host}")
-    host
-  end
-
   def execute(cmd)
     vprint_status("Execute: #{cmd}")
     output = cmd_exec(cmd)


### PR DESCRIPTION
This pull request is related to issue #3951. We're favoring cmd_exec over shell_command_token. There are several linux gather post modules using session.shell_command_token. It only happens on some modules when executing the `hostname` command. Also a couple of modules (`enum_system` and `enum_users_history`) used shell_command_token in unused code, so just code cleanup there.

I've tested all the modified modules with a shell session to confirm which they are working as before. It means, the "get_host" method is working as before still and you can see the message `[*] Running module against #{host}` correctly.

Test results:
- enum_configs

```
msf post(enum_configs) > run

[*] Running module against ubuntu
[*] Info:
[*]     Ubuntu 12.04.3 LTS
[*]     Linux ubuntu 3.8.0-29-generic #42~precise1-Ubuntu SMP Wed Aug 14 15:31:16 UTC 2013 i686 i686 i386 GNU/Linux
[*] my.cnf stored in /Users/jvazquez/.msf4/loot/20150629095427_default_172.16.158.136_linux.enum.conf_888878.txt
[*] ufw.conf stored in /Users/jvazquez/.msf4/loot/20150629095427_default_172.16.158.136_linux.enum.conf_854854.txt
[*] sysctl.conf stored in /Users/jvazquez/.msf4/loot/20150629095428_default_172.16.158.136_linux.enum.conf_524048.txt
[*] shells stored in /Users/jvazquez/.msf4/loot/20150629095428_default_172.16.158.136_linux.enum.conf_340707.txt
[*] sepermit.conf stored in /Users/jvazquez/.msf4/loot/20150629095429_default_172.16.158.136_linux.enum.conf_882477.txt
[*] ca-certificates.conf stored in /Users/jvazquez/.msf4/loot/20150629095429_default_172.16.158.136_linux.enum.conf_041486.txt
[*] access.conf stored in /Users/jvazquez/.msf4/loot/20150629095430_default_172.16.158.136_linux.enum.conf_788279.txt
[*] rpc stored in /Users/jvazquez/.msf4/loot/20150629095431_default_172.16.158.136_linux.enum.conf_683091.txt
[*] logrotate.conf stored in /Users/jvazquez/.msf4/loot/20150629095432_default_172.16.158.136_linux.enum.conf_103112.txt
[*] ldap.conf stored in /Users/jvazquez/.msf4/loot/20150629095433_default_172.16.158.136_linux.enum.conf_184547.txt
[*] sysctl.conf stored in /Users/jvazquez/.msf4/loot/20150629095434_default_172.16.158.136_linux.enum.conf_318378.txt
[*] Post module execution completed
```
- enum_network

```
msf post(enum_network) > run

[*] Running module against ubuntu
[*] Module running as juan
[+] Info:
[+]     Ubuntu 12.04.3 LTS
[+]     Linux ubuntu 3.8.0-29-generic #42~precise1-Ubuntu SMP Wed Aug 14 15:31:16 UTC 2013 i686 i686 i386 GNU/Linux
[*] Collecting data...
[*] Network config stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_564668.txt
[*] Route table stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_142320.txt
[*] Firewall config stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_466845.txt
[*] DNS config stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_014722.txt
[*] SSHD config stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_056897.txt
[*] Host file stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_571467.txt
[*] Active connections stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_151663.txt
[*] Wireless information stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_481594.txt
[*] Listening ports stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_693653.txt
[*] If-Up/If-Down stored in /Users/jvazquez/.msf4/loot/20150629095843_default_172.16.158.136_linux.enum.netwo_802425.txt
[*] Post module execution completed
```
- enum_protections

```
msf post(enum_protections) > run

[*] Running module against ubuntu
[*] Info:
[*]     Ubuntu 12.04.3 LTS
[*]     Linux ubuntu 3.8.0-29-generic #42~precise1-Ubuntu SMP Wed Aug 14 15:31:16 UTC 2013 i686 i686 i386 GNU/Linux
[*] Finding installed applications...
[+] ufw found: /usr/sbin/ufw
[+] logrotate found: /usr/sbin/logrotate
[+] tcpdump found: /usr/sbin/tcpdump
[*] Installed applications saved to notes.
[*] Post module execution completed
```
- enum_system

```
msf post(enum_system) > run

[+] Info:
[+]     Ubuntu 12.04.3 LTS
[+]     Linux ubuntu 3.8.0-29-generic #42~precise1-Ubuntu SMP Wed Aug 14 15:31:16 UTC 2013 i686 i686 i386 GNU/Linux
[+]     Module running as "juan" user
[*] Linux version stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_135264.txt
[*] User accounts stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_985117.txt
[*] Installed Packages stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_539665.txt
[*] Running Services stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_528624.txt
[*] Cron jobs stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_399550.txt
[*] Disk info stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_362917.txt
[*] Logfiles stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_944007.txt
[*] Setuid/setgid files stored in /Users/jvazquez/.msf4/loot/20150629101930_default_172.16.158.136_linux.enum.syste_035223.txt
[*] Post module execution completed
```
- enum_users_history

```
msf post(enum_system) > run

[+] Info:
[+]     Ubuntu 12.04.3 LTS
[+]     Linux ubuntu 3.8.0-29-generic #42~precise1-Ubuntu SMP Wed Aug 14 15:31:16 UTC 2013 i686 i686 i386 GNU/Linux
[+]     Module running as "juan" user
[*] Linux version stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_116072.txt
[*] User accounts stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_627772.txt
[*] Installed Packages stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_139561.txt
[*] Running Services stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_099335.txt
[*] Cron jobs stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_687245.txt
[*] Disk info stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_123414.txt
[*] Logfiles stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_698490.txt
[*] Setuid/setgid files stored in /Users/jvazquez/.msf4/loot/20150629102040_default_172.16.158.136_linux.enum.syste_864351.txt
[*] Post module execution completed
```
