### PR TITLE
restore PPID to the meterpreter process list table

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -391,13 +391,26 @@ class ProcessList < Array
     cols.delete_if { |c| !( first.has_key?(c.downcase) ) or first[c.downcase].nil? }
 
     opts = {
-      "Header"  => "Process List",
-      "Columns" => cols
+      'Header' => 'Process List',
+      'Indent' => 1,
+      'Columns' => cols
     }.merge(opts)
 
     tbl = Rex::Ui::Text::Table.new(opts)
     each { |process|
-      tbl << cols.map {|c| process[c.downcase] }.compact
+      tbl << cols.map { |c|
+        col = c.downcase
+        val = process[col]
+        if col == 'session'
+          val == 0xFFFFFFFF ? '' : val.to_s
+        elsif col == 'arch'
+          # for display and consistency with payload naming we switch the internal
+          # 'x86_64' value to display 'x64'
+          val == ARCH_X86_64 ? 'x64' : val
+        else
+          val
+        end
+      }.compact
     }
 
     tbl

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -447,14 +447,14 @@ class Console::CommandDispatcher::Stdapi::Sys
             print_line "You must select either x86 or x86_64"
             return false
           end
-          searched_procs << proc	if proc["arch"] == val
+          searched_procs << proc if proc["arch"] == val
         end
         processes = searched_procs
       when "-s"
         print_line "Filtering on SYSTEM processes..."
         searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
         processes.each do |proc|
-          searched_procs << proc	if proc["user"] == "NT AUTHORITY\\SYSTEM"
+          searched_procs << proc if proc["user"] == "NT AUTHORITY\\SYSTEM"
         end
         processes = searched_procs
       when "-U"
@@ -465,46 +465,18 @@ class Console::CommandDispatcher::Stdapi::Sys
             print_line "You must supply a search term!"
             return false
           end
-          searched_procs << proc	if proc["user"].match(/#{val}/)
+          searched_procs << proc if proc["user"].match(/#{val}/)
         end
         processes = searched_procs
       end
     }
 
-    tbl = Rex::Ui::Text::Table.new(
-      'Header'  => "Process list",
-      'Indent'  => 1,
-      'Columns' =>
-        [
-          "PID",
-          "Name",
-          "Arch",
-          "Session",
-          "User",
-          "Path"
-        ],
-      'SearchTerm' => search_term)
-
-    processes.each { |ent|
-      session = ent['session'] == 0xFFFFFFFF ? '' : ent['session'].to_s
-      arch    = ent['arch']
-
-      # for display and consistency with payload naming we switch the internal 'x86_64' value to display 'x64'
-      if( arch == ARCH_X86_64 )
-        arch = "x64"
-      end
-
-      row = [ ent['pid'].to_s, ent['name'], arch, session, ent['user'], ent['path'] ]
-
-      tbl << row #if (search_term.nil? or row.join(' ').to_s.match(search_term))
-    }
-
     if (processes.length == 0)
       print_line("No running processes were found.")
     else
+      tbl = processes.to_table('SearchTerm' => search_term)
       print_line
-      print("\n" + tbl.to_s + "\n")
-      print_line
+      print_line(tbl.to_s)
     end
     return true
   end


### PR DESCRIPTION
When I merged 66bd881ac5a6de636c2eea7528946bc2d3abd52c, I didn't notice that it removed the PPID column and near-duplicated the to_table method in ProcessList. This restores earlier behavior and re-adds the PPID column if it is supported, but merges the current search and output fixups as well. This fixes #5773
# Verification steps
- [x] Start a Windows meterpreter
- [x] Verify that 'ps' output shows a PPID column.
- [x] Start a PHP meterpreter, verify that no PPID column shows up
- [x] Ensure that the filtering functionality works still, e.g.:

```
meterpreter > ps -S svchost

Process List
============

 PID   PPID  Name                                 Arch  Session  User           Path
 ---   ----  ----                                 ----  -------  ----           ----
 292   576   svchost.exe
 428   576   svchost.exe
 656   576   svchost.exe
 696   576   svchost.exe
 788   576   svchost.exe
 884   576   svchost.exe
 932   576   svchost.exe
```
