### PR TITLE
Fix #6004 - make_nops doesn't take into account all the compatible encoders

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -342,14 +342,18 @@ class EncodedPayload
           self.nop_sled = nop.generate_sled(self.nop_sled_size,
             'BadChars'      => reqs['BadChars'],
             'SaveRegisters' => save_regs)
+
+          if nop_sled && nop_sled.length == nop_sled_size
+            break
+          else
+            dlog("#{pinst.refname}: Nop generator #{nop.refname} failed to generate sled for payload", 'core', LEV_1)
+          end
         rescue
           dlog("#{pinst.refname}: Nop generator #{nop.refname} failed to generate sled for payload: #{$!}",
             'core', LEV_1)
 
           self.nop = nil
         end
-
-        break
       }
 
       if (self.nop_sled == nil)

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1034,7 +1034,12 @@ class Exploit < Msf::Module
         nop_sled = nop.generate_sled(count,
           'BadChars'      => payload_badchars || '',
           'SaveRegisters' => save_regs)
-        break
+
+        if nop_sled && nop_sled.length == count
+          break
+        else
+          wlog("#{self.refname}: Nop generator #{nop.refname} failed to generate sled for exploit", 'core', LEV_0)
+        end
       rescue
         wlog("#{self.refname}: Nop generator #{nop.refname} failed to generate sled for exploit: #{$!}",
           'core', LEV_0)

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1034,12 +1034,11 @@ class Exploit < Msf::Module
         nop_sled = nop.generate_sled(count,
           'BadChars'      => payload_badchars || '',
           'SaveRegisters' => save_regs)
+        break
       rescue
         wlog("#{self.refname}: Nop generator #{nop.refname} failed to generate sled for exploit: #{$!}",
           'core', LEV_0)
       end
-
-      break
     }
 
     nop_sled


### PR DESCRIPTION
@dmaloney-r7 reported on #6004 which `make_nops` was failing to use all the compatible nop sled generators. And it's true indeed. This PR also fixes `EncodedPayload` for the same issue, iterate over all the compatible nop generators when generating the payload encoded.

@dmaloney-r7 reported a second on #6004, `make_nops` returning a nop sled with `badchars`. I've been unable to reproduce the issue with the steps provided on #6004. @dmaloney-r7 couldn't hit this issue again neither. He will ask the original reporter for more information / steps. I'll work on it again if the `badchars` problem arises again.
## Verification

(Sorry for the manual steps for verification, writing specs to test it would be a big hassle :( so I'm stuck with manual steps atm.
- [x] Modify the `exploit` method on modules/exploits/windows/tftp/tftpserver_wrq_bof to just do:

```
def exploit
    nops = make_nops(500)
    print_status(Rex::Text.to_hex_dump(nops))
    return
end
```
- [x] Modify the `generate_sled` method on  modules/nops/x86/single_byte.rb to just return nil

```
def generate_sled(length, opts = {})
  return nil
end
```
- [x] monitor the framework logs `tail -f ~/.msf4/logs/framework.log`
- [x] Run msfconsole
- [x] On the msfconsole: `setg LogLevel 5`
- [x] On the msfconsole: `use exploit/windows/tftp/tftpserver_wrq_bof`
- [x] On the msfconsole: `set RHOST 127.0.0.1`
- [x] On the msfconsole: `exploit`
- [x] VERIFY: the nop sled is print into the console and doesn't contain badchars "\x00\x2f"
- [x] VERIFY: check the framework log, you should see the next messages:

```
[10/16/2015 15:14:06] [d(1)] core: windows/meterpreter/reverse_tcp: Nop generator x86/single_byte failed to generate sled for payload
[10/16/2015 15:14:06] [w(0)] core: windows/tftp/tftpserver_wrq_bof: Nop generator x86/single_byte failed to generate sled for exploit
```
