### PR TITLE
Fix nil bug with an empty database.yml

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -169,7 +169,7 @@ class Driver < Msf::Ui::Driver
 
         unless configuration_pathname.nil?
           if configuration_pathname.readable?
-            dbinfo = YAML.load_file(configuration_pathname)
+            dbinfo = YAML.load_file(configuration_pathname) || {}
             dbenv  = opts['DatabaseEnv'] || Rails.env
             db     = dbinfo[dbenv]
           else


### PR DESCRIPTION
If you run `msfconsole` with an empty `database.yml`, you get the following error:

```
/Users/wvu/msf4/lib/msf/ui/console/driver.rb:174:in `initialize': undefined method `[]' for false:FalseClass (NoMethodError)
    from /Users/wvu/msf4/lib/metasploit/framework/command/console.rb:62:in `new'
    from /Users/wvu/msf4/lib/metasploit/framework/command/console.rb:62:in `driver'
    from /Users/wvu/msf4/lib/metasploit/framework/command/console.rb:48:in `start'
    from /Users/wvu/msf4/lib/metasploit/framework/command/base.rb:82:in `start'
    from ./msfconsole:48:in `<main>'
```

Discovered by @bcook-r7.

Yo, here are some verification steps:
- [x] Create an empty `~/.msf4/database.yml`
- [x] Start `msfconsole`
- [x] See "No database definition for environment production" instead of a stack trace

:-)
