### PR TITLE
Add detection for Windows 10 (IE11) for os.js

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -338,7 +338,6 @@ os_detect.getVersion = function(){
 				case "Windows NT 6.1": os_name = "Windows 7"; break;
 				case "Windows NT 6.2": os_name = "Windows 8"; break;
 				case "Windows NT 6.3": os_name = "Windows 8.1"; break;
-				case "Windows NT 10.0": os_name = "Windows 10"; break;
 			}
 		}
 		if (version.match(/Linux/)) {
@@ -972,6 +971,12 @@ os_detect.getVersion = function(){
 				// IE 10.0.8400.0 (Pre-release + KB2702844), Windows 8 x86 English Pre-release
 				ua_version = "10.0";
 				os_name = "Windows 8";
+				os_sp = "SP0";
+				break;
+			case "1100":
+				// IE 11.0.10011.0 Windows 10.0 (Build 10074) English - insider preview
+				ua_version = "11.0";
+				os_name = "Windows 10";
 				os_sp = "SP0";
 				break;
 			default:

--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -338,6 +338,7 @@ os_detect.getVersion = function(){
 				case "Windows NT 6.1": os_name = "Windows 7"; break;
 				case "Windows NT 6.2": os_name = "Windows 8"; break;
 				case "Windows NT 6.3": os_name = "Windows 8.1"; break;
+				case "Windows NT 10.0": os_name = "Windows 10"; break;
 			}
 		}
 		if (version.match(/Linux/)) {


### PR DESCRIPTION
For https://github.com/rapid7/metasploit-framework/issues/4248

According to [Wikipedia](https://en.wikipedia.org/wiki/Windows_NT), Windows 10's NT version is 10.0 but IE returns "windows nt 6.3":

![screen shot 2015-07-01 at 6 08 55 pm](https://cloud.githubusercontent.com/assets/1170914/8466807/4eb4c1e0-201c-11e5-97cb-a21c4097a43d.png)

I ended up adding another version-specific case for it.
## Verification
- [x] Install Windows 10 Insider Preview (download from MSDN Subscriptions)
- [x] Copy and paste os.js in the following format:

``` html
<html>
<script>
.... os.js code here ...

var osInfo = os_detect.getVersion();
alert(osInfo.os_name);
</script>
</html>
```
- [x] Save the HTML file as /tmp/test.html
- [x] Under /tmp, do this in a terminal: `ruby -run -e httpd . -p 8181`
- [x] On the Windows 10 box, open IE, and then open the test.html
- [x] You should see a prompt that says "Windows 10"
