### PR TITLE
Change job view to show bind port if applicable

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -658,7 +658,15 @@ class ReadableText
       ctx = framework.jobs[k].ctx
       row = [ k, framework.jobs[k].name ]
       row << (ctx[1].nil? ? (ctx[0].datastore['PAYLOAD'] || "") : ctx[1].refname)
-      row << (ctx[0].datastore['LPORT'] || "")
+
+      # Make the LPORT show the bind port if it's different
+      local_port = ctx[0].datastore['LPORT']
+      bind_port = ctx[0].datastore['ReverseListenerBindPort']
+      lport = (local_port || "").to_s
+      if bind_port && bind_port != 0 && bind_port != lport
+        lport << " (#{bind_port})"
+      end
+      row << lport
 
       if (verbose)
         uripath = ctx[0].get_resource if ctx[0].respond_to?(:get_resource)


### PR DESCRIPTION
When rendering the `jobs` list, the `LPORT` shows what was set in in the `LPORT` datastore option when the job was launched. This is fine, except in cases where the `ReverseListenerBindPort` is used to force the listener to bind on a different port. In this case the jobs list feels misleading because the port that is rendered can be the same as others:

```
$ ./msfconsole -x 'use multi/handler; set payload windows/meterpreter_reverse_tcp; set LHOST 127.0.0.1; set ExitOnSession false; set LPORT 4444; run -j; set payload windows/meterpreter/reverse_tcp; set ReverseListenerBindPort 5555; run -j'

... snip ...

msf exploit(handler) > jobs

Jobs
====

  Id  Name                    Payload                          LPORT
  --  ----                    -------                          -----
  0   Exploit: multi/handler  windows/meterpreter_reverse_tcp  4444
  1   Exploit: multi/handler  windows/meterpreter/reverse_tcp  4444
```

I use this mechanism often to force reconnects on the stageless listener once a staged connection has actually been staged.

It's not possible to determine which of these is actually listening on `4444`, and which is not.

This PR fixes this, and actually shows the bind port alongside the `LPORT` value if it is present and different to the `LPORT` value:

```
$ ./msfconsole -x 'use multi/handler; set payload windows/meterpreter_reverse_tcp; set LHOST 127.0.0.1; set ExitOnSession false; set LPORT 4444; run -j; set payload windows/meterpreter/reverse_tcp; set ReverseListenerBindPort 5555; run -j'

... snip ...

msf exploit(handler) > jobs

Jobs
====

  Id  Name                    Payload                          LPORT
  --  ----                    -------                          -----
  0   Exploit: multi/handler  windows/meterpreter_reverse_tcp  4444
  1   Exploit: multi/handler  windows/meterpreter/reverse_tcp  4444 (5555)
```

I decided to add this into the `LPORT` field instead of adding a new field because I felt that these were tied closely together.
## Verification
- [x] When `ReverseListenerBindPort` is _not_ set, the `jobs` command works as it did before.
- [x] When `ReverseListenerBindPort` is set to the same value as `LPORT`, the `jobs` command works as it did before.
- [x] When `ReverseListenerBindPort` is set to a _different_ value as `LPORT`, the `jobs` command works as it did before but the `LPORT` field in the table shows the value of `ReverseListenerBindPort` in parens alongside the actual `LPORT` value.
