### PR TITLE
Support migrating to processes by process name

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -816,6 +816,8 @@ class Console::CommandDispatcher::Core
   end
 
   @@migrate_opts = Rex::Parser::Arguments.new(
+    '-P' => [true, 'PID to migrate to.'],
+    '-N' => [true, 'Process name to migrate to.'],
     '-p'  => [true,  'Writable path - Linux only (eg. /tmp).'],
     '-t'  => [true,  'The number of seconds to wait for migration to finish (default: 60).'],
     '-h'  => [false, 'Help menu.']
@@ -823,9 +825,9 @@ class Console::CommandDispatcher::Core
 
   def cmd_migrate_help
     if client.platform =~ /linux/
-      print_line('Usage: migrate <pid> [-p writable_path] [-t timeout]')
+      print_line('Usage: migrate <<pid> | -P <pid> | -N <name>> [-p writable_path] [-t timeout]')
     else
-      print_line('Usage: migrate <pid> [-t timeout]')
+      print_line('Usage: migrate <<pid> | -P <pid> | -N <name>> [-t timeout]')
     end
     print_line
     print_line('Migrates the server instance to another process.')
@@ -840,29 +842,37 @@ class Console::CommandDispatcher::Core
   #   platforms a path for the unix domain socket used for IPC.
   # @return [void]
   def cmd_migrate(*args)
-    if args.length == 0 || args.include?('-h')
+    if args.length == 0 || args.any? { |arg| %w(-h --pid --name).include? arg }
       cmd_migrate_help
       return true
     end
 
-    pid = args[0].to_i
-    if pid == 0
-      print_error('A process ID must be specified, not a process name')
-      return
-    end
-
+    pid = nil
     writable_dir = nil
     opts = {
       timeout: nil
     }
 
-    @@transport_opts.parse(args) do |opt, idx, val|
+    @@migrate_opts.parse(args) do |opt, idx, val|
       case opt
       when '-t'
         opts[:timeout] = val.to_i
       when '-p'
         writable_dir = val
+      when '-P'
+        pid = val.to_i
+      when '-N'
+        unless (process = client.sys.process.processes.find { |p| p['name'] == val })
+          print_error("Could not find process name #{val}")
+          return
+        end
+        pid = process['pid']
       end
+    end
+
+    unless pid
+      print_error('A process ID or name must be provided')
+      return
     end
 
     begin


### PR DESCRIPTION
Fixes #6313, assuming there isn't already a better way of doing this.

Existing functionality remains unchanged, but you can now pass a PID or process name as an explicit, named argument.  If you pass the PID as a named argument, it functions as if you just specified the PID alone (IOW, `migrate 12345` == `migrate -P 12345`), but if you pass a process name, it finds the PID of that process and migrates to it:

```
meterpreter > ps

Process List
============

 PID   PPID  Name               Arch  Session  User                           Path
 ---   ----  ----               ----  -------  ----                           ----
 0     0     [System Process]                                                 
 4     0     System             x64   0                                       
 100   516   svchost.exe        x64   0        NT AUTHORITY\NETWORK SERVICE   C:\Windows\System32\svchost.exe
 264   4     smss.exe           x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\smss.exe
 356   348   csrss.exe          x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\csrss.exe
 408   348   wininit.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\wininit.exe
 420   400   csrss.exe          x64   1        NT AUTHORITY\SYSTEM            C:\Windows\System32\csrss.exe
 468   400   winlogon.exe       x64   1        NT AUTHORITY\SYSTEM            C:\Windows\System32\winlogon.exe
 516   408   services.exe       x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\services.exe
 524   408   lsass.exe          x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\lsass.exe
 532   408   lsm.exe            x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\lsm.exe
 612   608   powershell.exe     x86   0        NT AUTHORITY\SYSTEM            C:\Windows\syswow64\WindowsPowerShell\v1.0\powershell.exe
 632   516   svchost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\svchost.exe
 708   356   conhost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\conhost.exe
 712   516   svchost.exe        x64   0        NT AUTHORITY\NETWORK SERVICE   C:\Windows\System32\svchost.exe
 724   1160  regedit.exe        x64   1        ESSENTIALS-11-P\Administrator  C:\Windows\regedit.exe
 792   516   svchost.exe        x64   0        NT AUTHORITY\LOCAL SERVICE     C:\Windows\System32\svchost.exe
 852   516   svchost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\svchost.exe
 876   516   svchost.exe        x64   0        NT AUTHORITY\LOCAL SERVICE     C:\Windows\System32\svchost.exe
 900   516   svchost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\svchost.exe
 944   516   svchost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\svchost.exe
 1004  516   svchost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\svchost.exe
 1144  852   dwm.exe            x64   1        ESSENTIALS-11-P\Administrator  C:\Windows\System32\dwm.exe
 1160  1136  explorer.exe       x64   1        ESSENTIALS-11-P\Administrator  C:\Windows\explorer.exe
 1224  516   spoolsv.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\spoolsv.exe
 1272  516   svchost.exe        x64   0        NT AUTHORITY\LOCAL SERVICE     C:\Windows\System32\svchost.exe
 1384  516   svchost.exe        x64   0        NT AUTHORITY\LOCAL SERVICE     C:\Windows\System32\svchost.exe
 1420  3056  csrss.exe          x64   3        NT AUTHORITY\SYSTEM            C:\Windows\System32\csrss.exe
 1444  516   svchost.exe        x64   0        NT AUTHORITY\LOCAL SERVICE     C:\Windows\System32\svchost.exe
 1528  1160  vmtoolsd.exe       x64   1        ESSENTIALS-11-P\Administrator  C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 1544  516   SeaPort.EXE        x86   0        NT AUTHORITY\SYSTEM            C:\Program Files (x86)\Microsoft\BingBar\SeaPort.EXE
 1580  516   taskhost.exe       x64   1        ESSENTIALS-11-P\Administrator  C:\Windows\System32\taskhost.exe
 1788  516   SearchIndexer.exe  x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\SearchIndexer.exe
 1812  2816  LogonUI.exe        x64   3        NT AUTHORITY\SYSTEM            C:\Windows\System32\LogonUI.exe
 1880  516   cygrunsrv.exe      x86   0        NT AUTHORITY\SYSTEM            C:\cygwin\bin\cygrunsrv.exe
 1932  356   conhost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\conhost.exe
 1948  1916  sshd.exe           x86   0        NT AUTHORITY\SYSTEM            C:\cygwin\usr\sbin\sshd.exe
 2000  516   svchost.exe        x64   0        NT AUTHORITY\NETWORK SERVICE   C:\Windows\System32\svchost.exe
 2004  516   vmtoolsd.exe       x64   0        NT AUTHORITY\SYSTEM            C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 2040  516   WLIDSVC.EXE        x64   0        NT AUTHORITY\SYSTEM            C:\Program Files\Common Files\Microsoft Shared\Windows Live\WLIDSVC.EXE
 2100  1160  MSASCui.exe        x64   1        ESSENTIALS-11-P\Administrator  C:\Program Files\Windows Defender\MSASCui.exe
 2156  100   rdpclip.exe        x64   1        ESSENTIALS-11-P\Administrator  C:\Windows\System32\rdpclip.exe
 2200  2040  WLIDSVCM.EXE       x64   0        NT AUTHORITY\SYSTEM            C:\Program Files\Common Files\Microsoft Shared\Windows Live\WLIDSVCM.EXE
 2508  516   dllhost.exe        x64   0        NT AUTHORITY\SYSTEM            C:\Windows\System32\dllhost.exe
 2664  516   msdtc.exe          x64   0        NT AUTHORITY\NETWORK SERVICE   C:\Windows\System32\msdtc.exe
 2816  3056  winlogon.exe       x64   3        NT AUTHORITY\SYSTEM            C:\Windows\System32\winlogon.exe

meterpreter > migrate 2816
[*] Migrating from 612 to 2816...
[*] Migration completed successfully.
meterpreter > migrate -N vmtoolsd.exe
[*] Migrating from 2816 to 1528...
[*] Migration completed successfully.
meterpreter > migrate -P 2816
[*] Migrating from 1528 to 2816...
[*] Migration completed successfully.
meterpreter >
```
