### PR TITLE
Add user agent list, modify existing modules to use it

### DIFF
--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -7,6 +7,7 @@
 ##
 
 require 'uri'
+require 'rex/user_agent'
 
 module Msf
 class Auxiliary::Web::HTTP
@@ -118,7 +119,7 @@ class Auxiliary::Web::HTTP
 
     c.set_config({
       'vhost' => opts[:target].vhost,
-      'agent' => opts[:user_agent] || 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)',
+      'agent' => opts[:user_agent] || Rex::UserAgent.random,
       'domain' => domain
     })
     c

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -5,6 +5,7 @@ require 'rex/proto/ntlm/crypt'
 require 'rex/proto/ntlm/constants'
 require 'rex/proto/ntlm/utils'
 require 'rex/proto/ntlm/exceptions'
+
 module Msf
 
 ###

--- a/lib/msf/core/exploit/mssql_sqli.rb
+++ b/lib/msf/core/exploit/mssql_sqli.rb
@@ -153,8 +153,8 @@ module Exploit::Remote::MSSQL_SQLI
         'method'       => 'GET',
         'cookie'       => datastore['COOKIE'],
         'headers'      => {
-          'Accept'	=> '*/*',
-          'User-Agent'	=> 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+          'Accept'     => '*/*',
+          'User-Agent' => datastore['UserAgent']
         }
       }, 5)
     else
@@ -171,8 +171,8 @@ module Exploit::Remote::MSSQL_SQLI
         'data'         => post_data,
         'cookie'       => datastore['COOKIE'],
         'headers'      => {
-          'Accept'	=> '*/*',
-          'User-Agent'	=> 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+          'Accept'     => '*/*',
+          'User-Agent' => datastore['UserAgent']
         }
       }, 5)
     end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -5,6 +5,7 @@ require 'rex/payloads/meterpreter/uri_checksum'
 require 'rex/post/meterpreter'
 require 'rex/parser/x509_certificate'
 require 'msf/core/payload/windows/verify_ssl'
+require 'rex/user_agent'
 
 module Msf
 module Handler
@@ -50,7 +51,7 @@ module ReverseHttp
     register_advanced_options(
       [
         OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener']),
-        OptString.new('MeterpreterUserAgent', [ false, 'The user-agent that the payload should use for communication', 'Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)' ]),
+        OptString.new('MeterpreterUserAgent', [ false, 'The user-agent that the payload should use for communication', Rex::UserAgent.shortest]),
         OptString.new('MeterpreterServerName', [ false, 'The server header that the handler will send in response to requests', 'Apache' ]),
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -3,6 +3,7 @@ require 'uri'
 #require 'rex/proto/http'
 require 'rex/socket'
 require 'rex/text'
+require 'rex/user_agent'
 
 require 'pp'
 
@@ -12,7 +13,7 @@ module Http
 
 class ClientRequest
 
-  DefaultUserAgent = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
+  DefaultUserAgent = Rex::UserAgent.most_common
   DefaultConfig = {
     #
     # Regular HTTP stuff

--- a/lib/rex/user_agent.rb
+++ b/lib/rex/user_agent.rb
@@ -104,7 +104,7 @@ module Rex::UserAgent
   # Choose the agent with the shortest string (for use in payloads)
   #
   def self.shortest
-    COMMON_AGENTS.min { |a, b| a.size <=> b.size }
+    @@shortest_agent ||= COMMON_AGENTS.min { |a, b| a.size <=> b.size }
   end
 
   #

--- a/lib/rex/user_agent.rb
+++ b/lib/rex/user_agent.rb
@@ -1,0 +1,118 @@
+# -*- coding: binary -*-
+
+#
+# A helper module for using and referencing comming user agent strings.
+#
+module Rex::UserAgent
+
+  #
+  # List from https://techblog.willshouse.com/2012/01/03/most-common-user-agents/
+  # This article was updated on July 11th 2015. It's probably worth updating this
+  # list over time.
+  #
+  # This list is in the order of most common to least common.
+  #
+  COMMON_AGENTS = [
+    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.6.3 (KHTML, like Gecko) Version/8.0.6 Safari/600.6.3',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko',
+    'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:39.0) Gecko/20100101 Firefox/39.0',
+    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.125 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.5 Safari/600.5.17',
+    'Mozilla/5.0 (Windows NT 6.1; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.6.3 (KHTML, like Gecko) Version/7.1.6 Safari/537.85.15',
+    'Mozilla/5.0 (iPad; CPU OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F69 Safari/600.1.4',
+    'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko',
+    'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:39.0) Gecko/20100101 Firefox/39.0',
+    'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/600.5.17 (KHTML, like Gecko) Version/8.0.6 Safari/600.6.3',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/43.0.2357.81 Chrome/43.0.2357.81 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:39.0) Gecko/20100101 Firefox/39.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 5.1; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)',
+    'Mozilla/5.0 (Windows NT 6.1; rv:39.0) Gecko/20100101 Firefox/39.0',
+    'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)',
+    'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.4.10 (KHTML, like Gecko) Version/8.0.4 Safari/600.4.10',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.11 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.11',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.78.2 (KHTML, like Gecko) Version/6.1.6 Safari/537.78.2',
+    'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
+    'Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.3.18 (KHTML, like Gecko) Version/8.0.3 Safari/600.3.18',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.0) Gecko/20100101 Firefox/31.0',
+    'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.59.10 (KHTML, like Gecko) Version/5.1.9 Safari/534.59.10',
+    'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.81 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64; rv:31.0) Gecko/20100101 Firefox/31.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:38.0) Gecko/20100101 Firefox/38.0',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64; rv:31.0) Gecko/20100101 Firefox/31.0 Iceweasel/31.7.0',
+    'Mozilla/5.0 (iPad; CPU OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H143 Safari/600.1.4',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.132 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/7.1.7 Safari/537.85.16',
+    'Mozilla/5.0 (Windows NT 6.1; rv:31.0) Gecko/20100101 Firefox/31.0',
+    'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:37.0) Gecko/20100101 Firefox/37.0',
+  ]
+
+  #
+  # Pick a random agent from the common agent list.
+  #
+  def self.random
+    COMMON_AGENTS.sample
+  end
+
+  #
+  # Choose the agent with the shortest string (for use in payloads)
+  #
+  def self.shortest
+    COMMON_AGENTS.min { |a, b| a.size <=> b.size }
+  end
+
+  #
+  # Choose the most frequent user agent
+  #
+  def self.most_common
+    COMMON_AGENTS[0]
+  end
+
+end
+

