### PR TITLE
Add a wall(1) post module

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1148,12 +1148,12 @@ module Text
     # text in the cowsay banner, so just do it by hand.  This big mess wraps
     # the provided text in an ASCII-cloud and then makes it look like the cloud
     # is a thought/word coming from the ASCII-cow.  Each line in the
-    # ASCII-cloud is no more than the specified number-characters long, and the cloud corners are
-    # made to look rounded
-    text_lines = text.scan(Regexp.new(".{1,#{width}}"))
+    # ASCII-cloud is no more than the specified number-characters long, and the
+    # cloud corners are made to look rounded
+    text_lines = text.scan(Regexp.new(".{1,#{width-4}}"))
     max_length = text_lines.map(&:size).sort.last
     cloud_parts = []
-    cloud_parts << " #{'_' * (max_length + 2)} "
+    cloud_parts << " #{'_' * (max_length + 2)}"
     if text_lines.size == 1
       cloud_parts << "< #{text} >"
     else
@@ -1165,7 +1165,7 @@ module Text
       end
       cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
     end
-    cloud_parts << " #{'-' * (max_length + 2)} "
+    cloud_parts << " #{'-' * (max_length + 2)}"
     cloud_parts << <<EOS
        \\   ,__,
         \\  (oo)____

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1126,6 +1126,56 @@ module Text
     return output
   end
 
+  #
+  # Converts a string to one similar to what would be used by cowsay(1), a UNIX utility for
+  # displaying text as if it was coming from an ASCII-cow's mouth:
+  #
+  #       __________________
+  #      < the cow says moo >
+  #       ------------------
+  #              \   ^__^
+  #               \  (oo)\_______
+  #                  (__)\       )\/\
+  #                      ||----w |
+  #                      ||     ||
+  #
+  # @param text [String] The string to cowsay
+  # @param width [Fixnum] Width of the cow's cloud.  Default's to cowsay(1)'s default, 39.
+  def self.cowsay(text, width=39)
+    # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
+    # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
+    # split a word that has > 39 characters in it which results in oddly formed
+    # text in the cowsay banner, so just do it by hand.  This big mess wraps
+    # the provided text in an ASCII-cloud and then makes it look like the cloud
+    # is a thought/word coming from the ASCII-cow.  Each line in the
+    # ASCII-cloud is no more than the specified number-characters long, and the cloud corners are
+    # made to look rounded
+    text_lines = text.scan(Regexp.new(".{1,#{width}}"))
+    max_length = text_lines.map(&:size).sort.last
+    cloud_parts = []
+    cloud_parts << " #{'_' * (max_length + 2)} "
+    if text_lines.size == 1
+      cloud_parts << "< #{text} >"
+    else
+      cloud_parts << "/ #{text_lines.first.ljust(max_length, ' ')} \\"
+      if text_lines.size > 2
+        text_lines[1, text_lines.length - 2].each do |line|
+          cloud_parts << "| #{line.ljust(max_length, ' ')} |"
+        end
+      end
+      cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
+    end
+    cloud_parts << " #{'-' * (max_length + 2)} "
+    cloud_parts << <<EOS
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOS
+    cloud_parts.join("\n")
+  end
+
+
   ##
   #
   # Transforms

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Post
       text = datastore['MESSAGE']
     end
 
-    datastore['COWSAY'] ? Rex::Text.cowsay(text, 100) : text
+    datastore['COWSAY'] ? Rex::Text.cowsay(text) : text
   end
 
   def run

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -16,7 +16,9 @@ class Metasploit3 < Msf::Post
           to send messages to users on the target system.
         },
         'License'       => MSF_LICENSE,
-        'Author'        => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
+        'Author'        => [
+          'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
+        ],
         # TODO: is there a way to do this on Windows?
         'Platform'      => %w(linux osx unix),
         'SessionTypes'  => %w(shell meterpreter)
@@ -24,10 +26,41 @@ class Metasploit3 < Msf::Post
     )
     register_options(
       [
-        OptString.new('MESSAGE', [true, 'The message to send']),
+        OptString.new('MESSAGE', [false, 'The message to send', '']),
         OptString.new('USERS', [false, 'List of users to write(1) to, separated by commas. ' \
-                      ' wall(1)s to all users by default'])
+                      ' wall(1)s to all users by default']),
+        OptBool.new('COWSAY', [true, 'Display MESSAGE in a ~cowsay way', false])
       ], self.class)
