### PR TITLE
Allow the notes command to save notes as a file

### DIFF
--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -435,6 +435,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -h,--help                 Show this help information",
           "  -R,--rhosts               Set RHOSTS from the results of the search",
           "  -S,--search               Regular expression to match for search",
+          "  -o,--output               Save the notes to a csv file",
           "  --sort <field1,field2>    Fields to sort by (case sensitive)",
           "Examples:",
           "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41",


### PR DESCRIPTION
The -o option can save notes as a file.
## Verification

This assumes you already have notes in the database to do this test.
- [x] Start msfconsole
- [x] Do: `notes -h`
- [x] You should see the new option -o
- [x] Do: `notes -R [RHOSTS] -o /tmp/rhosts.csv`
- [x] Inspect /tmp/rhosts.csv. This file only has notes for the IP(s) you specified.
- [x] Do: `notes -t [NOTE TYPE] -o /tmp/type.csv`
- [x] Inspect /tmp/type.csv. This file only has notes with the same note type.
- [x] Do: `notes -S [SEARCH WORD] -o /tmp/search.csv`
- [x] Inspect /tmp/search.csv. This file should only have results related to the search word.
