### PR TITLE
use password_prompt? not @password_prompt for matching telnet prompts

### DIFF
--- a/lib/metasploit/framework/login_scanner/telnet.rb
+++ b/lib/metasploit/framework/login_scanner/telnet.rb
@@ -85,7 +85,7 @@ module Metasploit
               recvd_sample = @recvd.dup
               # Allow for slow echos
               1.upto(10) do
-                recv_telnet(self.sock, 0.10) unless @recvd.nil? or @recvd[/#{@password_prompt}/]
+                recv_telnet(self.sock, 0.10) unless @recvd.nil? || password_prompt?(@recvd)
               end
 
               if password_prompt?(credential.public)

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -256,7 +256,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # Allow for slow echos
     1.upto(10) do
-      recv(self.sock, 0.10) unless @recvd.nil? or @recvd[/#{@password_prompt}/]
+      recv(self.sock, 0.10) unless @recvd.nil? || password_prompt?(@recvd)
     end
 
     vprint_status("#{rhost}:#{rport} Prompt: #{@recvd.gsub(/[\r\n\e\b\a]/, ' ')}")


### PR DESCRIPTION
This fixes #5667. For some reason, there are two occurrences of matches with the instance variable @password_prompt in login_scanner/telnet and rlogin_login. This value is not set anywhere. Everywhere else, the password_prompt? method is called instead, which does case-insensitive regex matching. This PR simply adjusts the recv loop to bail on anything that matches password_prompt? instead.

Nothing in framework or pro appears to set @password_prompt at all, so I will assume it was a typo from 6decd3cbd2415c388009ecb22b2a540bfa374203.
# Verification steps
- [x] Start a telnet server (I installed telnetd on an Ubuntu VM and added a test account).
  Note that auxiliary/server/capture/telnet is not a sufficiently robust telnet server to work for this and it will hang.
- [x] Connect via the telnet login scanner and ensure that it still works:

```
./msfconsole -qx 'use auxiliary/scanner/telnet/telnet_login; set username test; set password test; set rhosts 192.168.56.101; run'
username => test
password => test
rhosts => 192.168.56.101
[+] 192.168.56.101:23 - LOGIN SUCCESSFUL: test:test
[*] Attempting to start session 192.168.56.101:23 with test:test
[*] Command shell session 1 opened (192.168.56.1:64138 -> 192.168.56.101:23) at 2015-07-27 19:33:51 -0500
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
