### PR TITLE
Fix nil bug and missing return in psexec

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -152,13 +152,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if smb_file_exist?(path)
       vprint_status('PowerShell found')
-      true
+      psh = true
     else
       vprint_status('PowerShell not found')
-      false
+      psh = false
     end
 
     simple.disconnect(share)
+
+    psh
   end
 
   def powershell

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -106,6 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
       )
       print_line(" ")
       disconnect
+      return
     end
 
     if datastore['SMBUser'].to_s.strip.length > 0
@@ -145,21 +146,19 @@ class Metasploit3 < Msf::Exploit::Remote
       path = datastore['PSH_PATH']
     end
 
-    begin
-      simple.connect(share)
+    simple.connect(share)
 
-      vprint_status("Checking for #{path}")
+    vprint_status("Checking for #{path}")
 
-      if smb_file_exist?(path)
-        vprint_status('PowerShell found')
-        true
-      else
-        vprint_status('PowerShell not found')
-        false
-      end
-    ensure
-      simple.disconnect(share)
+    if smb_file_exist?(path)
+      vprint_status('PowerShell found')
+      true
+    else
+      vprint_status('PowerShell not found')
+      false
     end
+
+    simple.disconnect(share)
   end
 
   def powershell


### PR DESCRIPTION
Some latent bugs.

Team: if you want to land, please ask me for repro steps, since I used our scan lab.

Before:

```
msf exploit(psexec) > run

[*] Started bind handler
[*] Connecting to the server...
[*] Authenticating to [redacted]:445 as user '[redacted]'...
[-] Exploit failed: TypeError no implicit conversion of nil into Integer
[*] Exploit completed, but no session was created.
msf exploit(psexec) > 
```

After:

```
msf exploit(psexec) > run

[*] Started bind handler
[*] Connecting to the server...
[*] Authenticating to [redacted]:445 as user '[redacted]'...
[-] Exploit failed [no-access]: Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_ACCESS_DENIED (Command=117 WordCount=0)
[*] Exploit completed, but no session was created.
msf exploit(psexec) > 
```
