### PR TITLE
Minor enhancement to smart_migrate

### DIFF
--- a/modules/post/windows/manage/smart_migrate.rb
+++ b/modules/post/windows/manage/smart_migrate.rb
@@ -27,6 +27,11 @@ class Metasploit3 < Msf::Post
     server = client.sys.process.open
     original_pid = server.pid
     print_status("Current server process: #{server.name} (#{server.pid})")
+    if server.name.casecmp("winlogon.exe") == 0 or server.name.casecmp("explorer.exe") == 0
+      print_good("Current process is already in #{server.name} process, exiting.")
+      return
+    end
+
 
     uid = client.sys.config.getuid
 


### PR DESCRIPTION
Adding a check to see if the user is currently already migrated to the "explorer.exe" and "winlogon.exe" processes prior to attempting migration.

The current smart_migrate post exploitation script does not check for whether or not the client is already migrated to one of the target processes (explorer.exe or winlogon.exe) prior to attempting migration. 

As a result, when this script is executed in a process that is already migrated, it results in the "stdapi_sys_process_get_processes" being sent to the client multiple times, one for each migration attempt. This increases the amount of network traffic, and unnecessarily displays error information to the user. 

Before (with 3 requests to stdapi_sys_process_get_processes):

```
meterpreter > run post/windows/manage/smart_migrate 

[*] [2015.11.19-13:24:03] Current server process: Explorer.EXE (2564)
[*] [2015.11.19-13:24:03] Attempting to move into explorer.exe for current user...
[+] [2015.11.19-13:24:03] Migrating to 2564
[-] [2015.11.19-13:24:04] Could not migrate in to process.
[-] [2015.11.19-13:24:04] Cannot migrate into current process
[*] [2015.11.19-13:24:04] Attempting to move into explorer.exe for other users...
[*] [2015.11.19-13:24:04] Attempting to move into winlogon.exe
[+] [2015.11.19-13:24:04] Migrating to 368
[-] [2015.11.19-13:24:04] Could not migrate in to process.
[-] [2015.11.19-13:24:04] Cannot migrate into this process (insufficient privileges)
[-] [2015.11.19-13:24:04] Was unable to successfully migrate into any of our likely candidates
```

After (No requests to stdapi_sys_process_get_processes):

```
meterpreter > run post/windows/manage/smart_migrate 

[*] [2015.11.19-13:23:31] Current server process: Explorer.EXE (2564)
[+] [2015.11.19-13:23:32] Current process is already in Explorer.EXE process, exiting.
```
