### PR TITLE
Minor D-Link fixes

### DIFF
--- a/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
+++ b/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
@@ -15,9 +15,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'DLink User-Agent Backdoor Scanner',
+      'Name'           => 'D-Link User-Agent Backdoor Scanner',
       'Description'    => %q{
-        This module attempts to find DLink devices running Alphanetworks web interfaces affected
+        This module attempts to find D-Link devices running Alphanetworks web interfaces affected
         by the backdoor found on the User-Agent header. This module has been tested successfully
         on a DIR-100 device with firmware version v1.13.
       },

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
           This module exploits an anonymous remote code execution vulnerability on D-Link DIR-605L routers. The
         vulnerability exists while handling user supplied captcha information, and is due to the
         insecure usage of sprintf on the getAuthCode() function. This module has been tested
-        successfully on DLink DIR-605L Firmware 1.13 under a QEMU environment.
+        successfully on D-Link DIR-605L firmware 1.13 (emulated) and firmware 1.12 (real).
       },
       'Author'         =>
         [

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'Targets'        =>
         [
-          [ 'DLink DIR-605L 1.13',
+          [ 'D-Link DIR-605L 1.13', # Works on 1.12 as well
             {
               'Offset'      => 94,
               'LibcBase'    => 0x2ab86000, # According to Original Exploit by Craig Heffner


### PR DESCRIPTION
This mainly just changes the spelling of 'DLink' to the more correct 'D-Link' in the few places where it showed up. Also, confirms that one exploit actually works against a slightly older firmware version that is listed.

Ultimately, just a docs/description change.
## Verification
- [x] Note the hyphen in 'D-Link'
- [x] Check for newly introduced grammar errors
