### PR TITLE
Add development tool Microsoft Patch Finder

### DIFF
--- a/tools/msu_finder.rb
+++ b/tools/msu_finder.rb
@@ -725,10 +725,10 @@ module MicrosoftPatchFinder
 
       case args[:search_engine]
       when :technet
-        print_debug("Searching advisories for #{keyword} via Technet")
+        print_debug("Searching advisories that include #{keyword} via Technet")
         msb_numbers = technet_search(keyword)
       when :google
-        print_debug("Searching advisories for #{keyword} via Google")
+        print_debug("Searching advisories that include #{keyword} via Google")
         msb_numbers = google_search(keyword, api_key, cx)
       end
 

--- a/tools/msu_finder.rb
+++ b/tools/msu_finder.rb
@@ -528,8 +528,8 @@ module MicrosoftPatchFinder
     %Q|
     Usage: #{__FILE__} [options]
 
-    The following example will download all IE 10 update links:
-    #{__FILE__} -q "Internet Explorer 10"
+    The following example will download all IE update links:
+    #{__FILE__} -q "Internet Explorer"
 
     Searching advisories via Technet:
     When you submit a query, the Technet search engine will first look it up from a product list.
@@ -578,7 +578,7 @@ module MicrosoftPatchFinder
         opt.separator ''
         opt.separator 'Specific options:'
 
-        opt.on('-q', '--query <keyword>', 'Regex keyword to search') do |v|
+        opt.on('-q', '--query <keyword>', 'Find advisories that include this keyword') do |v|
           options[:keyword] = v
         end
 
@@ -593,7 +593,7 @@ module MicrosoftPatchFinder
           end
         end
 
-        opt.on('-r', '--regex <string>', '(Optional) Regex download links') do |v|
+        opt.on('-r', '--regex <string>', '(Optional) Specify what type of links you want') do |v|
           options[:regex] = v
         end
 

--- a/tools/msu_finder.rb
+++ b/tools/msu_finder.rb
@@ -81,6 +81,7 @@ module MicrosoftPatchFinder
     # @option rhost [String] :vhost
     # @option rhost [String] :ip IPv4 address
     # @param opts [Hash] Information about the Rex request.
+    # @raise [RuntimeError] Failure to make a request.
     # @return [Rex::Proto::Http::Response]
     def send_http_request(rhost, opts={})
       res = nil
@@ -532,13 +533,10 @@ module MicrosoftPatchFinder
     #{__FILE__} -q "Internet Explorer"
 
     Searching advisories via Technet:
-    When you submit a query, the Technet search engine will first look it up from a product list.
-    If there is more than one match found, then the script will collect all of the advisories.
-    For example, the current product list has Internet Explorer 10 and 9, and if the query is
-    "Internet Explorer", then it will return results for both of them. If there's no match found,
-    then the Technet search engine will try a more generic search that doesn't use the product list.
-    But keep in mind this tends to return irrelevant results. If the generic search function kicks
-    in, you can use it to search via the MSB, KB, or even the CVE number.
+    When you submit a query, the Technet search engine will first look it up from a product list,
+    and then return all the advisories that include the keyword you are looking for. If there's
+    no match from the product list, then the script will try a generic search. The generic method
+    also means you can search by MSB, KB, or even the CVE number.
 
     Searching advisories via Google:
     Searching via Google requires an API key and an Search Engine ID from Google. To obtain these,


### PR DESCRIPTION
This tool allows you to find Microsoft patches and download links for them. If your research work involves diffing Windows patches, or you need to download a bunch of patches for a specific product for testing/analysis, you might find this tool handy.
## Usage

The tool supports two ways to find patches: Technet, and Google Custom Search API. By default, it uses Technet. You can read the tool's -h to read about the difference.

An example of using this tool to find all the MSIE 9 patches:

```
ruby tools/msu_finder.rb -q "Internet Explorer 9"
```

The above will search all the IE9 advisories and find all the download links. If for some reason you don't actually want the download links, you just want to see how many advisories are out there (which happens when you want to figure out how often some component changes or whatever), then you can add the -d flag.

You can also ask the tool to find the download links for a specific advisory like the following:

```
ruby tools/msu_finder.rb -q "ms15-100"
```

Obviously, this will give you links for all platforms and architectures. If you don't want all of them, you can use the -r option to narrow down what you're looking for. For example, if you want to narrow down the above results to x64 Win 8 patches, then your -r can be something like this:

```
ruby tools/msu_finder.rb -q "ms15-100" -r Windows8.+x64
```

Finally, as you can see the tool doesn't download links for you, it just finds them. So if that's what you want to do, here's a trick for that:

```
ruby tools/msu_finder.rb -q "ms15-100" -r x86 > /tmp/list.txt && wget -i /tmp/list.txt
```
## Testing
- [ ] Make sure Travis is green
- [ ] Please follow the above examples
