### PR TITLE
Allow the HTTP listener hostname and port to be overridden

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -98,7 +98,7 @@ module ReverseHttp
       callback_host = req.headers['Host']
     end
 
-    # Override these host and port as appropriate
+    # Override the host and port as appropriate
     if datastore['OverrideRequestHost'] || callback_host.nil?
       callback_name = datastore['OverrideLHOST'] || datastore['LHOST']
       callback_port = datastore['OverrideLPORT'] || datastore['LPORT']

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -55,7 +55,9 @@ module ReverseHttp
         OptString.new('MeterpreterServerName', [false, 'The server header that the handler will send in response to requests', 'Apache']),
         OptAddress.new('ReverseListenerBindAddress', [false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [false, 'The port to bind to on the local system if different from LPORT']),
-        OptBool.new('OverrideRequestHost', [false, 'Forces clients to connect to LHOST:LPORT instead of keeping original payload host', false]),
+        OptBool.new('OverrideRequestHost', [false, 'Forces a specific host and port instead of using what the client requests, defaults to LHOST:LPORT', false]),
+        OptString.new('OverrideLHOST', [false, 'When OverrideRequestHost is set, use this value as the host name for secondary requests']),
+        OptPort.new('OverrideLPORT', [false, 'When OverrideRequestHost is set, use this value as the port number for secondary requests']),
         OptString.new('HttpUnknownRequestResponse', [false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>']),
         OptBool.new('IgnoreUnknownPayloads', [false, 'Whether to drop connections from payloads using unknown UUIDs', false])
       ], Msf::Handler::ReverseHttp)
@@ -89,13 +91,23 @@ module ReverseHttp
   #
   # @return [String] A URI of the form +scheme://host:port/+
   def payload_uri(req)
-    if req and req.headers and req.headers['Host'] and not datastore['OverrideRequestHost']
+    callback_host = nil
+
+    # Extract whatever the client sent us in the Host header
+    if req and req.headers and req.headers['Host']
       callback_host = req.headers['Host']
-    elsif Rex::Socket.is_ipv6?(datastore['LHOST'])
-      callback_host = "[#{datastore['LHOST']}]:#{datastore['LPORT']}"
-    else
-      callback_host = "#{datastore['LHOST']}:#{datastore['LPORT']}"
     end
+
+    # Override these host and port as appropriate
+    if datastore['OverrideRequestHost'] || callback_host.nil?
+      callback_name = datastore['OverrideLHOST'] || datastore['LHOST']
+      callback_port = datastore['OverrideLPORT'] || datastore['LPORT']
+      if Rex::Socket.is_ipv6? callback_name
+        callback_name = "[#{callback_name}]"
+      end
+      callback_host = "#{callback_name}:#{callback_port}"
+    end
+
     "#{scheme}://#{callback_host}/"
   end
 


### PR DESCRIPTION
This changeset introduces two new advanced options, OverrideLHOST and OverrideLPORT. If the OverrideRequestHost option is set to true, these two new options will be preferred over the actual LHOST and LPORT values.

This change is needed when complex NAT setups are in place. For example, if the external port value is mapped to a different internal port (not LHOST).
