### PR TITLE
Rework the logging and DB interaction for ssh_identify_pubkeys

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -266,7 +266,7 @@ class Metasploit3 < Msf::Auxiliary
       private_key: (key[:data][:private]) ? 'Yes' : 'No',
       info: key_info
     } 
-    report_note(host: ip, port: port, type: "ssh.publickey", data: note_information, update: :unique_data)
+    report_note(host: ip, port: port, type: "ssh.publickey.accepted", data: note_information, update: :unique_data)
   
   
     if key[:data][:private]

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -29,13 +29,16 @@ class Metasploit3 < Msf::Auxiliary
         this module will record authorized public keys and hosts so you can
         track your process.
 
-
         Key files may be a single public (unencrypted) key, or several public
         keys concatenated together as an ASCII text file. Non-key data should be
         silently ignored. Private keys will only utilize the public key component
         stored within the key file.
       },
-      'Author'      => ['todb', 'hdm'],
+      'Author'      => [
+        'todb', 
+        'hdm',
+        'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>', # Reworked the storage (db, credentials, notes, loot) only
+       ],
       'License'     => MSF_LICENSE
     )
 
@@ -116,11 +119,14 @@ class Metasploit3 < Msf::Auxiliary
     keepers = []
     keys.each do |key|
       if key =~ /ssh-(dss|rsa)/
-        keepers << key
+        # A public key has been provided
+        keepers << { :public => key, :private => "" }
         next
-      else # Use the mighty SSHKey library from James Miller to convert them on the fly.
+      else 
+        # Use the mighty SSHKey library from James Miller to convert them on the fly. 
+        # This is where a PRIVATE key has been provided
         ssh_version = SSHKey.new(key).ssh_public_key rescue nil
-        keepers << ssh_version if ssh_version
+        keepers << { :public => ssh_version, :private => key } if ssh_version
         next
       end
 
@@ -130,8 +136,8 @@ class Metasploit3 < Msf::Auxiliary
       next unless key =~ /\n-----END [RD]SA (PRIVATE|PUBLIC) KEY-----\x0d?\x0a?$/m
       # Shouldn't have binary.
       next unless key.scan(/[\x00-\x08\x0b\x0c\x0e-\x1f\x80-\xff]/).empty?
-      # Add more tests to taste.
-      keepers << key
+      # Add more tests to test
+      keepers << { :public => key, :private => "" }
     end
     if keepers.empty?
       print_error "#{ip}:#{rport} SSH - No valid keys found"
@@ -142,9 +148,9 @@ class Metasploit3 < Msf::Auxiliary
   def pull_cleartext_keys(keys)
     cleartext_keys = []
     keys.each do |key|
-      next unless key
-      next if key =~ /Proc-Type:.*ENCRYPTED/
-      this_key = key.gsub(/\x0d/,"")
+      next unless key[:public]
+      next if key[:private] =~ /Proc-Type:.*ENCRYPTED/
+      this_key = { :public => key[:public].gsub(/\x0d/,""), :private => key[:private] }
       next if cleartext_keys.include? this_key
       cleartext_keys << this_key
     end
@@ -182,13 +188,13 @@ class Metasploit3 < Msf::Auxiliary
       @alerted_with_msg = true
     end
 
-    cleartext_keys.each_with_index do |key_data,key_idx|
-      key_info  = ""
 
-      if key_data =~ /ssh\-(rsa|dss)\s+([^\s]+)\s+(.*)/
+    cleartext_keys.each_with_index do |key_data,key_idx|
+
+      key_info  = ""
+      if key_data[:public] =~ /ssh\-(rsa|dss)\s+([^\s]+)\s+(.*)/
         key_info = "- #{$3.strip}"
       end
-
 
       accepted = []
       opt_hash = {
@@ -196,12 +202,12 @@ class Metasploit3 < Msf::Auxiliary
         :msframework  => framework,
         :msfmodule    => self,
         :port         => port,
-        :key_data     => key_data,
+        :key_data     => key_data[:public],
         :disable_agent     => true,
         :record_auth_info  => true,
         :skip_private_keys => true,
         :config =>false,
-        :accepted_key_callback => Proc.new {|key| accepted << key },
+        :accepted_key_callback => Proc.new {|key| accepted << { :data => key_data, :key => key } },
         :proxies	  => datastore['Proxies']
       }
 
