### PR TITLE
Bring module title in line with other WP modules.

### DIFF
--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'          => 'W3-Total-Cache Wordpress-plugin 0.9.2.4 (or before) Username and Hash Extract',
+      'Name'          => 'WordPress W3-Total-Cache plugin 0.9.2.4 (or before) Username and Hash Extract',
       'Description'   =>
         "The W3-Total-Cache Wordpress Plugin <= 0.9.2.4 can cache database statements
         and it's results in files for fast access. Version 0.9.2.4 has been fixed afterwards

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'          => 'WordPress W3-Total-Cache plugin 0.9.2.4 (or before) Username and Hash Extract',
+      'Name'          => 'WordPress W3-Total-Cache Plugin 0.9.2.4 (or before) Username and Hash Extract',
       'Description'   =>
         "The W3-Total-Cache Wordpress Plugin <= 0.9.2.4 can cache database statements
         and it's results in files for fast access. Version 0.9.2.4 has been fixed afterwards

--- a/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
+++ b/modules/auxiliary/scanner/http/wordpress_cp_calendar_sqli.rb
@@ -14,7 +14,7 @@ class Metasploit4 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'CP Multi-View Calendar Unauthenticated SQL Injection Scanner',
+      'Name'        => 'WordPress CP Multi-View Calendar Unauthenticated SQL Injection Scanner',
       'Description' => %q{
         This module will scan given instances for an unauthenticated SQL injection
         within the CP Multi-View Calendar plugin v1.1.4 for Wordpress.

--- a/modules/auxiliary/scanner/http/wp_contus_video_gallery_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_contus_video_gallery_sqli.rb
@@ -13,7 +13,7 @@ class Metasploit4 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Contus Video Gallery Unauthenticated SQL Injection Scanner',
+      'Name'        => 'WordPress Contus Video Gallery Unauthenticated SQL Injection Scanner',
       'Description' => %q{
       This module attempts to exploit a UNION-based SQL injection in Contus Video
       Gallery for Wordpress version 2.7 and likely prior in order if the instance is


### PR DESCRIPTION
Last 3 modules which don't fit with the other WP module naming.
