### PR TITLE
Update local exploit checks to follow the guidelines.

### DIFF
--- a/modules/exploits/osx/local/dyld_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dyld_print_to_file_root.rb
@@ -62,7 +62,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def check
-    (ver?) ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+    (ver?) ? Exploit::CheckCode::Appears : Exploit::CheckCode::Safe
   end
 
   def ver?

--- a/modules/exploits/osx/local/iokit_keyboard_root.rb
+++ b/modules/exploits/osx/local/iokit_keyboard_root.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def check
     if ver_lt(osx_ver, "10.10")
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
     end

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def check
     if ver_lt(xnu_ver, "1699.32.7") and xnu_ver.strip != "1699.24.8"
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
     end

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -60,7 +60,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def check
-    (ver? && admin?) ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Safe
+    (ver? && admin?) ? Exploit::CheckCode::Appears : Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/osx/local/rootpipe_entitlements.rb
+++ b/modules/exploits/osx/local/rootpipe_entitlements.rb
@@ -53,7 +53,7 @@ class Metasploit4 < Msf::Exploit::Local
   def check
     if ver? && admin?
       vprint_status("Version is between 10.9 and 10.10.3, and is admin.")
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Bluetooth Personal Area Networking (BthPan.sys) Privilege Escalation',
+      'Name'           => 'MS14-062 Microsoft Bluetooth Personal Area Networking (BthPan.sys) Privilege Escalation',
       'Description'    => %q{
         A vulnerability within Microsoft Bluetooth Personal Area Networking module,
         BthPan.sys, can allow an attacker to inject memory controlled by the attacker
@@ -53,6 +53,7 @@ class Metasploit3 < Msf::Exploit::Local
         ],
       'References'    =>
         [
+          [ 'MSB', 'MS14-062' ],
           [ 'CVE', '2014-4971' ],
           [ 'URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-002.txt' ],
           [ 'OSVDB', '109387' ]
@@ -136,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     session.railgun.kernel32.CloseHandle(handle)
 
-    return Exploit::CheckCode::Vulnerable
+    return Exploit::CheckCode::Detected
   end
 
   def exploit

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -65,12 +65,12 @@ class Metasploit3 < Msf::Exploit::Local
     srv_info = service_info(service)
 
     if srv_info.nil?
-      print_warning("Unable to enumerate services.")
+      vprint_warning("Unable to enumerate services.")
       return false
     end
 
     if srv_info && srv_info[:display].empty?
-      print_warning("Service #{service} does not exist.")
+      vprint_warning("Service #{service} does not exist.")
       return false
     else
       return true

--- a/modules/exploits/windows/local/lenovo_systemupdate.rb
+++ b/modules/exploits/windows/local/lenovo_systemupdate.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Local
     svc = service_info('SUService')
     if svc && svc[:display] =~ /System Update/
       vprint_good("Found service '#{svc[:display]}'")
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Local
     when /windows xp.*service pack 3/i
       return Exploit::CheckCode::Appears
     when /windows xp/i
-      print_error('Unsupported version of Windows XP detected')
+      vprint_error('Unsupported version of Windows XP detected')
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    return Exploit::CheckCode::Appears
+    return Exploit::CheckCode::Detected
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms13_053_schlamperei.rb
+++ b/modules/exploits/windows/local/ms13_053_schlamperei.rb
@@ -73,12 +73,12 @@ class Metasploit3 < Msf::Exploit::Local
 
     case build
     when 7600
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     when 7601
       if branch == 18
-        return Exploit::CheckCode::Vulnerable if revision < 18176
+        return Exploit::CheckCode::Appears if revision < 18176
       else
-        return Exploit::CheckCode::Vulnerable if revision < 22348
+        return Exploit::CheckCode::Appears if revision < 22348
       end
     end
     return Exploit::CheckCode::Unknown

--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Local
   def check
     os = sysinfo["OS"]
     if (os =~ /windows/i) == nil
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Safe
     end
 
     file_path = expand_path("%windir%") << "\\system32\\win32k.sys"
@@ -75,9 +75,9 @@ class Metasploit3 < Msf::Exploit::Local
 
     case build
     when 7600
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     when 7601
-      return Exploit::CheckCode::Vulnerable if revision <= 18126
+      return Exploit::CheckCode::Appears if revision <= 18126
     when 9200
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
+++ b/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Appears
   end
 
   def get_net_version

--- a/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
@@ -77,7 +77,8 @@ class Metasploit3 < Msf::Exploit::Local
     os = sysinfo["OS"]
 
     if os !~ /windows/i
-      return Exploit::CheckCode::Unknown
+      # Non-Windows systems are definitely not affected.
+      return Exploit::CheckCode::Safe
     end
 
     if sysinfo["Architecture"] =~ /(wow|x)64/i
@@ -94,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Local
     return Exploit::CheckCode::Safe if build == 9200
     return Exploit::CheckCode::Safe if build == 9600
 
-    return Exploit::CheckCode::Detected if [2600, 3790, 7600, 7601].include?(build)
+    return Exploit::CheckCode::Appears if [2600, 3790, 7600, 7601].include?(build)
 
     return Exploit::CheckCode::Unknown
   end

--- a/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
+++ b/modules/exploits/windows/local/ms14_070_tcpip_ioctl.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Local
     vprint_status("tcpip.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
     if ("#{major}.#{minor}.#{build}" == "5.2.3790" && revision < 5440)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     return Exploit::CheckCode::Safe if build > 7601
 
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/windows/local/ntapphelpcachecontrol.rb
+++ b/modules/exploits/windows/local/ntapphelpcachecontrol.rb
@@ -121,9 +121,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def check
     if sysinfo['OS'] =~ /Windows 8/
-      # Still an 0day, but since this check doesn't actually trigger the vulnerability
-      # so we should only flag this as CheckCode::Appears
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     end
 
     Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -82,39 +82,39 @@ class Metasploit3 < Msf::Exploit::Local
       major, minor, build, revision, branch = file_version(file_path)
       vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision}")
 
-      #WinXP x86 - 5.1.2600.6404
-      #WinXP/2003 5.2.3790.5174
-      #WinVista/2k8 - 6.0.6002.18861 / 6.0.6002.23132
-      #Win72k8R2 -  6.1.7601.18176 / 6.1.7601.22348
-      #Win8/2012 - 6.2.9200.16627 / 6.2.9200.20732
+      # WinXP x86 - 5.1.2600.6404
+      # WinXP/2003 5.2.3790.5174
+      # WinVista/2k8 - 6.0.6002.18861 / 6.0.6002.23132
+      # Win72k8R2 -  6.1.7601.18176 / 6.1.7601.22348
+      # Win8/2012 - 6.2.9200.16627 / 6.2.9200.20732
       case build
       when 2600
-        return Exploit::CheckCode::Vulnerable if revision < 6404
+        return Exploit::CheckCode::Appears if revision < 6404
       when 3790
-        return Exploit::CheckCode::Vulnerable if revision < 5174
+        return Exploit::CheckCode::Appears if revision < 5174
       when 6000
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       when 6001
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       when 6002
         if branch == 18
-          return Exploit::CheckCode::Vulnerable if revision < 18861
+          return Exploit::CheckCode::Appears if revision < 18861
         else
-          return Exploit::CheckCode::Vulnerable if revision < 23132
+          return Exploit::CheckCode::Appears if revision < 23132
         end
       when 7600
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       when 7601
         if branch == 18
-          return Exploit::CheckCode::Vulnerable if revision < 18176
+          return Exploit::CheckCode::Appears if revision < 18176
         else
-          return Exploit::CheckCode::Vulnerable if revision < 22348
+          return Exploit::CheckCode::Appears if revision < 22348
         end
       when 9200
         if branch == 16
-          return Exploit::CheckCode::Vulnerable if revision < 16627
+          return Exploit::CheckCode::Appears if revision < 16627
         else
-          return Exploit::CheckCode::Vulnerable if revision < 20732
+          return Exploit::CheckCode::Appears if revision < 20732
         end
       end
     end

--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -115,13 +115,13 @@ class Metasploit3 < Msf::Exploit::Local
 
     case minor
     when 0
-      return Exploit::CheckCode::Vulnerable if build < 26
+      return Exploit::CheckCode::Appears if build < 26
     when 1
-      return Exploit::CheckCode::Vulnerable if build < 34
+      return Exploit::CheckCode::Appears if build < 34
     when 2
-      return Exploit::CheckCode::Vulnerable if build < 26
+      return Exploit::CheckCode::Appears if build < 26
     when 3
-      return Exploit::CheckCode::Vulnerable if build < 12
+      return Exploit::CheckCode::Appears if build < 12
     end
 
     return Exploit::CheckCode::Safe


### PR DESCRIPTION
There are quite a few local exploit checks that are written passively, but passive checks don't qualify as Exploit::CheckCode::Vulnerable (even though passive usually seems pretty good already). This patch makes sure local checks follow the guidelines more consistently.
- [ ] Please see wiki "How to write a check() method" to learn how these check codes are determined:
  https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check%28%29-method
