### PR TITLE
Update modules to use metasploit-credential instead of report_auth_info

### DIFF
--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -33,6 +33,35 @@ class Metasploit3 < Msf::Auxiliary
     )
   end
 
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+
   def run
 
     vprint_status("#{rhost}:#{rport} - Trying to access the configuration of the device")
@@ -72,14 +101,14 @@ class Metasploit3 < Msf::Auxiliary
             vprint_good("user: #{@user}")
             vprint_good("pass: #{pass}")
 
-          report_auth_info(
-            :host => rhost,
-            :port => rport,
-            :sname => 'http',
-            :user => @user,
-            :pass => pass,
-            :active => true
-          )
+            report_cred(
+              ip: rhost,
+              port: rport,
+              service_name: 'http',
+              user: @user,
+              password: pass,
+              proof: line
+            )
           end
         end
       end

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -32,6 +32,33 @@ class Metasploit3 < Msf::Auxiliary
     )
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run
     vprint_status("#{rhost}:#{rport} - Trying to access the configuration of the device")
 
@@ -69,13 +96,13 @@ class Metasploit3 < Msf::Auxiliary
             pass = $1
             pass = Rex::Text.decode_base64(pass)
             print_good("#{rhost}:#{rport} - Credentials found: #{user} / #{pass}")
-            report_auth_info(
-              :host => rhost,
-              :port => rport,
-              :sname => 'http',
-              :user => user,
-              :pass => pass,
-              :active => true
+            report_cred(
+              ip: rhost,
+              port: rport,
+              sname: 'http',
+              user: user,
+              password: pass,
+              proof: line
             )
           end
         end

--- a/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
+++ b/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
@@ -47,6 +47,32 @@ class Metasploit4 < Msf::Auxiliary
     ], self.class)
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run
     user = datastore['USERNAME']
     pass = datastore['PASSWORD']
@@ -57,14 +83,13 @@ class Metasploit4 < Msf::Auxiliary
     print_status("Authenticating as: " << user)
     begin
       nsc.login
-      report_auth_info(
-        :host   => rhost,
-        :port   => rport,
-        :sname  => prot,
-        :user   => user,
-        :pass   => pass,
-        :proof  => '',
-        :active => true
+
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: prot,
+        user: user,
+        password: pass
       )
 
     rescue

--- a/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
+++ b/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
@@ -49,6 +49,33 @@ class Metasploit3 < Msf::Auxiliary
     datastore["PASSWORD"]
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+
   def run
 
     if user == pass
@@ -84,14 +111,13 @@ class Metasploit3 < Msf::Auxiliary
 
     if res and res.code == 200 and res.body =~ /Administrator account created/
       print_good("#{peer} - Admin account with credentials #{user}:#{pass} successfully created")
-      report_auth_info(
-        :host => rhost,
-        :port => rport,
-        :sname => 'http',
-        :user => user,
-        :pass => pass,
-        :active => true,
-        :proof  => res.body
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'http',
+        user: user,
+        password: pass,
+        proof: res.body
       )
     else
       print_error("#{peer} - Admin account creation failed")

--- a/modules/auxiliary/admin/misc/sercomm_dump_config.rb
+++ b/modules/auxiliary/admin/misc/sercomm_dump_config.rb
@@ -88,6 +88,32 @@ class Metasploit3 < Msf::Auxiliary
     parse_configuration(config[:data])
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   private
 
   def little_endian?
@@ -200,16 +226,14 @@ class Metasploit3 < Msf::Auxiliary
     @credentials.each do |k,v|
       next unless v[:user] and v[:password]
       print_status("#{peer} - #{k}: User: #{v[:user]} Pass: #{v[:password]}")
-      auth = {
-          :host => rhost,
-          :port => rport,
-          :user => v[:user],
-          :pass => v[:password],
-          :type => 'password',
-          :source_type => "exploit",
-          :active => true
-      }
-      report_auth_info(auth)
+      report_cred(
+        ip: rhost,
+        port: rport,
+        user: v[:user],
+        password: v[:password],
+        service_name: 'sercomm',
+        proof: v.inspect
+      )
     end
 
   end

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -36,6 +36,32 @@ class Metasploit3 < Msf::Auxiliary
 
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run
     return if not check_dependencies
 
@@ -56,13 +82,12 @@ class Metasploit3 < Msf::Auxiliary
           break
         end
       else
-        report_auth_info(
-            :host  => "#{datastore['RHOST']}",
-            :port  => "#{datastore['RPORT']}",
-            :sname => 'oracle',
-            :user  => "#{datastore['SID']}/#{datastore['DBUSER']}",
-            :pass  => "#{datastore['DBPASS']}",
-            :active => true
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'oracle',
+          user: "#{datastore['SID']}/#{datastore['DBUSER']}",
+          password: datastore['DBPASS']
         )
         print_status("Found user/pass of: #{datastore['DBUSER']}/#{datastore['DBPASS']} on #{datastore['RHOST']} with sid #{datastore['SID']}")
       end

--- a/modules/auxiliary/scanner/http/axis_local_file_include.rb
+++ b/modules/auxiliary/scanner/http/axis_local_file_include.rb
@@ -91,6 +91,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -122,7 +123,7 @@ class Metasploit3 < Msf::Auxiliary
 
           print_good("#{target_url} - Apache Axis - Credentials Found Username: '#{username}' - Password: '#{password}'")
 
-          report_cred(ip: rhost, port: rport, user: username, password: password)
+          report_cred(ip: rhost, port: rport, user: username, password: password, proof: res.body)
 
         else
           print_error("#{target_url} - Apache Axis - Not Vulnerable")

--- a/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
+++ b/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
@@ -109,6 +109,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -139,7 +140,7 @@ class Metasploit3 < Msf::Auxiliary
 
         print_good("#{peer} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
-        report_cred(ip: rhost, port: rport, user: user, password: pass)
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -135,6 +135,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -164,7 +165,7 @@ class Metasploit3 < Msf::Auxiliary
       if res and res.get_cookies.include?('authenticated=')
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
-        report_cred(ip: rhost, port: rport, user: user, password: pass)
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.get_cookies.inspect)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -178,6 +178,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -224,7 +225,7 @@ class Metasploit3 < Msf::Auxiliary
 
         do_logout(resp.get_cookies)
 
-        report_cred(ip: rhost, port: rport, user: user, password: pass)
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
         report_note(ip: rhost, type: 'cisco.cred.group', data: "User: #{user} / Group: #{group}")
         return :next_user
 

--- a/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
@@ -1,3 +1,4 @@
+
 ##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -103,6 +104,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -117,7 +119,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if result == :success
       print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
-      report_cred(ip: rhost, port: rport, user: user, password: pass)
+      report_cred(ip: rhost, port: rport, user: user, password: pass, proof: response.inspect)
 
       return :next_user
     else

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Auxiliary
     if result == :success
       print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
 
