### PR TITLE
Fix #5907 by replacing String#delete with String#gsub

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1524,6 +1524,7 @@ module Text
   def self.remove_badchars(data, badchars = '')
     badchars_pat = badchars.unpack("C*").map{|c| "\\x%.2x" % c}.join
     data.gsub!(/[#{badchars_pat}]/n, '')
+    data
   end
 
   #
@@ -1532,8 +1533,8 @@ module Text
   # @param keepers [String]
   # @return [String] All characters not contained in +keepers+
   def self.charset_exclude(keepers)
-    keepers_pat = keepers.unpack("C*").map{|c| "\\x%.2x" % c}.join
-    [*(0..255)].pack("C*").gsub(/[^#{keepers_pat}]/n, '')
+    excluded_bytes = [*(0..255)] - keepers.unpack("C*")
+    excluded_bytes.pack("C*")
   end
 
   #

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1522,7 +1522,8 @@ module Text
   # @param data [#delete]
   # @param badchars [String] A list of characters considered to be bad
   def self.remove_badchars(data, badchars = '')
-    data.delete(badchars)
+    badchars_pat = badchars.unpack("C*").map{|c| "\\x%.2x" % c}.join
+    data.gsub!(/[#{badchars_pat}]/n, '')
   end
 
   #
@@ -1531,7 +1532,8 @@ module Text
   # @param keepers [String]
   # @return [String] All characters not contained in +keepers+
   def self.charset_exclude(keepers)
-    [*(0..255)].pack('C*').delete(keepers)
+    keepers_pat = keepers.unpack("C*").map{|c| "\\x%.2x" % c}.join
+    [*(0..255)].pack("C*").gsub(/[^#{keepers_pat}]/n, '')
   end
 
   #

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1522,6 +1522,7 @@ module Text
   # @param data [#delete]
   # @param badchars [String] A list of characters considered to be bad
   def self.remove_badchars(data, badchars = '')
+    return data if badchars.length == 0
     badchars_pat = badchars.unpack("C*").map{|c| "\\x%.2x" % c}.join
     data.gsub!(/[#{badchars_pat}]/n, '')
     data


### PR DESCRIPTION
The String#delete method treats the argument as a transliteration. This means that hyphens (-) either
turn into a character range or they throw an error if the range is invalid. This ended up breaking
one encoder and may be the root cause of other hard-to-reproduce bugs.
