### PR TITLE
Use SSLVerifyMode and SSLCipher from the Exploit::Remote::Tcp mixin

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -100,15 +100,17 @@ module Exploit::Remote::Tcp
     end
 
     nsock = Rex::Socket::Tcp.create(
-      'PeerHost'   =>  opts['RHOST'] || rhost,
-      'PeerPort'   => (opts['RPORT'] || rport).to_i,
-      'LocalHost'  =>  opts['CHOST'] || chost || "0.0.0.0",
-      'LocalPort'  => (opts['CPORT'] || cport || 0).to_i,
-      'SSL'        =>  dossl,
-      'SSLVersion' =>  opts['SSLVersion'] || ssl_version,
-      'Proxies'    => proxies,
-      'Timeout'    => (opts['ConnectTimeout'] || connect_timeout || 10).to_i,
-      'Context'    =>
+      'PeerHost'      =>  opts['RHOST'] || rhost,
+      'PeerPort'      => (opts['RPORT'] || rport).to_i,
+      'LocalHost'     =>  opts['CHOST'] || chost || "0.0.0.0",
+      'LocalPort'     => (opts['CPORT'] || cport || 0).to_i,
+      'SSL'           =>  dossl,
+      'SSLVersion'    =>  opts['SSLVersion'] || ssl_version,
+      'SSLVerifyMode' =>  opts['SSLVerifyMode'] || ssl_verify_mode,
+      'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
+      'Proxies'       => proxies,
+      'Timeout'       => (opts['ConnectTimeout'] || connect_timeout || 10).to_i,
+      'Context'       =>
         {
           'Msf'        => framework,
           'MsfExploit' => self,
@@ -267,6 +269,20 @@ module Exploit::Remote::Tcp
   #
   def connect_timeout
     datastore['ConnectTimeout']
+  end
+
+  #
+  # Returns the SSL certification verification mechanism
+  #
+  def ssl_verify_mode
+    datastore['SSLVerifyMode']
+  end
+
+  #
+  # Returns the SSL cipher to use for the context
+  #
+  def ssl_cipher
+    datastore['SSLCipher']
   end
 
 protected


### PR DESCRIPTION
This pull request tries to finish #1726. Before this pull request, SSLVerifyMode and SSLCipher are had into account only if the Rex sockets are created manually. If the socket is created through the mixin, the options are not taken into account. I noticed it while working on #4803.

This pull request just tries to fix the Msf::Core::Exploit::Tcp mixin. A next pull request will try to update the LoginScanner related code to have all the advanced/evasion options provided by the Tcp mixin into account. But I'm trying to keep pull requests smaller. Since it's important code! 
## Verification
- [x] Same verification steps than  #1726, verify which works as expected when using rex classes directly.
- [x] Use any module including the Exploit::Remote::Tcp, verify which the rex sockets created by the mixin have SSLVerifyMode and SSLCipher into account.
