### PR TITLE
Add admin module for interfacing with ATGs

### DIFF
--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -28,9 +28,10 @@ class Metasploit3 < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles'],
+          ['URL', 'https://community.rapid7.com/community/infosec/blog/2015/01/22/the-internet-of-gas-station-tank-gauges'],
+          ['URL', 'http://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/the-gaspot-experiment'],
           ['URL', 'https://github.com/sjhilt/GasPot'],
-          ['URL', 'https://community.rapid7.com/community/infosec/blog/2015/01/22/the-internet-of-gas-station-tank-gauges']
+          ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles']
         ],
       'DefaultAction'  => 'INVENTORY',
       'Actions'        =>

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -17,16 +17,21 @@ class Metasploit3 < Msf::Auxiliary
       'Description'    => %q{
         This module acts as a simplistic administrative client for interfacing
         with Veeder-Root Automatic Tang Gauges (ATGs) or other devices speaking
-        the TLS-250 and TLS-350 protocols.
-       },
+        the TLS-250 and TLS-350 protocols.  This has been tested against
+        GasPot, a honeypot meant to simulate ATGs; it has not been tested
+        against anything else, so use at your own risk.
+      },
       'Author'         =>
         [
           'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
         ],
       'License'        => MSF_LICENSE,
-      'References'     => [
-        ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles']
-      ],
+      'References'     =>
+        [
+          ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles'],
+          ['URL', 'https://github.com/sjhilt/GasPot'],
+          ['URL', 'https://community.rapid7.com/community/infosec/blog/2015/01/22/the-internet-of-gas-station-tank-gauges']
+        ],
       'DefaultAction'  => 'INVENTORY',
       'Actions'        =>
         [

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Auxiliary
           ],
           [ 'SET_TANK_NAME',
             {
-              'Description' => 'S602 set tank name',
+              'Description' => 'S602 set tank name (use TANK_NUMBER and TANK_NAME options)',
               'TLS-350_CMD' => "\x01S602"
             }
           ],

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -57,8 +57,8 @@ class Metasploit3 < Msf::Auxiliary
           ],
           [ 'SET_TANK_NAME',
             {
-              'Description' => 'S6020 set tank name',
-              'TLS-350_CMD' => "\x01S6020"
+              'Description' => 'S602 set tank name',
+              'TLS-350_CMD' => "\x01S602"
             }
           ],
           [ 'STATUS',
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # ensure that the tank number is set for the commands that need it
     if action.name == 'SET_TANK_NAME'
-      fail "TANK_NUMBER #{tank_number} is invalid" if tank_number < 0
+      fail "TANK_NUMBER #{tank_number} is invalid" if tank_number < 0 || tank_number > 99
     end
   end
 
@@ -128,15 +128,15 @@ class Metasploit3 < Msf::Auxiliary
       case action.name
       when 'SET_TANK_NAME'
         vprint_status("#{peer} -- setting tank ##{tank_number} to #{tank_name}")
-        request = action.opts[protocol + '_CMD'] + "#{tank_number}#{tank_name}"
-        sock.puts(request)
+        request = action.opts[protocol + '_CMD'] + "#{'%02d' % tank_number}#{tank_name}\n"
+        sock.put(request)
         disconnect
         connect
-        sock.puts(actions.select { |a| a.name == 'INVENTORY' }.first.opts[protocol + '_CMD'])
+        sock.put(actions.select { |a| a.name == 'INVENTORY' }.first.opts[protocol + '_CMD'] + "\n")
         print_status("#{peer} #{datastore['PROTOCOL']} #{action.opts['Description']}:\n#{sock.get_once}")
       else
-        request = action.opts[datastore['PROTOCOL'] + '_CMD']
-        sock.puts(request)
+        request = action.opts[datastore['PROTOCOL'] + '_CMD'] + "\n"
+        sock.put(request)
         print_status("#{peer} #{datastore['PROTOCOL']} #{action.opts['Description']}:\n#{sock.get_once}")
       end
     ensure

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Auxiliary
             {
               'Description' => 'S50100 Set time of day (use TIME option) (untested)',
               # disabled, unsure how this works just yet
-              #'TLS-350_CMD' => "\x01S50100"
+              # 'TLS-350_CMD' => "\x01S50100"
             }
           ],
           [ 'STATUS',
@@ -158,16 +158,14 @@ class Metasploit3 < Msf::Auxiliary
         OptInt.new('TANK_NUMBER', [false, 'The tank number to operate on (use with SET_TANK_NAME, 0 to change all)', 1]),
         OptString.new('TANK_NAME', [false, 'The tank name to set (use with SET_TANK_NAME, defaults to random)']),
         OptString.new('TIME', [false, "The time to set (use with SET_TIME, defaults to Time.now (~#{Time.now.inspect})"])
-      ],
-      self.class
+      ]
     )
     deregister_options('SSL', 'SSLCipher', 'SSLVerifyMode', 'SSLVersion')
 
     register_advanced_options(
       [
         OptEnum.new('PROTOCOL', [true, 'The Veeder-Root TLS protocol to speak', 'TLS-350', %w(TLS-350 TLS-250)])
-      ],
-      self.class
+      ]
     )
   end
 

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -1,0 +1,108 @@
+##
+# encoding: utf-8
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'           => 'Veeder-Root Automatic Tank Gauge (ATG) Administrative Client',
+      'Description'    => %q{
+        This module acts as a simplistic administrative client for interfacing
+        with Veeder-Root Automatic Tang Gauges (ATGs) or other devices speaking
+        the TLS-250 and TLS-350 protocols.
+       },
+      'Author'         =>
+        [
+          'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     => [
+        ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles']
+      ],
+      'DefaultAction'  => 'INVENTORY',
+      'Actions'        =>
+        [
+          [ 'DELIVERY',
+            {
+              'Description' => 'I20200 Delivery report',
+              'TLS-350_CMD' => "\x01I20200"
+            }
+          ],
+          [ 'INVENTORY',
+            {
+              'Description' => 'I20100 In-tank inventory report',
+              'TLS-250_CMD' => "\x01200",
+              'TLS-350_CMD' => "\x01I20100"
+            }
+          ],
+          [ 'LEAK',
+            {
+              'Description' => 'I20300 Leak report',
+              'TLS-350_CMD' => "\x01I20300"
+            }
+          ],
+          [ 'SHIFT',
+            {
+              'Description' => 'I20400 Shift report',
+              'TLS-350_CMD' => "\x01I20400"
+            }
+          ],
+          [ 'STATUS',
+            {
+              'Description' => 'I20500 In-tank status report',
+              'TLS-350_CMD' => "\x01I20500"
+            }
+          ],
+          [ 'VERSION',
+            {
+              'Description' => 'Version information',
+              'TLS-250_CMD' => "\x01980",
+              'TLS-350_CMD' => "\x01I90200"
+            }
+          ]
+        ]
+    )
+
+    register_options(
+      [
+        Opt::RPORT(10001)
+      ],
+      self.class
+    )
+    deregister_options('SSL', 'SSLCipher', 'SSLVerifyMode', 'SSLVersion')
+
+    register_advanced_options(
+      [
+        OptEnum.new('PROTOCOL', [true, 'The Veeder-Root TLS protocol to speak', 'TLS-350', %w(TLS-350 TLS-250)])
+      ],
+      self.class
+    )
+  end
+
+  def setup
+    proto_cmd = datastore['PROTOCOL'] + "_CMD"
+    fail "#{action.name} not defined for #{datastore['PROTOCOL']}" unless action.opts.keys.include?(proto_cmd)
+  end
+
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
+  def run_host(_host)
+    begin
+      connect
+      sock.put(action.opts[datastore['PROTOCOL'] + '_CMD'])
+      print_status("#{peer}:\n#{sock.get_once}")
+    ensure
+      disconnect
+    end
+  end
+end

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -234,7 +234,7 @@ class Metasploit3 < Msf::Auxiliary
       else
         request = "#{action.opts[protocol + '_CMD']}\n"
         sock.put(request)
