### PR TITLE
Add method peer for jenkins_java_deserialize.rb

### DIFF
--- a/modules/exploits/linux/misc/jenkins_java_deserialize.rb
+++ b/modules/exploits/linux/misc/jenkins_java_deserialize.rb
@@ -54,6 +54,10 @@ class Metasploit3 < Msf::Exploit::Remote
     ], self.class)
   end
 
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
   def exploit
     unless vulnerable?
       fail_with(Failure::Unknown, "#{peer} - Jenkins is not vulnerable, aborting...")


### PR DESCRIPTION
Since this module isn't using the HttpClient mixin, it doesn't have the #peer method. So we must add one.

No verification provided here, I think it should be pretty straight forward.
