### PR TITLE
Instantiate payload modules so parameter validation occurs

### DIFF
--- a/lib/msf/util/payload_cached_size.rb
+++ b/lib/msf/util/payload_cached_size.rb
@@ -14,6 +14,27 @@ module Util
 
 class PayloadCachedSize
 
+  @opts = {
+    'Format'      => 'raw',
+    'Options'     => {
+      'CPORT' => 4444,
+      'LPORT' => 4444,
+      'LHOST' => '255.255.255.255',
+      'KHOST' => '255.255.255.255',
+      'AHOST' => '255.255.255.255',
+      'CMD' => '/bin/sh',
+      'URL' => 'http://a.com',
+      'PATH' => '/',
+      'BUNDLE' => 'data/isight.bundle',
+      'DLL' => 'external/source/byakugan/bin/XPSP2/detoured.dll',
+      'RC4PASSWORD' => 'Metasploit',
+      'DNSZONE' => 'corelan.eu',
+      'PEXEC' => '/bin/sh'
+    },
+    'Encoder'     => nil,
+    'DisableNops' => true
+  }
+
   # Insert a new CachedSize value into the text of a payload module
   #
   # @param data [String] The source code of a payload module
@@ -60,7 +81,7 @@ class PayloadCachedSize
   # @return [Fixnum]
   def self.compute_cached_size(mod)
     return ":dynamic" if is_dynamic?(mod)
-    return mod.new.size
+    return mod.generate_simple(@opts).size
   end
 
   # Determines whether a payload generates a static sized output
@@ -69,8 +90,9 @@ class PayloadCachedSize
   # @param generation_count [Fixnum] The number of iterations to use to
   #   verify that the size is static.
   # @return [Fixnum]
-  def self.is_dynamic?(mod,generation_count=5)
-    [*(1..generation_count)].map{|x| mod.new.size}.uniq.length != 1
+  def self.is_dynamic?(mod, generation_count=5)
+    [*(1..generation_count)].map{|x|
+      mod.generate_simple(@opts).size}.uniq.length != 1
   end
 
   # Determines whether a payload's CachedSize is up to date
@@ -78,9 +100,9 @@ class PayloadCachedSize
   # @param mod [Msf::Payload] The class of the payload module to update
   # @return [Boolean]
   def self.is_cached_size_accurate?(mod)
-    return true if mod.dynamic_size?
+    return true if mod.dynamic_size? && is_dynamic?(mod)
     return false if mod.cached_size.nil?
-    mod.cached_size == mod.new.size
+    mod.cached_size == mod.generate_simple(@opts).size
   end
 
 end

--- a/modules/payloads/singles/bsd/x64/exec.rb
+++ b/modules/payloads/singles/bsd/x64/exec.rb
@@ -17,7 +17,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 23
+  CachedSize = 31
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
@@ -40,7 +40,7 @@ module Metasploit3
 
   # build the shellcode payload dynamically based on the user-provided CMD
   def generate
-    cmd  = (datastore['CMD'] || '') << "\x00"
+    cmd  = (datastore['CMD'] || '') + "\x00"
     port = [datastore['LPORT'].to_i].pack('n')
     call = "\xe8" + [cmd.length].pack('V')
     payload =

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
@@ -49,7 +49,7 @@ module Metasploit3
       raise ArgumentError, "LHOST must be in IPv4 format."
     end
 
-    cmd  = (datastore['CMD'] || '') << "\x00"
+    cmd  = (datastore['CMD'] || '') + "\x00"
     port = [datastore['LPORT'].to_i].pack('n')
     ipaddr = [lhost.split('.').inject(0) {|t,v| (t << 8 ) + v.to_i}].pack("N")
 

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -17,7 +17,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 16
+  CachedSize = 24
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd

--- a/modules/payloads/singles/cmd/unix/generic.rb
+++ b/modules/payloads/singles/cmd/unix/generic.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 0
+  CachedSize = 8
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse.rb
+++ b/modules/payloads/singles/cmd/unix/reverse.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 100
+  CachedSize = 130
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 95
+  CachedSize = 110
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_lua.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 209
+  CachedSize = 224
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 20
+  CachedSize = 35
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 1911
+  CachedSize = 1971
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 152
+  CachedSize = 182
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 219
+  CachedSize = 234
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 129
+  CachedSize = 144
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 117
+  CachedSize = 132
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 567
+  CachedSize = 587
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 118
+  CachedSize = 133
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 170
+  CachedSize = 185
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 106
+  CachedSize = 136
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_zsh.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 95
+  CachedSize = 110
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 258
+  CachedSize = 97
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/generic.rb
+++ b/modules/payloads/singles/cmd/windows/generic.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 0
+  CachedSize = 8
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/core/handler/bind_tcp'
 
 module Metasploit3
 
