### PR TITLE
Change EXITFUNC acceptable options

### DIFF
--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -76,9 +76,12 @@ module Msf::Payload::Windows
     #	info['Alias'] = 'windows/' + info['Alias']
     #end
 
+
+    acceptable_exit_types = @@exit_types.keys.collect { |e| e.blank? ? "''" : e }.uniq
+
     register_options(
       [
-        Msf::OptEnum.new('EXITFUNC', [true, 'Exit technique', 'process', @@exit_types.keys])
+        Msf::OptEnum.new('EXITFUNC', [true, 'Exit technique', 'process', acceptable_exit_types])
       ], Msf::Payload::Windows )
     ret
   end


### PR DESCRIPTION
This patch basically skips the nil option, and changes the empty string to "". The nil option and empty string have the same value of 0x00, so we don't really need to see both.
## Verification:
- [x] start msfconsole
- [x] use exploit/windows/smb/ms08_067_netapi
- [x] set payload windows/meterpreter/reverse_tcp
- [x] show options
- [x] You should see you have these options for EXITFUNC:

```
   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
```
