### PR TITLE
Related to #4803, Update LoginScanner modules to have into account TCP advanced options

### DIFF
--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -30,6 +30,12 @@ module Metasploit
           # @!attribute port
           #   @return [Fixnum] The port to connect to
           attr_accessor :port
+          # @!attribute host
+          #   @return [String] The local host for outgoing connections
+          attr_accessor :local_host
+          # @!attribute port
+          #   @return [Fixnum] The local port for outgoing connections
+          attr_accessor :local_port
           # @!attribute proxies
           #   @return [String] The proxy directive to use for the socket
           attr_accessor :proxies

--- a/lib/metasploit/framework/login_scanner/rex_socket.rb
+++ b/lib/metasploit/framework/login_scanner/rex_socket.rb
@@ -19,17 +19,11 @@ module Metasploit
           #   @return [String] The version of SSL to implement
           attr_accessor :ssl_version
           # @!attribute ssl_verify_mode
-          #   @return [String] The SSL certification verification mechanism
+          #   @return [String] the SSL certification verification mechanism
           attr_accessor :ssl_verify_mode
           # @!attribute ssl_cipher
           #   @return [String] The SSL cipher to use for the context
           attr_accessor :ssl_cipher
-          # @!attribute chost
-          #   @return [String] The local host for outgoing connections
-          attr_accessor :chost
-          # @!attribute cport
-          #   @return [Fixnum] The local port for outgoing connections
-          attr_accessor :cport
 
           private
 
@@ -39,6 +33,14 @@ module Metasploit
 
           def rport
             port
+          end
+
+          def chost
+            local_host || '0.0.0.0'
+          end
+
+          def cport
+            local_port || 0
           end
         end
       end

--- a/lib/metasploit/framework/login_scanner/rex_socket.rb
+++ b/lib/metasploit/framework/login_scanner/rex_socket.rb
@@ -18,16 +18,20 @@ module Metasploit
           # @!attribute ssl_version
           #   @return [String] The version of SSL to implement
           attr_accessor :ssl_version
+          # @!attribute ssl_verify_mode
+          #   @return [String] The SSL certification verification mechanism
+          attr_accessor :ssl_verify_mode
+          # @!attribute ssl_cipher
+          #   @return [String] The SSL cipher to use for the context
+          attr_accessor :ssl_cipher
+          # @!attribute chost
+          #   @return [String] The local host for outgoing connections
+          attr_accessor :chost
+          # @!attribute cport
+          #   @return [Fixnum] The local port for outgoing connections
+          attr_accessor :cport
 
           private
-
-          def chost
-            '0.0.0.0'
-          end
-
-          def cport
-            0
-          end
 
           def rhost
             host

--- a/lib/metasploit/framework/tcp/client.rb
+++ b/lib/metasploit/framework/tcp/client.rb
@@ -82,15 +82,17 @@ module Metasploit
           end
 
           nsock = Rex::Socket::Tcp.create(
-              'PeerHost'   =>  opts['RHOST'] || rhost,
-              'PeerPort'   => (opts['RPORT'] || rport).to_i,
-              'LocalHost'  =>  opts['CHOST'] || chost || "0.0.0.0",
-              'LocalPort'  => (opts['CPORT'] || cport || 0).to_i,
-              'SSL'        =>  dossl,
-              'SSLVersion' =>  opts['SSLVersion'] || ssl_version,
-              'Proxies'    => proxies,
-              'Timeout'    => (opts['ConnectTimeout'] || connection_timeout || 10).to_i,
-              'Context'    => { 'Msf' => framework, 'MsfExploit' => framework_module }
+              'PeerHost'      =>  opts['RHOST'] || rhost,
+              'PeerPort'      => (opts['RPORT'] || rport).to_i,
+              'LocalHost'     =>  opts['CHOST'] || chost || "0.0.0.0",
+              'LocalPort'     => (opts['CPORT'] || cport || 0).to_i,
+              'SSL'           =>  dossl,
+              'SSLVersion'    =>  opts['SSLVersion'] || ssl_version,
+              'SSLVerifyMode' =>  opts['SSLVerifyMode'] || ssl_verify_mode,
+              'SSLCipher'     =>  opts['SSLCipher'] || ssl_cipher,
+              'Proxies'       => proxies,
+              'Timeout'       => (opts['ConnectTimeout'] || connection_timeout || 10).to_i,
+              'Context'       => { 'Msf' => framework, 'MsfExploit' => framework_module }
               )
           # enable evasions on this socket
           set_tcp_evasions(nsock)

--- a/lib/rex/socket/tcp.rb
+++ b/lib/rex/socket/tcp.rb
@@ -25,7 +25,6 @@ module Rex::Socket::Tcp
   # @see Rex::Socket::Parameters.from_hash
   def self.create(hash = {})
     hash['Proto'] = 'tcp'
-    puts "parameters: #{hash.inspect}"
     self.create_param(Rex::Socket::Parameters.from_hash(hash))
   end
 

--- a/lib/rex/socket/tcp.rb
+++ b/lib/rex/socket/tcp.rb
@@ -25,6 +25,7 @@ module Rex::Socket::Tcp
   # @see Rex::Socket::Parameters.from_hash
   def self.create(hash = {})
     hash['Proto'] = 'tcp'
