### PR TITLE
Fix #5761, pass the correct arch and platform for exe generation

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -112,7 +112,8 @@ module Exploit::CmdStager
   def generate_cmdstager(opts = {}, pl = nil)
     select_cmdstager(opts)
 
-    self.exe = generate_payload_exe(:code => pl)
+    exe_opts = { code: pl }.merge!(opts)
+    self.exe = generate_payload_exe(exe_opts)
 
     if exe.nil?
       raise ArgumentError, 'The executable could not be generated'

--- a/modules/exploits/linux/http/fritzbox_echo_exec.rb
+++ b/modules/exploits/linux/http/fritzbox_echo_exec.rb
@@ -108,10 +108,11 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("#{peer} - Exploiting...")
-
     execute_cmdstager(
-      :flavor  => :echo,
-      :linemax => 92
+      flavor: :echo,
+      linemax: 92,
+      platform: target.platform,
+      arch: target.arch
     )
   end
 end


### PR DESCRIPTION
Fix #5761

This patch allows an exploit to pass the correct arch and platform information to the cmd stager mixin, so that if the user selects a generic payload, the exe generator will be able to generate an exe.
## Verification

I don't actually have a Fritz!Box for testing. Instead, I set up a fake web server. Since the exploit wants a mipsle payload, the generic bindshell should be the same as the mipsle one.
- [x] Start a fake web server: `ruby -run -e httpd . -p 8181`
- [x] Start msfconsole
- [x] `use exploit/linux/http/fritzbox_echo_exec`
- [x] `set rhost [IP]`
- [x] `set rport 8181`
- [x] `set payload generic/shell_bind_tcp`
- [x] `run`
- [x] You should see that the exploit is sending the payload from the cmd stager
- [x] `set payload linux/mipsle/shell_bind_tcp`
- [x] `run`
- [x] You should see that the exploit is also sending the payload from the cmd stagner
- [x] Check the web server log. Both payloads should be the same thing (or if this is too difficult to read, you can do a `$stderr.puts payload.encoded` in the exploit)

If you actually have a Fritz!Box for testing, that's even better.

@jvazquez-r7 could you please take this? You merged the exploit from Mike so I imagine you're still pretty familiar with this? Thanks!
