### PR TITLE
Fix #5817 by allow to compare ipv4 vs ipv6 addresses on tables

### DIFF
--- a/lib/rex/ui/text/table.rb
+++ b/lib/rex/ui/text/table.rb
@@ -203,6 +203,10 @@ class Table
         cmp = Rex::Socket::addr_atoi(a[index]) <=> Rex::Socket::addr_atoi(b[index])
       elsif a[index] =~ /^[0-9]+$/ and b[index] =~ /^[0-9]+$/
         cmp = a[index].to_i <=> b[index].to_i
+      elsif a[index].kind_of?(IPAddr) && a[index].kind_of?(IPAddr) && a[index].ipv6? && b[index].ipv4?
+        cmp = 1
+      elsif a[index].kind_of?(IPAddr) && b[index].kind_of?(IPAddr) && a[index].ipv4? && b[index].ipv6?
+        cmp = -1
       else
         cmp = a[index] <=> b[index] # assumes otherwise comparable.
       end


### PR DESCRIPTION
After review the backtrace provided on https://github.com/rapid7/metasploit-framework/issues/5817 I was reviewing the `Rex::Ui::Text::Table#sort_rows` method. Since we haven't data to test the exception provided by  #5817 my first bet is which the problem could be due to IPv4 vs IPv6 addresses, since in this case the `<=>` operator will return nil.

In order to reproduce (from master) the next steps can be followed:

```
msf > workspace test_hosts
[*] Workspace: test_hosts
msf > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

msf > hosts -a 2a01:0111:f406:0402:0000:0000:0000:0014
[*] Time: 2015-08-17 19:59:46 UTC Host: host=2a01:111:f406:402::14
msf > hosts

Hosts
=====

address                mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------                ---  ----  -------  ---------  -----  -------  ----  --------
2a01:111:f406:402::14

msf > hosts -a 172.16.158.1
[*] Time: 2015-08-17 19:59:56 UTC Host: host=172.16.158.1
msf > hosts

[-] Error while running command hosts: comparison of Array with Array failed

Call stack:
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/table.rb:197:in `sort!'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/table.rb:197:in `sort_rows'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/table.rb:112:in `to_s'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:499:in `block in cmd_hosts'
/Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract/connection_pool.rb:294:in `with_connection'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:312:in `cmd_hosts'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ui/text/shell.rb:203:in `run'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/jvazquez/Projects/Code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```

Assuming it is the exception triggered #5817 the patch here tries to manage ipv4 vs ipv6 comparisions on `Rex::Ui::Text::Table`.
## Verification
- [ ] Create a new workspace

```
msf > workspace -a test_hosts
[*] Added workspace: test_hosts

```
- [ ] Add an ipv4 host

```
msf > hosts -a 172.16.158.1
[*] Time: 2015-08-17 20:02:06 UTC Host: host=172.16.158.1

```
- [ ] Add an ipv6 host

```
msf > hosts -a 2a01:0111:f406:0402:0000:0000:0000:0014
[*] Time: 2015-08-17 20:02:13 UTC Host: host=2a01:111:f406:402::14
```
- [ ] Run the `hosts` command. VERIFY: no exception is raised and hosts with ipv4 addresses are showed before the hosts with ipv6 addresses.

```
msf > hosts

Hosts
=====

address                mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------                ---  ----  -------  ---------  -----  -------  ----  --------
172.16.158.1
2a01:111:f406:402::14

```