+  end
+
+  def cowsay(text)
+    # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
+    # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
+    # split a word that has > 39 characters in it which results in oddly formed
+    # text in the cowsay banner, so just do it by hand
+    text_lines = text.scan(/.{1,34}/)
+    max_length = text_lines.map(&:size).sort.last
+    cloud_parts = []
+    cloud_parts << " #{'_' * (max_length + 2)} "
+    if text_lines.size == 1
+      cloud_parts << "< #{text} >"
+    else
+      cloud_parts << "/ #{text_lines.first.ljust(max_length, ' ')} \\"
+      if text_lines.size > 2
+        text_lines[1, text_lines.length - 2].each do |line|
+          cloud_parts << "| #{line.ljust(max_length, ' ')} |"
+        end
+      end
+      cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
+    end
+    cloud_parts << " #{'-' * (max_length + 2)} "
+    cloud_parts << <<EOS
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOS
+    cloud_parts.join("\n")
   end
 
   def users
@@ -35,14 +68,24 @@ class Metasploit3 < Msf::Post
   end
 
   def message
-    datastore['MESSAGE'] ? datastore['MESSAGE'] : "Hello metasploit session #{session.id}, the time is #{Time.now}"
+    if datastore['MESSAGE'].blank?
+      text = "Hello from a metasploit session at #{Time.now}"
+    else
+      text = datastore['MESSAGE']
+    end
+
+    datastore['COWSAY'] ? cowsay(text) : text
   end
 
   def run
     if users
+      # this requires that the target user has write turned on
       users.map { |user| cmd_exec("echo '#{message}' | write #{user}") }
     else
-      cmd_exec("echo '#{message}' | wall")
+      # this will send the messages to all users, regardless of whether or
+      # not they have write turned on.  If the session is root, the -n will disable
+      # the annoying banner
+      cmd_exec("echo '#{message}' | wall -n")
     end
   end
 end

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -33,40 +33,6 @@ class Metasploit3 < Msf::Post
       ], self.class)
   end
 
-  def cowsay(text)
-    # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
-    # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
-    # split a word that has > 39 characters in it which results in oddly formed
-    # text in the cowsay banner, so just do it by hand.  This big mess wraps
-    # the provided text in an ASCII-cloud and then makes it look like the cloud
-    # is a thought/word coming from the ASCII-cow.  Each line in the
-    # ASCII-cloud is no more than 34-characters long, and the cloud corners are
-    # made to look rounded
-    text_lines = text.scan(/.{1,34}/)
-    max_length = text_lines.map(&:size).sort.last
-    cloud_parts = []
-    cloud_parts << " #{'_' * (max_length + 2)} "
-    if text_lines.size == 1
-      cloud_parts << "< #{text} >"
-    else
-      cloud_parts << "/ #{text_lines.first.ljust(max_length, ' ')} \\"
-      if text_lines.size > 2
-        text_lines[1, text_lines.length - 2].each do |line|
-          cloud_parts << "| #{line.ljust(max_length, ' ')} |"
-        end
-      end
-      cloud_parts << "\\ #{text_lines.last.ljust(max_length, ' ')} /"
-    end
-    cloud_parts << " #{'-' * (max_length + 2)} "
-    cloud_parts << <<EOS
-       \\   ,__,
-        \\  (oo)____
-           (__)    )\\
-              ||--|| *
-EOS
-    cloud_parts.join("\n")
-  end
-
   def users
     datastore['USERS'] ? datastore['USERS'].split(/\s*,\s*/) : nil
   end
@@ -78,7 +44,7 @@ EOS
       text = datastore['MESSAGE']
     end
 
-    datastore['COWSAY'] ? cowsay(text) : text
+    datastore['COWSAY'] ? Rex::Text.cowsay(text, 100) : text
   end
 
   def run

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -37,7 +37,11 @@ class Metasploit3 < Msf::Post
     # cowsay(1) chunks a message up into 39-byte chunks and wraps it in '| ' and ' |'
     # Rex::Text.wordwrap(text, 0, 39, ' |', '| ') almost does this, but won't
     # split a word that has > 39 characters in it which results in oddly formed
-    # text in the cowsay banner, so just do it by hand
+    # text in the cowsay banner, so just do it by hand.  This big mess wraps
+    # the provided text in an ASCII-cloud and then makes it look like the cloud
+    # is a thought/word coming from the ASCII-cow.  Each line in the
+    # ASCII-cloud is no more than 34-characters long, and the cloud corners are
+    # made to look rounded
     text_lines = text.scan(/.{1,34}/)
     max_length = text_lines.map(&:size).sort.last
     cloud_parts = []

