### PR TITLE
Use datastore advanced options on Metasploit::Framework::LoginScanner::SMB

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -55,9 +55,6 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
-        OptString.new('SMBPass', [ false, "SMB Password" ]),
-        OptString.new('SMBUser', [ false, "SMB Username" ]),
-        OptString.new('SMBDomain', [ false, "SMB Domain", '' ]),
         OptBool.new('PRESERVE_DOMAINS', [ false, "Respect a username that contains a domain name.", true ]),
         OptBool.new('RECORD_GUEST', [ false, "Record guest-privileged random logins to the database", false ])
       ], self.class)
@@ -79,6 +76,16 @@ class Metasploit3 < Msf::Auxiliary
       send_delay: datastore['TCP::send_delay'],
       framework: framework,
       framework_module: self,
+      smb_verify_signature: datastore['SMB::VerifySignature'],
+      use_ntlmv2: datastore['NTLM::UseNTLMv2'],
+      use_ntlm2_session: datastore['NTLM::UseNTLM2_session'],
+      send_lm: datastore['NTLM::SendLM'],
+      use_lmkey: datastore['NTLM::UseLMKey'],
+      send_ntlm: datastore['NTLM::SendNTLM'],
+      smb_native_os: datastore['SMB::Native_OS'],
+      smb_native_lm: datastore['SMB::Native_LM'],
+      send_spn: datastore['NTLM::SendSPN'],
+      host: ip
     )
 
     bogus_result = @scanner.attempt_bogus_login(domain)


### PR DESCRIPTION
This pull requests does two things:
- Deletes the registration of datastore options SMBPass, SMBUser, SMBDomain since they are already registered by Msf::Exploit::Remote::SMB::Client::Authenticated as common datastore options.
- Initializes Metasploit::Framework::LoginScanner::SMB with several advanced NTLM and SMB options which were forbidden, and are used for SMB logins. It is related to #4803
## Verification
- [x] Use the module auxiliary/scanner/smb/smb_login

```
msf > use auxiliary/scanner/smb/smb_login
msf auxiliary(smb_login) > set rhosts 172.16.158.222
rhosts => 172.16.158.222
msf auxiliary(smb_login) > set smbdomain demo
smbdomain => demo
msf auxiliary(smb_login) > set smbuser juan
smbuser => juan
msf auxiliary(smb_login) > set smbpass juan
smbpass => juan
```
- [x] Set some of the new supported datastore options, like  `SMB::Native_OS` are `SMB::Native_OS`

```
msf auxiliary(smb_login) > set SMB::native_LM "Windows NATIVE LM"
SMB::native_LM => Windows NATIVE LM
msf auxiliary(smb_login) > set SMB::Native_OS "Windows NATIVE OS"
SMB::Native_OS => Windows NATIVE OS
```
- [x] Run the module

```
msf auxiliary(smb_login) > run

[*] 172.16.158.222:445 SMB - Starting SMB login bruteforce
[+] 172.16.158.222:445 SMB - Success: 'demo\juan:juan' Administrator
[*] 172.16.158.222:445 SMB - Domain is ignored for user juan
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- [x] Get a PCAP in the target and verify which the advanced options are being used

![screen shot 2015-09-21 at 5 55 23 pm](https://cloud.githubusercontent.com/assets/1742838/10007358/1c1914da-608a-11e5-8d2f-5fe3856621fd.png)
