### PR TITLE
Fixed NoMethodError for .match on nil

### DIFF
--- a/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
+++ b/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Auxiliary
       # can't simply return here as we'll print an error for each host
       fail_with "Either TARGET_URI or TARGET_URIS_FILE must be specified"
     end
-    if (turi and !turi.blank?)
+    if (turi && !turi.blank?)
       test_uris << normalize_uri(turi)
     end
     if (turis_file && !turis_file.blank?)
@@ -105,7 +105,7 @@ class Metasploit3 < Msf::Auxiliary
     return if res.nil?
 
     vprint_status("Status: #{res.code}")
-    if res and res.code == 401 and res['WWW-Authenticate'] and res['WWW-Authenticate'].match(/^NTLM/i)
+    if res && res.code == 401 && res['WWW-Authenticate'] && res['WWW-Authenticate'].match(/^NTLM/i)
       hash = res['WWW-Authenticate'].split('NTLM ')[1]
       # Parse out the NTLM and just get the Target Information Data
       target = Rex::Proto::NTLM::Message.parse(Rex::Text.decode_base64(hash))[:target_info].value()

--- a/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
+++ b/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
@@ -105,7 +105,7 @@ class Metasploit3 < Msf::Auxiliary
     return if res.nil?
 
     vprint_status("Status: #{res.code}")
-    if res and res.code == 401 and res['WWW-Authenticate'].match(/^NTLM/i)
+    if res and res.code == 401 and res['WWW-Authenticate'] and res['WWW-Authenticate'].match(/^NTLM/i)
       hash = res['WWW-Authenticate'].split('NTLM ')[1]
       # Parse out the NTLM and just get the Target Information Data
       target = Rex::Proto::NTLM::Message.parse(Rex::Text.decode_base64(hash))[:target_info].value()


### PR DESCRIPTION
In some cases, the server will return a message with a 401 response code that does not include a WWW-Authenticate header. In one observed case, the service (IIS/7.5 per the headers) responded with "401 - Unauthorized: Access is denied due to invalid credentials....You do not have permission to view this directory or page using the credentials that you supplied."

_Note:_ It may be worth reviewing the NTLM Negotiate Message options used by the module to see if there is a way to prevent this type of response. In the meantime, this PR provides a fix to prevent a crash.

**Example before fix**

```
2015-07-28 09:05:11 -0500 S:0 J:0 auxiliary(ntlm_info_enumeration) > run

[-] Auxiliary failed: NoMethodError undefined method `match' for nil:NilClass
[-] Call stack:
[-]   /home/kn0/code/metasploit-framework/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb:108:in `check_url'
[-]   /home/kn0/code/metasploit-framework/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb:54:in `block in run_host'
[-]   /home/kn0/code/metasploit-framework/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb:53:in `each'
[-]   /home/kn0/code/metasploit-framework/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb:53:in `run_host'
[-]   /home/kn0/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:116:in `block (2 levels) in run'
[-]   /home/kn0/code/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `call'
[-]   /home/kn0/code/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
[*] Auxiliary module execution completed
```

**Example after fix**

```
2015-07-28 09:06:43 -0500 S:0 J:0 auxiliary(ntlm_info_enumeration) > run

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
