### PR TITLE
Added check for hash syntax in msftidy

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -565,6 +565,12 @@ class Msftidy
     end
   end
 
+  def check_hash_syntax
+    if @source =~ /([^:]):(\w+)\s*=>\s/
+      warn('Please use "{ key: \'value\' }" instead of "{ :key => \'value\' }"')
+    end
+  end
+
   def check_vars_get
     test = @source.scan(/send_request_cgi\s*\(\s*\{?\s*['"]uri['"]\s*=>\s*[^=})]*?\?[^,})]+/im)
     unless test.empty?
@@ -684,6 +690,7 @@ def run_checks(full_filepath)
   tidy.check_print_debug
   tidy.check_register_datastore_debug
   tidy.check_use_datastore_debug
+  tidy.check_hash_syntax
   return tidy
 end
 


### PR DESCRIPTION
This PR suggests adding a check for msftidy when using the old hash syntax.

Code:

```
  report_service(:host=> rcrd[:ip],
      :port => rcrd[:port].to_i,
      :proto => srv_info[1],
      :name => srv_info[0],
      :host_name => rcrd[:target]
    )
```

Result:

```
$ ../tools/msftidy.rb /tmp/dns_srv_lookup.rb 
/tmp/dns_srv_lookup.rb - [WARNING] Please use "{ key: 'value' }" instead of "{ :key => 'value' }"
$
```