-      report_cred(ip: rhost, port: rport, user: user, password: pass)
+      report_cred(ip: rhost, port: rport, user: user, password: pass, proof: response.inspect)
 
       return :next_user
     else
@@ -131,6 +131,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)

--- a/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
@@ -104,6 +104,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -119,7 +120,7 @@ class Metasploit3 < Msf::Auxiliary
     if result == :success
       print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
 
-      report_cred(ip: rhost, port: rport, user: user, password: pass)
+      report_cred(ip: rhost, port: rport, user: user, password: pass, proof: response.inspect)
 
       return :next_user
     else

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -77,6 +77,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -125,7 +126,7 @@ class Metasploit3 < Msf::Auxiliary
     location = res.headers['Location']
     if res and res.headers and (location = res.headers['Location']) and location =~ /admin\//
       print_good("#{peer} - Successful login: \"#{user}:#{pass}\"")
-      report_cred(ip: rhost, port: rport, user: user, password: pass)
+      report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.headers['Location'])
       return :next_user
     else
       vprint_error("#{peer} - Bad login: \"#{user}:#{pass}\"")

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -79,7 +79,6 @@ class Metasploit3 < Msf::Auxiliary
     }.merge(service_data)
 
     login_data = {
-      last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::UNTRIED,
     }.merge(service_data)

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -81,6 +81,7 @@ class Metasploit3 < Msf::Auxiliary
     login_data = {
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -129,7 +130,8 @@ class Metasploit3 < Msf::Auxiliary
       report_cred(
         ip: Rex::Socket.getaddress(datastore['RHOST']),
         port: datastore['RPORT'],
-        user: user
+        user: user,
+        proof: base_uri+l
       )
     end
 

--- a/modules/auxiliary/scanner/http/ektron_cms400net.rb
+++ b/modules/auxiliary/scanner/http/ektron_cms400net.rb
@@ -145,6 +145,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -167,7 +168,7 @@ class Metasploit3 < Msf::Auxiliary
 
       if (res and res.code == 200 and res.body.to_s.match(/LoginSuceededPanel/i) != nil)
         print_good("#{target_url} [Ektron CMS400.NET] Successful login: '#{user}' : '#{pass}'")
-        report_cred(ip: rhost, port: rport, user: user, password: pass)
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
 
       elsif(res and res.code == 200)
         vprint_error("#{target_url} [Ekton CMS400.NET] - Failed login as: '#{user}'")

--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -87,6 +87,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -113,7 +114,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if res && res.code == 200 && res.body.include?("Home Page") && res.headers['Server'] && res.headers['Server'].include?("EtherPAD")
       print_good("#{peer} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
-      report_cred(ip: rhost, port: rport, user: user, password: pass)
+      report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
       return :next_user
     else
       vprint_error("#{peer} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")

--- a/modules/auxiliary/scanner/http/infovista_enum.rb
+++ b/modules/auxiliary/scanner/http/infovista_enum.rb
@@ -100,6 +100,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -126,7 +127,7 @@ class Metasploit3 < Msf::Auxiliary
         vprint_error("#{rhost}:#{rport} - FAILED LOGIN - #{user.inspect}:#{pass.inspect} with code #{res.code}")
       else
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
-        report_cred(ip: rhost, port: rport, user: user, password: pass)
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
         return :next_user
       end
 

--- a/modules/auxiliary/scanner/http/joomla_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/joomla_bruteforce_login.rb
@@ -130,6 +130,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -142,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if result == :success
       print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
-      report_cred(ip: rhost, port: rport, user: user, password: pass)
+      report_cred(ip: rhost, port: rport, user: user, password: pass, proof: response.inspect)
       return :abort if datastore['STOP_ON_SUCCESS']
       return :next_user
     else

--- a/modules/auxiliary/scanner/http/novell_mdm_creds.rb
+++ b/modules/auxiliary/scanner/http/novell_mdm_creds.rb
@@ -97,6 +97,7 @@ class Metasploit3 < Msf::Auxiliary
     login_data = {
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -122,7 +123,7 @@ class Metasploit3 < Msf::Auxiliary
         print_good("Got creds. Login:#{user} Password:#{pass}")
         print_good("Access the admin interface here: #{ip}:#{rport}#{target_uri.path}dashboard/")
 
-        report_cred(ip: ip, port: rport, user: user, password: pass)
+        report_cred(ip: ip, port: rport, user: user, password: pass, proof: res.body)
       else
         print_error("Zenworks MDM does not appear to be running at #{ip}")
         return :abort

--- a/modules/auxiliary/scanner/http/oracle_ilom_login.rb
+++ b/modules/auxiliary/scanner/http/oracle_ilom_login.rb
@@ -70,6 +70,33 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -96,16 +123,14 @@ class Metasploit3 < Msf::Auxiliary
 
     if (res and res.code == 200 and res.body.include?("/iPages/suntab.asp") and res.body.include?("SetWebSessionString"))
       print_good("#{peer} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
-      report_hash = {
-        :host   => rhost,
-        :port   => rport,
-        :sname  => 'Oracle Integrated Lights Out Manager Portal',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'
-      }
-      report_auth_info(report_hash)
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'Oracle Integrated Lights Out Manager Portal',
+        user: user,
+        password: pass,
+        proof: res.body
+      )
       return :next_user
     else
       vprint_error("#{peer} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")

--- a/modules/auxiliary/scanner/http/pocketpad_login.rb
+++ b/modules/auxiliary/scanner/http/pocketpad_login.rb
@@ -63,6 +63,33 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_time: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -86,16 +113,14 @@ class Metasploit3 < Msf::Auxiliary
 
     if (res && res.code == 200 && res.body.include?("Home Page") && res.headers['Server'] && res.headers['Server'].include?("Smeagol"))
       print_good("#{peer} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
-      report_hash = {
-        :host   => rhost,
-        :port   => rport,
-        :sname  => 'PocketPAD Portal',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'
-      }
-      report_auth_info(report_hash)
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'PocketPAD Portal',
+        user: user,
+        password: pass,
+        proof: res.body
+      )
       return :next_user
     else
       vprint_error("#{peer} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")

--- a/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
+++ b/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
@@ -128,22 +128,47 @@ class Metasploit3 < Msf::Auxiliary
 
         collect_info(user, pass)
 
-        report_hash = {
-          :host   => rhost,
-          :port   => rport,
-          :sname  => 'RFCode Reader',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'}
-
-        report_auth_info(report_hash)
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'RFCode Reader',
+          user: user,
+          password: pass,
+          proof: res.code.to_s
+        )
         return :next_user
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
       print_error("#{rhost}:#{rport} - HTTP Connection Failed, Aborting")
       return :abort
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   #

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
@@ -50,6 +50,30 @@ class Metasploit3 < Msf::Auxiliary
     }
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def enum_user(user='administrator', pass='pass')
     vprint_status("#{rhost}:#{rport} - Trying username:'#{user}' password:'#{pass}'")
     success = false
@@ -89,14 +113,12 @@ class Metasploit3 < Msf::Auxiliary
 
     if success
       print_good("#{rhost}:#{rport} - Successful login '#{user}' : '#{pass}'")
-      report_auth_info(
-        :host   => rhost,
-        :proto => 'tcp',
-        :sname  => 'sap-businessobjects',
-        :user   => user,
-        :pass   => pass,
-        :target_host => rhost,
-        :target_port => rport
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'sap-businessobjects',
+        user: user,
+        proof: res.body
       )
       return :next_user
     else

--- a/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
+++ b/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
@@ -69,6 +69,33 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -85,17 +112,14 @@ class Metasploit3 < Msf::Auxiliary
       if res and !res.get_cookies.empty?
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
-        report_hash = {
-          :host   => rhost,
-          :port   => rport,
-          :sname  => 'ServerTech Sentry Switched CDU',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'
-        }
-
-        report_auth_info(report_hash)
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'ServerTech Sentry Switched CDU',
+          user: user,
+          password: pass,
+          proof: res.get_cookies.inspect
+        )
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/sevone_enum.rb
+++ b/modules/auxiliary/scanner/http/sevone_enum.rb
@@ -65,6 +65,33 @@ class Metasploit3 < Msf::Auxiliary
     return false
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -98,17 +125,14 @@ class Metasploit3 < Msf::Auxiliary
       return :skip_pass
     else
       print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN. '#{user.inspect}' : '#{pass.inspect}'")
-
-      report_hash = {
-        :host   => rhost,
-        :port   => rport,
-        :sname  => 'SevOne Network Performance Management System Application',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type   => 'password'}
-
-      report_auth_info(report_hash)
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'SevOne Network Performance Management System Application',
+        user: user,
+        password: pass,
+        proof: key
+      )
       return :next_user
     end
 

