### PR TITLE
Fix #6330, generate_payload_exe returning nil for generic bind/reverse payloads

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -181,12 +181,12 @@ protected
     # Architecture shares the same load order.
 
     unless opts[:platform]
-      if self.respond_to? :payload_instance
+      if self.respond_to?(:payload_instance) && payload_instance.platform.platforms != [Msf::Module::Platform]
         opts[:platform] = payload_instance.platform
       elsif self.respond_to? :target_platform
         opts[:platform] = target_platform
       elsif self.respond_to? :platform
-       opts[:platform] = platform
+        opts[:platform] = platform
       end
     end
 
@@ -194,6 +194,7 @@ protected
       if self.respond_to? :payload_instance
         opts[:arch] = payload_instance.arch
       elsif self.respond_to? :target_arch
+        $stderr.puts "target specific arch"
         opts[:arch] = target_arch
       elsif self.respond_to? :arch
         opts[:arch] = arch

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -167,15 +167,23 @@ protected
     # Architecture shares the same load order.
 
     unless opts[:platform]
-      opts[:platform] ||= payload_instance.platform if self.respond_to? :payload_instance
-      opts[:platform] = target_platform             if self.respond_to? :target_platform
-      opts[:platform] ||= platform                  if self.respond_to? :platform
+      if self.respond_to? :payload_instance
+        opts[:platform] = payload_instance.platform
+      elsif self.respond_to? :target_platform
+        opts[:platform] = target_platform
+      elsif self.respond_to? :platform
+       opts[:platform] = platform
+      end
     end
 
     unless opts[:arch]
-      opts[:arch] ||= payload_instance.arch         if self.respond_to? :payload_instance
-      opts[:arch] = target_arch                     if self.respond_to? :target_arch
-      opts[:arch] ||= arch                          if self.respond_to? :arch
+      if self.respond_to? :payload_instance
+        opts[:arch] = payload_instance.arch
+      elsif self.respond_to? :target_arch
+        opts[:arch] = target_arch
+      elsif self.respond_to? :arch
+        opts[:arch] = arch
+      end
     end
   end
 

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -68,6 +68,11 @@ module Exploit::EXE
     end
 
     exe = Msf::Util::EXE.to_executable(framework, opts[:arch], opts[:platform], pl, opts)
+
+    unless exe
+      raise Msf::NoCompatiblePayloadError, "Failed to generate an executable payload due to an invalid platform or arch."
+    end
+
     exe_post_generation(opts)
     exe
   end

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -47,6 +47,15 @@ module Exploit::EXE
     exe
   end
 
+
+  # Returns an executable.
+  #
+  # @param opts [Hash]
+  # @option opts [String] :code Payload
+  # @option opts [Array] :arch Architecture
+  # @option opts [Msf::Module::PlatformList] :platform
+  # @raise [Msf::NoCompatiblePayloadError] When #genereate_payload_exe fails to generate a payload.
+  # @return [String]
   def generate_payload_exe(opts = {})
     return get_custom_exe unless datastore['EXE::Custom'].to_s.strip.empty?
     return get_eicar_exe if datastore['EXE::EICAR']

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -150,14 +150,33 @@ protected
         :sub_method => datastore['EXE::OldMethod']
       })
 
