### PR TITLE
Fix some unbalanced brackets in module Authors

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
       'Author'       =>
         [
           'jclaudius <jclaudius[at]trustwave.com>',
-          'lguay <laura.r.guay[at]gmail.com'
+          'lguay <laura.r.guay[at]gmail.com>'
         ],
       'License'     => MSF_LICENSE,
       'References'  =>

--- a/modules/auxiliary/scanner/quake/server_info.rb
+++ b/modules/auxiliary/scanner/quake/server_info.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
           This module uses the getstatus or getinfo request to obtain
           information from a Quakeserver.
         ),
-        'Author'        => 'Jon Hart <jon_hart[at]rapid7.com',
+        'Author'        => 'Jon Hart <jon_hart[at]rapid7.com>',
         'References'    =>
           [
             ['URL', 'ftp://ftp.idsoftware.com/idstuff/quake3/docs/server.txt']

--- a/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
+++ b/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Thomas Hibbert <thomas.hibbert@security-assessment.com' # Vulnerability discovery and MSF module
+          'Thomas Hibbert <thomas.hibbert@security-assessment.com>' # Vulnerability discovery and MSF module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         =>
         [
           'sinn3r',
-          'Sean Verity <veritysr1980[at]gmail.com'
+          'Sean Verity <veritysr1980[at]gmail.com>'
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       'Author'           => [
         'Royce @R3dy__ Davis <rdavis[at]accuvant.com>', # PSExec command module
-        'RageLtMan <rageltman[at]sempervictus' # PSH exploit, libs, encoders
+        'RageLtMan <rageltman[at]sempervictus>' # PSH exploit, libs, encoders
       ],
       'License'          => MSF_LICENSE,
       'Privileged'       => true,

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Post
         'Author' => [
           'Alberto Garcia Illera <agarciaillera[at]gmail.com>', # original module and research
           'Martin Vigo <martinvigo[at]gmail.com>', # original module and research
-          'Jon Hart <jon_hart[at]rapid7.com' # module rework and cleanup
+          'Jon Hart <jon_hart[at]rapid7.com>' # module rework and cleanup
         ],
         'Platform' => %w(linux osx unix win),
         'References'   => [['URL', 'http://www.martinvigo.com/a-look-into-lastpass/']],

--- a/modules/post/windows/gather/phish_windows_credentials.rb
+++ b/modules/post/windows/gather/phish_windows_credentials.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        =>
             [
-              'Wesley Neelen <security[at]forsec.nl', # Metasploit module, @wez3forsec on Twitter
+              'Wesley Neelen <security[at]forsec.nl>', # Metasploit module, @wez3forsec on Twitter
               'Matt Nelson'                           # Original powershell script, @enigma0x3 on Twitter
             ],
       'References'    => [ 'URL', 'https://forsec.nl/2015/02/windows-credentials-phishing-using-metasploit' ],


### PR DESCRIPTION
For reasons I couldn't figure out, if an `Author` has an email address and that email address has unbalanced angle brackets, the author will display oddly in `show info` and `info`:

```
Provided by:
  Jon Hart <jon_hart <Jon Hart <jon_hart@rapid7.com>
```

This updates msftidy to catch the really obvious cases of this, but unfortunately its existing handling of the `Author` field is pretty brittle so there may be some that this misses.  I've also fixed the 7 modules that had this problem.

If someone happens to know why these malformed authors get even more malformed when displayed and wants to toss a PR up against this to fix that, that'd be great.
