### PR TITLE
Support x64 payloads

### DIFF
--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Local
           'Ahmad Moghimi', # Vulnerability discovery
           'juan vazquez' # MSF module
         ],
-      'Arch'           => ARCH_X86,
+      'Arch'           => [ARCH_X86, ARCH_X86_64],
       'Platform'       => 'win',
       'SessionTypes'   => [ 'meterpreter' ],
       'Privileged'     => true,

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -45,6 +45,7 @@ class Metasploit3 < Msf::Exploit::Local
                 'WfsDelay'     => 10,
             },
         'DisclosureDate' => 'Jan 01 1999',
+        'Arch'          => [ARCH_X86, ARCH_X86_64],
         'Platform'      => [ 'win' ],
         'SessionTypes'  => [ 'meterpreter' ],
         'Targets' => [ [ 'Universal', {} ] ],

--- a/modules/exploits/windows/local/run_as.rb
+++ b/modules/exploits/windows/local/run_as.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Local
       'SessionTypes'         => ['meterpreter'],
       'Author'               => ['Kx499', 'Ben Campbell'],
       'Targets'              => [
-        [ 'Automatic', { 'Arch' => [ ARCH_X86 ] } ]
+        [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X86_64 ] } ]
       ],
       'DefaultTarget'        => 0,
       'References'           =>

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Local
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'scriptjunkie' ],
-      'Arch'          => [ ARCH_X86 ],
+      'Arch'          => [ ARCH_X86, ARCH_X86_64 ],
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ],
       'DefaultOptions' =>
@@ -165,9 +165,17 @@ class Metasploit3 < Msf::Exploit::Local
   # define the correct servicename.
   def write_exe(path, service_name=nil)
     vprint_status("[#{service_name}] Writing service executable to #{path}")
-    exe = generate_payload_exe_service({:servicename=>service_name})
+    exe = generate_payload_exe_service({servicename: service_name, arch: get_payload_arch})
     write_file(path, exe)
     register_files_for_cleanup(path)
+  end
+
+  def get_payload_arch
+    if payload.arch.include?(ARCH_X86_64)
+      return ARCH_X86_64
+    else
+      return ARCH_X86
+    end
   end
 
   def exploit

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -83,6 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ],
           [ 'URL', 'http://www.xfocus.net/articles/200305/smbrelay.html' ]
         ],
+      'Arch'           => [ARCH_X86, ARCH_X86_64],
       'Platform'       => 'win',
       'Targets'        =>
         [


### PR DESCRIPTION
This PR is related to #5728, allowing some exploits to support x64. As you can see I'm really conservative with the changes. A module is only updated either if 1) the description says it supports x64, or 2) there's some code in the module attempting to support x64 or other architectures other than the default x86. I'm fairly sure there's more modules that are capable of supporting x64, especially the ones that are high-level (ie: upload-exec kind of exploit), but those ones don't look like they were tested against x64 during development, so I didn't go for it. Like I said, I'm being pretty conservative.

For testing, please make sure that:
- [x] `show options` displays x64 payloads
- [x] `set payload` allows you to use an x64 payload
