### PR TITLE
Fix issues with using hop for new core

### DIFF
--- a/data/php/hop.php
+++ b/data/php/hop.php
@@ -33,7 +33,7 @@ if($url === "/control"){
 		if(array_key_exists('HTTP_X_INIT', $_SERVER)){
 			$f = fopen($tempdir."/init", "w"); //only one init file
 		}else{
-			$prefix = "down_" . bin2hex($_SERVER['HTTP_X_URLFRAG']);
+			$prefix = "down_" . sha1($_SERVER['HTTP_X_URLFRAG']);
 			$f = fopen(tempnam($tempdir,$prefix), "w");
 		}
 		fwrite($f, $postdata);
@@ -46,8 +46,8 @@ if($url === "/control"){
 	$postdata = file_get_contents("php://input");
 	//See if we should send anything down
 	if($postdata === "RECV\x00"){
-		findSendDelete($tempdir, "down_" . bin2hex($url));
-		$fname = $tempdir . "/up_recv_" . bin2hex($url); //Only keep one RECV poll
+		findSendDelete($tempdir, "down_" . sha1($url));
+		$fname = $tempdir . "/up_recv_" . sha1($url); //Only keep one RECV poll
 	}else{
 		$fname = tempnam($tempdir, "up_"); //actual data gets its own filename
 	}

--- a/data/php/hop.php
+++ b/data/php/hop.php
@@ -45,7 +45,7 @@ if($url === "/control"){
 	//get data
 	$postdata = file_get_contents("php://input");
 	//See if we should send anything down
-	if($postdata === 'RECV'){
+	if($postdata === "RECV\x00"){
 		findSendDelete($tempdir, "down_" . bin2hex($url));
 		$fname = $tempdir . "/up_recv_" . bin2hex($url); //Only keep one RECV poll
 	}else{

--- a/lib/msf/core/handler/reverse_hop_http.rb
+++ b/lib/msf/core/handler/reverse_hop_http.rb
@@ -17,6 +17,7 @@ module Handler
 module ReverseHopHttp
 
   include Msf::Handler::ReverseHttp
+  include Msf::Payload::UUIDOptions
 
   #
   # Magic bytes to know we are talking to a valid hop
@@ -256,6 +257,7 @@ module ReverseHopHttp
     # generate a new connect
     sum = uri_checksum_lookup(:connect)
     conn_id = generate_uri_uuid(sum, uuid)
+    conn_id = conn_id[1..-1] if conn_id.start_with? '/'
     url = full_uri + conn_id + "/\x00"
 
     print_status("Preparing stage for next session #{conn_id}")

--- a/lib/msf/core/handler/reverse_hop_http.rb
+++ b/lib/msf/core/handler/reverse_hop_http.rb
@@ -55,6 +55,13 @@ module ReverseHopHttp
   end
 
   #
+  # Returns the socket type. (hop)
+  #
+  def type?
+    return 'hop'
+  end
+
+  #
   # Sets up a handler. Doesn't do much since it's all in start_handler.
   #
   def setup_handler

--- a/lib/msf/core/handler/reverse_hop_http.rb
+++ b/lib/msf/core/handler/reverse_hop_http.rb
@@ -17,7 +17,6 @@ module Handler
 module ReverseHopHttp
 
   include Msf::Handler::ReverseHttp
-  include Msf::Payload::UUIDOptions
 
   #
   # Magic bytes to know we are talking to a valid hop


### PR DESCRIPTION
RECV poll has been modified to support the new null-terminator-included message.
Now-required type? method has been implemented.
