### PR TITLE
Support better parsing for HTML/XML/JSON HTTP responses

### DIFF
--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -119,16 +119,6 @@ class Response < Packet
     json
   end
 
-  # Returns the title from the HTML document.
-  # You will probably want to use this if you want to grab the web app's banner in the title.
-  #
-  # @return [String]
-  def get_html_title
-    n = get_html_document
-    title = n.at_xpath('//title')
-    title ? title.text : ''
-  end
-
   # Returns meta tags.
   # You will probably want to use this the web app's version info (or other stuff) can be found
   # in the metadata.

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -120,7 +120,7 @@ class Response < Packet
   end
 
   # Returns the title from the HTML document.
-  # Instead of using a regex, normally you should call this to retrieve the title tag.
+  # You will probably want to use this if you want to grab the web app's banner in the title.
   #
   # @return [String]
   def get_html_title
@@ -130,7 +130,8 @@ class Response < Packet
   end
 
   # Returns meta tags.
-  # Instead of using a regex, you should use this to collect the meta tags.
+  # You will probably want to use this the web app's version info (or other stuff) can be found
+  # in the metadata.
   #
   # @return [Array<Nokogiri::XML::Element>]
   def get_html_meta_elements

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -2,6 +2,7 @@
 require 'uri'
 require 'rex/proto/http'
 require 'nokogiri'
+require 'rkelly'
 
 module Rex
 module Proto
@@ -84,6 +85,71 @@ class Response < Packet
   end
 
 
+  # Returns a parsed HTML document.
+  # Instead of using regexes to parse the HTML body, you should use this and use the Nokogiri API.
+  #
+  # @see http://www.nokogiri.org/
+  # @return [Nokogiri::HTML::Document]
+  def get_html_document
+    Nokogiri::HTML(self.body)
+  end
+
+  # Returns a parsed XML document.
+  # Instead of using regexes to parse the XML body, you should use this and use the Nokogiri API.
+  #
+  # @see http://www.nokogiri.org/
+  # @return [Nokogiri::XML::Document]
+  def get_xml_document
+    Nokogiri::XML(self.body)
+  end
+
+  # Returns a parsed json document.
+  # Instead of using regexes to parse the JSON body, you should use this.
+  #
+  # @return [Hash]
+  def get_json_document
+    json = []
+
+    begin
+      json = JSON.parse(self.body)
+    rescue JSON::ParserError => e
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    end
+
+    json
+  end
+
+  # Returns the title from the HTML document.
+  # Instead of using a regex, normally you should call this to retrieve the title tag.
+  #
+  # @return [String]
+  def get_html_title
+    n = get_html_document
+    title = n.at_xpath('//title')
+    title ? title.text : ''
+  end
+
+  # Returns meta tags.
+  # Instead of using a regex, you should use this to collect the meta tags.
+  #
+  # @return [Array<Nokogiri::XML::Element>]
+  def get_html_meta_elements
+    n = get_html_document
+    n.search('//meta')
+  end
+
+  # Returns parsed JavaScript blocks.
+  # The parsed version is a RKelly object that allows you to be able do advanced parsing.
+  #
+  # @see https://github.com/tenderlove/rkelly
+  # @return [Array<RKelly::Nodes::SourceElementsNode>]
+  def get_html_scripts
+    n = get_html_document
+    rkelly = RKelly::Parser.new
+    n.search('//script').map { |s| rkelly.parse(s.text) }
+  end
+
+
   # Returns a collection of found hidden inputs
   #
   # @return [Array<Hash>] An array, each element represents a form that contains a hash of found hidden inputs
@@ -94,7 +160,7 @@ class Response < Packet
   #  session_id = inputs[0]['sessionid'] # The first form's 'sessionid' hidden input
   def get_hidden_inputs
     forms = []
-    noko = Nokogiri::HTML(self.body)
+    noko = get_html_document
     noko.search("form").each_entry do |form|
       found_inputs = {}
       form.search("input").each_entry do |input|

--- a/spec/lib/rex/proto/http/response_spec.rb
+++ b/spec/lib/rex/proto/http/response_spec.rb
@@ -133,10 +133,6 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
-  let (:html_title) do
-    'TEST'
-  end
-
   let (:meta_name) do
     'META_NAME'
   end
@@ -149,7 +145,7 @@ describe Rex::Proto::Http::Response do
     %Q|
     <html>
     <head>
-      <title>#{html_title}</title>
+      <title>TEST</title>
       <meta name="#{meta_name}" content="#{meta_content}">
     </head>
     <body>
@@ -263,14 +259,6 @@ describe Rex::Proto::Http::Response do
       context 'when a response is received' do
         it 'returns a Hash object' do
           expect(subject.get_json_document).to be_kind_of(Hash)
