### PR TITLE
Add reference for CVE-2015-2342 - VMWare VCenter JMX RMI RCE

### DIFF
--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -31,7 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'https://docs.oracle.com/javase/8/docs/technotes/guides/jmx/JMX_1_4_specification.pdf'],
-          ['URL', 'http://www.accuvant.com/blog/exploiting-jmx-rmi']
+          ['URL', 'http://www.accuvant.com/blog/exploiting-jmx-rmi'],
+          [ 'CVE', '2015-2342' ]
         ],
       'Platform'       => 'java',
       'Arch'           => ARCH_JAVA,

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['URL', 'https://docs.oracle.com/javase/8/docs/technotes/guides/jmx/JMX_1_4_specification.pdf'],
           ['URL', 'http://www.accuvant.com/blog/exploiting-jmx-rmi'],
-          [ 'CVE', '2015-2342' ]
+          ['CVE', '2015-2342']
         ],
       'Platform'       => 'java',
       'Arch'           => ARCH_JAVA,


### PR DESCRIPTION
Quick update that just adds the CVE number 2015-2342 to the references. The vulnerability can be exploited with the existing module, no need to change anything.

Additional references:
https://www.7elements.co.uk/resources/blog/cve-2015-2342-remote-code-execution-within-vmware-vcenter/

https://www.vmware.com/security/advisories/VMSA-2015-0007.html
