### PR TITLE
Fix #5078: Possible issue in HTTP lib when requesting files

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -53,7 +53,7 @@ module Exploit::Remote::HttpClient
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
-        OptInt.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout', 20])
+        OptInt.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout'])
       ], self.class
     )
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -308,7 +308,12 @@ module Exploit::Remote::HttpClient
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
   #
   def send_request_raw(opts={}, timeout = 20)
-    actual_timeout = datastore['HttpClientTimeout'] || opts[:timeout] || timeout
+    if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
+      actual_timeout = datastore['HttpClientTimeout']
+    else
+      actual_timeout =  opts[:timeout] || timeout
+    end
+
     begin
       c = connect(opts)
       r = c.request_raw(opts)
@@ -325,7 +330,12 @@ module Exploit::Remote::HttpClient
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_cgi.
   #
   def send_request_cgi(opts={}, timeout = 20)
-    actual_timeout = datastore['HttpClientTimeout'] || opts[:timeout] || timeout
+    if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
+      actual_timeout = datastore['HttpClientTimeout']
+    else
+      actual_timeout =  opts[:timeout] || timeout
+    end
+
     begin
       c = connect(opts)
       r = c.request_cgi(opts)
@@ -344,7 +354,12 @@ module Exploit::Remote::HttpClient
   #   will contain the full URI.
   #
   def send_request_cgi!(opts={}, timeout = 20, redirect_depth = 1)
-    actual_timeout = datastore['HttpClientTimeout'] || opts[:timeout] || timeout
+    if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
+      actual_timeout = datastore['HttpClientTimeout']
+    else
+      actual_timeout =  opts[:timeout] || timeout
+    end
+
     res = send_request_cgi(opts, actual_timeout)
     return res unless res && res.redirect? && redirect_depth > 0
 


### PR DESCRIPTION
On #5078, @rastating is reporting which Exploit::Remote::HttpClient/Rex::Proto::Http::Client is failing to download some files. 

The problem he is hitting is a Timeout exception when trying to download really BIG files (> 40MB). Which is absolutely true. Indeed I don't think the HTTP lib on framework is designed to download >40MB files. But this should be mitigated by allowing the `send_request_cgi` (and others) to use a bigger timeout, so they have enough time to download the full file.

Unfortunately after #5387 there is a new datastore option, `HttpRequestTimeout` which is always shadowing the timeout provided by the `send_request_cgi` parameters, since there is a default value of 20. 

I think would be a good idea to **not** provide a default value to the `HttpRequestTimeout` datastore option. So the `send_request_cgi` parameters are used unless the user explicitly sets a `HttpRequestTimeout`. It is what this pull request does.
## Verification
- [x] On a test machine install apache2 with php support.
- [x] Create the next `test.php`. I used it to simulate #5078 problem, but isn't really required. You can just try to download a big file directly.

```
<?php
// Send the file to the user
header( 'Content-Description: File Transfer' );
header( 'Content-Type: application/octet-stream' );
header( 'Content-Disposition: attachment; filename=test.zip' );
header( 'Content-Transfer-Encoding: binary' );
header( 'Expires: 0' );
header( 'Cache-Control: must-revalidate' );
header( 'Pragma: public' );
header( 'Content-Length: ' + filesize('test.zip') );

// Clear output buffering and read file content
while ( @ob_end_clean() );

// Load file content
$handle = fopen( 'test.zip', 'rb' );
while ( ! feof( $handle ) ) {
    echo fread( $handle, filesize('test.zip'));
}
fclose( $handle );

?>
```
- [ ] In the same folder than test.php, create a big test.zip with a lot of garbage data. My test.zip file has 44127267 bytes size.
- [ ] Use a module like this one to download the file:

``` ruby
##
# This module requires Metasploit: http://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

require 'msf/core'

class Metasploit3 < Msf::Auxiliary

  include Msf::Exploit::Remote::HttpClient

  def initialize(info = {})
    super(update_info(info,
      'Name'        => 'Issue 5078 test',
      'Description' => %q{
          This module tests issue #5078.
      },
      'Author'       =>
        [
          'juan vazquez'
        ],
      'License'     => MSF_LICENSE,
      'References'  =>
        [
          [ 'URL', 'https://github.com/rapid7/metasploit-framework/issues/5078' ]
        ],
      'DisclosureDate' => 'Apr 05 2015'))

    register_options(
      [
        Opt::RPORT(),
        OptString.new('TARGETURI',[ true, 'Path to test web app', '/test.php' ])
      ], self.class)
  end

  def run
    puts "sending request..."

    res = send_request_cgi(
      {
        'method'    => 'POST',
        'uri'       => target_uri.to_s
      }
    )

    if res.nil?
      fail_with(Failure::Unknown, "#{peer} - No response from the target")
    else
      print_good("Response is here: #{res.body.length}") if res.body
    end
  end

end
```
- [x] Run the module, it should fail libe below, otherwise, create a bigger test.zip file

```
msf > use auxiliary/admin/http/issue_5078
msf auxiliary(issue_5078) > set rhost 172.16.158.133
rhost => 172.16.158.133
msf auxiliary(issue_5078) > run

[*] Sending request...
[-] Auxiliary failed: RuntimeError unknown: 172.16.158.133:80 - No response from the target
[-] Call stack:
[-]   /Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/core/module.rb:295:in `fail_with'
[-]   /Users/jvazquez/.msf4/modules/auxiliary/admin/http/issue_5078.rb:47:in `run'
[*] Auxiliary module execution completed
```
- [x] Modify the `issue_5078.rb` module to call send_request_cgi with a bigger timeout (60 is good enough for me when downloading through a NAT vmware interface):

```
##
# This module requires Metasploit: http://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

require 'msf/core'

class Metasploit3 < Msf::Auxiliary

  include Msf::Exploit::Remote::HttpClient

  def initialize(info = {})
    super(update_info(info,
      'Name'        => 'Issue 5078 test',
      'Description' => %q{
          This module tests issue #5078.
      },
      'Author'       =>
        [
          'juan vazquez'
        ],
      'License'     => MSF_LICENSE,
      'References'  =>
        [
          [ 'URL', 'https://github.com/rapid7/metasploit-framework/issues/5078' ]
        ],
      'DisclosureDate' => 'Apr 05 2015'))

    register_options(
      [
        Opt::RPORT(),
        OptString.new('TARGETURI',[ true, 'Path to test web app', '/test.php' ])
      ], self.class)
  end

  def run
    print_status("Sending request...")

    res = send_request_cgi(
      {
        'method'    => 'POST',
        'uri'       => target_uri.to_s
      }, 60
    )

    if res.nil?
      fail_with(Failure::Unknown, "#{peer} - No response from the target")
    else
      print_good("Response is here: #{res.body.length}") if res.body
    end
  end

end
```
- [x] reload and run the module again and verify which it succeeds

```
msf auxiliary(issue_5078) > reload
[*] Reloading module...
msf auxiliary(issue_5078) > run

[*] Sending request...
[+] Response is here: 44127267
[*] Auxiliary module execution completed
```
