### PR TITLE
Fix #5755, Typo in DNS Fuzzer

### DIFF
--- a/modules/auxiliary/fuzzers/dns/dns_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/dns/dns_fuzzer.rb
@@ -340,7 +340,7 @@ class Metasploit3 < Msf::Auxiliary
       "DNSKEY,DHCID,NSEC3,NSEC3PARAM,HIP,NINFO,RKEY," <<
       "TALINK,SPF,UINFO,UID,GID,UNSPEC,TKEY,TSIG," <<
       "IXFR,AXFR,MAILA,MAILB,*,TA,DLV,RESERVED"
-    @fuzz_rr     = datastore['RR'].blank ? fuzz_rr_queries : datastore['RR']
+    @fuzz_rr     = datastore['RR'].blank? ? fuzz_rr_queries : datastore['RR']
   end
 
   def run_host(ip)


### PR DESCRIPTION
This is a quick typo fix for issue [#5755](https://github.com/rapid7/metasploit-framework/issues/5755).  In its current state, DNS Fuzzer errors out with NoMethodError: 'blank' for "".String.  This fix adds the missing "?" to ".blank".
