### PR TITLE
Fix #6213 - to_linux_x86_elf supporting custom :template

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -995,7 +995,7 @@ require 'msf/core/exe/segment_appender'
       # Use set_template_default to normalize the :template key. It will just end up doing
       # opts[:template] = File.join(opts[:template_path], opts[:template])
       # for us, check if the file exists.
-      set_template_default(opts)
+      set_template_default(opts, 'template_x86_linux.bin')
 
       # If this isn't our normal template, we have to do some fancy
       # header patching to mark the .text section rwx before putting our

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -992,6 +992,11 @@ require 'msf/core/exe/segment_appender'
     if default
       elf = to_exe_elf(framework, opts, "template_x86_linux.bin", code)
     else
+      # Use set_template_default to normalize the :template key. It will just end up doing
+      # opts[:template] = File.join(opts[:template_path], opts[:template])
+      # for us, check if the file exists.
+      set_template_default(opts)
+
       # If this isn't our normal template, we have to do some fancy
       # header patching to mark the .text section rwx before putting our
       # payload into the entry point.


### PR DESCRIPTION
When the to_linux_x86_elf parses a custom template, it forgets to normalize the path before using it, so this patch fixes that.

Fix #6213
## Verification
- [ ] Get a 32-bit ELF file from Linux. For example: /bin/bash. Or just run the following msfvenom command in Linux:
- [ ] Do: `./msfvenom -p linux/x86/meterpreter/reverse_tcp LHOST=IP lport=PORT -x /bin/bash -k  -f elf > /tmp/test.bin`. The -x param is the path to a custom binary
- [ ] It should generate a payload file without an error
- [ ] Do: `file /tmp/test.bin`. It should be a 32-bit ELF file.