--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -148,6 +148,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -190,7 +191,7 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       print_good("SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
-      report_cred(ip: datastore['RHOST'], port: datastore['RPORT'], user:user, password: pass)
+      report_cred(ip: datastore['RHOST'], port: datastore['RPORT'], user:user, password: pass, proof: res.code.to_s)
 
 
       return :next_user

--- a/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
+++ b/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
@@ -80,6 +80,30 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_enum(asset)
     begin
       res = send_request_cgi({
@@ -121,12 +145,12 @@ class Metasploit3 < Msf::Auxiliary
           @users_found[user] = :reported
         end
 
-        report_auth_info(
-        :host => rhost,
-        :sname => (ssl ? 'https' : 'http'),
-        :user => user,
-        :port => rport,
-        :proof => "WEBAPP=\"Squiz Matrix\", VHOST=#{vhost}")
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: (ssl ? 'https' : 'http'),
+          proof: "WEBAPP=\"Squiz Matrix\", VHOST=#{vhost}"
+        )
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE

--- a/modules/auxiliary/scanner/http/typo3_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/typo3_bruteforce.rb
@@ -39,20 +39,46 @@ class Metasploit3 < Msf::Auxiliary
     }
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def try_login(user, pass)
     vprint_status("#{peer} - Trying username:'#{user}' password: '#{pass}'")
     cookie = typo3_backend_login(user, pass)
     if cookie
       print_good("#{peer} - Successful login '#{user}' password: '#{pass}'")
-      report_auth_info({
-        :host   => rhost,
-        :proto => 'http',
-        :sname  => 'typo3',
-        :user   => user,
-        :pass   => pass,
-        :target_host => rhost,
-        :target_port => rport
-      })
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'typo3',
+        user: user,
+        password: pass,
+        proof: cookie
+      )
       return :next_user
     else
       vprint_error("#{peer} - failed to login as '#{user}' password: '#{pass}'")

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -71,6 +71,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -119,7 +120,7 @@ class Metasploit3 < Msf::Auxiliary
         vprint_status("#{peer} - Username found: #{user}")
       when /\<a href="process\.php\?logout=1"\>/
         print_good("#{peer} - Successful login: \"#{user}:#{pass}\"")
-        report_cred(ip: rhost, port: rport, user:user, password: pass)
+        report_cred(ip: rhost, port: rport, user:user, password: pass, proof: res.body)
         return :next_user
       end
     end

--- a/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
+++ b/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
@@ -151,6 +151,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -205,7 +206,7 @@ class Metasploit3 < Msf::Auxiliary
 
       # Report valid credentials under the CCTV DVR admin port (5920/TCP).
       # This is a proprietary protocol.
-      report_cred(ip: rhost, port: rport, user:user, password: pass)
+      report_cred(ip: rhost, port: rport, user:user, password: pass, proof: res.inspect)
 
       @valid_hosts << rhost
       return :next_user

--- a/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
@@ -138,14 +138,40 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    report_auth_info({
-      :host         => server,
-      :port         => port,
-      :sname        => 'ftp',
-      :duplicate_ok => false,
-      :user         => user,
-      :pass         => password
-    })
+    report_cred(
+      ip: server,
+      port: port,
+      service_name: 'ftp',
+      user: user,
+      password: password,
+      proof: conf.inspect
+    )
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def get_dvr_credentials(conf)

--- a/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
+++ b/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
@@ -37,6 +37,32 @@ class Metasploit3 < Msf::Auxiliary
     register_options( [ Opt::RPORT(9000) ], self.class)
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run_host(ip)
     req =
       "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x0E\x0F" +
@@ -76,14 +102,14 @@ class Metasploit3 < Msf::Auxiliary
     if creds.keys.length > 0
       creds.keys.sort.each do |user|
         pass = creds[user]
-        report_auth_info({
-          :host         => rhost,
-          :port         => rport,
-          :sname        => 'dvr',
-          :duplicate_ok => false,
-          :user         => user,
-          :pass         => pass
-        })
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'dvr',
+          user: user,
+          password: pass,
+          proof: pass
+        )
         info << "(user='#{user}' pass='#{pass}') "
       end
     end

--- a/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
+++ b/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
@@ -80,14 +80,41 @@ class Metasploit3 < Msf::Auxiliary
     #Store the password if the parser returns something
     if password
       print_status("Password retrieved: #{password.to_s}")
-      report_auth_info({
-        :host         => rhost,
-        :port         => rport,
-        :sname        => 'ipcam',
-        :duplicate_ok => false,
-        :pass         => password,
-      })
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'ipcam',
+        user: '',
+        password: password,
+        proof: password
+      )
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def parse_reply(pkt)

--- a/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
@@ -64,6 +64,33 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user=nil,pass=nil)
     begin
       ntp_send("< NTP/1.0 >\n",true) # send hello
@@ -84,15 +111,15 @@ class Metasploit3 < Msf::Auxiliary
       ntp_send("#{pass}\n",!@connected)
       if @result =~ /SERVER <|>.*<|> SERVER/is
         print_good("#{msg} SUCCESSFUL login for '#{user}' : '#{pass}'")
