### PR TITLE
Create MatchResult with status Failure on session failure

### DIFF
--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -96,7 +96,7 @@ module Msf::DBManager::Session
         MetasploitDataModels::AutomaticExploitation::MatchResult.create!(
           match: session.exploit.user_data[:match],
           run: session.exploit.user_data[:run],
-          state: 'succeeded',
+          state: MetasploitDataModels::AutomaticExploitation::MatchResult::SUCCEEDED,
         )
         infer_vuln_from_session(session, wspace)
       elsif session.via_exploit

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1285,6 +1285,14 @@ class Exploit < Msf::Module
       end
     end
 
+    if user_data_is_match?
+      MetasploitDataModels::AutomaticExploitation::MatchResult.create!(
+        match: user_data[:match],
+        run: user_data[:run],
+        state: MetasploitDataModels::AutomaticExploitation::MatchResult::FAILED,
+      )
+    end
+
     framework.db.report_exploit_failure(info)
   end
 


### PR DESCRIPTION
MSP-13104
#### Verification Steps
- [x] Checkout this branch
- [x] Start with a fresh DB
- [x] VERIFY specs pass
- In Pro
- [x] Run the site importer and select Fernando Push Demo
- [x] Go to single vuln view for a vuln. Run a module that matches up with a ref for that vuln.
- [x] Watch the module fail.
- [x] In rails console do

```
MetasploitDataModels::AutomaticExploitation::MatchResult.last
```
- [x] VERIFY you see a match result with a failure status.
- [x] Go back to the vuln index view and select a vuln you can exploit (MS08-067)
- [x] Click "Modules" button in the nav bar
- [x] Search for MS08-067
- [x] Run the MS08-067 module. Remember to select "bind"
- [x] VERIFY you get a session
- [x] In rails console do

```
MetasploitDataModels::AutomaticExploitation::MatchResult.last
```
- [ ] VERIFY you see a match result with a succeeded status.
