### PR TITLE
Avoid unreliable target for CVE-2015-5119

### DIFF
--- a/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
         Windows 7 SP1 (32-bit), IE11 and Adobe Flash 18.0.0.194,
         Windows 7 SP1 (32-bit), Firefox 38.0.5 and Adobe Flash 18.0.0.194,
-        Windows 8.1 (32-bit), Firefox and Adobe Flash 18.0.0.194,
-        Windows 8.1 (32-bit), IE11 and Flash 17.0.0.169, and
+        Windows 8.1 (32-bit), Firefox and Adobe Flash 18.0.0.194, and
         Linux Mint "Rebecca" (32 bits), Firefox 33.0 and Adobe Flash 11.2.202.468.
       },
       'License'             => MSF_LICENSE,
@@ -65,6 +64,15 @@ class Metasploit3 < Msf::Exploit::Remote
             end
 
             false
+          end,
+          :ua_ver  => lambda do |ver|
+            # Not reliable enough yet, don't fire
+            case target.name
+            when 'Windows'
+              return false if ver == '11.0'
+            end
+
+            true
           end,
           :flash   => lambda do |ver|
             case target.name

--- a/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
@@ -65,15 +65,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
             false
           end,
-          :ua_ver  => lambda do |ver|
-            # Not reliable enough yet, don't fire
-            case target.name
-            when 'Windows'
-              return false if ver == '11.0'
-            end
-
-            true
-          end,
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
@@ -113,6 +104,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def on_request_exploit(cli, request, target_info)
     print_status("Request: #{request.uri}")
+
+    if target_info[:os_name] == OperatingSystems::Match::WINDOWS_81 && target_info[:ua_ver] == '11.0'
+      print_warning("Target setup not supported")
+      send_not_found(cli)
+      return
+    end
 
     if request.uri =~ /\.swf$/
       print_status('Sending SWF...')


### PR DESCRIPTION
If we can't guarantee GreatRanking on a specific target, avoid it.
