### PR TITLE
Improve advanced, info and options commands

### DIFF
--- a/features/commands/help.feature
+++ b/features/commands/help.feature
@@ -24,7 +24,9 @@ Feature: Help command
           go_pro        Launch Metasploit web GUI
           grep          Grep the output of another command
           help          Help menu
-          info          Displays information about one or more module
+          advanced      Displays advanced options for one or more modules
+          info          Displays information about one or more modules
+          options       Displays global options or for one or more modules
           irb           Drop into irb scripting mode
           jobs          Displays and manages jobs
           kill          Kill a job

--- a/features/commands/help.feature
+++ b/features/commands/help.feature
@@ -12,6 +12,7 @@ Feature: Help command
           Command       Description
           -------       -----------
           ?             Help menu
+          advanced      Displays advanced options for one or more modules
           back          Move back from the current context
           banner        Display an awesome metasploit banner
           cd            Change the current working directory
@@ -24,15 +25,14 @@ Feature: Help command
           go_pro        Launch Metasploit web GUI
           grep          Grep the output of another command
           help          Help menu
-          advanced      Displays advanced options for one or more modules
           info          Displays information about one or more modules
-          options       Displays global options or for one or more modules
           irb           Drop into irb scripting mode
           jobs          Displays and manages jobs
           kill          Kill a job
           load          Load a framework plugin
           loadpath      Searches for and loads modules from a path
           makerc        Save commands entered since start to a file
+          options       Displays global options or for one or more modules
           popm          Pops the latest module off the stack and makes it active
           previous      Sets the previously loaded module as the current module
           pushm         Pushes the active or list of modules onto the module stack

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -125,7 +125,7 @@ class Core
       "help"       => "Help menu",
       "advanced"   => "Displays advanced options for one or more modules",
       "info"       => "Displays information about one or more modules",
-      "options"    => "Displays options for one or more modules",
+      "options"    => "Displays global options or for one or more modules",
       "irb"        => "Drop into irb scripting mode",
       "jobs"       => "Displays and manages jobs",
       "rename_job" => "Rename a job",

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -123,7 +123,9 @@ class Core
       "go_pro"     => "Launch Metasploit web GUI",
       "grep"       => "Grep the output of another command",
       "help"       => "Help menu",
-      "info"       => "Displays information about one or more module",
+      "advanced"   => "Displays advanced options for one or more modules",
+      "info"       => "Displays information about one or more modules",
+      "options"    => "Displays options for one or more modules",
       "irb"        => "Drop into irb scripting mode",
       "jobs"       => "Displays and manages jobs",
       "rename_job" => "Rename a job",
@@ -712,6 +714,36 @@ class Core
     Rex::ThreadSafe.sleep(args[0].to_f)
   end
 
+  def cmd_advanced_help
+    print_line 'Usage: advanced [mod1 mod2 ...]'
+    print_line
+    print_line 'Queries the supplied module or modules for advanced options. If no module is given,'
+    print_line 'show advanced options for the currently active module.'
+    print_line
+  end
+
+  def cmd_advanced(*args)
+    if args.empty?
+      if (active_module)
+        show_advanced_options(active_module)
+        return true
+      else
+        print_error('No module active')
+        return false
+      end
+    end
+
+    args.each { |name|
+      mod = framework.modules.create(name)
+
+      if (mod == nil)
+        print_error("Invalid module: #{name}")
+      else
+        show_advanced_options(mod)
+      end
+    }
+  end
+
   def cmd_info_help
     print_line "Usage: info <module name> [mod2 mod3 ...]"
     print_line
@@ -748,6 +780,47 @@ class Core
     }
   end
 
+  def cmd_options_help
+    print_line 'Usage: options [mod1 mod2 ...]'
+    print_line
+    print_line 'Queries the supplied module or modules for options. If no module is given,'
+    print_line 'show options for the currently active module.'
+    print_line
+  end
+
+  def cmd_options(*args)
+    if args.empty?
+      if (active_module)
+        show_options(active_module)
+        return true
+      else
+        show_global_options
+        return true
+      end
+    end
+
+    args.each { |name|
+      mod = framework.modules.create(name)
+
+      if (mod == nil)
+        print_error("Invalid module: #{name}")
+      else
+        show_options(mod)
+      end
+    }
+  end
+
+  #
+  # Tab completion for the advanced command (same as use)
+  #
+  # @param str [String] the string currently being typed before tab was hit
+  # @param words [Array<String>] the previously completed words on the command line.  words is always
+  # at least 1 when tab completion has reached this stage since the command itself has been completed
+
+  def cmd_advanced_tabs(str, words)
+    cmd_use_tabs(str, words)
+  end
+
   #
   # Tab completion for the info command (same as use)
   #
