### PR TITLE
Remove bad references (dead links)

### DIFF
--- a/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
+++ b/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
@@ -28,9 +28,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'BID', '19680' ],
           [ 'CVE', '2006-4313' ],
-          [ 'URL', 'http://www.cisco.com/warp/public/707/cisco-sa-20060823-vpn3k.shtml' ],
           [ 'OSVDB', '28139' ],
-          [ 'OSVDB', '28138' ],
+          [ 'OSVDB', '28138' ]
         ],
       'DisclosureDate' => 'Aug 23 2006'))
 

--- a/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
+++ b/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2011-0923' ],
           [ 'OSVDB', '72526' ],
           [ 'ZDI', '11-055' ],
-          [ 'URL', 'http://c4an-dl.blogspot.com/hp-data-protector-vuln.html' ],
           [ 'URL', 'http://hackarandas.com/blog/2011/08/04/hp-data-protector-remote-shell-for-hpux' ]
         ],
       'Author'         =>

--- a/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
+++ b/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
@@ -46,8 +46,7 @@ class Metasploit3 < Msf::Auxiliary
       'References' => [
         [ 'CVE', '2015-0964' ], # XSS vulnerability
         [ 'CVE', '2015-0965' ], # CSRF vulnerability
-        [ 'CVE', '2015-0966' ],  # "techician/yZgO8Bvj" web interface backdoor
-        [ 'URL', 'https://community.rapid7.com/rapid7_blogpostdetail?id=a111400000AanBs' ] # Original disclosure
+        [ 'CVE', '2015-0966' ]  # "techician/yZgO8Bvj" web interface backdoor
       ]
     ))
 

--- a/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
+++ b/modules/auxiliary/admin/http/arris_motorola_surfboard_backdoor_xss.rb
@@ -46,7 +46,8 @@ class Metasploit3 < Msf::Auxiliary
       'References' => [
         [ 'CVE', '2015-0964' ], # XSS vulnerability
         [ 'CVE', '2015-0965' ], # CSRF vulnerability
-        [ 'CVE', '2015-0966' ]  # "techician/yZgO8Bvj" web interface backdoor
+        [ 'CVE', '2015-0966' ], # "techician/yZgO8Bvj" web interface backdoor
+        [ 'URL', 'https://community.rapid7.com/community/infosec/blog/2015/06/05/r7-2015-01-csrf-backdoor-and-persistent-xss-on-arris-motorola-cable-modems' ],
       ]
     ))
 

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'EDB', '25252' ],
           [ 'OSVDB', '93013' ],
-          [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-018' ],
-          [ 'URL', 'http://www.dlink.com/de/de/home-solutions/connect/modems-and-gateways/dsl-320b-adsl-2-ethernet-modem' ],
+          [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-018' ]
         ],
       'Author'      => [
         'Michael Messner <devnull[at]s3cur1ty.de>'

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'OSVDB', '89912' ],
           [ 'BID', '57760' ],
           [ 'EDB', '24475' ],
-          [ 'URL', 'http://homesupport.cisco.com/de-eu/support/routers/E1500' ],
           [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-004' ]
         ],
       'DisclosureDate' => 'Feb 05 2013'))

--- a/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
@@ -29,7 +29,6 @@ class Metasploit3 < Msf::Auxiliary
       'License'         => MSF_LICENSE,
       'References'      =>
         [
-          [ 'URL', 'http://homesupport.cisco.com/en-eu/support/routers/WRT54GL' ],
           [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-01' ],
           [ 'URL', 'http://www.s3cur1ty.de/attacking-linksys-wrt54gl' ],
           [ 'EDB', '24202' ],

--- a/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
+++ b/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
@@ -27,7 +27,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2014-7862'],
           ['OSVDB', '116554'],
-          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/2']
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/2'],
+          ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_dc9_admin.txt'],
         ],
       'DisclosureDate' => 'Dec 31 2014'))
 

--- a/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
+++ b/modules/auxiliary/admin/http/manage_engine_dc_create_admin.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2014-7862'],
           ['OSVDB', '116554'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_dc9_admin.txt'],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/2']
         ],
       'DisclosureDate' => 'Dec 31 2014'))

--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -36,7 +36,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2014-7863'],
           ['OSVDB', '117696'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_failservlet.txt'],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114']
         ],
       'DisclosureDate' => 'Jan 28 2015'))

--- a/modules/auxiliary/admin/http/manageengine_dir_listing.rb
+++ b/modules/auxiliary/admin/http/manageengine_dir_listing.rb
@@ -36,7 +36,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2014-7863'],
           ['OSVDB', '117696'],
-          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114']
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114'],
+          ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_failservlet.txt']
         ],
       'DisclosureDate' => 'Jan 28 2015'))
 

--- a/modules/auxiliary/admin/http/manageengine_file_download.rb
+++ b/modules/auxiliary/admin/http/manageengine_file_download.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2014-7863'],
           ['OSVDB', '117695'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_failservlet.txt'],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114']
         ],
       'DisclosureDate' => 'Jan 28 2015'))

--- a/modules/auxiliary/admin/http/manageengine_file_download.rb
+++ b/modules/auxiliary/admin/http/manageengine_file_download.rb
@@ -34,7 +34,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2014-7863'],
           ['OSVDB', '117695'],
-          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114']
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/114'],
+          ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_failservlet.txt']
         ],
       'DisclosureDate' => 'Jan 28 2015'))
 

--- a/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
+++ b/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
@@ -34,7 +34,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2014-8499' ],
           [ 'OSVDB', '114485' ],
-          [ 'URL', 'http://seclists.org/fulldisclosure/2014/Nov/18' ]
+          [ 'URL', 'http://seclists.org/fulldisclosure/2014/Nov/18' ],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_pmp_privesc.txt' ],
         ],
       'DisclosureDate' => 'Nov 8 2014'))
 

--- a/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
+++ b/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2014-8499' ],
           [ 'OSVDB', '114485' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_pmp_privesc.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Nov/18' ]
         ],
       'DisclosureDate' => 'Nov 8 2014'))

--- a/modules/auxiliary/admin/http/netflow_file_download.rb
+++ b/modules/auxiliary/admin/http/netflow_file_download.rb
@@ -28,7 +28,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2014-5445' ],
           [ 'OSVDB', '115340' ],
-          [ 'URL', 'http://seclists.org/fulldisclosure/2014/Dec/9' ]
+          [ 'URL', 'http://seclists.org/fulldisclosure/2014/Dec/9' ],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/ManageEngine/me_netflow_it360_file_dl.txt' ]
         ],
       'DisclosureDate' => 'Nov 30 2014'))
 

--- a/modules/auxiliary/admin/http/netflow_file_download.rb
+++ b/modules/auxiliary/admin/http/netflow_file_download.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2014-5445' ],
           [ 'OSVDB', '115340' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_netflow_it360_file_dl.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Dec/9' ]
         ],
       'DisclosureDate' => 'Nov 30 2014'))

--- a/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
+++ b/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
@@ -29,9 +29,7 @@ class Metasploit4 < Msf::Auxiliary
       'License' => MSF_LICENSE,
       'References'  =>
         [
-          [ 'URL', 'https://community.rapid7.com/community/nexpose/blog/2013/08/16/r7-vuln-2013-07-24' ],
-          # Fill this in with the direct advisory URL from Infigo
-          [ 'URL', 'http://www.infigo.hr/in_focus/advisories/' ]
+          [ 'URL', 'https://community.rapid7.com/community/nexpose/blog/2013/08/16/r7-vuln-2013-07-24' ]
         ],
       'DefaultOptions' => {
         'SSL' => true

--- a/modules/auxiliary/admin/http/sysaid_admin_acct.rb
+++ b/modules/auxiliary/admin/http/sysaid_admin_acct.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
       'References' =>
         [
           [ 'CVE', '2015-2993' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/sysaid-14.4-multiple-vulns.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2015/Jun/8' ]
         ],
       'DisclosureDate' => 'Jun 3 2015'))

--- a/modules/auxiliary/admin/http/sysaid_admin_acct.rb
+++ b/modules/auxiliary/admin/http/sysaid_admin_acct.rb
@@ -27,7 +27,8 @@ class Metasploit3 < Msf::Auxiliary
       'References' =>
         [
           [ 'CVE', '2015-2993' ],
-          [ 'URL', 'http://seclists.org/fulldisclosure/2015/Jun/8' ]
+          [ 'URL', 'http://seclists.org/fulldisclosure/2015/Jun/8' ],
+          [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/sysaid-14.4-multiple-vulns.txt' ],
         ],
       'DisclosureDate' => 'Jun 3 2015'))
 

--- a/modules/auxiliary/admin/http/sysaid_file_download.rb
+++ b/modules/auxiliary/admin/http/sysaid_file_download.rb
@@ -34,7 +34,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2015-2996'],
           ['CVE', '2015-2997'],
-          ['URL', 'http://seclists.org/fulldisclosure/2015/Jun/8']
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Jun/8'],
+          ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/sysaid-14.4-multiple-vulns.txt'],
         ],
       'DisclosureDate' => 'Jun 3 2015'))
 

--- a/modules/auxiliary/admin/http/sysaid_file_download.rb
+++ b/modules/auxiliary/admin/http/sysaid_file_download.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2015-2996'],
           ['CVE', '2015-2997'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/sysaid-14.4-multiple-vulns.txt'],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Jun/8']
         ],
       'DisclosureDate' => 'Jun 3 2015'))

--- a/modules/auxiliary/admin/http/sysaid_sql_creds.rb
+++ b/modules/auxiliary/admin/http/sysaid_sql_creds.rb
@@ -29,7 +29,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2015-2996'],
           ['CVE', '2015-2998'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/sysaid-14.4-multiple-vulns.txt' ],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Jun/8']
         ],
       'DisclosureDate' => 'Jun 3 2015'))

--- a/modules/auxiliary/admin/http/sysaid_sql_creds.rb
+++ b/modules/auxiliary/admin/http/sysaid_sql_creds.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2015-2996'],
           ['CVE', '2015-2998'],
-          ['URL', 'http://seclists.org/fulldisclosure/2015/Jun/8']
+          ['URL', 'http://seclists.org/fulldisclosure/2015/Jun/8'],
+          ['URL', 'https://github.com/pedrib/PoC/blob/master/advisories/sysaid-14.4-multiple-vulns.txt']
         ],
       'DisclosureDate' => 'Jun 3 2015'))
 

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -21,11 +21,7 @@ class Metasploit3 < Msf::Auxiliary
           as well as read privileges to the target file.
       },
       'Author'         => [ 'todb' ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'URL', 'http://michaeldaw.org/sql-injection-cheat-sheet#postgres' ]
-        ]
+      'License'        => MSF_LICENSE
     ))
 
     register_options(

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -34,8 +34,7 @@ class Metasploit3 < Msf::Auxiliary
           ['CVE', '2003-0027'],
           ['OSVDB', '8201'],
           ['BID', '6665'],
-          ['URL', 'http://marc.info/?l=bugtraq&m=104326556329850&w=2'],
-          ['URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-77-1000898.1-1']
+          ['URL', 'http://marc.info/?l=bugtraq&m=104326556329850&w=2']
         ],
       # Tested OK against sol8.tor 20100624 -jjd
       'DisclosureDate' => 'Jan 22 2003')

--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -21,6 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'      => MSF_LICENSE,
       'References'   =>
         [
+          [ 'URL', 'https://github.com/claudijd/bnat' ],
           [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
         ]
     )

--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'      => MSF_LICENSE,
       'References'   =>
         [
-          [ 'URL', 'https://github.com/claudijd/BNAT-Suite'],
-          [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels'],
+          [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
         ]
     )
     register_options(

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'      => MSF_LICENSE,
       'References'   =>
         [
-          [ 'URL', 'https://github.com/claudijd/BNAT-Suite'],
-          [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels'],
+          [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
         ]
     )
 

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -25,6 +25,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'      => MSF_LICENSE,
       'References'   =>
         [
+          [ 'URL', 'https://github.com/claudijd/bnat'],
           [ 'URL', 'http://www.slideshare.net/claudijd/dc-skytalk-bnat-hijacking-repairing-broken-communication-channels']
         ]
     )

--- a/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
+++ b/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'BID', '1154'],
           [ 'CVE', '2000-0380'],
-          [ 'URL', 'http://www.cisco.com/warp/public/707/cisco-sa-20000514-ios-http-server.shtml'],
           [ 'OSVDB', '1302' ],
         ],
       'DisclosureDate' => 'Apr 26 2000'))

