### PR TITLE
Resolves #4380, check for warbird template

### DIFF
--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -66,9 +66,23 @@ module Exe
       shellcode.encoded + @payload
     end
 
+    def is_warbird?(pe)
+      pattern = /\x64\xA1\x30\x00\x00\x00\x2B\xCA\xD1\xF9\x8B\x40\x0C\x83\xC0\x0C/
+      sections = {}
+      pe.sections.each {|s| sections[s.name.to_s] = s}
+      if sections['.text'].encoded.pattern_scan(pattern).blank?
+        return false
+      end
+
+      true
+    end
+
     def generate_pe
       # Copy our Template into a new PE
       pe_orig = Metasm::PE.decode_file(template)
+      if is_warbird?(pe_orig)
+        raise RuntimeError, "The template to inject to appears to have license verification (warbird)"
+      end
       pe = pe_orig.mini_copy
 
       # Copy the headers and exports

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -67,6 +67,12 @@ module Exe
     end
 
     def is_warbird?(pe)
+      # The byte sequence is for the following code pattern:
+      # .text:004136B4                 mov     eax, large fs:30h
+      # .text:004136BA                 sub     ecx, edx
+      # .text:004136BC                 sar     ecx, 1
+      # .text:004136BE                 mov     eax, [eax+0Ch]
+      # .text:004136C1                 add     eax, 0Ch
       pattern = /\x64\xA1\x30\x00\x00\x00\x2B\xCA\xD1\xF9\x8B\x40\x0C\x83\xC0\x0C/
       sections = {}
       pe.sections.each {|s| sections[s.name.to_s] = s}

--- a/msfvenom
+++ b/msfvenom
@@ -274,7 +274,7 @@ if __FILE__ == $0
   begin
     generator_opts = parse_args(ARGV)
   rescue MsfVenomError, Msf::OptionValidateError => e
-    $stderr.puts e.message
+    $stderr.puts "Error: #{e.message}"
     exit(-1)
   end
 
@@ -335,7 +335,7 @@ if __FILE__ == $0
     payload = venom_generator.generate_payload
   rescue ::Exception => e
     elog("#{e.class} : #{e.message}\n#{e.backtrace * "\n"}")
-    $stderr.puts e.message
+    $stderr.puts "Error: #{e.message}"
   end
 
   # No payload generated, no point to go on
@@ -350,7 +350,7 @@ if __FILE__ == $0
     rescue ::Exception => e
       # If I can't save it, then I can't save it. I don't think it matters what error.
       elog("#{e.class} : #{e.message}\n#{e.backtrace * "\n"}")
-      $stderr.puts e.message
+      $stderr.puts "Error: #{e.message}"
     end
   else
     output_stream = $stdout


### PR DESCRIPTION
Resolves #4380. Adds a check for warbird (license verification) windows template. For reference please see: http://thisissecurity.net/2014/10/15/warbird-operation/
## Verification
- [x] Get a calc.exe from Windows 8.1 (in this case we name it as calc_win81.exe)
- [x] Run `./msfvenom -p windows/exec -f exe -e generic/none -i 0 -k -x calc_win81.exe CMD=calc EXITFUNC=thread -o /tmp/meh.exe`
- [x] The last message should be: "Error: The template to inject to appears to have license verification (warbird)"
- [x] Get a calc.exe from Win XP (name it calc_xp.exe)
- [x] Run `./msfvenom -p windows/exec -f exe -e generic/none -i 0 -k -x /Users/wchen/Desktop/calc_xp.exe CMD=calc EXITFUNC=thread -o /tmp/meh.exe`
- [x] Copy /tmp/meh.exe to a Windows machine, it should appear to be a Windows calculator