@@ -244,35 +250,63 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       accepted.each do |key|
-        print_brute :level => :good, :msg => "Accepted: '#{user}' with key '#{key[:fingerprint]}' #{key_info}"
-        do_report(ip, rport, user, key, key_data)
+        print_brute :level => :good, :msg => "Public key accepted: '#{user}' with key '#{key[:key][:fingerprint]}' #{key_info}"
+        do_report(ip, rport, user, key, key_data[:public], key_info)
       end
     end
   end
 
-  def do_report(ip, port, user, key, key_data)
+  def do_report(ip, port, user, key, key_data, key_info)
     return unless framework.db.active
-    keyfile_path = store_keyfile(ip,user,key[:fingerprint],key_data)
-    cred_hash = {
-      :host => ip,
-      :port => rport,
-      :sname => 'ssh',
-      :user => user,
-      :pass => keyfile_path,
-      :source_type => "user_supplied",
-      :type => 'ssh_pubkey',
-      :proof => "KEY=#{key[:fingerprint]}",
-      :duplicate_ok => true,
-      :active => true
-    }
-    this_cred = report_auth_info(cred_hash)
+  
+    # Store a note relating to the public key test
+    note_information = {
+      user: user,
+      public_key: key_data,
+      private_key: (key[:data][:private]) ? 'Yes' : 'No',
+      info: key_info
+    } 
+    report_note(host: ip, port: port, type: "ssh.publickey", data: note_information, update: :unique_data)
+  
+  
+    if key[:data][:private]
+      # Store these keys in loot
+      public_keyfile_path = store_public_keyfile(ip,user,key[:fingerprint],key_data)
+      private_keyfile_path = store_private_keyfile(ip,user,key[:fingerprint],key[:data][:private])
+
+      # Use the proper credential method to store credentials that we have
+      service_data = {
+        address: ip,
+        port: port,
+        service_name: 'ssh',
+        protocol: 'tcp',
+        workspace_id: myworkspace_id
+      }
+
+      credential_data = {
+        module_fullname: self.fullname,
+        origin_type: :service,
+        private_data: key[:data][:private],
+        private_type: :ssh_key,
+        username: key[:key][:user],
+      }.merge(service_data)
+    
+      login_data = {
+        core: create_credential(credential_data),
+        last_attempted_at: DateTime.now,
+        status: Metasploit::Model::Login::Status::SUCCESSFUL,
+        proof: private_keyfile_path
+      }.merge(service_data)
+      create_credential_login(login_data)
+  
+    end
   end
 
   def existing_loot(ltype, key_id)
     framework.db.loots(myworkspace).where(ltype: ltype).select {|l| l.info == key_id}.first
   end
 
-  def store_keyfile(ip,user,key_id,key_data)
+  def store_public_keyfile(ip,user,key_id,key_data)
     safe_username = user.gsub(/[^A-Za-z0-9]/,"_")
     ktype = key_data.match(/ssh-(rsa|dss)/)[1] rescue nil
     return unless ktype
@@ -286,6 +320,24 @@ class Metasploit3 < Msf::Auxiliary
       ip,
       (key_data + "\n"),
       "#{safe_username}_#{ktype}.pub",
+      key_id
+    )
+    return keyfile_path
+  end
+
+  def store_private_keyfile(ip,user,key_id,key_data)
+    safe_username = user.gsub(/[^A-Za-z0-9]/,"_")
+    ktype = key_data.match(/-----BEGIN ([RD]SA) (?:PRIVATE|PUBLIC) KEY-----/)[1].downcase rescue nil
+    return unless ktype
+    ltype = "host.unix.ssh.#{user}_#{ktype}_private"
+    keyfile = existing_loot(ltype, key_id)
+    return keyfile.path if keyfile
+    keyfile_path = store_loot(
+      ltype,
+      "application/octet-stream", # Text, but always want to mime-type attach it
+      ip,
+      (key_data + "\n"),
+      "#{safe_username}_#{ktype}.private",
       key_id
     )
     return keyfile_path

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
         stored within the key file.
       },
       'Author'      => [
-        'todb', 
+        'todb',
         'hdm',
         'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>', # Reworked the storage (db, credentials, notes, loot) only
        ],
