### PR TITLE
Fixes bug where "cert.rb:47: warning: flags ignored" happens due to s…

### DIFF
--- a/modules/auxiliary/scanner/http/cert.rb
+++ b/modules/auxiliary/scanner/http/cert.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    issuer_pattern = Regexp.new(datastore['ISSUER'], [Regexp::EXTENDED, 'n'])
+    issuer_pattern = Regexp.new(datastore['ISSUER'])
     sub = cert.subject.to_a
 
     before = Time.parse("#{cert.not_before}")


### PR DESCRIPTION
Happens for example when space is in attribute Organization.

issuer=/C=US/ST=Texas/L=Austin/O= LLC/OU=pilot/CN=pilotchip.com/emailAddress=pilot@serverengines.com
