### PR TITLE
Fix a small typo - OSVDB instead of OSVBD.

### DIFF
--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           ['EDB', '34449'],
-          ['OSVBD', '110522'],
+          ['OSVDB', '110522'],
           ['CVE', '2014-5377']
         ],
       'DisclosureDate' => 'Aug 28 2014'))


### PR DESCRIPTION
Fix a small typo in manageengine_deviceexpert_user_creds module.
OSVDB instead of OSVBD.

[]'s
