### PR TITLE
Add a NotImplementedError if "run" is used to run a local exploit

### DIFF
--- a/lib/msf/core/exploit/local.rb
+++ b/lib/msf/core/exploit/local.rb
@@ -19,4 +19,9 @@ class Msf::Exploit::Local < Msf::Exploit
   def exploit_type
     Msf::Exploit::Type::Local
   end
+
+  def run_simple(opts = {}, &block)
+    print_warning("test")
+    raise NotImplementedError, ' - This way of running the local exploit is currently not supported.'
+  end
 end

--- a/lib/msf/core/exploit/local.rb
+++ b/lib/msf/core/exploit/local.rb
@@ -21,7 +21,6 @@ class Msf::Exploit::Local < Msf::Exploit
   end
 
   def run_simple(opts = {}, &block)
-    print_warning("test")
     raise NotImplementedError, ' - This way of running the local exploit is currently not supported.'
   end
 end


### PR DESCRIPTION
Running a local exploit like a post is not currently supported, we should at least raise a warning or something, and not just let it backtrace and confuse the user.

I spoke to @jlee-r7 about whether we should allow a local exploit to be run by using the run command in the meterpreter prompt, we probably should, but it seems to be a hassle to implement, so let's at least raise NotImplementedError and inform the user about the invalid usage.

This is related to https://github.com/rapid7/metasploit-framework/issues/5924, but I am not sure if this PR is enough to address that, so merging this won't automatically close the ticket.
## Verification
- [x] Start a Windows 7 box for testing
- [x] Generate a meterpreter payload as an executable
- [x] Put the meterpreter executable on the Windows 7
- [x] Start msfconsole
- [x] Start a meterpreter listener
- [x] Double click on the meterpreter executable, and you should get a shell
- [x] At the meterpreter prompt, do: `run exploit/windows/local/ms15_051_client_copy_image`
- [x] It should say: `Error running command run: NotImplementedError  - This way of running the local exploit is currently not supported`
- [x] At the meterpreter prompt, do: `background`. That should take you back to the msf prompt.
- [x] At the msf prompt, do `use exploit/windows/local/ms15_051_client_copy_image`
- [x] Do: `run`
- [x] The exploit should run
