### PR TITLE
Fix crash on tab completion when spool is in use

### DIFF
--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -74,6 +74,21 @@ class Output < Rex::Ui::Output
   def reset
   end
 
+  def puts(*args)
+    args.each do |argument|
+      line = argument.to_s
+      print_raw(line)
+
+      unless line.ends_with? "\n"
+        # yes, this is output, but `IO#puts` uses `rb_default_rs`, which is
+        # [`$/`](https://github.com/ruby/ruby/blob/3af8e150aded9d162bfd41426aaaae0279e5a653/io.c#L12168-L12172),
+        # which is [`$INPUT_RECORD_SEPARATOR`](https://github.com/ruby/ruby/blob/3af8e150aded9d162bfd41426aaaae0279e5a653/lib/English.rb#L83)
+        print_raw($INPUT_RECORD_SEPARATOR)
+      end
+    end
+
+    nil
+  end
 end
 
 end

--- a/lib/rex/ui/text/output/stdio.rb
+++ b/lib/rex/ui/text/output/stdio.rb
@@ -71,22 +71,6 @@ class Output::Stdio < Rex::Ui::Text::Output
   end
   alias_method :write, :print_raw
 
-  def puts(*args)
-    args.each do |argument|
-      line = argument.to_s
-      write(line)
-
-      unless line.ends_with? "\n"
-        # yes, this is output, but `IO#puts` uses `rb_default_rs`, which is
-        # [`$/`](https://github.com/ruby/ruby/blob/3af8e150aded9d162bfd41426aaaae0279e5a653/io.c#L12168-L12172),
-        # which is [`$INPUT_RECORD_SEPARATOR`](https://github.com/ruby/ruby/blob/3af8e150aded9d162bfd41426aaaae0279e5a653/lib/English.rb#L83)
-        write($INPUT_RECORD_SEPARATOR)
-      end
-    end
-
-    nil
-  end
-
   def supports_color?
     case config[:color]
     when true


### PR DESCRIPTION
This fixes #6105 by moving the `puts` method into the base class.
