### PR TITLE
Bump jsobfu to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       bcrypt
-      jsobfu (~> 0.2.0)
+      jsobfu (~> 0.3.0)
       json
       metasm (~> 1.0.2)
       metasploit-concern (= 1.0.0)
@@ -103,7 +103,7 @@ GEM
       multi_json (~> 1.3)
     hike (1.2.3)
     i18n (0.7.0)
-    jsobfu (0.2.1)
+    jsobfu (0.3.0)
       rkelly-remix (= 0.0.6)
     json (1.8.3)
     mail (2.6.3)
@@ -251,3 +251,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.10.6

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.2.0'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.3.0'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasm compiler/decompiler/assembler


### PR DESCRIPTION
This version fixes a bug that allows obfuscating unicode strings properly. Reported in: https://github.com/rapid7/jsobfu/issues/12
