### PR TITLE
fix rpc session conditional to allow powershell read/write

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -481,15 +481,17 @@ private
   def _valid_session(sid,type)
 
     s = self.framework.sessions[sid.to_i]
+
     if(not s)
-      error(500, "Unknown Session ID")
+      error(500, "Unknown Session ID #{sid}")
     end
 
     if type == "ring"
       if not s.respond_to?(:ring)
         error(500, "Session #{s.type} does not support ring operations")
       end
-    elsif (s.type != type)
+    elsif (type == 'meterpreter' && s.type != type) ||
+      (type == 'shell' && s.type == 'meterpreter')
       error(500, "Session is not of type " + type)
     end
     s


### PR DESCRIPTION
- output invalid session id
- read/write on rpc session now allows powershell instead of hardcoded meterpreter vs command shell
