### PR TITLE
Fix #5659: Update CMD exploits payload compatibility options

### DIFF
--- a/modules/exploits/linux/http/accellion_fta_getstatus_oauth.rb
+++ b/modules/exploits/linux/http/accellion_fta_getstatus_oauth.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl bash telnet',
+              'RequiredCmd' => 'generic perl telnet',
             }
         },
       'Targets'        =>

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic telnet python perl bash gawk netcat netcat-e ruby php openssl',
+              'RequiredCmd' => 'generic telnet python perl gawk netcat netcat-e ruby php openssl',
             }
         },
       'Targets'        =>

--- a/modules/exploits/linux/http/kloxo_sqli.rb
+++ b/modules/exploits/linux/http/kloxo_sqli.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl python gawk bash-tcp netcat'
+              'RequiredCmd' => 'generic perl python gawk netcat'
             }
         },
       'Targets'        =>

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic telnet python perl bash',
+              'RequiredCmd' => 'generic telnet python perl',
             }
         },
       'Targets'        =>

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -38,7 +38,7 @@ class Metasploit4 < Msf::Exploit::Remote
                         'DisableNops' => true,
                         'Compat' => {
                           'PayloadType' => 'cmd',
-                          'RequiredCmd' => 'generic netcat perl ruby python bash telnet'
+                          'RequiredCmd' => 'generic netcat perl ruby python telnet'
                         }
                       },
                       'Platform' => %w(                      unix                      ),

--- a/modules/exploits/linux/http/symantec_web_gateway_pbcontrol.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_pbcontrol.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl bash telnet'
+              'RequiredCmd' => 'generic perl telnet'
             }
         },
       'Platform'       => ['unix'],

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic netcat netcat-e perl bash',
+              'RequiredCmd' => 'generic netcat netcat-e perl',
             }
         },
       'Targets'        =>

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Compat'	=>
         {
           'PayloadType' => 'cmd',
-          'RequiredCmd' => 'generic python perl bash',
+          'RequiredCmd' => 'generic python perl',
         },
       'Targets'        =>
         [

--- a/modules/exploits/linux/misc/accellion_fta_mpipe2.rb
+++ b/modules/exploits/linux/misc/accellion_fta_mpipe2.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet',
+              'RequiredCmd' => 'generic perl ruby telnet',
             }
         },
       'Targets'        =>

--- a/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
+++ b/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'perl python ruby bash telnet',
+              'RequiredCmd' => 'perl python ruby telnet',
               # *_perl, *_python and *_ruby work if they are installed
             }
         },

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'ConnectionType' => 'find',
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet'
+              'RequiredCmd' => 'generic perl ruby python telnet'
             }
         },
       'Platform'       => %w{ bsd linux osx unix win },

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -41,7 +41,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Compat' =>
         {
           'PayloadType' => 'cmd',
-          'RequiredCmd' => 'generic bash awk ruby'
+          'RequiredCmd' => 'generic awk ruby'
         },
       # Tested:
       # - CUPS version 1.4.3 on Ubuntu 10.04 (x86)

--- a/modules/exploits/multi/http/git_client_command_exec.rb
+++ b/modules/exploits/multi/http/git_client_command_exec.rb
@@ -69,7 +69,7 @@ class Metasploit4 < Msf::Exploit::Remote
                   'Compat'      =>
                     {
                       'PayloadType' => 'cmd cmd_bash',
-                      'RequiredCmd' => 'generic bash-tcp perl bash'
+                      'RequiredCmd' => 'generic bash-tcp perl'
                     }
                 }
             }

--- a/modules/exploits/multi/http/moodle_cmd_exec.rb
+++ b/modules/exploits/multi/http/moodle_cmd_exec.rb
@@ -44,7 +44,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Compat'     =>
       {
         'PayloadType'  => 'cmd',
-        'RequiredCmd'  => 'generic perl ruby bash telnet python',
+        'RequiredCmd'  => 'generic perl ruby telnet python',
       }
     },
     'Platform'       => ['unix', 'linux'],

