### PR TITLE
use EXITFUNC instead of ExitFunction

### DIFF
--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Payload'        =>
         {

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Payload'        =>
         {

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Payload'        =>
         {

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'ExitFunction' => 'none'
+          'EXITFUNC' => 'none'
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => 'none'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'WfsDelay' => 300,  #5 minutes
           'DisablePayloadHandler' => 'false',
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'WfsDelay' => 300,  #5 minutes
           'DisablePayloadHandler' => 'false',
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'WfsDelay' => 300,  #5 minutes
           'DisablePayloadHandler' => 'false',
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'none'
+          'EXITFUNC' => 'none'
         },
       'Targets'        =>
         [

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'none'
+          'EXITFUNC' => 'thread'
         },
       'Targets'        =>
         [

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'ExitFunction' => 'none'
+          'EXITFUNC' => 'none'
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => 'none'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/linux/misc/hp_vsa_login_bof.rb
+++ b/modules/exploits/linux/misc/hp_vsa_login_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => ['linux'],
       'Arch'           => ARCH_X86,

--- a/modules/exploits/linux/misc/hp_vsa_login_bof.rb
+++ b/modules/exploits/linux/misc/hp_vsa_login_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => ['linux'],
       'Arch'           => ARCH_X86,

--- a/modules/exploits/linux/misc/hp_vsa_login_bof.rb
+++ b/modules/exploits/linux/misc/hp_vsa_login_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => ['linux'],
       'Arch'           => ARCH_X86,

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Payload'        =>
         {

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Payload'        =>
         {

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Payload'        =>
         {

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Payload'        =>
         {

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Payload'        =>
         {

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
+++ b/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
+++ b/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
+++ b/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/php_volunteer_upload_exec.rb
+++ b/modules/exploits/multi/http/php_volunteer_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/php_volunteer_upload_exec.rb
+++ b/modules/exploits/multi/http/php_volunteer_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/php_volunteer_upload_exec.rb
+++ b/modules/exploits/multi/http/php_volunteer_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => %w{ linux php },
       'Targets'        =>

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => %w{ linux php },
       'Targets'        =>

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => %w{ linux php },
       'Targets'        =>

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Arch'           => ARCH_PHP,
       'Platform'       => ['php'],

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Arch'           => ARCH_PHP,
       'Platform'       => ['php'],

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Arch'           => ARCH_PHP,
       'Platform'       => ['php'],

--- a/modules/exploits/multi/misc/batik_svg_java.rb
+++ b/modules/exploits/multi/misc/batik_svg_java.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => %w{ java linux win },
       'Targets'        =>

--- a/modules/exploits/multi/misc/batik_svg_java.rb
+++ b/modules/exploits/multi/misc/batik_svg_java.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => %w{ java linux win },
       'Targets'        =>

--- a/modules/exploits/multi/misc/batik_svg_java.rb
+++ b/modules/exploits/multi/misc/batik_svg_java.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => %w{ java linux win },
       'Targets'        =>

--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/webapp/egallery_upload_exec.rb
+++ b/modules/exploits/unix/webapp/egallery_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/egallery_upload_exec.rb
+++ b/modules/exploits/unix/webapp/egallery_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/egallery_upload_exec.rb
+++ b/modules/exploits/unix/webapp/egallery_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/opensis_modname_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_modname_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'    =>
         {
-          'EXITFUNC'  => 'none'
+          'EXITFUNC' => 'thread'
         },
       'Platform'          => 'unix',
       'Arch'              => ARCH_CMD,

--- a/modules/exploits/unix/webapp/opensis_modname_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_modname_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'    =>
         {
-          'ExitFunction'  => 'none'
+          'EXITFUNC'  => 'none'
         },
       'Platform'          => 'unix',
       'Arch'              => ARCH_CMD,

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/windows/browser/clear_quest_cqole.rb
+++ b/modules/exploits/windows/browser/clear_quest_cqole.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC'         => "process",
+          'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/clear_quest_cqole.rb
+++ b/modules/exploits/windows/browser/clear_quest_cqole.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction'         => "process",
+          'EXITFUNC'         => "process",
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/getgodm_http_response_bof.rb
+++ b/modules/exploits/windows/browser/getgodm_http_response_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process',
+          'EXITFUNC' => 'process',
           'URIPATH'      => "/shakeitoff.mp3"
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/getgodm_http_response_bof.rb
+++ b/modules/exploits/windows/browser/getgodm_http_response_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
+          'EXITFUNC' => 'thread',
           'URIPATH'      => "/shakeitoff.mp3"
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction'         => "none",
+          'EXITFUNC'         => "none",
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC'         => "none",
+          'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction'         => "none",
+          'EXITFUNC'         => "none",
           'InitialAutoRunScript' => 'migrate -f',
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC'         => "none",
+          'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'migrate -f',
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction'         => "process",
+          'EXITFUNC'         => "process",
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC'         => "process",
+          'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC'         => "seh",
+          'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction'         => "seh",
+          'EXITFUNC'         => "seh",
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction'         => "process",
+          'EXITFUNC'         => "process",
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC'         => "process",
+          'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/actfax_import_users_bof.rb
+++ b/modules/exploits/windows/fileformat/actfax_import_users_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
+          'EXITFUNC' => 'thread',
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/actfax_import_users_bof.rb
+++ b/modules/exploits/windows/fileformat/actfax_import_users_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process',
+          'EXITFUNC' => 'process',
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process'
+          'EXITFUNC' => 'process'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/blazedvd_hdtv_bof.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_hdtv_bof.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "seh"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/blazedvd_hdtv_bof.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_hdtv_bof.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "seh"
+          'EXITFUNC' => "seh"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/bpftp_client_bps_bof.rb
+++ b/modules/exploits/windows/fileformat/bpftp_client_bps_bof.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/bpftp_client_bps_bof.rb
+++ b/modules/exploits/windows/fileformat/bpftp_client_bps_bof.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process'
+          'EXITFUNC' => 'process'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/easycdda_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/easycdda_pls_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/easycdda_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/easycdda_pls_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process'
+          'EXITFUNC' => 'process'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'SaveRegisters'  => [ 'ESP' ],
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "process",
+          'EXITFUNC' => "process",
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'SaveRegisters'  => [ 'ESP' ],
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "process",
+          'EXITFUNC' => 'thread',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "process",
+          'EXITFUNC' => "process",
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "process",
+          'EXITFUNC' => 'thread',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
+++ b/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
+++ b/modules/exploits/windows/fileformat/iftp_schedule_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process'
+          'EXITFUNC' => 'process'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
+++ b/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "process",
+          'EXITFUNC' => 'thread',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
+++ b/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "process",
+          'EXITFUNC' => "process",
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/lattice_pac_bof.rb
+++ b/modules/exploits/windows/fileformat/lattice_pac_bof.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "seh"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/lattice_pac_bof.rb
+++ b/modules/exploits/windows/fileformat/lattice_pac_bof.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "seh"
+          'EXITFUNC' => "seh"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process'
+          'EXITFUNC' => 'process'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction'          => "none",
+          'EXITFUNC'          => "none",
           'DisablePayloadHandler' => 'false'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC'          => "none",
+          'EXITFUNC' => 'thread',
           'DisablePayloadHandler' => 'false'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "process",
+          'EXITFUNC' => "process",
           'PrependMigrate' => true
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "process",
+          'EXITFUNC' => 'thread',
           'PrependMigrate' => true
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/publishit_pui.rb
+++ b/modules/exploits/windows/fileformat/publishit_pui.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process',
+          'EXITFUNC' => 'process',
         },
       'Platform'  => 'win',
       'Payload'  =>

--- a/modules/exploits/windows/fileformat/publishit_pui.rb
+++ b/modules/exploits/windows/fileformat/publishit_pui.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'thread',
+          'EXITFUNC' => 'process'
         },
       'Platform'  => 'win',
       'Payload'  =>

--- a/modules/exploits/windows/fileformat/publishit_pui.rb
+++ b/modules/exploits/windows/fileformat/publishit_pui.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
+          'EXITFUNC' => 'thread',
         },
       'Platform'  => 'win',
       'Payload'  =>

--- a/modules/exploits/windows/fileformat/real_player_url_property_bof.rb
+++ b/modules/exploits/windows/fileformat/real_player_url_property_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/real_player_url_property_bof.rb
+++ b/modules/exploits/windows/fileformat/real_player_url_property_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process'
+          'EXITFUNC' => 'process'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'seh'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'seh'
+          'EXITFUNC' => 'seh'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
+++ b/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'seh',
+          'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
+++ b/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'seh',
+          'EXITFUNC' => 'seh',
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/total_video_player_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/total_video_player_ini_bof.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process',
+          'EXITFUNC' => 'process',
         },
       'Platform'  => 'win',
       'Payload'  =>

--- a/modules/exploits/windows/fileformat/total_video_player_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/total_video_player_ini_bof.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
+          'EXITFUNC' => 'thread',
         },
       'Platform'  => 'win',
       'Payload'  =>

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/ezserver_http.rb
+++ b/modules/exploits/windows/http/ezserver_http.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'seh'
+          'EXITFUNC' => 'seh'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/http/ezserver_http.rb
+++ b/modules/exploits/windows/http/ezserver_http.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'seh'
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "thread"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/rabidhamster_r4_log.rb
+++ b/modules/exploits/windows/http/rabidhamster_r4_log.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "process"
+          'EXITFUNC' => "process"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/rabidhamster_r4_log.rb
+++ b/modules/exploits/windows/http/rabidhamster_r4_log.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "process"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/allmediaserver_bof.rb
+++ b/modules/exploits/windows/misc/allmediaserver_bof.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process', #none/process/thread/seh
+          'EXITFUNC' => 'process', #none/process/thread/seh
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/misc/allmediaserver_bof.rb
+++ b/modules/exploits/windows/misc/allmediaserver_bof.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process', #none/process/thread/seh
+          'EXITFUNC' => 'thread', #none/process/thread/seh
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/scada/winlog_runtime_2.rb
+++ b/modules/exploits/windows/scada/winlog_runtime_2.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunction' => 'process',
+          'EXITFUNC' => 'process',
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/scada/winlog_runtime_2.rb
+++ b/modules/exploits/windows/scada/winlog_runtime_2.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
+          'EXITFUNC' => 'thread',
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'ExitFunction' => "none"
+          'EXITFUNC' => "none"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "none"
+          'EXITFUNC' => "thread"
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'EXITFUNC' => "thread"
+          'EXITFUNC' => 'thread'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -555,6 +555,10 @@ class Msftidy
         end
       end
 
+      if ln =~ /['"]ExitFunction['"]\s*=>/
+        warn("Please use EXITFUNC instead of ExitFunction #{ln}", idx)
+      end
+
     end
   end
 


### PR DESCRIPTION
I stumbled upon this when testing https://github.com/rapid7/metasploit-framework/pull/5813

Many modules use the non existing `ExitFunction` option which should be `EXITUNC`

I also added a msftidy check for this
