### PR TITLE
Check if the payload has a include_send_uuid method before calling it

### DIFF
--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -45,7 +45,7 @@ module Msf::Payload::Stager
         proto = 'http'
     end
     send("transport_config_#{direction}_#{proto}", opts)
-  end 
+  end
 
   #
   # Sets the payload type to a stager.
@@ -159,10 +159,12 @@ module Msf::Payload::Stager
     if (stage_over_connection?)
       opts = {}
 
-      if include_send_uuid
-        uuid_raw = conn.get_once(16, 1)
-        if uuid_raw
-          opts[:uuid] = Msf::Payload::UUID.new({raw: uuid_raw})
+      if respond_to? :include_send_uuid
+        if include_send_uuid
+          uuid_raw = conn.get_once(16, 1)
+          if uuid_raw
+            opts[:uuid] = Msf::Payload::UUID.new({raw: uuid_raw})
+          end
         end
       end
 


### PR DESCRIPTION
Otherwise we get an undefined method exception and the payload fails to stage.
Fixes #6040 

This is sort-of nasty because it appears that we silently rescue exceptions thrown during staging, which makes this look like the stager hung (and the payload crashes) rather than a simpler-to-fix check for a method existence.

@OJ may want to refactor things so we do not need this, but this should stop the bleeding for now.
# Verification steps
- [x] Generate a 64-bit and 32-bit linux reverse TCP shell payload
- [x] Stage it and ensure that you get a shell.