-    # Prefer the target's platform/architecture information, but use
-    # the module's if no target specific information exists
-    opts[:platform] ||= payload_instance.platform if self.respond_to? :payload_instance
-    opts[:platform] ||= target_platform  if self.respond_to? :target_platform
-    opts[:platform] ||= platform         if self.respond_to? :platform
-    opts[:arch] ||= payload_instance.arch if self.respond_to? :payload_instance
-    opts[:arch] ||= target_arch          if self.respond_to? :target_arch
-    opts[:arch] ||= arch                 if self.respond_to? :arch
+    # This part is kind of tricky so we need to explain the logic behind the following load order.
+    # First off, platform can be seen from different sources:
+    #
+    # 1. From the opts argument. For example: When you are using generate_payload_exe, and you want
+    #    to set a specific platform. This is the most explicit. So we check first.
+    #
+    # 2. From the metadata of a payload module. Normally, a payload module should include the platform
+    #    information, with the exception of some generic payloads. For example: generic/shell_reverse_tcp.
+    #    This is the most trusted source.
+    #
+    # 3. From the exploit module's target.
+    #
+    # 4. From the exploit module's metadata.
+    #
+    # Architecture shares the same load order.
+
+    unless opts[:platform]
+      opts[:platform] ||= payload_instance.platform if self.respond_to? :payload_instance
+      opts[:platform] = target_platform             if self.respond_to? :target_platform
+      opts[:platform] ||= platform                  if self.respond_to? :platform
+    end
+
+    unless opts[:arch]
+      opts[:arch] ||= payload_instance.arch         if self.respond_to? :payload_instance
+      opts[:arch] = target_arch                     if self.respond_to? :target_arch
+      opts[:arch] ||= arch                          if self.respond_to? :arch
+    end
   end
 
   def exe_post_generation(opts)

--- a/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
+++ b/modules/exploits/freebsd/http/watchguard_cmd_exec.rb
@@ -95,10 +95,6 @@ class Metasploit4 < Msf::Exploit::Remote
     # Generate payload
     @pl = generate_payload_exe
 
-    if @pl.nil?
-      fail_with(Failure::BadConfig, 'Please select a native bsd payload')
-    end
-
     # Start the server and use primer to trigger fetching and running of the payload
     begin
       Timeout.timeout(datastore['HTTPDELAY']) { super }

--- a/modules/exploits/freebsd/local/watchguard_fix_corrupt_mail.rb
+++ b/modules/exploits/freebsd/local/watchguard_fix_corrupt_mail.rb
@@ -48,9 +48,6 @@ class Metasploit4 < Msf::Exploit::Local
 
   def setup
     @pl = generate_payload_exe
-    if @pl.nil?
-      fail_with(Failure::BadConfig, 'Please select a native bsd payload')
-    end
 
     super
   end

--- a/modules/exploits/linux/antivirus/escan_password_exec.rb
+++ b/modules/exploits/linux/antivirus/escan_password_exec.rb
@@ -113,9 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
     @pl           = generate_payload_exe
-    if @pl.blank?
-      fail_with(Failure::BadConfig, "#{peer} - Failed to generate the ELF, select a native payload")
-    end
+
     @payload_url  = ""
 
     if datastore['EXTURL'].blank?

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -111,14 +111,6 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def exploit
-    # Cannot use generic/shell_reverse_tcp inside an elf
-    # Checking before proceeds
-    if generate_payload_exe.blank?
-      fail_with(Failure::BadConfig,
-        "#{peer} - Failed to store payload inside executable, " +
-        "please select a native payload")
-    end
-
     execute_cmdstager(:linemax => 200, :nodelete => true)
   end
 

--- a/modules/exploits/linux/http/multi_ncc_ping_exec.rb
+++ b/modules/exploits/linux/http/multi_ncc_ping_exec.rb
@@ -123,10 +123,6 @@ class Metasploit3 < Msf::Exploit::Remote
     @payload_url  = ''
     @dropped_elf = rand_text_alpha(rand(5) + 3)
 
-    if @pl.blank?
-      fail_with(Failure::BadConfig, "#{peer} - Failed to generate the ELF, select a native payload")
-    end
-
     if datastore['EXTURL'].blank?
       begin
         Timeout.timeout(datastore['HTTPDELAY']) { super }

--- a/modules/exploits/linux/local/desktop_privilege_escalation.rb
+++ b/modules/exploits/linux/local/desktop_privilege_escalation.rb
@@ -83,9 +83,6 @@ class Metasploit4 < Msf::Exploit::Local
     # Cannot use generic/shell_reverse_tcp inside an elf
     # Checking before proceeds
     pl = generate_payload_exe
-    if pl.blank?
-      fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Failed to store payload inside executable, please select a native payload")
-    end
 
     exe_file = "#{datastore['WritableDir']}/#{rand_text_alpha(3 + rand(5))}.elf"
 

