### PR TITLE
Fix undef method has_key for module_references.rb tool

### DIFF
--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -89,7 +89,7 @@ opts.parse(ARGV) { |opt, idx, val|
     filter = val
   when "-t"
     val = (val || '').upcase
-    unless types.has_key(val)
+    unless types.has_key?(val)
       puts "Invalid Type Supplied: #{val}"
       puts "Please use one of these: #{types.keys.inspect}"
       exit


### PR DESCRIPTION
I made a typo. Should be has_key?, not has_key
