### PR TITLE
Do not lock SMTP STARTTLS to only use SSLv3

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -84,7 +84,7 @@ module Exploit::Remote::SMTPDeliver
     if res =~ /STARTTLS/
       print_status("Starting tls")
       raw_send_recv("STARTTLS\r\n", nsock)
-      swap_sock_plain_to_ssl
+      swap_sock_plain_to_ssl(nsock)
       res = raw_send_recv("EHLO #{domain}\r\n", nsock)
     end
 

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -229,7 +229,7 @@ protected
   end
 
   def generate_ssl_context
-    ctx = OpenSSL::SSL::SSLContext.new(:SSLv3)
+    ctx = OpenSSL::SSL::SSLContext.new
     ctx.key = OpenSSL::PKey::RSA.new(1024){ }
 
     ctx.session_id_context = Rex::Text.rand_text(16)


### PR DESCRIPTION
SSLv3 has been deprecated for some time, and is being actively disabled more and more (http://disablessl3.com, https://tools.ietf.org/html/rfc7568).

To maintain forward compatibility, we should not specify a maximum version in the SSL context, and instead use the default from the local OpenSSL library instead. Fallbacks to older versions will happen on handshake as needed.
# Verification
- [x] Create a file called 'emailer_config.yaml with these contents:

```
to: targets.csv
from: nobody@example.com
subject: "nqm5akkjashur"
type: text/html
msg_file: email_body.txt
wait: 5
add_name: false
sig: false
sig_file: sig.txt

attachment: false
attachment_file: test.jpg
attachment_file_name: msf.jpg
attachment_file_type: image/jpeg

make_payload: false
zip_payload: false
msf_ip: 127.0.0.1
msf_port: 443
msf_payload: windows/meterpreter/reverse_tcp
msf_filename: MS09-012.exe
msf_location: /pentest/exploits/framework3
msf_change_ext: false
msf_payload_ext: vxe
```
- [x] Create a targets.csv file with these contents:

```
TestSender,test@TestSender.CheckTLS.com
```
- [x] Create a couple of empty files as well:

```
touch email_body.txt
touch sig.txt
```
- [x] The, from msfconsole, run these commands (or run as an RC script):

```
use auxiliary/client/smtp/emailer
set USERNAME nobody
set RHOST CheckTLS.com
set YAML_CONFIG emailer_config.yaml
run
```
- [x] You should see STARTLS continue to work

```
./msfconsole -qr smtp.rc
[*] Processing smtp.rc for ERB directives.
resource (smtp.rc)> use auxiliary/client/smtp/emailer
resource (smtp.rc)> set USERNAME nobody
USERNAME => nobody
resource (smtp.rc)> set RHOST CheckTLS.com
RHOST => CheckTLS.com
resource (smtp.rc)> set YAML_CONFIG emailer_config.yaml
YAML_CONFIG => emailer_config.yaml
resource (smtp.rc)> run
[*] Emailing TestSender  at test@TestSender.CheckTLS.com

[*] Connecting to SMTP server CheckTLS.com:25...
[*] C: EHLO AXzxtQqpQBlKmfFIpk
[*] S: 250-www3.checktls.com Hello rrcs-67-79-192-238.sw.biz.rr.com [67.79.192.238], pleased to meet you
250-ENHANCEDSTATUSCODES
250-PIPELINING
250-8BITMIME
250-SIZE
250-DSN
250-ETRN
250-STARTTLS
250-DELIVERBY
250 HELP
[*] Starting tls
[*] C: STARTTLS
[*] S: 220 2.0.0 Ready to start TLS
[*] C: EHLO AXzxtQqpQBlKmfFIpk
[*] S: 250-www3.checktls.com Hello rrcs-67-79-192-238.sw.biz.rr.com [67.79.192.238], pleased to meet you
250-ENHANCEDSTATUSCODES
250-PIPELINING
250-8BITMIME
250-SIZE
250-DSN
250-ETRN
250-AUTH LOGIN PLAIN
250-DELIVERBY
250 HELP
[*] C: AUTH PLAIN ...
[*] S: 535 5.7.0 authentication failed
[*] C: MAIL FROM: <nobody@example.com>
[*] S: 250 2.1.0 <nobody@example.com>... Sender ok
[*] C: RCPT TO: <test@TestSender.CheckTLS.com>
[*] S: 550 5.7.1 <test@TestSender.CheckTLS.com>... Relaying denied. Proper authentication required.
[*] C: DATA
[*] S: 503 5.0.0 Need RCPT (recipient)
[*] C: Date: Fri, 10 Jul 2015 12:10:03 -0500
[*] S: 500 5.5.1 Command unrecognized: "Date: Fri, 10 Jul 2015 12:10:03 -0500"
[-] Server refused our mail
[*] Closing the connection...
[*] C: QUIT
[*] S: 221 2.0.0 www3.checktls.com closing connection
[*] Email sent..
[*] Auxiliary module execution completed
```
