### PR TITLE
Add Username to Creds Database with owa_login.rb

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -28,7 +28,8 @@ class Metasploit3 < Msf::Auxiliary
           'sinn3r',
           'Brandon Knight',
           'Pete (Bokojan) Arzamendi', # Outlook 2013 updates
-          'Nate Power'                # HTTP timing option
+          'Nate Power',                # HTTP timing option
+          'Chapman (R3naissance) Schleiss' # Save username in creds if response is less than 1 sec
         ],
       'License'        => MSF_LICENSE,
       'Actions'        =>
@@ -79,9 +80,9 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptInt.new('RPORT', [ true, "The target port", 443]),
-        OptAddress.new('RHOST', [ true, "The target address" ]),
+        OptAddress.new('RHOST', [ true, "The target address", true]),
         OptBool.new('ENUM_DOMAIN', [ true, "Automatically enumerate AD domain using NTLM authentication", true]),
-        OptBool.new('AUTH_TIME', [ false, "Check HTTP authentication response time", true])
+        OptBool.new('AUTH_TIME', [ false, "Check HTTP authentication response time and save to creds if under 1 sec", true])
       ], self.class)
 
 
@@ -225,9 +226,20 @@ class Metasploit3 < Msf::Auxiliary
       if reason == nil
         headers['Cookie'] = 'PBack=0;' << res.get_cookies
       else
-      # Login didn't work. no point on going on.
-        vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (HTTP redirect with reason #{reason})")
-        return :Skip_pass
+        # Login didn't work. no point in going on, however, check if valid domain account by response time.
+        if elapsed_time <= 1
+          report_cred(
+            ip: datastore['RHOST'],
+            port: datastore['RPORT'],
+            service_name: 'owa',
+            user: user
+          )
+          print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
+          return :Skip_pass
+        else
+          vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (HTTP redirect with reason #{reason})")
+          return :Skip_pass
+        end
       end
     else
        # The authentication info is in the cookies on this response
@@ -261,8 +273,19 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     if res.redirect?
-      vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (response was a #{res.code} redirect)")
-      return :skip_pass
+      if elapsed_time <= 1
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'owa',
+          user: user
+        )
+        print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
+        return :Skip_pass
+      else
+        vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (response was a #{res.code} redirect)")
+        return :skip_pass
+      end
     end
 
     if res.body =~ login_check
@@ -276,8 +299,19 @@ class Metasploit3 < Msf::Auxiliary
       )
       return :next_user
     else
-      vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (response body did not match)")
-      return :skip_pass
+      if elapsed_time <= 1
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'owa',
+          user: user
+        )
+        print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
+        return :Skip_pass
+      else
+        vprint_error("#{msg} FAILED LOGIN. #{elapsed_time} '#{user}' : '#{pass}' (response body did not match)")
+        return :skip_pass
+      end
     end
   end
 
@@ -331,13 +365,22 @@ class Metasploit3 < Msf::Auxiliary
       workspace_id: myworkspace_id
     }
 
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
+    # Test if password was passed, if so, add private_data. If not, assuming only username was found
+    if opts.has_key?(:password)
+      credential_data = {
+        origin_type: :service,
+        module_fullname: fullname,
+        username: opts[:user],
+        private_data: opts[:password],
+        private_type: :password
+      }.merge(service_data)
+    else
+      credential_data = {
+        origin_type: :service,
+        module_fullname: fullname,
+        username: opts[:user]
+      }.merge(service_data)
+    end
 
     login_data = {
       core: create_credential(credential_data),


### PR DESCRIPTION
Using the Auth_Time option within the module checks for the response time. If the response time is under 1 second, it indicates a valid domain username. Historically, the module output would only show the attempted account and the response time, the changes made will save the username (no private data) to the creds database in order to save legitimate usernames for more targeted attacks. Added code to check for response time, save to creds, print status of enumerated username.

```
if elapsed_time <= 1
  report_cred(
    ip: datastore['RHOST'],
    port: datastore['RPORT'],
    service_name: 'owa',
    user: user
  )
  print_status("#{msg} FAILED LOGIN, BUT USERNAME IS VALID. #{elapsed_time} '#{user}' : '#{pass}': SAVING TO CREDS")
```

Also modified the report_cred function to check if no password option is present and if so, don't include password_data/password_type as this would result in the creds database showing 'Blank Password'.

```
# Test if password was passed, if so, add private_data. If not, assuming only username was found
    if opts.has_key?(:password)
      credential_data = {
        origin_type: :service,
        module_fullname: fullname,
        username: opts[:user],
        private_data: opts[:password],
        private_type: :password
      }.merge(service_data)
    else
      credential_data = {
        origin_type: :service,
        module_fullname: fullname,
        username: opts[:user]
      }.merge(service_data)
    end
```
