### PR TITLE
Fix msfrop metasm require

### DIFF
--- a/lib/rex/ropbuilder.rb
+++ b/lib/rex/ropbuilder.rb
@@ -3,6 +3,6 @@ module Rex
 module RopBuilder
 
 require 'rex/ropbuilder/rop'
-require 'metasm/metasm'
+require 'metasm'
 end
 end


### PR DESCRIPTION
Now which metasm is a gem, there is no need to do `require 'metasm/metasm'` anymore.
## Verification
- [x]  From master do `msfrop -h`, you should trigger the next stack trace

```
$ ./msfrop -h
/Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `require': cannot load such file -- metasm/metasm (LoadError)
    from /Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `block in require'
    from /Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:214:in `load_dependency'
    from /Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `require'
    from /Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ropbuilder.rb:6:in `<module:RopBuilder>'
    from /Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ropbuilder.rb:3:in `<module:Rex>'
    from /Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/ropbuilder.rb:2:in `<top (required)>'
    from /Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `require'
    from /Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `block in require'
    from /Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:214:in `load_dependency'
    from /Users/jvazquez/.rvm/gems/ruby-2.1.6@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:229:in `require'
    from ./msfrop:24:in `<main>'
```
- [x] Do the same from this PR branch, VERIFY there are no errors:

```
$ ./msfrop -h
Usage ./msfrop <option> [targets]

Options:
    -d, --depth [size]               Number of maximum bytes to backwards disassemble from return instructions
    -s, --search [regex]             Search for gadgets matching a regex, match intel syntax or raw bytes
    -n, --nocolor                    Disable color. Useful for piping to other tools like the less and more commands
    -x, --export [filename]          Export gadgets to CSV format
    -i, --import [filename]          Import gadgets from previous collections
    -v, --verbose                    Output very verbosely
    -h, --help                       Show this message
```
- [x] Verify which msfrop works with 32bits binaries as before, for example: `./msfrop -v -x /tmp/test.txt /tmp/win32k.sys`
