### PR TITLE
ensure the database cache is always updated on start, be more accurate

### DIFF
--- a/lib/msf/core/module_manager/cache.rb
+++ b/lib/msf/core/module_manager/cache.rb
@@ -112,7 +112,6 @@ module Msf::ModuleManager::Cache
       else
         framework.db.update_all_module_details
       end
-
       refresh_cache_from_database(self.module_paths)
     end
   end
@@ -131,11 +130,7 @@ module Msf::ModuleManager::Cache
   # @return [true] if migrations have been run
   # @return [false] otherwise
   def framework_migrated?
-    if framework.db and framework.db.migrated
-      true
-    else
-      false
-    end
+    framework.db && framework.db.migrated
   end
 
   # @!attribute [rw] module_info_by_path

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1543,12 +1543,16 @@ class Core
       end
     }
 
-    if framework.db and framework.db.migrated and framework.db.modules_cached
-      search_modules_sql(match)
-      return
+    if framework.db
+      if framework.db.migrated && framework.db.modules_cached
+        search_modules_sql(match)
+        return
+      else
+        print_warning("Module database cache not built yet, using slow search")
+      end
+    else
+      print_warning("Database not connected, using slow search")
     end
-
-    print_warning("Database not connected or cache not built, using slow search")
 
     tbl = generate_module_table("Matching Modules")
     [

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -213,11 +213,8 @@ class Driver < Msf::Ui::Driver
     end
 
     if framework.db.active && !opts['DeferModuleLoads']
-      if self.framework.modules.cache_empty?
-        self.framework.threads.spawn("ModuleCacheRebuild", true) do
-          self.framework.modules.refresh_cache_from_module_files
-        end
-        print_status("The initial module cache will be built in the background, this can take 2-5 minutes...")
+      framework.threads.spawn("ModuleCacheRebuild", true) do
+        framework.modules.refresh_cache_from_module_files
       end
     end
 


### PR DESCRIPTION
As of #5914 it appears that the payload cache is not built on a fresh database, causing all searches to be slow. This PR corrects this and updates the search command to report accurately about the status when a search is started without a database or before the initial cache has been created.
# Validation steps
- [x] start with an initially-clean database *
- [x] run 'msfconsole' and check that running 'search' shows that the cache is being updated
- [x] wait a bit (check that ruby stops using 100% cpu after a few minutes)
- [x] run search again, verify that search is fast
- [x] disable database and restart msfconsole
- [x] ensure that slow search continues to work
- managing an 'initially-clean' database can be done with 'msfdb reinit' either in Kali linux or using the packages from http://osx.metasploit.com, etc.
