### PR TITLE
Ignore SMB exceptions during fingerprinting

### DIFF
--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -327,7 +327,14 @@ module Msf
         # Connect to the server if needed
         if not self.simple
           connect()
-          smb_login()
+          # The login method can throw any number of exceptions, we don't
+          # care since we still get the native_lm/native_os.
+          begin
+            smb_login()
+          rescue ::Rex::Proto::SMB::Exceptions::NoReply,
+                 ::Rex::Proto::SMB::Exceptions::ErrorCode,
+                 ::Rex::Proto::SMB::Exceptions::LoginError
+          end
         end
 
         fprint['native_os'] = smb_peer_os()


### PR DESCRIPTION
This fixes smb_version in cases where the remote server throws a Login error
for the default creds (null session). Prior to this fix, running `smb_version` against a machine that throws access denied would result in no fingerprint.
