### PR TITLE
Add timeout option for migration

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -782,7 +782,7 @@ class Console::CommandDispatcher::Core
   end
 
   @@migrate_opts = Rex::Parser::Arguments.new(
-    '-p'  => [true,  'Writable path (eg. /tmp).'],
+    '-p'  => [true,  'Writable path - Linux only (eg. /tmp).'],
     '-t'  => [true,  'The number of seconds to wait for migration to finish (default: 60).'],
     '-h'  => [false, 'Help menu.']
   )
@@ -826,7 +826,7 @@ class Console::CommandDispatcher::Core
       when '-t'
         opts[:timeout] = val.to_i
       when '-p'
-        writable_dir] = val
+        writable_dir = val
       end
     end
 
@@ -873,7 +873,7 @@ class Console::CommandDispatcher::Core
     if client.platform =~ /linux/
       client.core.migrate(pid, writable_dir, opts)
     else
-      client.core.migrate(pid, opts = opts)
+      client.core.migrate(pid, opts: opts)
     end
 
     print_status('Migration completed successfully.')

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -870,11 +870,7 @@ class Console::CommandDispatcher::Core
     server ? print_status("Migrating from #{server.pid} to #{pid}...") : print_status("Migrating to #{pid}")
 
     # Do this thang.
-    if client.platform =~ /linux/
-      client.core.migrate(pid, writable_dir, opts)
-    else
-      client.core.migrate(pid, opts: opts)
-    end
+    client.core.migrate(pid, writable_dir, opts)
 
     print_status('Migration completed successfully.')
 


### PR DESCRIPTION
This commit changes the migrate function so that an optional timeout parameter can be given. This means that people in high-latency scenarios can extend the timeout when migration in order to increase the chances that things will work.

This PR is a replacement for the one originally posted in #5757, and doesn't change the API in a way that breaks backwards compatibility.

The writable folder for linux is now passed with the `-p` flag.

The migrate function now takes an extra argument called `opts`, which contains the timeout value.

The code has a few "tidies" as well, bringing things closer to the current standard.
## Verification
- [ ] Migration still works as it always did.
- [ ] Use of the `-t` parameter does change the timeout value (hard to simulate, I used debug output).
- [ ] Help contains appropriate detail of the flags.

This is currently on hold while I do a bit more testing.
