### PR TITLE
Fix #4227 by improving parsing of nested elements

### DIFF
--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -31,40 +31,41 @@ module Parser
   def end_element(name=nil)
     block = @block
     case name
-    when "name"
-      return if not in_tag("result")
-      @state[:has_text] = true
-      @state[:vuln_name] = @text.strip if @text
-    when "description"
+    when 'name'
+      if in_tag('result')
+        @state[:has_text] = true
+        @state[:vuln_name] = @text.strip if @text
+      end
+    when 'description'
       @state[:has_text] = true
       @state[:vuln_desc] = @text.strip if @text
-    when "bid"
-      return unless in_tag("result")
-      return unless in_tag("nvt")
+    when 'bid'
+      if in_tag('result') && in_tag('nvt')
+        @state[:has_text] = true
+        @state[:bid] = @text.strip if @text
+      end
+    when 'cve'
+      if in_tag('result') && in_tag('nvt')
+        @state[:has_text] = true
+        @state[:cves] = @text.strip if @text
+      end
+    when 'risk_factor'
+      if in_tag('result') && in_tag('nvt')
+        #we do this to clean out the buffer so to speak
+        #if we don't set text to nil now, the text will show up later
+        @state[:has_text] = true
+      end
+    when 'cvss_base'
+      if in_tag('result')  && in_tag('nvt')
+        @state[:has_text] = true
+      end
+    when 'subnet'
       @state[:has_text] = true
-      @state[:bid] = @text.strip if @text
-    when "cve"
-      return unless in_tag("result")
-      return unless in_tag("nvt")
-      @state[:has_text] = true
-      @state[:cves] = @text.strip if @text
-    when "risk_factor"
-      return unless in_tag("result")
-      return unless in_tag("nvt")
-      #we do this to clean out the buffer so to speak
-      #if we don't set text to nil now, the text will show up later
-      @state[:has_text] = true
-    when "cvss_base"
-      return unless in_tag("result")
-      return unless in_tag("nvt")
-      @state[:has_text] = true
-    when "subnet"
-      @state[:has_text] = true
-    when "result"
-      record_vuln if in_tag("results")
-    when "threat"
-      @state[:has_text] = true if in_tag("ports") && in_tag("port")
-    when "host"
+    when 'result'
+      record_vuln if in_tag('results')
+    when 'threat'
+      @state[:has_text] = true if in_tag('ports') && in_tag('port')
+    when 'host'
       if in_tag('result')
         @state[:has_text] = true
         @state[:host] = @text.strip if @text
@@ -72,7 +73,7 @@ module Parser
         @state[:has_text] = true
         @state[:host] = @text.strip if @text
       end
-    when "port"
+    when 'port'
       if in_tag('result')
         @state[:has_text] = true
         if @text && @text.index('(')
@@ -102,8 +103,8 @@ module Parser
           record_service unless @state[:port] == 'general'
         end
       end
-    when "name"
-      return if not in_tag("result")
+    when 'name'
+      return if not in_tag('result')
       @state[:has_text] = true
     end
 

--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -15,6 +15,12 @@ module Parser
     attrs = normalize_attrs(attrs)
     block = @block
     @state[:current_tag][name] = true
+
+    unless @text.nil?
+      @state[:text_backup] = @text
+      @text = nil
+    end
+
     case name
     when "host"
       @state[:has_text] = true
@@ -29,93 +35,85 @@ module Parser
       return if not in_tag("result")
       @state[:has_text] = true
       @state[:vuln_name] = @text.strip if @text
-      @text = nil
     when "description"
       @state[:has_text] = true
       @state[:vuln_desc] = @text.strip if @text
-      @text = nil
     when "bid"
-      return if not in_tag("result")
-      return if not in_tag("nvt")
+      return unless in_tag("result")
+      return unless in_tag("nvt")
       @state[:has_text] = true
       @state[:bid] = @text.strip if @text
-      @text = nil
     when "cve"
-      return if not in_tag("result")
-      return if not in_tag("nvt")
+      return unless in_tag("result")
+      return unless in_tag("nvt")
       @state[:has_text] = true
       @state[:cves] = @text.strip if @text
-      @text = nil
     when "risk_factor"
