### PR TITLE
Fix Post WMIC issues with SYSTEM

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -8,6 +8,7 @@ module Msf::Post::Windows::Priv
   include Msf::Post::Windows::Registry
 
   INTEGRITY_LEVEL_SID = {
+      :untrusted => 'S-1-16-4096',
       :low => 'S-1-16-4096',
       :medium => 'S-1-16-8192',
       :high => 'S-1-16-12288',
@@ -145,6 +146,14 @@ module Msf::Post::Windows::Priv
         end
       end
     end
+  end
+
+  #
+  # Returns true if in a high integrity, or system, service
+  #
+  def is_high_integrity?
+    il = get_integrity_level
+    (il == INTEGRITY_LEVEL_SID[:high] || il == INTEGRITY_LEVEL_SIDE[:system])
   end
 
   #

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -8,7 +8,6 @@ module Msf::Post::Windows::Priv
   include Msf::Post::Windows::Registry
 
   INTEGRITY_LEVEL_SID = {
-      :untrusted => 'S-1-16-4096',
       :low => 'S-1-16-4096',
       :medium => 'S-1-16-8192',
       :high => 'S-1-16-12288',

--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -7,6 +7,7 @@ module Windows
 module WMIC
 
   include Msf::Post::File
+  include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ExtAPI
 
   def initialize(info = {})
@@ -32,13 +33,13 @@ module WMIC
       end
     end
 
-    if extapi
+    if extapi && !is_system?
       session.extapi.clipboard.set_text("")
       wcmd = "wmic #{wmic_user_pass_string}/output:CLIPBOARD /INTERACTIVE:off /node:#{server} #{query}"
     else
-      tmp = session.fs.file.expand_path("%TEMP%")
+      tmp = get_env('TEMP')
       out_file = "#{tmp}\\#{Rex::Text.rand_text_alpha(8)}"
-      wcmd = "wmic #{wmic_user_pass_string}/output:#{out_file} /INTERACTIVE:off /node:#{server} #{query}"
+      wcmd = "cmd.exe /c %SYSTEMROOT%\\system32\\wbem\\wmic.exe #{wmic_user_pass_string}/output:#{out_file} /INTERACTIVE:off /node:#{server} #{query}"
     end
 
     vprint_status("[#{server}] #{wcmd}")
@@ -48,9 +49,9 @@ module WMIC
     session.railgun.kernel32.WaitForSingleObject(ps.handle, (datastore['TIMEOUT'] * 1000))
     ps.close
 
-    if extapi
+    if extapi && !is_system?
       result = session.extapi.clipboard.get_data.first
-      if result[1].has_key? 'Text'
+      if result && result[1] && result[1].has_key?('Text')
         result_text = result[1]['Text']
       else
         result_text = ""

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -11,7 +11,6 @@ class Metasploit3 < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
-  include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
   include Msf::Post::Windows::Registry
   include Msf::Exploit::EXE
@@ -66,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Local
       return
     end
 
-    if is_uac_enabled?
+    unless is_high_integrity?
       print_error("This module requires UAC to be bypassed first")
       return
     end

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -46,7 +46,6 @@ class Metasploit3 < Msf::Exploit::Local
         OptBool.new('SCHTASK', [ true, 'Create a Scheduled Task for the EXE.', false]),
         OptBool.new('RUNKEY', [ true, 'Create AutoRun Key for the EXE', false]),
         OptInt.new('DELAY', [ true, 'Delay in Minutes for Reconnect attempt. Needs SCHTASK set to true to work. Default delay is 1 minute.', 1]),
-        OptInt.new('WMIC_WRITE_TIMEOUT', [ true, 'Timeout in seconds to allow the wmic process to flush output', 5]),
         OptString.new('RPATH', [ false, 'Path on remote system to place Executable. Example: \\\\Windows\\\\Temp (DO NOT USE C:\\ in your RPATH!)', ]),
       ], self.class)
 
@@ -193,53 +192,6 @@ class Metasploit3 < Msf::Exploit::Local
     clean_rc = clean_data()
     file_local_write(clean_rc, @clean_up)
     print_status("Cleanup Meterpreter RC File: #{clean_rc}")
-  end
-
-  #
-  # Execute a WMIC command
-  #
-  def wmic_query(wmic_cmd)
-    tmp_out = ''
-    old_timeout = session.response_timeout
-    session.response_timeout = 120
-    begin
-      tmp = expand_path('%TEMP%')
-      wmi_cfl = tmp + "\\" + sprintf('%.5d', rand(100000))
-      r = session.sys.process.execute("cmd.exe /c %SYSTEMROOT%\\system32\\wbem\\wmic.exe /append:#{wmi_cfl} #{wmic_cmd}", nil, {'Hidden' => true})
-      Rex.sleep(2)
-
-      # Making sure that wmic finishes before executing next wmic command
-      found = 0
-      while found == 0
-        session.sys.process.get_processes.each do |x|
-          found =1
-          if 'wmic.exe' == x['name'].downcase
-            Rex.sleep(0.5)
-            found = 0
-          end
-        end
-      end
-      r.close
-
-      # Give the process time to flush the output
-      Rex.sleep(datastore['WMIC_WRITE_TIMEOUT'])
-
-      # Read the output file of the wmic commands
-      wmi_out_file = session.fs.file.new(wmi_cfl, 'rb')
-      until wmi_out_file.eof?
-        tmp_out << wmi_out_file.read
-      end
-      wmi_out_file.close
-    rescue ::Exception => e
-      print_error("Error running WMIC commands: #{e.class} #{e}")
-    end
-    # We delete the file with the wmic command output.
-    c = session.sys.process.execute("cmd.exe /c del #{wmi_cfl}", nil, {'Hidden' => true})
-    c.close
-    tmp_out.gsub!(/[^[:print:]]/,'') #scrub out garbage
-
-    session.response_timeout = old_timeout
-    tmp_out
   end
 
 end


### PR DESCRIPTION
This is a proper fix for #4558 and reverts #5777.

The VSS Persistence module was calling `is_uac_enabled?` This only returns false if UAC is disabled in the registry, or if the process `is_system?`. It doesn't actually check if the process is high integrity and should not be used for that purpose. 

As such, the VSS Persistence module only ran with `SYSTEM` privs. However it only needs to be run as a normal administrative user (in high integrity).

I have added a `is_high_integrity?` check to Privs which is better suited to this...

Running as a SYSTEM user causes the WMIC library some issues, I don't think `SYSTEM` has a clipboard... So we fall back to the file read/write mechanism for this. SYSTEM doesn't like running `wmic` on its own, so I have specified a fuller path via `cmd.exe` to make it more robust.