-  CachedSize = 1510
+  CachedSize = 1518
 
   include Msf::Payload::Single
   include Rex::Powershell::Command

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 
 module Metasploit3
 
-  CachedSize = 1518
+  CachedSize = 1526
 
   include Msf::Payload::Single
   include Rex::Powershell::Command

--- a/modules/payloads/singles/cmd/windows/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_lua.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 209
+  CachedSize = 224
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 133
+  CachedSize = 148
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 1189
+  CachedSize = 1204
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 111
+  CachedSize = 126
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = :dynamic
+  CachedSize = 1019
 
   include Msf::Payload::Single
   include Msf::Payload::Firefox

--- a/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 0
+  CachedSize = 1501
 
   include Msf::Payload::Single
   include Msf::Payload::JSP

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 7748
+  CachedSize = 7761
 
   include Msf::Payload::Single
   include Msf::Payload::Java

--- a/modules/payloads/singles/linux/armle/exec.rb
+++ b/modules/payloads/singles/linux/armle/exec.rb
@@ -15,7 +15,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 22
+  CachedSize = 29
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/mipsbe/exec.rb
+++ b/modules/payloads/singles/linux/mipsbe/exec.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 48
+  CachedSize = 52
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 0
+  CachedSize = 184
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 48
+  CachedSize = 52
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 0
+  CachedSize = 184
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 40
+  CachedSize = 47
 
   include Msf::Payload::Single
   include Msf::Payload::Linux
@@ -29,7 +29,7 @@ module Metasploit3
   end
 
   def generate_stage(opts={})
-    cmd = (datastore['CMD'] || '') << "\x00"
+    cmd = (datastore['CMD'] || '') + "\x00"
     call = "\xe8" + [cmd.length].pack('V')
     payload =
       "\x6a\x3b"                     + # pushq  $0x3b

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -15,7 +15,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 36
+  CachedSize = 43
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 62
+  CachedSize = 63
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 103
+  CachedSize = 70
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
@@ -14,7 +14,7 @@ require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
-  CachedSize = 473
+  CachedSize = 488
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 501
+  CachedSize = 516
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/osx/x64/exec.rb
+++ b/modules/payloads/singles/osx/x64/exec.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 23
+  CachedSize = 31
 
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
@@ -37,7 +37,7 @@ module Metasploit3
 
   # build the shellcode payload dynamically based on the user-provided CMD
   def generate
-    cmd  = (datastore['CMD'] || '') << "\x00"
+    cmd  = (datastore['CMD'] || '') + "\x00"
     port = [datastore['LPORT'].to_i].pack('n')
     call = "\xe8" + [cmd.length].pack('V')
     payload =

--- a/modules/payloads/singles/osx/x64/shell_find_tag.rb
+++ b/modules/payloads/singles/osx/x64/shell_find_tag.rb
@@ -40,7 +40,7 @@ module Metasploit3
   # ensures the setting of tag to a four byte value
   #
   def generate
-    cmd  = (datastore['CMD'] || '') << "\x00"
+    cmd  = (datastore['CMD'] || '') + "\x00"
     call = "\xe8" + [cmd.length].pack('V')
 
     payload =

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -45,7 +45,7 @@ module Metasploit3
       raise ArgumentError, "LHOST must be in IPv4 format."
     end
 
-    cmd  = (datastore['CMD'] || '') << "\x00"
+    cmd  = (datastore['CMD'] || '') + "\x00"
     port = [datastore['LPORT'].to_i].pack('n')
     ipaddr = [lhost.split('.').inject(0) {|t,v| (t << 8 ) + v.to_i}].pack("N")
 

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -16,7 +16,7 @@ require 'msf/core'
 ###
 module Metasploit3
 
-  CachedSize = 16
+  CachedSize = 24
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd::X86

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit4
 
-  CachedSize = 25679
+  CachedSize = 25685
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 381
+  CachedSize = 401
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 537
+  CachedSize = 557
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/ruby/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 496
+  CachedSize = 516
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby

--- a/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 424
+  CachedSize = 444
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby

--- a/modules/payloads/singles/solaris/sparc/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_find_port.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = :dynamic
+  CachedSize = 136
 
   include Msf::Payload::Single
   include Msf::Payload::Solaris

--- a/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 160
+  CachedSize = 95
 
   include Msf::Payload::Single
   include Msf::Payload::Solaris

