### PR TITLE
SMTPDeliver should not block when sending SMTP DATA contents

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -146,14 +146,18 @@ module Exploit::Remote::SMTPDeliver
     # If the user supplied a Date field, use that, else use the current
     # DateTime in the proper RFC2822 format.
     if datastore['DATE'].present?
-      raw_send_recv("Date: #{datastore['DATE']}\r\n", nsock)
+      #raw_send_recv("Date: #{datastore['DATE']}\r\n", nsock)
+      date = "Date: #{datastore['DATE']}\r\n"
     else
-      raw_send_recv("Date: #{DateTime.now.rfc2822}\r\n", nsock)
+      #raw_send_recv("Date: #{DateTime.now.rfc2822}\r\n", nsock)
+      date = "Date: #{DateTime.now.rfc2822}\r\n"
     end
 
     # If the user supplied a Subject field, use that
+    subject = nil
     if datastore['SUBJECT'].present?
-      raw_send_recv("Subject: #{datastore['SUBJECT']}\r\n", nsock)
+      #raw_send_recv("Subject: #{datastore['SUBJECT']}\r\n", nsock)
+      subject = "Subject: #{datastore['SUBJECT']}\r\n"
     end
 
     # Avoid sending tons of data and killing the connection if the server
@@ -161,6 +165,10 @@ module Exploit::Remote::SMTPDeliver
     if not resp or not resp[0,3] == '354'
       print_error("Server refused our mail")
     else
+      full_msg = ''
+      full_msg << date
+      full_msg << subject unless subject.nil?
+      full_msg << data
       send_status = raw_send_recv("#{data}\r\n.\r\n", nsock)
     end
 

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -166,7 +166,7 @@ module Exploit::Remote::SMTPDeliver
       full_msg << date
       full_msg << subject unless subject.nil?
       full_msg << data
-      send_status = raw_send_recv("#{data}\r\n.\r\n", nsock)
+      send_status = raw_send_recv("#{full_msg}\r\n.\r\n", nsock)
     end
 
     if not already_connected

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -146,17 +146,14 @@ module Exploit::Remote::SMTPDeliver
     # If the user supplied a Date field, use that, else use the current
     # DateTime in the proper RFC2822 format.
     if datastore['DATE'].present?
-      #raw_send_recv("Date: #{datastore['DATE']}\r\n", nsock)
       date = "Date: #{datastore['DATE']}\r\n"
     else
-      #raw_send_recv("Date: #{DateTime.now.rfc2822}\r\n", nsock)
       date = "Date: #{DateTime.now.rfc2822}\r\n"
     end
 
     # If the user supplied a Subject field, use that
     subject = nil
     if datastore['SUBJECT'].present?
-      #raw_send_recv("Subject: #{datastore['SUBJECT']}\r\n", nsock)
       subject = "Subject: #{datastore['SUBJECT']}\r\n"
     end
 


### PR DESCRIPTION
MSP-13501

This PR allows SMTPDeliver to not block expecting an answer when sending the Subject or the Date headers.

Verification
- [ ] Start msfconsole
- [ ] `use auxiliary/client/smtp/emailer`
- [ ] Set a correct emailer_config.yaml `set YAML_CONFIG /tmp/emailer_config.yaml`

```
# YAML:1.0
# Configuration file for emailer.rb module
# Taken from Jabra spl0it.org
#
# Emails CSV File (Fname Lname,email)
to: /tmp/targets.csv
# Email is sent from this address
from: attacker@metasf.com
# Subject
subject: "[SECURITY-ALERT] Critical Windows Vulnerability"
# Type ( text or text/html )
type: text/html
# Msg body file
msg_file: /tmp/email_body.txt
# Number of seconds to wait before next email
wait: 5
# Prepend the first name to the email body
add_name: true
# Add custom signature from file
sig: true
# Signature file
sig_file: /tmp/sig.txt

#### Attachment Information ####
# Add an email attachment (File exploit anyone?)
attachment: false

#### Metasploit/Payload Creation ####
# create a metasploit payload
make_payload: false
```
- [ ]  run the module. VERIFY it doesn't block after sending the `Date:` header

```
msf auxiliary(emailer) > run

[*] Emailing Juan Vazquez at juan.vazquez.test@gmail.com

[*] Connecting to SMTP server 127.0.0.1:25...
[*] C: EHLO aBmepPnfOeIdpGuSIWX
[*] S: 250-AUS-MAC-0916.local
250-PIPELINING
250-SIZE 10485760
250-VRFY
250-ETRN
250-ENHANCEDSTATUSCODES
250-8BITMIME
250 DSN
[*] C: MAIL FROM: <attacker@metasf.com>
[*] S: 250 2.1.0 Ok
[*] C: RCPT TO: <juan.vazquez.test@gmail.com>
[*] S: 250 2.1.5 Ok
[*] C: DATA
[*] S: 354 End data with <CR><LF>.<CR><LF>
[*] C: Date: Fri, 6 Nov 2015 11:20:27 -0600 <-------- IT SHOULDN'T BLOCK AFTER IT
MIME-Version: 1.0
Content-Type: multipart/mixed; boundary="_Part_534_3936722139_2...
[*] S: 250 2.0.0 Ok: queued as 963D35A0D988
[*] Closing the connection...
[*] C: QUIT
[*] S: 221 2.0.0 Bye

[*] Email sent..
[*] Auxiliary module execution completed
```
- [ ] Verify you get the spam email in your inbox