--- a/modules/auxiliary/dos/dns/bind_tkey.rb
+++ b/modules/auxiliary/dos/dns/bind_tkey.rb
@@ -30,8 +30,7 @@ class Metasploit4 < Msf::Auxiliary
       'References'     => [
         ['CVE', '2015-5477'],
         ['URL', 'https://www.isc.org/blogs/cve-2015-5477-an-error-in-handling-tkey-queries-can-cause-named-to-exit-with-a-require-assertion-failure/'],
-        ['URL', 'https://kb.isc.org/article/AA-01272'],
-        ['URL', 'https://github.com/rapid7/metasploit-framework/issues/5790']
+        ['URL', 'https://kb.isc.org/article/AA-01272']
       ],
       'DisclosureDate' => 'Jul 28 2015',
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
+++ b/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://lists.immunitysec.com/pipermail/dailydave/2006-February/002982.html' ],
           [ 'BID', '16838' ],
           [ 'OSVDB', '23511' ],
           [ 'CVE', '2006-0900' ],

--- a/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
+++ b/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
@@ -30,7 +30,6 @@ class Metasploit4 < Msf::Auxiliary
        'References'     =>
          [
            ['CVE', '2014-0050'],
-           ['URL', 'http://markmail.org/message/kpfl7ax4el2owb3o'],
            ['URL', 'http://tomcat.apache.org/security-8.html'],
            ['URL', 'http://tomcat.apache.org/security-7.html']
          ],

--- a/modules/auxiliary/dos/http/monkey_headers.rb
+++ b/modules/auxiliary/dos/http/monkey_headers.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CVE', '2013-3843'],
           ['OSVDB', '93853'],
-          ['BID', '60333'],
-          ['URL', 'http://bugs.monkey-project.com/ticket/182']
+          ['BID', '60333']
         ],
       'DisclosureDate' => 'May 30 2013'))
 

--- a/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
+++ b/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
@@ -29,8 +29,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2005-4797' ],
           [ 'BID', '14510' ],
-          [ 'OSVDB', '18650' ],
-          [ 'URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-26-101842-1'],
+          [ 'OSVDB', '18650' ]
         ]
       ))
 

--- a/modules/auxiliary/dos/ssl/openssl_aesni.rb
+++ b/modules/auxiliary/dos/ssl/openssl_aesni.rb
@@ -28,7 +28,8 @@ class Metasploit4 < Msf::Auxiliary
       'License'		=> MSF_LICENSE,
       'References'	=>
         [
-          [ 'CVE', '2012-2686']
+          [ 'CVE', '2012-2686'],
+          [ 'URL', 'https://www.openssl.org/news/secadv/20130205.txt' ]
         ],
       'DisclosureDate' => 'Feb 05 2013'))
 

--- a/modules/auxiliary/dos/ssl/openssl_aesni.rb
+++ b/modules/auxiliary/dos/ssl/openssl_aesni.rb
@@ -28,8 +28,7 @@ class Metasploit4 < Msf::Auxiliary
       'License'		=> MSF_LICENSE,
       'References'	=>
         [
-          [ 'CVE', '2012-2686'],
-          [ 'URL', 'https://www.openssl.org/news/secadv_20130205.txt']
+          [ 'CVE', '2012-2686']
         ],
       'DisclosureDate' => 'Feb 05 2013'))
 

--- a/modules/auxiliary/dos/windows/games/kaillera.rb
+++ b/modules/auxiliary/dos/windows/games/kaillera.rb
@@ -19,10 +19,6 @@ class Metasploit3 < Msf::Auxiliary
       },
       'Author'         => ["Sil3nt_Dre4m"],
       'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'URL', 'http://kaillerahacks.blogspot.com/2011/07/kaillera-server-086-dos-vulnerability.html' ]
-        ],
       'DisclosureDate' => 'Jul 2 2011'))
 
     register_options([

--- a/modules/auxiliary/gather/citrix_published_bruteforce.rb
+++ b/modules/auxiliary/gather/citrix_published_bruteforce.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'OSVDB', '50617' ],
-          [ 'BID', '5817' ],
-          [ 'URL', 'http://sh0dan.org/oldfiles/hackingcitrix.html' ],
+          [ 'BID', '5817' ]
         ]
     ))
 

--- a/modules/auxiliary/gather/dns_cache_scraper.rb
+++ b/modules/auxiliary/gather/dns_cache_scraper.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Auxiliary
       ],
       'License' => MSF_LICENSE,
       'References' => [
-        ['URL', 'http://304geeks.blogspot.com/2013/01/dns-scraping-for-corporate-av-detection.html'],
-        ['URL', 'http://www.rootsecure.net/content/downloads/pdf/dns_cache_snooping.pdf']
+        ['URL', 'http://304geeks.blogspot.com/2013/01/dns-scraping-for-corporate-av-detection.html']
       ]))
 
     register_options([

--- a/modules/auxiliary/gather/eventlog_cred_disclosure.rb
+++ b/modules/auxiliary/gather/eventlog_cred_disclosure.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2014-6039' ],
           [ 'OSVDB', '114342' ],
           [ 'OSVDB', '114344' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_eventlog_info_disc.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Nov/12' ]
         ],
       'DisclosureDate' => 'Nov 5 2014'))

--- a/modules/auxiliary/gather/huawei_wifi_info.rb
+++ b/modules/auxiliary/gather/huawei_wifi_info.rb
@@ -70,8 +70,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['CWE', '425'],
           ['CVE', '2013-6031'],
-          ['US-CERT-VU', '341526'],
-          ['URL', 'http://www.huaweidevice.co.in/Support/Downloads/'],
+          ['US-CERT-VU', '341526']
         ],
       'DisclosureDate' => "Nov 11 2013" ))
 

--- a/modules/auxiliary/gather/ie_uxss_injection.rb
+++ b/modules/auxiliary/gather/ie_uxss_injection.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2015-0072' ],
           [ 'OSVDB', '117876' ],
           [ 'MSB', 'MS15-018' ],
-          [ 'URL', 'http://www.deusen.co.uk/items/insider3show.3362009741042107/'],
           [ 'URL', 'http://innerht.ml/blog/ie-uxss.html' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2015/Feb/10' ]
         ],

--- a/modules/auxiliary/gather/trackit_sql_domain_creds.rb
+++ b/modules/auxiliary/gather/trackit_sql_domain_creds.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2014-4872' ],
           [ 'OSVDB', '112741' ],
           [ 'US-CERT-VU', '121036' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/bmc-track-it-11.3.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Oct/34' ]
         ],
       'DisclosureDate' => 'Oct 7 2014'

--- a/modules/auxiliary/scanner/chargen/chargen_probe.rb
+++ b/modules/auxiliary/scanner/chargen/chargen_probe.rb
@@ -35,8 +35,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'  =>
         [
           [ 'CVE', '1999-0103' ], # Note, does not actually trigger a flood.
-          [ 'URL', 'https://www.cert.be/pro/docs/chargensnmp-ddos-attacks-rise' ],
-          [ 'URL', 'http://tools.ietf.org/html/rfc864' ],
+          [ 'URL', 'http://tools.ietf.org/html/rfc864' ]
         ],
       'DisclosureDate' => 'Feb 08 1996')
 

--- a/modules/auxiliary/scanner/dect/call_scanner.rb
+++ b/modules/auxiliary/scanner/dect/call_scanner.rb
@@ -14,8 +14,7 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'DECT Call Scanner',
       'Description'    => 'This module scans for active DECT calls',
       'Author'         => [ 'DK <privilegedmode[at]gmail.com>' ],
-      'License'        => MSF_LICENSE,
-      'References'     => [ ['URL', 'http://www.dedected.org'] ]
+      'License'        => MSF_LICENSE
     )
   end
 

--- a/modules/auxiliary/scanner/dect/station_scanner.rb
+++ b/modules/auxiliary/scanner/dect/station_scanner.rb
@@ -14,8 +14,7 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'DECT Base Station Scanner',
       'Description'    => 'This module scans for DECT base stations',
       'Author'         => [ 'DK <privilegedmode[at]gmail.com>' ],
-      'License'        => MSF_LICENSE,
-      'References'     => [ ['URL', 'http://www.dedected.org'] ]
+      'License'        => MSF_LICENSE
     )
 
   end

--- a/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'BID', '2936'],
           [ 'CVE', '2001-0537'],
-          [ 'URL', 'http://www.cisco.com/warp/public/707/cisco-sa-20010627-ios-http-level.shtml'],
           [ 'OSVDB', '578' ],
         ],
       'DisclosureDate' => 'Jun 27 2001'))

--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'   =>
         [
           [ 'CVE', '2011-3305' ],
-          [ 'OSVDB', '76080'],
-          [ 'URL', 'http://www.cisco.com/warp/public/707/cisco-sa-20111005-nac.shtml' ]
+          [ 'OSVDB', '76080']
         ],
       'Author'      => [ 'Nenad Stojanovski <nenad.stojanovski[at]gmail.com>' ],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
@@ -39,7 +39,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2010-2861' ],
           [ 'BID', '42342' ],
           [ 'OSVDB', '67047' ],
-          [ 'URL', 'http://www.procheckup.com/vulnerability_manager/vulnerabilities/pr10-07' ],
           [ 'URL', 'http://www.gnucitizen.org/blog/coldfusion-directory-traversal-faq-cve-2010-2861' ],
           [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-18.html' ],
         ]

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
           ['OSVDB', '70762'],
           ['CVE', '2011-0049'],
           ['CVE', '2011-0063'],
-          ['URL', 'https://sitewat.ch/en/Advisory/View/1'],
           ['URL', 'http://sotiriu.de/adv/NSOADV-2011-003.txt'],
           ['EDB', '16103']
         ],

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Auxiliary
       },
       'References'     =>
         [
-          [ 'OSVDB', '80262'],
-          [ 'URL', 'http://retrogod.altervista.org/9sg_me_adv.htm' ]
+          [ 'OSVDB', '80262']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
+++ b/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'OSVDB', '86881' ],
           [ 'BID', '57969' ],
           [ 'EDB', '24504' ],
-          [ 'URL', 'http://www.tp-link.com/en/support/download/?model=TL-WA701ND&version=V1' ],
           [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-011' ]
         ],
       'Author'      => [ 'Michael Messner <devnull[at]s3cur1ty.de>' ],

--- a/modules/auxiliary/scanner/misc/poisonivy_control_scanner.rb
+++ b/modules/auxiliary/scanner/misc/poisonivy_control_scanner.rb
@@ -18,10 +18,6 @@ class Metasploit3 < Msf::Auxiliary
       'Description' => %q{
         Enumerate Poison Ivy Command and Control (C&C) on ports 3460, 80, 8080 and 443. Adaptation of iTrust Python script.
       },
-      'References'  =>
-        [
-          ['URL', 'www.malware.lu/Pro/RAP002_APT1_Technical_backstage.1.0.pdf'],
-        ],
       'Author'      => ['SeawolfRN'],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
+++ b/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
@@ -23,10 +23,6 @@ class Metasploit3 < Msf::Auxiliary
         The protocol deisgn issue also allows attackers to reset passwords on the device.
       },
       'Author'      => 'Ben Schmidt',
-      'References'  =>
-        [
-          [ 'URL', 'http://spareclockcycles.org/exploiting-an-ip-camera-control-protocol/' ],
-        ],
       'License'     => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2012-2215' ],
           [ 'OSVDB', '80230' ],
-          [ 'URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=975' ],
-          [ 'URL', 'http://support.novell.com/docs/Readmes/InfoDocument/patchbuilder/readme_5127930.html' ]
+          [ 'URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=975' ]
         ]
     ))
 

