### PR TITLE
Add new http banner module.

### DIFF
--- a/modules/auxiliary/scanner/http/http_banner.rb
+++ b/modules/auxiliary/scanner/http/http_banner.rb
@@ -9,6 +9,7 @@ class Metasploit3 < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
 
   def initialize(info={})
     super(update_info(info,
@@ -48,10 +49,10 @@ class Metasploit3 < Msf::Auxiliary
       unless banner.nil?
         print_good "Found: #{banner}"
         report_service(
-          :host => ip,
-          :port => rport,
-          :name => "http",
-          :info => "#{banner}"
+          host: ip,
+          port: rport,
+          name: "http",
+          info: "#{banner}"
         )
       end
     end

--- a/modules/auxiliary/scanner/http/http_banner.rb
+++ b/modules/auxiliary/scanner/http/http_banner.rb
@@ -1,0 +1,63 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'HTTP Banner Detection',
+      'Description' => %q{ This module shows HTTP Banner returned by webserver. If you have loaded a database 
+plugin and connected to a database this module will record the info so you can list all banners. },
+      'Author'      =>  'Manuel Mancera (sinkmanu)',
+      'References'  =>
+      [
+        ['URL', 'http://tools.ietf.org/html/rfc4229']
+      ],
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options([
+	  OptString.new('METHOD', [ true, 'HTTP Method to use', 'GET']),
+	  OptString.new('PROTOCOL', [ false, 'Protocol to use', 'HTTP']),
+      	  OptString.new('TARGETURI', [ true, 'The URI to use', '/']),
+	  OptInt.new('TIMEOUT', [ false, "The timeout waiting for the server response", 10])
+    ])
+  end
+
+  def timeout
+  	datastore['TIMEOUT']
+  end
+
+  def run_host(ip)
+	print_status "Trying #{peer}"
+	uri = normalize_uri(target_uri.path)
+	method = datastore['METHOD']
+	proto = datastore['PROTOCOL']
+
+	res = send_request_raw({
+    	'method'  => method,
+      	'uri'     => uri,
+	'proto'   => proto
+    }, timeout)
+
+    if res
+		banner = res.headers['Server']
+		if !banner.nil? 
+			print_good "Found: #{banner}"
+			report_service(
+    			:host => ip,
+    			:port => rport,
+        		:name => "http",
+          		:info => "#{banner}"
+        	)
+		end
+	end
+  end
+end

--- a/modules/auxiliary/scanner/http/http_banner.rb
+++ b/modules/auxiliary/scanner/http/http_banner.rb
@@ -23,10 +23,9 @@ class Metasploit3 < Msf::Auxiliary
     ))
 
     register_options([
-      OptString.new('METHOD', [ true, 'HTTP Method to use', 'GET']),
+      OptString.new('HTTP_METHOD', [ true, 'HTTP Method to use', 'GET']),
       OptString.new('PROTOCOL', [ false, 'Protocol to use', 'HTTP']),
-      OptString.new('TARGETURI', [ true, 'The URI to use', '/']),
-      OptInt.new('TIMEOUT', [ false, "The timeout waiting for the server response", 10])
+      OptString.new('TARGETURI', [ true, 'The URI to use', '/'])
     ])
   end
 
@@ -37,18 +36,16 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(ip)
     print_status "Trying #{peer}"
     uri = normalize_uri(target_uri.path)
-    method = datastore['METHOD']
-    proto = datastore['PROTOCOL']
 
     res = send_request_raw({
-      'method'  => method,
+      'method'  => datastore['HTTP_METHOD'],
       'uri'     => uri,
-      'proto'   => proto
-    }, timeout)
+      'proto'   => datastore['PROTOCOL']
+    })
 
     if res
       banner = res.headers['Server']
-      if !banner.nil?
+      unless banner.nil?
         print_good "Found: #{banner}"
         report_service(
           :host => ip,

--- a/modules/auxiliary/scanner/http/http_banner.rb
+++ b/modules/auxiliary/scanner/http/http_banner.rb
@@ -13,8 +13,7 @@ class Metasploit3 < Msf::Auxiliary
   def initialize(info={})
     super(update_info(info,
       'Name'        => 'HTTP Banner Detection',
-      'Description' => %q{ This module shows HTTP Banner returned by webserver. If you have loaded a database 
-plugin and connected to a database this module will record the info so you can list all banners. },
+      'Description' => %q{ This module shows HTTP Banner returned by webserver. If you have loaded a database plugin and connected to a database this module will record the info so you can list all banners. },
       'Author'      =>  'Manuel Mancera (sinkmanu)',
       'References'  =>
       [
@@ -24,40 +23,40 @@ plugin and connected to a database this module will record the info so you can l
     ))
 
     register_options([
-	  OptString.new('METHOD', [ true, 'HTTP Method to use', 'GET']),
-	  OptString.new('PROTOCOL', [ false, 'Protocol to use', 'HTTP']),
-      	  OptString.new('TARGETURI', [ true, 'The URI to use', '/']),
-	  OptInt.new('TIMEOUT', [ false, "The timeout waiting for the server response", 10])
+      OptString.new('METHOD', [ true, 'HTTP Method to use', 'GET']),
+      OptString.new('PROTOCOL', [ false, 'Protocol to use', 'HTTP']),
+      OptString.new('TARGETURI', [ true, 'The URI to use', '/']),
+      OptInt.new('TIMEOUT', [ false, "The timeout waiting for the server response", 10])
     ])
   end
 
   def timeout
-  	datastore['TIMEOUT']
+    datastore['TIMEOUT']
   end
 
   def run_host(ip)
-	print_status "Trying #{peer}"
-	uri = normalize_uri(target_uri.path)
-	method = datastore['METHOD']
-	proto = datastore['PROTOCOL']
+    print_status "Trying #{peer}"
+    uri = normalize_uri(target_uri.path)
+    method = datastore['METHOD']
+    proto = datastore['PROTOCOL']
 
-	res = send_request_raw({
-    	'method'  => method,
-      	'uri'     => uri,
-	'proto'   => proto
+    res = send_request_raw({
+      'method'  => method,
+      'uri'     => uri,
+      'proto'   => proto
     }, timeout)
 
     if res
-		banner = res.headers['Server']
-		if !banner.nil? 
-			print_good "Found: #{banner}"
-			report_service(
-    			:host => ip,
-    			:port => rport,
-        		:name => "http",
-          		:info => "#{banner}"
-        	)
-		end
-	end
+      banner = res.headers['Server']
+      if !banner.nil? 
+        print_good "Found: #{banner}"
+        report_service(
+          :host => ip,
+          :port => rport,
+          :name => "http",
+          :info => "#{banner}"
+        )
+      end
+    end
   end
 end

--- a/modules/auxiliary/scanner/http/http_banner.rb
+++ b/modules/auxiliary/scanner/http/http_banner.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if res
       banner = res.headers['Server']
-      if !banner.nil? 
+      if !banner.nil?
         print_good "Found: #{banner}"
         report_service(
           :host => ip,


### PR DESCRIPTION
It is useful to get a list of banners and save it in the database. Some IPS could block the normal HTTP traffic, but if We make a bad HTTP request (FOO method) for example we can avoid the IPS and obtain the banner (e.g)
