### PR TITLE
Added Feature to Add Color Background (Prompt)

### DIFF
--- a/lib/rex/ui/text/color.rb
+++ b/lib/rex/ui/text/color.rb
@@ -75,6 +75,15 @@ module Color
     str.gsub!(/%und/, pre_color+colorize('underline')+post_color)
     str.gsub!(/%bld/, pre_color+colorize('bold')+post_color)
     str.gsub!(/%clr/, pre_color+colorize('clear')+post_color)
+    # Background Color
+    str.gsub!(/%bgblu/, pre_color+colorize('on_blue')+post_color)
+    str.gsub!(/%bgyel/, pre_color+colorize('on_yellow')+post_color)
+    str.gsub!(/%bggrn/, pre_color+colorize('on_green')+post_color)
+    str.gsub!(/%bgmag/, pre_color+colorize('on_magenta')+post_color)
+    str.gsub!(/%bgblk/, pre_color+colorize('on_black')+post_color)
+    str.gsub!(/%bgred/, pre_color+colorize('on_red')+post_color)
+    str.gsub!(/%bgcyn/, pre_color+colorize('on_cyan')+post_color)
+    str.gsub!(/%bgwhi/, pre_color+colorize('on_white')+post_color)
 
     str
   end


### PR DESCRIPTION
This pull request suggests putting color into background of the prompt.

Before:
![screenhunter_66 aug 01 18 45](https://cloud.githubusercontent.com/assets/1926764/9023762/369ef888-3880-11e5-9c23-84e474d1f9bf.jpg)

After:
![screenhunter_67 aug 01 18 52](https://cloud.githubusercontent.com/assets/1926764/9023763/3de69592-3880-11e5-96f9-646a2261d2a8.jpg)

Another:
![screenhunter_68 aug 01 19 16](https://cloud.githubusercontent.com/assets/1926764/9023794/f3f52820-3881-11e5-87b6-b4dc2bc0ec6b.jpg)

Original idea here:
https://gist.github.com/dtrip/45bf09be328aa8995aac

I don't know if I would use like a rainbow hahaha. But it's nice to know that there is this option. :P  

[]'s
