### PR TITLE
This changes the version requirement for adobe_flash_hacking_team_uaf.rb

### DIFF
--- a/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
             when 'Windows'
               # Note: Chrome might be vague about the version.
               # Instead of 18.0.0.203, it just says 18.0
-              return true if ver =~ /^18\./ && Gem::Version.new(ver) <= Gem::Version.new('18.0.0.194')
+              return true if Gem::Version.new(ver) <= Gem::Version.new('18.0.0.194')
             when 'Linux'
               return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.468')
             end

--- a/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
@@ -19,10 +19,11 @@ class Metasploit3 < Msf::Exploit::Remote
         described as an Use After Free while handling ByteArray objects. This module has
         been tested successfully on:
 
-        Windows XP, Chrome 43 and Adobe Flash 18.0.0.194,
+        Windows XP, Chrome 43 and Flash 18.0.0.194,
         Windows 7 SP1 (32-bit), IE11 and Adobe Flash 18.0.0.194,
         Windows 7 SP1 (32-bit), Firefox 38.0.5 and Adobe Flash 18.0.0.194,
         Windows 8.1 (32-bit), Firefox and Adobe Flash 18.0.0.194,
+        Windows 8.1 (32-bit), IE11 and Flash 17.0.0.169,
         Linux Mint "Rebecca" (32 bits), Firefox 33.0 and Adobe Flash 11.2.202.468.
       },
       'License'             => MSF_LICENSE,


### PR DESCRIPTION
Because it works for Win 8.1 + IE11 too
