### PR TITLE
Skip WfsDelay when the exploit has clearly failed

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -237,6 +237,9 @@ module Exploit
 
     # Report the failure (and attempt) in the database
     self.report_failure
+
+    # Interrupt any session waiters in the handler
+    self.interrupt_handler
   end
   #
   # Calls the class method.

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1193,10 +1193,8 @@ class Exploit < Msf::Module
   # value can be one of the Handler::constants.
   #
   def handler(*args)
-    return unless (
-      payload_instance &&
-      handler_enabled?
-    )
+    return unless payload_instance
+    return unless handler_enabled?
     payload_instance.handler(*args)
   end
 
@@ -1204,11 +1202,9 @@ class Exploit < Msf::Module
   # Break out of the session wait loop (WfsDelay)
   #
   def interrupt_handler
-    return unless (
-      payload_instance &&
-      handler_enabled? &&
-      payload_instance.respond_to?(:interrupt_wait_for_session)
-    )
+    return unless payload_instance
+    return unless handler_enabled?
+    return unless payload_instance.respond_to?(:interrupt_wait_for_session)
     payload_instance.interrupt_wait_for_session()
   end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1193,9 +1193,23 @@ class Exploit < Msf::Module
   # value can be one of the Handler::constants.
   #
   def handler(*args)
-    return if not payload_instance
-    return if not handler_enabled?
-    return payload_instance.handler(*args)
+    return unless (
+      payload_instance &&
+      handler_enabled?
+    )
+    payload_instance.handler(*args)
+  end
+
+  #
+  # Break out of the session wait loop (WfsDelay)
+  #
+  def interrupt_handler
+    return unless (
+      payload_instance &&
+      handler_enabled? &&
+      payload_instance.respond_to?(:interrupt_wait_for_session)
+    )
+    payload_instance.interrupt_wait_for_session()
   end
 
   ##

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -163,6 +163,14 @@ module Handler
   end
 
   #
+  # Interrupts a wait_for_session call by notifying with a nil event
+  #
+  def interrupt_wait_for_session
+    return unless session_waiter_event
+    session_waiter_event.notify(nil)
+  end
+
+  #
   # Set by the exploit module to configure handler
   #
   attr_accessor :exploit_config


### PR DESCRIPTION
This fast-forwards through the WfsDelay wait if the exploit has clearly failed using `fail_with` or by raising a common exception.

Before:

```
hdm@fang:/work/msf-hdm (master)*$ time ./msfconsole -q -x 'use exploit/windows/smb/ms08_067_netapi; set RHOST 127.1.1.1; set WfsDelay 90; run; exit'
RHOST => 127.1.1.1
WfsDelay => 90
[*] Started reverse handler on 192.168.152.128:8443 
[-] Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (127.1.1.1:445).

real    1m37.078s
user    0m4.284s
sys 0m0.502s
```

After:

```
hdm@fang:/work/msf-hdm (feature/break-wfsdelay-on-failure)*$ time ./msfconsole -q -x 'use exploit/windows/smb/ms08_067_netapi; set RHOST 127.1.1.1; set WfsDelay 90; run; exit'
RHOST => 127.1.1.1
WfsDelay => 90
[*] Started reverse handler on 192.168.152.128:8443 
[-] Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (127.1.1.1:445).

real    0m5.075s
user    0m4.481s
sys 0m0.490s
```