--- a/modules/auxiliary/scanner/rogue/rogue_recv.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_recv.rb
@@ -18,11 +18,7 @@ class Metasploit3 < Msf::Auxiliary
       must match the rogue_send parameters used exactly.
       },
       'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          ['URL', 'http://www.metasploit.com/research/projects/rogue_network/'],
-        ]
+      'License'     => MSF_LICENSE
     )
 
     register_options([

--- a/modules/auxiliary/scanner/rogue/rogue_send.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_send.rb
@@ -21,11 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       system is using as its default route.
       },
       'Author'      => 'hdm',
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          ['URL', 'http://www.metasploit.com/research/projects/rogue_network/'],
-        ]
+      'License'     => MSF_LICENSE
     )
 
     register_options([

--- a/modules/auxiliary/scanner/sap/sap_router_info_request.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_info_request.rb
@@ -37,7 +37,6 @@ class Metasploit4 < Msf::Auxiliary
       'References' => [
           [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ],
           [ 'URL', 'http://help.sap.com/saphelp_nw70ehp3/helpdata/en/48/6c68b01d5a350ce10000000a42189d/content.htm'],
-          [ 'URL', 'http://www.onapsis.com/research-free-solutions.php' ], # Bizsploit Opensource ERP Pentesting Framework
           [ 'URL', 'http://conference.hitb.org/hitbsecconf2010ams/materials/D2T2%20-%20Mariano%20Nunez%20Di%20Croce%20-%20SAProuter%20.pdf' ]
         ],
       'Author' =>

--- a/modules/auxiliary/scanner/udp_scanner_template.rb
+++ b/modules/auxiliary/scanner/udp_scanner_template.rb
@@ -22,10 +22,6 @@ class Metasploit3 < Msf::Auxiliary
           Simply address any of the TODOs.
         ),
         'Author'         => 'Joe Contributor <joe_contributor[at]example.com>',
-        'References'     =>
-          [
-            ['URL', 'https://example.com/~jcontributor']
-          ],
         'DisclosureDate' => 'Mar 15 2014',
         'License'        => MSF_LICENSE
       )

--- a/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
+++ b/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
@@ -47,7 +47,6 @@ class Metasploit3 < Msf::Auxiliary
       'References' => [
         ['CVE', '2015-1793'],
         ['CWE', '754'],
-        ['URL', 'http://www.openssl.org/news/secadv_20150709.txt'],
         ['URL', 'http://git.openssl.org/?p=openssl.git;a=commit;h=f404943bcab4898d18f3ac1b36479d1d7bbbb9e6']
       ],
       'DisclosureDate' => 'Jul 9 2015'

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2008-3996' ],
-          [ 'OSVDB', '49321'],
-          [ 'URL', 'http://www.appsecinc.com/resources/alerts/oracle/2008-08.shtml'],
+          [ 'OSVDB', '49321']
         ],
       'DisclosureDate' => 'Oct 22 2008'))
 

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2008-3995' ],
-          [ 'OSVDB', '49320'],
-          [ 'URL', 'http://www.appsecinc.com/resources/alerts/oracle/2008-09.shtml' ],
+          [ 'OSVDB', '49320']
         ],
       'DisclosureDate' => 'Oct 22 2008'))
 

--- a/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2008-3982'],
           [ 'OSVDB', '49324'],
-          [ 'URL', 'http://www.oracle.com/technology/deploy/security/critical-patch-updates/cpuoct2008.html' ],
-          [ 'URL', 'http://www.appsecinc.com/resources/alerts/oracle/2008-10.shtml' ],
+          [ 'URL', 'http://www.oracle.com/technology/deploy/security/critical-patch-updates/cpuoct2008.html' ]
         ],
       'DisclosureDate' => 'Oct 13 2008'))
 

--- a/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
+++ b/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2007-5511'],
           [ 'OSVDB', '40079'],
           [ 'BID', '26098' ],
-          [ 'URL', 'http://rawlab.mindcreations.com/codes/exp/oracle/sys-lt-findricsetV2.sql'],
           [ 'URL', 'http://www.oracle.com/technology/deploy/security/critical-patch-updates/cpuoct2007.html'],
         ],
       'DisclosureDate' => 'Oct 17 2007'))

--- a/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2008-3983'],
           [ 'OSVDB', '49325'],
           [ 'URL', 'http://www.oracle.com/technology/deploy/security/critical-patch-updates/cpuoct2008.html' ],
-          [ 'URL', 'http://www.appsecinc.com/resources/alerts/oracle/2008-10.shtml' ],
           [ 'URL', 'http://www.dsecrg.com/pages/expl/show.php?id=23' ]
 
         ],

--- a/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
@@ -22,9 +22,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2008-3984' ],
-          [ 'OSVDB', '49326'],
-          [ 'URL', 'http://www.appsecinc.com/resources/alerts/oracle/2008-10.shtml' ],
-
+          [ 'OSVDB', '49326']
         ],
       'DisclosureDate' => 'Oct 13 2008'))
 

--- a/modules/exploits/irix/lpd/tagprinter_exec.rb
+++ b/modules/exploits/irix/lpd/tagprinter_exec.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2001-0800'],
-          ['OSVDB', '8573'],
-          ['URL',   'http://www.lsd-pl.net/code/IRIX/irx_lpsched.c'],
+          ['OSVDB', '8573']
         ],
       'Privileged'     => false,
       'Platform'       => %w{ irix unix },

--- a/modules/exploits/linux/http/airties_login_cgi_bof.rb
+++ b/modules/exploits/linux/http/airties_login_cgi_bof.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['EDB', '36577'],
-          ['URL', 'http://www.bmicrosystems.com/blog/exploiting-the-airties-air-series/'], #advisory
           ['URL', 'http://www.bmicrosystems.com/exploits/airties5650tt.txt'] #PoC
         ],
       'Targets'        =>

--- a/modules/exploits/linux/http/peercast_url.rb
+++ b/modules/exploits/linux/http/peercast_url.rb
@@ -24,9 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2006-1148'],
           ['OSVDB', '23777'],
-          ['BID', '17040'],
-          ['URL', 'http://www.infigo.hr/in_focus/INFIGO-2006-03-01'],
-
+          ['BID', '17040']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/linux/http/vcms_upload.rb
+++ b/modules/exploits/linux/http/vcms_upload.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2011-4828'],
           ['OSVDB', '77183'],
           ['BID', '50706'],
-          ['URL', 'http://bugs.v-cms.org/view.php?id=53'],
           ['URL', 'http://xforce.iss.net/xforce/xfdb/71358']
         ],
       'Payload'        =>

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -33,8 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['OSVDB', '85344'],
-          ['OSVDB', '85345'],
-          ['URL', 'http://itsecuritysolutions.org/2012-08-12-wanem-v2.3-multiple-vulnerabilities/']
+          ['OSVDB', '85345']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/linux/ids/snortbopre.rb
+++ b/modules/exploits/linux/ids/snortbopre.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2005-3252'],
           ['OSVDB', '20034'],
-          ['BID', '15131'],
-          ['URL','http://xforce.iss.net/xforce/alerts/id/207'] ,
+          ['BID', '15131']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -50,8 +50,7 @@ class Metasploit4 < Msf::Exploit::Local
           [
             [ 'CVE', '2009-2692' ],
             [ 'OSVDB', '56992' ],
-            [ 'URL', 'http://blog.cr0.org/2009/08/linux-null-pointer-dereference-due-to.html' ],
-            [ 'URL', 'http://www.grsecurity.net/~spender/wunderbar_emporium2.tgz' ],
+            [ 'URL', 'http://blog.cr0.org/2009/08/linux-null-pointer-dereference-due-to.html' ]
           ],
         'Targets'       =>
           [

--- a/modules/exploits/linux/misc/hp_data_protector_cmd_exec.rb
+++ b/modules/exploits/linux/misc/hp_data_protector_cmd_exec.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2011-0923'],
           [ 'OSVDB', '72526'],
           [ 'ZDI', '11-055'],
-          [ 'URL', 'http://c4an-dl.blogspot.com/hp-data-protector-vuln.html'],
           [ 'URL', 'http://hackarandas.com/blog/2011/08/04/hp-data-protector-remote-shell-for-hpux'],
           [ 'URL', 'https://community.rapid7.com/thread/2253' ]
         ],

--- a/modules/exploits/linux/mysql/mysql_yassl_getname.rb
+++ b/modules/exploits/linux/mysql/mysql_yassl_getname.rb
@@ -47,8 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '37943' ],
           [ 'BID', '37974' ],
           [ 'OSVDB', '61956' ],
-          [ 'URL', 'http://secunia.com/advisories/38344/' ],
-          [ 'URL', 'http://intevydis.blogspot.com/2010/01/mysq-yassl-stack-overflow.html' ]
+          [ 'URL', 'http://secunia.com/advisories/38344/' ]
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
+++ b/modules/exploits/linux/ssh/ceragon_fibeair_known_privkey.rb
@@ -40,7 +40,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2015-0936'],
           ['URL', 'https://gist.github.com/todb-r7/5d86ecc8118f9eeecc15'], # Original Disclosure
-          ['URL', 'https://hdm.io/blog/2015/01/20/partial-disclosure-is-annoying'] # Related issue with hardcoded user:pass
         ],
       'DisclosureDate' => "Apr 01 2015", # Not a joke
       'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE',   '2012-3579'],
           ['OSVDB', '85028'],
           ['BID',   '55143'],
-          ['URL',   'https://www.sec-consult.com/files/20120829-0_Symantec_Mail_Gateway_Support_Backdoor.txt'],
           ['URL',   'http://www.symantec.com/security_response/securityupdates/detail.jsp?fid=security_advisory&pvid=security_advisory&suid=20120827_00']
         ],
       'DefaultOptions'  =>

--- a/modules/exploits/multi/browser/java_calendar_deserialize.rb
+++ b/modules/exploits/multi/browser/java_calendar_deserialize.rb
@@ -37,8 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [ 'OSVDB', '50500'],
         [ 'URL', 'http://slightlyrandombrokenthoughts.blogspot.com/2008/12/calendar-bug.html' ],
         [ 'URL', 'http://landonf.bikemonkey.org/code/macosx/CVE-2008-5353.20090519.html' ],
-        [ 'URL', 'http://blog.cr0.org/2009/05/write-once-own-everyone.html' ],
-        [ 'URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-26-244991-1' ]
+        [ 'URL', 'http://blog.cr0.org/2009/05/write-once-own-everyone.html' ]
       ],
       'Platform'      => %w{ linux osx solaris win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },

--- a/modules/exploits/multi/browser/java_setdifficm_bof.rb
+++ b/modules/exploits/multi/browser/java_setdifficm_bof.rb
@@ -41,8 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2009-3869' ],
           [ 'OSVDB', '59710' ],
           [ 'BID', '36881' ],
-          [ 'URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-66-270474-1' ],
-          [ 'ZDI', '09-078' ],
+          [ 'ZDI', '09-078' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -38,9 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'        => [ 'natron' ],
       'References'    =>
         [
-          [ 'URL', 'http://www.defcon.org/images/defcon-17/dc-17-presentations/defcon-17-valsmith-metaphish.pdf' ],
-          # list of trusted Certificate Authorities by java version
-          [ 'URL', 'http://www.spikezilla-software.com/blog/?p=21' ]
+          [ 'URL', 'http://www.defcon.org/images/defcon-17/dc-17-presentations/defcon-17-valsmith-metaphish.pdf' ]
         ],
       'Platform'      => %w{ java linux osx solaris win },
       'Payload'       => { 'BadChars' => '', 'DisableNops' => true },

--- a/modules/exploits/multi/browser/mozilla_navigatorjava.rb
+++ b/modules/exploits/multi/browser/mozilla_navigatorjava.rb
@@ -41,8 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE',    '2006-3677'],
           ['OSVDB',  '27559'],
           ['BID',    '19192'],
-          ['URL',    'http://www.mozilla.org/security/announce/mfsa2006-45.html'],
-          ['URL',    'http://browserfun.blogspot.com/2006/07/mobb-28-mozilla-navigator-object.html'],
+          ['URL',    'http://www.mozilla.org/security/announce/mfsa2006-45.html']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -45,7 +45,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2014-3996' ],
           [ 'OSVDB', '110198' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/me_dc_pmp_it360_sqli.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Aug/55' ]
         ],
       'Arch'           => ARCH_X86,

--- a/modules/exploits/multi/http/manageengine_auth_upload.rb
+++ b/modules/exploits/multi/http/manageengine_auth_upload.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2014-5301'],
           ['OSVDB', '116733'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_sd_file_upload.txt'],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Jan/5']
         ],
       'DefaultOptions' => { 'WfsDelay' => 30 },

