### PR TITLE
Fix bad use of get_profile (now browser_profile)

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_avm2.rb
+++ b/modules/exploits/windows/browser/adobe_flash_avm2.rb
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending HTML...")
     tag = retrieve_tag(cli, request)
-    profile = get_profile(tag)
+    profile = browser_profile[tag]
     profile[:tried] = false unless profile.nil? # to allow request the swf
     send_exploit_html(cli, exploit_template(cli, target_info), {'Pragma' => 'no-cache'})
   end

--- a/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
+++ b/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
@@ -95,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending HTML...")
     tag = retrieve_tag(cli, request)
-    profile = get_profile(tag)
+    profile = browser_profile[tag]
     profile[:tried] = false unless profile.nil? # to allow request the swf
     send_exploit_html(cli, exploit_template(cli, target_info), {'Pragma' => 'no-cache'})
   end

--- a/modules/exploits/windows/browser/adobe_flash_pcre.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pcre.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending HTML...")
     tag = retrieve_tag(cli, request)
-    profile = get_profile(tag)
+    profile = browser_profile[tag]
     profile[:tried] = false unless profile.nil? # to allow request the swf
     send_exploit_html(cli, exploit_template(cli, target_info), {'Pragma' => 'no-cache'})
   end

--- a/modules/exploits/windows/browser/adobe_flash_regex_value.rb
+++ b/modules/exploits/windows/browser/adobe_flash_regex_value.rb
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending HTML...")
     tag = retrieve_tag(cli, request)
-    profile = get_profile(tag)
+    profile = browser_profile[tag]
     profile[:tried] = false unless profile.nil? # to allow request the swf
     send_exploit_html(cli, exploit_template(cli, target_info), {'Pragma' => 'no-cache'})
   end


### PR DESCRIPTION
This fixes a stack trace in the Adobe Flash modules first reported at https://community.rapid7.com/thread/7666

These modules were overlooked when the new browser profile changes were implemented. This change swaps the call to `get_profile` for the correct `browser_profile` hash accessor.
