### PR TITLE
unfold override lhost/lport logic

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -347,13 +347,30 @@ protected
 
         resp['Content-Type'] = 'application/octet-stream'
 
+        lhost = datastore['LHOST']
+        lport = datastore['LPORT']
+
+        if datastore['OverrideRequestHost']
+          if datastore['OverrideLHOST']
+            lhost = datastore['OverrideLHOST']
+          else
+            if req && req.headers && req.headers['Host']
+              lhost = req.headers['Host']
+            end
+          end
+
+          if datastore['OverrideLPORT']
+            lport = datastore['OverrideLPORT']
+          end
+        end
+
         # generate the stage, but pass in the existing UUID and connection id so that
         # we don't get new ones generated.
         blob = obj.stage_payload(
           uuid: uuid,
           uri:  conn_id,
-          lhost: datastore['OverrideRequestHost'] ? datastore['OverrideLHOST'] : (req && req.headers && req.headers['Host']) ? req.headers['Host'] : datastore['LHOST'],
-          lport: datastore['OverrideRequestHost'] ? datastore['OverrideLPORT'] : datastore['LPORT']
+          lhost: lhost,
+          lport: lport
         )
 
         resp.body = encode_stage(blob)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -344,33 +344,17 @@ protected
       when :init_native
         print_status("#{cli.peerhost}:#{cli.peerport} (UUID: #{uuid.to_s}) Staging Native payload ...")
         url = payload_uri(req) + conn_id + "/\x00"
+        uri = URI(payload_uri(req) + conn_id)
 
         resp['Content-Type'] = 'application/octet-stream'
-
-        lhost = datastore['LHOST']
-        lport = datastore['LPORT']
-
-        if datastore['OverrideRequestHost']
-          if datastore['OverrideLHOST']
-            lhost = datastore['OverrideLHOST']
-          else
-            if req && req.headers && req.headers['Host']
-              lhost = req.headers['Host']
-            end
-          end
-
-          if datastore['OverrideLPORT']
-            lport = datastore['OverrideLPORT']
-          end
-        end
 
         # generate the stage, but pass in the existing UUID and connection id so that
         # we don't get new ones generated.
         blob = obj.stage_payload(
           uuid: uuid,
           uri:  conn_id,
-          lhost: lhost,
-          lport: lport
+          lhost: uri.host,
+          lport: uri.port
         )
 
         resp.body = encode_stage(blob)


### PR DESCRIPTION
This PR unfolds the nested ternary logic from #6234 to fix #6289, and makes it a little easier to follow what's happening.  I think this also preserves the original intent of #6234 as well.

What do you think @scriptjunkie / @sammbertram ? Did I understand the original issue? At any rate, this fixes the normal case when OverrideRequestHost is unset.
