### PR TITLE
Fix #4273, print error in create_session

### DIFF
--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -189,7 +189,14 @@ protected
     # If the payload we merged in with has an associated session factory,
     # allocate a new session.
     if (self.session)
-      s = self.session.new(conn, opts)
+      begin
+        s = self.session.new(conn, opts)
+      rescue ::Exception => e
+        # We just wanna show and log the error, not trying to swallow it.
+        print_error("#{e.class} #{e.message}")
+        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        raise e
+      end
 
       # Pass along the framework context
       s.framework = framework


### PR DESCRIPTION
Fix #4273 

According to #4273, it sounds like it's possible to see an exception in the create_session method. I'm not exactly sure which exceptions would raise (in the backtrace, it's OpenSSL::SSL::SSLError, but there might be others), so basically what I do here is `rescue ::Exception`, print_error & log it, and the raise it again to avoid shutting it up.

@bcook-r7 Could you please take a look at this and see if it's okay?