--- a/modules/exploits/multi/http/openmediavault_cmd_exec.rb
+++ b/modules/exploits/multi/http/openmediavault_cmd_exec.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'Compat'     =>
         {
           'PayloadType'  => 'cmd',
-          'RequiredCmd'  => 'generic perl ruby bash telnet python',
+          'RequiredCmd'  => 'generic perl ruby telnet python',
         }
       },
       'Platform'       => ['unix', 'linux'],

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           {
             'ConnectionType' => 'find',
             'PayloadType'    => 'cmd',
-            'RequiredCmd'    => 'generic perl ruby bash telnet python'
+            'RequiredCmd'    => 'generic perl ruby telnet python'
           }
         },
       'Platform'       => %w{ linux unix },

--- a/modules/exploits/multi/http/snortreport_exec.rb
+++ b/modules/exploits/multi/http/snortreport_exec.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'Compat'     =>
         {
           'PayloadType'  => 'cmd',
-          'RequiredCmd'  => 'generic perl ruby bash telnet python',
+          'RequiredCmd'  => 'generic perl ruby telnet python',
         }
       },
       'Platform'       => %w{ linux unix },

--- a/modules/exploits/multi/http/zabbix_script_exec.rb
+++ b/modules/exploits/multi/http/zabbix_script_exec.rb
@@ -35,7 +35,7 @@ class Metasploit4 < Msf::Exploit::Remote
         'Compat'     =>
         {
           'PayloadType'  => 'cmd',
-          'RequiredCmd'  => 'generic perl ruby bash telnet python',
+          'RequiredCmd'  => 'generic perl ruby telnet python',
         }
       },
       'Platform'       => ['unix', 'linux'],

--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'   =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet bash'
+              'RequiredCmd' => 'generic perl telnet'
             }
         },
       'DefaultOptions'  =>

--- a/modules/exploits/osx/browser/software_update.rb
+++ b/modules/exploits/osx/browser/software_update.rb
@@ -33,8 +33,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby bash telnet bash-tcp',
             }
         },
       'Platform'	=> 'osx',

--- a/modules/exploits/osx/email/mailapp_image_exec.rb
+++ b/modules/exploits/osx/email/mailapp_image_exec.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'Platform'       => 'unix',
               'Arch'           => ARCH_CMD,
               'PayloadCompat' => {
-                'RequiredCmd'    => 'generic perl ruby bash telnet',
+                'RequiredCmd'    => 'generic perl ruby bash-tcp telnet',
               }
             }
           ],

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic bash telnet ruby',
+              'RequiredCmd' => 'generic telnet ruby',
             }
         },
       'Targets'        => [ [ 'Automatic Target', { }] ],

--- a/modules/exploits/unix/ftp/proftpd_modcopy_exec.rb
+++ b/modules/exploits/unix/ftp/proftpd_modcopy_exec.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic gawk bash python perl'
+              'RequiredCmd' => 'generic gawk python perl'
             }
         },
       'Targets'        =>

--- a/modules/exploits/unix/http/ctek_skyrouter.rb
+++ b/modules/exploits/unix/http/ctek_skyrouter.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet netcat netcat-e bash',
+              'RequiredCmd' => 'generic perl telnet netcat netcat-e',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet',
+              'RequiredCmd' => 'generic perl ruby telnet',
             }
         },
       'Targets'        =>

--- a/modules/exploits/unix/misc/distcc_exec.rb
+++ b/modules/exploits/unix/misc/distcc_exec.rb
@@ -38,8 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet openssl',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby bash telnet openssl bash-tcp',
             }
         },
       'Targets'        =>

