### PR TITLE
Pre-Bloggery cleanup

### DIFF
--- a/modules/auxiliary/gather/lansweeper_collector.rb
+++ b/modules/auxiliary/gather/lansweeper_collector.rb
@@ -6,14 +6,16 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name' => 'Lansweeper Collector',
+      'Name' => 'Lansweeper Credential Collector',
       'Description' => %q(
-        Lansweeper stores the credentials it uses to scan the computers in its MSSQL database.
-        The passwords are XTea-encrypted with a 68 character long key, which first 8 character
-        are stored with the password in the database, and the other 60 is static. Lansweeper by
-        default creates an MSSQL user "lansweeperuser" whose password is "mysecretpassword0*",
-        and stores its data in a database called "lansweeperdb". This module will query the MSSQL
-        database for the credentials.
+        Lansweeper stores the credentials it uses to scan the computers
+        in its Microsoft SQL database.  The passwords are XTea-encrypted with a
+        68 character long key, in which the first 8 characters are stored with
+        the password in the database and the other 60 is static. Lansweeper, by
+        default, creates an MSSQL user "lansweeperuser" with the password is
+        "mysecretpassword0*", and stores its data in a database called
+        "lansweeperdb". This module will query the MSSQL database for the
+        credentials.
       ),
       'Author' =>
         [

--- a/modules/auxiliary/server/browser_autopwn2.rb
+++ b/modules/auxiliary/server/browser_autopwn2.rb
@@ -15,35 +15,29 @@ class Metasploit3 < Msf::Auxiliary
         This module will automatically serve browser exploits. Here are the options you can
         configure:
 
-        The Include option allows you to specify the kind of exploits to be loaded. For example,
+        The INCLUDE_PATTERN option allows you to specify the kind of exploits to be loaded. For example,
         if you wish to load just Adobe Flash exploits, then you can set Include to 'adobe_flash'.
 
-        The Exclude option will ignore exploits. For example, if you don't want any Adobe Flash
+        The EXCLUDE_PATTERN option will ignore exploits. For example, if you don't want any Adobe Flash
         exploits, you can set this. Also note that the Exclude option will always be evaludated
         after the Include option.
 
-        The MaxExploits option specifies the max number of exploits to load by Browser Autopwn.
+        The MaxExploitCount option specifies the max number of exploits to load by Browser Autopwn.
         By default, 20 will be loaded. But note that the client will probably not be vulnerable
         to all 20 of them, so only some will actually be served to the client.
 
-        The Content option allows you to provide a basic webpage. This is what the user behind
+        The HTMLContent option allows you to provide a basic webpage. This is what the user behind
         the vulnerable browser will see. You can simply set a string, or you can do the file://
         syntax to load an HTML file. Note this option might break exploits so try to keep it
         as simple as possible.
 
-        The WhiteList option can be used to avoid visitors that are outside the scope of your
-        pentest engagement. IPs that are not on the list will not be attacked.
-
-        The MaxSessions option is used to limit how many sessions Browser Autopwn is allowed to
+        The MaxSessionCount option is used to limit how many sessions Browser Autopwn is allowed to
         get. The default -1 means unlimited. Combining this with other options such as RealList
         and Custom404, you can get information about which visitors (IPs) clicked on your malicious
         link, what exploits they might be vulnerable to, redirect them to your own internal
         training website without actually attacking them.
 
-        The RealList is an option that will list what exploits the client might be vulnerable to
-        based on basic browser information. If possible, you can run the exploits for validation.
-
-        For more information about Browser Autopwn, please see the reference link.
+        For more information about Browser Autopwn, please see the referenced blog post.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'sinn3r' ],

--- a/modules/exploits/windows/fileformat/homm3_h3m.rb
+++ b/modules/exploits/windows/fileformat/homm3_h3m.rb
@@ -319,3 +319,4 @@ class Metasploit3 < Msf::Exploit::Remote
     res
   end
 end
+

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -14,11 +14,10 @@ class Metasploit3 < Msf::Post
           This module suggests local meterpreter exploits that can be used. The
           exploits are suggested based on the architecture and platform that
           the user has a shell opened as well as the available exploits in
-          meterpreter. Additionally, the ShowDescription option can be set
-          to 'true' to a detailed description on the suggested exploits.
+          meterpreter.
 
           It's important to note that not all local exploits will be fired.
-          They are chosen based on these conditions: session type,
+          Exploits are chosen based on these conditions: session type,
           platform, architecture, and required default options.
         },
         'License'       => MSF_LICENSE,


### PR DESCRIPTION
Edited modules/auxiliary/gather/lansweeper_collector.rb first landed in #5614, fix up title and minor description word choice changes.

Edited modules/auxiliary/server/browser_autopwn2.rb first landed in #5650, accurately name all the referenced options in the description. Also removed from the description the missing options of 'WhiteList' and 'RealList' -- those don't appear to be available according to `show options` and `show advanced`, @wchen-r7.

Edited modules/post/multi/recon/local_exploit_suggester.rb first landed in #5823, mv local_exploit_{suggestor,suggester} for minor description cleanup and axing the description of the SHOWDESCRIPTION option (it's already described identically on the option itself).

Assigning to @MSadek-r7 , opportunistically, though if I screwed up the BAPv2 edits, please stop me/him, @wchen-r7 .
