### PR TITLE
Bump MDM to 1.2.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ PATH
       activerecord (>= 4.0.9, < 4.1.0)
       metasploit-credential (= 1.0.1)
       metasploit-framework (= 4.11.4)
-      metasploit_data_models (= 1.2.5)
+      metasploit_data_models (= 1.2.6)
       pg (>= 0.11)
     metasploit-framework-pcap (4.11.4)
       metasploit-framework (= 4.11.4)
@@ -126,7 +126,7 @@ GEM
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
     metasploit-payloads (1.0.15)
-    metasploit_data_models (1.2.5)
+    metasploit_data_models (1.2.6)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       arel-helpers

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # Metasploit::Credential database models
   spec.add_runtime_dependency 'metasploit-credential', '1.0.1'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models', '1.2.5'
+  spec.add_runtime_dependency 'metasploit_data_models', '1.2.6'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code
   spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
   # Needed for module caching in Mdm::ModuleDetails


### PR DESCRIPTION
MSP-13344

This Mdm bump fixes the crawler not saving to the database anymore - causes stack trace, fails to collect anything

See:
This Mdm bump fixes the following:
https://github.com/rapid7/metasploit-framework/issues/5515
https://github.com/rapid7/metasploit_data_models/pull/134