--- a/modules/exploits/multi/http/op5_license.rb
+++ b/modules/exploits/multi/http/op5_license.rb
@@ -24,8 +24,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2012-0261'],
           ['OSVDB', '78064'],
-          ['URL', 'http://www.ekelow.se/file_uploads/Advisories/ekelow-aid-2012-01.pdf'],
-          ['URL', 'http://www.op5.com/news/support-news/fixed-vulnerabilities-op5-monitor-op5-appliance/'],
           ['URL', 'http://secunia.com/advisories/47417/'],
         ],
       'Privileged' => true,

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -24,8 +24,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2012-0262'],
           ['OSVDB', '78065'],
-          ['URL', 'http://www.ekelow.se/file_uploads/Advisories/ekelow-aid-2012-01.pdf'],
-          ['URL', 'http://www.op5.com/news/support-news/fixed-vulnerabilities-op5-monitor-op5-appliance/'],
           ['URL', 'http://secunia.com/advisories/47417/'],
         ],
       'Privileged' => true,

--- a/modules/exploits/multi/http/opmanager_socialit_file_upload.rb
+++ b/modules/exploits/multi/http/opmanager_socialit_file_upload.rb
@@ -29,7 +29,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2014-6034' ],
           [ 'OSVDB', '112276' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_opmanager_socialit_it360.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Sep/110' ]
         ],
       'Privileged'  => true,

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -41,8 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ "CVE", "2012-3153" ],
           [ "OSVDB", "86395" ], # Matches CVE-2012-3152
           [ "OSVDB", "86394" ], # Matches CVE-2012-3153
-          [ "EDB", "31253" ],
-          [ 'URL', "http://netinfiltration.com" ]
+          [ "EDB", "31253" ]
         ],
       'Stance'          => Msf::Exploit::Stance::Aggressive,
       'Platform'        => ['win', 'linux'],

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2011-4075'],
           ['OSVDB', '76594'],
           ['BID', '50331'],
-          ['URL', 'http://sourceforge.net/support/tracker.php?aid=3417184'],
-          ['EDB', '18021'],
+          ['EDB', '18021']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -113,7 +113,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'  =>
         [
-          ['URL', 'https://charlie.bz/blog/rails-3.2.10-remote-code-execution'], #Initial exploit vector was taken from here
           ['URL', 'http://robertheaton.com/2013/07/22/how-to-hack-a-rails-app-using-its-secret-token/']
         ],
       'DisclosureDate' => 'Apr 11 2013',

--- a/modules/exploits/multi/http/splunk_mappy_exec.rb
+++ b/modules/exploits/multi/http/splunk_mappy_exec.rb
@@ -35,9 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '51061' ],
           [ 'CVE', '2011-4642' ],
           [ 'URL', 'http://www.splunk.com/view/SP-CAAAGMM' ],
-          [ 'URL', 'http://www.sec-1.com/blog/?p=233' ],
-          [ 'URL', 'http://www.sec-1.com/blog/wp-content/uploads/2011/12/Attacking_Splunk_Release.pdf' ],
-          [ 'URL', 'http://www.sec-1.com/blog/wp-content/uploads/2011/12/splunkexploit.zip' ]
+          [ 'URL', 'http://www.sec-1.com/blog/?p=233' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -36,8 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2012-0391'],
           [ 'OSVDB', '78277'],
-          [ 'EDB', '18329'],
-          [ 'URL', 'https://www.sec-consult.com/files/20120104-0_Apache_Struts2_Multiple_Critical_Vulnerabilities.txt']
+          [ 'EDB', '18329']
         ],
       'Platform'      => %w{ java linux win },
       'Privileged'     => true,

--- a/modules/exploits/multi/http/struts_dev_mode.rb
+++ b/modules/exploits/multi/http/struts_dev_mode.rb
@@ -35,8 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2012-0394'],
           [ 'OSVDB', '78276'],
           [ 'EDB', '18329'],
-          [ 'URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20120104-0_Apache_Struts2_Multiple_Critical_Vulnerabilities.txt' ],
-          [ 'URL', 'http://www.pwntester.com/blog/2014/01/21/struts-2-devmode/' ]
+          [ 'URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20120104-0_Apache_Struts2_Multiple_Critical_Vulnerabilities.txt' ]
         ],
       'Platform'       => 'java',
       'Arch'           => ARCH_JAVA,

--- a/modules/exploits/multi/http/sun_jsws_dav_options.rb
+++ b/modules/exploits/multi/http/sun_jsws_dav_options.rb
@@ -32,9 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2010-0361' ],
-          [ 'OSVDB', '61851' ],
-          [ 'URL', 'http://intevydis.blogspot.com/2010/01/sun-java-system-web-server-70u7-webdav.html' ],
-          [ 'URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-66-275850-1' ]
+          [ 'OSVDB', '61851' ]
         ],
       'Platform'       => [ 'win' ],
       'Privileged'     => true,

--- a/modules/exploits/multi/http/sysaid_auth_file_upload.rb
+++ b/modules/exploits/multi/http/sysaid_auth_file_upload.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'  =>
         [
           ['CVE', '2015-2994'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/sysaid-14.4-multiple-vulns.txt'],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Jun/8']
         ],
       'DefaultOptions' => { 'WfsDelay' => 5 },

--- a/modules/exploits/multi/http/sysaid_rdslogs_file_upload.rb
+++ b/modules/exploits/multi/http/sysaid_rdslogs_file_upload.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'  =>
         [
           [ 'CVE', '2015-2995' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/sysaid-14.4-multiple-vulns.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2015/Jun/8' ]
         ],
       'DefaultOptions' => { 'WfsDelay' => 30 },

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['OSVDB', '78508'],
           ['BID', '51647'],
-          ['URL', 'http://www.vbseo.com/f5/vbseo-security-bulletin-all-supported-versions-patch-release-52783/'],
           ['EDB', '18424']
         ],
       'Privileged'     => false,

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -33,8 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2011-4451'],
           ['OSVDB', '77393'],
-          ['EDB', '18177'],
-          ['URL', 'http://wush.net/trac/wikka/ticket/1098']
+          ['EDB', '18177']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/zenworks_configuration_management_upload.rb
+++ b/modules/exploits/multi/http/zenworks_configuration_management_upload.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2015-0779'],
           ['OSVDB', '120382'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/zenworks_zcm_rce.txt'],
           ['URL', 'http://seclists.org/fulldisclosure/2015/Apr/21']
         ],
       'DefaultOptions' => { 'WfsDelay' => 30 },

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '84913' ],
           [ 'EDB', '20168' ],
-          [ 'URL', 'http://offensivecomputing.net/?q=node/1417'],
           [ 'URL', 'http://resources.infosecinstitute.com/pbot-analysis/']
         ],
       'Platform'       => %w{ unix win },

--- a/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
+++ b/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
@@ -26,9 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2004-1389' ],
           [ 'OSVDB', '11026' ],
-          [ 'BID', '11494' ],
-          [ 'URL', 'http://seer.support.veritas.com/docs/271727.htm' ],
-
+          [ 'BID', '11494' ]
         ],
       'Privileged'     => true,
       'Platform'       => %w{ linux unix win },

--- a/modules/exploits/multi/realserver/describe.rb
+++ b/modules/exploits/multi/realserver/describe.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2002-1643' ],
-          [ 'OSVDB', '4468'],
-          [ 'URL', 'http://lists.immunitysec.com/pipermail/dailydave/2003-August/000030.html']
+          [ 'OSVDB', '4468']
         ],
       'Privileged'     => true,
       'Payload'        =>

--- a/modules/exploits/multi/vpn/tincd_bof.rb
+++ b/modules/exploits/multi/vpn/tincd_bof.rb
@@ -41,9 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2013-1428'],
           ['OSVDB', '92653'],
           ['BID', '59369'],
-          ['URL', 'http://www.floyd.ch/?p=741'],
-          ['URL', 'http://sitsec.net/blog/2013/04/22/stack-based-buffer-overflow-in-the-vpn-software-tinc-for-authenticated-peers/'],
-          ['URL', 'http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2013-1428']
+          ['URL', 'http://www.floyd.ch/?p=741']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/multi/vpn/tincd_bof.rb
+++ b/modules/exploits/multi/vpn/tincd_bof.rb
@@ -41,7 +41,8 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2013-1428'],
           ['OSVDB', '92653'],
           ['BID', '59369'],
-          ['URL', 'http://www.floyd.ch/?p=741']
+          ['URL', 'http://www.floyd.ch/?p=741'],
+          ['URL', 'http://sitsec.net/blog/2013/04/22/stack-based-buffer-overflow-in-the-vpn-software-tinc-for-authenticated-peers/']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
+++ b/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
@@ -31,9 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '55839'],
           ['US-CERT-VU', '654545'],
           ['URL', 'http://snosoft.blogspot.com/'],
-          ['URL', 'http://www.theregister.co.uk/2009/07/10/wyse_remote_exploit_bugs/'],
-          ['URL', 'http://www.wyse.com/serviceandsupport/support/WSB09-01.zip'],
-          ['URL', 'http://www.wyse.com/serviceandsupport/Wyse%20Security%20Bulletin%20WSB09-01.pdf'],
+          ['URL', 'http://www.theregister.co.uk/2009/07/10/wyse_remote_exploit_bugs/']
         ],
       'Privileged'     => true,
       'Payload'        =>

--- a/modules/exploits/osx/arkeia/type77.rb
+++ b/modules/exploits/osx/arkeia/type77.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2005-0491'],
           [ 'OSVDB', '14011'],
-          [ 'BID', '12594'],
-          [ 'URL', 'http://lists.netsys.com/pipermail/full-disclosure/2005-February/031831.html'],
+          [ 'BID', '12594']
         ],
       'Privileged'     => true,
       'Payload'        =>

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2003-0722'],
           ['OSVDB', '4585'],
-          ['BID', '8615'],
-          ['URL', 'http://lists.insecure.org/lists/vulnwatch/2003/Jul-Sep/0115.html'],
+          ['BID', '8615']
         ],
       'Privileged'     => true,
       'Platform'       => %w{ solaris unix },

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'OSVDB', '69562'],
-          [ 'BID', '45150' ],
-          [ 'URL', 'http://sourceforge.net/mailarchive/message.php?msg_name=alpine.DEB.2.00.1012011542220.12930%40familiar.castaglia.org' ],
+          [ 'BID', '45150' ]
         ],
       'Privileged'     => true,
       'Platform'       => [ 'unix' ],

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2012-5975'],
           ['EDB', '23082'],
           ['OSVDB', '88103'],
-          ['URL', 'http://seclists.org/fulldisclosure/2012/Dec/12'],
-          ['URL', 'http://www.ssh.com/index.php/component/content/article/531.html']
+          ['URL', 'http://seclists.org/fulldisclosure/2012/Dec/12']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/awstatstotals_multisort.rb
+++ b/modules/exploits/unix/webapp/awstatstotals_multisort.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2008-3922'],
           ['OSVDB', '47807'],
-          ['BID', '30856'],
-          ['URL', 'http://userwww.service.emory.edu/~ekenda2/EMORY-2008-01.txt'],
+          ['BID', '30856']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/barracuda_img_exec.rb
+++ b/modules/exploits/unix/webapp/barracuda_img_exec.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2005-2847'],
           ['OSVDB', '19279'],
           ['BID', '14712'],
