### PR TITLE
Exploit for ZDI-15-448: Kaseya VSA privilege escalation

### DIFF
--- a/modules/auxiliary/admin/http/kaseya_master_admin.rb
+++ b/modules/auxiliary/admin/http/kaseya_master_admin.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
           ['CVE', '2015-6922'],
           ['ZDI', '15-448'],
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/kaseya-vsa-vuln-2.txt'],
-          ['URL', 'TODO_FULLDISC_URL']
+          ['URL', 'http://seclists.org/bugtraq/2015/Sep/132']
         ],
       'DisclosureDate' => 'Sep 23 2015'))
 


### PR DESCRIPTION
Hi,

This is an exploit for ZDI-15-448 / CVE-2015-6922. This module allows an unauthenticated attacker to become a master administrator on the Kaseya console. For more details see my advisory https://raw.githubusercontent.com/pedrib/PoC/master/advisories/kaseya-vsa-vuln-2.txt.

This module has been well tested! Please let me know your comments.