@@ -122,8 +122,8 @@ class Metasploit3 < Msf::Auxiliary
         # A public key has been provided
         keepers << { :public => key, :private => "" }
         next
-      else 
-        # Use the mighty SSHKey library from James Miller to convert them on the fly. 
+      else
+        # Use the mighty SSHKey library from James Miller to convert them on the fly.
         # This is where a PRIVATE key has been provided
         ssh_version = SSHKey.new(key).ssh_public_key rescue nil
         keepers << { :public => ssh_version, :private => key } if ssh_version
@@ -259,7 +259,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def do_report(ip, port, user, key, key_data, key_info, private_key_present)
     return unless framework.db.active
-  
+
     public_keyfile_path = store_public_keyfile(ip,user,key[:fingerprint],key_data)
 
     # Store a note relating to the public key test
@@ -268,9 +268,9 @@ class Metasploit3 < Msf::Auxiliary
       public_key: key_data,
       private_key: private_key_present,
       info: key_info
-    } 
+    }
     report_note(host: ip, port: port, type: "ssh.publickey.accepted", data: note_information, update: :unique_data)
-  
+
     if key[:data][:private] != ""
       # Store these keys in loot
       private_keyfile_path = store_private_keyfile(ip,user,key[:fingerprint],key[:data][:private])
@@ -291,7 +291,7 @@ class Metasploit3 < Msf::Auxiliary
         private_type: :ssh_key,
         username: key[:key][:user],
       }.merge(service_data)
-    
+
       login_data = {
         core: create_credential(credential_data),
         last_attempted_at: DateTime.now,
@@ -299,7 +299,7 @@ class Metasploit3 < Msf::Auxiliary
         proof: private_keyfile_path
       }.merge(service_data)
       create_credential_login(login_data)
-  
+
     end
   end
 


### PR DESCRIPTION
# Overview

When using the _ssh_identify_pubkeys_ auxiliary module in anger, I noticed that a bunch of warning message appears due to usage of the deprecated report_auth_info method.

```
msf > use auxiliary/scanner/ssh/ssh_identify_pubkeys
msf auxiliary(ssh_identify_pubkeys) > set RHOSTS 127.0.0.3
RHOSTS => 127.0.0.3
msf auxiliary(ssh_identify_pubkeys) > set KEY_FILE /tmp/msf
KEY_FILE => /tmp/msf
msf auxiliary(ssh_identify_pubkeys) > set USERNAME stuart
USERNAME => stuart
msf auxiliary(ssh_identify_pubkeys) > show options

Module options (auxiliary/scanner/ssh/ssh_identify_pubkeys):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   KEY_FILE          /tmp/msf         no        Filename of one or several cleartext public keys.
   RHOSTS            127.0.0.3        yes       The target address range or CIDR identifier
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads
   USERNAME          stuart           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf auxiliary(ssh_identify_pubkeys) > run

[*] 127.0.0.3:22 SSH - Trying 1 cleartext key per user.
[+] 127.0.0.3:22 SSH - [1/1] - Accepted: 'stuart' with key '9a:90:c2:a0:d9:ac:02:46:b4:85:c3:18:71:47:67:aa'
[!] *** auxiliary/scanner/ssh/ssh_identify_pubkeys is still calling the deprecated report_auth_info method! This needs to be updated!
[!] *** For detailed information about LoginScanners and the Credentials objects see:
[!]      https://github.com/rapid7/metasploit-framework/wiki/Creating-Metasploit-Framework-LoginScanners
[!]      https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-HTTP-LoginScanner-Module
[!] *** For examples of modules converted to just report credentials without report_auth_info, see:
[!]      https://github.com/rapid7/metasploit-framework/pull/5376
[!]      https://github.com/rapid7/metasploit-framework/pull/5377
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

It turns out that it is not quite as simple a fix because _ssh_identify_pubkeys_ works by presenting the _public_ key component to test whether authentication would be permitted, and there will not necessarily be a private key to store in the database.

Therefore, I have reworked this module to differentiate between public keys that you have given and private keys that you have derived the public key from. The module now:
- Stores the private key (if present) with the public key in an internal hash.
- If that public key could be used to successfully SSH to a box, display it as a 'good' finding in the console.
- Add the private key to loot and add it to the creds DB if we have the corresponding private key.
- Record the results of each successful public key attempt in notes. The 'creds' database shouldn't be used to store non-credentials. 
# Example
- The workspace was cleared.

```
msf auxiliary(ssh_identify_pubkeys) > creds
Credentials
===========

