### PR TITLE
When unable to determine destination MAC in capture_sendto, vprint and return false

### DIFF
--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -242,7 +242,8 @@ module Msf
         dev              ||= datastore['INTERFACE']
         dst_mac, src_mac = lookup_eth(dhost, dev)
         if dst_mac == nil and not bcast
-          raise RuntimeError, 'Unable to determine the destination MAC and bcast is false'
+          vprint_error("Unable to determine the destination MAC for #{dhost} on #{dev} and bcast is false")
+          return false
         end
         inject_eth(:payload => payload, :eth_daddr => dst_mac, :eth_saddr => src_mac)
       end

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -232,10 +232,16 @@ module Msf
         end
       end
 
-      # capture_sendto is intended to replace the old Rex::Socket::Ip.sendto method. It requires
-      # a payload and a destination address. To send to the broadcast address, set bcast
-      # to true (this will guarantee that packets will be sent even if ARP doesn't work
-      # out).
+      # Sends a payload to a given target using the pcap capture interface
+      #
+      # == Parameters:
+      # payload:: The payload String to send
+      # dhost:: the destination host to send to
+      # bcast:: set to `true` to send to the broadcast address if necessary
+      # dev:: the name of the network interface to send the payload on
+      #
+      # == Returns:
+      # The number of bytes sent iff the payload was successfully sent/injected.  `false` otherwise
       def capture_sendto(payload="", dhost=nil, bcast=false, dev=nil)
         raise RuntimeError, "Could not access the capture process (remember to open_pcap first!)" unless self.capture
         raise RuntimeError, "Must specify a host to sendto" unless dhost

--- a/spec/lib/msf/core/exploit/capture_spec.rb
+++ b/spec/lib/msf/core/exploit/capture_spec.rb
@@ -17,6 +17,17 @@ describe Msf::Exploit::Capture do
     subject.should be_a_kind_of Msf::Exploit::Capture
   end
 
+  context '#capture_sendto' do
+    it 'should return false if the destination MAC cannot be determined and broadcast is not desired' do
+    end
+
+    it 'should return the correct number of bytes if the destination MAC cannot be determined and broadcast is desired' do
+    end
+
+    it 'should return the correct number of bytes if the destination MAC can be determined' do
+    end
+  end
+
   context '#stats_*' do
 
     it 'should show received packets' do

--- a/spec/lib/msf/core/exploit/capture_spec.rb
+++ b/spec/lib/msf/core/exploit/capture_spec.rb
@@ -18,14 +18,31 @@ describe Msf::Exploit::Capture do
   end
 
   context '#capture_sendto' do
+    let(:payload) { Rex::Text::rand_text_alphanumeric(100 + rand(1024)) }
+
+    before(:each) do
+      allow(subject).to receive(:capture).and_return(true)
+    end
+
+    it 'should return the correct number of bytes if the destination MAC can be determined, regardless of broadcast' do
+      allow(subject).to receive(:lookup_eth).and_return(%w(de:ad:be:ef:ca:fe 01:02:03:04:05:06))
+      allow(subject).to receive(:inject_eth).and_return(payload.size)
+      subject.capture_sendto(payload, '127.0.0.1', false).should == payload.size
+      subject.capture_sendto(payload, '127.0.0.1', true).should == payload.size
+    end
+
     it 'should return false if the destination MAC cannot be determined and broadcast is not desired' do
+      allow(subject).to receive(:lookup_eth).and_return(nil)
+      subject.capture_sendto(payload, '127.0.0.1').should be_falsey
+      subject.capture_sendto(payload, '127.0.0.1', false).should be_falsey
     end
 
     it 'should return the correct number of bytes if the destination MAC cannot be determined and broadcast is desired' do
+      allow(subject).to receive(:lookup_eth).and_return(nil)
+      allow(subject).to receive(:inject_eth).and_return(payload.size)
+      subject.capture_sendto(payload, '127.0.0.1', true).should == payload.size
     end
 
-    it 'should return the correct number of bytes if the destination MAC can be determined' do
-    end
   end
 
   context '#stats_*' do


### PR DESCRIPTION
Fixes #6006.  

~20 modules are affected by #6006, causing them to stop mid-run because of the `RuntimeError`, which is especially bad in the case of `Scanner`-based modules which may be scanning many hosts, some of which may not be alive and would cause the module to stop running, perhaps without scanning hosts that are alive.  This simply reverts to the original behavior of returning `false` but adds some logging so that it is more obvious what went wrong.   I'm not entirely committed to this logging, though.

The real fix for what I put in #5840 is now in #6008.  This PR simply fixes the biggest issue (`RuntimeError`)

Ping @cpowell, who reported #6006 
