### PR TITLE
Update Android Device Lock module titles

### DIFF
--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -12,7 +12,7 @@ class Metasploit4 < Msf::Post
 
   def initialize(info={})
     super( update_info( info, {
-        'Name'          => "Android Settings Remove Device Locks",
+        'Name'          => "Android Settings Remove Device Locks (4.0-4.3)",
         'Description'   => %q{
             This module exploits a bug in the Android 4.0 to 4.3 com.android.settings.ChooseLockGeneric class.
             Any unprivileged app can exploit this vulnerability to remove the lockscreen.

--- a/modules/post/android/manage/remove_lock_root.rb
+++ b/modules/post/android/manage/remove_lock_root.rb
@@ -12,7 +12,7 @@ class Metasploit4 < Msf::Post
 
   def initialize(info={})
     super( update_info( info, {
-        'Name'          => "Android Root Remove Device Locks",
+        'Name'          => "Android Root Remove Device Locks (root)",
         'Description'   => %q{
             This module uses root privileges to remove the device lock.
             In some cases the original lock method will still be present but any key/gesture will


### PR DESCRIPTION
Cosmetic change to make the requirements for the unlock clear in the module title. This was somewhat confusing before. 
