### PR TITLE
derive major/minor/patch versions from tags or version.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metasploit-framework (4.11.3)
+    metasploit-framework (4.11.4)
       actionpack (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       bcrypt
@@ -20,14 +20,14 @@ PATH
       rubyzip (~> 1.1)
       sqlite3
       tzinfo
-    metasploit-framework-db (4.11.3)
+    metasploit-framework-db (4.11.4)
       activerecord (>= 4.0.9, < 4.1.0)
       metasploit-credential (= 1.0.0)
-      metasploit-framework (= 4.11.3)
+      metasploit-framework (= 4.11.4)
       metasploit_data_models (= 1.2.5)
       pg (>= 0.11)
-    metasploit-framework-pcap (4.11.3)
-      metasploit-framework (= 4.11.3)
+    metasploit-framework-pcap (4.11.4)
+      metasploit-framework (= 4.11.4)
       network_interface (~> 0.0.1)
       pcaprub
 
@@ -104,7 +104,7 @@ GEM
     i18n (0.7.0)
     jsobfu (0.2.1)
       rkelly-remix (= 0.0.6)
-    json (1.8.2)
+    json (1.8.3)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     metasploit-concern (1.0.0)
@@ -138,7 +138,7 @@ GEM
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (4.7.5)
-    msgpack (0.6.0)
+    msgpack (0.6.1)
     multi_json (1.11.1)
     multi_test (0.1.2)
     network_interface (0.0.1)
@@ -198,7 +198,7 @@ GEM
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
-    rubyntlm (0.5.0)
+    rubyntlm (0.5.1)
     rubyzip (1.1.7)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
Currently, we have a hardcoded set of version numbers in metasploit-framework which are, at least in theory, driven by the version numbering of the msf pro releases. These have frequently lagged in updating because it is a manual process (and the pro build actually hacks the version.rb file at build time).

This change causes version.rb to automatically grab the latest release tag from git if it is available and uses it instead to generate the version file. One slightly annoying bit about this change is that folks Gemspec.lock file will wiggle when a new tag version is released, but at least we'll notice that it needs to be updated.

For the purpose of getting the number to bump as well in packaged releases without git, this can also read the version info from a version.yml file, similar to how we were getting the hashes before.
# Verification steps
- [ ] Starting msfconsole from a git checkout of framework, it should have a version tag that matches this output:

```
git tag | grep -e '^[0-9\.]\+[-][0-9]\+$' | tail -n1 | cut -d- -f1
4.11.4
```

```
msfconsole
...
       =[ metasploit v4.11.4-dev-9f49f809                 ]
```
- [ ] dropping a version.yml file into the framework root directory changes everything:
  version.yml:

```

---
major: 5
minor: 6
patch: 7
date: '20150621'
build_framework_rev: 575ccbd
```

```
       =[ metasploit v5.6.7-dev-575ccbd                   ]
```
