### PR TITLE
Fix #6287, check DisablePayloadHandler value in exploit.rb

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -154,7 +154,8 @@ class Exploit
     else
       # If we didn't run a payload handler for this exploit it doesn't
       # make sense to complain to the user that we didn't get a session
-      unless (mod.datastore["DisablePayloadHandler"])
+      disable_handler = /^true$/i === mod.datastore["DisablePayloadHandler"] ? true : false
+      unless disable_handler
         fail_msg = 'Exploit completed, but no session was created.'
         print_status(fail_msg)
         begin


### PR DESCRIPTION
Fixes #6287

It looks like active_module datastore options are always strings. They are actually different than what the module uses (normalized), so we have to always have to check.
- [x] Do: `ruby -run -e httpd . -p 8181`
- [x] Do: `exploit/windows/http/ia_webmail`
- [x] Do: `set rhost [IP]`
- [x] Do: `set RPORT [port]`
- [x] Do: `run`
- [x] You should see "Exploit completed, but no session was created."
