### PR TITLE
Update metasploit payloads to 1.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (= 1.0.0)
       metasploit-model (= 1.0.0)
-      metasploit-payloads (= 1.0.4)
+      metasploit-payloads (= 1.0.6)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -123,7 +123,7 @@ GEM
       activemodel (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
-    metasploit-payloads (1.0.4)
+    metasploit-payloads (1.0.6)
     metasploit_data_models (1.2.5)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -62,7 +62,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '1.0.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.0.4'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.0.6'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler


### PR DESCRIPTION
This bumps the metasploit payloads gem version so that it includes the new fix for the HTTP/S communications fallback documented in https://github.com/rapid7/metasploit-payloads/pull/5

/cc @bcook-r7 