-        end
-      end
-    end
-
-    describe '#get_html_title' do
-      context "when the title in the HTML is 'TEST'" do
-        it "returns 'TEST'" do
-          expect(subject.get_html_title).to eq(html_title)
         end
       end
     end

--- a/spec/lib/rex/proto/http/response_spec.rb
+++ b/spec/lib/rex/proto/http/response_spec.rb
@@ -1,8 +1,9 @@
 require 'rex/proto/http/response'
+require 'nokogiri'
 
 describe Rex::Proto::Http::Response do
 
-  def get_cookies_test_no_cookies
+  let(:get_cookies_test_no_cookies) do
     <<-HEREDOC.gsub(/^ {6}/, '')
       HTTP/1.1 200 OK
       Date: Fri, 26 Apr 2013 12:43:12 GMT
@@ -21,7 +22,7 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
-  def get_cookies_test_five_cookies
+  let(:get_cookies_test_five_cookies) do
     <<-HEREDOC.gsub(/^ {6}/, '')
       HTTP/1.1 200 OK
       Date: Fri, 26 Apr 2013 08:44:54 GMT
@@ -46,7 +47,7 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
-  def get_cookies_test_five_ordered_cookies
+  let (:get_cookies_test_five_ordered_cookies) do
     <<-HEREDOC.gsub(/^ {6}/, '')
       HTTP/1.1 200 OK
       Date: Fri, 26 Apr 2013 08:44:54 GMT
@@ -71,7 +72,7 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
-  def get_cookies_test_with_empty_cookie
+  let (:get_cookies_test_with_empty_cookie) do
     <<-HEREDOC.gsub(/^ {6}/, '')
       HTTP/1.1 200 OK
       Date: Fri, 26 Apr 2013 08:44:54 GMT
@@ -96,7 +97,7 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
-  def get_cookies_test_one_set_cookie_header
+  let (:get_cookies_test_one_set_cookie_header) do
     <<-HEREDOC.gsub(/^ {6}/, '')
       HTTP/1.1 200 OK
       Date: Wed, 25 Sep 2013 20:29:23 GMT
@@ -116,7 +117,7 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
-  def get_cookies_comma_separated
+  let (:get_cookies_comma_separated) do
     <<-HEREDOC.gsub(/^ {6}/, '')
       HTTP/1.1 200 OK
       Expires: Thu, 26 Oct 1978 00:00:00 GMT
@@ -132,6 +133,64 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
+  let (:html_title) do
+    'TEST'
+  end
+
+  let (:meta_name) do
+    'META_NAME'
+  end
+
+  let (:meta_content) do
+    'META_CONTENT'
+  end
+
+  let (:get_html_body) do
+    %Q|
+    <html>
+    <head>
+      <title>#{html_title}</title>
+      <meta name="#{meta_name}" content="#{meta_content}">
+    </head>
+    <body>
+    <form action="test.php">
+      <input name="input_1" type="hidden" value="some_value_1" />
+    </form>
+    <form>
+      <input name="input_0" type="text" value="Not a hidden input" />
+      <input name="input_1" type="hidden" value="some_value_1" />
+      <INPUT name="input_2" type="hidden" value="" />
+    </form>
+    <script>
+    function test() {
+      alert("hello, world!");
+    }
+    </script>
+    </body>
+    </htm>
+    |
+  end
+
+  let (:get_xml_body) do
+    %Q|<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications 
+      with XML.</description>
+   </book>
+</catalog>
+    |
+  end
+
+  let (:get_json_body) do
+    %Q|{ "firstName": "John" }|
+  end
+
   def cookie_sanity_check(meth)
     resp = described_class.new()
     resp.parse(self.send meth)
@@ -141,26 +200,10 @@ describe Rex::Proto::Http::Response do
     cookies.split(';').map(&:strip)
   end
 
-
-  describe '#get_hidden_inputs' do
+  describe 'HTML parsing' do
     let(:response) do
       res = Rex::Proto::Http::Response.new(200, 'OK')
-      res.body = %Q|
-      <html>
-      <head>
-      <body>
-      <form action="test.php">
-        <input name="input_1" type="hidden" value="some_value_1" />
-      </form>
-      <form>
-        <input name="input_0" type="text" value="Not a hidden input" />
-        <input name="input_1" type="hidden" value="some_value_1" />
-        <INPUT name="input_2" type="hidden" value="" />
-      </form>
-      </body>
-      </head>
-      </htm>
-      |
+      res.body = get_html_body
       res
     end
 
@@ -180,27 +223,114 @@ describe Rex::Proto::Http::Response do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
     end
 