-      return if not in_tag("result")
-      return if not in_tag("nvt")
-
+      return unless in_tag("result")
+      return unless in_tag("nvt")
       #we do this to clean out the buffer so to speak
       #if we don't set text to nil now, the text will show up later
       @state[:has_text] = true
-      @text = nil
     when "cvss_base"
-      return if not in_tag("result")
-      return if not in_tag("nvt")
+      return unless in_tag("result")
+      return unless in_tag("nvt")
       @state[:has_text] = true
-      @text = nil
     when "subnet"
       @state[:has_text] = true
-      @text = nil
     when "result"
-      return if not in_tag("results")
-      record_vuln
+      record_vuln if in_tag("results")
     when "threat"
-      return if not in_tag("ports")
-      return if not in_tag("port")
-      @state[:has_text] = true
-
-      if not @text.index('(')
-        @state[:name] = nil
-        @state[:port] = nil
-        @state[:proto] = nil
-        @text = nil
-        return
-      end
-
-      @state[:name] = @text.split(' ')[0] if @text
-      @state[:port] = @text.split('(')[1].split('/')[0] if @text
-      @state[:proto] = @text.split('(')[1].split('/')[1].split(')')[0] if @text
-
-      @text = nil
+      @state[:has_text] = true if in_tag("ports") && in_tag("port")
     when "host"
       if in_tag('result')
         @state[:has_text] = true
         @state[:host] = @text.strip if @text
-        @text = nil
-      elsif in_tag('ports')
-        return if not in_tag('port')
+      elsif in_tag('ports') && in_tag('port')
         @state[:has_text] = true
         @state[:host] = @text.strip if @text
-        @text = nil
       end
     when "port"
       if in_tag('result')
         @state[:has_text] = true
-        if not @text.index('(')
+        if @text && @text.index('(')
+          @state[:proto] = @text.split('(')[1].split('/')[1].gsub(/\)/, '')
+          @state[:port] = @text.split('(')[1].split('/')[0].gsub(/\)/, '')
+        elsif @text && @text.index('/')
+          @state[:proto] = @text.split('/')[1].strip
+          @state[:port] = @text.split('/')[0].strip
+        else
           @state[:proto] = nil
           @state[:port] = nil
-          @text = nil
-          return
         end
-        @state[:proto] = @text.split('(')[0].strip if @text
-        @state[:port] = @text.split('(')[1].split('/')[0].gsub(/\)/, '') if @text
-        @text = nil
+
+        if @state[:port] && @state[:port] == 'general'
+          @state[:proto] = nil
+          @state[:port] = nil
+        end
       elsif in_tag('ports')
-        record_service
+        if @text && @text.index('(')
+          @state[:name] = @text.split(' ')[0]
+          @state[:port] = @text.split('(')[1].split('/')[0]
+          @state[:proto] = @text.split('(')[1].split('/')[1].split(')')[0]
+          record_service unless @state[:name].nil?
+        elsif @text && @text.index('/')
+          @state[:port] = @text.split('/')[0]
+          @state[:proto] = @text.split('/')[1]
+          record_service unless @state[:port] == 'general'
+        end
       end
     when "name"
       return if not in_tag("result")
       @state[:has_text] = true
-      @text = nil
+    end
+
+    if @state[:text_backup]
+      @text = @state[:text_backup]
+      @state[:text_backup] = nil
     else
       @text = nil
     end
+
     @state[:current_tag].delete name
   end
 
@@ -153,8 +151,6 @@ module Parser
   end
 
   def record_service
-    return if not @state[:name]
-
     service_info = {}
     service_info[:host] = @state[:host]
     service_info[:name] = @state[:name]


### PR DESCRIPTION
This PR tries to fix #4227 by improving the parsing of nested elements on OpenVAS XML reports.

Basically the problem is which the parser was designed to parse <ports> with this format:

```
<ports start="1" max="-1">
<port>
<host>192.168.1.129</host>https (443/tcp)
<threat>High</threat></port>
<port>
<host>192.168.1.129</host>microsoft-ds (445/tcp)
<threat>High</threat></port>
<port>
<host>192.168.1.129</host>epmap (135/tcp)
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>general/SMBClient
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>general/tcp
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>http (80/tcp)
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>mysql (3306/tcp)
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>netbios-ssn (139/tcp)
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>ntp (123/udp)
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>tftp (69/udp)
<threat>Low</threat></port>
<port>
<host>192.168.1.129</host>blackjack (1025/tcp)
<threat>Log</threat></port>
<port>
<host>192.168.1.129</host>commplex-main (5000/tcp)
<threat>Log</threat></port>
<port>
<host>192.168.1.129</host>general/CPE-T
<threat>Log</threat></port>
<port>
<host>192.168.1.129</host>general/HOST-T
<threat>Log</threat></port>
<port>
<host>192.168.1.129</host>general/icmp
<threat>Log</threat></port>
<port>
<host>192.168.1.129</host>netbios-ns (137/udp)
<threat>Log</threat></port>
</ports>
```

Unfortunately under OpenVAS v7 reports appears to have a format like:

```
        <ports max="12" start="1">
            <count>2</count>
            <port>80/tcp<host>172.16.158.133</host><severity>4.3</severity><threat>Medium</threat></port>
            <port>general/tcp<host>172.16.158.133</host><severity>2.6</severity><threat>Low</threat></port>
            <port>general/icmp<host>172.16.158.133</host><severity>0.0</severity><threat>Log</threat></port>
            <port>general/CPE-T<host>172.16.158.133</host><severity>0.0</severity><threat>Log</threat></port>
            <port>5353/tcp<host>172.16.158.133</host><severity>0.0</severity><threat>Log</threat></port>
        </ports>

```

Even when doesn't look like a big change the current OpenVAS importer design makes it super dependent on the XML format. Making really hard to adapt it to XML changes.

For example, before this PR the information about a port was not being processed when ending a </port> element but when finishing a <threat> element. It should be really avoided, because makes parsing even harder.

The solution I'm proposing here is to allow a better parsing of nested elements. So if a new element starts while we're processing another one:
- its @text is backed up
- the new element is processed and 
- the context of the @text is backed up once we're done with the new element.

It works pretty good in the reports I've been able to test. But could fail if at some moment multiple (nested) levels of processing start simultaneously. If it's the case the next fix will be an stack of backups =)
## Verification
- [ ] Get any OpenVAS XML report < v7. Parse it on master, verify the hosts, services and vulns reported. 

```
msf > workspace -a openvas
[*] Added workspace: openvas
msf > db_import /tmp/openvas_report.xml
[*] Importing 'OpenVAS XML' data
[*] Successfully imported /tmp/openvas_report.xml
msf > hosts

Hosts
=====

address        mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------        ---  ----  -------  ---------  -----  -------  ----  --------
192.168.1.129             Unknown                    device

msf > services

Services
========

host           port  proto  name           state  info
----           ----  -----  ----           -----  ----
192.168.1.129  69    udp    tftp           open
192.168.1.129  80    tcp    http           open
192.168.1.129  123   udp    ntp            open
192.168.1.129  135   tcp    epmap          open
192.168.1.129  137   udp    netbios-ns     open
192.168.1.129  139   tcp    netbios-ssn    open
192.168.1.129  443   tcp    https          open
192.168.1.129  445   tcp    microsoft-ds   open
192.168.1.129  1025  tcp    blackjack      open
192.168.1.129  3306  tcp    mysql          open
192.168.1.129  5000  tcp    commplex-main  open

msf > vulns
[*] Time: 2015-08-31 16:58:52 UTC Vuln: host=192.168.1.129 name=Vulnerabilities in SMB Could Allow Remote Code Execution
(958687) - Remote refs=CVE-2008-4114,CVE-2008-4834,CVE-2008-4835,BID-31179
[*] Time: 2015-08-31 16:58:52 UTC Vuln: host=192.168.1.129 name=Microsoft Windows SMB Server NTLM Multiple Vulnerabilities
(971468) refs=CVE-2010-0020,CVE-2010-0021,CVE-2010-0022,CVE-2010-0231
[*] Time: 2015-08-31 16:58:52 UTC Vuln: host=192.168.1.129 name=TCP Sequence Number Approximation Reset Denial of Service
Vulnerability refs=CVE-2004-0230,BID-10183
[*] Time: 2015-08-31 16:58:52 UTC Vuln: host=192.168.1.129 name=ICMP Timestamp Detection refs=CVE-1999-0524
msf >
```
- [ ] Parse it again on this branch. Verify which any information is lost.