-        print_status("#{peer} #{protocol} #{action.opts['Description']}:\n#{sock.get_once}")
+        print_good("#{peer} #{protocol} #{action.opts['Description']}:\n#{sock.get_once}")
       end
     ensure
       disconnect

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -31,7 +31,8 @@ class Metasploit3 < Msf::Auxiliary
           ['URL', 'https://community.rapid7.com/community/infosec/blog/2015/01/22/the-internet-of-gas-station-tank-gauges'],
           ['URL', 'http://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/the-gaspot-experiment'],
           ['URL', 'https://github.com/sjhilt/GasPot'],
-          ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles']
+          ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles'],
+          ['URL', 'http://www.chipkin.com/files/liz/576013-635.pdf']
         ],
       'DefaultAction'  => 'INVENTORY',
       'Actions'        =>

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -36,6 +36,18 @@ class Metasploit3 < Msf::Auxiliary
       'DefaultAction'  => 'INVENTORY',
       'Actions'        =>
         [
+          [ 'ALARM',
+            {
+              'Description' => 'I30200 Sensor alarm history (untested)',
+              'TLS-350_CMD' => "\x01I30200"
+            }
+          ],
+          [ 'ALARM_RESET',
+            {
+              'Description' => 'IS00300 Remote alarm reset (untested)',
+              'TLS-350_CMD' => "\x01IS00300"
+            }
+          ],
           [ 'DELIVERY',
             {
               'Description' => 'I20200 Delivery report',
@@ -44,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
           ],
           [ 'INVENTORY',
             {
-              'Description' => 'I20100 In-tank inventory report',
+              'Description' => '200/I20100 In-tank inventory report',
               'TLS-250_CMD' => "\x01200",
               'TLS-350_CMD' => "\x01I20100"
             }
@@ -53,6 +65,36 @@ class Metasploit3 < Msf::Auxiliary
             {
               'Description' => 'I20300 Leak report',
               'TLS-350_CMD' => "\x01I20300"
+            }
+          ],
+          [ 'RELAY',
+            {
+              'Description' => 'I40600 Relay status (untested)',
+              'TLS-350_CMD' => "\x01I40600"
+            }
+          ],
+          [ 'RESET',
+            {
+              'Description' => 'IS00100 Reset (untested)',
+              'TLS-350_CMD' => "\x01IS00100"
+            }
+          ],
+          [ 'CLEAR_RESET',
+            {
+              'Description' => 'IS00200 Clear Reset Flag (untested)',
+              'TLS-350_CMD' => "\x01IS00200"
+            }
+          ],
+          [ 'SENSOR',
+            {
+              'Description' => 'I30100 Sensor status (untested)',
+              'TLS-350_CMD' => "\x01I30100"
+            }
+          ],
+          [ 'SENSOR_DIAG',
+            {
+              'Description' => 'IB0100 Sensor diagnostics (untested)',
+              'TLS-350_CMD' => "\x01IB0100"
             }
           ],
           [ 'SHIFT',
@@ -67,10 +109,34 @@ class Metasploit3 < Msf::Auxiliary
               'TLS-350_CMD' => "\x01S602"
             }
           ],
+          [ 'SET_TIME',
+            {
+              'Description' => 'S50100 Set time of day (untested)',
+              'TLS-350_CMD' => "\x01S50100"
+            }
+          ],
           [ 'STATUS',
             {
               'Description' => 'I20500 In-tank status report',
               'TLS-350_CMD' => "\x01I20500"
+            }
+          ],
+          [ 'SYSTEM_STATUS',
+            {
+              'Description' => 'I10100 System status report (untested)',
+              'TLS-350_CMD' => "\x01I10100"
+            }
+          ],
+          [ 'TANK_ALARM',
+            {
+              'Description' => 'I20600 Tank alarm history (untested)',
+              'TLS-350_CMD' => "\x01I20600"
+            }
+          ],
+          [ 'TANK_DIAG',
+            {
+              'Description' => 'IA0100 Tank diagnostics (untested)',
+              'TLS-350_CMD' => "\x01IA0100"
             }
           ],
           [ 'VERSION',

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -113,8 +113,9 @@ class Metasploit3 < Msf::Auxiliary
           ],
           [ 'SET_TIME',
             {
-              'Description' => 'S50100 Set time of day (untested)',
-              'TLS-350_CMD' => "\x01S50100"
+              'Description' => 'S50100 Set time of day (use TIME option) (untested)',
+              # disabled, unsure how this works just yet
+              #'TLS-350_CMD' => "\x01S50100"
             }
           ],
           [ 'STATUS',
@@ -155,7 +156,8 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(10001),
         OptInt.new('TANK_NUMBER', [false, 'The tank number to operate on (use with SET_TANK_NAME, 0 to change all)', 1]),
-        OptString.new('TANK_NAME', [false, 'The tank name to set (use with SET_TANK_NAME, defaults to random)'])
+        OptString.new('TANK_NAME', [false, 'The tank name to set (use with SET_TANK_NAME, defaults to random)']),
+        OptString.new('TIME', [false, "The time to set (use with SET_TIME, defaults to Time.now (~#{Time.now.inspect})"])
       ],
       self.class
     )
