### PR TITLE
Fix tab completion for set StageEncoder

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2936,7 +2936,7 @@ class Core
       return option_values_payloads() if opt.upcase == 'PAYLOAD'
       return option_values_targets()  if opt.upcase == 'TARGET'
       return option_values_nops()     if opt.upcase == 'NOPS'
-      return option_values_encoders() if opt.upcase == 'StageEncoder'
+      return option_values_encoders() if opt.upcase == 'STAGEENCODER'
     end
 
     # Well-known option names specific to modules with actions


### PR DESCRIPTION
This fixes the tab completion for `set StageEncoder`. It looks like this never worked because `opt.upcase` would never equal `StageEncoder`. Using this patch though allows the valid encoders to be tab completed for the StageEncoder option.

Verification:
- [x] Use an exploit and set a payload for it
- [x] Try to set the StageEncoder option and ensure tab completion shows valid encoders for the selected payload
