### PR TITLE
Fix #5968, some modules are not handling ADSI exceptions

### DIFF
--- a/modules/post/windows/gather/credentials/enum_laps.rb
+++ b/modules/post/windows/gather/credentials/enum_laps.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Post
 
     begin
       q = query(search_filter, max_search, FIELDS)
-    rescue RuntimeError => e
+    rescue ::RuntimeError, ::Rex::Post::Meterpreter::RequestError => e
       print_error(e.message)
       return
     end

--- a/modules/post/windows/gather/enum_ad_bitlocker.rb
+++ b/modules/post/windows/gather/enum_ad_bitlocker.rb
@@ -39,7 +39,13 @@ class Metasploit3 < Msf::Post
     fields = datastore['FIELDS'].gsub(/\s+/, "").split(',')
     search_filter = datastore['FILTER']
     max_search = datastore['MAX_SEARCH']
-    q = query(search_filter, max_search, fields)
+
+    begin
+      q = query(search_filter, max_search, fields)
+    rescue ::RuntimeError, ::Rex::Post::Meterpreter::RequestError => e
+      print_error(e.message)
+      return
+    end
 
     if q.nil? || q[:results].empty?
       print_status('No results found...')

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -60,7 +60,13 @@ class Metasploit3 < Msf::Post
     fields = datastore['FIELDS'].gsub(/\s+/,"").split(',')
     search_filter = datastore['FILTER']
     max_search = datastore['MAX_SEARCH']
-    q = query(search_filter, max_search, fields)
+
+    begin
+      q = query(search_filter, max_search, fields)
+    rescue ::RuntimeError, ::Rex::Post::Meterpreter::RequestError => e
+      print_error(e.message)
+      return
+    end
 
     return if q.nil? or q[:results].empty?
 


### PR DESCRIPTION
As explained and analyzed on #5968, post modules trying to use the LDAP mixin (ADSI queries), will raise exceptions when running from non supported OSes (like Windows XP SP3).

This modifies some modules forgetting to handle `::Rex::Post::Meterpreter::RequestError` exceptions when calling `query`. 
## Verification
- [x] Install a Windows 2008 DC
- [x] Add Windows XP SP3 client station to the domain
- From master
- [x] Get a session on the XP SP3 workstation (joined to the domain)

```
msf exploit(handler) > run

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Sending stage (885806 bytes) to 172.16.158.135
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.135:1106) at 2015-09-21 13:52:36 -0500

meterpreter > background
[*] Backgrounding session 1...
```
- [x] Run, for example, the post module `enum_ad_computers`, an exception will raise:

```
msf exploit(handler) > use post/windows/gather/enum_ad_computers
msf post(enum_ad_computers) > set session 1
session => 1
msf post(enum_ad_computers) > set DOMAIN testing.local
DOMAIN => testing.local
msf post(enum_ad_computers) > run

[-] Post failed: Rex::Post::Meterpreter::RequestError extapi_adsi_domain_query: Operation failed: 2147950650
[-] Call stack:
[-]   /Users/jvazquez/Projects/Code/metasploit-framework/lib/rex/post/meterpreter/extensions/extapi/adsi/adsi.rb:49:in `domain_query'
[-]   /Users/jvazquez/Projects/Code/metasploit-framework/lib/msf/core/post/windows/ldap.rb:126:in `query'
[-]   /Users/jvazquez/Projects/Code/metasploit-framework/modules/post/windows/gather/enum_ad_computers.rb:63:in `run'
[*] Post module execution completed
```
- From this PR
- [x] Get a session on the XP SP3 workstation (joined to the domain)
- [x] Run, for example, the post module `enum_ad_computers`, this time an error should show up, but not an unhandled exception:

```
msf post(enum_ad_computers) > run

[-] extapi_adsi_domain_query: Operation failed: 2147950650
[*] Post module execution completed
```
