### PR TITLE
bump nokogiri to 1.6.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,14 +137,14 @@ GEM
       recog (~> 2.0)
     method_source (0.8.2)
     mime-types (2.6.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (4.7.5)
     msgpack (0.7.1)
     multi_json (1.11.2)
     multi_test (0.1.2)
     network_interface (0.0.1)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     openssl-ccm (1.2.1)
     packetfu (1.1.11)
       network_interface (~> 0.0)
@@ -249,3 +249,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
This PR bumps nokogiri to 1.6.7 which addresses CVE-2015-1819, CVE-2015-7941_1, CVE-2015-7941_2, CVE-2015-7942, CVE-2015-7942-2, CVE-2015-8035, CVE-2015-7995 and adds Windows support for Ruby 2.2.x and native build.
- [x] `rake:spec`
- [x] ensure all tests pass
