### PR TITLE
Add CVE/URL references to module manage_engine_opmanager_rce

### DIFF
--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -31,6 +31,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'EDB', '38174' ],
+          [ 'CVE', '2015-7765' ], # Hardcoded password
+          [ 'CVE', '2015-7766' ], # SQL query bypass
+          [ 'URL', 'http://seclists.org/fulldisclosure/2015/Sep/66' ],
+          [ 'URL', 'https://support.zoho.com/portal/manageengine/helpcenter/articles/pgsql-submitquery-do-vulnerability' ]
         ],
       'Platform'       => ['java'],
       'Arch'           => ARCH_JAVA,


### PR DESCRIPTION
This adds the CVE/URL references to the manage_engine_opmanager_rce exploit module.