### PR TITLE
Fix #5814 Mod telnet_login to disconnect the scanner socket when login fails

### DIFF
--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -89,6 +89,7 @@ class Metasploit3 < Msf::Auxiliary
       else
         invalidate_login(credential_data)
         vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        disconnect(scanner.sock)
       end
     end
   end


### PR DESCRIPTION
On #5814  @vallejocc has reported which telnet_login is failing against some devices Comtrend AR-5387un and Comtrend VR-3025un, apparently because of the quantity of sockets opened against the device (and left opened). These devices don't allow more than two simultaneous telnet connections. I haven't these devices for testing. But I've verified which `attempt_login` connects a new socket for every login attempt. So I bet it doesn't hurt disconnecting the sockets when the login fails.  /cc @dmaloney-r7 
## Verification
- [x] Install an ubuntu target with a telnet server.
- [x] Run the telnet_login module with a set of usernames and passwords

```
msf auxiliary(telnet_login) > show options

Module options (auxiliary/scanner/telnet/telnet_login):

   Name              Current Setting                                                                       Required  Description
   ----              ---------------                                                                       --------  -----------
   BLANK_PASSWORDS   false                                                                                 no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                                                                                     yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false                                                                                 no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false                                                                                 no        Add all passwords in the current database to the list
   DB_ALL_USERS      false                                                                                 no        Add all users in the current database to the list
   PASSWORD          test                                                                                  no        A specific password to authenticate with
   PASS_FILE         /Users/jvazquez/Projects/Code/metasploit-framework/data/wordlists/unix_passwords.txt  no        File containing passwords, one per line
   RHOSTS            172.16.158.133                                                                        yes       The target address range or CIDR identifier
   RPORT             23                                                                                    yes       The target port
   STOP_ON_SUCCESS   false                                                                                 yes       Stop guessing when a credential works for a host
   THREADS           1                                                                                     yes       The number of concurrent threads
   USERNAME          test                                                                                  no        A specific username to authenticate as
   USERPASS_FILE                                                                                           no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false                                                                                 no        Try the username as the password for all users
   USER_FILE         /Users/jvazquez/Projects/Code/metasploit-framework/data/wordlists/unix_users.txt      no        File containing usernames, one per line
   VERBOSE           true                                                                                  yes       Whether to print output for all attempts
msf auxiliary(telnet_login) > run

[-] 172.16.158.133:23 TELNET - LOGIN FAILED: test:test (Incorrect: )
[-] 172.16.158.133:23 TELNET - LOGIN FAILED: test:123456 (Incorrect: )
[-] 172.16.158.133:23 TELNET - LOGIN FAILED: test:12345 (Incorrect: )
```
- [x] VERIFY which every connection is disconnected after failed login attempts.

![screen shot 2015-08-17 at 6 26 54 pm](https://cloud.githubusercontent.com/assets/1742838/9318847/a7a38c76-450d-11e5-8a88-c738e519e0ed.png)
