### PR TITLE
Host header transport

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -351,7 +351,9 @@ protected
         # we don't get new ones generated.
         blob = obj.stage_payload(
           uuid: uuid,
-          uri:  conn_id
+          uri:  conn_id,
+          lhost: datastore['OverrideRequestHost'] ? datastore['OverrideLHOST'] : (req && req.headers && req.headers['Host']) ? req.headers['Host'] : datastore['LHOST'],
+          lport: datastore['OverrideRequestHost'] ? datastore['OverrideLPORT'] : datastore['LPORT']
         )
 
         resp.body = encode_stage(blob)

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -55,8 +55,8 @@ module Msf::Payload::TransportConfig
 
     {
       :scheme       => 'http',
-      :lhost        => datastore['LHOST'],
-      :lport        => datastore['LPORT'].to_i,
+      :lhost        => opts[:lhost],
+      :lport        => opts[:lport].to_i,
       :uri          => uri,
       :comm_timeout => datastore['SessionCommunicationTimeout'].to_i,
       :retry_total  => datastore['SessionRetryTotal'].to_i,


### PR DESCRIPTION
The `Host` header is ignored when using an intermediary proxy with the reverse_http handler. Priority is meant to be given to the `Host` header for incoming requests, but when the initial transport is established only the `datastore['LHOST']` and `datastore['LPORT']` are considered. There is no consideration to the `OverrideRequestHost`, `OverrideLPORT`, and `OverrideLHOST` options either. 
