### PR TITLE
Fix a small typo in mswin_tiff_overflow

### DIFF
--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -789,7 +789,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   #
-  # Loads a fiile
+  # Loads a file
   #
   def read_file(fname)
     buf = ''


### PR DESCRIPTION
Fixed a "fiile" -> "file" in module mswin_tiff_overflow
