### PR TITLE
Resolve 'duplicate key' warning for some modules

### DIFF
--- a/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
@@ -206,7 +206,6 @@ class Metasploit3 < Msf::Auxiliary
         service_name: 'dvr',
         user: user,
         password: password,
-        service_name: 'http',
         proof: "user_id: #{user_id}, active: #{active}"
       )
     }

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -75,7 +75,6 @@ class Metasploit3 < Msf::Auxiliary
       send_delay: datastore['TCP::send_delay'],
       framework: framework,
       framework_module: self,
-      ssl: datastore['SSL'],
       ssl_version: datastore['SSLVersion'],
       ssl_verify_mode: datastore['SSLVerifyMode'],
       ssl_cipher: datastore['SSLCipher'],

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -85,7 +85,6 @@ class Metasploit3 < Msf::Auxiliary
       smb_native_os: datastore['SMB::Native_OS'],
       smb_native_lm: datastore['SMB::Native_LM'],
       send_spn: datastore['NTLM::SendSPN'],
-      host: ip
     )
 
     bogus_result = @scanner.attempt_bogus_login(domain)

--- a/modules/post/linux/gather/mount_cifs_creds.rb
+++ b/modules/post/linux/gather/mount_cifs_creds.rb
@@ -115,7 +115,6 @@ class Metasploit3 < Msf::Post
       username: opts[:user],
       private_data: opts[:password],
       private_type: :password,
-      module_fullname: fullname,
       session_id: session_db_id,
       post_reference_name: self.refname
     }.merge(service_data)


### PR DESCRIPTION
Before:

```
/home/jhart/rapid7/metasploit-framework/modules/auxiliary/scanner/smb/smb_login.rb:70: warning: duplicated key at line 88 ignored: :host
/home/jhart/rapid7/metasploit-framework/modules/auxiliary/scanner/pop3/pop3_login.rb:70: warning: duplicated key at line 78 ignored: :ssl
/home/jhart/rapid7/metasploit-framework/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb:206: warning: duplicated key at line 209 ignored: :service_name
/home/jhart/rapid7/metasploit-framework/modules/post/linux/gather/mount_cifs_creds.rb:114: warning: duplicated key at line 118 ignored: :module_fullname
```

Afterwards, the warnings are gone.