--- a/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Auxiliary
       'method'  => 'GET',
       'headers' =>
       {
-        'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+        'User-Agent' => datastore['UserAgent'],
         'Connection' => 'Close',
       }
     }, 25)
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
       'method'  => 'GET',
       'headers' =>
       {
-        'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+        'User-Agent' => datastore['UserAgent'],
         'Connection' => 'Close',
       }
     },25)

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
       'method'  => 'GET',
       'headers' =>
       {
-        'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+        'User-Agent' => datastore['UserAgent'],
         'Connection' => 'Close',
       }
     }, 25)

--- a/modules/auxiliary/gather/search_email_collector.rb
+++ b/modules/auxiliary/gather/search_email_collector.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'net/http'
+require 'rex/user_agent'
 
 class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
@@ -63,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
     print_status("Searching Yahoo for email addresses from #{targetdom}")
     response = ""
     emails = []
-    header = { 'User-Agent' => "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/4.0.221.6 Safari/525.13"}
+    header = { 'User-Agent' => Rex::UserAgent.random }
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("search.yahoo.com")
     searches = ["1", "101","201", "301", "401", "501"]
     searches.each { |num|
@@ -84,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
     print_status("Searching Bing email addresses from #{targetdom}")
     response = ""
     emails = []
-    header = { 'User-Agent' => "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/4.0.221.6 Safari/525.13"}
+    header = { 'User-Agent' => Rex::UserAgent.random }
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("www.bing.com")
     searches = 1
     while searches < 201

--- a/modules/auxiliary/scanner/http/enum_wayback.rb
+++ b/modules/auxiliary/scanner/http/enum_wayback.rb
@@ -3,9 +3,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 require 'msf/core'
 require 'net/http'
+require 'rex/user_agent'
 
 class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
   def pull_urls(targetdom)
     response = ""
     pages = []
-    header = { 'User-Agent' => "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/4.0.221.6 Safari/525.13"}
+    header = { 'User-Agent' => Rex::UserAgent.random }
     clnt = Net::HTTP::Proxy(@proxysrv,@proxyport,@proxyuser,@proxypass).new("wayback.archive.org")
     resp = clnt.get2("/web/*/http://"+targetdom+"/*",header)
     response << resp.body

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -28,11 +28,6 @@ class Metasploit3 < Msf::Auxiliary
       'Author'      => 'Matteo Cantoni <goony[at]nothink.org>',
       'License'     => MSF_LICENSE
     )