-          ['URL', 'http://www.nessus.org/plugins/index.php?view=single&id=19556'],
-          ['URL', 'http://www.securiweb.net/wiki/Ressources/AvisDeSecurite/2005.1'],
+          ['URL', 'http://www.nessus.org/plugins/index.php?view=single&id=19556']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/mitel_awc_exec.rb
+++ b/modules/exploits/unix/webapp/mitel_awc_exec.rb
@@ -21,8 +21,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-
-          ['URL', 'http://www.procheckup.com/vulnerability_manager/vulnerabilities/pr10-14'],
           ['OSVDB', '69934'],
       #		['CVE',   ''],
       #		['BID',   '']

--- a/modules/exploits/unix/webapp/mybb_backdoor.rb
+++ b/modules/exploits/unix/webapp/mybb_backdoor.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '76111' ],
           [ 'BID', '49993' ],
           [ 'SECUNIA', '46300' ],
-          [ 'URL', 'http://blog.mybb.com/2011/10/06/1-6-4-security-vulnerabilit/' ],
-          [ 'URL', 'http://blog.mybb.com/wp-content/uploads/2011/10/mybb_1604_patches.txt' ]
+          [ 'URL', 'http://blog.mybb.com/2011/10/06/1-6-4-security-vulnerabilit/' ]
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/nagios3_history_cgi.rb
+++ b/modules/exploits/unix/webapp/nagios3_history_cgi.rb
@@ -31,8 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2012-6096' ],
           [ 'OSVDB', '88322' ],
           [ 'BID', '56879' ],
-          [ 'EDB', '24084' ],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2012-December/089125.html' ]
+          [ 'EDB', '24084' ]
         ],
       'Platform'       => %w{ linux unix },
       'Arch'           => [ ARCH_X86 ],

--- a/modules/exploits/unix/webapp/openx_banner_edit.rb
+++ b/modules/exploits/unix/webapp/openx_banner_edit.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '60499' ],
           [ 'BID', '37110' ],
           [ 'URL', 'http://archives.neohapsis.com/archives/bugtraq/2009-11/0166.html' ],
-          [ 'URL', 'https://developer.openx.org/jira/browse/OX-5747' ],
           [ 'URL', 'http://www.openx.org/docs/2.8/release-notes/openx-2.8.2' ],
           # References for making small images:
           [ 'URL', 'http://php.net/manual/en/function.getimagesize.php' ],

--- a/modules/exploits/unix/webapp/squirrelmail_pgp_plugin.rb
+++ b/modules/exploits/unix/webapp/squirrelmail_pgp_plugin.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2003-0990'],
           ['OSVDB', '3178'],
-          ['URL', 'http://lists.immunitysec.com/pipermail/dailydave/2007-July/004456.html'],
           ['URL', 'http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=330'],
           ['URL', 'http://www.wslabi.com/wabisabilabi/initPublishedBid.do?'],
         ],

--- a/modules/exploits/windows/backupexec/remote_agent.rb
+++ b/modules/exploits/windows/backupexec/remote_agent.rb
@@ -28,8 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2005-0773'],
           [ 'OSVDB', '17624'],
           [ 'BID', '14022'],
-          [ 'URL', 'http://www.idefense.com/application/poi/display?id=272&type=vulnerabilities'],
-          [ 'URL', 'http://seer.support.veritas.com/docs/276604.htm'],
+          [ 'URL', 'http://www.idefense.com/application/poi/display?id=272&type=vulnerabilities']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/brightstor/tape_engine.rb
+++ b/modules/exploits/windows/brightstor/tape_engine.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2006-6076' ],
           [ 'OSVDB', '30637' ],
           [ 'BID', '21221' ],
-          [ 'EDB', '3086' ],
-          [ 'URL', 'http://www.ca.com/us/securityadvisor/newsinfo/collateral.aspx?cid=101317' ],
+          [ 'EDB', '3086' ]
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/adobe_flash_avm2.rb
+++ b/modules/exploits/windows/browser/adobe_flash_avm2.rb
@@ -34,8 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '102849' ],
           [ 'BID', '65327' ],
           [ 'URL', 'http://helpx.adobe.com/security/products/flash-player/apsb14-04.html' ],
-          [ 'URL', 'http://blogs.technet.com/b/mmpc/archive/2014/02/17/a-journey-to-cve-2014-0497-exploit.aspx' ],
-          [ 'URL', 'http://blog.vulnhunt.com/index.php/2014/02/20/cve-2014-0497_analysis/' ]
+          [ 'URL', 'http://blogs.technet.com/b/mmpc/archive/2014/02/17/a-journey-to-cve-2014-0497-exploit.aspx' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -37,7 +37,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '84607'],
           [ 'BID', '55009'],
           [ 'URL', 'http://labs.alienvault.com/labs/index.php/2012/cve-2012-1535-adobe-flash-being-exploited-in-the-wild/' ],