-    context 'when an HTML page contains two forms containing hidden inputs' do
-      it 'returns an array' do
-        expect(subject.get_hidden_inputs).to be_kind_of(Array)
-      end
-
-      it 'returns hashes in the array' do
-        subject.get_hidden_inputs.each do |form|
-          expect(form).to be_kind_of(Hash)
+    describe '#get_html_document' do
+      context 'when a response is received' do
+        it 'returns a Nokogiri::HTML::Document object' do
+          expect(subject.get_html_document).to be_kind_of(Nokogiri::HTML::Document)
         end
       end
+    end
 
-      it 'returns \'some_value_1\' in the input_1 hidden input from the first element' do
-        expect(subject.get_hidden_inputs[0]['input_1']).to eq('some_value_1')
+    describe '#get_xml_document' do
+      let(:response) do
+        res = Rex::Proto::Http::Response.new(200, 'OK')
+        res.body = get_xml_body
+        res
       end
 
-      it 'returns two hidden inputs in the second element' do
-        expect(subject.get_hidden_inputs[1].length).to eq(2)
+      before(:each) do
+        allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
       end
 
-      it 'returns an empty string for the input_2 hidden input from the second element' do
-        expect(subject.get_hidden_inputs[1]['input_2']).to be_empty
+      context 'when a response is received' do
+        it 'returns a Nokogiri::XML::Document object' do
+          expect(subject.get_xml_document).to be_kind_of(Nokogiri::XML::Document)
+        end
+      end
+    end
+
+    describe '#get_json_document' do
+      let(:response) do
+        res = Rex::Proto::Http::Response.new(200, 'OK')
+        res.body = get_json_body
+        res
+      end
+
+      before(:each) do
+        allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
+      end
+
+      context 'when a response is received' do
+        it 'returns a Hash object' do
+          expect(subject.get_json_document).to be_kind_of(Hash)
+        end
+      end
+    end
+
+    describe '#get_html_title' do
+      context "when the title in the HTML is 'TEST'" do
+        it "returns 'TEST'" do
+          expect(subject.get_html_title).to eq(html_title)
+        end
+      end
+    end
+
+    describe '#get_html_meta_elements' do
+      let(:meta_elements) do
+        subject.get_html_meta_elements
+      end
+
+      context 'when there is a meta tag in the HTML body' do
+        it 'returns one Nokogiri::XML::Element object' do
+          expect(meta_elements.length).to eq(1)
+        end
+
+        it 'returns the meta tag name' do
+          expect(meta_elements.first.attributes['name'].value).to eq(meta_name)
+        end
+
+        it 'returns the meta tag content' do
+          expect(meta_elements.first.attributes['content'].value).to eq(meta_content)
+        end
+      end
+    end
+
+    describe '#get_html_scripts' do
+      let(:script_elements) do
+        subject.get_html_scripts
+      end
+
+      context 'when there is a script block' do
+        it 'returns one RKelly::Nodes::SourceElementsNode object' do
+          expect(script_elements.length).to eq(1)
+          expect(script_elements.first).to be_kind_of(RKelly::Nodes::SourceElementsNode)
+        end
+      end
+    end
+
+    describe '#get_hidden_inputs' do
+      context 'when an HTML page contains two forms containing hidden inputs' do
+        it 'returns an array' do
+          expect(subject.get_hidden_inputs).to be_kind_of(Array)
+        end
+
+        it 'returns hashes in the array' do
+          subject.get_hidden_inputs.each do |form|
+            expect(form).to be_kind_of(Hash)
+          end
+        end
+
+        it 'returns \'some_value_1\' in the input_1 hidden input from the first element' do
+          expect(subject.get_hidden_inputs[0]['input_1']).to eq('some_value_1')
+        end
+
+        it 'returns two hidden inputs in the second element' do
+          expect(subject.get_hidden_inputs[1].length).to eq(2)
+        end
+
+        it 'returns an empty string for the input_2 hidden input from the second element' do
+          expect(subject.get_hidden_inputs[1]['input_2']).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
As a module writer, the new features in this pull request allow you to parse HTTP responses more properly and more precisely than just regular expressions.
## Description

**Parsing HTML**

If you need to walk through the HTML elements in order to find something specific, then instead of calling `res.body` and do regular expressions, you can just call `res.get_html_document`. This will give you a Nokogiri::HTML::Document object that gives you access to the Nokogiri API.

**Parsing XML**

Same thing for parsing XML. Instead of calling `res.body`, You can call `res.get_xml_document`, and that will give you a Nokogiri::XML::Document.

**Parsing JSON**

And of course, the `res.get_json_document` is for the same purpose. You get a hash. Handy for REST API responses.

**Other Features**

I have also added other methods such as:
- get_meta_elements - If you need to grab the version or whatever, you can use this.
- get_html_scripts - If you have to parse the web app's JavaScript, then you can use this. Each script block is an RKelly object that allows advanced parsing, or you can just call #text and that will give you the raw JavaScript code.
## Verification
- [x] Make sure Travis is green
