### PR TITLE
Fix #5854 Ensure disconnect on auxiliary/scanner/oracle/sid_brute.rb

### DIFF
--- a/modules/auxiliary/scanner/oracle/sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/sid_brute.rb
@@ -85,10 +85,11 @@ class Metasploit3 < Msf::Auxiliary
         vprint_status "#{hostport} Oracle - Refused '#{sid}'"
         return :fail
       end
-      disconnect
     rescue ::Rex::ConnectionError, ::Errno::EPIPE
       print_error("#{hostport} Oracle - unable to connect to a TNS listener")
       return :abort
+    ensure
+      disconnect
     end
   end
 


### PR DESCRIPTION
This pull request tries to fix #5854. As correctly diagnosed by @ewilded, `sid_brute` doesn't disconnect correctly (returns before disconnecting). So apparently when using a big `SID_FILE` it can exhaust the resources (sockets) on the database server. This fix is just ensuring disconnect. @ewilded also proposed to reuse the same connection when checking different sid's against the same host. But I preferred to be conservative, and leave the old behavior, one connection by SID. Just ensure disconnecting the sockets to allow the server to free resources.
## Verification
- [ ] Install a Windows 2003 SP2 target with Oracle Database Express edition, which can be downloaded from http://www.oracle.com/technetwork/database/database-technologies/express-edition/overview/index.html
- [ ] Run the auxiliary/scanner/oracle/sid_brute.rb module from master. Verify which, even when the server sends a FIN/ACK. The client (us) doesn't disconnect so the socket remains open until for example, you stop the module.

![master](https://cloud.githubusercontent.com/assets/1742838/9447670/53ccb400-4a5e-11e5-9901-4e83f41b944f.png)
- [ ] Run the auxiliary/scanner/oracle/sid_brute.rb module from this branch. Verify which the client (us) disconnect after every sid check.

![fixed](https://cloud.githubusercontent.com/assets/1742838/9447685/6e7872a8-4a5e-11e5-92c9-998fed6c85d1.png)
