### PR TITLE
Increase Meterpreter Dispatcher Throughput

### DIFF
--- a/lib/rex/post/meterpreter/packet_response_waiter.rb
+++ b/lib/rex/post/meterpreter/packet_response_waiter.rb
@@ -57,22 +57,24 @@ class PacketResponseWaiter
   # If the interval is -1 we can wait forever.
   #
   def wait(interval)
-    if( interval and interval == -1 )
-      while(not self.done)
-        ::IO.select(nil, nil, nil, 0.1)
+    if interval && interval < 0
+      while !self.done
+        ::IO.select(nil, nil, nil, 0.001)
       end
     else
       begin
-        Timeout.timeout(interval) {
-          while(not self.done)
-            ::IO.select(nil, nil, nil, 0.1)
+        Timeout.timeout(interval) do
+          while !self.done
+            ::IO.select(nil, nil, nil, 0.001)
           end
-        }
+        end
       rescue Timeout::Error
         self.response = nil
       end
     end
-    return self.response
+
+    # TODO Doesn't look like the return value is used? See PacketDispatcher.send_packet_wait_response
+    self.response
   end
 
   attr_accessor :rid, :done, :response # :nodoc:


### PR DESCRIPTION
A meterpreter python rev_tcp, connected via localhost download of 65M takes 106s for me. (See benchmark code in #5845).  Note this is urandom so wont benefit from any compression etc.

These changes attempts to make the dispatcher faster with more responsive sleep times. By default this causes CPU usage to go through the roof with 20-30+ meterpreters connected. However I have added an exponential backoff when the queue is empty which prevents this.

Current download speed is around 3s-5s (with 30 meterpreters up and running). 

I hope this also speeds up other comms traffic, e.g. portfwds and routing. However there are a number of selects in `Rex::Socket` and also a reasonably large one in  `Rex::Proto::Sockets::Socks4a`

Indentation and some of the syntax was pretty nasty so fixed that up too. But it makes the changes look slightly more extensive than they are :(

Queries:

Should add an exponential back off if we have queued unhandled packets? (The second sleep in packet_dispatcher)

Poke @jlee-r7  and @hmoore-r7 :)
## Verification
- [ ] Check CPU usage with 10,20,30,100 meterps!
- [ ] Check download response times increase.
- [ ] Check other stuff is faster?
- [ ] Check that meterpreter is still stable? Including TCP and HTTP transports?
