### PR TITLE
My final round of updating modules to use the metasploit-credential API

### DIFF
--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -68,16 +68,41 @@ class Metasploit3 < Msf::Auxiliary
     datastore['TIMEOUT']
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user]
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: DateTime.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def user_exists(user)
     exists = wordpress_user_exists?(user)
     if exists
       print_good("#{peer} - Username \"#{username}\" is valid")
-      report_auth_info(
-        :host => rhost,
-        :sname => (ssl ? 'https' : 'http'),
-        :user => user,
-        :port => rport,
-        :proof => "WEBAPP=\"Wordpress\", VHOST=#{vhost}"
+      report_cred(
+        ip: rhost,
+        port: rport,
+        user: user,
+        service_name: (ssl ? 'https' : 'http'),
+        proof: "WEBAPP=\"Wordpress\", VHOST=#{vhost}"
       )
 
       return true

--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -103,6 +103,33 @@ class Metasploit3 < Msf::Auxiliary
     }
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+
   def run
 
     print_status("#{rhost}:#{rport} - Fingerprinting...")
@@ -183,13 +210,13 @@ class Metasploit3 < Msf::Auxiliary
       print_status("#{rhost}:#{rport} - Recovering Hashes...")
       json_info["result"]["resultSet"].each { |result|
         print_good("#{rhost}:#{rport} - Found cred: #{result["username"]}:#{result["password"]}")
-        report_auth_info(
-          :host => rhost,
-          :port => rport,
-          :sname => "Apache Rave",
-          :user => result["username"],
-          :pass => result["password"],
-          :active => result["enabled"]
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'Apache Rave',
+          user: result["username"],
+          password: result["password"],
+          proof: user_data
         )
       }
 

--- a/modules/auxiliary/gather/d20pass.rb
+++ b/modules/auxiliary/gather/d20pass.rb
@@ -182,6 +182,32 @@ class Metasploit3 < Msf::Auxiliary
     return res
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   # Parse the usernames, passwords, and security levels from the config
   # It's a little ugly (lots of hard-coded offsets).
   # The userdata starts at an offset dictated by the B014USERS config
@@ -213,13 +239,13 @@ class Metasploit3 < Msf::Auxiliary
         break
       end
       logins <<  [accounttype,  accountname,  accountpass]