+    puts "parameters: #{hash.inspect}"
     self.create_param(Rex::Socket::Parameters.from_hash(hash))
   end
 

--- a/modules/auxiliary/scanner/acpp/login.rb
+++ b/modules/auxiliary/scanner/acpp/login.rb
@@ -74,6 +74,12 @@ class Metasploit3 < Msf::Auxiliary
       send_delay: datastore['TCP::send_delay'],
       framework: framework,
       framework_module: self,
+      ssl: datastore['SSL'],
+      ssl_version: datastore['SSLVersion'],
+      ssl_verify_mode: datastore['SSLVerifyMode'],
+      ssl_cipher: datastore['SSLCipher'],
+      local_port: datastore['CPORT'],
+      local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -69,6 +69,12 @@ class Metasploit3 < Msf::Auxiliary
         send_delay: datastore['TCP::send_delay'],
         framework: framework,
         framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -67,6 +67,12 @@ class Metasploit3 < Msf::Auxiliary
         send_delay: datastore['TCP::send_delay'],
         framework: framework,
         framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -81,6 +81,12 @@ class Metasploit3 < Msf::Auxiliary
         connection_timeout: 30,
         framework: framework,
         framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -58,6 +58,12 @@ class Metasploit3 < Msf::Auxiliary
         windows_authentication: datastore['USE_WINDOWS_AUTHENT'],
         framework: framework,
         framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -66,6 +66,12 @@ class Metasploit3 < Msf::Auxiliary
             send_delay: datastore['TCP::send_delay'],
             framework: framework,
             framework_module: self,
+            ssl: datastore['SSL'],
+            ssl_version: datastore['SSLVersion'],
+            ssl_verify_mode: datastore['SSLVerifyMode'],
+            ssl_cipher: datastore['SSLCipher'],
+            local_port: datastore['CPORT'],
+            local_host: datastore['CHOST']
         )
 
         scanner.scan! do |result|

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -75,6 +75,12 @@ class Metasploit3 < Msf::Auxiliary
       send_delay: datastore['TCP::send_delay'],
       framework: framework,
       framework_module: self,
+      ssl: datastore['SSL'],
+      ssl_version: datastore['SSLVersion'],
+      ssl_verify_mode: datastore['SSLVerifyMode'],
+      ssl_cipher: datastore['SSLCipher'],
+      local_port: datastore['CPORT'],
+      local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
+++ b/modules/auxiliary/scanner/telnet/brocade_enable_login.rb
@@ -116,6 +116,12 @@ class Metasploit4 < Msf::Auxiliary
           pre_login: lambda { |s| raw_send("enable\r\n", s.sock) },
           framework: framework,
           framework_module: self,
+          ssl: datastore['SSL'],
+          ssl_version: datastore['SSLVersion'],
+          ssl_verify_mode: datastore['SSLVerifyMode'],
+          ssl_cipher: datastore['SSLCipher'],
+          local_port: datastore['CPORT'],
+          local_host: datastore['CHOST']
       )
 
       scanner.scan! do |result|

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -72,6 +72,12 @@ class Metasploit3 < Msf::Auxiliary
         telnet_timeout: datastore['TelnetTimeout'],
         framework: framework,
         framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -78,6 +78,12 @@ class Metasploit3 < Msf::Auxiliary
       send_delay: datastore['TCP::send_delay'],
       framework: framework,
       framework_module: self,
+      ssl: datastore['SSL'],
+      ssl_version: datastore['SSLVersion'],
+      ssl_verify_mode: datastore['SSLVerifyMode'],
+      ssl_cipher: datastore['SSLCipher'],
+      local_port: datastore['CPORT'],
+      local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -83,6 +83,12 @@ class Metasploit3 < Msf::Auxiliary
         send_delay: datastore['TCP::send_delay'],
         framework: framework,
         framework_module: self,
+        ssl: datastore['SSL'],
+        ssl_version: datastore['SSLVersion'],
+        ssl_verify_mode: datastore['SSLVerifyMode'],
+        ssl_cipher: datastore['SSLCipher'],
+        local_port: datastore['CPORT'],
+        local_host: datastore['CHOST']
     )
 
     scanner.scan! do |result|


### PR DESCRIPTION
This PR tries to finally fix #4803 by updating the modules using LoginScanner classes to have into account advanced options provided by the `Exploit::Remote::Tcp` mixin.
## Verification
- [x] use auxiliary/scanner/acpp/login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use auxiliary/scanner/afp/afp_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use auxiliary/scanner/db2/db2_auth, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use auxiliary/scanner/ftp/ftp_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use auxiliary/scanner/mssql/mssql_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use auxiliary/scanner/mysql/mysql_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use auxiliary/scanner/pop3/pop3_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use modules/auxiliary/scanner/telnet/brocade_enable_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use modules/auxiliary/scanner/telnet/telnet_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use modules/auxiliary/scanner/vmware/vmauthd_login, VERIFY which all the advanced options are have into account when creating the Rex socket
- [x] use auxiliary/scanner/vnc/vnc_login, VERIFY which all the advanced options are have into account when creating the Rex socket
