### PR TITLE
Update to recog 2.0.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
       packetfu (= 1.1.11)
       railties
       rb-readline-r7
-      recog (= 2.0.6)
+      recog (= 2.0.14)
       robots
       rubyzip (~> 1.1)
       sqlite3
@@ -176,7 +176,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rb-readline-r7 (0.5.2.0)
-    recog (2.0.6)
+    recog (2.0.14)
       nokogiri
     redcarpet (3.2.3)
     rkelly-remix (0.0.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |spec|
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
   spec.add_runtime_dependency 'railties'
   # required for OS fingerprinting
-  spec.add_runtime_dependency 'recog', '2.0.6'
+  spec.add_runtime_dependency 'recog', '2.0.14'
 
   # rb-readline doesn't work with Ruby Installer due to error with Fiddle:
   #   NoMethodError undefined method `dlopen' for Fiddle:Module


### PR DESCRIPTION
Exactly as the summary says :smile: 

recog isues fixed / PRS landed since 2.0.6, not all of which actually impact metasploit-framework:

https://github.com/rapid7/recog/issues/66
https://github.com/rapid7/recog/issues/73
https://github.com/rapid7/recog/issues/74
https://github.com/rapid7/recog/issues/76
https://github.com/rapid7/recog/issues/77
https://github.com/rapid7/recog/issues/78
https://github.com/rapid7/recog/issues/79
https://github.com/rapid7/recog/issues/80
https://github.com/rapid7/recog/issues/81
https://github.com/rapid7/recog/issues/82
https://github.com/rapid7/recog/issues/85
https://github.com/rapid7/recog/issues/86
https://github.com/rapid7/recog/issues/87
https://github.com/rapid7/recog/issues/91
https://github.com/rapid7/recog/issues/92
https://github.com/rapid7/recog/issues/93
https://github.com/rapid7/recog/issues/94

I tested this by confirming that `msfconsole` still loads and the various points in metasploit where recog interaction happens still appear to function.
