### PR TITLE
Fix autofilter values for aggressive modules

### DIFF
--- a/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
+++ b/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
@@ -277,4 +277,8 @@ class Metasploit4 < Msf::Exploit::Remote
     send_response(cli, @pl)
   end
 
+  def autofilter
+    true
+  end
+
 end

--- a/modules/exploits/linux/antivirus/escan_password_exec.rb
+++ b/modules/exploits/linux/antivirus/escan_password_exec.rb
@@ -107,6 +107,10 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
+  def autofilter
+    true
+  end
+
   def exploit
     @pl           = generate_payload_exe
     if @pl.blank?

--- a/modules/exploits/multi/http/coldfusion_rds.rb
+++ b/modules/exploits/multi/http/coldfusion_rds.rb
@@ -148,6 +148,10 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
+  def autofilter
+    true
+  end
+
   #task scheduler is pretty bad at handling binary files and likes to mess up our meterpreter :-(
   #instead we use a CFML filedropper to embed our payload and execute it.
   #this also removes the dependancy of using the probe.cfm to execute the file.

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -326,6 +326,10 @@ class Metasploit3 < Msf::Exploit::Remote
     res
   end
 
+  def autofilter
+    true
+  end
+
   # Try to autodetect the target platform
   def detect_platform(res)
     if (res.body =~ /<td.*?OSName.*?(Linux|FreeBSD|Windows).*?<\/td>/m)

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -170,6 +170,10 @@ class Metasploit3 < Msf::Exploit::Remote
     send_response(cli, @pl)
   end
 
+  def autofilter
+    true
+  end
+
   def upload_payload
     print_status "#{peer} - Uploading payload ..."
     path = "/#{@local_path}#{@payload_dir}#{@payload_name}"

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -343,6 +343,10 @@ class Metasploit3 < Msf::Exploit::Remote
     send_response(cli, @pl)
   end
 
+  def autofilter
+    true
+  end
+
   # wait for the data to be sent
   def wait_payload
     print_status("#{rhost}:#{rport} - Waiting for the victim to request the payload...")

--- a/modules/exploits/multi/misc/arkeia_agent_exec.rb
+++ b/modules/exploits/multi/misc/arkeia_agent_exec.rb
@@ -552,4 +552,9 @@ class Metasploit3 < Msf::Exploit::Remote
       register_files_for_cleanup("c:\\#{@down_file}.exe")
     end
   end
+
+  def autofilter
+    true
+  end
+
 end

--- a/modules/exploits/multi/misc/java_jmx_server.rb
+++ b/modules/exploits/multi/misc/java_jmx_server.rb
@@ -93,6 +93,10 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
+  def autofilter
+    return true
+  end
+
   def check
     connect
 

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -59,6 +59,10 @@ class Metasploit3 < Msf::Exploit::Remote
     send_response(cli, data)
   end
 
+  def autofilter
+    true
+  end
+
   def check
     res = send_request_cgi({
       'uri'      => '/search',

--- a/modules/exploits/unix/webapp/joomla_akeeba_unserialize.rb
+++ b/modules/exploits/unix/webapp/joomla_akeeba_unserialize.rb
@@ -146,4 +146,8 @@ class Metasploit3 < Msf::Exploit::Remote
     send_not_found(cli)
   end
 
+  def autofilter
+    true
+  end
+
 end

--- a/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
+++ b/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
@@ -63,6 +63,10 @@ class Metasploit3 < Msf::Exploit::Remote
       "#{get_uri}.php"
   end
 
+  def autofilter
+    true
+  end
+
   def call_payload(file_name)
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/windows/http/rejetto_hfs_exec.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_exec.rb
@@ -81,6 +81,10 @@ class Metasploit3 < Msf::Exploit::Remote
     remove_resource(get_resource)
   end
 
+  def autofilter
+    true
+  end
+
   def primer
     file_name = rand_text_alpha(rand(10)+5)
     file_ext = '.vbs'

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -74,6 +74,10 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
+  def autofilter
+    true
+  end
+
   def process_get(cli, request)
     if request.uri =~ /#{@basename}(\d)\.bcl/
       print_status("GET => Payload")


### PR DESCRIPTION
These modules are aggressive (aka they make an outbound connection to trigger the vulnerability), but  because they included a passive-mode mixin, their `autofilter` return value was `false`. This was incorrect and impacts automation tasks that depend on it.
