### PR TITLE
Fix nil in executable generation

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -108,18 +108,21 @@ module Exploit::CmdStager
   # @option opts :decoder [Symbol] The decoder stub to use.
   # @param pl [String] String containing the payload to execute
   # @return [Array] The list of commands to execute
-  # @raise [ArgumentError] raised if the cmd stub cannot be generated
+  # @raise [ArgumentError] raised if the exe or cmd stub cannot be generated
   def generate_cmdstager(opts = {}, pl = nil)
     select_cmdstager(opts)
 
     self.exe = generate_payload_exe(:code => pl)
 
+    if exe.nil?
+      raise ArgumentError, 'The executable could not be generated'
+    end
+
     self.stager_instance = create_stager
     cmd_list = stager_instance.generate(opts_with_decoder(opts))
 
-    if (cmd_list.nil? || cmd_list.length < 1)
-      print_error("The command stager could not be generated")
-      raise ArgumentError
+    if cmd_list.nil? || cmd_list.length.zero?
+      raise ArgumentError, 'The command stager could not be generated'
     end
 
     cmd_list


### PR DESCRIPTION
In `CmdStager`.

Fixes #5718. Repro within.
