### PR TITLE
Resolve 6174, require meterpreter_options

### DIFF
--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'msf/core'
+require 'msf/base/sessions/meterpreter_options'
 require 'msf/core/payload/uuid/options'
 
 module Msf


### PR DESCRIPTION
Resolve https://github.com/rapid7/metasploit-framework/issues/6174. Before this PR, the python meterpreter_loader was including the mixin at https://github.com/rapid7/metasploit-framework/blob/7f19d95ad830f11788c7174d08f62a0a3b2c3ee2/lib/msf/core/payload/python/meterpreter_loader.rb#L17 which was complaining about the uninitialized constant. 