--- a/modules/post/multi/general/wall.rb
+++ b/modules/post/multi/general/wall.rb
@@ -1,0 +1,48 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Post
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Write Messages to Users',
+        'Description'   => %q{
+          This module utilizes the wall(1) or write(1) utilities, as appropriate,
+          to send messages to users on the target system.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
+        # TODO: is there a way to do this on Windows?
+        'Platform'      => %w(linux osx unix),
+        'SessionTypes'  => %w(shell meterpreter)
+      )
+    )
+    register_options(
+      [
+        OptString.new('MESSAGE', [true, 'The message to send']),
+        OptString.new('USERS', [false, 'List of users to write(1) to, separated by commas. ' \
+                      ' wall(1)s to all users by default'])
+      ], self.class)
+  end
+
+  def users
+    datastore['USERS'] ? datastore['USERS'].split(/\s*,\s*/) : nil
+  end
+
+  def message
+    datastore['MESSAGE'] ? datastore['MESSAGE'] : "Hello metasploit session #{session.id}, the time is #{Time.now}"
+  end
+
+  def run
+    if users
+      users.map { |user| cmd_exec("echo '#{message}' | write #{user}") }
+    else
+      cmd_exec("echo '#{message}' | wall")
+    end
+  end
+end

--- a/spec/lib/rex/text_spec.rb
+++ b/spec/lib/rex/text_spec.rb
@@ -167,6 +167,61 @@ describe Rex::Text do
       end
     end
 
+    context ".cowsay" do
+
+      def moo(num)
+        (%w(moo) * num).join(' ')
+      end
+
+      it "should cowsay single lines correctly" do
+        cowsaid = <<EOCOW
+ _____________________
+< moo moo moo moo moo >
+ ---------------------
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOCOW
+        described_class.cowsay(moo(5)).should eq(cowsaid)
+      end
+
+      it "should cowsay two lines correctly" do
+        cowsaid = <<EOCOW
+ _____________________________________
+/ moo moo moo moo moo moo moo moo moo \\
+\\  moo moo moo moo moo moo            /
+ -------------------------------------
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOCOW
+        described_class.cowsay(moo(15)).should eq(cowsaid)
+      end
+
+      it "should cowsay three+ lines correctly" do
+        cowsaid = <<EOCOW
+ _____________________________________
+/ moo moo moo moo moo moo moo moo moo \\
+|  moo moo moo moo moo moo moo moo mo |
+| o moo moo moo moo moo moo moo moo m |
+\\ oo moo moo moo                      /
+ -------------------------------------
+       \\   ,__,
+        \\  (oo)____
+           (__)    )\\
+              ||--|| *
+EOCOW
+        described_class.cowsay(moo(30)).should eq(cowsaid)
+      end
+
+      it "should respect the wrap" do
+        wrap = 40 + rand(100)
+        cowsaid = described_class.cowsay(moo(1000), wrap)
+        max_len = cowsaid.split(/\n/).map(&:length).sort.last
+        max_len.should eq(wrap)
+      end
+    end
   end
 end
-


### PR DESCRIPTION
This is a simple wrapper around the `wall(1)` and `write(1)` commands available on most UNIX-like targets that may be useful in similar shenanigan-laden situations in which you'd probably use [post/osx/admin/say](https://github.com/rapid7/metasploit-framework/blob/master/modules/post/osx/admin/say.rb).  Yes, there are probably plent of existing post modules or tricks you could use to achieve the same end goal, but I figured this might be fun for someone.  Oh, and it has a cowsay option that doesn't rely on cowsay being installed.  

With `msfconsole` running as `jhart` and the root-privileged session connecting to `eth0`:

```
msf post(wall) > run
```

In all terminals, including `msfconsole`, I see:

```
Hello from a metasploit session at 2015-11-11 12:11:16 -0800                   
```

With a custom `MESSAGE`:

```
msf post(wall) > set MESSAGE hello?  is this on?
MESSAGE => hello? is this on?
msf post(wall) > run
```

In all terminals, including `msfconsole`, I see:

```
hello? is this on?                                                             
```

With `COWSAY` on:

```
msf post(wall) > set COWSAY true
COWSAY => true
msf post(wall) > run
```

In all terminals, including `msfconsole`, I see:

```
 ____________________                                                          
< hello? is this on? >                                                         
 --------------------                                                          
       \   ,__,                                                                
        \  (oo)____                                                            
           (__)    )\                                                          
              ||--|| *                                                         

```

Targeting just root:

```
msf post(wall) > set USERS root
USERS => root
msf post(wall) > run
```

And in a login shell for root with `mesg` `y`, I see:

```
root@jhart-laptop:~# mesg y
root@jhart-laptop:~# 
Message from root@jhart-laptop on pts/27 at 12:13 ...
 ____________________ 
< hello? is this on? >
 -------------------- 
       \   ,__,
        \  (oo)____
           (__)    )\
              ||--|| *

EOF
```
