### PR TITLE
Update workspace command to support deleting all workspaces

### DIFF
--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -535,6 +535,10 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
   end
 
   describe "#cmd_workspace" do
+    before(:each) do
+      db.cmd_workspace "-D"
+      @output = []
+    end
     describe "<no arguments>" do
       it "should list default workspace" do
         db.cmd_workspace
@@ -545,10 +549,11 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
 
       it "should list all workspaces" do
         db.cmd_workspace("-a", "foo")
+        @output = []
         db.cmd_workspace
         @output.should =~ [
-          "default",
-          " * foo"
+          "  default",
+          "* foo"
         ]
       end
     end
@@ -567,9 +572,11 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
     describe "-d" do
       it "should delete a workspace" do
         db.cmd_workspace("-a", "foo")
+        @output = []
         db.cmd_workspace("-d", "foo")
         @output.should =~ [
-          "Deleted workspace: foo"
+          "Deleted workspace: foo",
+          "Switched workspace: default"
         ]
       end
     end
@@ -577,10 +584,12 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
     describe "-D" do
       it "should delete all workspaces" do
         db.cmd_workspace("-a", "foo")
+        @output = []
         db.cmd_workspace("-D")
         @output.should =~ [
           "Deleted and recreated the default workspace",
-          "Deleted workspace: foo"
+          "Deleted workspace: foo",
+          "Switched workspace: default"
         ]
       end
     end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -547,21 +547,23 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         db.cmd_workspace "-a foo"
         db.cmd_workspace
         @output.should =~ [
-          "default"
+          "default",
           " * foo"
         ]
       end
     end
+
     describe "-a" do
       it "should add workspaces" do
         db.cmd_workspace "-a foo bar baf"
         @output.should =~ [
-          "Added workspace: foo"
-          "Added workspace: bar"
+          "Added workspace: foo",
+          "Added workspace: bar",
           "Added workspace: baf"
         ]
       end
     end
+
     describe "-d" do
       it "should delete a workspace" do
         db.cmd_workspace "-a foo"
@@ -571,6 +573,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         ]
       end
     end
+
     describe "-D" do
       it "should delete all workspaces" do
         db.cmd_workspace "-a foo"
@@ -581,6 +584,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         ]
       end
     end
+
     describe "-h" do
       it "should show a help message" do
         db.cmd_workspace "-h"

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -535,6 +535,52 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
   end
 
   describe "#cmd_workspace" do
+    describe "<no arguments>" do
+      it "should list default workspace" do
+        db.cmd_workspace
+        @output.should =~ [
+          "* default"
+        ]
+      end
+
+      it "should list all workspaces" do
+        db.cmd_workspace "-a foo"
+        db.cmd_workspace
+        @output.should =~ [
+          "default"
+          " * foo"
+        ]
+      end
+    end
+    describe "-a" do
+      it "should add workspaces" do
+        db.cmd_workspace "-a foo bar baf"
+        @output.should =~ [
+          "Added workspace: foo"
+          "Added workspace: bar"
+          "Added workspace: baf"
+        ]
+      end
+    end
+    describe "-d" do
+      it "should delete a workspace" do
+        db.cmd_workspace "-a foo"
+        db.cmd_workspace "-d foo"
+        @output.should =~ [
+          "Deleted workspace: foo"
+        ]
+      end
+    end
+    describe "-D" do
+      it "should delete all workspaces" do
+        db.cmd_workspace "-a foo"
+        db.cmd_workspace "-D"
+        @output.should =~ [
+          "Deleted and recreated the default workspace",
+          "Deleted workspace: foo"
+        ]
+      end
+    end
     describe "-h" do
       it "should show a help message" do
         db.cmd_workspace "-h"

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -544,7 +544,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
       end
 
       it "should list all workspaces" do
-        db.cmd_workspace "-a foo"
+        db.cmd_workspace("-a", "foo")
         db.cmd_workspace
         @output.should =~ [
           "default",
@@ -555,7 +555,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
 
     describe "-a" do
       it "should add workspaces" do
-        db.cmd_workspace "-a foo bar baf"
+        db.cmd_workspace("-a", "foo", "bar", "baf")
         @output.should =~ [
           "Added workspace: foo",
           "Added workspace: bar",
@@ -566,8 +566,8 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
 
     describe "-d" do
       it "should delete a workspace" do
-        db.cmd_workspace "-a foo"
-        db.cmd_workspace "-d foo"
+        db.cmd_workspace("-a", "foo")
+        db.cmd_workspace("-d", "foo")
         @output.should =~ [
           "Deleted workspace: foo"
         ]
@@ -576,8 +576,8 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
 
     describe "-D" do
       it "should delete all workspaces" do
-        db.cmd_workspace "-a foo"
-        db.cmd_workspace "-D"
+        db.cmd_workspace("-a", "foo")
+        db.cmd_workspace("-D")
         @output.should =~ [
           "Deleted and recreated the default workspace",
           "Deleted workspace: foo"

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -544,6 +544,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "    workspace [name]           Switch workspace",
           "    workspace -a [name] ...    Add workspace(s)",
           "    workspace -d [name] ...    Delete workspace(s)",
+          "    workspace -D               Delete all workspaces",
           "    workspace -r <old> <new>   Rename workspace",
           "    workspace -h               Show this help information"
         ]

--- a/spec/support/shared/contexts/msf/ui_driver.rb
+++ b/spec/support/shared/contexts/msf/ui_driver.rb
@@ -9,6 +9,10 @@ shared_context 'Msf::UIDriver' do
         @output ||= []
         @output.concat string.split("\n")
       end
+      driver.stub(:print_status).with(kind_of(String)) do |string|
+        @output ||= []
+        @output.concat string.split("\n")
+      end
       driver.stub(:print_error).with(kind_of(String)) do |string|
         @error ||= []
         @error.concat string.split("\n")


### PR DESCRIPTION
I use workspaces to separate the various things I happen to be working on, but it is pretty rare that I need to keep any workspace for very long.  After a while I get a lot and have the urge to purge and prefer to not have to do this at the database level, so I figured the ability to delete all workspaces would be helpful.  This complements other delete functionality but is a bit more dangerous.
## Validation
- [x] Specs pass
- [x] Basic CLI testing:

```
msf > workspace 
* default
msf > workspace -a foo bar baf blargh
[*] Added workspace: foo
[*] Added workspace: bar
[*] Added workspace: baf
[*] Added workspace: blargh
msf > workspace -d blargh 
[*] Deleted workspace: blargh
[*] Switched workspace: default
msf > workspace 
* default
  foo
  bar
  baf
msf > workspace -D
[*] Deleted and recreated the default workspace
[*] Deleted workspace: foo
[*] Deleted workspace: bar
[*] Deleted workspace: baf
msf > workspace 
* default
```

Also, I know the specs I added are currently broken, because the existing testing framework only tests stuff that comes from `print_line` and `print_error`.  I could convert `workspace` to use `print_line` or I could update 
