### PR TITLE
Fix #6085, NoMethodError in vim_soap.rb

### DIFF
--- a/lib/msf/core/exploit/vim_soap.rb
+++ b/lib/msf/core/exploit/vim_soap.rb
@@ -185,8 +185,8 @@ module Exploit::Remote::VIMSoap
       'headers' => { 'SOAPAction' => @soap_action}
     }, 25)
     return false unless res and res.code == 200
-     @server_objects = Hash.from_xml(res.body)['Envelope']['Body']['RetrieveServiceContentResponse']['returnval']
-     @soap_action = "urn:vim25/#{@server_objects['about']['apiVersion']}"
+     @server_objects = (((Hash.from_xml(res.body)['Envelope'] || {})['Body'] || {})['RetrieveServiceContentResponse'] || {})['returnval']
+     @soap_action = "urn:vim25/#{(@server_objects['about'] || {})['apiVersion']}"
     if res.headers['Set-Cookie']
       @vim_cookie = res.headers['Set-Cookie']
       return true


### PR DESCRIPTION
Fix #6085 
## Verification
- [x] We haven't been able to get the XML data that would cause the error, all we have is a [backtrace](https://github.com/rapid7/metasploit-framework/issues/6085#issue-111337077). So "verification" is purely code reading. If you think this patch should fix the problem, feel free to land.