@@ -756,6 +829,17 @@ class Core
   # at least 1 when tab completion has reached this stage since the command itself has been completed
 
   def cmd_info_tabs(str, words)
+    cmd_use_tabs(str, words)
+  end
+
+  #
+  # Tab completion for the options command (same as use)
+  #
+  # @param str [String] the string currently being typed before tab was hit
+  # @param words [Array<String>] the previously completed words on the command line.  words is always
+  # at least 1 when tab completion has reached this stage since the command itself has been completed
+
+  def cmd_options_tabs(str, words)
     cmd_use_tabs(str, words)
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3551,7 +3551,6 @@ class Core
 
   def show_advanced_options(mod) # :nodoc:
     mod_opt = Serializer::ReadableText.dump_advanced_options(mod, '   ')
-    print("\nModule options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)
     print("\nModule advanced options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)
 
     # If it's an exploit and a payload is defined, create it and

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3551,7 +3551,8 @@ class Core
 
   def show_advanced_options(mod) # :nodoc:
     mod_opt = Serializer::ReadableText.dump_advanced_options(mod, '   ')
-    print("\nModule advanced options:\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)
+    print("\nModule options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)
+    print("\nModule advanced options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)
 
     # If it's an exploit and a payload is defined, create it and
     # display the payload's options

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2204,7 +2204,7 @@ class Core
   end
 
   def cmd_show_help
-    global_opts = %w{all encoders nops exploits payloads auxiliary plugins options}
+    global_opts = %w{all encoders nops exploits payloads auxiliary plugins info options}
     print_status("Valid parameters for the \"show\" command are: #{global_opts.join(", ")}")
 
     module_opts = %w{ missing advanced evasion targets actions }
@@ -2244,6 +2244,8 @@ class Core
           show_auxiliary
         when 'post'
           show_post
+        when 'info'
+          cmd_info(*args[1, args.length])
         when 'options'
           if (mod)
             show_options(mod)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -813,31 +813,28 @@ class Core
   #
   # Tab completion for the advanced command (same as use)
   #
-  # @param str [String] the string currently being typed before tab was hit
-  # @param words [Array<String>] the previously completed words on the command line.  words is always
-  # at least 1 when tab completion has reached this stage since the command itself has been completed
+  # @param str (see #cmd_use_tabs)
+  # @param words (see #cmd_use_tabs)
 
   def cmd_advanced_tabs(str, words)
     cmd_use_tabs(str, words)
   end
 
   #
-  # Tab completion for the info command (same as use)
+  # Tab completion for the advanced command (same as use)
   #
-  # @param str [String] the string currently being typed before tab was hit
-  # @param words [Array<String>] the previously completed words on the command line.  words is always
-  # at least 1 when tab completion has reached this stage since the command itself has been completed
+  # @param str (see #cmd_use_tabs)
+  # @param words (see #cmd_use_tabs)
 
   def cmd_info_tabs(str, words)
     cmd_use_tabs(str, words)
   end
 
   #
-  # Tab completion for the options command (same as use)
+  # Tab completion for the advanced command (same as use)
   #
-  # @param str [String] the string currently being typed before tab was hit
-  # @param words [Array<String>] the previously completed words on the command line.  words is always
-  # at least 1 when tab completion has reached this stage since the command itself has been completed
+  # @param str (see #cmd_use_tabs)
+  # @param words (see #cmd_use_tabs)
 
   def cmd_options_tabs(str, words)
     cmd_use_tabs(str, words)


### PR DESCRIPTION
For the longest time I've been stumbling every once in a while on the difference between the module-specific commands, `show advanced` and `show options` and the also module specific but differently named 'info' command.  Too often I'm using a module and type `show info` to get the info but that does not work.  Similarly, I have a bad habit of thinking that I can run `options <module>` or `advanced <module>` like you can with `info <module>`.  

Yes, old habits die hard but I figured I'd put a PR up in the event that others trip over this too.

Before you could do this:

```
info <module1> [module2 ...] # in module or global scope, the later show info for all specified modules
show advanced # in module scope only
show options # in module or global scope, the later showing global options
```

Now you can also do:

```
show info
advanced <module1> [module2 ...]
options <module1> [module2 ...]
```

IOW, the `advanced`, `info` and `options` related commands can now be run with `<type>` or `show <type>`.

I have not yet added `rspec` coverage for this.  Actually, for all I know it will fail once this PR posts :).  
