### PR TITLE
Cleanup and improvements to rsync modules_list

### DIFF
--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_negotiate
     # rsync is promiscuous and will send the negotitation and motd
     # upon connecting.  abort if we get nothing
-    return unless greeting = sock.get(read_timeout)
+    return unless greeting = sock.get_once
 
     # parse the greeting control and data lines.  With some systems, the data
     # lines at this point will be the motd.
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    _, post_neg_data_lines = rsync_parse_lines(sock.get(read_timeout))
+    _, post_neg_data_lines = rsync_parse_lines(sock.get_once)
 
     motd_lines = greeting_data_lines + post_neg_data_lines
     [ version, motd_lines.empty? ? nil : motd_lines.join("\n") ]

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -56,17 +56,17 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_list
     sock.puts("#list\n")
 
-    list = []
+    listing_metadata = []
     # the module listing is the module name and comment separated by a tab, each module
     # on its own line, lines separated with a newline
     sock.get(read_timeout).split(/\n/).map(&:strip).map do |module_line|
       next if module_line =~ /^#{RSYNC_HEADER} EXIT$/
       name, comment = module_line.split(/\t/).map(&:strip)
       next unless name
-      list << { name: name, comment: comment }
+      listing_metadata << { name: name, comment: comment }
     end
 
-    list
+    listing_metadata
   end
 
   # Attempts to negotiate the rsync protocol with the endpoint.
@@ -141,21 +141,21 @@ class Metasploit3 < Msf::Auxiliary
     )
     vprint_good("#{ip}:#{rport} - rsync MOTD: #{motd}") if motd
 
-    listing = rsync_list
+    listing_metadata = rsync_list
     disconnect
-    if listing.empty?
+    if listing_metadata.empty?
       print_status("#{ip}:#{rport} - rsync #{version}: no modules found")
     else
-      print_good("#{ip}:#{rport} - rsync #{version}: #{listing.size} modules found: " \
-                 "#{listing.map(&:first).join(', ')}")
+      modules = listing_metadata.map { |m| m[:name] }
+      print_good("#{ip}:#{rport} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
 
       table_columns = %w(Name Comment)
       if datastore['TEST_AUTHENTICATION']
         table_columns << 'Authentication?'
-        listing.each do |listing_metadata|
+        listing_metadata.each do |module_metadata|
           connect
           rsync_negotiate(false)
-          listing_metadata[:authentication?] = rsync_requires_auth?(listing_metadata[:name])
+          module_metadata[:authentication?] = rsync_requires_auth?(module_metadata[:name])
           disconnect
         end
       end
@@ -165,7 +165,7 @@ class Metasploit3 < Msf::Auxiliary
         Msf::Ui::Console::Table::Style::Default,
         'Header' => "rsync modules for #{ip}:#{rport}",
         'Columns' => table_columns,
-        'Rows' => listing
+        'Rows' => listing_metadata.map(&:values)
       )
       vprint_line(listing_table.to_s)
 
@@ -174,7 +174,7 @@ class Metasploit3 < Msf::Auxiliary
         proto: 'tcp',
         port: rport,
         type: 'rsync_modules',
-        data: { modules: listing },
+        data: { modules: listing_metadata }
       )
     end
   end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -107,6 +107,8 @@ class Metasploit3 < Msf::Auxiliary
     if listing.empty?
       print_status("#{ip}:#{rport} - rsync #{version}: no modules found")
     else
+      print_good("#{ip}:#{rport} - rsync #{version}: #{listing.size} modules found: " \
+                 "#{listing.map(&:first).join(', ')}")
       listing.each do |name_comment|
         connect
         rsync_negotiate
@@ -125,9 +127,6 @@ class Metasploit3 < Msf::Auxiliary
           ],
         'Rows' => listing
       )