host  origin  service  public  private  realm  private_type
----  ------  -------  ------  -------  -----  ------------

msf auxiliary(ssh_identify_pubkeys) > loot

Loot
====

host  service  type  name  content  info  path
----  -------  ----  ----  -------  ----  ----

msf auxiliary(ssh_identify_pubkeys) > notes
msf auxiliary(ssh_identify_pubkeys) > 
```
- A public key was obtained and stored in /tmp/msf.pub for the purposes of the demonstration. The intention is for this to be tested against an SSH server listening on 127.0.0.3. The remote SSH server is configured to accept this key.

```
msf auxiliary(ssh_identify_pubkeys) > cat /tmp/msf.pub
[*] exec: cat /tmp/msf.pub

ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxxLaPtNBvdAbMAuwuiVUP6cmKhisnaAVFvdFxhMi+B2V1xyY08bEGdfZh0Zt+xNl31ZSQu3UlGXhSir6YLSBpnUD0Xxb6ngTNp1j9f8JPzYiWHCx5svDY451L83FQFUHugVKz/2RjhyblHNu+e1NgJ06jiOxYTZKUIeCryc0kDYBTXdi9r160/H1EOd3JeaeyzhXHE/D5BUTOEn2HjEd+bQ/RmEPJRoBHik1/BCxgqn8XaarZ2gJBpl7jZ3xSs/nC5xzOKty98/XNWANpigqSzKz7j4bqdi3DErl5Mj/kZ+Y8Iow0yUBmEF2IWCIQjPul50LhJYZLFIkDBMLDykVz

msf auxiliary(ssh_identify_pubkeys) > show options

Module options (auxiliary/scanner/ssh/ssh_identify_pubkeys):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   KEY_FILE          /tmp/msf.pub     no        Filename of one or several cleartext public keys.
   RHOSTS            127.0.0.3        yes       The target address range or CIDR identifier
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads
   USERNAME          stuart           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf auxiliary(ssh_identify_pubkeys) > rerun
[*] Reloading module...

[*] 127.0.0.3:22 SSH - Trying 1 cleartext key per user.
[+] 127.0.0.3:22 SSH - [1/1] - Public key accepted: 'stuart' with key '9a:90:c2:a0:d9:ac:02:46:b4:85:c3:18:71:47:67:aa' (Private Key: No)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ssh_identify_pubkeys) > creds
Credentials
===========

host  origin  service  public  private  realm  private_type
----  ------  -------  ------  -------  -----  ------------

msf auxiliary(ssh_identify_pubkeys) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
127.0.0.3             Unknown                    device         

msf auxiliary(ssh_identify_pubkeys) > loot

Loot
====

host       service  type                             name            content                   info  path
----       -------  ----                             ----            -------                   ----  ----
127.0.0.3           host.unix.ssh.stuart_rsa_public  stuart_rsa.pub  application/octet-stream        /home/stuart/.msf4/loot/20151205212932_pr_127.0.0.3_host.unix.ssh.st_860410.pub

