### PR TITLE
Fix #5816 - Check query results to avoid nil dereferences on the DNS Resolver

### DIFF
--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -839,7 +839,7 @@ module Net # :nodoc:
         if name.include? "."
           @logger.debug "Search(#{name},#{Net::DNS::RR::Types.new(type)},#{Net::DNS::RR::Classes.new(cls)})"
           ans = query(name,type,cls)
-          return ans if ans.header.anCount > 0
+          return ans if ans && ans.header && ans.header.anCount > 0
         end
 
         # If the name doesn't end in a dot then apply the search list.
@@ -848,7 +848,7 @@ module Net # :nodoc:
             newname = name + "." + domain
             @logger.debug "Search(#{newname},#{Net::DNS::RR::Types.new(type)},#{Net::DNS::RR::Classes.new(cls)})"
             ans = query(newname,type,cls)
-            return ans if ans.header.anCount > 0
+            return ans if ans && ans.header && ans.header.anCount > 0
           end
         end
 


### PR DESCRIPTION
This PR tries to fix #5816 by fixing the DNS resolver embedded with metasploit. Basically this PR fixes the `search` method to avoid nil dereferences when using the `query` results. 

The `search` method should be able to return `nil` as response. Unfortunately in the case of early tries when the name contains at least one dot or if the name doesn't end in a dot, the `search` method  use the `query` results without checking against `nil` first.

On #5816 this issue arises when the connectivity with the NS is lost while running the auxiliary modules `dns_bruteforce` or `dns_info`. But similar exceptions can be raised when using an incorrect NS in the module.
## Verification
- [ ] From master run auxiliary/gather/dns_info with an incorrect NS as 8.8.8.1, you should get an exception:

```
msf auxiliary(dns_info) > set DOMAIN www.google.com
msf auxiliary(dns_info) > set NS 8.8.8.1
NS => 8.8.8.1
msf auxiliary(dns_info) > run

[*] Enumerating google.com
[*] Using DNS server: 8.8.8.1
W, [2015-08-17T17:20:58.355821 #7946]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-17T17:20:58.355910 #7946] FATAL -- : No response from nameservers list: aborting
[-] Auxiliary failed: NoMethodError undefined method `header' for nil:NilClass
[-] Call stack:
[-]   /Users/jvazquez/Projects/Code/metasploit-framework/lib/net/dns/resolver.rb:842:in `search'
[-]   /Users/jvazquez/Projects/Code/metasploit-framework/modules/auxiliary/gather/dns_info.rb:122:in `get_ip'
[-]   /Users/jvazquez/Projects/Code/metasploit-framework/modules/auxiliary/gather/dns_info.rb:55:in `run'
[*] Auxiliary module execution completed

```
- [ ] From this PR run auxiliary/gather/dns_info with an incorrect NS as 8.8.8.1, it shouldn't raise an exception anymore:

```
msf auxiliary(dns_info) > set NS 8.8.8.1
NS => 8.8.8.1
msf auxiliary(dns_info) > run

[*] Enumerating www.google.com
[*] Using DNS server: 8.8.8.1
W, [2015-08-24T09:20:49.880221 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:20:49.880315 #2052] FATAL -- : No response from nameservers list: aborting
W, [2015-08-24T09:20:54.959917 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:20:54.960017 #2052] FATAL -- : No response from nameservers list: aborting
W, [2015-08-24T09:21:00.034407 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:21:00.034481 #2052] FATAL -- : No response from nameservers list: aborting
W, [2015-08-24T09:21:05.119856 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:21:05.119960 #2052] FATAL -- : No response from nameservers list: aborting
W, [2015-08-24T09:21:10.215941 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:21:10.216042 #2052] FATAL -- : No response from nameservers list: aborting
W, [2015-08-24T09:21:15.287231 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:21:15.287475 #2052] FATAL -- : No response from nameservers list: aborting
W, [2015-08-24T09:21:20.365981 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:21:20.366078 #2052] FATAL -- : No response from nameservers list: aborting
W, [2015-08-24T09:21:25.439969 #2052]  WARN -- : Nameserver 8.8.8.1 not responding within UDP timeout, trying next one
F, [2015-08-24T09:21:25.440040 #2052] FATAL -- : No response from nameservers list: aborting
[*] Auxiliary module execution completed
```
- [ ] From this PR run auxiliary/gather/dns_info with a correct NS as 8.8.8.8, it should work correctly:

```
msf auxiliary(dns_info) > set DOMAIN www.google.com
DOMAIN => www.google.com
msf auxiliary(dns_info) > set NS 8.8.8.8
NS => 8.8.8.8
msf auxiliary(dns_info) > run

[*] Enumerating www.google.com
[*] Using DNS server: 8.8.8.8
[+] www.google.com - Address 173.194.115.50 found. Record type: A
[+] www.google.com - Address 173.194.115.49 found. Record type: A
[+] www.google.com - Address 173.194.115.51 found. Record type: A
[+] www.google.com - Address 173.194.115.52 found. Record type: A
[+] www.google.com - Address 173.194.115.48 found. Record type: A
[+] www.google.com - Address 2607:f8b0:4000:805::1010 found. Record type: AAAA
[*] Auxiliary module execution completed
```
