### PR TITLE
Suggest the correct replacement for the deprecated module

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Module::Deprecated
 
-  deprecated(Date.new(2015, 8, 11), 'exploit/multi/browser/adobe_flash_uncompress_zlib_uaf')
+  deprecated(Date.new(2015, 11, 9), 'exploit/multi/browser/adobe_flash_pixel_bender_bof.rb')
 
   def initialize(info={})
     super(update_info(info,


### PR DESCRIPTION
The deprecated module has been suggesting the wrong replacement, it should be exploits/multi/browser/adobe_flash_pixel_bender_bof.rb

Also extending 30 more days before removal.
## Verification
- [x] Check the file paths. The deprecated module is adobe_flash_pixel_bender_bof.rb, the replacement is also adobe_flash_pixel_bender_bof.rb. The difference is the first is under windows, and the replacement is under multi.
- [x] When you use the deprecated module in msfconsole, the warning messsage should look like this:

```
[!] ************************************************************************
[!] *The module windows/browser/adobe_flash_pixel_bender_bof is deprecated!*
[!] *              It will be removed on or about 2015-11-09               *
[!] *  Use exploit/multi/browser/adobe_flash_pixel_bender_bof.rb instead   *
[!] ************************************************************************
```