@@ -190,6 +192,14 @@ class Metasploit3 < Msf::Auxiliary
     datastore['TANK_NUMBER']
   end
 
+  def time
+    if datastore['TIME']
+      Time.parse(datastore['TIME']).to_i
+    else
+      Time.now.to_i
+    end
+  end
+
   def peer
     "#{rhost}:#{rport}"
   end
@@ -220,6 +230,9 @@ class Metasploit3 < Msf::Auxiliary
         else
           print_warning message
         end
+      when 'SET_TIME'
+        request = "#{action.opts[protocol + '_CMD']}#{Time.now.to_i}\n"
+        sock.put(request)
       else
         request = "#{action.opts[protocol + '_CMD']}\n"
         sock.put(request)

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -32,7 +32,8 @@ class Metasploit3 < Msf::Auxiliary
           ['URL', 'http://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/the-gaspot-experiment'],
           ['URL', 'https://github.com/sjhilt/GasPot'],
           ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles'],
-          ['URL', 'http://www.chipkin.com/files/liz/576013-635.pdf']
+          ['URL', 'http://www.chipkin.com/files/liz/576013-635.pdf'],
+          ['URL', 'http://www.veeder.com/gold/download.cfm?doc_id=6227']
         ],
       'DefaultAction'  => 'INVENTORY',
       'Actions'        =>

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -156,8 +156,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(10001),
         OptInt.new('TANK_NUMBER', [false, 'The tank number to operate on (use with SET_TANK_NAME, 0 to change all)', 1]),
