### PR TITLE
Enable 64-bit payloads for MSSQL modules

### DIFF
--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -42,6 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Scott Sutherland "nullbind" <scott.sutherland[at]netspi.com>'
         ],
       'Platform'      => [ 'win' ],
+      'Arch'           => [ ARCH_X86, ARCH_X86_64 ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '4797' ]
         ],
       'Platform'       => 'win',
+      'Arch'           => [ ARCH_X86, ARCH_X86_64 ],
       'Targets'        =>
         [
           [ 'Automatic', { } ],

--- a/modules/exploits/windows/mssql/mssql_payload_sqli.rb
+++ b/modules/exploits/windows/mssql/mssql_payload_sqli.rb
@@ -75,6 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
         ],
       'Platform'       => 'win',
+      'Arch'           => [ ARCH_X86, ARCH_X86_64 ],
       'Payload'        =>
         {
           'BadChars' 	=> "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c&=+?:;-,/#.\\\$\%",


### PR DESCRIPTION
This patch enables 64-bit payloads for the MSSQL modules.
