### PR TITLE
Fix #5837 Allow unserialization of hosts data when importing msf reports v5

### DIFF
--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -241,7 +241,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
       host_data = {}
       host_data[:task] = args[:task]
       host_data[:workspace] = wspace
-      host_data[:host] = nils_for_nulls(host.elements["address"].text.to_s.strip)
+      host_data[:host] = nils_for_nulls(unserialize_object(host.elements["address"]))
       if bl.include? host_data[:host]
         next
       else


### PR DESCRIPTION
This patch tries to fix #5837 where failures to import Metasploit exported XML reports has been notified.

Basically, v5 metasploit reports safe the hosts (::Mdm::Host) as serialized an encoded with base64. But the importing code wasn't updated to take care of this new encoding. Allowing the importer to decode/unserialize the new data with the help of `unserialize_object` is solving the problems on my tests.
## Verification
- [x] Create a new workspace  `export_test`: `workspace -a export_test`

```
msf > workspace -a export_test
[*] Added workspace: export_test
```
- [x] From the new workspace create a new host: `hosts -a 172.16.158.131`

```
msf > hosts -a 172.16.158.131
[*] Time: 2015-08-17 18:55:08 UTC Host: host=172.16.158.131
```
- [x] Export the current workspace (export_test) to an xml

```
msf > db_export -f xml -a /tmp/test.xml
[*] Starting export of workspace export_test to /tmp/test.xml [ xml ]...
[*]     >> Starting export of report
[*]     >> Starting export of hosts
[*]     >> Starting export of events
[*]     >> Starting export of services
[*]     >> Starting export of web sites
[*]     >> Starting export of web pages
[*]     >> Starting export of web forms
[*]     >> Starting export of web vulns
[*]     >> Starting export of module details
[*]     >> Finished export of report
[*] Finished export of workspace export_test to /tmp/test.xml [ xml ]...
```
- [x] Create a new workspace `import_test`: `workspace -a import_test`

```
msf > workspace -a import_test
[*] Added workspace: import_test
```
- [x] From `import_test` try to import the exported xml: `db_import /tmp/test.xml`. VERIFY: there shouldn't be errors while importing, specially the error reported on #5837 shouldn't happen

```
msf > db_import /tmp/test.xml
[*] Importing 'Metasploit XML' data
[*] Importing host 172.16.158.131
[*] Successfully imported /tmp/test.xml
```
- [x] The XML should be correctly imported and the host should be visible with the `hosts` command

```
msf > hosts

Hosts
=====

address         mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------         ---  ----  -------  ---------  -----  -------  ----  --------
172.16.158.131
```
- [x] Additionally I've imported older reports versions to be sure they are working after this patch: MetasploitExpressV1, MetasploitExpressV2, MetasploitV4. Feel free to test with other versions of reports if you have them available.
