### PR TITLE
update to metasploit-payloads 1.0.19

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       metasploit-concern (= 1.0.0)
       metasploit-credential (= 1.0.1)
       metasploit-model (= 1.0.0)
-      metasploit-payloads (= 1.0.18)
+      metasploit-payloads (= 1.0.19)
       metasploit_data_models (= 1.2.9)
       msgpack
       network_interface (~> 0.0.1)
@@ -123,7 +123,7 @@ GEM
       activemodel (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
-    metasploit-payloads (1.0.18)
+    metasploit-payloads (1.0.19)
     metasploit_data_models (1.2.9)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -68,7 +68,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '1.0.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.0.18'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.0.19'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.


### PR DESCRIPTION
The only change here is to revert the utf8 registry support, which caused some problems running the hashdump module. This is functionally equivalient to 1.0.17, but adds stageless python meterpreter with http/s.

MS-847