--- a/modules/exploits/multi/browser/java_atomicreferencearray.rb
+++ b/modules/exploits/multi/browser/java_atomicreferencearray.rb
@@ -138,13 +138,8 @@ class Metasploit3 < Msf::Exploit::Remote
         # NOTE: The EXE mixin automagically handles detection of arch/platform
         data = generate_payload_exe
 
-        if data
-          print_status("Generated executable to drop (#{data.length} bytes)." )
-          data = Rex::Text.to_hex( data, prefix="" )
-        else
-          print_error("Failed to generate the executable." )
-          return
-        end
+        print_status("Generated executable to drop (#{data.length} bytes)." )
+        data = Rex::Text.to_hex( data, prefix="" )
 
       end
 

--- a/modules/exploits/multi/browser/java_calendar_deserialize.rb
+++ b/modules/exploits/multi/browser/java_calendar_deserialize.rb
@@ -133,13 +133,8 @@ class Metasploit3 < Msf::Exploit::Remote
         # NOTE: The EXE mixin automagically handles detection of arch/platform
         data = generate_payload_exe
 
-        if data
-          print_status( "Generated executable to drop (#{data.length} bytes)." )
-          data = Rex::Text.to_hex( data, prefix="" )
-        else
-          print_error( "Failed to generate the executable." )
-          return
-        end
+        print_status( "Generated executable to drop (#{data.length} bytes)." )
+        data = Rex::Text.to_hex( data, prefix="" )
 
       end
 

--- a/modules/exploits/multi/browser/java_verifier_field_access.rb
+++ b/modules/exploits/multi/browser/java_verifier_field_access.rb
@@ -137,13 +137,8 @@ class Metasploit3 < Msf::Exploit::Remote
         # NOTE: The EXE mixin automagically handles detection of arch/platform
         data = generate_payload_exe
 
-        if data
-          print_status("Generated executable to drop (#{data.length} bytes)." )
-          data = Rex::Text.to_hex( data, prefix="" )
-        else
-          print_error("Failed to generate the executable." )
-          return
-        end
+        print_status("Generated executable to drop (#{data.length} bytes)." )
+        data = Rex::Text.to_hex( data, prefix="" )
 
       end
 

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -99,12 +99,6 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def exploit
-    # Cannot use generic/shell_reverse_tcp inside an elf
-    # Checking before proceeds
-    if generate_payload_exe.blank?
-      fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Failed to store payload inside executable, please select a native payload")
-    end
-
     execute_cmdstager(linemax: 500)
     handler
   end

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -99,12 +99,6 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def exploit
-    # Cannot use generic/shell_reverse_tcp inside an elf
-    # Checking before proceeds
-    if generate_payload_exe.blank?
-      fail_with(Failure::BadConfig, "#{peer} - Failed to store payload inside executable, please select a native payload")
-    end
-
     execute_cmdstager(:linemax => datastore['CMD_MAX_LENGTH'], :nodelete => true)
 
     # A last chance after the cmdstager

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -120,9 +120,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #Set up generic values.
     payload_exe = rand_text_alphanumeric(4 + rand(4))
     pl_exe = generate_payload_exe
-    if pl_exe.nil?
-      fail_with(Failure::BadConfig, "#{peer} - Failed to generate an EXE payload, please select a correct payload")
-    end
+
     append = false
     #Now arch specific...
     case target['Platform']

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -129,16 +129,6 @@ class Metasploit3 < Msf::Exploit::Remote
     vprint_status("Sent command #{cmd}")
   end
 
-  #
-  # generate_payload_exe doesn't respect module's platform unless it's Windows, or the user
-  # manually sets one. This method is a temp work-around.
-  #
-  def check_generate_payload_exe
-    if generate_payload_exe.nil?
-      fail_with(Failure::BadConfig, "#{peer} - Failed to generate the ELF. Please manually set a payload.")
-    end
-  end
-
   def exploit
 
     # Handle single command shot
@@ -153,8 +143,6 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("#{peer} - Blind Exploitation - unknown exploitation state")
       return
     end