-
-      print_good("#{ip}:#{rport} - rsync #{version}: #{listing.size} modules found: " \
-                 "#{listing.map(&:first).join(', ')}")
       vprint_line(listing_table.to_s)
 
       report_note(

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -60,11 +60,20 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_requires_auth?(rmodule)
     sock.puts("#{rmodule}\n")
     res = sock.get_once(-1, read_timeout)
-    if res && (res =~ /^#{RSYNC_HEADER} AUTHREQD/)
-      true
+    if res
+      if res =~ /^#{RSYNC_HEADER} AUTHREQD/
+        true
+      elsif res =~ /^#{RSYNC_HEADER} OK/
+        false
+      else
+        vprint_error("#{peer} - unexpected response when connecting to #{rmodule}: #{res}")
+        'unknown'
+      end
     else
-      false
+      vprint_error("#{peer} - no response when connecting to #{rmodule}")
+      'unknown'
     end
+
   end
 
   def rsync_list

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -166,7 +166,7 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
-    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
+    print_status("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
 
     modules_metadata = {}
     begin

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -45,6 +45,8 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptBool.new('SHOW_MOTD',
                     [ true, 'Show the rsync motd, if found', false ]),
+        OptBool.new('SHOW_VERSION',
+                    [ true, 'Show the rsync version', false ]),
         OptInt.new('READ_TIMEOUT', [ true, 'Seconds to wait while reading rsync responses', 2 ])
       ]
     )
@@ -166,6 +168,7 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
+    print_status("#{peer} - rsync version: #{version}") if datastore['SHOW_VERSION']
     print_status("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
 
     modules_metadata = {}
@@ -179,10 +182,10 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     if modules_metadata.empty?
-      print_status("#{peer} - rsync #{version}: no modules found")
+      print_status("#{peer} - no rsync modules found")
     else
       modules = modules_metadata.map { |m| m[:name] }
-      print_good("#{peer} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
+      print_good("#{peer} - #{modules.size} rsync modules found: #{modules.join(', ')}")
 
       table_columns = %w(Name Comment)
       if datastore['TEST_AUTHENTICATION']

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -51,7 +51,8 @@ class Metasploit3 < Msf::Auxiliary
     # on its own line, lines separated with a newline
     sock.get(read_timeout).split(/\n/).map(&:strip).map do |module_line|
       next if module_line =~ /^#{RSYNC_HEADER} EXIT$/
-      list << module_line.split(/\t/).map(&:strip)
+      name, comment = module_line.split(/\t/).map(&:strip)
+      list << [ name, comment ]
     end
 
     list

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -87,6 +87,7 @@ class Metasploit3 < Msf::Auxiliary
     connect
     version, motd = rsync_negotiate
     unless version
+      vprint_error("#{ip}:#{rport} - does not appear to be rsync")
       disconnect
       return
     end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -80,7 +80,8 @@ class Metasploit3 < Msf::Auxiliary
         proto: 'tcp',
         port: rport,
         type: 'rsync_listing',
-        data: listing_table
+        :data   => { :modules => listing_table.rows },
+        :update => :unique_data
       )
     end
   end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -58,23 +58,22 @@ class Metasploit3 < Msf::Auxiliary
     datastore['READ_TIMEOUT']
   end
 
-  def rsync_requires_auth?(rmodule)
+  def get_rsync_auth_state(rmodule)
     sock.puts("#{rmodule}\n")
     res = sock.get_once(-1, read_timeout)
     if res
       if res =~ /^#{RSYNC_HEADER} AUTHREQD/
-        true
+        'required'
       elsif res =~ /^#{RSYNC_HEADER} OK/
-        false
+        'not required'
       else
         vprint_error("#{peer} - unexpected response when connecting to #{rmodule}: #{res}")
-        'unknown'
+        'unexpected response'
       end
     else
       vprint_error("#{peer} - no response when connecting to #{rmodule}")
-      'unknown'
+      'no response'
     end
-
   end
 
   def rsync_list
@@ -176,7 +175,7 @@ class Metasploit3 < Msf::Auxiliary
         modules_metadata.each do |module_metadata|
           connect
           rsync_negotiate
-          module_metadata[:authentication?] = rsync_requires_auth?(module_metadata[:name])
+          module_metadata[:authentication?] = get_rsync_auth_state(module_metadata[:name])
           disconnect
         end
       end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
     _, post_neg_data_lines = rsync_parse_lines(sock.get(read_timeout))
 
     motd_lines = greeting_data_lines + post_neg_data_lines
-    [ version, motd_lines.join("\n") ]
+    [ version, motd_lines.empty? ? nil : motd_lines.join("\n") ]
   end
 
   # parses the control and data lines from the provided response data

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -14,9 +14,17 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Rsync Unauthenticated List Command',
-      'Description' => 'List all (listable) modules from a rsync daemon',
-      'Author'      => 'ikkini',
+      'Name'        => 'List Rsync Modules',
+      'Description' => %q(
+        An rsync module is essentially a directory share.  These modules can
+        optionally be protected by a password.  This module connects to and
+        negotiates with an rsync server, lists the available modules and,
+        optionally, determines if the module requires a password to access.
+      ),
+      'Author'      => [
+        'ikkini', # original metasploit module
+        'Jon Hart <jon_hart[at]rapid7.com>' # improved metasploit module
+      ],
       'References'  =>
         [
           ['URL', 'http://rsync.samba.org/ftp/rsync/rsync.html']

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -23,7 +23,8 @@ class Metasploit3 < Msf::Auxiliary
       ),
       'Author'      => [
         'ikkini', # original metasploit module
-        'Jon Hart <jon_hart[at]rapid7.com>' # improved metasploit module
+        'Jon Hart <jon_hart[at]rapid7.com>', # improved metasploit module
+        'Nixawk' # improved metasploit module
       ],
       'References'  =>
         [

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -6,7 +6,6 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
@@ -35,13 +34,13 @@ class Metasploit3 < Msf::Auxiliary
     return if version.blank?
 
     print_good("#{ip}:#{rport} - rsync #{version.strip} found")
-    report_service(:host => ip, :port => rport, :proto => 'tcp', :name => 'rsync')
+    report_service(host: ip, port: rport, proto: 'tcp', name: 'rsync')
     report_note(
-        :host => ip,
-        :proto => 'tcp',
-        :port => rport,
-        :type => 'rsync_version',
-        :data => version.strip
+      host: ip,
+      proto: 'tcp',
+      port: rport,
+      type: 'rsync_version',
+      data: version.strip
     )
 
     # making sure we match the version of the server
@@ -59,11 +58,11 @@ class Metasploit3 < Msf::Auxiliary
 
     vprint_status("#{ip}:#{rport} - #{version.rstrip} #{listing_sanitized}")
     report_note(
-        :host => ip,
-        :proto => 'tcp',
-        :port => rport,
-        :type => 'rsync_listing',
-        :data => listing_sanitized
+      host: ip,
+      proto: 'tcp',
+      port: rport,
+      type: 'rsync_listing',
+      data: listing_sanitized
     )
   end
 end

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -39,6 +39,10 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
   def read_timeout
     10
   end
@@ -90,7 +94,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     unless version
-      vprint_error("#{ip}:#{rport} - no rsync negotation found")
+      vprint_error("#{peer} - no rsync negotiation found")
       return
     end
 
@@ -125,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
     connect
     version, motd = rsync_negotiate(true)
     unless version
-      vprint_error("#{ip}:#{rport} - does not appear to be rsync")
+      vprint_error("#{peer} - does not appear to be rsync")
       disconnect
       return
     end
@@ -139,15 +143,15 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
-    vprint_good("#{ip}:#{rport} - rsync MOTD: #{motd}") if motd
+    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd
 
     listing_metadata = rsync_list
     disconnect
     if listing_metadata.empty?
-      print_status("#{ip}:#{rport} - rsync #{version}: no modules found")
+      print_status("#{peer} - rsync #{version}: no modules found")
     else
       modules = listing_metadata.map { |m| m[:name] }
-      print_good("#{ip}:#{rport} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
+      print_good("#{peer} - rsync #{version}: #{modules.size} modules found: #{modules.join(', ')}")
 
       table_columns = %w(Name Comment)
       if datastore['TEST_AUTHENTICATION']
@@ -163,7 +167,7 @@ class Metasploit3 < Msf::Auxiliary
       # build a table to store the module listing in
       listing_table = Msf::Ui::Console::Table.new(
         Msf::Ui::Console::Table::Style::Default,
-        'Header' => "rsync modules for #{ip}:#{rport}",
+        'Header' => "rsync modules for #{peer}",
         'Columns' => table_columns,
         'Rows' => listing_metadata.map(&:values)
       )

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
     # the module listing is the module name and comment separated by a tab, each module
     # on its own line, lines separated with a newline
     sock.get(read_timeout).split(/\n/).map(&:strip).map do |module_line|
-      next if module_line =~ /^#{RSYNC_HEADER} EXIT$/
+      break if module_line =~ /^#{RSYNC_HEADER} EXIT$/
       name, comment = module_line.split(/\t/).map(&:strip)
       next unless name
       modules_metadata << { name: name, comment: comment }

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -42,6 +42,8 @@ class Metasploit3 < Msf::Auxiliary
 
     register_advanced_options(
       [
+        OptBool.new('SHOW_MOTD',
+                    [ true, 'Show the rsync motd, if found', false ]),
         OptInt.new('READ_TIMEOUT', [ true, 'Seconds to wait while reading rsync responses', 2 ])
       ]
     )
@@ -148,7 +150,7 @@ class Metasploit3 < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
-    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd
+    vprint_good("#{peer} - rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
 
     modules_metadata = rsync_list
     disconnect

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -59,9 +59,6 @@ class Metasploit3 < Msf::Auxiliary
       listing_table = Msf::Ui::Console::Table.new(
         Msf::Ui::Console::Table::Style::Default,
         'Header' => "rsync modules",
-        'Prefix' => "\n",
-        'Postfix' => "\n",
-        'Indent' => 1,
         'Columns' =>
           [
             "Name",

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
   def rsync_negotiate(get_motd)
     # rsync is promiscuous and will send the negotitation and motd
     # upon connecting.  abort if we get nothing
-    return unless greeting = sock.get_once
+    return unless (greeting = sock.get_once)
 
     # parse the greeting control and data lines.  With some systems, the data
     # lines at this point will be the motd.


### PR DESCRIPTION
I've had this hanging out in my fork for a while and just recently dusted it off.  The existing rsync module was designed to connect to an rsync server and list the available shares (referred to as a module in rsync terminology, but that is confusing in the scope of discussing a metasploit module).

I've done a few things here:
- Updated the logging/reporting to work better when run against an `RHOSTS` with lots of targets
- Support handling of rsync motd messages, which causes the existing module to fail to detect the rsync shares properly
- Determines if the rsync share requires authentication

Testing against `rsync.samba.org` without this PR -- as you can see, it doesn't find the modules:

```
[*] Error: 2a01:4f8:192:486::443:2: Errno::EAFNOSUPPORT Address family not supported by protocol - connect(2) for [2a01:4f8:192:486::443:2]:873  <----------------- this seems unrelated
[+] 144.76.82.156:873 - rsync @RSYNCD: 31.0 found
[+] 144.76.82.156:873 - rsync listing found
[*] 144.76.82.156:873 - @RSYNCD: 31.0 Welcome to the samba.org anonymous rsync archives.\x0a\x0aContact tpot@samba.org if you have problems with this service. \x0a\x0a------
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
resource (/tmp/rsync.rc)> services

Services
========

host           port  proto  name   state  info
----           ----  -----  ----   -----  ----
144.76.82.156  873   tcp    rsync  open   

resource (/tmp/rsync.rc)> notes
[*] Time: 2015-11-02 18:16:12 UTC Note: host=144.76.82.156 service=rsync port=873 protocol=tcp type=rsync_version data="@RSYNCD: 31.0"
[*] Time: 2015-11-02 18:16:12 UTC Note: host=144.76.82.156 service=rsync port=873 protocol=tcp type=rsync_listing data="Welcome to the samba.org anonymous rsync archives.\\x0a\\x0aContact tpot@samba.org if you have problems with this service. \\x0a\\x0a------"
resource (/tmp/rsync.rc)>
```

After, using the following rc file:

```
workspace -d rsync
workspace -a rsync
use auxiliary/scanner/rsync/modules_list
set RHOSTS rsync-motd.vuln rsync-motd-no-modules.vuln rsync-no-motd.vuln rsync-no-motd-no-modules.vuln rsync.samba.org
set THREADS 10
run
set VERBOSE true
run
services
notes
```

(some of those hosts are internal but are obviously named)

```
resource (/tmp/rsync.rc)> run
[+] 10.4.24.11:873 - rsync 30.0: 3 modules found: share1, share3, share55555555555555555555555
[*] 10.4.19.249:873 - rsync 30.0: no modules found
[*] Scanned 3 of 6 hosts (50% complete)
[+] 144.76.82.156:873 - rsync 31.0: 9 modules found: ftp, sambaftp, sambaftp-mirror, rsyncftp, sambawww, distccwww, cvs, tivo, gnokii
[+] 10.4.28.171:873 - rsync 30.0: 4 modules found: share1, share3, share4, share55555555555555555555555
[*] 10.4.28.115:873 - rsync 30.0: no modules found
[*] Scanned 6 of 6 hosts (100% complete)
[*] Auxiliary module execution completed
resource (/tmp/rsync.rc)> set VERBOSE true
VERBOSE => true
resource (/tmp/rsync.rc)> run
[+] 10.4.24.11:873 - rsync 30.0: 3 modules found: share1, share3, share55555555555555555555555
[*] 10.4.19.249:873 - rsync 30.0: no modules found

rsync modules for 10.4.24.11:873
================================

   Name                          Comment                                Authentication?
   ----                          -------                                ---------------
   share1                        Public Share1                          false
   share3                        Public Share3                          true
   share55555555555555555555555  this is a really long comment because  false


[*] Scanned 3 of 6 hosts (50% complete)
[+] 144.76.82.156:873 - rsync 31.0: 9 modules found: ftp, sambaftp, sambaftp-mirror, rsyncftp, sambawww, distccwww, cvs, tivo, gnokii
[*] 10.4.28.115:873 - rsync 30.0: no modules found
[+] 10.4.28.171:873 - rsync 30.0: 4 modules found: share1, share3, share4, share55555555555555555555555

rsync modules for 144.76.82.156:873
===================================

   Name             Comment                                                   Authentication?
   ----             -------                                                   ---------------
   cvs              CVS repository                                            false
   distccwww        distcc WWW pages                                          false
   ftp              whole ftp area (approx 2 GB)                              false
   gnokii           gnokii ftp area                                           false
   rsyncftp         rsync ftp area                                            false
   sambaftp         Samba ftp area (approx 500Mb)                             false
   sambaftp-mirror  Samba ftp area including Binary_Packages (approx 1.4 GB)  true
   sambawww         Samba WWW pages (approx 100 MB)                           false
   tivo                                                                       false



rsync modules for 10.4.28.171:873
=================================

   Name                          Comment                                Authentication?
   ----                          -------                                ---------------
   share1                        Public Share1                          false
   share3                        Public Share3                          true
   share4                        Public Share4                          true
   share55555555555555555555555  this is a really long comment because  false


[*] Scanned 6 of 6 hosts (100% complete)
[*] Auxiliary module execution completed
resource (/tmp/rsync.rc)> services

Services
========

host           port  proto  name   state  info
----           ----  -----  ----   -----  ----
10.4.19.249    873   tcp    rsync  open   rsync protocol version 30.0, MOTD 'Welcome to Ubuntu 12.04 LTS (GNU/Linux 3.2.0-23-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Wed Nov  4 08:19:04 PST 2015

  System load: 0.0               Memory usage: 3%   Processes:       96
  Usage of /:  2.8% of 98.85GB   Swap usage:   0%   Users logged in: 0

  Graph this data and manage this system at https://landscape.canonical.com/

195 packages can be updated.
107 updates are security updates.

195 packages can be updated.
107 updates are security updates.

New release '14.04.3 LTS' available.
Run 'do-release-upgrade' to upgrade to it.'
10.4.24.11     873   tcp    rsync  open   rsync protocol version 30.0, MOTD 'Welcome to Ubuntu 12.04 LTS (GNU/Linux 3.2.0-23-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Wed Nov  4 08:00:33 PST 2015

  System load:  0.01              Processes:           70
  Usage of /:   2.8% of 98.85GB   Users logged in:     0
  Memory usage: 26%               IP address for eth0: 10.4.24.11
  Swap usage:   0%

  Graph this data and manage this system at https://landscape.canonical.com/

195 packages can be updated.
107 updates are security updates.

195 packages can be updated.
107 updates are security updates.

New release '14.04.3 LTS' available.
Run 'do-release-upgrade' to upgrade to it.'
10.4.28.115    873   tcp    rsync  open   rsync protocol version 30.0
10.4.28.171    873   tcp    rsync  open   rsync protocol version 30.0
144.76.82.156  873   tcp    rsync  open   rsync protocol version 31.0, MOTD 'Welcome to the samba.org anonymous rsync archives.

Contact tpot@samba.org if you have problems with this service. 

------'

resource (/tmp/rsync.rc)> notes
[*] Time: 2015-11-04 18:18:47 UTC Note: host=10.4.24.11 service=rsync port=873 protocol=tcp type=rsync_modules data={:modules=>[{:name=>"share1", :comment=>"Public Share1", :authentication?=>false}, {:name=>"share3", :comment=>"Public Share3", :authentication?=>true}, {:name=>"share55555555555555555555555", :comment=>"this is a really long comment because", :authentication?=>false}]}
[*] Time: 2015-11-04 18:18:54 UTC Note: host=144.76.82.156 service=rsync port=873 protocol=tcp type=rsync_modules data={:modules=>[{:name=>"ftp", :comment=>"whole ftp area (approx 2 GB)", :authentication?=>false}, {:name=>"sambaftp", :comment=>"Samba ftp area (approx 500Mb)", :authentication?=>false}, {:name=>"sambaftp-mirror", :comment=>"Samba ftp area including Binary_Packages (approx 1.4 GB)", :authentication?=>true}, {:name=>"rsyncftp", :comment=>"rsync ftp area", :authentication?=>false}, {:name=>"sambawww", :comment=>"Samba WWW pages (approx 100 MB)", :authentication?=>false}, {:name=>"distccwww", :comment=>"distcc WWW pages", :authentication?=>false}, {:name=>"cvs", :comment=>"CVS repository", :authentication?=>false}, {:name=>"tivo", :comment=>nil, :authentication?=>false}, {:name=>"gnokii", :comment=>"gnokii ftp area", :authentication?=>false}]}
[*] Time: 2015-11-04 18:18:57 UTC Note: host=10.4.28.171 service=rsync port=873 protocol=tcp type=rsync_modules data={:modules=>[{:name=>"share1", :comment=>"Public Share1", :authentication?=>false}, {:name=>"share3", :comment=>"Public Share3", :authentication?=>true}, {:name=>"share4", :comment=>"Public Share4", :authentication?=>true}, {:name=>"share55555555555555555555555", :comment=>"this is a really long comment because", :authentication?=>false}]}
```

https://www.gentoo.org/support/rsync-mirrors/ also has some potentially good test targets too.
