### PR TITLE
Use concat instead of assignment on java proxy classes encoding

### DIFF
--- a/lib/rex/java/serialization/model/contents.rb
+++ b/lib/rex/java/serialization/model/contents.rb
@@ -88,7 +88,7 @@ module Rex
             when NewClassDesc
               encoded << [TC_CLASSDESC].pack('C')
             when ProxyClassDesc
-              content = [TC_PROXYCLASSDESC].pack('C')
+              encoded << [TC_PROXYCLASSDESC].pack('C')
             when NullReference
               encoded << [TC_NULL].pack('C')
             when Reset


### PR DESCRIPTION
- encoding was missing proxy classes because of assignment instead of concatenation
- fixes bug in java serialization encoding proxy class

blame @jvazquez-r7  :)