-        report_auth_info(
-          :host => rhost,
-          :port => rport,
-          :sname => 'nessus-ntp',
-          :user => user,
-          :pass => pass,
-          :source_type => "user_supplied",
-          :active => true
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'nessus-ntp',
+          user: user,
+          password: pass,
+          proof: @result
         )
+
         disconnect
         @connected = false
         return :next_user

--- a/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
+++ b/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
@@ -66,6 +66,33 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user='nxadmin', pass='nxadmin')
     vprint_status("Trying username:'#{user}' with password:'#{pass}'")
     headers = {
@@ -100,16 +127,14 @@ class Metasploit3 < Msf::Auxiliary
       if res.body =~ /LoginResponse.*success="1"/
         print_good("SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
 
-        report_hash = {
-          :host   => datastore['RHOST'],
-          :port   => datastore['RPORT'],
-          :sname  => 'nexpose',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'}
-
-        report_auth_info(report_hash)
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'nexpose',
+          user: user,
+          password: pass,
+          proof: res.code.to_s
+        )
         return :next_user
       end
     end

--- a/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
+++ b/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
@@ -101,20 +101,44 @@ class Metasploit3 < Msf::Auxiliary
     if res.code == 303
       print_good("#{msg} SUCCESSFUL LOGIN. '#{user}' : '#{pass}'")
 
-      report_hash = {
-        :host   => datastore['RHOST'],
-        :port   => datastore['RPORT'],
-        :sname  => 'openvas-gsa',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'}
-
-      report_auth_info(report_hash)
+      report_cred(
+        ip: datastore['RHOST'],
+        port: datastore['RPORT'],
+        service_name: 'openvas-gsa',
+        user: user,
+        password: pass,
+        proof: res.code.to_s
+      )
       return :next_user
     end
     vprint_error("#{msg} FAILED LOGIN. '#{user}' : '#{pass}'")
     return :skip_pass
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def msg

--- a/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
@@ -60,6 +60,33 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user=nil,pass=nil)
     begin
       vprint_status("#{msg} Trying user:'#{user}' with password:'#{pass}'")
@@ -67,14 +94,13 @@ class Metasploit3 < Msf::Auxiliary
       omp_send(cmd,true) # send hello
       if @result =~ /<authenticate_response.*status="200"/is
         print_good("#{msg} SUCCESSFUL login for '#{user}' : '#{pass}'")
-        report_auth_info(
-          :host => rhost,
-          :port => rport,
-          :sname => 'openvas-omp',
-          :user => user,
-          :pass => pass,
-          :source_type => "user_supplied",
-          :active => true
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'openvas-omp',
+          user: user,
+          password: pass,
+          proof: @result
         )
         disconnect
         @connected = false

--- a/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
@@ -61,6 +61,33 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user=nil,pass=nil)
     begin
       otp_send("< OTP/1.0 >\n",true) # send hello
@@ -81,14 +108,13 @@ class Metasploit3 < Msf::Auxiliary
       otp_send("#{pass}\n",!@connected)
       if @result =~ /SERVER <|>.*<|> SERVER/is
         print_good("#{msg} SUCCESSFUL login for '#{user}' : '#{pass}'")
-        report_auth_info(
-          :host => rhost,
-          :port => rport,
-          :sname => 'openvas-otp',
-          :user => user,
-          :pass => pass,
-          :source_type => "user_supplied",
-          :active => true
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'openvas-otp',
+          user: user,
+          password: pass,
+          proof: @result
         )
         disconnect
         @connected = false

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -52,6 +52,32 @@ class Metasploit4 < Msf::Auxiliary
       ], self.class)
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run_host(ip)
     data = '<?xml version="1.0" encoding="utf-8" ?>'
     data << '<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
@@ -99,12 +125,12 @@ class Metasploit4 < Msf::Auxiliary
         else
           print_good("[SAP] #{ip}:#{rport} - User '#{datastore['BAPI_USER']}' with password '#{datastore['BAPI_PASSWORD']}' created")
           report_auth_info(
-            :host => ip,
-            :port => rport,
-            :sname => "sap",
-            :user => "#{datastore['BAPI_USER']}",
-            :pass => "#{datastore['BAPI_PASSWORD']}",
-            :active => true
+            ip: ip,
+            port: rport,
+            service_name: 'sap',
+            user: datastore['BAPI_USER'],
+            password: datastore['BAPI_PASSWORD'],
+            proof: res.body
           )
           return
         end

--- a/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
@@ -107,6 +107,33 @@ class Metasploit4 < Msf::Auxiliary
 
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def bruteforce(uri,user,pass,cli)
     begin
       path = "sap/bc/gui/sap/its/webgui/"
@@ -134,30 +161,26 @@ class Metasploit4 < Msf::Auxiliary
     end
 
     if res and res.code == 302
-      report_auth_info(
-        :host => rhost,
-        :port => rport,
-        :sname => "sap_webgui",
-        :proto => "tcp",
-        :user => "#{user}",
-        :pass => "#{pass}",
-        :proof => "SAP Client: #{cli}",
-        :active => true
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'sap_webgui',
+        user: user,
+        password: pass,
+        proof: "SAP Client: #{cli}"
       )
       return true
     elsif res and res.code == 200
       if res.body =~ /log on again/
         return false
       elsif res.body =~ /<title>Change Password - SAP Web Application Server<\/title>/
-        report_auth_info(
-          :host => rhost,
-          :port => rport,
-          :sname => "sap_webgui",
-          :proto => "tcp",
-          :user => "#{user}",
-          :pass => "#{pass}",
-          :proof => "SAP Client: #{cli}",
-          :active => true
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'sap_webgui',
+          user: user,
+          password: pass,
+          proof: "SAP Client: #{cli}"
         )
         return true
       elsif res.body =~ /Password logon no longer possible - too many failed attempts/

--- a/modules/auxiliary/scanner/scada/koyo_login.rb
+++ b/modules/auxiliary/scanner/scada/koyo_login.rb
@@ -141,7 +141,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/scanner/scada/koyo_login.rb
+++ b/modules/auxiliary/scanner/scada/koyo_login.rb
@@ -114,17 +114,43 @@ class Metasploit3 < Msf::Auxiliary
       next if not res
 
       print_good "#{rhost}:#{rport} - KOYO - Found passcode: #{passcode}"
