### PR TITLE
Add capability to import masscan output to database

### DIFF
--- a/lib/msf/core/auxiliary/masscan.rb
+++ b/lib/msf/core/auxiliary/masscan.rb
@@ -1,0 +1,277 @@
+# -*- coding: binary -*-
+require 'rex/parser/masscan_nokogiri'
+require 'rex/parser/masscan_xml'
+require 'open3'
+
+module Msf
+
+###
+#
+# This module provides methods for interacting with nmap.
+# Modules that include this should define their own nmap_build_args()
+# function, and usually should have some method for dealing with
+# the data yielded from nmap_hosts(). See auxiliary/scanner/oracle/oracle_login
+# for an example implementation.
+#
+###
+
+module Auxiliary::Masscan
+
+attr_accessor :massscan_args, :masscan_bin, :masscan_log
+attr_reader :masscan_pid, :masscan_ver
+
+def initialize(info = {})
+  super
+
+  register_options([
+    OptAddressRange.new('RHOSTS', [ true, "The target address range or CIDR identifier"]),
+    OptBool.new('NMAP_VERBOSE', [ false, 'Display nmap output', true]),
+    OptString.new('RPORTS', [ false, 'Ports to target']), # RPORT supersedes RPORTS
+  ], Auxiliary::Nmap)
+
+  deregister_options("RPORT")
+  @masscan_args = []
+  @masscan_bin = masscan_binary_path
+end
+
+def rports
+  datastore['RPORTS']
+end
+
+def rport
+  datastore['RPORT']
+end
+
+def set_masscan_cmd
+  self.masscan_bin || (raise RuntimeError, "Cannot locate massscan binary")
+  masscan_set_log
+  masscan_add_ports
+  masscan_cmd = [self.nmap_bin]
+  self.masscan_args.unshift("-oX #{self.masscan_log[1]}")
+  masscan_cmd << self.masscan_args.join(" ")
+  masscan_cmd << datastore['RHOSTS']
+  masscan_cmd.join(" ")
+end
+
+def get_masscan_ver
+  self.masscan_bin || (raise RuntimeError, "Cannot locate nmap binary")
+  res = ""
+  masscan_cmd = [self.masscan_bin]
+  masscan_cmd << "--version"
+  res << %x{#{masscan_cmd.join(" ")}} rescue nil
+  res.gsub(/[\x0d\x0a]/n,"")
+end
+
+# Takes a version string in the form of Major.Minor and compares to
+# the found version. It yells at you specifically if you try to
+# compare a float b/c that's going to be a super common error.
+# Comparing an Integer is okay, though.
+def masscan_version_at_least?(test_ver=nil)
+  raise ArgumentError, "Cannot compare a Float, use a String or Integer" if test_ver.kind_of? Float
+  unless test_ver.to_s[/^([0-9]+(\x2e[0-9]+)?)/n]
+    raise ArgumentError, "Bad Nmap comparison version: #{test_ver.inspect}"
+  end
+  test_ver_str = test_ver.to_s
+  tnum_arr = $1.split(/\x2e/n)[0,2].map {|x| x.to_i}
+  installed_ver = get_nmap_ver()
+  vtag = installed_ver.split[2] # Should be ["Nmap", "version", "X.YZTAG", "(", "http..", ")"]
+  return false if (vtag.nil? || vtag.empty?)
+  return false unless (vtag =~ /^([0-9]+\x2e[0-9]+)/n) # Drop the tag.
+  inum_arr = $1.split(/\x2e/n)[0,2].map {|x| x.to_i}
+  return true if inum_arr[0] > tnum_arr[0]
+  return false if inum_arr[0] < tnum_arr[0]
+  inum_arr[1].to_i >= tnum_arr[1].to_i
+end
+
+def masscan_build_args
+  raise RuntimeError, "nmap_build_args() not defined by #{self.refname}"
+end
+
+def masscan_run
+  masscan_cmd = set_masscan_cmd
+  begin
+    masscan_pipe = ::Open3::popen3(masscan_cmd)
+    @masscan_pid = masscan_pipe.last.pid
+    print_status "Masscan: Starting masscan with pid #{@masscan_pid}"
+    temp_masscan_threads = []
+    temp_masscan_threads << framework.threads.spawn("Module(#{self.refname})-MasscanStdout", false, masscan_pipe[1]) do |np_1|
+      np_1.each_line do |masscan_out|
+        next if masscan_out.strip.empty?
+        print_status "Masscan: #{masscan_out.strip}" if datastore['MASSCAN_VERBOSE']
+      end
+    end
+
+    temp_masscan_threads << framework.threads.spawn("Module(#{self.refname})-MasscanStderr", false, masscan_pipe[2]) do |np_2|
+      np_2.each_line do |masscan_err|
+        next if masscan_err.strip.empty?
+        print_status  "Massscan: '#{masscan_err.strip}'"
+      end
+    end
+
+    temp_masscan_threads.map {|t| t.join rescue nil}
+    masscan_pipe.each {|p| p.close rescue nil}
+    if self.masscan_log[0].size.zero?
+      print_error "Masscan Warning: Output file is empty, no useful results can be processed."
+    end
+  rescue ::IOError
+  end
+end
+
+def masscan_binary_path
+  ret = Rex::FileUtils.find_full_path("masscan") || Rex::FileUtils.find_full_path("masscan.exe")
+  if ret
+    fullpath = ::File.expand_path(ret)
+    if fullpath =~ /\s/ # Thanks, "Program Files"
+      return "\"#{fullpath}\""
+    else
+      return fullpath
+    end
+  end
+end
+
+# Returns the [filehandle, pathname], and sets the same
+# to self.masscan_log.
+# Only supports XML format since that's the most useful.
+def masscan_set_log
+  outfile = Rex::Quickfile.new("msf3-masscan-")
+  if Rex::Compat.is_cygwin and self.masscan_bin =~ /cygdrive/i
+    outfile_path = Rex::Compat.cygwin_to_win32(outfile.path)
+  else
+    outfile_path = outfile.path
+  end
+  self.nmap_log = [outfile,outfile_path]
+end
+
+def masscan_show_args
+  print_status self.masscan_args.join(" ")
+end
+
+def masscan_append_arg(str)
+  if masscan_validate_arg(str)
+    self.masscan_args << str
+  end
+end
+
+def masscan_reset_args
+  self.masscan_args = []
+end
+
+# A helper to add in rport or rports as a -p argument
+def masscan_add_ports
+  if not masscan_validate_rports
+    raise RuntimeError, "Cannot continue without a valid port list."
+  end
+  port_arg = "-p \"#{datastore['RPORT'] || rports}\""
+  if masscan_validate_arg(port_arg)
+    self.masscan_args << port_arg
+  else
+    raise RunTimeError, "Argument is invalid"
+  end
+end
+
+# Validates the correctness of ports passed to masscan's -p
+# option. Note that this will not validate named ports (like
+# 'http'), nor will it validate when brackets are specified.
+# The acceptable formats for this is:
+#
+# 80
+# 80-90
+# 22,23
+# U:53,T:80
+# and combinations thereof.
+def massscan_validate_rports
+  # If there's an RPORT specified, use that instead.
+  if datastore['RPORT'] && (datastore['RPORT'].kind_of?(Fixnum) || !datastore['RPORT'].empty?)
+    return true
+  end
+  if rports.nil? || rports.empty?
+    print_error "Missing RPORTS"
+    return false
+  end
+  rports.split(/\s*,\s*/).each do |r|
+    if r =~ /^([TU]:)?[0-9]*-?[0-9]*$/
+      next
+    else
+      print_error "Malformed masscan port: #{r}"
+      return false
+    end
+  end
+  print_status "Using RPORTS range #{datastore['RPORTS']}"
+  return true
+end
+
+# Validates an argument to be passed on the command
+# line to nmap. Most special characters aren't allowed,
+# and commas in arguments are only allowed inside a
+# quoted argument.
+def masscan_validate_arg(str)
+  # Check for existence
+  if str.nil? || str.empty?
+    print_error "Missing nmap argument"
+    return false
+  end
+  # Check for quote balance
+  if !(str.scan(/'/).size % 2).zero? or !(str.scan(/"/).size % 2).zero?
+    print_error "Unbalanced quotes in nmap argument: #{str}"
+    return false
+  end
+  # Check for characters that enable badness
+  disallowed_characters = /([\x00-\x19\x21\x23-\x26\x28\x29\x3b\x3e\x60\x7b\x7c\x7d\x7e-\xff])/n
+  badchar = str[disallowed_characters]
+  if badchar
+    print_error "Malformed nmap arguments (contains '#{badchar}'): #{str}"
+    return false
+  end
+  # Check for commas outside of quoted arguments
+  quoted_22 = /\x22[^\x22]*\x22/n
+  requoted_str = str.gsub(/'/,"\"")
+  if requoted_str.split(quoted_22).join[/,/]
+    print_error "Malformed nmap arguments (unquoted comma): #{str}"
+    return false
+  end
+  return true
+end
+
+# Takes a block, and yields back the host object as discovered
+# by the Rex::Parser::NmapXMLStreamParser. It's up to the
+# module to ferret out whatever's interesting in this host
+# object.
+def masscan_hosts(&block)
+  @masscan_bin || (raise RuntimeError, "Cannot locate the nmap binary.")
+  fh = self.nmap_log[0]
+  nmap_data = fh.read(fh.stat.size)
+  # fh.unlink
+  if Rex::Parser.nokogiri_loaded && framework.db.active
+    wspace = framework.db.find_workspace(datastore['WORKSPACE'])
+    wspace ||= framework.db.workspace
+    import_args = { :data => nmap_data, :wspace => wspace }
+    framework.db.import_masscan_noko_stream(import_args) { |type, data| yield type, data }
+  else
+    nmap_parser = Rex::Parser::NmapXMLStreamParser.new
+    nmap_parser.on_found_host = Proc.new { |h|
+      if (h["addrs"].has_key?("ipv4"))
+        addr = h["addrs"]["ipv4"]
+      elsif (h["addrs"].has_key?("ipv6"))
+        addr = h["addrs"]["ipv6"]
+      else
+        # Can't do much with it if it doesn't have an IP
+        next
+      end
+      yield h
+    }
+    REXML::Document.parse_stream(masscan_data, masscan_parser)
+  end
+end
+
+#Saves the data from the nmap scan to a file in the MSF::Config.local_directory
+def masscan_save()
+  print_status "Masscan: saving masscan log file"
+  fh = self.masscan_log[0]
+  masscan_data = fh.read(fh.stat.size)
+  saved_path = store_local("masscan.scan.xml", "text/xml", masscan_data, "masscan_#{Time.now.utc.to_i}.xml")
+  print_status "Saved Masscan XML results to #{saved_path}"
+end
+
+end
+end
+

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -284,12 +284,12 @@ module Msf::DBManager::Import
           newline = line.dup
           newline =~ /<([a-zA-Z0-9\-\_]+)\sscanner\W\"([a-zA-Z0-9\-\_]+)\"/
           case $2
-            when "nmap"
-              @import_filedata[:type] = "Nmap XML"
-              return :nmap_xml
-            when "masscan"
-              @import_filedata[:type] = "Masscan XML"
-              return :masscan_xml
+          when "nmap"
+            @import_filedata[:type] = "Nmap XML"
+            return :nmap_xml
+          when "masscan"
+            @import_filedata[:type] = "Masscan XML"
+            return :masscan_xml
           end
         when "openvas-report"
           @import_filedata[:type] = "OpenVAS Report"

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -23,6 +23,7 @@ module Msf::DBManager::Import
   autoload :IP360, 'msf/core/db_manager/import/ip360'
   autoload :IPList, 'msf/core/db_manager/import/ip_list'
   autoload :Libpcap, 'msf/core/db_manager/import/libpcap'
+  autoload :Masscan, 'msf/core/db_manager/import/masscan'
   autoload :MBSA, 'msf/core/db_manager/import/mbsa'
   autoload :MetasploitFramework, 'msf/core/db_manager/import/metasploit_framework'
   autoload :Nessus, 'msf/core/db_manager/import/nessus'
@@ -48,6 +49,7 @@ module Msf::DBManager::Import
   include Msf::DBManager::Import::IP360
   include Msf::DBManager::Import::IPList
   include Msf::DBManager::Import::Libpcap
+  include Msf::DBManager::Import::Masscan
   include Msf::DBManager::Import::MBSA
   include Msf::DBManager::Import::MetasploitFramework
   include Msf::DBManager::Import::Nessus
@@ -62,6 +64,7 @@ module Msf::DBManager::Import
   include Msf::DBManager::Import::Retina
   include Msf::DBManager::Import::Spiceworks
   include Msf::DBManager::Import::Wapiti
+
 
   # If hex notation is present, turn them into a character.
   def dehex(str)
@@ -153,6 +156,7 @@ module Msf::DBManager::Import
   # :ip360_xml_v3
   # :ip_list
   # :libpcap
+  # :masscan_xml
   # :mbsa_xml
   # :msf_cred_dump_zip
   # :msf_pwdump
@@ -272,14 +276,21 @@ module Msf::DBManager::Import
       line_count = 0
       data.each_line { |line|
         line =~ /<([a-zA-Z0-9\-\_]+)[ >]/
-
         case $1
         when "niktoscan"
           @import_filedata[:type] = "Nikto XML"
           return :nikto_xml
         when "nmaprun"
-          @import_filedata[:type] = "Nmap XML"
-          return :nmap_xml
+          newline = line.dup
+          newline =~ /<([a-zA-Z0-9\-\_]+)\sscanner\W\"([a-zA-Z0-9\-\_]+)\"/
+          case $2
+            when "nmap"
+              @import_filedata[:type] = "Nmap XML"
+              return :nmap_xml
+            when "masscan"
+              @import_filedata[:type] = "Masscan XML"
+              return :masscan_xml
+          end
         when "openvas-report"
           @import_filedata[:type] = "OpenVAS Report"
           return :openvas_xml

--- a/lib/msf/core/db_manager/import/masscan.rb
+++ b/lib/msf/core/db_manager/import/masscan.rb
@@ -1,0 +1,259 @@
+require 'rex/parser/masscan_nokogiri'
+require 'rex/parser/masscan_xml'
+
+module Msf::DBManager::Import::Masscan
+  def import_masscan_noko_stream(args, &block)
+    if block
+      doc = Rex::Parser::MasscanDocument.new(args,framework.db) {|type, data| yield type,data }
+    else
+      doc = Rex::Parser::MasscanDocument.new(args,self)
+    end
+    parser = ::Nokogiri::XML::SAX::Parser.new(doc)
+    parser.parse(args[:data])
+  end
+
+  # If you have Nokogiri installed, you'll be shunted over to
+  # that. Otherwise, you'll hit the old MasscanXMLStreamParser.
+  def import_masscan_xml(args={}, &block)
+    return nil if args[:data].nil? or args[:data].empty?
+    wspace = args[:wspace] || workspace
+    bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
+
+    if Rex::Parser.nokogiri_loaded
+      noko_args = args.dup
+      noko_args[:blacklist] = bl
+      noko_args[:wspace] = wspace
+      if block
+        yield(:parser, "Nokogiri v#{::Nokogiri::VERSION}")
+        import_masscan_noko_stream(noko_args) {|type, data| yield type,data }
+      else
+        import_masscan_noko_stream(noko_args)
+      end
+      return true
+    end
+
+    # XXX: Legacy masscan xml parser starts here.
+    print "Legacy masscan xml parser\n"
+    fix_services = args[:fix_services]
+    data = args[:data]
+
+    # Use a stream parser instead of a tree parser so we can deal with
+    # huge results files without running out of memory.
+    parser = Rex::Parser::MasscanXMLStreamParser.new
+    yield(:parser, parser.class.name) if block
+
+    # Whenever the parser pulls a host out of the masscan results, store
+    # it, along with any associated services, in the database.
+    parser.on_found_host = Proc.new { |h|
+      hobj = nil
+      data = {:workspace => wspace}
+      if (h["addrs"].has_key?("ipv4"))
+        addr = h["addrs"]["ipv4"]
+      elsif (h["addrs"].has_key?("ipv6"))
+        addr = h["addrs"]["ipv6"]
+      else
+        # Can't report it if it doesn't have an IP
+        raise RuntimeError, "At least one IPv4 or IPv6 address is required"
+      end
+      next if bl.include? addr
+      data[:host] = addr
+      if (h["addrs"].has_key?("mac"))
+        data[:mac] = h["addrs"]["mac"]
+      end
+      data[:state] = (h["status"] == "up") ? Msf::HostState::Alive : Msf::HostState::Dead
+      data[:task] = args[:task]
+
+      if ( h["reverse_dns"] )
+        data[:name] = h["reverse_dns"]
+      end
+
+      # Only report alive hosts with ports to speak of.
+      if(data[:state] != Msf::HostState::Dead)
+        if h["ports"].size > 0
+          if fix_services
+            port_states = h["ports"].map {|p| p["state"]}.reject {|p| p == "filtered"}
+            next if port_states.compact.empty?
+          end
+          yield(:address,data[:host]) if block
+          hobj = report_host(data)
+          report_import_note(wspace,hobj)
+        end
+      end
+
+      if( h["os_vendor"] )
+        note = {
+          :workspace => wspace,
+          :host => hobj || addr,
+          :type => 'host.os.masscan_fingerprint',
+          :task => args[:task],
+          :data => {
+            :os_vendor   => h["os_vendor"],
+            :os_family   => h["os_family"],
+            :os_version  => h["os_version"],
+            :os_accuracy => h["os_accuracy"]
+          }
+        }
+
+        if(h["os_match"])
+          note[:data][:os_match] = h['os_match']
+        end
+
+        report_note(note)
+      end
+
+      if (h["last_boot"])
+        report_note(
+          :workspace => wspace,
+          :host => hobj || addr,
+          :type => 'host.last_boot',
+          :task => args[:task],
+          :data => {
+            :time => h["last_boot"]
+          }
+        )
+      end
+
+      if (h["trace"])
+        hops = []
+        h["trace"]["hops"].each do |hop|
+          hops << {
+            "ttl"     => hop["ttl"].to_i,
+            "address" => hop["ipaddr"].to_s,
+            "rtt"     => hop["rtt"].to_f,
+            "name"    => hop["host"].to_s
+          }
+        end
+        report_note(
+          :workspace => wspace,
+          :host => hobj || addr,
+          :type => 'host.masscan.traceroute',
+          :task => args[:task],
+          :data => {
+            'port'  => h["trace"]["port"].to_i,
+            'proto' => h["trace"]["proto"].to_s,
+            'hops'  => hops
+          }
+        )
+      end
+
+
+      # Put all the ports, regardless of state, into the db.
+      h["ports"].each { |p|
+        # Localhost port results are pretty unreliable -- if it's
+        # unknown, it's no good (possibly Windows-only)
+        if (
+          p["state"] == "unknown" &&
+          h["status_reason"] == "localhost-response"
+        )
+          next
+        end
+        extra = ""
+        extra << p["product"]   + " " if p["product"]
+        extra << p["version"]   + " " if p["version"]
+        extra << p["extrainfo"] + " " if p["extrainfo"]
+
+        data = {}
+        data[:workspace] = wspace
+        if fix_services
+          data[:proto] = masscan_msf_service_map(p["protocol"])
+        else
+          data[:proto] = p["protocol"].downcase
+        end
+        data[:port]  = p["portid"].to_i
+        data[:state] = p["state"]
+        data[:host]  = hobj || addr
+        data[:info]  = extra if not extra.empty?
+        data[:task]  = args[:task]
+        data[:name]  = p['tunnel'] ? "#{p['tunnel']}/#{p['name'] || 'unknown'}" : p['name']
+        report_service(data)
+      }
+      #Parse the scripts output
+      if h["scripts"]
+        h["scripts"].each do |key,val|
+          if key == "smb-check-vulns"
+            if val =~ /MS08-067: VULNERABLE/
+              vuln_info = {
+                :workspace => wspace,
+                :task => args[:task],
+                :host =>  hobj || addr,
+                :port => 445,
+                :proto => 'tcp',
+                :name => 'MS08-067',
+                :info => 'Microsoft Windows Server Service Crafted RPC Request Handling Unspecified Remote Code Execution',
+                :refs =>['CVE-2008-4250',
+                  'BID-31874',
+                  'OSVDB-49243',
+                  'CWE-94',
+                  'MSFT-MS08-067',
+                  'MSF-Microsoft Server Service Relative Path Stack Corruption',
+                  'NSS-34476']
+              }
+              report_vuln(vuln_info)
+            end
+            if val =~ /MS06-025: VULNERABLE/
+              vuln_info = {
+                :workspace => wspace,
+                :task => args[:task],
+                :host =>  hobj || addr,
+                :port => 445,
+                :proto => 'tcp',
+                :name => 'MS06-025',
+                :info => 'Vulnerability in Routing and Remote Access Could Allow Remote Code Execution',
+                :refs =>['CVE-2006-2370',
+                  'CVE-2006-2371',
+                  'BID-18325',
+                  'BID-18358',
+                  'BID-18424',
+                  'OSVDB-26436',
+                  'OSVDB-26437',
+                  'MSFT-MS06-025',
+                  'MSF-Microsoft RRAS Service RASMAN Registry Overflow',
+                  'NSS-21689']
+              }
+              report_vuln(vuln_info)
+            end
+            # This one has NOT been  Tested , remove this comment if confirmed working
+            if val =~ /MS07-029: VULNERABLE/
+              vuln_info = {
+                :workspace => wspace,
+                :task => args[:task],
+                :host =>  hobj || addr,
+                :port => 445,
+                :proto => 'tcp',
+                :name => 'MS07-029',
+                :info => 'Vulnerability in Windows DNS RPC Interface Could Allow Remote Code Execution',
+                # Add more refs based on nessus/nexpose .. results
+                :refs =>['CVE-2007-1748',
+                  'OSVDB-34100',
+                  'MSF-Microsoft DNS RPC Service extractQuotedChar()',
+                  'NSS-25168']
+              }
+              report_vuln(vuln_info)
+            end
+          end
+        end
+      end
+    }
+
+    # XXX: Legacy masscan xml parser ends here.
+
+    REXML::Document.parse_stream(data, parser)
+  end
+
+  #
+  # Import Masscan's -oX xml output
+  #
+  def import_masscan_xml_file(args={})
+    filename = args[:filename]
+    wspace = args[:wspace] || workspace
+    data = ""
+    ::File.open(filename, 'rb') do |f|
+      data = f.read(f.stat.size)
+    end
+    import_masscan_xml(args.merge(:data => data))
+  end
+
+  def masscan_msf_service_map(proto)
+    service_name_map(proto)
+  end
+end

--- a/lib/msf/core/db_manager/import/masscan.rb
+++ b/lib/msf/core/db_manager/import/masscan.rb
@@ -18,7 +18,6 @@ module Msf::DBManager::Import::Masscan
     return nil if args[:data].nil? or args[:data].empty?
     wspace = args[:wspace] || workspace
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
-
     if Rex::Parser.nokogiri_loaded
       noko_args = args.dup
       noko_args[:blacklist] = bl
@@ -31,12 +30,8 @@ module Msf::DBManager::Import::Masscan
       end
       return true
     end
-
     # XXX: Legacy masscan xml parser starts here.
-    print "Legacy masscan xml parser\n"
-    fix_services = args[:fix_services]
     data = args[:data]
-
     # Use a stream parser instead of a tree parser so we can deal with
     # huge results files without running out of memory.
     parser = Rex::Parser::MasscanXMLStreamParser.new
@@ -57,85 +52,17 @@ module Msf::DBManager::Import::Masscan
       end
       next if bl.include? addr
       data[:host] = addr
-      if (h["addrs"].has_key?("mac"))
-        data[:mac] = h["addrs"]["mac"]
-      end
-      data[:state] = (h["status"] == "up") ? Msf::HostState::Alive : Msf::HostState::Dead
-      data[:task] = args[:task]
-
-      if ( h["reverse_dns"] )
-        data[:name] = h["reverse_dns"]
-      end
-
+      # Masscan only reports hosts that are alive
+      data[:state] = Msf::HostState::Alive
+      #data[:task] = args[:task]
       # Only report alive hosts with ports to speak of.
       if(data[:state] != Msf::HostState::Dead)
         if h["ports"].size > 0
-          if fix_services
-            port_states = h["ports"].map {|p| p["state"]}.reject {|p| p == "filtered"}
-            next if port_states.compact.empty?
-          end
           yield(:address,data[:host]) if block
           hobj = report_host(data)
           report_import_note(wspace,hobj)
         end
       end
-
-      if( h["os_vendor"] )
-        note = {
-          :workspace => wspace,
-          :host => hobj || addr,
-          :type => 'host.os.masscan_fingerprint',
-          :task => args[:task],
-          :data => {
-            :os_vendor   => h["os_vendor"],
-            :os_family   => h["os_family"],
-            :os_version  => h["os_version"],
-            :os_accuracy => h["os_accuracy"]
-          }
-        }
-
-        if(h["os_match"])
-          note[:data][:os_match] = h['os_match']
-        end
-
-        report_note(note)
-      end
-
-      if (h["last_boot"])
-        report_note(
-          :workspace => wspace,
-          :host => hobj || addr,
-          :type => 'host.last_boot',
-          :task => args[:task],
-          :data => {
-            :time => h["last_boot"]
-          }
-        )
-      end
-
-      if (h["trace"])
-        hops = []
-        h["trace"]["hops"].each do |hop|
-          hops << {
-            "ttl"     => hop["ttl"].to_i,
-            "address" => hop["ipaddr"].to_s,
-            "rtt"     => hop["rtt"].to_f,
-            "name"    => hop["host"].to_s
-          }
-        end
-        report_note(
-          :workspace => wspace,
-          :host => hobj || addr,
-          :type => 'host.masscan.traceroute',
-          :task => args[:task],
-          :data => {
-            'port'  => h["trace"]["port"].to_i,
-            'proto' => h["trace"]["proto"].to_s,
-            'hops'  => hops
-          }
-        )
-      end
-
 
       # Put all the ports, regardless of state, into the db.
       h["ports"].each { |p|
@@ -147,92 +74,15 @@ module Msf::DBManager::Import::Masscan
         )
           next
         end
-        extra = ""
-        extra << p["product"]   + " " if p["product"]
-        extra << p["version"]   + " " if p["version"]
-        extra << p["extrainfo"] + " " if p["extrainfo"]
 
         data = {}
         data[:workspace] = wspace
-        if fix_services
-          data[:proto] = masscan_msf_service_map(p["protocol"])
-        else
-          data[:proto] = p["protocol"].downcase
-        end
         data[:port]  = p["portid"].to_i
         data[:state] = p["state"]
         data[:host]  = hobj || addr
-        data[:info]  = extra if not extra.empty?
-        data[:task]  = args[:task]
-        data[:name]  = p['tunnel'] ? "#{p['tunnel']}/#{p['name'] || 'unknown'}" : p['name']
+        #data[:task]  = args[:task]
         report_service(data)
       }
-      #Parse the scripts output
-      if h["scripts"]
-        h["scripts"].each do |key,val|
-          if key == "smb-check-vulns"
-            if val =~ /MS08-067: VULNERABLE/
-              vuln_info = {
-                :workspace => wspace,
-                :task => args[:task],
-                :host =>  hobj || addr,
-                :port => 445,
-                :proto => 'tcp',
-                :name => 'MS08-067',
-                :info => 'Microsoft Windows Server Service Crafted RPC Request Handling Unspecified Remote Code Execution',
-                :refs =>['CVE-2008-4250',
-                  'BID-31874',
-                  'OSVDB-49243',
-                  'CWE-94',
-                  'MSFT-MS08-067',
-                  'MSF-Microsoft Server Service Relative Path Stack Corruption',
-                  'NSS-34476']
-              }
-              report_vuln(vuln_info)
-            end
-            if val =~ /MS06-025: VULNERABLE/
-              vuln_info = {
-                :workspace => wspace,
-                :task => args[:task],
-                :host =>  hobj || addr,
-                :port => 445,
-                :proto => 'tcp',
-                :name => 'MS06-025',
-                :info => 'Vulnerability in Routing and Remote Access Could Allow Remote Code Execution',
-                :refs =>['CVE-2006-2370',
-                  'CVE-2006-2371',
-                  'BID-18325',
-                  'BID-18358',
-                  'BID-18424',
-                  'OSVDB-26436',
-                  'OSVDB-26437',
-                  'MSFT-MS06-025',
-                  'MSF-Microsoft RRAS Service RASMAN Registry Overflow',
-                  'NSS-21689']
-              }
-              report_vuln(vuln_info)
-            end
-            # This one has NOT been  Tested , remove this comment if confirmed working
-            if val =~ /MS07-029: VULNERABLE/
-              vuln_info = {
-                :workspace => wspace,
-                :task => args[:task],
-                :host =>  hobj || addr,
-                :port => 445,
-                :proto => 'tcp',
-                :name => 'MS07-029',
-                :info => 'Vulnerability in Windows DNS RPC Interface Could Allow Remote Code Execution',
-                # Add more refs based on nessus/nexpose .. results
-                :refs =>['CVE-2007-1748',
-                  'OSVDB-34100',
-                  'MSF-Microsoft DNS RPC Service extractQuotedChar()',
-                  'NSS-25168']
-              }
-              report_vuln(vuln_info)
-            end
-          end
-        end
-      end
     }
 
     # XXX: Legacy masscan xml parser ends here.

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1704,7 +1704,7 @@ class Db
         begin
           warnings = 0
           framework.db.import_file(:filename => filename) do |type,data|
-	    case type
+            case type
             when :debug
               print_error("DEBUG: #{data.inspect}")
             when :vuln
@@ -1821,8 +1821,6 @@ class Db
   # Import Masscan data from a file
   #
   def cmd_db_masscan(*args)
-
-    print "command_dispatcher/db.rb def cmd_db_masscan\n"
     return unless active?
   ::ActiveRecord::Base.connection_pool.with_connection {
     if (args.length == 0)
@@ -1855,15 +1853,13 @@ class Db
 
     begin
       # When executing native Masscan in Cygwin, expand the Cygwin path to a Win32 path
-      if(Rex::Compat.is_cygwin and masscan =~ /cygdrive/)
+      if (Rex::Compat.is_cygwin and masscan =~ /cygdrive/)
         # Custom function needed because cygpath breaks on 8.3 dirs
         tout = Rex::Compat.cygwin_to_win32(fd.path)
         arguments.push('-oX', tout)
       else
         arguments.push('-oX', fd.path)
       end
-
-      print "inside cmd_db_masscan arguments push\n"
       begin
         masscan_pipe = ::Open3::popen3([masscan, 'masscan'], *arguments)
         temp_masscan_threads = []
@@ -1881,16 +1877,16 @@ class Db
           end
         end
 
-        temp_masscan_threads.map {|t| t.join rescue nil}
-        masscan_pipe.each {|p| p.close rescue nil}
+        temp_masscan_threads.map { |t| t.join rescue nil }
+        masscan_pipe.each { |p| p.close rescue nil }
       rescue ::IOError
       end
       framework.db.import_masscan_xml_file(:filename => fd.path)
 
       print_status("Saved Masscan XML results to #{fd.path}") if save
-    #ensure
-      #fd.close
-      #fd.unlink unless save
+    ensure
+      fd.close
+      fd.unlink unless save
     end
   }
   end

--- a/lib/rex/parser/masscan_nokogiri.rb
+++ b/lib/rex/parser/masscan_nokogiri.rb
@@ -1,0 +1,395 @@
+# -*- coding: binary -*-
+require "rex/parser/nokogiri_doc_mixin"
+
+module Rex
+  module Parser
+
+    # If Nokogiri is available, define Masscan document class.
+    load_nokogiri && class MasscanDocument < Nokogiri::XML::SAX::Document
+
+    include NokogiriDocMixin
+
+    def determine_port_state(v)
+      case v
+      when "open"
+        Msf::ServiceState::Open
+      when "closed"
+        Msf::ServiceState::Closed
+      when "filtered"
+        Msf::ServiceState::Filtered
+      else
+        Msf::ServiceState::Unknown
+      end
+    end
+
+    # Compare OS fingerprinting data
+    def better_os_match(orig_hash,new_hash)
+      return false unless new_hash.has_key? "accuracy"
+      return true unless orig_hash.has_key? "accuracy"
+      new_hash["accuracy"].to_i > orig_hash["accuracy"].to_i
+    end
+
+    # Triggered every time a new element is encountered. We keep state
+    # ourselves with the @state variable, turning things on when we
+    # get here (and turning things off when we exit in end_element()).
+    def start_element(name=nil,attrs=[])
+      attrs = normalize_attrs(attrs)
+      block = @block
+      @state[:current_tag][name] = true
+      case name
+      when "state"
+        record_host_status(attrs)
+      when "address"
+        record_address(attrs)
+      when "osclass"
+        record_host_osclass(attrs)
+      when "osmatch"
+        record_host_osmatch(attrs)
+      when "uptime"
+        record_host_uptime(attrs)
+      when "hostname"
+        record_hostname(attrs)
+      when "port"
+        record_port(attrs)
+      when "state"
+        record_port_state(attrs)
+      when "service"
+        record_port_service(attrs)
+      when "script" # Not actually used in import?
+        record_port_script(attrs)
+        record_host_script(attrs)
+        # Ignoring post scripts completely
+      when "trace"
+        record_host_trace(attrs)
+      when "hop"
+        record_host_hop(attrs)
+      end
+    end
+
+    # When we exit a tag, this is triggered.
+    def end_element(name=nil)
+      block = @block
+      case name
+      when "os"
+        collect_os_data
+        @state[:os] = {}
+      when "port"
+        collect_port_data
+        @state[:port] = {}
+      when "host" # Roll everything up now
+        collect_host_data
+        host_object = report_host &block
+        if host_object
+          db.report_import_note(@args[:wspace],host_object)
+          report_services(host_object,&block)
+          report_fingerprint(host_object)
+          report_uptime(host_object)
+          report_traceroute(host_object)
+        end
+        @state.delete_if {|k| k != :current_tag}
+        @report_data = {:wspace => @args[:wspace]}
+      end
+      @state[:current_tag].delete name
+    end
+
+    # We can certainly get fancier with self.send() magic, but
+    # leaving this pretty simple for now.
+
+    def record_host_hop(attrs)
+      return unless in_tag("host")
+      return unless in_tag("trace")
+      hops = attr_hash(attrs)
+      hops["name"] = hops.delete "host"
+      @state[:trace][:hops] << hops
+    end
+
+    def record_host_trace(attrs)
+      return unless in_tag("host")
+      @state[:trace] = attr_hash(attrs)
+      @state[:trace][:hops] = []
+    end
+
+    def record_host_uptime(attrs)
+      return unless in_tag("host")
+      @state[:uptime] = attr_hash(attrs)
+    end
+
+    def record_host_osmatch(attrs)
+      return unless in_tag("host")
+      return unless in_tag("os")
+      temp_hash = attr_hash(attrs)
+      if temp_hash["accuracy"].to_i == 100
+        @state[:os] ||= {}
+        @state[:os]["osmatch"] = temp_hash["name"]
+      end
+    end
+
+    def record_host_osclass(attrs)
+      return unless in_tag("host")
+      return unless in_tag("os")
+      @state[:os] ||= {}
+      temp_hash = attr_hash(attrs)
+      if better_os_match(@state[:os],temp_hash)
+        @state[:os] = temp_hash
+      end
+    end
+
+    def record_hostname(attrs)
+      return unless in_tag("host")
+      if attr_hash(attrs)["type"] == "PTR"
+        @state[:hostname] = attr_hash(attrs)["name"]
+      end
+    end
+
+    def record_host_script(attrs)
+      return unless in_tag("host")
+      return if in_tag("port")
+      temp_hash = attr_hash(attrs)
+
+      if temp_hash["id"] and temp_hash["output"]
+        @state[:scripts] ||= []
+        @state[:scripts] << { temp_hash["id"] => temp_hash["output"] }
+      end
+    end
+
+    def record_port_script(attrs)
+      return unless in_tag("host")
+      return unless in_tag("port")
+      temp_hash = attr_hash(attrs)
+      if temp_hash["id"] and temp_hash["output"]
+        @state[:port][:scripts] ||= []
+        @state[:port][:scripts] << { temp_hash["id"] => temp_hash["output"] }
+      end
+    end
+
+    def record_port_service(attrs)
+      return unless in_tag("host")
+      return unless in_tag("port")
+      svc = attr_hash(attrs)
+      if svc["name"] && @args[:fix_services]
+        svc["name"] = db.masscan_msf_service_map(svc["name"])
+      end
+      @state[:port] = @state[:port].merge(svc)
+    end
+
+    def record_port_state(attrs)
+      return unless in_tag("host")
+      return unless in_tag("port")
+      temp_hash = attr_hash(attrs)
+      @state[:port] = @state[:port].merge(temp_hash)
+    end
+
+    def record_port(attrs)
+      return unless in_tag("host")
+      @state[:port] ||= {}
+      svc = attr_hash(attrs)
+      @state[:port] = @state[:port].merge(svc)
+    end
+
+    def record_host_status(attrs)
+      return unless in_tag("host")
+      attrs.each do |k,v|
+        next unless k == "state"
+        @state[:host_alive] = (v == "open")
+      end
+    end
+
+    def record_address(attrs)
+      return unless in_tag("host")
+      @state[:addresses] ||= {}
+      address = nil
+      type = nil
+      attrs.each do |k,v|
+        if k == "addr"
+          address = v
+        elsif k == "addrtype"
+          type = v
+        end
+      end
+      @state[:addresses][type] = address
+    end
+
+    def collect_os_data
+      return unless in_tag("host")
+      if @state[:os]
+        @report_data[:os_fingerprint] = {
+          :type => "host.os.masscan_fingerprint",
+          :data => {
+            :os_vendor => @state[:os]["vendor"],
+            :os_family => @state[:os]["osfamily"],
+            :os_version => @state[:os]["osgen"],
+            :os_accuracy => @state[:os]["accuracy"].to_i
+          }
+        }
+        if @state[:os].has_key? "osmatch"
+          @report_data[:os_fingerprint][:data][:os_match] = @state[:os]["osmatch"]
+        end
+      end
+    end
+
+    def collect_host_data
+      if @state[:host_alive]
+        @report_data[:state] = Msf::HostState::Alive
+      else
+        @report_data[:state] = Msf::HostState::Dead
+      end
+      if @state[:addresses]
+        if @state[:addresses].has_key? "ipv4"
+          @report_data[:host] = @state[:addresses]["ipv4"]
+        elsif @state[:addresses].has_key? "ipv6"
+          @report_data[:host] = @state[:addresses]["ipv6"]
+        end
+      end
+      if @state[:addresses] and @state[:addresses].has_key?("mac")
+        @report_data[:mac] = @state[:addresses]["mac"]
+      end
+      if @state[:hostname]
+        @report_data[:name] = @state[:hostname]
+      end
+      if @state[:uptime]
+        @report_data[:last_boot] = @state[:uptime]["lastboot"]
+      end
+      if @state[:trace] and @state[:trace].has_key?(:hops)
+        @report_data[:traceroute] = @state[:trace]
+      end
+      if @state[:scripts]
+        @report_data[:scripts] = @state[:scripts]
+      end
+    end
+
+    def collect_port_data
+      return unless in_tag("host")
+      if @args[:fix_services]
+        if @state[:port]["state"] == "filtered"
+          return
+        end
+      end
+      @report_data[:ports] ||= []
+      port_hash = {}
+      extra = []
+      @state[:port].each do |k,v|
+        case k
+        when "protocol"
+          port_hash[:proto] = v
+        when "portid"
+          port_hash[:port] = v
+        when "state"
+          port_hash[:state] = determine_port_state(v)
+        when "name"
+          port_hash[:name] = v
+        when "tunnel"
+          port_hash[:name] = "#{v}/#{port_hash[:name] || 'unknown'}"
+        when "reason"
+          port_hash[:reason] = v
+        when "product"
+          extra[0] = v
+        when "version"
+          extra[1] = v
+        when "extrainfo"
+          extra[2] = v
+        when :scripts
+          port_hash[:scripts] = v
+        end
+      end
+      port_hash[:info] = extra.compact.join(" ") unless extra.empty?
+      # Skip localhost port results when they're unknown
+      if( port_hash[:reason] == "localhost-response" &&
+          port_hash[:state] == Msf::ServiceState::Unknown )
+        @report_data[:ports]
+      else
+        @report_data[:ports] << port_hash
+      end
+    end
+
+    def report_traceroute(host_object)
+      return unless host_object.kind_of? ::Mdm::Host
+      return unless @report_data[:traceroute]
+      tr_note = {
+        :workspace => host_object.workspace,
+        :host => host_object,
+        :type => "host.masscan.traceroute",
+        :data => { 'port' => @report_data[:traceroute]["port"].to_i,
+          'proto' => @report_data[:traceroute]["proto"].to_s,
+          'hops' => @report_data[:traceroute][:hops] }
+      }
+      db_report(:note, tr_note)
+    end
+
+    def report_uptime(host_object)
+      return unless host_object.kind_of? ::Mdm::Host
+      return unless @report_data[:last_boot]
+      up_note = {
+        :workspace => host_object.workspace,
+        :host => host_object,
+        :type => "host.last_boot",
+        :data => { :time => @report_data[:last_boot] }
+      }
+      db_report(:note, up_note)
+    end
+
+    def report_fingerprint(host_object)
+      return unless host_object.kind_of? ::Mdm::Host
+      return unless @report_data[:os_fingerprint]
+      fp_note = @report_data[:os_fingerprint].merge(
+        {
+        :workspace => host_object.workspace,
+        :host => host_object
+      })
+      db_report(:note, fp_note)
+    end
+
+    def report_host(&block)
+      if host_is_okay
+        scripts = @report_data.delete(:scripts) || []
+        host_object = db_report(:host, @report_data.merge( :workspace => @args[:wspace] ) )
+        db.emit(:address,@report_data[:host],&block) if block
+
+        scripts.each do |script|
+          script.each_pair do |k,v|
+            ntype =
+            nse_note = {
+              :workspace => host_object.workspace,
+              :host => host_object,
+              :type => "masscan.nse.#{k}.host",
+              :data => { 'output' => v },
+              :update => :unique_data
+            }
+            db_report(:note, nse_note)
+          end
+        end
+        host_object
+      end
+    end
+
+    def report_services(host_object,&block)
+      return unless host_object.kind_of? ::Mdm::Host
+      return unless @report_data[:ports]
+      return if @report_data[:ports].empty?
+      reported = []
+      @report_data[:ports].each do |svc|
+        scripts = svc.delete(:scripts) || []
+        svc_obj = db_report(:service, svc.merge(:host => host_object))
+        scripts.each do |script|
+          script.each_pair do |k,v|
+            ntype =
+            nse_note = {
+              :workspace => host_object.workspace,
+              :host => host_object,
+              :service => svc_obj,
+              :type => "masscan.nse.#{k}." + (svc[:proto] || "tcp") +".#{svc[:port]}",
+              :data => { 'output' => v },
+              :update => :unique_data
+            }
+            db_report(:note, nse_note)
+          end
+        end
+        reported << svc_obj
+      end
+      reported
+    end
+
+  end
+
+end
+end
+

--- a/lib/rex/parser/masscan_nokogiri.rb
+++ b/lib/rex/parser/masscan_nokogiri.rb
@@ -21,13 +21,6 @@ module Rex
       end
     end
 
-    # Compare OS fingerprinting data
-    def better_os_match(orig_hash,new_hash)
-      return false unless new_hash.has_key? "accuracy"
-      return true unless orig_hash.has_key? "accuracy"
-      new_hash["accuracy"].to_i > orig_hash["accuracy"].to_i
-    end
-
     # Triggered every time a new element is encountered. We keep state
     # ourselves with the @state variable, turning things on when we
     # get here (and turning things off when we exit in end_element()).
@@ -36,32 +29,14 @@ module Rex
       block = @block
       @state[:current_tag][name] = true
       case name
-      when "state"
-        record_host_status(attrs)
       when "address"
         record_address(attrs)
-      when "osclass"
-        record_host_osclass(attrs)
-      when "osmatch"
-        record_host_osmatch(attrs)
-      when "uptime"
-        record_host_uptime(attrs)
-      when "hostname"
-        record_hostname(attrs)
       when "port"
         record_port(attrs)
       when "state"
+        # record host stats as up, masscan only includes active hosts
+        record_host_status(attrs)
         record_port_state(attrs)
-      when "service"
-        record_port_service(attrs)
-      when "script" # Not actually used in import?
-        record_port_script(attrs)
-        record_host_script(attrs)
-        # Ignoring post scripts completely
-      when "trace"
-        record_host_trace(attrs)
-      when "hop"
-        record_host_hop(attrs)
       end
     end
 
@@ -69,9 +44,6 @@ module Rex
     def end_element(name=nil)
       block = @block
       case name
-      when "os"
-        collect_os_data
-        @state[:os] = {}
       when "port"
         collect_port_data
         @state[:port] = {}
@@ -81,94 +53,11 @@ module Rex
         if host_object
           db.report_import_note(@args[:wspace],host_object)
           report_services(host_object,&block)
-          report_fingerprint(host_object)
-          report_uptime(host_object)
-          report_traceroute(host_object)
         end
         @state.delete_if {|k| k != :current_tag}
         @report_data = {:wspace => @args[:wspace]}
       end
       @state[:current_tag].delete name
-    end
-
-    # We can certainly get fancier with self.send() magic, but
-    # leaving this pretty simple for now.
-
-    def record_host_hop(attrs)
-      return unless in_tag("host")
-      return unless in_tag("trace")
-      hops = attr_hash(attrs)
-      hops["name"] = hops.delete "host"
-      @state[:trace][:hops] << hops
-    end
-
-    def record_host_trace(attrs)
-      return unless in_tag("host")
-      @state[:trace] = attr_hash(attrs)
-      @state[:trace][:hops] = []
-    end
-
-    def record_host_uptime(attrs)
-      return unless in_tag("host")
-      @state[:uptime] = attr_hash(attrs)
-    end
-
-    def record_host_osmatch(attrs)
-      return unless in_tag("host")
-      return unless in_tag("os")
-      temp_hash = attr_hash(attrs)
-      if temp_hash["accuracy"].to_i == 100
-        @state[:os] ||= {}
-        @state[:os]["osmatch"] = temp_hash["name"]
-      end
-    end
-
-    def record_host_osclass(attrs)
-      return unless in_tag("host")
-      return unless in_tag("os")
-      @state[:os] ||= {}
-      temp_hash = attr_hash(attrs)
-      if better_os_match(@state[:os],temp_hash)
-        @state[:os] = temp_hash
-      end
-    end
-
-    def record_hostname(attrs)
-      return unless in_tag("host")
-      if attr_hash(attrs)["type"] == "PTR"
-        @state[:hostname] = attr_hash(attrs)["name"]
-      end
-    end
-
-    def record_host_script(attrs)
-      return unless in_tag("host")
-      return if in_tag("port")
-      temp_hash = attr_hash(attrs)
-
-      if temp_hash["id"] and temp_hash["output"]
-        @state[:scripts] ||= []
-        @state[:scripts] << { temp_hash["id"] => temp_hash["output"] }
-      end
-    end
-
-    def record_port_script(attrs)
-      return unless in_tag("host")
-      return unless in_tag("port")
-      temp_hash = attr_hash(attrs)
-      if temp_hash["id"] and temp_hash["output"]
-        @state[:port][:scripts] ||= []
-        @state[:port][:scripts] << { temp_hash["id"] => temp_hash["output"] }
-      end
-    end
-
-    def record_port_service(attrs)
-      return unless in_tag("host")
-      return unless in_tag("port")
-      svc = attr_hash(attrs)
-      if svc["name"] && @args[:fix_services]
-        svc["name"] = db.masscan_msf_service_map(svc["name"])
-      end
-      @state[:port] = @state[:port].merge(svc)
     end
 
     def record_port_state(attrs)
@@ -187,10 +76,7 @@ module Rex
 
     def record_host_status(attrs)
       return unless in_tag("host")
-      attrs.each do |k,v|
-        next unless k == "state"
-        @state[:host_alive] = (v == "open")
-      end
+      @state[:host_alive] = TRUE
     end
 
     def record_address(attrs)
@@ -207,25 +93,7 @@ module Rex
       end
       @state[:addresses][type] = address
     end
-
-    def collect_os_data
-      return unless in_tag("host")
-      if @state[:os]
-        @report_data[:os_fingerprint] = {
-          :type => "host.os.masscan_fingerprint",
-          :data => {
-            :os_vendor => @state[:os]["vendor"],
-            :os_family => @state[:os]["osfamily"],
-            :os_version => @state[:os]["osgen"],
-            :os_accuracy => @state[:os]["accuracy"].to_i
-          }
-        }
-        if @state[:os].has_key? "osmatch"
-          @report_data[:os_fingerprint][:data][:os_match] = @state[:os]["osmatch"]
-        end
-      end
-    end
-
+    
     def collect_host_data
       if @state[:host_alive]
         @report_data[:state] = Msf::HostState::Alive
@@ -239,30 +107,11 @@ module Rex
           @report_data[:host] = @state[:addresses]["ipv6"]
         end
       end
-      if @state[:addresses] and @state[:addresses].has_key?("mac")
-        @report_data[:mac] = @state[:addresses]["mac"]
-      end
-      if @state[:hostname]
-        @report_data[:name] = @state[:hostname]
-      end
-      if @state[:uptime]
-        @report_data[:last_boot] = @state[:uptime]["lastboot"]
-      end
-      if @state[:trace] and @state[:trace].has_key?(:hops)
-        @report_data[:traceroute] = @state[:trace]
-      end
-      if @state[:scripts]
-        @report_data[:scripts] = @state[:scripts]
-      end
     end
 
     def collect_port_data
-      return unless in_tag("host")
-      if @args[:fix_services]
-        if @state[:port]["state"] == "filtered"
-          return
-        end
-      end
+      # masscan port data in tag port
+      return unless in_tag("port")
       @report_data[:ports] ||= []
       port_hash = {}
       extra = []
@@ -274,23 +123,10 @@ module Rex
           port_hash[:port] = v
         when "state"
           port_hash[:state] = determine_port_state(v)
-        when "name"
-          port_hash[:name] = v
-        when "tunnel"
-          port_hash[:name] = "#{v}/#{port_hash[:name] || 'unknown'}"
         when "reason"
           port_hash[:reason] = v
-        when "product"
-          extra[0] = v
-        when "version"
-          extra[1] = v
-        when "extrainfo"
-          extra[2] = v
-        when :scripts
-          port_hash[:scripts] = v
         end
       end
-      port_hash[:info] = extra.compact.join(" ") unless extra.empty?
       # Skip localhost port results when they're unknown
       if( port_hash[:reason] == "localhost-response" &&
           port_hash[:state] == Msf::ServiceState::Unknown )
@@ -299,44 +135,6 @@ module Rex
         @report_data[:ports] << port_hash
       end
     end
-
-    def report_traceroute(host_object)
-      return unless host_object.kind_of? ::Mdm::Host
-      return unless @report_data[:traceroute]
-      tr_note = {
-        :workspace => host_object.workspace,
-        :host => host_object,
-        :type => "host.masscan.traceroute",
-        :data => { 'port' => @report_data[:traceroute]["port"].to_i,
-          'proto' => @report_data[:traceroute]["proto"].to_s,
-          'hops' => @report_data[:traceroute][:hops] }
-      }
-      db_report(:note, tr_note)
-    end
-
-    def report_uptime(host_object)
-      return unless host_object.kind_of? ::Mdm::Host
-      return unless @report_data[:last_boot]
-      up_note = {
-        :workspace => host_object.workspace,
-        :host => host_object,
-        :type => "host.last_boot",
-        :data => { :time => @report_data[:last_boot] }
-      }
-      db_report(:note, up_note)
-    end
-
-    def report_fingerprint(host_object)
-      return unless host_object.kind_of? ::Mdm::Host
-      return unless @report_data[:os_fingerprint]
-      fp_note = @report_data[:os_fingerprint].merge(
-        {
-        :workspace => host_object.workspace,
-        :host => host_object
-      })
-      db_report(:note, fp_note)
-    end
-
     def report_host(&block)
       if host_is_okay
         scripts = @report_data.delete(:scripts) || []

--- a/lib/rex/parser/masscan_nokogiri.rb
+++ b/lib/rex/parser/masscan_nokogiri.rb
@@ -3,7 +3,6 @@ require "rex/parser/nokogiri_doc_mixin"
 
 module Rex
   module Parser
-
     # If Nokogiri is available, define Masscan document class.
     load_nokogiri && class MasscanDocument < Nokogiri::XML::SAX::Document
 

--- a/lib/rex/parser/masscan_xml.rb
+++ b/lib/rex/parser/masscan_xml.rb
@@ -1,0 +1,166 @@
+# -*- coding: binary -*-
+
+require 'rexml/document'
+
+module Rex
+module Parser
+
+#
+# Stream parser for masscan -oX xml output
+#
+# Yields a hash representing each host found in the xml stream.  Each host
+# will look something like the following:
+#	{
+#		"status" => "up",
+#		"addrs"  => { "ipv4" => "192.168.0.1", "mac" => "00:0d:87:a1:df:72" },
+#		"ports"  => [
+#			{ "portid" => "22", "state" => "closed", ... },
+#			{ "portid" => "80", "state" => "open", ... },
+#			...
+#		]
+#	}
+#
+# Usage:
+#   parser = MasscanXMLStreamParser.new { |host|
+#     # do stuff with the host
+#   }
+#   REXML::Document.parse_stream(File.new(masscan_xml), parser)
+# -- or --
+#   parser = MasscanXMLStreamParser.new
+#   parser.on_found_host = Proc.new { |host|
+#     # do stuff with the host
+#   }
+#   REXML::Document.parse_stream(File.new(masscan_xml), parser)
+#
+# This parser does not maintain state as well as a tree parser, so malformed
+# xml will trip it up.  Masscan shouldn't ever output malformed xml, so it's not
+# a big deal.
+#
+class MasscanXMLStreamParser
+
+  #
+  # Callback for processing each found host
+  #
+  attr_accessor :on_found_host
+
+  #
+  # Create a new stream parser for Masscan XML output
+  #
+  # If given a block, it will be stored in +on_found_host+, otherwise you
+  # need to set it explicitly, e.g.:
+  #   parser = MasscanXMLStreamParser.new
+  #   parser.on_found_host = Proc.new { |host|
+  #     # do stuff with the host
+  #   }
+  #   REXML::Document.parse_stream(File.new(masscan_xml), parser)
+  #
+  def initialize(&block)
+    reset_state
+    on_found_host = block if block
+  end
+
+  def reset_state
+    @host = { "status" => nil, "addrs" => {}, "ports" => [], "scripts" => {} }
+    @state = nil
+  end
+
+  def tag_start(name, attributes)
+    begin
+      case name
+      when "address"
+        @host["addrs"][attributes["addrtype"]] = attributes["addr"]
+        if (attributes["addrtype"] =~ /ipv[46]/)
+          @host["addr"] = attributes["addr"]
+        end
+      when "osclass"
+        # If there is more than one, take the highest accuracy.  In case of
+        # a tie, this will have the effect of taking the last one in the
+        # list.  Last is really no better than first but ____  appears to
+        # put OSes in chronological order, at least for Windows.
+        # Accordingly, this will report XP instead of 2000, 7 instead of
+        # Vista, etc, when each has the same accuracy.
+        if (@host["os_accuracy"].to_i <= attributes["accuracy"].to_i)
+          @host["os_vendor"]   = attributes["vendor"]
+          @host["os_family"]   = attributes["osfamily"]
+          @host["os_version"]  = attributes["osgen"]
+          @host["os_accuracy"] = attributes["accuracy"]
+        end
+      when "osmatch"
+        if(attributes["accuracy"].to_i == 100)
+          @host["os_match"] = attributes["name"]
+        end
+      when "uptime"
+        @host["last_boot"]   = attributes["lastboot"]
+      when "hostname"
+        if(attributes["type"] == "PTR")
+          @host["reverse_dns"] = attributes["name"]
+        end
+      when "status"
+        # <status> refers to the liveness of the host; values are "up" or "down"
+        @host["status"] = attributes["state"]
+        @host["status_reason"] = attributes["reason"]
+      when "port"
+        @host["ports"].push(attributes)
+      when "state"
+        # <state> refers to the state of a port; values are "open", "closed", or "filtered"
+        @host["ports"].last["state"] = attributes["state"]
+      when "service"
+        # Store any service and script info with the associated port.  There shouldn't
+        # be any collisions on attribute names here, so just merge them.
+        @host["ports"].last.merge!(attributes)
+      when "script"
+        # Associate scripts under a port tag with the appropriate port.
+        # Other scripts from <hostscript> tags can only be associated with
+        # the host and scripts from <postscript> tags don't really belong
+        # to anything, so ignore them
+        if @state == :in_port_tag
+          @host["ports"].last["scripts"] ||= {}
+          @host["ports"].last["scripts"][attributes["id"]] = attributes["output"]
+        elsif @host
+          @host["scripts"] ||= {}
+          @host["scripts"][attributes["id"]] = attributes["output"]
+        else
+          # post scripts are used for things like comparing all the found
+          # ssh keys to see if multiple hosts have the same key
+          # fingerprint.  Ignore them.
+        end
+      when "trace"
+        @host["trace"] = {"port" => attributes["port"], "proto" => attributes["proto"], "hops" => [] }
+      when "hop"
+        if @host["trace"]
+          @host["trace"]["hops"].push(attributes)
+        end
+      end
+    rescue NoMethodError => err
+      raise err unless err.message =~ /NilClass/
+    end
+  end
+
+  def tag_end(name)
+    case name
+    when "port"
+      @state = nil
+    when "host"
+      on_found_host.call(@host) if on_found_host
+      reset_state
+    end
+  end
+
+  # We don't need these methods, but they're necessary to keep REXML happy
+  def text(str) # :nodoc:
+  end
+  def xmldecl(version, encoding, standalone) # :nodoc:
+  end
+  def cdata # :nodoc:
+  end
+  def comment(str) # :nodoc:
+  end
+  def instruction(name, instruction) # :nodoc:
+  end
+  def attlist # :nodoc:
+  end
+end
+
+end
+end
+

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -348,6 +348,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "    IP360 ASPL",
           "    IP360 XML v3",
           "    Libpcap Packet Capture",
+	  "    Masscan XML",
           "    Metasploit PWDump Export",
           "    Metasploit XML",
           "    Metasploit Zip Export",


### PR DESCRIPTION
This pull request copies the db_import and db_nmap related files and functions and adds capability to run masscan in the same way. Fixes #6208.

Masscan results are similar to nmap but it runs asynchronously, operating more like scanrand, unicornscan, and ZMap.

Homepage: https://github.com/robertdavidgraham/masscan 
Tested on: Masscan 1.0.3 (Mac OS 10.10.5, Kali Linux 2.0.0 (VirtualBox VM))
Usage:
- install Masscan (comes with Kali Linux)
- modify permissions (if needed)
  I ran my msfconsole as a non-root user per the instructions for [setting up a metasploit development environment](https://github.com/rapid7/metasploit-framework/wiki/Setting-Up-a-Metasploit-Development-Environment), on a Kali Linux VM. On Kali Linux I couldn't run masscan as non-root, so I created a group that could run the masscan command with CAP_NET_RAW and CAP_NET_ADMIN capabilities and added my user to it. I did not have to modify permissions on the Mac.
  
  ```
  groupadd pcap
  usermod -a -G pcap msfdev
  chgrp pcap /usr/bin/masscan
  chmod 750 /usr/bin/masscan
  setcap cap_net_raw,cap_net_admin=eip /usr/bin/masscan
  ```
- run db_import with a masscan xml file or db_masscan to import masscan results into msf database
# Example Output

db_masscan shows up as an option in help menu

```
msf > help
...
Database Backend Commands
=========================

    Command           Description
    -------           -----------
    creds             List all credentials in the database
    db_connect        Connect to an existing database
    db_disconnect     Disconnect from the current database instance
    db_export         Export a file containing the contents of the database
    db_import         Import a scan result file (filetype will be auto-detected)
    db_masscan        Executes masscan and records the output automatically
    db_nmap           Executes nmap and records the output automatically
    db_rebuild_cache  Rebuilds the database-stored module cache
    db_status         Show the current database status
    hosts             List all hosts in the database
    loot              List all loot in the database
    notes             List all notes in the database
    services          List all services in the database
    vulns             List all vulnerabilities in the database
    workspace         Switch between database workspaces
```

Masscan XML also shows up as a supported file type under db_import

```
msf > db_import
Usage: db_import <filename> [file2...]

Filenames can be globs like *.xml, or **/*.xml which will search recursively
Currently supported file types include:
    Acunetix
    Amap Log
    Amap Log -m
    Appscan
    Burp Session XML
    CI
    Foundstone
    FusionVM XML
    IP Address List
    IP360 ASPL
    IP360 XML v3
    Libpcap Packet Capture
    Masscan XML
    Metasploit PWDump Export
    Metasploit XML
    Metasploit Zip Export
    Microsoft Baseline Security Analyzer
    NeXpose Simple XML
    NeXpose XML Report
    Nessus NBE Report
    Nessus XML (v1)
    Nessus XML (v2)
    NetSparker XML
    Nikto XML
    Nmap XML
    OpenVAS Report
    OpenVAS XML
    Outpost24 XML
    Qualys Asset XML
    Qualys Scan XML
    Retina XML
    Spiceworks CSV Export
    Wapiti XML
```

Running the db_masscan command

```
msf > db_masscan -p80 192.168.22.0/24
[*] Masscan: 'Starting masscan 1.0.3 (http://bit.ly/14GZzcT) at 2015-11-10 16:37:47 GMT'
[*] Masscan: '-- forced options: -sS -Pn -n --randomize-hosts -v --send-eth'
[*] Masscan: 'Initiating SYN Stealth Scan'
[*] Masscan: 'Scanning 256 hosts [1 port/host]'
rate:  0.00-kpps, 100.00% done, waiting 0-secs, found=43'          ound=0       
msf > hosts

Hosts
=====

address      mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------      ---  ----  -------  ---------  -----  -------  ----  --------
192.168.22.48              Unknown                    device         
192.168.22.59              Unknown                    device         
192.168.22.65              Unknown                    device         
192.168.22.68              Unknown                    device         
192.168.22.69              Unknown                    device         
...
```

Running masscan externally to msfconsole and then importing the saved file

```
msfdev@kali:~$ masscan -p80 -p80 192.168.22.0/24 -oX output.xml

Starting masscan 1.0.3 (http://bit.ly/14GZzcT) at 2015-11-10 16:53:13 GMT
 -- forced options: -sS -Pn -n --randomize-hosts -v --send-eth
Initiating SYN Stealth Scan
Scanning 256 hosts [1 port/host]
msfdev@kali:~$ ./msfconsole       

msf > db_import /home/msfdev/output.xml
[*] Importing 'Masscan XML' data
[*] Import: Parsing with 'Nokogiri v1.6.6.2'
[*] Importing host 192.168..22.169
[*] Importing host 192.168..22.147
[*] Importing host 192.168..22.74
[*] Importing host 192.168..22.69
[*] Importing host 192.168..22.97
...
```