--- a/modules/exploits/unix/misc/spamassassin_exec.rb
+++ b/modules/exploits/unix/misc/spamassassin_exec.rb
@@ -34,8 +34,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/smtp/clamav_milter_blackhole.rb
+++ b/modules/exploits/unix/smtp/clamav_milter_blackhole.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/smtp/exim4_string_format.rb
+++ b/modules/exploits/unix/smtp/exim4_string_format.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet',
+              'RequiredCmd' => 'generic perl ruby telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/awstats_configdir_exec.rb
+++ b/modules/exploits/unix/webapp/awstats_configdir_exec.rb
@@ -36,8 +36,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 512,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python telnet bash-tcp',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/awstats_migrate_exec.rb
+++ b/modules/exploits/unix/webapp/awstats_migrate_exec.rb
@@ -39,8 +39,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 512,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/awstatstotals_multisort.rb
+++ b/modules/exploits/unix/webapp/awstatstotals_multisort.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 512,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/barracuda_img_exec.rb
+++ b/modules/exploits/unix/webapp/barracuda_img_exec.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 4000,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/basilic_diff_exec.rb
+++ b/modules/exploits/unix/webapp/basilic_diff_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet'
+              'RequiredCmd' => 'generic perl ruby python telnet'
             }
         },
       'Targets'        =>

--- a/modules/exploits/unix/webapp/cacti_graphimage_exec.rb
+++ b/modules/exploits/unix/webapp/cacti_graphimage_exec.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'RequiredCmd' => 'generic perl ruby python telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/dogfood_spell_exec.rb
+++ b/modules/exploits/unix/webapp/dogfood_spell_exec.rb
@@ -41,8 +41,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'    => %q|'"`|,  # quotes are escaped by PHP's magic_quotes_gpc in a default install
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Targets'        => [ ['Automatic', { }], ],

--- a/modules/exploits/unix/webapp/foswiki_maketext.rb
+++ b/modules/exploits/unix/webapp/foswiki_maketext.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic ruby python bash telnet'
+              'RequiredCmd' => 'generic ruby python telnet'
             }
         },
       'Platform'       => [ 'unix' ],

--- a/modules/exploits/unix/webapp/generic_exec.rb
+++ b/modules/exploits/unix/webapp/generic_exec.rb
@@ -30,8 +30,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl telnet netcat netcat-e bash',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl telnet netcat netcat-e bash-tcp',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -37,8 +37,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 4000,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl bash telnet netcat netcat-e',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl bash-tcp telnet netcat netcat-e',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
+++ b/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
@@ -39,8 +39,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Platform'       => %w{ linux unix win },

--- a/modules/exploits/unix/webapp/mitel_awc_exec.rb
+++ b/modules/exploits/unix/webapp/mitel_awc_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'RequiredCmd' => 'generic perl ruby python telnet',
             }
         },
       'Targets'        => [ ['Automatic', { }], ],

--- a/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
+++ b/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'    => '<>',
           'Compat'      =>
             {
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Targets'        =>

--- a/modules/exploits/unix/webapp/nagios_graph_explorer.rb
+++ b/modules/exploits/unix/webapp/nagios_graph_explorer.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl python ruby bash telnet',
+              'RequiredCmd' => 'generic perl python ruby telnet',
             }
         },
       'Platform'       => ['unix'],

--- a/modules/exploits/unix/webapp/narcissus_backend_exec.rb
+++ b/modules/exploits/unix/webapp/narcissus_backend_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Compat'         =>
         {
           'PayloadType' => 'cmd',
-          'RequiredCmd' => 'generic perl ruby python bash netcat netcat-e'
+          'RequiredCmd' => 'generic perl ruby python netcat netcat-e'
         },
       'Targets'        =>
         [

--- a/modules/exploits/unix/webapp/opensis_modname_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_modname_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'        =>
             {
             'PayloadType' => 'cmd',
-            'RequiredCmd' => 'generic telnet bash netcat netcat-e perl ruby python',
+            'RequiredCmd' => 'generic telnet netcat netcat-e perl ruby python',
             }
         },
       'DefaultOptions'    =>

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
             'PayloadType' => 'cmd',
