### PR TITLE
Fix #5875, Add report_vuln for Msf::Exploit::CheckCode::Vulnerable

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -164,6 +164,16 @@ module ModuleCommandDispatcher
     end
   end
 
+  def report_vuln(instance)
+    framework.db.report_vuln(
+      workspace: instance.workspace,
+      host: instance.rhost,
+      name: instance.name,
+      info: "This was flagged as vulnerable by the explicit check of #{instance.fullname}.",
+      refs: instance.references
+    )
+  end
+
   def check_simple(instance=nil)
     unless instance
       instance = mod 
@@ -184,6 +194,7 @@ module ModuleCommandDispatcher
       if (code and code.kind_of?(Array) and code.length > 1)
         if (code == Msf::Exploit::CheckCode::Vulnerable)
           print_good("#{peer} - #{code[1]}")
+          report_vuln(instance)
         else
           print_status("#{peer} - #{code[1]}")
         end


### PR DESCRIPTION
See https://github.com/rapid7/metasploit-framework/issues/5875.

The discussion in the above issue favors using report_vuln to report vulns found by local_exploit_suggester. However, most local checks are Msf::Exploit::CheckCode::Appears (or Detected, because they are passive checks), and not Msf::Exploit::CheckCode::Vulnerable, so report_vuln wouldn't kick in most of the time. The exploit suggester still uses report_note to record all the vuln checks reported by the module, but this PR also allows report_vuln to kick in whenever Msf::Exploit::CheckCode::Vulnerable is seen (and all modules will benefit from this).

If you are not familiar with the guidelines of using check vuln checks, please read:
https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check%28%29-method#check-codes
## Verification
- [x] Start msfconsole
- [x] Do: `workspace -a vuln_check_test`
- [x] Test an exploit module. For example: Fire ms08_067_netapi against a vulnerable XP machine.
- [x] Test an auxiliary module that uses the Scanner mixin. For example: Fire ms15_034_ulonglongadd against a vulnerable Win 8.1 machine.
- [x] On msfconsole, do: `vulns`
- [x] You should see there are two vuln reports in there.
