### PR TITLE
Feature PacketStorm Reference Display

### DIFF
--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -113,6 +113,8 @@ class Msf::Module::SiteReference < Msf::Module::Reference
       self.site = "http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}"
     elsif (in_ctx_id == 'WPVDB')
       self.site = "https://wpvulndb.com/vulnerabilities/#{in_ctx_val}"
+    elsif (in_ctx_id == 'PKT')
+      self.site = "https://packetstormsecurity.com/files/#{in_ctx_val}"
     elsif (in_ctx_id == 'URL')
       self.site = in_ctx_val.to_s
     else

--- a/tools/module_reference.rb
+++ b/tools/module_reference.rb
@@ -33,6 +33,7 @@ def types
     'US-CERT-VU' => 'http://www.kb.cert.org/vuls/id/#{in_ctx_val}',
     'ZDI'        => 'http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}',
     'WPVDB'      => 'https://wpvulndb.com/vulnerabilities/#{in_ctx_val}',
+    'PKT'        => 'https://packetstormsecurity.com/files/#{in_ctx_val}',
     'URL'        => '#{in_ctx_val}'
   }
 end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -193,6 +193,8 @@ class Msftidy
           warn("Invalid ZDI reference") if value !~ /^\d{2}-\d{3}$/
         when 'WPVDB'
           warn("Invalid WPVDB reference") if value !~ /^\d+$/
+        when 'PKT'
+          warn("Invalid PKT reference") if value !~ /^\d+$/
         when 'URL'
           if value =~ /^http:\/\/www\.osvdb\.org/
             warn("Please use 'OSVDB' for '#{value}'")
@@ -208,6 +210,8 @@ class Msftidy
             warn("Please use 'US-CERT-VU' for '#{value}'")
           elsif value =~ /^https:\/\/wpvulndb\.com\/vulnerabilities\//
             warn("Please use 'WPVDB' for '#{value}'")
+          elsif value =~ /^http:\/\/packetstormsecurity\.com\/files\//
+            warn("Please use 'PKT' for '#{value}'")
           end
         end
       end


### PR DESCRIPTION
Sorry guys for opening a new PR. Via #5786 

This pull request suggests putting reference to the site ["PacketStormSecurity"](https://packetstormsecurity.com/) using "PKT" acronym.

From:

``` ruby
'References'      =>
  [
    [ 'URL', 'http://packetstormsecurity.com/files/122799/ZeroShell-2.0RC2-File-Disclosure-Command-Execution.html' ]
  ],
```

To:

``` ruby
'References'      =>
  [
    [ 'PKT', '122799' ]
  ],
```

Following the pattern:

``` ruby
https://packetstormsecurity.com/files/#{in_ctx_val}
```

Old URL that are in references such as:
http://packetstormsecurity.org/files/117070/ProjectPier-0.8.8-Shell-Upload.html
It also works with the numerical identification only. Like:
https://packetstormsecurity.com/files/117070

It can be modified later if this PR is accepted.
Also changed the msftidy tool for verification.

Example:

```
$ ../tools/msftidy.rb exploits/unix/webapp/zeroshell_exec.rb
exploits/unix/webapp/zeroshell_exec.rb - [WARNING] Please use 'PKT' for 'http://packetstormsecurity.com/files/122799/ZeroShell-2.0RC2-File-Disclosure-Command-Execution.html'
$ gvim exploits/unix/webapp/zeroshell_exec.rb
$ ../tools/msftidy.rb exploits/unix/webapp/zeroshell_exec.rb
exploits/unix/webapp/zeroshell_exec.rb - [WARNING] Invalid PKT reference
$
```

[]`s