-            'RequiredCmd' => 'generic telnet bash netcat netcat-e perl ruby python',
+            'RequiredCmd' => 'generic telnet netcat netcat-e perl ruby python',
             }
         },
       'DefaultOptions'  =>

--- a/modules/exploits/unix/webapp/phpbb_highlight.rb
+++ b/modules/exploits/unix/webapp/phpbb_highlight.rb
@@ -41,8 +41,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/qtss_parse_xml_exec.rb
+++ b/modules/exploits/unix/webapp/qtss_parse_xml_exec.rb
@@ -34,8 +34,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 512,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/skybluecanvas_exec.rb
+++ b/modules/exploits/unix/webapp/skybluecanvas_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'ConnectionType' => 'find',
               'PayloadType'    => 'cmd',
-              'RequiredCmd'    => 'generic perl ruby bash telnet python'
+              'RequiredCmd'    => 'generic perl ruby telnet python'
             }
         },
       'Platform'       => %w{ unix },

--- a/modules/exploits/unix/webapp/squirrelmail_pgp_plugin.rb
+++ b/modules/exploits/unix/webapp/squirrelmail_pgp_plugin.rb
@@ -46,8 +46,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'    => '',
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Targets'        =>

--- a/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
@@ -38,8 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic perl ruby python bash-tcp telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/twiki_maketext.rb
+++ b/modules/exploits/unix/webapp/twiki_maketext.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic ruby python bash telnet'
+              'RequiredCmd' => 'generic ruby python telnet'
             }
         },
       'Platform'       => [ 'unix' ],

--- a/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'PayloadType' => 'cmd',
               # Based on vicibox availability of binaries
-              'RequiredCmd' => 'generic perl python awk bash telnet nc openssl',
+              'RequiredCmd' => 'generic perl python awk telnet nc openssl',
             }
         },
       'Targets'        =>

--- a/modules/exploits/unix/webapp/webmin_show_cgi_exec.rb
+++ b/modules/exploits/unix/webapp/webmin_show_cgi_exec.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl ruby python bash telnet',
+              'RequiredCmd' => 'generic perl ruby python telnet',
             }
         },
       'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic telnet python perl bash',
+              'RequiredCmd' => 'generic telnet python perl',
             },
         },
       'Targets'        =>


### PR DESCRIPTION
As #5659 points, some ARCH_CMD exploits are using incorrectly the compatiblity payload options "PayloadType" and "RequiredCmd". 

As #5659 describes there is a a lot of confusion about using "bash" as "RequiredCmd". Basically after https://github.com/rapid7/metasploit-framework/commit/e70ac6cc198787c9e79e15d3e31b60113ea6de2c (2009, maybe before), using "RequiredCmd" as "bash" hasn't sense anymore. Instead "PayloadType" as "cmd_bash" and "RequiredCmd" as "bash-tcp" should be used.

Basically this PR updates exploits to

a) For exploits after https://github.com/rapid7/metasploit-framework/commit/e70ac6cc198787c9e79e15d3e31b60113ea6de2c using "bash as "RequiredCmd" it is just deleted. Because obviously it wasn't even tested. Indeed the reverse_bash payload wasn't available even when listing the compatible payloads.
b) For exploits before https://github.com/rapid7/metasploit-framework/commit/e70ac6cc198787c9e79e15d3e31b60113ea6de2c using "bash as "RequiredCmd" the metadata is updated to use "PayloadType" as "cmd_bash" and "RequiredCmd" as "bash-tcp", so the cmd/unix/reverse_bash payload is available again when autocompleting.

Verification
- [x] Use any of the modified exploits.
- [x] For exploits where the "bash" as "RequiredCmd" has been deleted, nothing should change. If you select the "unix" target (when necessary) and try "set payload cmd/unix/[tab]" the autocomplete should list the same list as before.
- [x] For exploits where the metadata has been update, if you select the "unix" target and try "set payload cmd/unix/[tab]" the autocomplete should list the "reverse_bash" payload.
