### PR TITLE
ensure that the metasploit database environment variable is unset

### DIFF
--- a/spec/lib/metasploit/framework/database_spec.rb
+++ b/spec/lib/metasploit/framework/database_spec.rb
@@ -619,6 +619,10 @@ RSpec.describe Metasploit::Framework::Database do
     end
 
     context 'without MSF_DATABASE_CONFIG' do
+      before(:each) do
+        ENV.delete('MSF_DATABASE_CONFIG')
+      end
+
       it { is_expected.to be_nil }
     end
   end


### PR DESCRIPTION
The "without MSF_DATABASE_CONFIG" setup should ensure that MSF_DATABASE_CONFIG is actually not set before running the test. Otherwise there can be random failures depending on whether the previous test set MSF_DATABASE_CONFIG.
# Validation
- [x] Passes specs multiple times without failures (I ran about 30)
- [x] Passes with this seed: rspec --seed 15437 spec/lib/metasploit/framework/database_spec.rb