-      report_auth_info(
-        :host => datastore['RHOST'],
-        :port => 23,
-        :sname => "telnet",
-        :user => accountname,
-        :pass => accountpass,
-        :active => true
+      report_cred(
+        ip: datastore['RHOST'],
+        port: 23,
+        service_name: 'telnet',
+        user: accountname,
+        password: accountpass,
+        proof: accounttype
       )
     end
     if not logins.rows.empty?

--- a/modules/auxiliary/gather/hp_snac_domain_creds.rb
+++ b/modules/auxiliary/gather/hp_snac_domain_creds.rb
@@ -88,6 +88,34 @@ class Metasploit3 < Msf::Auxiliary
     return results
   end
 
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+
   def run
 
     print_status("#{peer} - Get Domain Info")
@@ -121,14 +149,14 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     credentials.each do |record|
-      report_auth_info({
-        :host  => record[0],
-        :port  => record[1],
-        :sname => record[2].downcase,
-        :user  => record[3],
-        :pass  => record[4],
-        :source_type => "vuln"
-      })
+      report_cred(
+        ip: record[0],
+        port: record[1],
+        service_name: record[2].downcase,
+        user: record[3],
+        password: record[4],
+        proof: domain_info.inspect
+      )
       cred_table << [record[0], record[3], record[4]]
     end
 

--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -198,6 +198,32 @@ class Metasploit3 < Msf::Auxiliary
 
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def parse_client_unattend(data)
 
     begin
@@ -216,15 +242,13 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def report_creds(domain, user, pass)
-    report_auth_info(
-      :host  => rhost,
-      :port => 445,
-      :sname => 'smb',
-      :proto => 'tcp',
-      :source_id => nil,
-      :source_type => "aux",
-      :user => "#{domain}\\#{user}",
-      :pass => pass
+    report_cred(
+      ip: rhost,
+      port: 445,
+      service_name: 'smb',
+      user: "#{domain}\\#{user}",
+      password: pass,
+      proof: domain
     )
   end
 

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -95,6 +95,7 @@ class Metasploit3 < Msf::Auxiliary
     }.merge(service_data)
 
     login_data = {
+      last_attempted_at: Time.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
       proof: opts[:proof]

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -76,6 +76,33 @@ class Metasploit3 < Msf::Auxiliary
     nil
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash,
+      jtr_format: 'md5,des'
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def run_host(ip)
     users_found = false
 
@@ -117,14 +144,13 @@ class Metasploit3 < Msf::Auxiliary
         unless match.nil?
           print_good("Username: #{match[0]}")
           print_good("Password Hash: #{match[1]}")
-          report_auth_info(
-              host: rhost,
-              port: rport,
-              sname: ssl ? 'https' : 'http',
-              user: match[0],
-              pass: match[1],
-              active: true,
-              type: 'hash'
+          report_cred(
+            ip: rhost,
+            port: rport,
+            service_name: ssl ? 'https' : 'http',
+            user: match[0],
+            password: match[1],
+            proof: result.body
           )
           users_found = true
         end

--- a/modules/auxiliary/scanner/couchdb/couchdb_login.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_login.rb
@@ -74,6 +74,32 @@ class Metasploit3 < Msf::Auxiliary
       vprint_error("'#{rhost}':'#{rport}' - Failed to connect to the web server")
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user, pass)
     vprint_status("Trying username:'#{user}' with password:'#{pass}'")
     begin
@@ -91,17 +117,14 @@ class Metasploit3 < Msf::Auxiliary
         return :skip_pass
       else
         vprint_good("#{rhost}:#{rport} - Successful login with. '#{user}' : '#{pass}'")
-
-        report_hash = {
-          :host   => datastore['RHOST'],
-          :port   => datastore['RPORT'],
-          :sname  => 'couchdb',
-          :user   => user,
-          :pass   => pass,
-          :active => true,
-          :type => 'password'}
-
-        report_auth_info(report_hash)
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'couchdb',
+          user: user,
+          password: pass,
+          proof: res.code.to_s
+        )
         return :next_user
       end
 

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -216,15 +216,40 @@ class Metasploit3 < Msf::Auxiliary
     print_status("Raw version of #{archi} saved as: #{p}")
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def report_creds(domain, user, pass)
-    report_auth_info(
-      :host  => rhost,
-      :port => 4050,
-      :sname => 'dcerpc',
-      :proto => 'tcp',
-      :source_id => nil,
-      :source_type => "aux",
-      :user => "#{domain}\\#{user}",
-      :pass => pass)
+    report_cred(
+      ip: rhost,
+      port: 4050,
+      service_name: 'dcerpc',
+      user: "#{domain}\\#{user}",
+      password: pass,
+      proof: domain
+    )
   end
 end

--- a/modules/auxiliary/scanner/http/openmind_messageos_login.rb
+++ b/modules/auxiliary/scanner/http/openmind_messageos_login.rb
@@ -72,6 +72,32 @@ class Metasploit3 < Msf::Auxiliary
     end
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   #
   # Brute-force the login page
   #
@@ -96,16 +122,14 @@ class Metasploit3 < Msf::Auxiliary
 
     if (res and res.code == 302 and res.headers['Location'].include?("frameset"))
       print_good("#{peer} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
-      report_hash = {
-        :host   => rhost,
-        :port   => rport,
-        :sname  => 'OpenMind Message-OS Provisioning Portal',
-        :user   => user,
-        :pass   => pass,
-        :active => true,
-        :type => 'password'
-      }
-      report_auth_info(report_hash)
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'OpenMind Message-OS Provisioning Portal',
+        user: user,
+        password: pass,
+        proof: res.headers['Location']
+      )
       return :next_user
     else
       vprint_error("#{peer} - FAILED LOGIN - #{user.inspect}:#{pass.inspect}")

--- a/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
@@ -33,6 +33,32 @@ class Metasploit3 < Msf::Auxiliary
 
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_login(user=nil,pass=nil)
     post_data = "username=#{Rex::Text.uri_encode(user.to_s)}&password=#{Rex::Text.uri_encode(pass.to_s)}&RedirectTo=%2Fnames.nsf"
     vprint_status("http://#{vhost}:#{rport} - Lotus Domino - Trying username:'#{user}' with password:'#{pass}'")
@@ -48,15 +74,13 @@ class Metasploit3 < Msf::Auxiliary
       if res and res.code == 302
         if res.get_cookies.match(/DomAuthSessId=(.*);(.*)/i)
           print_good("http://#{vhost}:#{rport} - Lotus Domino - SUCCESSFUL login for '#{user}' : '#{pass}'")
-          report_auth_info(
-            :host   => rhost,
-            :port => rport,
-            :sname => (ssl ? "https" : "http"),
-            :user   => user,
-            :pass   => pass,
-            :proof  => "WEBAPP=\"Lotus Domino\", VHOST=#{vhost}, COOKIE=#{res.get_cookies}",
-            :source_type => "user_supplied",
-            :active => true
+          report_cred(
+            ip: rhost,
+            port: rport,
+            service_name: (ssl ? "https" : "http"),
+            user: user,
+            password: pass,
+            proof: "WEBAPP=\"Lotus Domino\", VHOST=#{vhost}, COOKIE=#{res.get_cookies}"
           )
           return :next_user
         end

--- a/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
@@ -51,6 +51,7 @@ class Metasploit3 < Msf::Auxiliary
     }.merge(service_data)
 
     login_data = {
+      last_attempted_at: Time.now,
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
       proof: opts[:proof]

--- a/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
@@ -200,16 +200,42 @@ class Metasploit3 < Msf::Auxiliary
         user_active = true
       end
 
-      report_auth_info({
-        :host         => rhost,
-        :port         => rport,
-        :sname        => 'dvr',
-        :duplicate_ok => false,
-        :user         => user,
-        :pass         => password,
-        :active       => user_active
-      })
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: 'dvr',
+        user: user,
+        password: password,
+        service_name: 'http',
+        proof: "user_id: #{user_id}, active: #{active}"
+      )
     }
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/oracle/isqlplus_login.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_login.rb
@@ -231,18 +231,46 @@ class Metasploit3 < Msf::Auxiliary
     )
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def report_isqlauth_info(ip,user,pass,sid)
     ora_info = {
-      :host => ip, :port => rport, :proto => "tcp",
-      :pass => pass, :source_type => "user_supplied",
-      :active => true
+      ip: ip,
+      port: rport,
+      password: pass,
+      proof: sid.inspect,
+      service_name: 'tcp'
     }
     if sid.nil? || sid.empty?
       ora_info.merge! :user => user
     else
       ora_info.merge! :user => "#{sid}/#{user}"
     end
