### PR TITLE
remove bundler 1.10 fingerprint from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,3 @@ DEPENDENCIES
   simplecov
   timecop
   yard
-
-BUNDLED WITH
-   1.10.6


### PR DESCRIPTION
For now, let's keep our Gemfile.lock < 1.10 compatibile
