### PR TITLE
Fix calls to stage_payload

### DIFF
--- a/lib/msf/core/payload/generic.rb
+++ b/lib/msf/core/payload/generic.rb
@@ -20,23 +20,13 @@ module Payload::Generic
   def initialize(info = {})
     super(merge_info(info,
       'Arch'     => ARCH_ALL - [ARCH_TTY],
-      'Platform' => ''))
+      'Platform' => ''
+    ))
 
-    register_advanced_options(
-      [
-        OptString.new('PLATFORM',
-          [
-            false,
-            "The platform that is being targeted",
-            nil
-          ]),
-        OptString.new('ARCH',
-          [
-            false,
-            "The architecture that is being targeted",
-            nil
-          ])
-      ], Msf::Payload::Generic)
+    register_advanced_options([
+      OptString.new('PLATFORM', [false, "The platform that is being targeted", nil]),
+      OptString.new('ARCH', [false, "The architecture that is being targeted", nil])
+    ], Msf::Payload::Generic)
   end
 
   #
@@ -103,8 +93,8 @@ module Payload::Generic
   # Stager overrides
   #
 
-  def stage_payload
-    redirect_to_actual(:stage_payload)
+  def stage_payload(*args)
+    redirect_to_actual(:stage_payload, *args)
   end
 
   def stage_offsets

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -88,7 +88,7 @@ module Msf::Payload::Stager
   # Can be nil if the final stage is not pre-assembled.
   #
   # @return [String,nil]
-  def stage_payload
+  def stage_payload(opts = {})
     return module_info['Stage']['Payload']
   end
 

--- a/lib/msf/core/payload/windows/reflectivedllinject.rb
+++ b/lib/msf/core/payload/windows/reflectivedllinject.rb
@@ -70,7 +70,7 @@ module Payload::Windows::ReflectiveDllInject
     ^
   end
 
-  def stage_payload
+  def stage_payload(opts = {})
     # Exceptions will be thrown by the mixin if there are issues.
     dll, offset = load_rdi_dll(library_path)
 

--- a/lib/msf/core/payload/windows/x64/reflectivedllinject.rb
+++ b/lib/msf/core/payload/windows/x64/reflectivedllinject.rb
@@ -71,7 +71,7 @@ module Payload::Windows::ReflectiveDllInject_x64
     ^
   end
 
-  def stage_payload
+  def stage_payload(opts = {})
     # Exceptions will be thrown by the mixin if there are issues.
     dll, offset = load_rdi_dll(library_path)
 


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/issues/5818 was submitted by @enigma0x3 indicating that we had some issues with the DLL injection payload. This commit fixes _half_ of it. It simple fixes up the calls to `stage_payload` that weren't updated to include the options.

Thought this fixes up the calls, it doesn't fix the issue that the generated DLLs don't seem to have exports!

![met-dll](https://cloud.githubusercontent.com/assets/28896/9157499/6fc4a508-3f43-11e5-9d3c-188e1c8488fa.png)

I haven't looked into why this is the case just yet as I'm really stuck for time. Promise I'll take a look into it when I get the chance.

This PR changes the error from:

```
[-] [2015.08.10-09:21:47] Exception handling request: wrong number of arguments (1 for 0)
```

to

```
[-] [2015.08.10-09:31:22] Exception handling request: undefined method `entries' for nil:NilClass
```

http://www.youtube.com/watch?v=dEYgG7qOhXQ
