### PR TITLE
reverse_http should display ReverseListenerBindPort if used

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -81,7 +81,7 @@ module ReverseHttp
   # @return [String] A URI of the form +scheme://host:port/+
   def listener_uri
     uri_host = Rex::Socket.is_ipv6?(listener_address) ? "[#{listener_address}]" : listener_address
-    "#{scheme}://#{uri_host}:#{datastore['LPORT']}/"
+    "#{scheme}://#{uri_host}:#{bind_port}/"
   end
 
   # Return a URI suitable for placing in a payload.


### PR DESCRIPTION
ReverseListenerBindPort overrides LPORT if it is used. The `listener_uri` method should use the output `bind_port` to account for this.

```
$ ./msfconsole -x 'use multi/handler; set PAYLOAD windows/meterpreter/reverse_http; set LHOST 127.0.0.1; set LPORT 4444; set ReverseListenerBindPort 5555; run'

...
PAYLOAD => windows/meterpreter/reverse_http
LHOST => 127.0.0.1
LPORT => 4444
ReverseListenerBindPort => 5555
[*] Started HTTP reverse handler on http://0.0.0.0:4444/
```

The correct message is:

```
[*] Started HTTP reverse handler on http://0.0.0.0:5555/
```
