### PR TITLE
Remove default true of datastore of owa_login

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptInt.new('RPORT', [ true, "The target port", 443]),
-        OptAddress.new('RHOST', [ true, "The target address", '']),
+        OptAddress.new('RHOST', [ true, "The target address" ]),
         OptBool.new('ENUM_DOMAIN', [ true, "Automatically enumerate AD domain using NTLM authentication", true]),
         OptBool.new('AUTH_TIME', [ false, "Check HTTP authentication response time", true])
       ], self.class)

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptInt.new('RPORT', [ true, "The target port", 443]),
-        OptAddress.new('RHOST', [ true, "The target address", true]),
+        OptAddress.new('RHOST', [ true, "The target address", '']),
         OptBool.new('ENUM_DOMAIN', [ true, "Automatically enumerate AD domain using NTLM authentication", true]),
         OptBool.new('AUTH_TIME', [ false, "Check HTTP authentication response time", true])
       ], self.class)


### PR DESCRIPTION
Using the modules/auxiliary/scanner/http/owa_login on an engagement today I realized the default datastore value of RHOST is set to true. Since it is an OptAddress option, the default value should be empty rather than true. 
