### PR TITLE
When the port state is open|filtered should be unknown, no open

### DIFF
--- a/lib/rex/parser/nmap_nokogiri.rb
+++ b/lib/rex/parser/nmap_nokogiri.rb
@@ -17,7 +17,7 @@ module Rex
         Msf::ServiceState::Closed
       when "filtered"
         Msf::ServiceState::Filtered
-      when "unknown"
+      else
         Msf::ServiceState::Unknown
       end
     end


### PR DESCRIPTION
Hello, I am working with db_import and nmap. I saw that when a port is open|filtered, Metasploit adds the port to the database as "open" and maybe it is not open. 
Then i think that the better result is 'unknown'. Especially with the udp ports. 