-        OptString.new('TANK_NAME', [false, 'The tank name to set (use with SET_TANK_NAME, defaults to random)']),
-        OptString.new('TIME', [false, "The time to set (use with SET_TIME, defaults to Time.now (~#{Time.now.inspect})"])
+        OptString.new('TANK_NAME', [false, 'The tank name to set (use with SET_TANK_NAME, defaults to random)'])
       ]
     )
     deregister_options('SSL', 'SSLCipher', 'SSLVerifyMode', 'SSLVersion')
@@ -165,6 +164,7 @@ class Metasploit3 < Msf::Auxiliary
     register_advanced_options(
       [
         OptEnum.new('PROTOCOL', [true, 'The Veeder-Root TLS protocol to speak', 'TLS-350', %w(TLS-350 TLS-250)]),
+        OptString.new('TIME', [false, "The time to set (use with SET_TIME, defaults to Time.now (~#{Time.now.inspect})"]),
         OptInt.new('TIMEOUT', [true, 'Time in seconds to wait for responses to our probes', 5])
       ]
     )

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Auxiliary
     begin
       connect
       sock.put(action.opts[datastore['PROTOCOL'] + '_CMD'])
-      print_status("#{peer}:\n#{sock.get_once}")
+      print_status("#{peer} #{datastore['PROTOCOL']} #{action.opts['Description']}:\n#{sock.get_once}")
     ensure
       disconnect
     end

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -106,9 +106,7 @@ class Metasploit3 < Msf::Auxiliary
     fail "#{action.name} not defined for #{protocol}" unless action.opts.keys.include?(proto_cmd)
 
     # ensure that the tank number is set for the commands that need it
