### PR TITLE
Resolve #5738, update LHOST, URIHOST, URIPORT options

### DIFF
--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -659,12 +659,19 @@ module Msf
         # We haven't URIHOST and URIPORT into account here because
         # the framework uses them only on `get_uri`
         host = ''
-        if datastore['SRVHOST'] && datastore['SRVHOST'] != '0.0.0.0'
+        if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
+          host = datastore['URIHOST']
+        elsif datastore['SRVHOST'] && datastore['SRVHOST'] != '0.0.0.0'
           host = datastore['SRVHOST']
         else
           host = Rex::Socket.source_address
         end
-        port = datastore['SRVPORT']
+        if datastore['URIPORT'] && datastore['URIPORT'] != 0
+          port = datastore['URIPORT']
+        else
+          port = datastore['SRVPORT']
+        end
+
         resource = mod.datastore['URIPATH']
         url = "#{proto}://#{host}:#{port}#{resource}"
         urls << url

--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -136,6 +136,8 @@ module Msf
       xploit.datastore['Retries']     = datastore['Retries'] if datastore['Retries']
       xploit.datastore['SSL']         = datastore['SSL'] if datastore['SSL']
       xploit.datastore['SSLVersion']  = datastore['SSLVersion'] if datastore['SSLVersion']
+      xploit.datastore['URIHOST']     = datastore['URIHOST'] if datastore['URIHOST']
+      xploit.datastore['URIPORT']     = datastore['URIPORT'] if datastore['URIPORT']
       xploit.datastore['LHOST']       = get_payload_lhost
 
       # Set options only configurable by BAP.
@@ -562,9 +564,21 @@ module Msf
       super
       show_ready_exploits
       proto = (datastore['SSL'] ? "https" : "http")
-      srvhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
-      srvport = datastore['SRVPORT']
-      port = datastore['URIPORT'] == 0 ? datastore['SRVPORT'] : datastore['URIPORT']
+
+      if datastore['URIHOST'] && datastore['URIHOST'] != '0.0.0.0'
+        srvhost = datastore['URIHOST']
+      elsif datastore['SRVHOST'] && datastore['SRVHOST'] != '0.0.0.0'
+        srvhost = datastore['SRVHOST']
+      else
+        srvhost = Rex::Socket.source_address
+      end
+
+      if datastore['URIPORT'] && datastore['URIPORT'] != 0
+        srvport = datastore['URIPORT']
+      else
+        srvport = datastore['SRVPORT']
+      end
+
       service_uri = "#{proto}://#{srvhost}:#{srvport}#{get_resource}"
       print_good("Please use the following URL for the browser attack:")
       print_good("BrowserAutoPwn URL: #{service_uri}")

--- a/modules/auxiliary/server/browser_autopwn2.rb
+++ b/modules/auxiliary/server/browser_autopwn2.rb
@@ -73,7 +73,8 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptRegexp.new('INCLUDE_PATTERN', [false, 'Pattern search to include specific modules']),
-        OptRegexp.new('EXCLUDE_PATTERN', [false, 'Pattern search to exclude specific modules'])
+        OptRegexp.new('EXCLUDE_PATTERN', [false, 'Pattern search to exclude specific modules']),
+
       ], self.class)
 
     register_advanced_options([
@@ -91,6 +92,7 @@ class Metasploit3 < Msf::Auxiliary
     DEFAULT_PAYLOADS.each_pair do |platform, payload_info|
       opts << OptString.new("PAYLOAD_#{platform.to_s.upcase}", [true, "Payload for #{platform} browser exploits", payload_info[:payload] ])
       opts << OptInt.new("PAYLOAD_#{platform.to_s.upcase}_LPORT", [true, "Payload LPORT for #{platform} browser exploits", payload_info[:lport]])
+      opts << OptAddress.new("LHOST", [true, "The local host for the exploits and handlers", Rex::Socket.source_address])
     end
 
     opts


### PR DESCRIPTION
Resolve #5738
## Verification
- [ ] Start msfconsole
- [ ] use auxiliary/server/browser_autopwn2
- [ ] do "show advanced"
- [ ] You should see LHOST as an option
- [ ] If you set URIHOST and URIPORT, the BAP URL should be using URIHOST and URIPORT
- [ ] When you connect to the BAP URL w/ your browser, the JavaScript should be using URIHOST and URIPORT
