### PR TITLE
Resolve #5753, Support Origin for the creds command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -983,6 +983,10 @@ class Db
         set_rhosts = true
       when '-O', '--origins'
         hosts = args.shift
+        if !hosts
+          print_error("Argument required for -O")
+          return
+        end
         arg_host_range(hosts, origin_ranges)
       else
         # Anything that wasn't an option is a host to search for
@@ -1074,8 +1078,7 @@ class Db
           next
         end
 
-        if core.logins.empty?
-
+        if core.logins.empty? && origin_ranges.empty?
           tbl << [
             "", # host
             "", # cred

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -837,6 +837,7 @@ class Db
     print_line "  -s <svc names>        List creds matching comma-separated service names"
     print_line "  -u,--user <regex>     List users that match this regex"
     print_line "  -t,--type <type>      List creds that match the following types: #{allowed_cred_types.join(',')}"
+    print_line "  -O,--origins          List creds that match these origins"
     print_line "  -R,--rhosts           Set RHOSTS from the results of the search"
 
     print_line
@@ -925,15 +926,16 @@ class Db
   end
 
   def creds_search(*args)
-    host_ranges = []
-    port_ranges = []
-    svcs        = []
-    rhosts      = []
+    host_ranges   = []
+    origin_ranges = []
+    port_ranges   = []
+    svcs          = []
+    rhosts        = []
 
     set_rhosts = false
 
     #cred_table_columns = [ 'host', 'port', 'user', 'pass', 'type', 'proof', 'active?' ]
-    cred_table_columns = [ 'host', 'service', 'public', 'private', 'realm', 'private_type' ]
+    cred_table_columns = [ 'host', 'origin' , 'service', 'public', 'private', 'realm', 'private_type' ]
     user = nil
     delete_count = 0
 
@@ -979,6 +981,9 @@ class Db
         mode = :delete
       when '-R', '--rhosts'
         set_rhosts = true
+      when '-O', '--origins'
+        hosts = args.shift
+        arg_host_range(hosts, origin_ranges)
       else
         # Anything that wasn't an option is a host to search for
         unless (arg_host_range(arg, host_ranges))
@@ -1058,11 +1063,23 @@ class Db
           next
         end
 
+        origin = ''
+        if core.origin.kind_of?(Metasploit::Credential::Origin::Service)
+          origin = core.origin.service.host.address
+        elsif core.origin.kind_of?(Metasploit::Credential::Origin::Session)
+          origin = core.origin.session.host.address
+        end
+
+        if !origin.empty? && origin_ranges.present? && !origin_ranges.any? {|range| range.include?(origin) }
+          next
+        end
+
         if core.logins.empty?
 
           tbl << [
             "", # host
-            "", # port
+            "", # cred
+            "", # service
             core.public,
             core.private,
             core.realm,
@@ -1070,7 +1087,6 @@ class Db
           ]
         else
           core.logins.each do |login|
-
             # If none of this Core's associated Logins is for a host within
             # the user-supplied RangeWalker, then we don't have any reason to
             # print it out. However, we treat the absence of ranges as meaning
@@ -1078,7 +1094,9 @@ class Db
             if host_ranges.present? && !host_ranges.any? { |range| range.include?(login.service.host.address) }
               next
             end
+
             row = [ login.service.host.address ]
+            row << origin
             rhosts << login.service.host.address
             if login.service.name.present?
               row << "#{login.service.port}/#{login.service.proto} (#{login.service.name})"

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -107,65 +107,63 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
       context "when the credential is present" do
         it "should show a user that matches the given expression" do
           db.cmd_creds("-u", username)
-          @output.should =~ [
+          expect(@output).to eq([
             "Credentials",
             "===========",
             "",
-            "host  service  public    private   realm  private_type",
-            "----  -------  ------    -------   -----  ------------",
-            "               thisuser  thispass         Password",
-          ]
+            "host  origin  service  public    private   realm  private_type",
+            "----  ------  -------  ------    -------   -----  ------------",
+            "                       thisuser  thispass         Password"
+          ])
         end
 
         it 'should match a regular expression' do
           subject.cmd_creds("-u", "^#{username}$")
-          @output.should =~
-          [
+          expect(@output).to eq([
             "Credentials",
             "===========",
             "",
-            "host  service  public    private   realm  private_type",
-            "----  -------  ------    -------   -----  ------------",
-            "               thisuser  thispass         Password",
-          ]
+            "host  origin  service  public    private   realm  private_type",
+            "----  ------  -------  ------    -------   -----  ------------",
+            "                       thisuser  thispass         Password"
+          ])
         end
 
         it 'should return nothing for a non-matching regular expression' do
           subject.cmd_creds("-u", "^#{nomatch_username}$")
-          @output.should =~
-          [
+          expect(@output).to eq([
             "Credentials",
             "===========",
             "",
-            "host  service  public  private  realm  private_type",
-            "----  -------  ------  -------  -----  ------------",
-          ]
+            "host  origin  service  public  private  realm  private_type",
+            "----  ------  -------  ------  -------  -----  ------------"
+          ])
         end
 
         context "and when the username is blank" do
           it "should show a user that matches the given expression" do
             db.cmd_creds("-u", blank_username)
-            @output.should =~ [
+            expect(@output).to eq([
               "Credentials",
               "===========",
               "",
-              "host  service  public  private        realm  private_type",
-              "----  -------  ------  -------        -----  ------------",
-              "                       nonblank_pass         Password",
-            ]
+              "host  origin  service  public  private        realm  private_type",
+              "----  ------  -------  ------  -------        -----  ------------",
+              "                               nonblank_pass         Password"
+            ])
           end
         end
         context "and when the password is blank" do
           it "should show a user that matches the given expression" do
             db.cmd_creds("-P", blank_password)
-            @output.should =~ [
+            expect(@output).to eq([
               "Credentials",
               "===========",
               "",
-              "host  service  public         private  realm  private_type",
-              "----  -------  ------         -------  -----  ------------",
-              "               nonblank_user                  Password",
-            ]
+              "host  origin  service  public         private  realm  private_type",
+              "----  ------  -------  ------         -------  -----  ------------",
+              "                       nonblank_user                  Password"
+            ])
           end
         end
       end
@@ -174,25 +172,25 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         context "due to a nonmatching username" do
           it "should return a blank set" do
             db.cmd_creds("-u", nomatch_username)
-            @output.should =~ [
+            expect(@output).to eq([
               "Credentials",
               "===========",
               "",
-              "host  service  public  private  realm  private_type",
-              "----  -------  ------  -------  -----  ------------",
-            ]
+              "host  origin  service  public  private  realm  private_type",
+              "----  ------  -------  ------  -------  -----  ------------"
+            ])
           end
         end
         context "due to a nonmatching password" do
           it "should return a blank set" do
             db.cmd_creds("-P", nomatch_password)
-            @output.should =~ [
+            expect(@output).to eq([
               "Credentials",
               "===========",
               "",
-              "host  service  public  private  realm  private_type",
-              "----  -------  ------  -------  -----  ------------",
-            ]
+              "host  origin  service  public  private  realm  private_type",
+              "----  ------  -------  ------  -------  -----  ------------"
+            ])
           end
         end
       end
@@ -257,14 +255,14 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           it "should show just the password" do
             db.cmd_creds("-t", "password")
             # Table matching really sucks
-            @output.should =~ [
+            expect(@output).to eq([
               "Credentials",
               "===========",
               "",
-              "host  service  public    private   realm  private_type",
-              "----  -------  ------    -------   -----  ------------",
-              "               thisuser  thispass         Password"
-            ]
+              "host  origin  service  public    private   realm  private_type",
+              "----  ------  -------  ------    -------   -----  ------------",
+              "                       thisuser  thispass         Password"
+            ])
           end
         end
 


### PR DESCRIPTION
Resolve #5753. Add an Origin column and allow the user to search by origin.
## Verification
- [x] To test this, make sure your database has some credentials.
- [x] Do `creds -h`
- [x] You should see the new -O (or --origins) option
- [x] Do `creds`
- [x] You should see all the creds listed
- [x] Pick an origin from the list, and then do `creds -O [origin IP]`
- [x] You should see all the creds with the same origin
- [x] Pick a host (not origin) from the list, and then do `creds -R [host IP]`
- [x] You should see all the creds with the same host