-    if action.name == 'SET_TANK_NAME'
-      fail "TANK_NUMBER #{tank_number} is invalid" if tank_number < 0 || tank_number > 99
-    end
+    fail "TANK_NUMBER #{tank_number} is invalid" if action.name == 'SET_TANK_NAME' && (tank_number < 0 || tank_number > 99)
   end
 
   def protocol
@@ -133,11 +131,11 @@ class Metasploit3 < Msf::Auxiliary
       case action.name
       when 'SET_TANK_NAME'
         vprint_status("#{peer} -- setting tank ##{tank_number} to #{tank_name}")
-        request = action.opts[protocol + '_CMD'] + "#{'%02d' % tank_number}#{tank_name}\n"
+        request = action.opts[protocol + '_CMD'] + "#{format('%02d', tank_number)}#{tank_name}\n"
         sock.put(request)
         disconnect
         connect
-        sock.put(actions.select { |a| a.name == 'INVENTORY' }.first.opts[protocol + '_CMD'] + "\n")
+        sock.put(actions.find { |a| a.name == 'INVENTORY' }.opts[protocol + '_CMD'] + "\n")
         print_status("#{peer} #{datastore['PROTOCOL']} #{action.opts['Description']}:\n#{sock.get_once}")
       else
         request = action.opts[datastore['PROTOCOL'] + '_CMD'] + "\n"

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -155,7 +155,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(10001),
         OptInt.new('TANK_NUMBER', [false, 'The tank number to operate on (use with SET_TANK_NAME, 0 to change all)', 1]),
-        OptString.new('TANK_NAME', [false, 'The tank name to set (use with SET_TANK_NAME), defaults to random'])
+        OptString.new('TANK_NAME', [false, 'The tank name to set (use with SET_TANK_NAME, defaults to random)'])
       ],
       self.class
     )

--- a/modules/auxiliary/admin/atg/client.rb
+++ b/modules/auxiliary/admin/atg/client.rb
@@ -111,13 +111,12 @@ class Metasploit3 < Msf::Auxiliary
               'TLS-350_CMD' => "\x01S602"
             }
           ],
