### PR TITLE
Fix PHP stagers

### DIFF
--- a/lib/msf/core/payload/php/bind_tcp.rb
+++ b/lib/msf/core/payload/php/bind_tcp.rb
@@ -54,7 +54,7 @@ module Payload::Php::BindTcp
       ip = '[::]'
     end
 
-    php = %Q^//<?php
+    php = %Q^/*<?php /**/
 error_reporting(0);
 $ip = '#{ip}';
 $port = #{opts[:port]};

--- a/lib/msf/core/payload/php/reverse_tcp.rb
+++ b/lib/msf/core/payload/php/reverse_tcp.rb
@@ -52,7 +52,7 @@ module Payload::Php::ReverseTcp
       opts[:host] = "[#{opts[:host]}]"
     end
 
-    php = %Q^//<?php
+    php = %Q^/*<?php /**/
 error_reporting(0);
 $ip = '#{opts[:host]}';
 $port = #{opts[:port]};

--- a/modules/payloads/stagers/php/bind_tcp.rb
+++ b/modules/payloads/stagers/php/bind_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module Metasploit4
 
-  CachedSize = 1183
+  CachedSize = 1188
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_ipv6.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module Metasploit4
 
-  CachedSize = 1182
+  CachedSize = 1187
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_ipv6_uuid.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6_uuid.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module Metasploit4
 
-  CachedSize = 1356
+  CachedSize = 1361
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/bind_tcp_uuid.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module Metasploit4
 
-  CachedSize = 1357
+  CachedSize = 1362
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/reverse_tcp.rb
+++ b/modules/payloads/stagers/php/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 931
+  CachedSize = 936
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/stagers/php/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/reverse_tcp_uuid.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 1105
+  CachedSize = 1110
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
There was a bug in the PHP stagers (both `bind_tcp` and `reverse_tcp`) which was causing them to not work correctly in cases where the payloads were invoked from within PHP directly (such as `eval()` calls). The reason was due to the `Rex::Text.compress` call putting all the code on the same line. That line started with `//`, and hence it was all commented out!

This PR changes the comment mechanism so that it works both in and out of `eval()`-like calls.
## Verification
- [x] Create `bind_tcp`, and `reverse_tcp` PHP payloads.
- [x] Run the payloads directly from a .php file, make sure they work.
- [x] Run the payloads inside `eval()` calls, make sure they work.

Thanks to @justinsteven for help with finding and testing.
