### PR TITLE
Query for vulns without specifying service when service is nil

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -47,7 +47,10 @@ module Msf::DBManager::Vuln
   def find_vuln_by_refs(refs, host, service=nil)
     ref_ids = refs.find_all { |ref| ref.name.starts_with? 'CVE-'}
     relation = host.vulns.includes(:refs)
-    relation.where(service_id: service.try(:id), refs: { id: ref_ids}).first || relation.where(refs: { id: ref_ids}).first
+    if !service.try(:id).nil?
+      return relation.where(service_id: service.try(:id), refs: { id: ref_ids}).first
+    end
+    return relation.where(refs: { id: ref_ids}).first
   end
 
   def get_vuln(wspace, host, service, name, data='')


### PR DESCRIPTION
https://jira.tor.rapid7.com/browse/MSP-13284

This commit is dependent on PR: https://github.com/rapid7/pro/pull/2249

This commit ensures that when querying for a vuln by refs and no service is passed, we do not specify a nil service in our query. 
# Verification
- [x] Ensure you have cloned qe repo to ~/rapid7
- [x] Run Pro cucumber spec: features/import/import_third_party_file.features
- [x] Verify 20 scenarios (20 passed)
- [x] Verify 360 steps (360 passed)