msf auxiliary(ssh_identify_pubkeys) > notes
[*] Time: 2015-12-05 21:29:32 UTC Note: host=127.0.0.3 type=ssh.publickey.accepted data={:user=>"stuart", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxxLaPtNBvdAbMAuwuiVUP6cmKhisnaAVFvdFxhMi+B2V1xyY08bEGdfZh0Zt+xNl31ZSQu3UlGXhSir6YLSBpnUD0Xxb6ngTNp1j9f8JPzYiWHCx5svDY451L83FQFUHugVKz/2RjhyblHNu+e1NgJ06jiOxYTZKUIeCryc0kDYBTXdi9r160/H1EOd3JeaeyzhXHE/D5BUTOEn2HjEd+bQ/RmEPJRoBHik1/BCxgqn8XaarZ2gJBpl7jZ3xSs/nC5xzOKty98/XNWANpigqSzKz7j4bqdi3DErl5Mj/kZ+Y8Iow0yUBmEF2IWCIQjPul50LhJYZLFIkDBMLDykVz", :private_key=>"No", :info=>""}
```

The module will record a note showing that the public key has been accepted (storing a copy of the public key in the note and in a separate loot file) but will not store anything in the credential store. This is because we do not actually have any credentials for them.
- The workspace was reset, a candidate private key was obtained and stored in /tmp/msf for the purposes of the demonstration. 

```
msf auxiliary(ssh_identify_pubkeys) > show options

Module options (auxiliary/scanner/ssh/ssh_identify_pubkeys):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   KEY_FILE          /tmp/msf         no        Filename of one or several cleartext public keys.
   RHOSTS            127.0.0.3        yes       The target address range or CIDR identifier
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads
   USERNAME          stuart           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf auxiliary(ssh_identify_pubkeys) > cat /tmp/msf
[*] exec: cat /tmp/msf

-----BEGIN RSA PRIVATE KEY-----
MIIEpQIBAAKCAQEAscS2j7TQb3QGzALsLolVD+nJioYrJ2gFRb3RcYTIvgdldccm
NPGxBnX2YdGbfsTZd9WUkLt1JRl4Uoq+mC0gaZ1A9F8W+p4EzadY/X/CT82Ilhws
ebLw2OOdS/NxUBVB7oFSs/9kY4cm5RzbvntTYCdOo4jsWE2SlCHgq8nNJA2AU13Y
va9etPx9RDndyXmnss4VxxPw+QVEzhJ9h4xHfm0P0ZhDyUaAR4pNfwQsYKp/F2mq
2doCQaZe42d8UrP5wucczircvfP1zVgDaYoKksys+4+G6nYtwxK5eTI/5GfmPCKM
...snipped...

msf auxiliary(ssh_identify_pubkeys) > set KEY_FILE /tmp/msf
KEY_FILE => /tmp/msf

msf auxiliary(ssh_identify_pubkeys) > rerun
[*] Reloading module...

[*] 127.0.0.3:22 SSH - Trying 1 cleartext key per user.
[+] 127.0.0.3:22 SSH - [1/1] - Public key accepted: 'stuart' with key '9a:90:c2:a0:d9:ac:02:46:b4:85:c3:18:71:47:67:aa' (Private Key: Yes)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ssh_identify_pubkeys) > creds
Credentials
===========

host       origin     service       public  private                                          realm  private_type
----       ------     -------       ------  -------                                          -----  ------------
127.0.0.3  127.0.0.3  22/tcp (ssh)  stuart  9a:90:c2:a0:d9:ac:02:46:b4:85:c3:18:71:47:67:aa         SSH key

msf auxiliary(ssh_identify_pubkeys) > loot

Loot
====

host       service  type                              name                content                   info  path
----       -------  ----                              ----                -------                   ----  ----
127.0.0.3           host.unix.ssh.stuart_rsa_private  stuart_rsa.private  application/octet-stream        /home/stuart/.msf4/loot/20151205222347_pr_127.0.0.3_host.unix.ssh.st_971186.bin
127.0.0.3           host.unix.ssh.stuart_rsa_public   stuart_rsa.pub      application/octet-stream        /home/stuart/.msf4/loot/20151205222347_pr_127.0.0.3_host.unix.ssh.st_948699.pub

