### PR TITLE
Add CVE/URL references to manageengine_eventlog_analyzer_rce

### DIFF
--- a/modules/exploits/windows/misc/manageengine_eventlog_analyzer_rce.rb
+++ b/modules/exploits/windows/misc/manageengine_eventlog_analyzer_rce.rb
@@ -31,7 +31,9 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['EDB', '38173']
+          ['EDB', '38173'],
+	  ['CVE', '2015-7387'],
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Sep/59']
         ],
       'Platform'       => ['win'],
       'Arch'           => ARCH_X86,


### PR DESCRIPTION
This adds the CVE/URL references to the manageengine_eventlog_analyzer_rce exploit module.