### PR TITLE
Bump mime-types to 2.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       railties (>= 4.0.9, < 4.1.0)
       recog (~> 2.0)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (4.7.5)
     msgpack (0.6.2)


### PR DESCRIPTION
Currently, we're stuck on mime-types 2.4.3. Doesn't seem to be any reason for this, and incidentally, 2.4.3 is signed with an old and unfindable cert. We should bump to 2.6.1 to get out of gem signing purgatory.
## Diffs

https://github.com/mime-types/ruby-mime-types/compare/v2.4.3...v2.6.1
## Related issue

https://github.com/mime-types/ruby-mime-types/issues/78#issuecomment-134665088
## Verification
- [ ] `rvm gemset empty`
- [ ] `gem install bundler`
- [ ] `bundle install`
- [ ] `rake spec`

All specs should pass.
## Example of failure

We don't yet support signing, but individual gems should not be unfixable, since someday, we'll want to at least support a `MediumSecurity` trust policy.

```
[ruby-2.1.6@metasploit-framework]
todb@mazikeen:~$ gem install -P MediumSecurity mime-types -v 2.4.3
ERROR:  While executing gem ... (Gem::Security::Exception)
    certificate /CN=austin/DC=rubyforge/DC=org not valid after 2015-02-22 03:41:43 UTC
[ruby-2.1.6@metasploit-framework]
todb@mazikeen:~$ gem install -P MediumSecurity mime-types
WARNING:  mime-types-2.6.1 is not signed
Successfully installed mime-types-2.6.1
Parsing documentation for mime-types-2.6.1
Done installing documentation for mime-types after 0 seconds
1 gem installed
[ruby-2.1.6@metasploit-framework]
```