-
-    register_options(
-      [
-        OptString.new('UserAgent', [ true, "The HTTP User-Agent sent in the request", 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)' ])
-      ], self.class)
   end
 
   def run_host(target_host)

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'rex/user_agent'
 
 class Metasploit3 < Msf::Auxiliary
 
@@ -39,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('SITE', [ true, 'The web site to test via alleged web proxy (default is www.google.com)', 'www.google.com' ]),
         OptString.new('ValidCode', [ false, "Valid HTTP code for a successfully request", '200,302' ]),
         OptString.new('ValidPattern', [ false, "Valid HTTP server header for a successfully request", 'server: gws' ]),
-        OptString.new('UserAgent', [ true, 'The HTTP User-Agent sent in the request', 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)' ]),
+        OptString.new('UserAgent', [ true, 'The HTTP User-Agent sent in the request', Rex::UserAgent.random]),
       ], self.class)
 
     register_advanced_options(

--- a/modules/exploits/multi/http/jboss_seam_upload_exec.rb
+++ b/modules/exploits/multi/http/jboss_seam_upload_exec.rb
@@ -58,7 +58,6 @@ class Metasploit3 < Msf::Exploit::Remote
         register_options(
         [
             Opt::RPORT(8080),
-            OptString.new('AGENT',  [ true,  "User-Agent to send with requests", "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)"]),
             OptString.new('CTYPE',  [ true,  "Content-Type to send with requests", "application/x-www-form-urlencoded"]),
             OptString.new('TARGETURI',  [ true,  "URI that is built on JBoss Seam 2", "/admin-console/login.seam"]),
             OptInt.new('TIMEOUT', [ true, 'Timeout for web requests', 10]),
@@ -76,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'uri'       => normalize_uri(uri),
             'method'    => 'POST',
             'ctype'     => datastore['CTYPE'],
-            'agent'     => datastore['AGENT'],
+            'agent'     => datastore['UserAgent'],
             'data' => "actionOutcome=/success.xhtml?user%3d%23{expressions.getClass().forName('java.lang.Runtime').getDeclaredMethod('getRuntime')}"
         }, timeout=datastore['TIMEOUT'])
         if (res and res.code == 302 and res.headers['Location'])
@@ -111,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'uri'       => normalize_uri(uri),
             'method'    => 'POST',
             'ctype'     => datastore['CTYPE'],
-            'agent'     => datastore['AGENT'],
+            'agent'     => datastore['UserAgent'],
             'data' => "actionOutcome=/success.xhtml?user%3d%23{expressions.getClass().forName('java.lang.Runtime').getDeclaredMethod('getRuntime').invoke(expressions.getClass().forName('java.lang.Runtime')).exec('#{cmd_to_run}')}"
         }, timeout=datastore['TIMEOUT'])
         if (res and res.code == 302 and res.headers['Location'])
@@ -139,7 +138,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'uri'       => normalize_uri(uri),
             'method'    => 'POST',
             'ctype'     => datastore['CTYPE'],
-            'agent'     => datastore['AGENT'],
+            'agent'     => datastore['UserAgent'],
             'data' => "sessionid=" + Rex::Text.rand_text_alpha(32)
         }, timeout=datastore['TIMEOUT'])
         if (res and res.code == 200)
@@ -184,7 +183,7 @@ EOJSP
             'uri'       => normalize_uri(uri),
             'method'    => 'POST',
             'ctype'     => datastore['CTYPE'],
-            'agent'     => datastore['AGENT'],
+            'agent'     => datastore['UserAgent'],
             'data' => "actionOutcome=/success.xhtml?user%3d%23{expressions.getClass().forName('java.io.FileOutputStream').getConstructor('java.lang.String',expressions.getClass().forName('java.lang.Boolean').getField('TYPE').get(null)).newInstance(request.getRealPath('/#{filename}').replaceAll('\\\\\\\\','/'),#{append}).write(expressions.getClass().forName('sun.misc.BASE64Decoder').getConstructor(null).newInstance(null).decodeBuffer(request.getParameter('c'))).close()}&c=" + b64
         }, timeout=datastore['TIMEOUT'])
         if (res and res.code == 302 and res.headers['Location'])
@@ -211,7 +210,7 @@ EOJSP
             'uri'       => normalize_uri(uri),
             'method'    => 'POST',
             'ctype'     => datastore['CTYPE'],
-            'agent'     => datastore['AGENT'],
+            'agent'     => datastore['UserAgent'],
             'data' => "actionOutcome=/success.xhtml?user%3d%23{request.getRealPath('/#{filename}').replaceAll('\\\\\\\\','/')}"
         }, timeout=datastore['TIMEOUT'])
         if (res and res.code == 302 and res.headers['Location'])

--- a/modules/exploits/multi/http/spree_search_exec.rb
+++ b/modules/exploits/multi/http/spree_search_exec.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'  => 'GET',
       'headers' =>
       {
-        'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+        'User-Agent' => datastore['UserAgent'],
         'Connection' => 'Close',
       }
     }, 0.4 ) #short timeout, we don't care about the response

