### PR TITLE
bump mdm to 1.2.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ PATH
       activerecord (>= 4.0.9, < 4.1.0)
       metasploit-credential (= 1.0.1)
       metasploit-framework (= 4.11.4)
-      metasploit_data_models (= 1.2.7)
+      metasploit_data_models (= 1.2.8)
       pg (>= 0.11)
     metasploit-framework-pcap (4.11.4)
       metasploit-framework (= 4.11.4)
@@ -126,7 +126,7 @@ GEM
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
     metasploit-payloads (1.0.15)
-    metasploit_data_models (1.2.7)
+    metasploit_data_models (1.2.8)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       arel-helpers
@@ -251,3 +251,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.10.6

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   # Metasploit::Credential database models
   spec.add_runtime_dependency 'metasploit-credential', '1.0.1'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models', '1.2.7'
+  spec.add_runtime_dependency 'metasploit_data_models', '1.2.8'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code
   spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
   # Needed for module caching in Mdm::ModuleDetails


### PR DESCRIPTION
MSP-13273
## Description

Bumping mdm to 1.2.8 in order to add the following:
- host name search scope added to notes
- host name search scope added to services
- address search scope added to vulns
- host name search scope added to loots
## Verification
- [x] Make sure Travis is green
