### PR TITLE
Support meterpreter for osx/capture/screen

### DIFF
--- a/modules/post/osx/capture/screen.rb
+++ b/modules/post/osx/capture/screen.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Post
             'Peter Toth <globetother[at]gmail.com>' # ported windows version to osx
           ],
         'Platform'      => [ 'osx' ],
-        'SessionTypes'  => [ 'shell' ]
+        'SessionTypes'  => ['meterpreter', 'shell' ]
       ))
 
     register_options(


### PR DESCRIPTION
It works for me with python/meterpreter/reverse_tcp, so we should probably add meterpreter to the list.

Testing
- [ ] Get a session with python/meterpreter/reverse_tcp
- [ ] At the meterpreter prompt, do: `run post/osx/capture/screen`
- [ ] Follow the instruction the module gives you, and you should seen that you have a screenshot in the loot folder.

I've only tested it with python/meterpreter/reverse_tcp, please feel free to test other meterpreters as well (such as java)
