### PR TITLE
Correct the storage of ssh banners in service.info

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -53,33 +53,44 @@ class Metasploit3 < Msf::Auxiliary
 
         resp = sock.get_once(-1, timeout)
 
-        if resp
-          ident, first_message = resp.split(/[\r\n]+/)
-          if /^SSH-\d+\.\d+-(?<banner>.*)$/ =~ ident
-            if recog_match = Recog::Nizer.match('ssh.banner', banner)
-              info = recog_match.to_s
-            else
-              info = 'UNKNOWN'
-              print_warning("#{peer} unknown SSH banner: #{banner}")
-            end
-            # Check to see if this is Kippo, which sends a premature
-            # key init exchange right on top of the SSH version without
-            # waiting for the required client identification string.
-            if first_message && first_message.size >= 5
-              extra = first_message.unpack("NCCA*") # sz, pad_sz, code, data
-              if (extra.last.size + 2 == extra[0]) && extra[2] == 20
-                info << " (Kippo Honeypot)"
-              end
-            end
-            print_status("#{peer}, SSH server version: #{ident}")
-            report_service(host: rhost, port: rport, name: 'ssh', proto: 'tcp', info: info)
-          else
-            vprint_warning("#{peer} was not SSH --"  \
-                          " #{resp.size} bytes beginning with #{resp[0, 12]}")
-          end
-        else
+        if ! resp
           vprint_warning("#{peer} no response")
+          return
         end
+
+        ident, first_message = resp.split(/[\r\n]+/)
+        info = ""
+
+        if /^SSH-\d+\.\d+-(.*)$/ !~ ident
+          vprint_warning("#{peer} was not SSH -- #{resp.size} bytes beginning with #{resp[0, 12]}")
+          return
+        end
+
+        banner = $1
+
+        # Try to match with Recog and show the relevant fields to the user
+        recog_match = Recog::Nizer.match('ssh.banner', banner)
+        if recog_match
+          info << " ( "
+          recog_match.each_pair do |k,v|
+            next if k == 'matched'
+            info << "#{k}=#{v} "
+          end
+          info << ")"
+        end
+
+        # Check to see if this is Kippo, which sends a premature
+        # key init exchange right on top of the SSH version without
+        # waiting for the required client identification string.
+        if first_message && first_message.size >= 5
+          extra = first_message.unpack("NCCA*") # sz, pad_sz, code, data
+          if (extra.last.size + 2 == extra[0]) && extra[2] == 20
+            info << " (Kippo Honeypot)"
+          end
+        end
+
+        print_status("#{peer} SSH server version: #{ident}#{info}")
+        report_service(host: rhost, port: rport, name: 'ssh', proto: 'tcp', info: ident)
       end
     rescue Timeout::Error
       vprint_warning("#{peer} timed out after #{timeout} seconds. Skipping.")


### PR DESCRIPTION
This corrects a regression in how service.info was populated for SSH. 