-      report_auth_info(
-        :host   => rhost,
-        :port   => rport.to_i,
-        :proto  => 'udp',
-        :user   => '',
-        :pass   => passcode, # NOTE: Human readable
-        :active => true
+      report_cred(
+        ip: rhost,
+        port: rport.to_i,
+        service_name: 'koyo',
+        user: '',
+        password: passcode,
+        proof: res
       )
       break
     end
 
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'udp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def crc16(buf, crc=0)

--- a/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
@@ -140,13 +140,26 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def do_report(ip, user, port)
-    report_auth_info(
-      :host   => ip,
-      :port   => rport,
-      :sname  => 'ssh',
-      :user   => user,
-      :active => true
-    )
+    service_data = {
+      address: ip,
+      port: rport,
+      service_name: 'ssh',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: user,
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def peer(rhost=nil)

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -118,13 +118,26 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def do_report(ip, user, port)
-    report_auth_info(
-      :host   => ip,
-      :port   => rport,
-      :sname  => 'ssh',
-      :user   => user,
-      :active => true
-    )
+    service_data = {
+      address: ip,
+      port: rport,
+      service_name: 'ssh',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: user,
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   # Because this isn't using the AuthBrute mixin, we don't have the

--- a/modules/auxiliary/scanner/telnet/telnet_ruggedcom.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_ruggedcom.rb
@@ -79,6 +79,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -95,7 +96,7 @@ class Metasploit3 < Msf::Auxiliary
           mac  = banner_santized.match(/((?:[0-9a-f]{2}[-]){5}[0-9a-f]{2})/i)[0]
           password = mac_to_password(mac)
           info = get_info(banner_santized)
-          report_cred(ip: rhost, port: rport, user:'factory', password: password)
+          report_cred(ip: rhost, port: rport, user:'factory', password: password, proof: banner_santized)
           break
         else
           print_status("It doesn't seem to be a RuggedCom service.")

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -58,6 +58,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -70,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
       case result
       when :success
         print_good "#{rhost}:#{rport} - Successful Login! (#{user}:#{pass})"
-        report_cred(ip: rhost, port: rport, user: user, password: pass)
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: result)
         return if datastore['STOP_ON_SUCCESS']
       when :fail
         print_error "#{rhost}:#{rport} - Login Failure (#{user}:#{pass})"

--- a/modules/auxiliary/server/capture/drda.rb
+++ b/modules/auxiliary/server/capture/drda.rb
@@ -251,7 +251,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/server/capture/drda.rb
+++ b/modules/auxiliary/server/capture/drda.rb
@@ -216,14 +216,13 @@ class Metasploit3 < Msf::Auxiliary
 
     if @state[c][:user] and @state[c][:pass]
       print_status("DRDA LOGIN #{@state[c][:name]} Database: #{@state[c][:database]}; #{@state[c][:user]} / #{@state[c][:pass]}")
-      report_auth_info(
-        :host      => @state[c][:ip],
-        :port      => datastore['SRVPORT'],
-        :sname     => 'db2_client',
-        :user      => @state[c][:user],
-        :pass      => @state[c][:pass],
-        :source_type => "captured",
-        :active    => true
+      report_cred(
+        ip: @state[c][:ip],
+        port: datastore['SRVPORT'],
+        service_name: 'db2_client',
+        user: @state[c][:user],
+        password: @state[c][:pass],
+        proof: @state.inspect
       )
 
       params = []
@@ -236,6 +235,32 @@ class Metasploit3 < Msf::Auxiliary
       drda_send_cmd(c, cmd)
       #c.close
     end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def on_client_close(c)

--- a/modules/auxiliary/server/capture/ftp.rb
+++ b/modules/auxiliary/server/capture/ftp.rb
@@ -51,6 +51,32 @@ class Metasploit3 < Msf::Auxiliary
     c.put "220 FTP Server Ready\r\n"
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def on_client_data(c)
     data = c.get_once
     return if not data
@@ -71,14 +97,13 @@ class Metasploit3 < Msf::Auxiliary
     if(cmd.upcase == "PASS")
       @state[c][:pass] = arg
 
-      report_auth_info(
-        :host      => @state[c][:ip],
-        :port => datastore['SRVPORT'],
-        :sname     => 'ftp',
-        :user      => @state[c][:user],
-        :pass      => @state[c][:pass],
-        :source_type => "captured",
-        :active    => true
+      report_cred(
+        ip: @state[c][:ip],
+        port: datastore['SRVPORT'],
+        service_name: 'ftp',
+        user: @state[c][:user],
+        password: @state[c][:pass],
+        proof: arg
       )
 
       print_status("FTP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")

--- a/modules/auxiliary/server/capture/ftp.rb
+++ b/modules/auxiliary/server/capture/ftp.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -58,19 +58,44 @@ class Metasploit3 < Msf::Auxiliary
     exploit
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def on_request_uri(cli, req)
     if(req['Authorization'] and req['Authorization'] =~ /basic/i)
       basic,auth = req['Authorization'].split(/\s+/)
       user,pass  = Rex::Text.decode_base64(auth).split(':', 2)
 
-      report_auth_info(
-        :host        => cli.peerhost,
-        :port        => datastore['SRVPORT'],
-        :sname       => 'HTTP',
-        :user        => user,
-        :pass        => pass,
-        :source_type => "captured",
-        :active      => true
+      report_cred(
+        ip: cli.peerhost,
+        port: datastore['SRVPORT'],
+        service_name: 'HTTP',
+        user: user,
+        password: pass,
+        proof: req['Authorization']
       )
 
       print_good("#{cli.peerhost} - Credential collected: \"#{user}:#{pass}\" => #{req.resource}")

--- a/modules/auxiliary/server/capture/mysql.rb
+++ b/modules/auxiliary/server/capture/mysql.rb
@@ -128,6 +128,32 @@ class Metasploit3 < Msf::Auxiliary
     c.put data
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def on_client_data(c)
     info = { :errors => [] }
     data = c.get_once
@@ -144,16 +170,14 @@ class Metasploit3 < Msf::Auxiliary
         print_status("#{@state[c][:name]} - User: #{info[:username]}; Challenge: #{@challenge.unpack('H*')[0]}; Response: #{info[:response].unpack('H*')[0]}")
       end
       hash_line = "#{info[:username]}:$mysql$#{@challenge.unpack("H*")[0]}$#{info[:response].unpack('H*')[0]}"
-      report_auth_info(
-        :host  => c.peerhost,
-        :port => datastore['SRVPORT'],
-        :sname => 'mysql_client',
-        :user => info[:username],
-        :pass => hash_line,
-        :type => "mysql_hash",
-        :proof => info[:database] ? info[:database] : hash_line,
-        :source_type => "captured",
-        :active => true
+
+      report_cred(
+        ip: c.peerhost,
+        port: datastore['SRVPORT'],
+        service_name: 'mysql_client',
+        user: info[:username],
+        pass: hash_line,
+        proof: info[:database] ? info[:database] : hash_line
       )
 
       if (datastore['CAINPWFILE'])

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -56,6 +56,32 @@ class Metasploit3 < Msf::Auxiliary
     c.put "+OK\r\n"
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def on_client_data(c)
     data = c.get_once
     return if not data
@@ -71,14 +97,13 @@ class Metasploit3 < Msf::Auxiliary
     if(cmd.upcase == "PASS")
       @state[c][:pass] = arg
 
-      report_auth_info(
-        :host      => @state[c][:ip],
-        :port      => @myport,
-        :sname     => 'pop3',
-        :user      => @state[c][:user],
-        :pass      => @state[c][:pass],
-        :source_type => "captured",
-        :active    => true
+      report_cred(
+        ip: @state[c][:ip],
+        port: @myport,
+        service_name: 'pop3',
+        user: @state[c][:user],
+        password: @state[c][:pass],
+        proof: arg
       )
       print_status("POP3 LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
       @state[c][:pass] = data.strip

--- a/modules/auxiliary/server/capture/postgresql.rb
+++ b/modules/auxiliary/server/capture/postgresql.rb
@@ -42,6 +42,32 @@ class Metasploit3 < Msf::Auxiliary
     exploit()
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def on_client_connect(c)
     @state[c] = {
       :name    => "#{c.peerhost}:#{c.peerport}",
@@ -74,16 +100,13 @@ class Metasploit3 < Msf::Auxiliary
       # Password message
       data.slice!(0, 5).unpack("N")[0] # skip over length
       @state[c][:password] = data.slice!(0, data.index("\x00") + 1).unpack("Z*")[0]
-      report_auth_info(
-        :host  => c.peerhost,
-        :port => datastore['SRVPORT'],
-        :sname => 'psql_client',
-        :user => @state[c][:username],
-        :pass => @state[c][:password],
-        :type => "PostgreSQL credentials",
-        :proof => @state[c][:database],
-        :source_type => "captured",
-        :active => true
+      report_cred(
+        ip: c.peerhost,
+        port: datastore['SRVPORT'],
+        service_name: 'psql_client',
+        user: @state[c][:username],
+        password: @state[c][:password],
+        proof: @state[c][:database]
       )
       print_status("PostgreSQL LOGIN #{@state[c][:name]} #{@state[c][:username]} / #{@state[c][:password]} / #{@state[c][:database]}")
       # send failure message

--- a/modules/auxiliary/server/capture/postgresql.rb
+++ b/modules/auxiliary/server/capture/postgresql.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -104,6 +104,32 @@ class Metasploit3 < Msf::Auxiliary
     return addr
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run
     begin
       @port = datastore['SRVPORT'].to_i
@@ -141,16 +167,13 @@ class Metasploit3 < Msf::Auxiliary
             proof = "client: #{client_ip}; username: #{username}; nonce: #{datastore['NONCE']}; response: #{response}; algorithm: #{algorithm}"
             print_status("SIP LOGIN: #{proof}")
 
-            report_auth_info(
-              :host  => @requestor[:ip],
-              :port => @requestor[:port],
-              :sname => 'sip_client',
-              :user => username,
-              :pass => response + ":" + auth_tokens['nonce'] + ":" + algorithm,
-              :type => "sip_hash",
-              :proof => proof,
-              :source_type => "captured",
-              :active => true
+            report_cred(
+              ip: @requestor[:ip],
+              port: @requestor[:port],
+              service_name: 'sip_client',
+              user: username,
+              password: response + ":" + auth_tokens['nonce'] + ":" + algorithm,
+              proof: proof
             )
 
             if datastore['JOHNPWFILE']

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -118,7 +118,7 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :nonreplayable_hash
+      private_type: :password
     }.merge(service_data)
 
     login_data = {

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -118,14 +118,13 @@ class Metasploit3 < Msf::Auxiliary
 
       @state[c][:pass] = arg
 
-      report_auth_info(
-        :host      => @state[c][:ip],
-        :port      => datastore['SRVPORT'],
-        :sname     => 'pop3',
-        :user      => @state[c][:user],
-        :pass      => @state[c][:pass],
-        :source_type => "captured",
-        :active    => true
+      report_cred(
+        ip: @state[c][:ip],
+        port: datastore['SRVPORT'],
+        service_name: 'pop3',
+        user: @state[c][:user],
+        password: @state[c][:pass],
+        proof: arg
       )
       print_status("SMTP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
     end
@@ -133,6 +132,32 @@ class Metasploit3 < Msf::Auxiliary
     c.put "503 Server Error\r\n"
     return
 
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def on_client_close(c)

--- a/modules/auxiliary/voip/asterisk_login.rb
+++ b/modules/auxiliary/voip/asterisk_login.rb
@@ -72,6 +72,7 @@ class Metasploit3 < Msf::Auxiliary
       last_attempted_at: DateTime.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
     }.merge(service_data)
 
     create_credential_login(login_data)
@@ -117,7 +118,7 @@ class Metasploit3 < Msf::Auxiliary
         send_manager(cmd)
         if /Response: Success/.match(@result)
           print_good("User: \"#{user}\" using pass: \"#{pass}\" - can login on #{rhost}:#{rport}!")
-          report_cred(ip: rhost, port: rport, user: user, password: pass)
+          report_cred(ip: rhost, port: rport, user: user, password: pass, proof: @result)
           disconnect
           return :next_user
         else

--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -371,6 +371,32 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def exploit
     print_status("#{peer} - Checking for a valid node id...")
     node_id = get_node

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -7,10 +7,11 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
 
-  FAKE_IP   = '192.168.12.123'
-  FAKE_PORT = 80
-  FAKE_USER = 'user'
-  FAKE_PASS = 'password'
+  FAKE_IP    = '192.168.12.123'
+  FAKE_PORT  = 80
+  FAKE_USER  = 'user'
+  FAKE_PASS  = 'password'
+  FAKE_PROOF = 'proof'
 
   def initialize(info = {})
     super(update_info(info,
@@ -125,265 +126,177 @@ class Metasploit3 < Msf::Auxiliary
 
   def test_hp_imc_som_create_account
     mod = framework.auxiliary.create('admin/hp/hp_imc_som_create_account')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'https',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'https', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_dlink_dir_645_password_extractor
     mod = framework.auxiliary.create('admin/http/dlink_dir_645_password_extractor')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'http',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_dlink_dsl320b_password_extractor
     mod = framework.auxiliary.create('admin/http/dlink_dsl320b_password_extractor')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'http',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
   end
 
   def test_nexpose_xxe_file_read
     mod = framework.auxiliary.create('admin/http/nexpose_xxe_file_read')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'http',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_vbulletin_upgrade_admin
     mod = framework.auxiliary.create('admin/http/vbulletin_upgrade_admin')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'http',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_wp_custom_contact_forms
     mod = framework.auxiliary.create('admin/http/wp_custom_contact_forms')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      service_name: 'WordPress',
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, service_name: 'WordPress', proof: FAKE_PROOF)
   end
 
   def test_zyxel_admin_password_extractor
     mod = framework.auxiliary.create('admin/http/zyxel_admin_password_extractor')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'ZyXEL GS1510-16',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'ZyXEL GS1510-16', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_sercomm_dump_config
     mod = framework.auxiliary.create('admin/misc/sercomm_dump_config')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      service_name: 'sercomm',
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, service_name: 'sercomm', proof: FAKE_PROOF)
   end
 
   def test_vnc
     mod = framework.auxiliary.create('server/capture/vnc')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'vnc_client',
-      user: '',
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'vnc_client', user: '', password: FAKE_PASS, proof: FAKE_PROOF )
   end
 
   def test_smtp
     mod = framework.auxiliary.create('server/capture/smtp')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'pop3',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'pop3', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_sip
     mod = framework.auxiliary.create('server/capture/sip')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'sip_client',
-      user:FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sip_client', user:FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_oracle_login
     mod = framework.auxiliary.create('admin/oracle/oracle_login')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'oracle',
-      user: FAKE_USER,
-      password: FAKE_PASS
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'oracle', user: FAKE_USER, password: FAKE_PASS )
   end
 
   def test_postgresql
     mod = framework.auxiliary.create('server/capture/postgresql')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'psql_client',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'psql_client', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_pop3
     mod = framework.auxiliary.create('server/capture/pop3')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'pop3',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'pop3', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
   end
 
   def test_http_basic
     mod = framework.auxiliary.create('server/capture/http_basic')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'HTTP',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'HTTP', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
   end
 
   def test_ftp
     mod = framework.auxiliary.create('server/capture/ftp')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'ftp',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'ftp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_drda
     mod = framework.auxiliary.create('server/capture/drda')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'db2_client',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'db2_client', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_koyo_login
     mod = framework.auxiliary.create('scanner/scada/koyo_login')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'koyo',
-      user: '',
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'koyo', user: '', password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_openvas_otp_login
     mod = framework.auxiliary.create('scanner/openvas/openvas_otp_login')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'openvas-otp',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'openvas-otp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_openvas_omp_login
     mod = framework.auxiliary.create('scanner/openvas/openvas_omp_login')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'openvas-omp',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: @result
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'openvas-omp', user: FAKE_USER, password: FAKE_PASS, proof: @result)
   end
 
   def test_openvas_gsad_login
     mod = framework.auxiliary.create('scanner/openvas/openvas_gsad_login')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'openvas-gsa',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'openvas-gsa', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_nexpose_api_login
     mod = framework.auxiliary.create('scanner/nexpose/nexpose_api_login')
-    mod.report_cred(
-      ip: FAKE_IP,
-      port: FAKE_PORT,
-      service_name: 'nexpose',
-      user: FAKE_USER,
-      password: FAKE_PASS,
-      proof: ''
-    )
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'nexpose', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_nessus_ntp_login
+    mod = framework.auxiliary.create('scanner/nessus/nessus_ntp_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'nessus-ntp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_msf_web_login
+    mod = framework.auxiliary.create('scanner/msf/msf_web_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'msf-web', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_msf_rpc_login
+    mod = framework.auxiliary.create('scanner/msf/msf_rpc_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'msf-rpc', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF )
+  end
+
+  def test_mongodb_login
+    mod = framework.auxiliary.create('scanner/mongodb/mongodb_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'mongodb', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_rosewill_rxs3211_passwords
+    mod = framework.auxiliary.create('scanner/misc/rosewill_rxs3211_passwords')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'ipcam', user: '', password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_raysharp_dvr_passwords
+    mod = framework.auxiliary.create('scanner/misc/raysharp_dvr_passwords')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'dvr', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_oki_scanner
+    mod = framework.auxiliary.create('scanner/misc/oki_scanner')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_dvr_config_disclosure
+    mod = framework.auxiliary.create('scanner/misc/dvr_config_disclosure')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'ftp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_typo3_bruteforce
+    mod = framework.auxiliary.create('scanner/http/typo3_bruteforce')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'typo3', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_squiz_matrix_user_enum
+    mod = framework.auxiliary.create('scanner/http/squiz_matrix_user_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', proof: FAKE_PROOF)
+  end
+
+  def test_sevone_enum
+    mod = framework.auxiliary.create('scanner/http/sevone_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: '') 
+  end
+
+  def test_sentry_cdu_enum
+    mod = framework.auxiliary.create('scanner/http/sentry_cdu_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_sap_businessobjects_user_brute_web
+    mod = framework.auxiliary.create('scanner/http/sap_businessobjects_user_brute_web')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sap-businessobjects', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def run

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -9,7 +9,7 @@ class Metasploit3 < Msf::Auxiliary
 
   FAKE_IP   = '192.168.12.123'
   FAKE_PORT = 80
-  FAKE_USER = 'username'
+  FAKE_USER = 'user'
   FAKE_PASS = 'password'
 
   def initialize(info = {})
@@ -121,6 +121,269 @@ class Metasploit3 < Msf::Auxiliary
   def test_asterisk_login
     mod = framework.auxiliary.create('voip/asterisk_login')
     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+  end
+
+  def test_hp_imc_som_create_account
+    mod = framework.auxiliary.create('admin/hp/hp_imc_som_create_account')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'https',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_dlink_dir_645_password_extractor
+    mod = framework.auxiliary.create('admin/http/dlink_dir_645_password_extractor')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'http',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_dlink_dsl320b_password_extractor
+    mod = framework.auxiliary.create('admin/http/dlink_dsl320b_password_extractor')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'http',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_nexpose_xxe_file_read
+    mod = framework.auxiliary.create('admin/http/nexpose_xxe_file_read')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'http',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_vbulletin_upgrade_admin
+    mod = framework.auxiliary.create('admin/http/vbulletin_upgrade_admin')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'http',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_wp_custom_contact_forms
+    mod = framework.auxiliary.create('admin/http/wp_custom_contact_forms')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      service_name: 'WordPress',
+      proof: ''
+    )
+  end
+
+  def test_zyxel_admin_password_extractor
+    mod = framework.auxiliary.create('admin/http/zyxel_admin_password_extractor')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'ZyXEL GS1510-16',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_sercomm_dump_config
+    mod = framework.auxiliary.create('admin/misc/sercomm_dump_config')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      service_name: 'sercomm',
+      proof: ''
+    )
+  end
+
+  def test_vnc
+    mod = framework.auxiliary.create('server/capture/vnc')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'vnc_client',
+      user: '',
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_smtp
+    mod = framework.auxiliary.create('server/capture/smtp')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'pop3',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_sip
+    mod = framework.auxiliary.create('server/capture/sip')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'sip_client',
+      user:FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_oracle_login
+    mod = framework.auxiliary.create('admin/oracle/oracle_login')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'oracle',
+      user: FAKE_USER,
+      password: FAKE_PASS
+    )
+  end
+
+  def test_postgresql
+    mod = framework.auxiliary.create('server/capture/postgresql')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'psql_client',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_pop3
+    mod = framework.auxiliary.create('server/capture/pop3')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'pop3',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_http_basic
+    mod = framework.auxiliary.create('server/capture/http_basic')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'HTTP',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_ftp
+    mod = framework.auxiliary.create('server/capture/ftp')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'ftp',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_drda
+    mod = framework.auxiliary.create('server/capture/drda')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'db2_client',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_koyo_login
+    mod = framework.auxiliary.create('scanner/scada/koyo_login')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'koyo',
+      user: '',
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_openvas_otp_login
+    mod = framework.auxiliary.create('scanner/openvas/openvas_otp_login')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'openvas-otp',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_openvas_omp_login
+    mod = framework.auxiliary.create('scanner/openvas/openvas_omp_login')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'openvas-omp',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: @result
+    )
+  end
+
+  def test_openvas_gsad_login
+    mod = framework.auxiliary.create('scanner/openvas/openvas_gsad_login')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'openvas-gsa',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
+  end
+
+  def test_nexpose_api_login
+    mod = framework.auxiliary.create('scanner/nexpose/nexpose_api_login')
+    mod.report_cred(
+      ip: FAKE_IP,
+      port: FAKE_PORT,
+      service_name: 'nexpose',
+      user: FAKE_USER,
+      password: FAKE_PASS,
+      proof: ''
+    )
   end
 
   def run

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -324,20 +324,69 @@ class Metasploit3 < Msf::Auxiliary
     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'Oracle Integrated Lights Out Manager Portal', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
+  def test_mysql
+    mod = framework.auxiliary.create('server/capture/mysql')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'mysql_client', user: FAKE_USER, pass: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_http
+    mod = framework.auxiliary.create('server/capture/http')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, pass: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_ssh_enumusers
+    mod = framework.auxiliary.create('scanner/ssh/ssh_enumusers')
+    mod.do_report(FAKE_IP, FAKE_USER, FAKE_PORT)
+  end
+
+  def test_cerberus_sftp_enumusers
+    mod = framework.auxiliary.create('scanner/ssh/cerberus_sftp_enumusers')
+    mod.do_report(FAKE_IP, FAKE_USER, FAKE_PORT)
+  end
+
+  def test_sap_web_gui_brute_login
+    mod = framework.auxiliary.create('scanner/sap/sap_web_gui_brute_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sap_webgui', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_sap_soap_rfc_brute_login
+    mod = framework.auxiliary.create('scanner/sap/sap_soap_rfc_brute_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sap', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_sap_soap_bapi_user_create1
+    mod = framework.auxiliary.create('scanner/sap/sap_soap_bapi_user_create1')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sap', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  
+
   def run
+    counter_all  = 0
+    counter_good = 0
+    counter_bad = 0
     self.methods.each do |m|
       next if m.to_s !~ /^test_.+/
       print_status("Trying: ##{m.to_s}")
       begin
         self.send(m)
         print_good("That didn't blow up. Good!")
+        counter_good += 1
       rescue ::Exception => e
         print_error("That blew up :-(")
         print_line("#{e.class} #{e.message}\n#{e.backtrace*"\n"}")
+        counter_bad += 1
       ensure
         print_line
       end
+
+      counter_all += 1
     end
+
+    print_good("Number of test cases that passed: #{counter_good}")
+    print_error("Number of test cases that failed: #{counter_bad}")
+    print_status("Number of test cases overall: #{counter_all}")
+    print_line
   end
 
 end

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -26,102 +26,102 @@ class Metasploit3 < Msf::Auxiliary
 
   def test_novell_mdm_creds
     mod = framework.auxiliary.create('scanner/http/novell_mdm_creds')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_joomla_bruteforce_login
     mod = framework.auxiliary.create('scanner/http/joomla_bruteforce_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_infovista_enum
     mod = framework.auxiliary.create('scanner/http/infovista_enum')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_etherpad_duo_login
     mod = framework.auxiliary.create('scanner/http/etherpad_duo_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_ektron_cms400net
     mod = framework.auxiliary.create('scanner/http/ektron_cms400net')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_drupal_views_user_enum
     mod = framework.auxiliary.create('scanner/http/drupal_views_user_enum')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, proof: FAKE_PROOF)
   end
 
   def test_dolibarr_login
     mod = framework.auxiliary.create('scanner/http/dolibarr_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_dlink_dir_session_cgi_http_login
     mod = framework.auxiliary.create('scanner/http/dlink_dir_session_cgi_http_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_dlink_dir_615h_http_login
     mod = framework.auxiliary.create('scanner/http/dlink_dir_615h_http_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_dlink_dir_300_615_http_login
     mod = framework.auxiliary.create('scanner/http/dlink_dir_300_615_http_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_cisco_ssl_vpn
     mod = framework.auxiliary.create('scanner/http/cisco_ssl_vpn')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_cisco_ironport_enum
     mod = framework.auxiliary.create('scanner/http/cisco_ironport_enum')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_cisco_asa_asdm
     mod = framework.auxiliary.create('scanner/http/cisco_asa_asdm')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_axis_local_file_include
     mod = framework.auxiliary.create('scanner/http/axis_local_file_include')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_splunk_web_login
     mod = framework.auxiliary.create('scanner/http/splunk_web_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_cctv_dvr_login
     mod = framework.auxiliary.create('scanner/misc/cctv_dvr_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_http_vcms_login
     mod = framework.auxiliary.create('scanner/http/vcms_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_telnet_ruggedcom
     mod = framework.auxiliary.create('scanner/telnet/telnet_ruggedcom')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: 'factory', password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: 'factory', password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_vmware_http_login
     mod = framework.auxiliary.create('scanner/vmware/vmware_http_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_asterisk_login
     mod = framework.auxiliary.create('voip/asterisk_login')
-    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def test_hp_imc_som_create_account
@@ -297,6 +297,31 @@ class Metasploit3 < Msf::Auxiliary
   def test_sap_businessobjects_user_brute_web
     mod = framework.auxiliary.create('scanner/http/sap_businessobjects_user_brute_web')
     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sap-businessobjects', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_sap_businessobjects_user_brute
+    mod = framework.auxiliary.create('scanner/http/sap_businessobjects_user_brute')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sap-businessobjects', user: FAKE_USER, proof: FAKE_PROOF)
+  end
+
+  def test_rfcode_reader_enum
+    mod = framework.auxiliary.create('scanner/http/rfcode_reader_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'RFCode Reader', user: FAKE_USER, password:FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_radware_appdictor_enum
+    mod = framework.auxiliary.create('scanner/http/radware_appdirector_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'Radware AppDirector', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_pocketpad_login
+    mod = framework.auxiliary.create('scanner/http/pocketpad_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'PocketPAD Portal', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_oracle_ilom_login
+    mod = framework.auxiliary.create('scanner/http/oracle_ilom_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'Oracle Integrated Lights Out Manager Portal', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
   def run


### PR DESCRIPTION
This patch updates modules to use the metasploit-credential API. It also updates existing ones to always provide :proof. There's a lot of files changed so I figured it's enough for this round.
## Verification
- [x] Start msfconsole
- [x] `loadpath test/modules`
- [x] `use test/report_auth_info`
- [x] `run`
- [x] All should be green, no red.
