### PR TITLE
Heroes of M&M3 HD version should be the default

### DIFF
--- a/modules/exploits/windows/fileformat/homm3_h3m.rb
+++ b/modules/exploits/windows/fileformat/homm3_h3m.rb
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'Privileged'     => false,
       'DisclosureDate' => 'Jul 29 2015',
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 1))
 
     register_options(
       [


### PR DESCRIPTION
I find it far more likely that this version will be actually installed on people's machines, since it's novel and funny and distributed by Steam and not old enough to drive.

What do you think @wvu-r7 ?
