### PR TITLE
Support meterpreter for OS X post modules

### DIFF
--- a/modules/post/osx/admin/say.rb
+++ b/modules/post/osx/admin/say.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r'],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ]
+      'SessionTypes'  => [ "meterpreter", "shell" ]
     ))
 
   register_options(

--- a/modules/post/osx/capture/screen.rb
+++ b/modules/post/osx/capture/screen.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Post
             'Peter Toth <globetother[at]gmail.com>' # ported windows version to osx
           ],
         'Platform'      => [ 'osx' ],
-        'SessionTypes'  => [ 'shell' ]
+        'SessionTypes'  => [ 'meterpreter', 'shell' ]
       ))
 
     register_options(

--- a/modules/post/osx/gather/autologin_password.rb
+++ b/modules/post/osx/gather/autologin_password.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Post
       'References'    => [
         ['URL', 'http://www.brock-family.org/gavin/perl/kcpassword.html']
       ],
-      'SessionTypes'  => [ 'shell' ]
+      'SessionTypes'  => [ 'meterpreter', 'shell' ]
     ))
 
     register_advanced_options([

--- a/modules/post/osx/gather/enum_adium.rb
+++ b/modules/post/osx/gather/enum_adium.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r'],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ],
+      'SessionTypes'  => [ "meterpreter", "shell" ],
       'Actions'       =>
         [
           ['ACCOUNTS', { 'Description' => 'Collect account-related plists' } ],

--- a/modules/post/osx/gather/enum_airport.rb
+++ b/modules/post/osx/gather/enum_airport.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r'],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ]
+      'SessionTypes'  => [ "meterpreter", "shell" ]
     ))
   end
 

--- a/modules/post/osx/gather/enum_chicken_vnc_profile.rb
+++ b/modules/post/osx/gather/enum_chicken_vnc_profile.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r'],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ]
+      'SessionTypes'  => [ "meterpreter", "shell" ]
     ))
 
   end

--- a/modules/post/osx/gather/enum_colloquy.rb
+++ b/modules/post/osx/gather/enum_colloquy.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r'],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ],
+      'SessionTypes'  => [ "meterpreter", "shell" ],
       'Actions'       =>
         [
           ['ACCOUNTS', { 'Description' => 'Collect the preferences plists' } ],

--- a/modules/post/osx/gather/enum_keychain.rb
+++ b/modules/post/osx/gather/enum_keychain.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'ipwnstuff <e[at]ipwnstuff.com>', 'joev' ],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ 'shell' ]
+      'SessionTypes'  => [ 'meterpreter', 'shell' ]
     ))
 
     register_options(

--- a/modules/post/osx/gather/enum_osx.rb
+++ b/modules/post/osx/gather/enum_osx.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
         'Platform'      => [ 'osx' ],
-        'SessionTypes'  => [ "shell" ]
+        'SessionTypes'  => [ "meterpreter", "shell" ]
       ))
 
   end

--- a/modules/post/osx/gather/safari_lastsession.rb
+++ b/modules/post/osx/gather/safari_lastsession.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r'],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ 'shell' ],
+      'SessionTypes'  => [ 'meterpreter','shell' ],
       'References'    =>
         [
           ['URL', 'http://www.securelist.com/en/blog/8168/Loophole_in_Safari']

--- a/modules/post/osx/manage/mount_share.rb
+++ b/modules/post/osx/manage/mount_share.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Post
             'joev'
           ],
         'Platform'      => [ 'osx' ],
-        'SessionTypes'  => [ 'shell' ],
+        'SessionTypes'  => [ 'meterpreter', 'shell' ],
         'Actions'       => [
           [ 'LIST',    { 'Description' => 'Show a list of stored network share credentials' } ],
           [ 'MOUNT',   { 'Description' => 'Mount a network shared volume using stored credentials' } ],


### PR DESCRIPTION
These OS X post modules support python meterpreter without any code changes.

**Testing**

I've only tried them with osx/x64/shell_reverse_tcp and python/meterpreter/reverse_tcp, please feel to try other OS X or cross-platform payloads.
