### PR TITLE
Fix #6008, incorrect usage of capture_sendto

### DIFF
--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -86,7 +86,7 @@ module Auxiliary::UDPScanner
     p.recalc
     print_status("Sending #{num_packets} packet(s) to #{ip} from #{srcip}")
     1.upto(num_packets) do |x|
-      capture_sendto(p, ip)
+      break unless capture_sendto(p, ip)
     end
     close_pcap
   end

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Auxiliary
 
       ackbpf = "tcp [8:4] == 0x#{(p.tcp_seq + 1).to_s(16)}"
       pcap.setfilter("tcp and tcp[13] == 18 and not host #{ip} and src port #{p.tcp_dst} and dst port #{p.tcp_src} and #{ackbpf}")
-      capture_sendto(p, ip)
+      break unless capture_sendto(p, ip)
       reply = probe_reply(pcap, to)
       next if reply.nil?
 

--- a/modules/auxiliary/dos/mdns/avahi_portzero.rb
+++ b/modules/auxiliary/dos/mdns/avahi_portzero.rb
@@ -45,10 +45,7 @@ class Metasploit3 < Msf::Auxiliary
     p.udp_dport = datastore['RPORT'].to_i
     p.payload = Rex::Text.rand_text(rand(0x20)) # UDP needs at least one data byte, may as well send a few.
     p.recalc
-    capture_sendto(p, rhost)
-
+    capture_sendto(p, rhost) and print_status("Avahi should be down now")
     close_pcap
-
-    print_status("Avahi should be down now")
   end
 end

--- a/modules/auxiliary/dos/tcp/synflood.rb
+++ b/modules/auxiliary/dos/tcp/synflood.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
       p.tcp_sport = sport
       p.tcp_seq = rand(0x100000000)
       p.recalc
-      capture_sendto(p,rhost)
+      break unless capture_sendto(p,rhost)
       sent += 1
     end
 

--- a/modules/auxiliary/scanner/ip/ipidseq.rb
+++ b/modules/auxiliary/scanner/ip/ipidseq.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
 
       probe = buildprobe(shost, sport, ip, rport)
 
-      capture_sendto(probe, ip)
+      next unless capture_sendto(probe, ip)
 
       reply = probereply(pcap, to)
 

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -53,9 +53,11 @@ class Metasploit3 < Msf::Auxiliary
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0
 
+    # we copy the hosts because some may not be reachable and need to be ejected
+    host_queue = hosts.dup
     # Spread the load across the hosts
     ports.each do |dport|
-      hosts.each do |dhost|
+      host_queue.each do |dhost|
         shost, sport = getsource(dhost)
 
         self.capture.setfilter(getfilter(shost, sport, dhost, dport))
@@ -63,7 +65,10 @@ class Metasploit3 < Msf::Auxiliary
         begin
           probe = buildprobe(shost, sport, dhost, dport)
 
-          capture_sendto(probe, dhost)
+          unless capture_sendto(probe, dhost)
+            host_queue.delete(dhost)
+            next
+          end
 
           reply = probereply(self.capture, to)
 

--- a/modules/auxiliary/scanner/rogue/rogue_send.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_send.rb
@@ -43,9 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 
     pcap = self.capture
 
-    capture_sendto(build_tcp_syn(ip), ip)
-
-    capture_sendto(build_icmp(ip), ip)
+    capture_sendto(build_tcp_syn(ip), ip) && capture_sendto(build_icmp(ip), ip)
 
     close_pcap
   end

--- a/modules/auxiliary/scanner/rogue/rogue_send.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_send.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 
     pcap = self.capture
 
-    capture_sendto(build_tcp_syn(ip), ip) && capture_sendto(build_icmp(ip), ip)
+    capture_sendto(build_tcp_syn(ip), ip) and capture_sendto(build_icmp(ip), ip)
 
     close_pcap
   end

--- a/modules/exploits/multi/ids/snort_dce_rpc.rb
+++ b/modules/exploits/multi/ids/snort_dce_rpc.rb
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{rhost}:#{rport} Sending crafted SMB packet from #{shost}...")
 
-    capture_sendto(p, rhost)
+    return unless capture_sendto(p, rhost)
 
     handler
   end

--- a/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname.rb
+++ b/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname.rb
@@ -204,10 +204,10 @@ class Metasploit3 < Msf::Exploit::Remote
       p.payload = sploit
       p.recalc
 
-      capture_sendto(p, rhost)
+      sent = capture_sendto(p, rhost)
       close_pcap
 
-      handler
+      handler if sent
     else
       print_status("Sending malformed LWRES packet to #{rhost}")
       connect_udp

--- a/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
+++ b/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
@@ -215,7 +215,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       while true
         break if session_created? and datastore['ExitOnSession']
-        capture_sendto(p, rhost)
+        break unless capture_sendto(p, rhost)
         select(nil,nil,nil,datastore['DELAY'])
       end
 


### PR DESCRIPTION
Please see my analysis in #6008. 

I've done what I can to test these, which is:
- `msfconsole` starts without warnings about syntax in the modified code
- For many of them, simulated the failure conditions described in #6008 by trying to scan a host that does not exist
