### PR TITLE
Updating version to 4.11.3

### DIFF
--- a/lib/metasploit/framework/version.rb
+++ b/lib/metasploit/framework/version.rb
@@ -3,7 +3,7 @@ module Metasploit
     module Version
       MAJOR = 4
       MINOR = 11
-      PATCH = 0
+      PATCH = 3
       PRERELEASE = 'dev'
     end
 


### PR DESCRIPTION
This will be changed to the most recent git hash for next round, at least making accurate for now.
- [ ] Version should be 4.11.3
