### PR TITLE
Minor description fixes

### DIFF
--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -45,6 +45,7 @@ class Metasploit4 < Msf::Post
       ],
       'References' => [
         ['URL', 'https://social.technet.microsoft.com/Forums/windows/en-US/a3968ec9-5824-4bc2-82a2-a37ea88c273a/sticky-keys-exploit'],
+        ['URL', 'http://carnal0wnage.attackresearch.com/2012/04/privilege-escalation-via-sticky-keys.html']
       ],
       'DefaultAction' => 'ADD'
     ))

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -43,6 +43,9 @@ class Metasploit4 < Msf::Post
         ['ADD',    {'Description' => 'Add the backdoor to the target.'}],
         ['REMOVE', {'Description' => 'Remove the backdoor from the target.'}]
       ],
+      'References' => [
+        ['URL', 'https://social.technet.microsoft.com/Forums/windows/en-US/a3968ec9-5824-4bc2-82a2-a37ea88c273a/sticky-keys-exploit'],
+      ],
       'DefaultAction' => 'ADD'
     ))
 

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -25,10 +25,10 @@ class Metasploit4 < Msf::Post
 
         The module options allow for this hack to be applied to:
 
-        - SETHC   - sethc.exe is invoked when SHIFT is pressed 5 times.
-        - UTILMAN - Utilman.exe is invoked by pressing WINDOWS+U.
-        - OSK     - osk.exe is invoked by pressing WINDOWS+U, then launching the on-screen keyboard.
-        - DISP    - DisplaySwitch.exe is invoked by pressing WINDOWS+P.
+        SETHC   (sethc.exe is invoked when SHIFT is pressed 5 times),
+        UTILMAN (Utilman.exe is invoked by pressing WINDOWS+U),
+        OSK     (osk.exe is invoked by pressing WINDOWS+U, then launching the on-screen keyboard), and
+        DISP    (DisplaySwitch.exe is invoked by pressing WINDOWS+P).
 
         The hack can be added using the ADD action, and removed with the REMOVE action.
 


### PR DESCRIPTION
Avoid using bullet lists in module descriptions (I swear I'm going to invent a msftidy.rb rule for this) and add some references to what this module actually is leveraging.

First landed in #5760, from @OJ 
## Validation
- [x] Behold the new rendering of the description and refs for the sticky keys post module:

```
Description:
  This module makes it possible to apply the 'sticky keys' hack to a 
  session with appropriate rights. The hack provides a means to get a 
  SYSTEM shell using UI-level interaction at an RDP login screen or 
  via a UAC confirmation dialog. The module modifies the Debug 
  registry setting for certain executables. The module options allow 
  for this hack to be applied to: SETHC (sethc.exe is invoked when 
  SHIFT is pressed 5 times), UTILMAN (Utilman.exe is invoked by 
  pressing WINDOWS+U), OSK (osk.exe is invoked by pressing WINDOWS+U, 
  then launching the on-screen keyboard), and DISP (DisplaySwitch.exe 
  is invoked by pressing WINDOWS+P). The hack can be added using the 
  ADD action, and removed with the REMOVE action. Custom payloads and 
  binaries can be run as part of this exploit, but must be manually 
  uploaded to the target prior to running the module. By default, a 
  SYSTEM command prompt is installed using the registry method if this 
  module is run without modifying any parameters.

References:
  https://social.technet.microsoft.com/Forums/windows/en-US/a3968ec9-5824-4bc2-82a2-a37ea88c273a/sticky-keys-exploit
  http://carnal0wnage.attackresearch.com/2012/04/privilege-escalation-via-sticky-keys.html

msf > 
```
