### PR TITLE
Move Compat into Payload so that is actually used

### DIFF
--- a/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
+++ b/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
@@ -37,17 +37,17 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'US-CERT-VU', '345260' ],
           [ 'URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20130308-0_GroundWork_Monitoring_Multiple_critical_vulnerabilities_wo_poc_v10.txt' ]
         ],
-      'Arch'            => ARCH_CMD,
+      'Arch'           => ARCH_CMD,
       'Payload'        =>
         {
           'Space'       => 8190,
           'DisableNops' => true,
           'Compat'          =>
             {
-              'PayloadType' => 'cmd'
+              'PayloadType' => 'cmd',
+              # Based on the default Ubuntu 10.04 VM appliance
+              'RequiredCmd' => 'generic telnet netcat perl python'
             },
-          # Based on the default Ubuntu 10.04 VM appliance
-          'RequiredCmd' => 'generic telnet netcat perl python'
         },
       'Platform'       => %w{ linux unix },
       'Targets'        =>

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -39,11 +39,11 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'BadChars'    => "\x00",
           'DisableNops' => true,
-        },
-      'Compat'	=>
-        {
-          'PayloadType' => 'cmd',
-          'RequiredCmd' => 'generic python perl',
+          'Compat'	=>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic python perl',
+            },
         },
       'Targets'        =>
         [

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -36,12 +36,12 @@ class Metasploit4 < Msf::Exploit::Remote
         {
           'Space' => 1024,
           'BadChars' => "\x00\x0A\x0D",
-          'DisableNops' => true
-        },
-      'Compat' =>
-        {
-          'PayloadType' => 'cmd',
-          'RequiredCmd' => 'generic awk ruby'
+          'DisableNops' => true,
+          'Compat' =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic awk ruby'
+            },
         },
       # Tested:
       # - CUPS version 1.4.3 on Ubuntu 10.04 (x86)

--- a/modules/exploits/unix/webapp/narcissus_backend_exec.rb
+++ b/modules/exploits/unix/webapp/narcissus_backend_exec.rb
@@ -35,15 +35,15 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'Payload'        =>
         {
-          'BadChars' => "\x00\x0d\x0a"
+          'BadChars' => "\x00\x0d\x0a",
+          'Compat'         =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic perl ruby python netcat netcat-e'
+            },
         },
       'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
-      'Compat'         =>
-        {
-          'PayloadType' => 'cmd',
-          'RequiredCmd' => 'generic perl ruby python netcat netcat-e'
-        },
       'Targets'        =>
         [
           ['Narcissus', {}]


### PR DESCRIPTION
These four modules had `Compat` in the wrong section of the module boilerplate, causing their `RequiredCmd` parameters to be ignored.
