### PR TITLE
The db_export command generates bad XML for the host address

### DIFF
--- a/lib/msf/core/db_export.rb
+++ b/lib/msf/core/db_export.rb
@@ -313,6 +313,8 @@ class Export
 
       # Host attributes
       h.attributes.each_pair do |k,v|
+        # Convert IPAddr -> String
+        v = v.to_s if k == 'address'
         el = create_xml_element(k,v)
         report_file.write("    #{el}\n") # Not checking types
       end

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -241,7 +241,18 @@ module Msf::DBManager::Import::MetasploitFramework::XML
       host_data = {}
       host_data[:task] = args[:task]
       host_data[:workspace] = wspace
-      host_data[:host] = nils_for_nulls(unserialize_object(host.elements["address"]))
+
+      # A regression resulted in the address field being serialized in some cases.
+      # Lets handle both instances to keep things happy. See #5837 & #5985
+      addr = nils_for_nulls(host.elements["address"])
+      next unless addr
+
+      # No period or colon means this must be in base64-encoded serialized form
+      if addr !~ /[\.\:]/
+        addr = unserialize_object(addr)
+      end
+
+      host_data[:host] = addr
       if bl.include? host_data[:host]
         next
       else


### PR DESCRIPTION
Prepatch, we were getting serialized IPAddr objects in the XML. This was likely the result of a `pg` gem update that changed the default stringification of IPADDR column types. These busted XML imports would not properly import.

Before:

```
<?xml version="1.0" encoding="UTF-8"?>
<MetasploitV5>
<generated time="2015-09-16 09:50:23 UTC" user="hdm" project="ww" product="framework"/>
<hosts>
  <host>
    <id>9</id>
    <created-at>2015-09-14 15:55:05 UTC</created-at>
    <address>BAhvOgtJUEFkZHIIOgxAZmFtaWx5aQc6CkBhZGRybCsHgZiowDoPQG1hc2tfYWRkcmwrB/////8=</address>
```

After:

```
<?xml version="1.0" encoding="UTF-8"?>
<MetasploitV5>
<generated time="2015-09-16 09:58:40 UTC" user="hdm" project="ww" product="framework"/>
<hosts>
  <host>
    <id>9</id>
    <created-at>2015-09-14 15:55:05 UTC</created-at>
    <address>192.168.152.129</address>
```