-    report_auth_info(ora_info)
+    report_cred(ora_info)
   end
 
 end

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -50,6 +50,32 @@ class Metasploit3 < Msf::Auxiliary
     datastore['RPORT']
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def do_fingerprint(user=nil,pass=nil,database=nil)
     begin
       msg = "#{rhost}:#{rport} Postgres -"
@@ -79,13 +105,13 @@ class Metasploit3 < Msf::Auxiliary
       )
 
       if self.postgres_conn
-        report_auth_info(
-          :host => rhost,
-          :port => rport,
-          :sname => "postgres",
-          :user => user,
-          :pass => password,
-          :active => true
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: 'postgres',
+          user: user,
+          password: password,
+          proof: "postgres_conn = #{self.postgres_conn.inspect}"
         )
       end
 

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -220,6 +220,31 @@ class Metasploit3 < Msf::Auxiliary
     [ sd, lport ]
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 
   def start_rsh_session(host, port, user, luser, proof, stderr_sock)
     report_auth_info(

--- a/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_user_mgmt.rb
+++ b/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_user_mgmt.rb
@@ -68,20 +68,47 @@ class Metasploit4 < Msf::Auxiliary
 
     vprint_status("#{rhost}:#{rport} - Adding User to Group...")
     uri = '/ctc/ConfigServlet?param=com.sap.ctc.util.UserConfig;ADD_USER_TO_GROUP;USERNAME=' + datastore['USERNAME'] + ',GROUPNAME=' + datastore['GROUP']
-    if send_request(uri)
+    res = send_request(uri)
+    if res
       print_good("#{rhost}:#{rport} - User #{datastore['USERNAME']} added to group #{datastore['GROUP']}")
     else
       return
     end
 
-    report_auth_info(
-      :host => rhost,
-      :port => rport,
-      :user => datastore['USERNAME'],
-      :pass => datastore['PASSWORD'],
-      :ptype => "password",
-      :active => true
+    report_cred(
+      ip: rhost,
+      port: rport,
+      service_name: 'sap',
+      user: datastore['USERNAME'],
+      pass: datastore['PASSWORD'],
+      proof: res.body
     )
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
   end
 
   def send_request(uri)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -61,6 +61,32 @@ class Metasploit4 < Msf::Auxiliary
 
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def enum_user(user, pass, uri)
 
     # Replace placeholder with SAP SID, if present
@@ -140,16 +166,13 @@ class Metasploit4 < Msf::Auxiliary
         vprint_error("#{peer} [SAP] Login '#{user}' NOT authorized to perform OSExecute calls")
       end
 
-      report_auth_info(
-        :host => rhost,
-        :sname => 'sap-managementconsole',
-        :proto => 'tcp',
-        :port => rport,
-        :user => user,
-        :pass => pass,
-        :source_type => "user_supplied",
-        :target_host => rhost,
-        :target_port => rport
+      report_cred(
+        ip: rhost,
+        port: port,
+        user: user,
+        password: pass,
+        service_name: 'sap-managementconsole',
+        proof: res.body
       )
     else
       vprint_error("#{peer} [SAP] failed to login as '#{user}':'#{pass}'")

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -124,7 +124,7 @@ class Metasploit4 < Msf::Auxiliary
           return
         else
           print_good("[SAP] #{ip}:#{rport} - User '#{datastore['BAPI_USER']}' with password '#{datastore['BAPI_PASSWORD']}' created")
-          report_auth_info(
+          report_auth(
             ip: ip,
             port: rport,
             service_name: 'sap',

--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -397,6 +397,33 @@ class Metasploit3 < Msf::Exploit::Remote
     create_credential_login(login_data)
   end
 
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :nonreplayable_hash,
+      jtr_format: 'md5,raw-md5'
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
   def exploit
     print_status("#{peer} - Checking for a valid node id...")
     node_id = get_node
@@ -417,6 +444,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
     for i in 0..count_users - 1
       user = get_user_data(node_id, i)
+      report_cred(
+        ip: rhost,
+        port: rport,
+        user: user[0],
+        password: user[1],
+        service_name: (ssl ? "https" : "http"),
+        proof: "salt: #{user[2]}"
+      )
       report_auth_info({
         :host => rhost,
         :port => rport,

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -450,6 +450,36 @@ class Metasploit3 < Msf::Auxiliary
     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'hp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
+  def test_d20pass
+     mod = framework.auxiliary.create('gather/d20pass')
+     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'hp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_doliwamp_traversal_creds
+    mod = framework.auxiliary.create('gather/doliwamp_traversal_creds')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'hp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_apache_rave_creds
+    mod = framework.auxiliary.create('gather/apache_rave_creds')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'Apache Rave', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_wordpress_long_password_dos
+    mod = framework.auxiliary.create('dos/http/wordpress_long_password_dos')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, proof: FAKE_PROOF)
+  end
+
+  def test_modicon_password_recovery
+    mod = framework.auxiliary.create('admin/scada/modicon_password_recovery')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_advantech_webaccess_dbvisitor_sqli
+    mod = framework.auxiliary.create('admin/scada/advantech_webaccess_dbvisitor_sqli')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
   def run
     counter_all  = 0
     counter_good = 0

--- a/test/modules/auxiliary/test/report_auth_info.rb
+++ b/test/modules/auxiliary/test/report_auth_info.rb
@@ -359,7 +359,96 @@ class Metasploit3 < Msf::Auxiliary
     mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'sap', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
   end
 
-  
+  def test_mount_cifs_creds
+    mod = framework.post.create('linux/gather/mount_cifs_creds')
+    mock_post_mod_session(mod)
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'smb', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_mysql_enum
+    mod = framework.auxiliary.create('admin/mysql/mysql_enum')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'mysql', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_jtr_oracle_fast
+    mod = framework.auxiliary.create('analyze/jtr_oracle_fast')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'oracle', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_vbulletin_vote_sqli_exec
+    mod = framework.exploits.create('unix/webapp/vbulletin_vote_sqli_exec')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)    
+  end
+
+  def test_sap_mgmt_con_brute_login
+    mod = framework.auxiliary.create('scanner/sap/sap_mgmt_con_brute_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_sap_ctc_verb_tampering_user_mgmt
+    mod = framework.auxiliary.create('scanner/sap/sap_ctc_verb_tampering_user_mgmt')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_scanner_oracle_login
+    mod = framework.auxiliary.create('scanner/oracle/oracle_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'tcp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF, status: Metasploit::Model::Login::Status::SUCCESSFUL)
+  end
+
+  def test_isqlplus_login
+    mod = framework.auxiliary.create('scanner/oracle/isqlplus_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'tcp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_dvr_config_disclosure
+    mod = framework.auxiliary.create('scanner/misc/dvr_config_disclosure')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_lotus_domino_login
+    mod = framework.auxiliary.create('scanner/lotus/lotus_domino_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_openmind_messageos_login
+    mod = framework.auxiliary.create('scanner/http/openmind_messageos_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_dell_idrac
+    mod = framework.auxiliary.create('scanner/http/dell_idrac')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_windows_deployment_services
+    mod = framework.auxiliary.create('scanner/dcerpc/windows_deployment_services')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'dcerpc', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_couchdb_login
+    mod = framework.auxiliary.create('scanner/couchdb/couchdb_login')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'couchdb', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_wp_w3_total_cache_hash_extract
+    mod = framework.auxiliary.create('gather/wp_w3_total_cache_hash_extract')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_windows_deployment_services_shares
+    mod = framework.auxiliary.create('gather/windows_deployment_services_shares')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'smb', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_vbulletin_vote_sqli
+    mod = framework.auxiliary.create('gather/vbulletin_vote_sqli')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'http', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
+
+  def test_hp_snac_domain_creds
+    mod = framework.auxiliary.create('gather/hp_snac_domain_creds')
+    mod.report_cred(ip: FAKE_IP, port: FAKE_PORT, service_name: 'hp', user: FAKE_USER, password: FAKE_PASS, proof: FAKE_PROOF)
+  end
 
   def run
     counter_all  = 0
@@ -387,6 +476,10 @@ class Metasploit3 < Msf::Auxiliary
     print_error("Number of test cases that failed: #{counter_bad}")
     print_status("Number of test cases overall: #{counter_all}")
     print_line
+  end
+
+  def mock_post_mod_session(mod)
+    mod.define_singleton_method(:session_db_id) { 1 }
   end
 
 end


### PR DESCRIPTION
This is my final round of updating modules to use the metasploit-credential API.

Test:
- [x] Start msfconsole
- [x] loadpath test/modules
- [x] `use auxiliary/test/report_auth_info`
- [x] `run`
- [x] You should get:

```
[+] Number of test cases that passed: 90
[-] Number of test cases that failed: 0
[*] Number of test cases overall: 90
```