--- a/modules/exploits/multi/http/spree_searchlogic_exec.rb
+++ b/modules/exploits/multi/http/spree_searchlogic_exec.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'headers' =>
       {
         'HTTP_AUTHORIZATION' => 'ABCD', #needs to be present
-        'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+        'User-Agent' => datastore['UserAgent'],
         'Connection' => 'Close',
       }
     }, 0.4 ) #short timeout, we don't care about the response

--- a/modules/exploits/unix/webapp/redmine_scm_exec.rb
+++ b/modules/exploits/unix/webapp/redmine_scm_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'  => 'GET',
       'headers' =>
       {
-        'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+        'User-Agent' => datastore['UserAgent'],
         'Connection' => 'Close',
       }
     }, 25)

--- a/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'method'  => 'GET',
         'headers' =>
           {
-            'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+            'User-Agent' => datastore['UserAgent'],
             'Connection' => 'Close',
           }
       }, 5)
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'  => 'GET',
       'headers' =>
         {
-          'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+          'User-Agent' => datastore['UserAgent'],
           'Connection' => 'Close',
         }
       }, 5)
@@ -142,7 +142,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'  => 'GET',
       'headers' =>
         {
-          'User-Agent' => 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+          'User-Agent' => datastore['UserAgent'],
           'Connection' => 'Close',
         }
       }, 5)

--- a/modules/exploits/windows/http/hp_nnm_ovas.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovas.rb
@@ -85,9 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(7510),
-        OptString.new('UserAgent', [ true, "The HTTP User-Agent sent in the request",
-          'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/4.0; SIMBAR={7DB0F6DE-8DE7-4841-9084-28FA914B0F2E}; SLCC1; .N' ])
+        Opt::RPORT(7510)
       ], self.class)
   end
 

--- a/modules/exploits/windows/lotus/domino_http_accept_language.rb
+++ b/modules/exploits/windows/lotus/domino_http_accept_language.rb
@@ -133,16 +133,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Trying target #{target.name}...")
     send_request_raw({
-            'uri'			=> "#{uri}",
-            'method'		=> 'GET',
-            'headers'		=>
+            'uri'     => "#{uri}",
+            'method'  => 'GET',
+            'headers' =>
             {
-              'Accept'		=> '*/*',
-              'Accept-Language'	=> "#{lang}",
-              'Accept-Encoding'	=> 'gzip,deflate',
-              'Keep-Alive'		=> '300',
-              'Connection'		=> 'keep-alive',
-              'User-Agent'		=> 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)',
+              'Accept'          => '*/*',
+              'Accept-Language' => "#{lang}",
+              'Accept-Encoding' => 'gzip,deflate',
+              'Keep-Alive'      => '300',
+              'Connection'      => 'keep-alive',
+              'User-Agent'      => datastore['UserAgent']
             }
           }, 5)
     handler

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = 446
+  CachedSize = 466
 
   include Msf::Payload::Stager
 

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/uuid/options'
 
 module Metasploit3
 
-  CachedSize = 742
+  CachedSize = 762
 
   include Msf::Payload::Stager
   include Msf::Payload::UUID::Options


### PR DESCRIPTION
This PR comes off the back of me working on evading AV and IDS in my spare time... yes, I'm sad.

This commit adds a `user_agent` module which includes a list of common user agents. The module intends to allow for exploits and modules to refererence user agents easily. The module exposes a full list of agents, a function to select a random agent, a function to select the most common agent, and another function which returns the shortest possible agent (used for Meterpreter payloads).

The goal of this PR is to:
- Try to get some sanity around the use of user agent strings.
- Allow for easy access to the most common user agents.
- Prevent the use of user agents that make it _easier_ to identify MSF and Meterpreter (see http://blog.didierstevens.com/2015/05/11/detecting-network-traffic-from-metasploits-meterpreter-reverse-http-module/ for a classic example of where we're using incorrect user agents)

Existing modules have been updated to reference this new module (some using random agents, some using the most common) so that we have a single-stop shop. There might be more cases where this is required, but I was hesitate to change some of the exploits in case those user agents were important.
## Verification

I don't have access to all the required software to make sure I haven't broken all the modules that I've touched. However, each of them loads correctly and the `UserAgent` can be set/used.
- [ ] Load all modules, make sure they don't break on load.
- [ ] Make sure that user agent settings can be set/overridden.
- [ ] Make sure the default user agents are sane.
- [ ] Create an HTTP/S Meterpreter session and make sure that the user agent is sent through once Meterpreter is established (this can be done by running `transport list -v`).

I realise that more work might need to be done, and that it might not be the right approach, so I'm hoping for the powers-that-be to offer guidance. At least it gets the conversation going!
