### PR TITLE
change the default SMBDomain to .

### DIFF
--- a/lib/msf/core/exploit/smb/client/authenticated.rb
+++ b/lib/msf/core/exploit/smb/client/authenticated.rb
@@ -14,7 +14,7 @@ module Exploit::Remote::SMB::Client::Authenticated
       [
         OptString.new('SMBUser', [ false, 'The username to authenticate as', '']),
         OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
-        OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', 'WORKGROUP']),
+        OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.']),
       ], Msf::Exploit::Remote::SMB::Client::Authenticated)
   end
 end


### PR DESCRIPTION
Due to a recent change using WORKGROUP
as the SMBDomain causes Trust errors.
Using '.' instead works fine.

VERIFICATION STEPS
- [x] `./msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] `show options`
- [x] VERIFY SMBDomain has defaulted to a .
