### PR TITLE
DispatcherShell: Ensure exceptions don't interfere with busy state

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -426,6 +426,7 @@ module DispatcherShell
     else
       dispatcher.send('cmd_' + method, *arguments)
     end
+  ensure
     self.busy = false
   end
 


### PR DESCRIPTION
I have been working with the Meterpreter shell via the remote API (`console.write` and `.read` methods) and encountered a bug where issuing a command that raised an exception (e.g., `mv invalid_file.txt new_file.txt`) would yield the expected response when reading the console, but left the `busy` variable `true`.

All this does is `ensure` that `busy` is set to `false` after the command has been handled.
