### PR TITLE
Fix #5740, remove variable ROP for adobe_flashplayer_flash10o

### DIFF
--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -193,7 +193,7 @@ class Metasploit3 < Msf::Exploit::Remote
       #Target Addr=0x0c0c0c0c
       p = generate_rop_payload('java', payload.encoded)
     else
-      p = rop + payload.encoded
+      p = payload.encoded
     end
 
     arch = Rex::Arch.endian(my_target.arch)


### PR DESCRIPTION
The variable rop isn't needed for older targets such as IE6 and 7
