### PR TITLE
Get rid of some tabs in COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -5,15 +5,15 @@ Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
     * Redistributions of source code must retain the above copyright notice,
-	  this list of conditions and the following disclaimer.
+    this list of conditions and the following disclaimer.
 
     * Redistributions in binary form must reproduce the above copyright notice,
-	  this list of conditions and the following disclaimer in the documentation
-	  and/or other materials provided with the distribution.
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
 
     * Neither the name of Rapid7, Inc. nor the names of its contributors
-	  may be used to endorse or promote products derived from this software
-	  without specific prior written permission.
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
Turns out, there were some tabs hiding in the COPYING file.
## Verification
- [x] Read COPYING in an editor that highlights tabs
- [x] Note the lack of tabs
- [x] See that the right margin still lines up with glorious spaces
