### PR TITLE
Remove extra Content-Length HTTP header

### DIFF
--- a/modules/exploits/unix/webapp/oscommerce_filemanager.rb
+++ b/modules/exploits/unix/webapp/oscommerce_filemanager.rb
@@ -82,7 +82,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'headers' =>
       {
         'Content-Type'	 => 'application/x-www-form-urlencoded',
-        'Content-Length' => data.length,
       }
     }, 3)
 


### PR DESCRIPTION
Regarding the osCommerce 2.2 Arbitrary PHP Code Execution module:

The send_request_raw already sets the header and if it's set also in the
module, Metasploit sends the header twice.

Some servers might not appreciate the duplicate headers. My test server responded with `HTTP 413 Request Entity Too Large` and the module echoed `[-] Server returned non-302 status code (413)`.

On my test setup, this prevented the exploit from working. I got the following in my log files and was not able to execute any payloads:

```
==> error.log <==
[Thu Nov 05 05:56:10 2015] [error] [client 1.2.3.4] Invalid Content-Length
[Thu Nov 05 05:56:10 2015] [error] [client 1.2.3.4] script '/var/www/catalog/PlSlFsVm.php' not found or unable to stat
==> access.log <==
1.2.3.4 - - [05/Nov/2015:05:56:10 -0800] "GET /catalog/PlSlFsVm.php HTTP/1.1" 404 481 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
```

HTTP 413 responses can also stick out in the server's logs ;)