-          [ 'URL', 'http://vrt-blog.snort.org/2012/08/cve-2012-1535-flash-0-day-in-wild.html' ],
           [ 'URL', 'https://developer.apple.com/fonts/TTRefMan/RM06/Chap6.html' ],
           [ 'URL', 'http://contagiodump.blogspot.com.es/2012/08/cve-2012-1535-samples-and-info.html' ],
           [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/08/17/adobe-flash-player-exploit-cve-2012-1535-now-available-for-metasploit' ],

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -37,8 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'ZDI', '11-276' ],
           [ 'URL', 'http://www.kahusecurity.com/2011/cve-2011-2140-caught-in-the-wild/' ],
           [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb11-21.html' ],
-          [ 'URL', 'http://0x1byte.blogspot.com/2011/11/analysis-of-cve-2011-2140-adobe-flash.html' ],
-          [ 'URL', 'http://www.abysssec.com/blog/2012/01/31/exploiting-cve-2011-2140-another-flash-player-vulnerability/' ]
+          [ 'URL', 'http://0x1byte.blogspot.com/2011/11/analysis-of-cve-2011-2140-adobe-flash.html' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/adobe_flatedecode_predictor02.rb
+++ b/modules/exploits/windows/browser/adobe_flatedecode_predictor02.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '36600' ],
           [ 'OSVDB', '58729' ],
           [ 'URL', 'http://blogs.adobe.com/psirt/2009/10/adobe_reader_and_acrobat_issue_1.html' ],
-          [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb09-15.html' ],
-          [ 'URL', 'http://www.fortiguard.com/analysis/pdfanalysis.html' ],
+          [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb09-15.html' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/adobe_jbig2decode.rb
+++ b/modules/exploits/windows/browser/adobe_jbig2decode.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE' , '2009-0658' ],
           [ 'OSVDB', '52073' ],
-          [ 'URL', 'http://bl4cksecurity.blogspot.com/2009/03/adobe-acrobatreader-universal-exploit.html'],
           [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb09-04.html']
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
+++ b/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2010-3653'],
           [ 'OSVDB', '68803'],
-          [ 'URL', 'http://www.exploit-db.com/sploits/Adobe_Shockwave_Director_rcsL_Chunk_Memory_Corruption.zip' ],
           [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-25.html' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
@@ -35,8 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2007-0015' ],
           [ 'OSVDB', '31023'],
-          [ 'BID', '21829' ],
-          [ 'URL', 'http://projects.info-pull.com/moab/MOAB-01-01-2007.html' ],
+          [ 'BID', '21829' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ask_shortformat.rb
+++ b/modules/exploits/windows/browser/ask_shortformat.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2007-5107' ],
-          [ 'OSVDB', '37735' ],
-          [ 'URL', 'http://wslabi.com/wabisabilabi/showBidInfo.do?code=ZD-00000148' ],
+          [ 'OSVDB', '37735' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/athocgov_completeinstallation.rb
+++ b/modules/exploits/windows/browser/athocgov_completeinstallation.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         => [ 'MC' ],
       'References'     =>
         [
-          [ 'OSVDB', '94557' ],
-          [ 'URL', 'http://www.athoc.com/products/IWSAlerts_overview.aspx' ]
+          [ 'OSVDB', '94557' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/awingsoft_web3d_bof.rb
+++ b/modules/exploits/windows/browser/awingsoft_web3d_bof.rb
@@ -50,7 +50,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2009-4588' ],
           [ 'OSVDB', '60017' ],
           [ 'EDB', '9116' ],
-          [ 'URL', 'http://www.shinnai.net/exploits/nsGUdeley3EHfKEV690p.txt' ],
           [ 'URL', 'http://www.rec-sec.com/2009/07/28/awingsoft-web3d-buffer-overflow/' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2008-2551' ],
           [ 'OSVDB', '45960' ],
-          [ 'BID', '29519' ],
-          [ 'URL', 'http://retrogod.altervista.org/9sg_c6_download_exec.html' ],
+          [ 'BID', '29519' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '89030' ],
           [ 'BID', '57174' ],
           [ 'EDB', '23944' ],
-          [ 'URL', 'http://retrogod.altervista.org/9sg_foxit_overflow.htm' ],
           [ 'URL', 'http://secunia.com/advisories/51733/' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/browser/hp_loadrunner_addfile.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_addfile.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2008-0492'],
           [ 'OSVDB', '40762'],
           [ 'BID', '27456' ],
-          [ 'EDB', '4987' ],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2007-December/059296.html' ],
+          [ 'EDB', '4987' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/hp_loadrunner_addfolder.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_addfolder.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2007-6530'],
           [ 'OSVDB', '39901'],
-          [ 'BID', '27025' ],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2007-December/059296.html' ],
+          [ 'BID', '27025' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -50,7 +50,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'MSB', 'MS13-008' ],
           [ 'URL', 'http://blog.fireeye.com/research/2012/12/council-foreign-relations-water-hole-attack-details.html'],
           [ 'URL', 'http://eromang.zataz.com/2012/12/29/attack-and-ie-0day-informations-used-against-council-on-foreign-relations/'],
-          [ 'URL', 'http://blog.vulnhunt.com/index.php/2012/12/29/new-ie-0day-coming-mshtmlcdwnbindinfo-object-use-after-free-vulnerability/' ],
           [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2794220' ],
           [ 'URL', 'http://blogs.technet.com/b/srd/archive/2012/12/29/new-vulnerability-affecting-internet-explorer-8-users.aspx' ],
           [ 'URL', 'http://blog.exodusintel.com/2013/01/02/happy-new-year-analysis-of-cve-2012-4792/' ],

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -50,8 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '85532' ],
           [ 'MSB', 'MS12-063' ],
           [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2757760' ],
-          [ 'URL', 'http://eromang.zataz.com/2012/09/16/zero-day-season-is-really-not-over-yet/' ],
-          [ 'URL', 'http://blog.vulnhunt.com/index.php/2012/09/17/ie-execcommand-fuction-use-after-free-vulnerability-0day/']
+          [ 'URL', 'http://eromang.zataz.com/2012/09/16/zero-day-season-is-really-not-over-yet/' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/macrovision_downloadandexecute.rb
+++ b/modules/exploits/windows/browser/macrovision_downloadandexecute.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2007-5660' ],
-          [ 'OSVDB', '38347' ],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2007-December/059288.html' ],
+          [ 'OSVDB', '38347' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/mcafee_mcsubmgr_vsprintf.rb
+++ b/modules/exploits/windows/browser/mcafee_mcsubmgr_vsprintf.rb
@@ -28,8 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2006-3961'],
           [ 'OSVDB', '27698'],
-          [ 'BID', '19265'],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2006-August/048565.html'],
+          [ 'BID', '19265']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
+++ b/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
@@ -36,8 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['MSB', 'MS06-001'],
           ['BID', '16074'],
           ['URL', 'http://www.microsoft.com/technet/security/advisory/912840.mspx'],
-          ['URL', 'http://wvware.sourceforge.net/caolan/ora-wmf.html'],
-          ['URL', 'http://www.geocad.ru/new/site/Formats/Graphics/wmf/wmf.txt'],
+          ['URL', 'http://wvware.sourceforge.net/caolan/ora-wmf.html']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms06_013_createtextrange.rb
+++ b/modules/exploits/windows/browser/ms06_013_createtextrange.rb
@@ -40,8 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['US-CERT-VU', '876678'],
           ['URL', 'http://secunia.com/secunia_research/2006-7/advisory/'],
           ['URL', 'http://seclists.org/lists/bugtraq/2006/Mar/0410.html'],
-          ['URL', 'http://seclists.org/lists/fulldisclosure/2006/Mar/1439.html'],
-          ['URL', 'http://www.shog9.com/crashIE.html'],
+          ['URL', 'http://seclists.org/lists/fulldisclosure/2006/Mar/1439.html']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms06_057_webview_setslice.rb
+++ b/modules/exploits/windows/browser/ms06_057_webview_setslice.rb
@@ -28,8 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2006-3730'],
           [ 'OSVDB', '27110' ],
           [ 'MSB', 'MS06-057'],
-          [ 'BID', '19030' ],
-          [ 'URL', 'http://browserfun.blogspot.com/2006/07/mobb-18-webviewfoldericon-setslice.html' ]
+          [ 'BID', '19030' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms06_067_keyframe.rb
+++ b/modules/exploits/windows/browser/ms06_067_keyframe.rb
@@ -49,8 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2006-4777' ],
           [ 'OSVDB', '28842' ],
           [ 'BID', '20047' ],
-          [ 'MSB', 'MS06-067' ],
-          [ 'URL', 'https://www.blackhat.com/presentations/bh-eu-07/Sotirov/Sotirov-Source-Code.zip' ]
+          [ 'MSB', 'MS06-067' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
@@ -46,8 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '33629'],
           ['BID', '23194'],
           ['MSB', 'MS07-017'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/935423.mspx'],
-          ['URL', 'http://www.determina.com/security.research/vulnerabilities/ani-header.html'],
+          ['URL', 'http://www.microsoft.com/technet/security/advisory/935423.mspx']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -46,7 +46,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2010-1885' ],
           [ 'OSVDB', '65264' ],
-          [ 'URL', 'http://lock.cmpxchg8b.com/b10a58b75029f79b5f93f4add3ddf992/ADVISORY' ],
           [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2219475.mspx' ],
           [ 'MSB', 'MS10-042']
         ],

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -50,8 +50,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2488013.mspx' ],
           [ 'URL', 'http://www.wooyun.org/bugs/wooyun-2010-0885' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2010/Dec/110' ],
-          [ 'URL', 'http://xcon.xfocus.net/XCon2010_ChenXie_EN.pdf' ],  # .NET 2.0 ROP (slide 25)
-          [ 'URL', 'http://www.breakingpointsystems.com/community/blog/ie-vulnerability/' ],
           [ 'MSB', 'MS11-003' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -48,8 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'MSB', 'MS12-004'],
           [ 'CVE', '2012-0003' ],
           [ 'OSVDB', '78210'],
-          [ 'BID', '51292'],
-          [ 'URL', 'http://www.vupen.com/blog/20120117.Advanced_Exploitation_of_Windows_MS12-004_CVE-2012-0003.php' ]
+          [ 'BID', '51292']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
+++ b/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
@@ -40,8 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2012-1876' ],
           [ 'OSVDB', '82866'],
           [ 'BID', '53848' ],
-          [ 'MSB', 'MS12-037' ],
-          [ 'URL', 'http://www.vupen.com/blog/20120710.Advanced_Exploitation_of_Internet_Explorer_HeapOv_CVE-2012-1876.php' ]
+          [ 'MSB', 'MS12-037' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -46,7 +46,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '91197' ],
           [ 'BID', '58570' ],
           [ 'MSB', 'MS13-037' ],
-          [ 'URL', 'http://www.vupen.com/blog/20130522.Advanced_Exploitation_of_IE10_Windows8_Pwn2Own_2013.php' ],
           [ 'URL', 'http://binvul.com/viewthread.php?tid=311' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -46,7 +46,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'MSB', 'MS12-043'],
           [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2719615' ],
           [ 'URL', 'http://www.zdnet.com/blog/security/state-sponsored-attackers-using-ie-zero-day-to-hijack-gmail-accounts/12462' ],
-          [ 'URL', 'http://hi.baidu.com/inking26/blog/item/9c2ab11c4784e5aa86d6b6c1.html' ],
           [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/06/18/metasploit-exploits-critical-microsoft-vulnerabilities' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/browser/nctaudiofile2_setformatlikesample.rb
+++ b/modules/exploits/windows/browser/nctaudiofile2_setformatlikesample.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2007-0018' ],
           [ 'OSVDB', '32032' ],
           [ 'BID', '22196' ],
-          [ 'US-CERT-VU', '292713' ],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2007-May/062911.html' ]
+          [ 'US-CERT-VU', '292713' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/persits_xupload_traversal.rb
+++ b/modules/exploits/windows/browser/persits_xupload_traversal.rb
@@ -29,8 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2009-3693'],
-          [ 'OSVDB', '60001'],
-          [ 'URL', 'http://retrogod.altervista.org/9sg_hp_loadrunner.html' ]
+          [ 'OSVDB', '60001']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -36,10 +36,6 @@ class Metasploit3 < Msf::Exploit::Remote
           ['BID', '49172'],
           # ZDI advisory
           ['ZDI', '11-265'],
-          # Vendor advisory
-          ['URL', 'http://service.real.com/realplayer/security/08162011_player/en/'],
-          #Fix commit
-          ['URL', 'http://lists.helixcommunity.org/pipermail/datatype-cvs/2011-April/015469.html'],
         ],
       'Payload' =>
         {

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -36,6 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['BID', '49172'],
           # ZDI advisory
           ['ZDI', '11-265'],
+          ['URL', 'http://service.real.com/realplayer/security/08162011_player/en/'],
         ],
       'Payload' =>
         {

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -43,8 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'OSVDB', '93696' ],
-          [ 'EDB', '25712' ],
-          [ 'URL', 'http://retrogod.altervista.org/9sg_siemens_adv_ii.htm' ]
+          [ 'EDB', '25712' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/wmi_admintools.rb
+++ b/modules/exploits/windows/browser/wmi_admintools.rb
@@ -46,7 +46,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2010-3973' ],
           [ 'BID', '45546' ],
           [ 'URL', 'http://wooyun.org/bug.php?action=view&id=1006' ],
-          [ 'URL', 'http://xcon.xfocus.net/XCon2010_ChenXie_EN.pdf' ],  # .NET 2.0 ROP (slide 25)
           [ 'URL', 'http://secunia.com/advisories/42693' ],
           [ 'URL', 'http://www.microsoft.com/downloads/en/details.aspx?FamilyID=6430f853-1120-48db-8cc5-f2abdc3ed314' ]
         ],

--- a/modules/exploits/windows/browser/yahoomessenger_server.rb
+++ b/modules/exploits/windows/browser/yahoomessenger_server.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2007-3147' ],
-          [ 'OSVDB', '37082' ],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2007-June/063817.html' ],
+          [ 'OSVDB', '37082' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
@@ -40,9 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2007-1765'],
           ['OSVDB', '33629'],
           ['BID', '23194'],
-          ['URL', 'http://www.microsoft.com/technet/security/advisory/935423.mspx'],
-          ['URL', 'http://www.determina.com/security_center/security_advisories/securityadvisory_0day_032907.asp'],
-          ['URL', 'http://www.determina.com/security.research/vulnerabilities/ani-header.html'],
+          ['URL', 'http://www.microsoft.com/technet/security/advisory/935423.mspx']
         ],
       'Stance'         => Msf::Exploit::Stance::Passive,
       'DefaultOptions' =>

--- a/modules/exploits/windows/emc/networker_format_string.rb
+++ b/modules/exploits/windows/emc/networker_format_string.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2012-2288' ],
           [ 'OSVDB', '85116' ],
           [ 'BID', '55330' ],
-          [ 'URL', 'http://blog.exodusintel.com/2012/08/29/when-wrapping-it-up-goes-wrong/' ],
           [ 'URL', 'http://aluigi.altervista.org/misc/aluigi0216_story.txt' ]
         ],
       'Platform'       => [ 'win' ],

--- a/modules/exploits/windows/fileformat/adobe_flatedecode_predictor02.rb
+++ b/modules/exploits/windows/fileformat/adobe_flatedecode_predictor02.rb
@@ -31,8 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '36600' ],
           [ 'OSVDB', '58729' ],
           [ 'URL', 'http://blogs.adobe.com/psirt/2009/10/adobe_reader_and_acrobat_issue_1.html' ],
-          [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb09-15.html' ],
-          [ 'URL', 'http://www.fortiguard.com/analysis/pdfanalysis.html' ],
+          [ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb09-15.html' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
+++ b/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2009-4195' ],
           [ 'BID', '37192' ],
           [ 'OSVDB', '60632' ],
-          [ 'URL', 'http://retrogod.altervista.org/9sg_adobe_illuso.html' ],
           [ 'EDB', '10281' ],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/adobe_jbig2decode.rb
+++ b/modules/exploits/windows/fileformat/adobe_jbig2decode.rb
@@ -31,8 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE' , '2009-0658' ],
-          [ 'OSVDB', '52073' ],
-          [ 'URL', 'http://bl4cksecurity.blogspot.com/2009/03/adobe-acrobatreader-universal-exploit.html'],
+          [ 'OSVDB', '52073' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
+++ b/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
@@ -37,7 +37,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '77529' ],
           [ 'BID', '50922' ],
           [ 'URL', 'http://www.adobe.com/support/security/advisories/apsa11-04.html' ],
-          [ 'URL', 'http://blog.vulnhunt.com/index.php/2011/12/12/cve-2011-2462-pdf-0day-analysis/' ],
           [ 'URL', 'http://blog.9bplus.com/analyzing-cve-2011-2462' ],
           [ 'URL', 'https://sites.google.com/site/felipeandresmanzano/PDFU3DExploitJS_CVE_2009_2990.py?attredirects=0'], #Original PoC
           [ 'URL', 'http://contagiodump.blogspot.com/2011/12/adobe-zero-day-cve-2011-2462.html' ]

--- a/modules/exploits/windows/fileformat/etrust_pestscan.rb
+++ b/modules/exploits/windows/fileformat/etrust_pestscan.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2009-4225' ],
-          [ 'OSVDB', '60862'],
-          [ 'URL', 'http://www.my-etrust.com/Extern/RoadRunner/PestScan/scan.htm' ],
+          [ 'OSVDB', '60862']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
+++ b/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
@@ -36,8 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2010-0033' ],
           [ 'OSVDB', '62241' ],
           [ 'MSB', 'MS10-004' ],
-          [ 'ZDI', '10-017' ],
-          [ 'URL', 'http://www.snoop-security.com/blog/index.php/2010/03/exploiting-ms10-004-ppt-viewer/' ]
+          [ 'ZDI', '10-017' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -38,8 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '70263' ],
           [ 'MSB', 'MS11-006' ],
           [ 'BID', '45662' ],
-          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2490606.mspx' ],
-          [ 'URL', 'http://www.powerofcommunity.net/schedule.html' ]
+          [ 'URL', 'http://www.microsoft.com/technet/security/advisory/2490606.mspx' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
+++ b/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
@@ -33,8 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2011-0105'],
           ['OSVDB', '71765'],
           ['MSB', 'MS11-021'],
-          ['ZDI', '11-121'],
-          ['URL', 'http://www.abysssec.com/blog/2011/11/02/microsoft-excel-2007-sp2-buffer-overwrite-vulnerability-ba-exploit-ms11-021/']
+          ['ZDI', '11-121']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ms12_027_mscomctl_bof.rb
+++ b/modules/exploits/windows/fileformat/ms12_027_mscomctl_bof.rb
@@ -36,8 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '81125' ],
           [ 'BID', '52911' ],
           [ 'MSB', 'MS12-027' ],
-          [ 'URL', 'http://contagiodump.blogspot.com.es/2012/04/cve2012-0158-south-china-sea-insider.html' ],
-          [ 'URL', 'http://abysssec.com/files/The_Arashi.pdf' ]
+          [ 'URL', 'http://contagiodump.blogspot.com.es/2012/04/cve2012-0158-south-china-sea-insider.html' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
+++ b/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
@@ -61,8 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['MSB', 'MS14-060'],
           ['BID', '70419'],
           ['URL' , 'http://www.isightpartners.com/2014/10/cve-2014-4114/'],
-          ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/an-analysis-of-windows-zero-day-vulnerability-cve-2014-4114-aka-sandworm/'],
-          ['URL', 'http://blog.vulnhunt.com/index.php/2014/10/14/cve-2014-4114_sandworm-apt-windows-ole-package-inf-arbitrary-code-execution/']
+          ['URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/an-analysis-of-windows-zero-day-vulnerability-cve-2014-4114-aka-sandworm/']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/vlc_modplug_s3m.rb
+++ b/modules/exploits/windows/fileformat/vlc_modplug_s3m.rb
@@ -34,8 +34,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '72143' ],
           #[ 'BID', 'xxx' ],
           [ 'URL', 'http://modplug-xmms.git.sourceforge.net/git/gitweb.cgi?p=modplug-xmms/modplug-xmms;a=commitdiff;h=aecef259828a89bb00c2e6f78e89de7363b2237b' ],
-          [ 'URL', 'http://hackipedia.org/File%20formats/Music/html/s3mformat.php' ],
-          [ 'URL', 'https://www.sec-consult.com/files/20110407-0_libmodplug_stackoverflow.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2011/Apr/113' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/firewall/blackice_pam_icq.rb
+++ b/modules/exploits/windows/firewall/blackice_pam_icq.rb
@@ -29,8 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2004-0362'],
           ['OSVDB', '4355'],
-          ['URL',   'http://www.eeye.com/html/Research/Advisories/AD20040318.html'],
-          ['URL',   'http://xforce.iss.net/xforce/alerts/id/166'],
+          ['URL',   'http://www.eeye.com/html/Research/Advisories/AD20040318.html']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/firewall/kerio_auth.rb
+++ b/modules/exploits/windows/firewall/kerio_auth.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2003-0220'],
           ['OSVDB', '6294'],
-          ['BID', '7180'],
-          ['URL', 'http://www1.corest.com/common/showdoc.php?idx=314&idxseccion=10'],
+          ['BID', '7180']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
+++ b/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
@@ -31,8 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2005-0277'],
           [ 'OSVDB', '12810'],
           [ 'OSVDB', '12811'],
-          [ 'BID', '12155'],
-          [ 'URL', 'ftp://ftp.3com.com/pub/utilbin/win32/3cdv2r10.zip'],
+          [ 'BID', '12155']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
@@ -37,9 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '38262' ],
           [ 'URL', 'http://paulmakowski.wordpress.com/2010/02/28/increasing-payload-size-w-return-address-overwrite/' ],
           [ 'URL', 'http://paulmakowski.wordpress.com/2010/04/19/metasploit-plugin-for-easyftp-server-exploit' ],
-          [ 'URL', 'http://seclists.org/bugtraq/2010/Feb/202' ],
-          [ 'URL', 'http://code.google.com/p/easyftpsvr/'],
-          [ 'URL', 'https://tegosecurity.com/etc/return_overwrite/RCE_easy_ftp_server_1.7.0.2.zip' ]
+          [ 'URL', 'http://seclists.org/bugtraq/2010/Feb/202' ]
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/windows/ftp/freeftpd_user.rb
+++ b/modules/exploits/windows/ftp/freeftpd_user.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2005-3683'],
           [ 'OSVDB', '20909'],
-          [ 'BID', '15457'],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2005-November/038808.html'],
+          [ 'BID', '15457']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -33,8 +33,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2004-0330'],
           [ 'OSVDB', '4073'],
           [ 'URL', 'http://archives.neohapsis.com/archives/bugtraq/2004-02/0654.html'],
-          [ 'URL', 'http://www.cnhonker.com/advisory/serv-u.mdtm.txt'],
-          [ 'URL', 'http://www.cnhonker.com/index.php?module=releases&act=view&type=3&id=54'],
           [ 'BID', '9751'],
         ],
       'Privileged'     => false,

--- a/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
@@ -49,8 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'OSVDB', '62163' ],
-          [ 'EDB', '11293' ],
-          [ 'URL', 'http://www.global-evolution.info/news/files/vftpd/vftpd.txt' ]
+          [ 'EDB', '11293' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/ftp/warftpd_165_pass.rb
+++ b/modules/exploits/windows/ftp/warftpd_165_pass.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '1999-0256'],
           [ 'OSVDB', '875'    ],
-          [ 'BID', '10078'	],
-          [ 'URL', 'http://lists.insecure.org/lists/bugtraq/1998/Feb/0014.html' ],
+          [ 'BID', '10078'	]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/ftp/warftpd_165_user.rb
+++ b/modules/exploits/windows/ftp/warftpd_165_user.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '1999-0256'],
           [ 'OSVDB', '875'    ],
-          [ 'BID', '10078'	],
-          [ 'URL', 'http://lists.insecure.org/lists/bugtraq/1998/Feb/0014.html' ],
+          [ 'BID', '10078'	]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/http/apache_chunked.rb
+++ b/modules/exploits/windows/http/apache_chunked.rb
@@ -34,9 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2002-0392' ],
           [ 'OSVDB', '838'],
-          [ 'BID', '5033' ],
-          [ 'URL', 'http://lists.insecure.org/lists/bugtraq/2002/Jun/0184.html'],
-
+          [ 'BID', '5033' ]
         ],
       'Privileged'     => true,
       'Platform'       => 'win',

--- a/modules/exploits/windows/http/bea_weblogic_transfer_encoding.rb
+++ b/modules/exploits/windows/http/bea_weblogic_transfer_encoding.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2008-4008' ],
-          [ 'OSVDB', '49283' ],
-          [ 'URL', 'http://support.bea.com/application_content/product_portlets/securityadvisories/2806.html'],
+          [ 'OSVDB', '49283' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
@@ -31,8 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2014-5005'],
           ['OSVDB', '110643'],
-          ['URL', 'http://seclists.org/fulldisclosure/2014/Aug/88'],
-          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/me_dc9_file_upload.txt']
+          ['URL', 'http://seclists.org/fulldisclosure/2014/Aug/88']
         ],
       'Platform'       => 'win',
       'Arch'           => ARCH_X86,

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_main.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_main.rb
@@ -44,8 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2010-1964' ],
           [ 'OSVDB', '65552' ],
           [ 'BID', '40873' ],
-          [ 'ZDI', '10-108' ],
-          [ 'URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c02217439' ]
+          [ 'ZDI', '10-108' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
@@ -44,7 +44,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '65427' ],
           [ 'BID', '40637' ],
           [ 'ZDI', '10-105' ],
-          [ 'URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c02217439' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
@@ -45,7 +45,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2010-2703' ],
           [ 'OSVDB', '66514' ],
           [ 'BID', '41829' ],
-          [ 'URL', 'http://www.vupen.com/english/advisories/2010/1866' ],
           [ 'ZDI', '10-137' ],
           [ 'URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c02286088' ]
         ],

--- a/modules/exploits/windows/http/mcafee_epolicy_source.rb
+++ b/modules/exploits/windows/http/mcafee_epolicy_source.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2006-5156' ],
           [ 'OSVDB', '29421' ],
           [ 'EDB', '2467' ],
-          [ 'URL', 'http://www.remote-exploit.org/advisories/mcafee-epo.pdf' ],
           [ 'BID', '20288' ],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/http/peercast_url.rb
+++ b/modules/exploits/windows/http/peercast_url.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2006-1148'],
           ['OSVDB', '23777'],
-          ['BID', '17040'],
-          ['URL', 'http://www.infigo.hr/in_focus/INFIGO-2006-03-01'],
+          ['BID', '17040']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/windows/http/servu_session_cookie.rb
+++ b/modules/exploits/windows/http/servu_session_cookie.rb
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2009-4006' ], # unsure
           [ 'OSVDB', '59772' ],
-          [ 'URL', 'http://rangos.de/ServU-ADV.txt' ],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2009-November/071370.html' ],
+          [ 'URL', 'http://rangos.de/ServU-ADV.txt' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/http/trackit_file_upload.rb
+++ b/modules/exploits/windows/http/trackit_file_upload.rb
@@ -34,8 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2014-4872' ],
           [ 'OSVDB', '112741' ],
           [ 'US-CERT-VU', '121036' ],
-          [ 'URL', 'http://seclists.org/fulldisclosure/2014/Oct/34' ],
-          [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/generic/bmc-track-it-11.3.txt' ]
+          [ 'URL', 'http://seclists.org/fulldisclosure/2014/Oct/34' ]
         ],
       'DefaultOptions' => { 'WfsDelay' => 30 },
       'Platform'       => 'win',

--- a/modules/exploits/windows/imap/mailenable_login.rb
+++ b/modules/exploits/windows/imap/mailenable_login.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2006-6423'],
           [ 'OSVDB', '32125'],
-          [ 'BID', '21492'],
-          [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2006-December/051229.html'],
+          [ 'BID', '21492']
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/imap/novell_netmail_auth.rb
+++ b/modules/exploits/windows/imap/novell_netmail_auth.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'OSVDB', '55175' ],
-          [ 'URL', 'http://www.w00t-shell.net/' ],
+          [ 'OSVDB', '55175' ]
         ],
       'Privileged'     => true,
       'DefaultOptions' =>

--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -47,8 +47,7 @@ class Metasploit3 < Msf::Exploit::Local
       'References'     =>
         [
           [ 'OSVDB', '96208' ],
-          [ 'EDB', '27282' ],
-          [ 'URL', 'http://mallocat.com/a-journey-to-antivirus-escalation/' ]
+          [ 'EDB', '27282' ]
         ],
       'DisclosureDate' => 'Aug 02 2013',
       'DefaultTarget'  => 0

--- a/modules/exploits/windows/local/ask.rb
+++ b/modules/exploits/windows/local/ask.rb
@@ -28,9 +28,6 @@ class Metasploit3 < Msf::Exploit::Local
       'SessionTypes'  => ['meterpreter'],
       'Targets'       => [['Windows', {}]],
       'DefaultTarget' => 0,
-      'References'    => [
-        ['URL', 'http://www.room362.com/blog/2012/1/3/uac-user-assisted-compromise.html']
-      ],
       'DisclosureDate' => 'Jan 3 2012'
     ))
 

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -78,7 +78,6 @@ class Metasploit3 < Msf::Exploit::Local
           %w(EDB 30014),
           %w(URL http://labs.portcullis.co.uk/blog/cve-2013-5065-ndproxy-array-indexing-error-unpatched-vulnerability/),
           %w(URL http://technet.microsoft.com/en-us/security/advisory/2914486),
-          %w(URL https://github.com/ShahinRamezany/Codes/blob/master/CVE-2013-5065/CVE-2013-5065.cpp),
           %w(URL http://www.secniu.com/blog/?p=53),
           %w(URL http://www.fireeye.com/blog/technical/cyber-exploits/2013/11/ms-windows-local-privilege-escalation-zero-day-in-the-wild.html),
           %w(URL http://blog.spiderlabs.com/2013/12/the-kernel-is-calling-a-zeroday-pointer-cve-2013-5065-ring-ring.html)

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -53,8 +53,7 @@ class Metasploit3 < Msf::Exploit::Local
       'References'    =>
         [
           [ 'OSVDB', '46578' ],
-          [ 'BID', '30001' ],
-          [ 'URL', 'http://support.novell.com/docs/Readmes/InfoDocument/patchbuilder/readme_5028543.html' ]
+          [ 'BID', '30001' ]
         ],
       'DisclosureDate'=> 'Jun 26 2008',
       'DefaultTarget' => 0

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -76,8 +76,7 @@ class Metasploit3 < Msf::Exploit::Local
           ['CVE', '2014-0983'],
           ['BID', '66133'],
           ['URL', 'http://www.coresecurity.com/advisories/oracle-virtualbox-3d-acceleration-multiple-memory-corruption-vulnerabilities'],
-          ['URL', 'http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=publication&name=oracle_virtualbox_3d_acceleration'],
-          ['URL', 'http://www.vupen.com/blog/20140725.Advanced_Exploitation_VirtualBox_VM_Escape.php']
+          ['URL', 'http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=publication&name=oracle_virtualbox_3d_acceleration']
         ],
       'DisclosureDate' => 'Mar 11 2014',
       'DefaultTarget'  => 0

--- a/modules/exploits/windows/misc/bomberclone_overflow.rb
+++ b/modules/exploits/windows/misc/bomberclone_overflow.rb
@@ -28,8 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2006-0460'],
           ['OSVDB', '23263'],
-          ['BID', '16697'],
-          ['URL', 'http://www.frsirt.com/english/advisories/2006/0643' ],
+          ['BID', '16697']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/enterasys_netsight_syslog_bof.rb
+++ b/modules/exploits/windows/misc/enterasys_netsight_syslog_bof.rb
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2011-5227'],
           ['OSVDB', '77971'],
           ['BID', '51124'],
-          ['ZDI', '11-350'],
-          ['URL', 'https://cp-enterasys.kb.net/article.aspx?article=14206&p=1']
+          ['ZDI', '11-350']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
@@ -40,7 +40,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2012-0124' ],
           [ 'OSVDB', '80105' ],
           [ 'BID', '52431' ],
-          [ 'URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c03229235' ],
           [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/07/06/an-example-of-egghunting-to-exploit-cve-2012-0124' ]
         ],
       'Payload'        =>

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '83774' ],
           [ 'EDB', '19613' ],
           [ 'URL', 'http://www.signal11.eu/en/research/articles/targeted_2010.pdf' ],
-          [ 'URL', 'http://badishi.com/own-and-you-shall-be-owned' ],
           [ 'URL', 'http://samvartaka.github.io/malware/2015/09/07/poison-ivy-reliable-exploitation/' ],
         ],
       'DisclosureDate' => 'Jun 24 2012',

--- a/modules/exploits/windows/misc/poppeeper_date.rb
+++ b/modules/exploits/windows/misc/poppeeper_date.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2009-1029' ],
           [ 'OSVDB', '53560'],
-          [ 'BID', '34093' ],
-          [ 'URL', 'http://www.krakowlabs.com/res/adv/KL0209ADV-poppeeper_date-bof.txt' ],
+          [ 'BID', '34093' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/misc/poppeeper_uidl.rb
+++ b/modules/exploits/windows/misc/poppeeper_uidl.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '53559' ],
           [ 'CVE', '2009-1029' ],
-          [ 'BID', '33926' ],
-          [ 'URL', 'http://www.krakowlabs.com/res/adv/KL0209ADV-poppeeper_uidl-bof.txt' ]
+          [ 'BID', '33926' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/mysql/mysql_payload.rb
+++ b/modules/exploits/windows/mysql/mysql_payload.rb
@@ -35,9 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'References'     =>
           [
             # Bernardo's work with cmd exec via udf
-            [ 'URL', 'http://bernardodamele.blogspot.com/2009/01/command-execution-with-mysql-udf.html' ],
-            # Advice from 2005 on securing MySQL on Windows, kind of helpful.
-            [ 'URL', 'http://dev.mysql.com/tech-resources/articles/securing_mysql_windows.html' ]
+            [ 'URL', 'http://bernardodamele.blogspot.com/2009/01/command-execution-with-mysql-udf.html' ]
           ],
         'Platform'       => 'win',
         'Targets'        =>

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '87334'],
           [ 'BID', '56539' ],
-          [ 'EDB', '22738' ],
-          [ 'URL', 'http://retrogod.altervista.org/9sg_novell_netiq_ldapagnt_adv.htm' ]
+          [ 'EDB', '22738' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
@@ -32,7 +32,8 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '65361' ],
           [ 'BID', '40486' ],
-          [ 'ZDI', '10-090' ]
+          [ 'ZDI', '10-090' ],
+          [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7005572' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '65361' ],
           [ 'BID', '40486' ],
-          [ 'ZDI', '10-090' ],
-          [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7005572' ]
+          [ 'ZDI', '10-090' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/novell/zenworks_preboot_op4c_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op4c_bof.rb
@@ -33,8 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2011-3176' ],
           [ 'OSVDB', '80231' ],
           [ 'BID', '52659' ],
-          [ 'URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=974' ],
-          [ 'URL', 'http://support.novell.com/docs/Readmes/InfoDocument/patchbuilder/readme_5127930.html' ]
+          [ 'URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=974' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/novell/zenworks_preboot_op6_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op6_bof.rb
@@ -32,7 +32,8 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '65361' ],
           [ 'BID', '40486' ],
-          [ 'ZDI', '10-090' ]
+          [ 'ZDI', '10-090' ],
+          [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7005572' ],
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/novell/zenworks_preboot_op6_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op6_bof.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '65361' ],
           [ 'BID', '40486' ],
-          [ 'ZDI', '10-090' ],
-          [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7005572' ]
+          [ 'ZDI', '10-090' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/novell/zenworks_preboot_op6c_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op6c_bof.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2011-3175' ],
           [ 'OSVDB', '80231' ],
           [ 'BID', '52659' ],
-          [ 'URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=973' ],
-          [ 'URL', 'http://support.novell.com/docs/Readmes/InfoDocument/patchbuilder/readme_5127930.html' ]
+          [ 'URL', 'http://www.verisigninc.com/en_US/products-and-services/network-intelligence-availability/idefense/public-vulnerability-reports/articles/index.xhtml?id=973' ]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/oracle/tns_service_name.rb
+++ b/modules/exploits/windows/oracle/tns_service_name.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2002-0965'],
           [ 'OSVDB', '5041'],
           [ 'BID', '4845'],
-          [ 'URL', 'http://www.appsecinc.com/resources/alerts/oracle/02-0013.shtml' ],
           [ 'URL', 'http://www.oracle.com/technology/deploy/security/pdf/net9_dos_alert.pdf' ],
         ],
       'Privileged'     => true,

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -37,7 +37,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://sqlmap.sourceforge.net/doc/BlackHat-Europe-09-Damele-A-G-Advanced-SQL-injection-whitepaper.pdf', ],
           [ 'URL', 'http://lab.lonerunners.net/blog/sqli-writing-files-to-disk-under-postgresql' ], # A litte more specific to PostgreSQL
         ],
       'Platform'       => 'win',

--- a/modules/exploits/windows/scada/citect_scada_odbc.rb
+++ b/modules/exploits/windows/scada/citect_scada_odbc.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '46105' ],
           [ 'URL', 'http://www.coresecurity.com/content/citect-scada-odbc-service-vulnerability' ],
           [ 'URL', 'http://www.auscert.org.au/render.html?it=9433' ],
-          [ 'URL', 'http://www.controsys.hu/anyagok/group_quality_assurance.pdf' ],
           [ 'URL', 'http://www.citect.com/documents/news_and_media/pr-citect-address-security.pdf' ],
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/scada/procyon_core_server.rb
+++ b/modules/exploits/windows/scada/procyon_core_server.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2011-3322'],
           ['OSVDB', '75371'],
-          ['URL', 'http://www.uscert.gov/control_systems/pdf/ICSA-11-216-01.pdf'],
           ['URL', 'http://www.stratsec.net/Research/Advisories/Procyon-Core-Server-HMI-Remote-Stack-Overflow']
         ],
       'Payload'        =>

--- a/modules/exploits/windows/smb/ms04_007_killbill.rb
+++ b/modules/exploits/windows/smb/ms04_007_killbill.rb
@@ -42,7 +42,6 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2003-0818'],
           [ 'OSVDB', '3902' ],
           [ 'BID', '9633'],
-          [ 'URL', 'http://www.phreedom.org/solar/exploits/msasn1-bitstring/'],
           [ 'MSB', 'MS04-007'],
 
         ],

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -80,8 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'MSB', 'MS08-068'],
           [ 'URL', 'http://blogs.technet.com/swi/archive/2008/11/11/smb-credential-reflection.aspx'],
           [ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ],
-          [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ],
-          [ 'URL', 'http://www.xfocus.net/articles/200305/smbrelay.html' ]
+          [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
         ],
       'Arch'           => [ARCH_X86, ARCH_X86_64],
       'Platform'       => 'win',

--- a/modules/exploits/windows/tftp/attftp_long_filename.rb
+++ b/modules/exploits/windows/tftp/attftp_long_filename.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2006-6184'],
           ['OSVDB', '11350'],
           ['BID', '21320'],
-          ['EDB', '2887'],
-          ['URL', 'ftp://guest:guest@ftp.alliedtelesyn.co.uk/pub/utilities/at-tftpd19.zip'],
+          ['EDB', '2887']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/tftp/futuresoft_transfermode.rb
+++ b/modules/exploits/windows/tftp/futuresoft_transfermode.rb
@@ -28,8 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['CVE', '2005-1812'],
           ['OSVDB', '16954'],
-          ['BID', '13821'],
-          ['URL', 'http://www.security.org.sg/vuln/tftp2000-1001.html'],
+          ['BID', '13821']
 
         ],
       'DefaultOptions' =>

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Post
           'Jon Hart <jon_hart[at]rapid7.com' # module rework and cleanup
         ],
         'Platform' => %w(linux osx unix win),
-        'References'   => [['URL', 'http://www.martinvigo.com/a-look-into-lastpass/']],
         'SessionTypes' => %w(meterpreter shell)
       )
     )

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -22,6 +22,7 @@ class Metasploit3 < Msf::Post
           'Jon Hart <jon_hart[at]rapid7.com' # module rework and cleanup
         ],
         'Platform' => %w(linux osx unix win),
+        'References'   => [['URL', 'http://www.martinvigo.com/a-look-into-lastpass/']],
         'SessionTypes' => %w(meterpreter shell)
       )
     )

--- a/modules/post/windows/escalate/golden_ticket.rb
+++ b/modules/post/windows/escalate/golden_ticket.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Post
       'SessionTypes' => [ 'meterpreter' ],
       'References'   =>
             [
-              ['URL', 'https:/github.com/gentilkiwi/mimikatz/wiki/module-~-kerberos'],
-              ['URL', 'http://blog.cobalstrike.com/2014/05/14/meterpreter-kiwi-extension-golden-ticket-howto/']
+              ['URL', 'https:/github.com/gentilkiwi/mimikatz/wiki/module-~-kerberos']
             ]
     ))
 

--- a/modules/post/windows/escalate/ms10_073_kbdlayout.rb
+++ b/modules/post/windows/escalate/ms10_073_kbdlayout.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Post
           [ 'OSVDB', '68552' ],
           [ 'CVE', '2010-2743' ],
           [ 'MSB', 'MS10-073' ],
-          [ 'URL', 'http://www.vupen.com/blog/20101018.Stuxnet_Win32k_Windows_Kernel_0Day_Exploit_CVE-2010-2743.php' ],
           [ 'URL', 'http://www.reversemode.com/index.php?option=com_content&task=view&id=71&Itemid=1' ],
           [ 'EDB', '15985' ]
         ],

--- a/modules/post/windows/escalate/screen_unlock.rb
+++ b/modules/post/windows/escalate/screen_unlock.rb
@@ -27,11 +27,7 @@ class Metasploit3 < Msf::Post
           'Metlstorm'                        # Based on the winlockpwn tool released by Metlstorm: http://www.storm.net.nz/projects/16
         ],
       'Platform'      => [ 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ],
-      'References'    =>
-        [
-          [ 'URL', 'http://www.storm.net.nz/projects/16' ]
-        ]
+      'SessionTypes'  => [ 'meterpreter' ]
     ))
 
     register_options([


### PR DESCRIPTION
These links are no longer available (404). They are dead links.

These bad links were originally picked up by tools/modules/module_reference.rb, and then manually verified one by one while I was updating the modules.
- [x] To verify, you can manually try the links.
