### PR TITLE
Relocate Webarchive into the Exploit namespace, fixes #5717

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,3 @@ DEPENDENCIES
   simplecov
   timecop
   yard
-
-BUNDLED WITH
-   1.10.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,3 +247,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.10.3

--- a/lib/msf/core/exploit/format/webarchive.rb
+++ b/lib/msf/core/exploit/format/webarchive.rb
@@ -4,7 +4,7 @@
 # installing extensions from extensions.apple.com.
 #
 module Msf
-module Exploit
+class Exploit
 module Format
 module Webarchive
 

--- a/lib/msf/core/exploit/format/webarchive.rb
+++ b/lib/msf/core/exploit/format/webarchive.rb
@@ -4,6 +4,7 @@
 # installing extensions from extensions.apple.com.
 #
 module Msf
+module Exploit
 module Format
 module Webarchive
 
@@ -360,6 +361,7 @@ function reportStolenCookies() {
     datastore['STEAL_FILES']
   end
 
+end
 end
 end
 end

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -4,12 +4,12 @@
 ###
 
 require 'msf/core'
-require 'msf/core/format/webarchive'
+require 'msf/core/exploit/format/webarchive'
 
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Exploit::Remote::FtpServer
-  include Msf::Format::Webarchive
+  include Msf::Exploit::Format::Webarchive
   include Msf::Auxiliary::Report
 
   def initialize(info = {})


### PR DESCRIPTION
This relocates Msf::Format::Webarchive into Msf::Exploit::Format::Archive, which is a better fit for the mixin layout.
