### PR TITLE
Bump PacketFu to latest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
       metasploit-payloads (= 1.0.8)
       msgpack
       nokogiri
-      packetfu (= 1.1.9)
+      packetfu (= 1.1.11)
       railties
       rb-readline-r7
       recog (= 2.0.6)
@@ -144,7 +144,9 @@ GEM
     network_interface (0.0.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    packetfu (1.1.9)
+    packetfu (1.1.11)
+      network_interface (~> 0.0)
+      pcaprub (~> 0.12)
     pcaprub (0.12.0)
     pg (0.18.2)
     pg_array_parser (0.0.9)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   # Needed by anemone crawler
   spec.add_runtime_dependency 'nokogiri'
   # Needed by db.rb and Msf::Exploit::Capture
-  spec.add_runtime_dependency 'packetfu', '1.1.9'
+  spec.add_runtime_dependency 'packetfu', '1.1.11'
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
   spec.add_runtime_dependency 'railties'
   # required for OS fingerprinting


### PR DESCRIPTION
This bumps PacketFu to the latest version, released today. 20 months in the making, you know it's good. Thanks @claudijd for kicking this at me until I couldn't dodge it any more.
## Verification
- [ ] `bundle install` should pass without error.
- [ ] `rake spec` should pass without error.
- [ ] A test run of any module that uses the `Capture` mixin should still work. A recent example would be `modules/auxiliary/dos/dns/bind_tkey.rb`
## Next steps

Alert @lsanchez-r7 about the gemfile change before pushing this, or Pro will certainly fail. At least, that's how I understand it.
## More info

Read up on the changes [here](https://github.com/packetfu/packetfu/releases/tag/version-1.1.11)