--- a/modules/payloads/singles/solaris/x86/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/x86/shell_find_port.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 151
+  CachedSize = 86
 
   include Msf::Payload::Single
   include Msf::Payload::Solaris

--- a/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 156
+  CachedSize = 91
 
   include Msf::Payload::Single
   include Msf::Payload::Solaris

--- a/modules/payloads/singles/windows/adduser.rb
+++ b/modules/payloads/singles/windows/adduser.rb
@@ -15,7 +15,7 @@ require 'msf/core/payload/windows/exec'
 ###
 module Metasploit3
 
-  CachedSize = 443
+  CachedSize = 282
 
   include Msf::Payload::Windows::Exec
 

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 275
+  CachedSize = 285
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 439
+  CachedSize = 423
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/exec.rb
+++ b/modules/payloads/singles/windows/exec.rb
@@ -13,7 +13,7 @@ require 'msf/core/payload/windows/exec'
 ###
 module Metasploit3
 
-  CachedSize = 185
+  CachedSize = 192
 
   include Msf::Payload::Windows::Exec
 

--- a/modules/payloads/singles/windows/loadlibrary.rb
+++ b/modules/payloads/singles/windows/loadlibrary.rb
@@ -13,7 +13,7 @@ require 'msf/core/payload/windows/loadlibrary'
 ###
 module Metasploit3
 
-  CachedSize = 183
+  CachedSize = 230
 
   include Msf::Payload::Windows::LoadLibrary
 

--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -16,7 +16,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
-  CachedSize = 1695
+  CachedSize = 1703
 
   include Msf::Payload::Windows::Exec
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -16,7 +16,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 ###
 module Metasploit3
 
-  CachedSize = 1703
+  CachedSize = 1711
 
   include Msf::Payload::Windows::Exec
   include Msf::Payload::Windows::Powershell

--- a/modules/payloads/singles/windows/x64/exec.rb
+++ b/modules/payloads/singles/windows/x64/exec.rb
@@ -9,7 +9,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 268
+  CachedSize = 275
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/x64/loadlibrary.rb
+++ b/modules/payloads/singles/windows/x64/loadlibrary.rb
@@ -9,7 +9,7 @@ require 'msf/core'
 
 module Metasploit3
 
-  CachedSize = 267
+  CachedSize = 314
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
@@ -16,7 +16,7 @@ require 'msf/core/handler/bind_tcp'
 ###
 module Metasploit3
 
-  CachedSize = 1778
+  CachedSize = 1786
 
   include Msf::Payload::Windows::Exec_x64
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -16,7 +16,7 @@ require 'msf/core/handler/reverse_tcp_ssl'
 ###
 module Metasploit3
 
-  CachedSize = 1786
+  CachedSize = 1794
 
   include Msf::Payload::Windows::Exec_x64
   include Msf::Payload::Windows::Powershell

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
-  CachedSize = 5499
+  CachedSize = 5505
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/uuid/options'
 
 module Metasploit3
 
-  CachedSize = 6307
+  CachedSize = 6313
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 5487
+  CachedSize = 5500
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/core/payload/linux/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 193
+  CachedSize = 71
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp

--- a/modules/payloads/stagers/linux/x86/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp_uuid.rb
@@ -10,7 +10,7 @@ require 'msf/core/payload/linux/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 236
+  CachedSize = 114
 
   include Msf::Payload::Stager
   include Msf::Payload::Linux::ReverseTcp

--- a/modules/payloads/stagers/netware/reverse_tcp.rb
+++ b/modules/payloads/stagers/netware/reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module Metasploit3
 
-  CachedSize = 279
+  CachedSize = 281
 
   include Msf::Payload::Stager
   include Msf::Payload::Netware

--- a/modules/payloads/stagers/php/reverse_tcp.rb
+++ b/modules/payloads/stagers/php/reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 936
+  CachedSize = 951
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/stagers/php/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/reverse_tcp_uuid.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module Metasploit4
 
-  CachedSize = 1110
+  CachedSize = 1125
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
-  CachedSize = 342
+  CachedSize = 362
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit4
 
-  CachedSize = 446
+  CachedSize = 466
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/reverse_http'
 
 module Metasploit4
 
-  CachedSize = 312
+  CachedSize = 327
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
+++ b/modules/payloads/stagers/windows/reverse_http_proxy_pstore.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/uuid/options'
 
 module Metasploit3
 
-  CachedSize = 650
+  CachedSize = 665
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/reverse_https.rb
+++ b/modules/payloads/stagers/windows/reverse_https.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/reverse_https'
 
 module Metasploit4
 
