### PR TITLE
Bug/msp 13064/svv validations not created

### DIFF
--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -98,6 +98,7 @@ module Msf::DBManager::Session
           run: session.exploit.user_data[:run],
           state: 'succeeded',
         )
+        infer_vuln_from_session(session, wspace)
       elsif session.via_exploit
         # This is a live session, we know the host is vulnerable to something.
         infer_vuln_from_session(session, wspace)

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -98,7 +98,6 @@ module Msf::DBManager::Session
           run: session.exploit.user_data[:run],
           state: 'succeeded',
         )
-        infer_vuln_from_session(session, wspace)
       elsif session.via_exploit
         # This is a live session, we know the host is vulnerable to something.
         infer_vuln_from_session(session, wspace)

--- a/spec/support/shared/examples/msf/db_manager/session.rb
+++ b/spec/support/shared/examples/msf/db_manager/session.rb
@@ -123,9 +123,15 @@ shared_examples_for 'Msf::DBManager::Session' do
           end
 
           context 'with a match in user_data' do
+            let(:vuln) do
+              FactoryGirl.create(:mdm_vuln,
+                                 name: parent_module_name,
+                                 host: host)
+            end
+
             let(:user_data) do
               {
-                match: FactoryGirl.build(:automatic_exploitation_match),
+                match: FactoryGirl.build(:automatic_exploitation_match, matchable: vuln),
                 match_set: FactoryGirl.build(:automatic_exploitation_match_set),
                 run: FactoryGirl.build(:automatic_exploitation_run, workspace: session_workspace),
               }


### PR DESCRIPTION
This PR fixes the fact that validated vulns don't show successful exploit attempts, only failed ones, in vuln validation.
# Verification Steps
- [x] start on master branch and choose an exploit for which you have a vulnerable host.
- [x] attempt to utilize an exploit on a vulnerable host
- [x] after you get a session, notice that the successful exploit attempt is not added to the list of exploit attempts for this vuln.
- [x] kill session, restart victim host if needed.
- [x] pull topic branch
- [x] attempt to utilize exploit on vulnerable host
- [x] verify that the successful exploit attempt is added to the list of exploit attempts for this vulnerability
- [x] verify that the exploit attempt is listed as successful.
