### PR TITLE
Added report_note to suggester

### DIFF
--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -5,6 +5,8 @@
 
 require 'msf/core'
 
+include Msf::Auxiliary::Report
+
 class Metasploit3 < Msf::Post
 
   def initialize(info={})
@@ -14,11 +16,10 @@ class Metasploit3 < Msf::Post
           This module suggests local meterpreter exploits that can be used. The
           exploits are suggested based on the architecture and platform that
           the user has a shell opened as well as the available exploits in
-          meterpreter. Additionally, the ShowDescription option can be set
-          to 'true' to a detailed description on the suggested exploits.
+          meterpreter.
 
           It's important to note that not all local exploits will be fired.
-          They are chosen based on these conditions: session type,
+          Exploits are chosen based on these conditions: session type,
           platform, architecture, and required default options.
         },
         'License'       => MSF_LICENSE,
@@ -138,7 +139,7 @@ class Metasploit3 < Msf::Post
     end
 
     show_found_exploits
-
+    results = []
     @local_exploits.each do |m|
       begin
         checkcode = m.check
@@ -146,6 +147,7 @@ class Metasploit3 < Msf::Post
         if is_check_interesting?(checkcode)
           # Prints the full name and the checkcode message for the exploit
           print_good("#{m.fullname}: #{checkcode.second}")
+          results << [m.fullname, checkcode.second]
           # If the datastore option is true, a detailed description will show
           if datastore['SHOWDESCRIPTION']
             # Formatting for the description text
@@ -160,8 +162,12 @@ class Metasploit3 < Msf::Post
         vprint_error("#{e.class} #{m.shortname} failled to run: #{e.message}")
       end
     end
+    report_note(
+                :host => rhost,
+                :type => "les_results",
+                :data => results.inspect
+                )
   end
-
 
   def is_check_interesting?(checkcode)
     [


### PR DESCRIPTION
# Verification
- [x] Run the local_exploit_suggestor post module
- [x] Type `notes` in msf

Output should be a record of the hosts and the vulnerabilities found for each. 
Note: You must have a database linked in order to set feature
