### PR TITLE
Fix nil error when target not found

### DIFF
--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -88,17 +88,21 @@ class Metasploit3 < Msf::Exploit::Remote
   def on_request_uri(cli, request)
     agent = request.headers['User-Agent']
     if agent !~ /Firefox\/3\.6\.(16|17)/
-      print_error("This browser is not supported: #{agent.to_s}")
+      print_error("This browser is not supported: #{agent}")
       send_not_found(cli)
       return
     end
 
     my_target = target
     if my_target.name == 'Automatic'
-      if agent =~ /NT 5\.1/ and agent =~ /Firefox\/3\.6\.16/
+      if agent =~ /NT 5\.1/ && agent =~ /Firefox\/3\.6\.16/
         my_target = targets[1]
-      elsif agent =~ /NT 6\.1/ and agent =~ /Firefox\/3\.6\.16/
+      elsif agent =~ /NT 6\.[01]/ && agent =~ /Firefox\/3\.6\.16/
         my_target = targets[2]
+      else
+        print_error("This browser is not a viable target: #{agent}")
+        send_not_found(cli)
+        return
       end
     end
 


### PR DESCRIPTION
Discovered in #5624.
- [x] Fire up `exploit/windows/browser/mozilla_reduceright`
- [x] Test with an unexpected user agent
- [x] See a 404
- [x] Don't see a `nil` error in `msfconsole`
- [x] Test with an expected user agent
- [x] See the exploit code

I'm using "NT 5.1 Firefox/3.6.16" as a valid user agent.
