### PR TITLE
Improve meterpreter packet dispatch performance

### DIFF
--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -455,15 +455,16 @@ module PacketDispatcher
   # if anyone.
   #
   def notify_response_waiter(response)
+    handled = false
     self.waiters.each() { |waiter|
       if (waiter.waiting_for?(response))
         waiter.notify(response)
-
         remove_response_waiter(waiter)
-
+        handled = true
         break
       end
     }
+    return handled
   end
 
   #

--- a/lib/rex/post/meterpreter/packet_response_waiter.rb
+++ b/lib/rex/post/meterpreter/packet_response_waiter.rb
@@ -27,7 +27,8 @@ class PacketResponseWaiter
       self.completion_routine = completion_routine
       self.completion_param   = completion_param
     else
-      self.done  = false
+      self.mutex = Mutex.new
+      self.cond  = ConditionVariable.new
     end
   end
 
@@ -48,7 +49,9 @@ class PacketResponseWaiter
     if (self.completion_routine)
       self.completion_routine.call(response, self.completion_param)
     else
-      self.done = true
+      self.mutex.synchronize {
+        self.cond.signal
+      }
     end
   end
 
@@ -57,25 +60,14 @@ class PacketResponseWaiter
   # If the interval is -1 we can wait forever.
   #
   def wait(interval)
-    if( interval and interval == -1 )
-      while(not self.done)
-        ::IO.select(nil, nil, nil, 0.1)
-      end
-    else
-      begin
-        Timeout.timeout(interval) {
-          while(not self.done)
-            ::IO.select(nil, nil, nil, 0.1)
-          end
-        }
-      rescue Timeout::Error
-        self.response = nil
-      end
-    end
+    interval = nil if interval and interval == -1
+    self.mutex.synchronize {
+      self.cond.wait(self.mutex, interval)
+    }
     return self.response
   end
 
-  attr_accessor :rid, :done, :response # :nodoc:
+  attr_accessor :rid, :mutex, :cond, :response # :nodoc:
   attr_accessor :completion_routine, :completion_param # :nodoc:
 end
 


### PR DESCRIPTION
This PR attempts to fix #5845 by switching away from select() based sleeps instead of reducing the sleep times as in #5849. The fix is in three parts: use Queue.pop() in the dispatch thread, use a Mutex/CV in the packet waiter, and a bug fix in the waiter notification.

Switching `pqueue` to a `Queue` allows pop to be used to wait for a packet. Until a packet is pushed into the queue [the thread is suspended](http://ruby-doc.org/core-2.1.6/Queue.html#method-i-pop). My testing shows that this is more efficient than the current approach of sleeping and polling the queue length.

Similarly I switched the packet response waiter back to a Mutex/CV based solution. This differs from the original implementation in that I make use of the `wait()` method's timeout parameter instead of a separate use of the `Timeout` class. Hopefully this solves the race which caused the change to the current select code (5757685b5904e473acb5b4a1bcd2adaf9090203b). However, I'm not sure what that issue actually was so I can't be certain.

Finally I noticed that the `backlog == incomplete` delay was being triggered very often, even for a file that's read in a single packet. It turned out that `dispatch_inbound_packet()` would check the return value of `notify_response_waiter()` to see if the response had been handled. If the loop is broken early due to a waiter being notified `nil` is returned leading to the dispatch thread believing that the packet wasn't handled. It then goes into the incomplete list and goes around again.

In my tests all of these changes mean that a 32M download goes from 52s to 0.5s on localhost and from 65s to 15s over the internet. I also didn't notice any significant increase in CPU usage with 30 sessions connected.
