### PR TITLE
Feature check wpvdb msftidy

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -191,6 +191,8 @@ class Msftidy
           warn("Invalid US-CERT-VU reference") if value !~ /^\d+$/
         when 'ZDI'
           warn("Invalid ZDI reference") if value !~ /^\d{2}-\d{3}$/
+        when 'WPVDB'
+          warn("Invalid WPVDB reference") if value !~ /^\d+$/
         when 'URL'
           if value =~ /^http:\/\/www\.osvdb\.org/
             warn("Please use 'OSVDB' for '#{value}'")
@@ -204,6 +206,8 @@ class Msftidy
             warn("Please use 'EDB' for '#{value}'")
           elsif value =~ /^http:\/\/www\.kb\.cert\.org\/vuls\/id\//
             warn("Please use 'US-CERT-VU' for '#{value}'")
+          elsif value =~ /^http:\/\/wpvulndb\.com\/vulnerabilities\//
+            warn("Please use 'WPVDB' for '#{value}'")
           end
         end
       end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -206,7 +206,7 @@ class Msftidy
             warn("Please use 'EDB' for '#{value}'")
           elsif value =~ /^http:\/\/www\.kb\.cert\.org\/vuls\/id\//
             warn("Please use 'US-CERT-VU' for '#{value}'")
-          elsif value =~ /^http:\/\/wpvulndb\.com\/vulnerabilities\//
+          elsif value =~ /^https:\/\/wpvulndb\.com\/vulnerabilities\//
             warn("Please use 'WPVDB' for '#{value}'")
           end
         end


### PR DESCRIPTION
This PR suggests include a check on msftidy tool to include WPVDB when used in references.

```
$ tools/msftidy.rb ../wpsploit/modules/auxiliary/scanner/http/wordpress/wp_example.rb
../wpsploit/modules/auxiliary/scanner/http/wordpress/wp_example.rb - [WARNING] Please use 'WPVDB' for 'https://wpvulndb.com/vulnerabilities/8090'
$ nano ../wpsploit/modules/auxiliary/scanner/http/wordpress/wp_example.rb
$ tools/msftidy.rb ../wpsploit/modules/auxiliary/scanner/http/wordpress/wp_example.rb
../wpsploit/modules/auxiliary/scanner/http/wordpress/wp_example.rb - [WARNING] Invalid WPVDB reference
$
```

[]'s
