### PR TITLE
Fix #5675 Synchronize access to stop_handler

### DIFF
--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -22,6 +22,7 @@ class ExploitDriver
     self.use_job                = false
     self.job_id                 = nil
     self.force_wait_for_session = false
+    self.semaphore              = Mutex.new
   end
 
   #
@@ -181,6 +182,9 @@ class ExploitDriver
   attr_accessor :force_wait_for_session # :nodoc:
   attr_accessor :session # :nodoc:
 
+  # To synchronize threads cleaning up the exploit and the handler
+  attr_accessor :semaphore
+
 protected
 
 
@@ -318,12 +322,12 @@ protected
     exploit, payload = ctx
 
     # Ensure that, no matter what, clean up of the handler occurs
-    payload.stop_handler
+    semaphore.synchronize { payload.stop_handler }
 
     exploit.framework.events.on_module_complete(exploit)
 
     # Allow the exploit to cleanup after itself, that messy bugger.
-    exploit.cleanup
+    semaphore.synchronize { exploit.cleanup }
   end
 
 end


### PR DESCRIPTION
This pull request tries to fix https://github.com/rapid7/metasploit-framework/issues/5675. As far as I can say after my analysis, this issue is due to two different threads trying to run the `stop_handler`  on the `reverse_tcp` handler (for the meterpreter/reverse_tcp default payload).

The two threads involved are:

a) The thread spawned from the job started by the ExploitDriver when `run` is executed:

``` ruby
      e.job_id = e.framework.jobs.start_bg_job(
        "Exploit: #{e.refname}",
        ctx,
        Proc.new { |ctx_| job_run_proc(ctx_) },
        Proc.new { |ctx_| job_cleanup_proc(ctx_) }
      )
```

The thread is spawned on `Rex::Job#start`:

``` ruby
      self.job_thread = Rex::ThreadFactory.spawn("JobID(#{jid})-#{name}", false) {
        # Deschedule our thread momentarily
        ::IO.select(nil, nil, nil, 0.01)

        begin
          run_proc.call(ctx)
        ensure
          clean_proc.call(ctx)
          container.remove_job(self)
        end
      }
```

If you review carefully the thread spawned will run the `clean_proc` procedure in the `ensure_block`. The procedure called isn't other than `ExploitDriver#job_cleanup_proc`.

 b) The thread stopping the jobs after the `jobs -K` command:

```
        when "-K"
          print_line("Stopping all jobs...")
          framework.jobs.each_key do |i|
            framework.jobs.stop_job(i)
          end
```

The `Rex::Job#stop` also will call the `clean_proc` procedure:

``` ruby
  def stop
    if (self.job_thread)
      self.job_thread.kill
      self.job_thread = nil
    end

    clean_proc.call(ctx) if (clean_proc)
  end
```

After reviewing the `ExploitDriver#job_cleanup_proc` method it's important to point which two calls will end on the `stop_handler` method. The first call is the `payload.stop_handler` of course, and the second one is the `exploit.cleanup`:

``` ruby
  def job_cleanup_proc(ctx)
    exploit, payload = ctx

    # Ensure that, no matter what, clean up of the handler occurs
    payload.stop_handler

    exploit.framework.events.on_module_complete(exploit)

    # Allow the exploit to cleanup after itself, that messy bugger.
    exploit.cleanup
  end

```

These two calls inside `job_cleanup_proc` will try to `#stop_handler` which is creating a race condition when accessing `listener_sock` in the backtraces I've been able to retrieve when using the default meterpreter/reverse_tcp payload:

``` ruby
  def stop_handler
    # Terminate the listener thread
    if (self.listener_thread and self.listener_thread.alive? == true)
      self.listener_thread.kill
      self.listener_thread = nil
    end

    # Terminate the handler thread
    if (self.handler_thread and self.handler_thread.alive? == true)
      self.handler_thread.kill
      self.handler_thread = nil
    end

    if (self.listener_sock)
      self.listener_sock.close
      self.listener_sock = nil
    end
  end

```

So my fix creates a initializes a mutex in ExploitDriver. This drive will act as semaphore, synchronizing the accesses to `#stop_handler` and its resources.
## Verification
- [x] Run the console
- [x] use exploit/windows/browser/ms14_064_ole_code_execution
- [x] run
- [x] jobs -k

```
msf > use exploit/windows/browser/ms14_064_ole_code_execution
msf exploit(ms14_064_ole_code_execution) > run
[*] Exploit running as background job.

[*] Started reverse handler on 1.1.1.1:4444
msf exploit(ms14_064_ole_code_execution) > [*] Using URL: http://0.0.0.0:8080/dodxuVAYHzMXK
[*] Local IP: http://1.1.1.1:8080/dodxuVAYHzMXK
[*] Server started.

msf exploit(ms14_064_ole_code_execution) >
msf exploit(ms14_064_ole_code_execution) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf exploit(ms14_064_ole_code_execution) >
[*] Server stopped.

msf exploit(ms14_064_ole_code_execution) >
msf exploit(ms14_064_ole_code_execution) >
msf exploit(ms14_064_ole_code_execution) > jobs

Jobs
====

No active jobs.

msf exploit(ms14_064_ole_code_execution) > exit -y
```
- [x] Verify which there are no backtraces because of Exceptions in the log files. Also verify which the payload handler neither the HTTP server are listening anymore.

ping @wchen-r7 and @trosen-r7 since we have been discussing this issue today. Also to @limhoff-r7 since according to @wchen-r7 he is familiar with the issue and maybe has feedback here.
