### PR TITLE
Add target IP to verb testing results

### DIFF
--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -77,10 +77,10 @@ class Metasploit3 < Msf::Auxiliary
 
       next if not resauth
 
-      print_status("Testing verb #{tv}, resp code: [#{resauth.code}]")
+      print_status("[#{ip}] Testing verb #{tv}, resp code: [#{resauth.code}]")
 
       if resauth.code != auth_code and resauth.code <= 302
-        print_status("Possible authentication bypass with verb #{tv} code #{resauth.code}")
+        print_good("[#{ip}] Possible authentication bypass with verb #{tv} code #{resauth.code}")
 
         # Unable to use report_web_vuln as method is not in list of allowed methods.
 

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -51,13 +51,13 @@ class Metasploit3 < Msf::Auxiliary
     return if not res
 
     if not res.headers['WWW-Authenticate']
-      print_status("[#{ip}] Authentication not required. #{datastore['PATH']} #{res.code}")
+      print_status("[#{ip}:#{datastore['RPORT']}#{datastore['PATH']}] Authentication not required, resp code: [#{res.code}]")
       return
     end
 
     auth_code = res.code
 
-    print_status("#{ip} requires authentication: #{res.headers['WWW-Authenticate']} [#{auth_code}]")
+    print_status("[#{ip}:#{datastore['RPORT']}#{datastore['PATH']}] Authentication required: #{res.headers['WWW-Authenticate']}, resp code [#{auth_code}]")
 
     report_note(
       :host   => ip,
@@ -77,10 +77,10 @@ class Metasploit3 < Msf::Auxiliary
 
       next if not resauth
 
-      print_status("[#{ip}] Testing verb #{tv}, resp code: [#{resauth.code}]")
+      print_status("[#{ip}:#{datastore['RPORT']}#{datastore['PATH']}] Testing verb #{tv}, resp code: [#{resauth.code}]")
 
       if resauth.code != auth_code and resauth.code <= 302
-        print_good("[#{ip}] Possible authentication bypass with verb #{tv} code #{resauth.code}")
+        print_good("[#{ip}:#{datastore['RPORT']}#{datastore['PATH']}] Possible authentication bypass with verb #{tv}, resp code: [#{resauth.code}]")
 
         # Unable to use report_web_vuln as method is not in list of allowed methods.
 

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 
     auth_code = res.code
 
-    print_status("[#{ip}:#{datastore['RPORT']}#{datastore['PATH']}] Authentication required: #{res.headers['WWW-Authenticate']}, resp code [#{auth_code}]")
+    print_status("[#{ip}:#{datastore['RPORT']}#{datastore['PATH']}] Authentication required: #{res.headers['WWW-Authenticate']}, resp code: [#{auth_code}]")
 
     report_note(
       :host   => ip,


### PR DESCRIPTION
When specifying multiple hosts the resulting output is difficult to use because you don't know which verb goes to what IP address.  This will also use print_good when reporting a potential bypass in order to make finding the resulting output easier (again, can get lost when using large numbers of hosts).