msf auxiliary(ssh_identify_pubkeys) > notes
[*] Time: 2015-12-05 22:23:47 UTC Note: host=127.0.0.3 type=ssh.publickey.accepted data={:user=>"stuart", :public_key=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCxxLaPtNBvdAbMAuwuiVUP6cmKhisnaAVFvdFxhMi+B2V1xyY08bEGdfZh0Zt+xNl31ZSQu3UlGXhSir6YLSBpnUD0Xxb6ngTNp1j9f8JPzYiWHCx5svDY451L83FQFUHugVKz/2RjhyblHNu+e1NgJ06jiOxYTZKUIeCryc0kDYBTXdi9r160/H1EOd3JeaeyzhXHE/D5BUTOEn2HjEd+bQ/RmEPJRoBHik1/BCxgqn8XaarZ2gJBpl7jZ3xSs/nC5xzOKty98/XNWANpigqSzKz7j4bqdi3DErl5Mj/kZ+Y8Iow0yUBmEF2IWCIQjPul50LhJYZLFIkDBMLDykVz", :private_key=>"Yes", :info=>""}
```

As the public key was derived from the private key, both the public and private keys are recorded in loot and a note is created. The main difference from the example above is that the private_key option is set to 'Yes' in both the console output and the note.
- The workspace was reset and a new key file was used which was not reflected on the server.

```
msf auxiliary(ssh_identify_pubkeys) > show options

Module options (auxiliary/scanner/ssh/ssh_identify_pubkeys):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   KEY_FILE          /tmp/msfinvalid  no        Filename of one or several cleartext public keys.
   RHOSTS            127.0.0.3        yes       The target address range or CIDR identifier
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads
   USERNAME          stuart           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf auxiliary(ssh_identify_pubkeys) > run

[*] 127.0.0.3:22 SSH - Trying 1 cleartext key per user.
[-] 127.0.0.3:22 SSH - [1/1] - User stuart does not accept key 1
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ssh_identify_pubkeys) > creds
Credentials
===========

host  origin  service  public  private  realm  private_type
----  ------  -------  ------  -------  -----  ------------

msf auxiliary(ssh_identify_pubkeys) > loot

Loot
====

host  service  type  name  content  info  path
----  -------  ----  ----  -------  ----  ----

msf auxiliary(ssh_identify_pubkeys) > notes
msf auxiliary(ssh_identify_pubkeys) > 
```
# Logging

For interest, the log files were inspected and, regardless of whether the key was successful or not, the only log entry per connection at INFO level is shown below.

```
Dec  5 22:36:04 <auth.info> studev sshd[72728]: Connection closed by 127.0.0.3 [preauth]
```

At DEBUG level, the following additional entries were present when the key was correct. In both cases below, there was an additional info line logged which was only included when the log level was set to DEBUG.

```
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: KEX done [preauth]
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: userauth-request for user stuart service ssh-connection method publickey [preauth]
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: attempt 0 failures 0 [preauth]
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: test whether pkalg/pkblob are acceptable [preauth]
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: trying public key file /home/stuart/.ssh/authorized_keys
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: fd 4 clearing O_NONBLOCK
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: matching key found: file /home/stuart/.ssh/authorized_keys, line 2 RSA 9a:90:c2:a0:d9:ac:02:46:b4:85:c3:18:71:47:67:aa
Dec  5 22:38:47 <auth.info> studev sshd[72773]: Postponed publickey for stuart from 127.0.0.3 port 53974 ssh2 [preauth]
Dec  5 22:38:47 <auth.info> studev sshd[72773]: Connection closed by 127.0.0.3 [preauth]
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: do_cleanup [preauth]
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: monitor_read_log: child log fd closed
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: do_cleanup
Dec  5 22:38:47 <auth.debug> studev sshd[72773]: debug1: Killing privsep child 72774
```

At DEBUG level, the following additional entries were present when the key was incorrect.

```
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: userauth-request for user stuart service ssh-connection method publickey [preauth]
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: attempt 0 failures 0 [preauth]
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: test whether pkalg/pkblob are acceptable [preauth]
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: trying public key file /home/stuart/.ssh/authorized_keys
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: fd 4 clearing O_NONBLOCK
Dec  5 22:41:29 <auth.info> studev sshd[72851]: Failed publickey for stuart from 127.0.0.3 port 25171 ssh2: RSA 63:44:e4:3b:37:d8:21:db:52:c9:16:98:6c:01:26:37
Dec  5 22:41:29 <auth.info> studev sshd[72851]: Connection closed by 127.0.0.3 [preauth]
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: do_cleanup [preauth]
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: monitor_read_log: child log fd closed
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: do_cleanup
Dec  5 22:41:29 <auth.debug> studev sshd[72851]: debug1: Killing privsep child 72852
```
