### PR TITLE
Resolve #6020, Better RPC exception handling

### DIFF
--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -57,7 +57,7 @@ require 'rex/proto/smb/exceptions'
     case self.handle.protocol
       when 'ncacn_ip_tcp'
         if self.socket.type? != 'tcp'
-          raise "ack, #{self.handle.protocol} requires socket type tcp, not #{self.socket.type?}!"
+          raise ::Rex::Proto::DCERPC::Exceptions::InvalidSocket, "ack, #{self.handle.protocol} requires socket type tcp, not #{self.socket.type?}!"
         end
       when 'ncacn_np'
         if self.socket.class == Rex::Proto::SMB::SimpleClient::OpenPipe
@@ -65,11 +65,11 @@ require 'rex/proto/smb/exceptions'
         elsif self.socket.type? == 'tcp'
           self.smb_connect()
         else
-          raise "ack, #{self.handle.protocol} requires socket type tcp, not #{self.socket.type?}!"
+          raise ::Rex::Proto::DCERPC::Exceptions::InvalidSocket, "ack, #{self.handle.protocol} requires socket type tcp, not #{self.socket.type?}!"
         end
         # No support ncacn_ip_udp (is it needed now that its ripped from Vista?)
       else
-        raise "Unsupported protocol : #{self.handle.protocol}"
+        raise ::Rex::Proto::DCERPC::Exceptions::InvalidSocket, "Unsupported protocol : #{self.handle.protocol}"
     end
   end
 
@@ -255,7 +255,7 @@ require 'rex/proto/smb/exceptions'
       bind, context = Rex::Proto::DCERPC::Packet.make_bind(*self.handle.uuid)
     end
 
-    raise 'make_bind failed' if !bind
+    raise ::Rex::Proto::DCERPC::Exceptions::BindError, 'make_bind failed' if !bind
 
     self.write(bind)
     raw_response = self.read()
@@ -264,11 +264,11 @@ require 'rex/proto/smb/exceptions'
     self.last_response = response
     if response.type == 12 or response.type == 15
       if self.last_response.ack_result[context] == 2
-        raise "Could not bind to #{self.handle}"
+        raise ::Rex::Proto::DCERPC::Exceptions::BindError, "Could not bind to #{self.handle}"
       end
       self.context = context
     else
-      raise "Could not bind to #{self.handle}"
+      raise ::Rex::Proto::DCERPC::Exceptions::BindError, "Could not bind to #{self.handle}"
     end
   end
 

--- a/lib/rex/proto/dcerpc/exceptions.rb
+++ b/lib/rex/proto/dcerpc/exceptions.rb
@@ -132,6 +132,32 @@ class NoResponse < Error
   end
 end
 
+class BindError < Error
+    def initialize(message=nil)
+        @message = message
+    end
+
+    def to_s
+        str = 'Failed to bind.'
+        if @message
+            str += " #{@message}"
+        end
+    end
+end
+
+class InvalidSocket < Error
+    def initialize(message=nil)
+        @message = message
+    end
+
+    def to_s
+        str = 'Invalid Socket.'
+        if @message
+            str += " #{@message}"
+        end
+    end
+end
+
 class InvalidPacket < Error
   def initialize(message = nil)
     @message = message

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -99,7 +99,8 @@ class Metasploit3 < Msf::Auxiliary
     print_status("#{peer} - Executing the command...")
     begin
       return psexec(execute)
-    rescue Rex::Proto::SMB::Exceptions::Error => exec_command_error
+    rescue Rex::Proto::DCERPC::Exceptions::Error, Rex::Proto::SMB::Exceptions::Error => exec_command_error
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}", 'rex', LEV_3)
       print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
       return false
     end


### PR DESCRIPTION
Resolve #6020. Avoid trying to rescue RuntimeError. This replaces #6075 

I currently don't actually know exactly how to reproduce #6020, but if you want:
- [x] Try to at least get a shell with psexec
- [x] Attempt psexec with an invalid cred
