### PR TITLE
X64 compat for payload_inject

### DIFF
--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -27,6 +27,7 @@ class Metasploit3 < Msf::Exploit::Local
           'sinn3r'
         ],
       'Platform'      => [ 'win' ],
+      'Arch'          => [ ARCH_X86, ARCH_X86_64 ],
       'SessionTypes'  => [ 'meterpreter' ],
       'Targets'       => [ [ 'Windows', {} ] ],
       'DefaultTarget' => 0,


### PR DESCRIPTION
Related to https://github.com/rapid7/metasploit-framework/pull/5868

Changes to payload targeting mean that the payload cannot be overridden. A number of modules don't correctly specify x64 arch support so only x86 is supported by default. 
