### PR TITLE
altered module to default to replace RHOST with VHOST if it is defined.

### DIFF
--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Auxiliary
     if rport == 443 or ssl
       proto = "https"
     end
-    "#{proto}://#{rhost}:#{rport}#{@uri.to_s}"
+    "#{proto}://#{vhost}:#{rport}#{@uri.to_s}"
   end
 
   def run_host(ip)


### PR DESCRIPTION
# Verification Steps

```
VHOST: ms-w03-3u-1.ms.scanlab.rapid7.com
RHOST:10.20.36.79
```
- [ ] load the topic branch for this ticket on your metasploit-framework
- [ ] start foreman
- [ ] create a workspace with network range: `10.6.0.1-254`
- [ ] Select the http_login scanner
- [ ] enter '10.20.36.79' into the target addresses list.
- [ ] click 'run module'
- [ ] verify that the second line of the task log reads 'http://10.20.36.79:80 No URI found that asks for HTTP authentication"
- [ ] Select the http_login scanner again.
- [ ] enter '10.20.36.79'  into the target addresses list.
- [ ] enter webtarget1.ms.scanlab.rapid7.com  into the VHOST field.
- [ ] click 'run module' again.
- [ ] verify that the second line of the task log reads 'http://webtarget1.ms.scanlab.rapid7.com:80 No URI found that asks for HTTP authentication"

MSP-11167
