### PR TITLE
Fix ZDI ref on sandbox escape module

### DIFF
--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
         'joev' # discovery, module
       ],
       'References'  => [
-        ['ZDI', '15-288'],
+        ['ZDI', '15-228'],
         ['CVE', '2015-1155'],
         ['URL', 'https://support.apple.com/en-us/HT204826']
       ],


### PR DESCRIPTION
Should be ZDI-15-228, not ZDI-15-288. Thanks for the spot @jvazquez-r7 