```
msf > db_import /tmp/openvas_report.xml
[*] Importing 'OpenVAS XML' data
[*] Successfully imported /tmp/openvas_report.xml
msf > hosts

Hosts
=====

address        mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------        ---  ----  -------  ---------  -----  -------  ----  --------
192.168.1.129             Unknown                    device

msf > services

Services
========

host           port  proto  name           state  info
----           ----  -----  ----           -----  ----
192.168.1.129  69    udp    tftp           open
192.168.1.129  80    tcp    http           open
192.168.1.129  123   udp    ntp            open
192.168.1.129  135   tcp    epmap          open
192.168.1.129  137   udp    netbios-ns     open
192.168.1.129  139   tcp    netbios-ssn    open
192.168.1.129  443   tcp    https          open
192.168.1.129  445   tcp    microsoft-ds   open
192.168.1.129  1025  tcp    blackjack      open
192.168.1.129  3306  tcp    mysql          open
192.168.1.129  5000  tcp    commplex-main  open

msf > vulns
[*] Time: 2015-08-31 17:01:02 UTC Vuln: host=192.168.1.129 name=Vulnerabilities in SMB Could Allow Remote Code Execution
(958687) - Remote refs=CVE-2008-4114,CVE-2008-4834,CVE-2008-4835,BID-31179
[*] Time: 2015-08-31 17:01:02 UTC Vuln: host=192.168.1.129 name=Microsoft Windows SMB Server NTLM Multiple Vulnerabilities
(971468) refs=CVE-2010-0020,CVE-2010-0021,CVE-2010-0022,CVE-2010-0231
[*] Time: 2015-08-31 17:01:02 UTC Vuln: host=192.168.1.129 name=TCP Sequence Number Approximation Reset Denial of Service
Vulnerability refs=CVE-2004-0230,BID-10183
[*] Time: 2015-08-31 17:01:02 UTC Vuln: host=192.168.1.129 name=ICMP Timestamp Detection refs=CVE-1999-0524
msf >
```
- [ ] Get OpenVAS XML report v7. Parse it on master, services shouldn't be available.

```
msf > workspace -a openvas
[*] Added workspace: openvas
msf > db_import /tmp/report.xml
[*] Importing 'OpenVAS XML' data
[*] Successfully imported /tmp/report.xml
msf > hosts

Hosts
=====

address         mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------         ---  ----  -------  ---------  -----  -------  ----  --------
172.16.158.133

msf > services

Services
========

host  port  proto  name  state  info
----  ----  -----  ----  -----  ----

msf > vulns
[*] Time: 2015-08-31 17:02:55 UTC Vuln: host=172.16.158.133 name=Apache Web Server ETag Header Information Disclosure Weakness refs=CVE-2003-1418,BID-6939
[*] Time: 2015-08-31 17:02:55 UTC Vuln: host=172.16.158.133 name=ICMP Timestamp Detection refs=CVE-1999-0524
msf >
```
- [ ] Get the same OpenVAS XML report v7. Parse it on this branch, services should be available.

```
msf > workspace -a openvas
[*] Added workspace: openvas
msf > db_import /tmp/report.xml
[*] Importing 'OpenVAS XML' data
[*] Successfully imported /tmp/report.xml
msf > hosts

Hosts
=====

address         mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------         ---  ----  -------  ---------  -----  -------  ----  --------
172.16.158.133             Unknown                    device

msf > services

Services
========

host            port  proto  name  state  info
----            ----  -----  ----  -----  ----
172.16.158.133  80    tcp          open
172.16.158.133  5353  tcp          open

msf > vulns
[*] Time: 2015-08-31 17:00:18 UTC Vuln: host=172.16.158.133 name=Apache Web Server ETag Header Information Disclosure Weakness refs=CVE-2003-1418,BID-6939
[*] Time: 2015-08-31 17:00:18 UTC Vuln: host=172.16.158.133 name=ICMP Timestamp Detection refs=CVE-1999-0524
msf >
```
