### PR TITLE
Show the Shodan error message if no result are found

### DIFF
--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -112,7 +112,12 @@ class Metasploit4 < Msf::Auxiliary
     results[page] = shodan_query(query, apikey, page)
 
     if results[page]['total'].nil? || results[page]['total'] == 0
-      print_error('No Results Found!')
+      msg = "No results."
+      if results[page]['error'].to_s.length > 0
+        msg << " Error: #{results[page]['error']}"
+      end
+      print_error(msg)
+      return
     end
 
     # Determine page count based on total results


### PR DESCRIPTION
This patch fixes a stack trace when Shodan returns an error for a query and now shows the error.
