### PR TITLE
Move help functionality for ps command

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -422,6 +422,11 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Lists running processes.
   #
   def cmd_ps(*args)
+    if args.include?('-h')
+      cmd_ps_help
+      return true
+    end
+
     # Init vars
     processes = client.sys.process.get_processes
     search_term = nil
@@ -435,9 +440,6 @@ class Console::CommandDispatcher::Stdapi::Sys
           print_error("Enter a search term")
           return true
         end
-      when '-h'
-        cmd_ps_help
-        return true
       when "-A"
         print_line "Filtering on arch..."
         searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new


### PR DESCRIPTION
This is a small piece of the puzzle identified in issue #5863, in that it moves the `-h` handling for the `ps` command so that it's handled prior to the call which lists all the processes on the target.

This is just a small "patch" I had sitting in one of my forks. I have a lot of other stuff I want to get done with `ps`, including client-side filtering. But for now, this should at least let people see the help without having to wait for Meterpreter to enumerate the processes behind the scenes. This caused issues on high latency networks where the number of processes was huge.