-
-    check_generate_payload_exe
 
     # Handle payload upload using CmdStager mixin
     execute_cmdstager({:flavor => :printf})

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -203,10 +203,13 @@ class Metasploit3 < Msf::Exploit::Remote
     end
     exe = ''
     opts = { :servicename => servicename }
-    exe = generate_payload_exe_service(opts)
+    begin
+      exe = generate_payload_exe_service(opts)
 
-    fd << exe
-    fd.close
+      fd << exe
+    ensure
+      fd.close
+    end
 
     if subfolder
       print_status("Created \\#{fileprefix}\\#{filename}...")

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -140,18 +140,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
     fd = rclient.open("\\#{filename}", 'rwct')
 
-    exe = ''
-    opts = {
-      :servicename => servicename,
-      :code => code.encoded
-    }
-    if (datastore['PAYLOAD'].include? 'x64')
-      opts.merge!({ :arch => ARCH_X64 })
-    end
-    exe = generate_payload_exe_service(opts)
+    begin
+      exe = ''
+      opts = {
+        :servicename => servicename,
+        :code => code.encoded
+      }
+      if (datastore['PAYLOAD'].include? 'x64')
+        opts.merge!({ :arch => ARCH_X64 })
+      end
+      exe = generate_payload_exe_service(opts)
 
-    fd << exe
-    fd.close
+      fd << exe
+    ensure
+      fd.close if fd
+    end
 
     print_status("Created \\#{filename}...")
 


### PR DESCRIPTION
This fixes a problem of exploits not being able to generate an executable payload, because the generic payload selected does not have a specific platform or architecture. And most exploits don't manually handle this scenario, so most that use `generate_payload_exe` don't work with generic bind/reverse payloads.

In addition, it looks like the Msf::Exploit::EXE should be aware that platform and arch can come from one of these sources:
1. From the `opts` argument.
2. Payload module.
3. Exploit module's target
4. Exploit's module's metadata

I also decided to raise a Msf::NoCompatiblePayloadError with a meaningful message instead of allowing generate_payload_exe to return nil. This is because most exploits don't really bother checking nil, they just assume they will have a payload. And if it does return nil, the error will probably end up being something like "undefined method for nil", which makes debugging more difficult.
## Verification
- [x] Download this gist https://gist.github.com/wchen-r7/3d8b95aa9f3e14df8d65, and save it as modules/exploits/multi/misc/test.rb
- [x] Start msfconsole, and load the test module

---
- [x] In the test module's metadata, change Platform to `'win'`
- [x] `set payload generic/shell_reverse_tcp`
- [x] Run it. It should say the payload is a Windows payload.

---
- [x] In the test module's metadata, change Platform to `'linux'`
- [x] `set payload generic/shell_reverse_tcp`
- [x] Run it. It should say the payload is a Linux payload.

---
- [x] Comment out Platform and Arch from the metadata
- [x] set target 0
- [x] `set payload generic/shell_reverse_tcp`
- [x] It should not generate a payload.

---
- [x] Platform and Arch in the metadata remain commented out
- [x] set target 1
- [x] `set payload generic/shell_reverse_tcp`
- [x] It should generate a windows payload

---
- [x] Platform and Arch in the metadata remain commented out
- [x] set target 2
- [x] `set payload generic/shell_reverse_tcp`
- [x] It should generate a Linux payload

---
- [x] Platform and Arch in the metadata remain commented out
- [x] set target 3
- [x] `set payload generic/shell_reverse_tcp`
- [x] It should generate an OS X payload

---
- [x] In source, change `generate_payload_exe` to `generate_payload_exe(platform:[Msf::Module::Platform::Linux])`
- [x] set target 0
- [x] `set payload generic/shell_reverse_tcp`
- [x] It should generate a linux payload

---
- [x] In source, change `generate_payload_exe` to `generate_payload_exe(platform: [Msf::Module::Platform::Linux], arch: ARCH_PHP)`
- [x] It should raise a Msf::NoCompatiblePayloadError exception.

---

You are also more than welcome to test existing exploits that use generate_payload_exe, and see if they still behave correctly.