-          [ 'SET_TIME',
-            {
-              'Description' => 'S50100 Set time of day (use TIME option) (untested)',
-              # disabled, unsure how this works just yet
-              # 'TLS-350_CMD' => "\x01S50100"
-            }
-          ],
+          # [ 'SET_TIME',
+          #   {
+          #     'Description' => 'S50100 Set time of day (use TIME option) (untested)',
+          #     'TLS-350_CMD' => "\x01S50100"
+          #   }
+          # ],
           [ 'STATUS',
             {
               'Description' => 'I20500 In-tank status report',
@@ -164,7 +163,6 @@ class Metasploit3 < Msf::Auxiliary
     register_advanced_options(
       [
         OptEnum.new('PROTOCOL', [true, 'The Veeder-Root TLS protocol to speak', 'TLS-350', %w(TLS-350 TLS-250)]),
-        OptString.new('TIME', [false, "The time to set (use with SET_TIME, defaults to Time.now (~#{Time.now.inspect})"]),
         OptInt.new('TIMEOUT', [true, 'Time in seconds to wait for responses to our probes', 5])
       ]
     )
@@ -243,8 +241,6 @@ class Metasploit3 < Msf::Auxiliary
         else
           print_warning message
         end
-      when 'SET_TIME'
-        response = get_response("#{action.opts[protocol_opt_name]}#{Time.now.to_i}\n")
       else
         response = get_response("#{action.opts[protocol_opt_name]}\n")
         print_good("#{peer} #{protocol} #{action.opts['Description']}:\n#{response}")


### PR DESCRIPTION
This is a simple module for interacting with Veeder-Root Automatic Tank Gauges (ATGs).  It is written in very simplistic manner and is only known to work with the TLS-350 protocol that @sjhilt's [GasPot](https://github.com/sjhilt/GasPot) speaks, but based on some other research I've done this should also work on more real ATGs.  The TLS-250 protocol is not implemented by GasPot but the subset I've implemented here should work based on some research I've done.

Examples below were tested against a local copy of GasPot.

Default mode:

```
msf auxiliary(client) > run

[*] 127.0.0.1:10001 TLS-350 I20100 In-tank inventory report:

I20100
11/10/2015 22:51

    PILOT TRUCK STOP



IN-TANK INVENTORY

TANK PRODUCT             VOLUME TC VOLUME   ULLAGE   HEIGHT    WATER     TEMP
  1  SUPER                 6697      6840     5426    25.22     8.50    60.61
  2  UNLEAD                3409      3524     9509    26.22     6.60    51.39
  3  DIESEL                4048      4200     6217    42.62     8.12    52.99
  4  PREMIUM               3147      3261     5497    59.53     0.40    59.53

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Show/use some different actions, one of which is not supported by gaspot (but will be by most ATGs):

```
msf auxiliary(client) > set ACTION 
set ACTION DELIVERY       set ACTION LEAK           set ACTION SHIFT          set ACTION VERSION        
set ACTION INVENTORY      set ACTION SET_TANK_NAME  set ACTION STATUS         
msf auxiliary(client) > set ACTION VERSION 
ACTION => VERSION
msf auxiliary(client) > run

[*] 127.0.0.1:10001 TLS-350 Version information:
9999FF1B

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(client) > set ACTION STATUS
ACTION => STATUS
msf auxiliary(client) > run

[*] 127.0.0.1:10001 TLS-350 I20500 In-tank status report:

I20500
11/10/2015 22:56


PILOT TRUCK STOP


TANK   PRODUCT                 STATUS

  1    SUPER                                    NORMAL

  2    UNLEAD                                  HIGH WATER ALARM
                               HIGH WATER WARNING

  3    DIESEL                                  NORMAL

  4    PREMIUM                                NORMAL

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Set tank #3 to claim that it is full of pudding:

```
msf auxiliary(client) > set ACTION SET_TANK_NAME 
ACTION => SET_TANK_NAME
msf auxiliary(client) > set TANK_NUMBER 3
TANK_NUMBER => 3
msf auxiliary(client) > set TANK_NAME pudding
TANK_NAME => pudding
msf auxiliary(client) > run

[*] 127.0.0.1:10001 TLS-350 S602 set tank name:

I20100
11/10/2015 22:56

    PILOT TRUCK STOP



IN-TANK INVENTORY

TANK PRODUCT             VOLUME TC VOLUME   ULLAGE   HEIGHT    WATER     TEMP
  1  SUPER                 6697      6840     5426    25.22     8.50    60.61
  2  UNLEAD                3409      3524     9509    26.22     6.60    51.39
  3  pudding               4048      4200     6217    42.62     8.12    52.99
  4  PREMIUM               3147      3261     5497    59.53     0.40    59.53

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Similarly, but set all tanks to show that they are holding water:

```
msf auxiliary(client) > set TANK_NUMBER 0
TANK_NUMBER => 0
msf auxiliary(client) > set TANK_NAME water
TANK_NAME => water
msf auxiliary(client) > run

[*] 127.0.0.1:10001 TLS-350 S602 set tank name:

I20100
11/10/2015 22:57

    PILOT TRUCK STOP



IN-TANK INVENTORY

TANK PRODUCT             VOLUME TC VOLUME   ULLAGE   HEIGHT    WATER     TEMP
  1  water                 6697      6840     5426    25.22     8.50    60.61
  2  water                 3409      3524     9509    26.22     6.60    51.39
  3  water                 4048      4200     6217    42.62     8.12    52.99
  4  water                 3147      3261     5497    59.53     0.40    59.53

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