-  CachedSize = 332
+  CachedSize = 347
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -10,7 +10,7 @@ require 'msf/core/handler/reverse_https_proxy'
 
 module Metasploit3
 
-  CachedSize = 391
+  CachedSize = 397
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_http.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_http.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/x64/reverse_http'
 
 module Metasploit4
 
-  CachedSize = 486
+  CachedSize = 501
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/windows/x64/reverse_https'
 
 module Metasploit4
 
-  CachedSize = 517
+  CachedSize = 532
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -863,7 +863,7 @@ describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/firefox/exec'
                           ],
-                          dynamic_size: true,
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'firefox/exec'
   end
@@ -2320,7 +2320,7 @@ describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_find_port'
                           ],
-                          dynamic_size: true,
+                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_find_port'
   end
@@ -3886,7 +3886,7 @@ describe 'modules/payloads', :content do
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/powershell_reverse_tcp'
   end
-  
+
   context 'windows/x64/shell/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -70,6 +70,7 @@
 #   `:ancestor_reference_names`.
 # @return [void]
 shared_examples_for 'payload cached size is consistent' do |options|
+
   options.assert_valid_keys(:ancestor_reference_names, :modules_pathname, :reference_name, :dynamic_size)
 
   ancestor_reference_names = options.fetch(:ancestor_reference_names)
@@ -84,6 +85,30 @@ shared_examples_for 'payload cached size is consistent' do |options|
   module_type = 'payload'
 
   include_context 'Msf::Simple::Framework#modules loading'
+
+  datastore = {
+  }
+
+  opts = {
+    'Format'      => 'raw',
+    'Options'     => {
+      'CPORT' => 4444,
+      'LPORT' => 4444,
+      'LHOST' => '255.255.255.255',
+      'KHOST' => '255.255.255.255',
+      'AHOST' => '255.255.255.255',
+      'CMD' => '/bin/sh',
+      'URL' => 'http://a.com',
+      'PATH' => '/',
+      'BUNDLE' => 'data/isight.bundle',
+      'DLL' => 'external/source/byakugan/bin/XPSP2/detoured.dll',
+      'RC4PASSWORD' => 'Metasploit',
+      'DNSZONE' => 'corelan.eu',
+      'PEXEC' => '/bin/sh'
+    },
+    'Encoder'     => nil,
+    'DisableNops' => true
+  }
 
   #
   # lets
@@ -111,6 +136,8 @@ shared_examples_for 'payload cached size is consistent' do |options|
       )
     end
 
+    next if reference_name =~ /generic/
+
     if dynamic_size
       it 'is dynamic_size?' do
         pinst = load_and_create_module(
@@ -132,7 +159,7 @@ shared_examples_for 'payload cached size is consistent' do |options|
         )
         expect(pinst.cached_size).to_not(be_nil)
         expect(pinst.dynamic_size?).to be(false)
-        expect(pinst.cached_size).to eq(pinst.size)
+        expect(pinst.cached_size).to eq(pinst.generate_simple(opts).size)
       end
     end
   end

--- a/tools/update_payload_cached_sizes.rb
+++ b/tools/update_payload_cached_sizes.rb
@@ -22,8 +22,11 @@ require 'msf/util/payload_cached_size'
 framework = Msf::Simple::Framework.create('DisableDatabase' => true)
 
 framework.payloads.each_module do |name, mod|
-  next if Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod)
+  next if name =~ /generic/
+  mod_inst = framework.payloads.create(name)
+  #mod_inst.datastore.merge!(framework.datastore)
+  next if Msf::Util::PayloadCachedSize.is_cached_size_accurate?(mod_inst)
   $stdout.puts "[*] Updating the CacheSize for #{mod.file_path}..."
-  Msf::Util::PayloadCachedSize.update_module_cached_size(mod)
+  Msf::Util::PayloadCachedSize.update_module_cached_size(mod_inst)
 end
 


### PR DESCRIPTION
Calling .new on payload modules does not perform parameter validation, leading to a number cached sizes based on invalid parameters. Most notably, normalization does not occur either, which makes all OptBool params default to true. This caused the windows/adduser to be larger with its cached size parameter than it would be if you generate it with msfvenom or from framework directly.
# Validation steps
- [x] The following command works without validation errors:
  `./msfconsole -qx 'use exploit/windows/smb/ms08_067_netapi; set payload windows/adduser'`
- [x] tab completion with `set payload` using ms08_67_netapi should show 141 entries, not 119.
- [x] specs should pass consistently
