### PR TITLE
Identify Managed AD Security Groups

### DIFF
--- a/modules/post/windows/gather/enum_ad_managedby_groups.rb
+++ b/modules/post/windows/gather/enum_ad_managedby_groups.rb
@@ -1,0 +1,97 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex'
+require 'msf/core'
+
+class Metasploit3 < Msf::Post
+  include Msf::Auxiliary::Report
+  include Msf::Post::Windows::LDAP
+#  include Msf::Post::Windows::Accounts
+
+  USER_FIELDS = ['name',
+                 'distinguishedname',
+                 'description'].freeze
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'         => 'Windows Gather Active Directory Groups',
+      'Description'  => %{
+        This module will enumerate AD groups on the specified domain.
+      },
+      'License'      => MSF_LICENSE,
+      'Author'       => [
+        'Stuart Morgan <stuart.morgan[at]mwrinfosecurity.com>'
+      ],
+      'Platform'     => [ 'win' ],
+      'SessionTypes' => [ 'meterpreter' ]
+    ))
+
+    register_options([
+      OptString.new('ADDITIONAL_FIELDS', [false, 'Additional fields to retrieve, comma separated', nil]),
+    ], self.class)
+  end
+
+  def run
+    @user_fields = USER_FIELDS.dup
+
+    if datastore['ADDITIONAL_FIELDS']
+      additional_fields = datastore['ADDITIONAL_FIELDS'].gsub(/\s+/,"").split(',')
+      @user_fields.push(*additional_fields)
+    end
+
+    max_search = datastore['MAX_SEARCH']
+
+    begin
+      q = query('(objectClass=group)', max_search, @user_fields)
+    rescue ::RuntimeError, ::Rex::Post::Meterpreter::RequestError => e
+      # Can't bind or in a network w/ limited accounts
+      print_error(e.message)
+      return
+    end
+
+    if q.nil? || q[:results].empty?
+      print_status('No results returned.')
+    else
+      results_table = parse_results(q[:results])
+      print_line results_table.to_s
+    end
+  end
+
+  # Takes the results of LDAP query, parses them into a table
+  # and records and usernames as {Metasploit::Credential::Core}s in
+  # the database.
+  #
+  # @param [Array<Array<Hash>>] the LDAP query results to parse
+  # @return [Rex::Ui::Text::Table] the table containing all the result data
+  def parse_results(results)
+    domain = datastore['DOMAIN'] || get_domain
+    domain_ip = client.net.resolve.resolve_host(domain)[:ip]
+    # Results table holds raw string data
+    results_table = Rex::Ui::Text::Table.new(
+      'Header'     => "Domain Groups",
+      'Indent'     => 1,
+      'SortIndex'  => -1,
+      'Columns'    => @user_fields
+    )
+
+    results.each do |result|
+      row = []
+
+      result.each do |field|
+        if field.nil?
+          row << ""
+        else
+          row << field[:value]
+        end
+      end
+
+      results_table << row
+    end
+    results_table
+  end
+
+end

--- a/modules/post/windows/gather/enum_ad_managedby_groups.rb
+++ b/modules/post/windows/gather/enum_ad_managedby_groups.rb
@@ -94,8 +94,8 @@ class Metasploit3 < Msf::Post
       end
       if datastore['RESOLVE_MANAGERS']
         begin
-          managedBy_cn = result[2][:value].split(',')[0]
-          m = query("(&(objectClass=user)(objectCategory=person)(#{managedBy_cn}))", 1, ['sAMAccountName'])
+          managedby_cn = result[2][:value].split(',')[0]
+          m = query("(&(objectClass=user)(objectCategory=person)(#{managedby_cn}))", 1, ['sAMAccountName'])
           if !m.nil? && !m[:results].empty?
             row << m[:results][0][0][:value]
           else
@@ -104,8 +104,7 @@ class Metasploit3 < Msf::Post
         rescue
           row << ""
         end
-    end
-
+      end
       results_table << row
     end
     results_table

--- a/modules/post/windows/gather/enum_ad_managedby_groups.rb
+++ b/modules/post/windows/gather/enum_ad_managedby_groups.rb
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Post
       end
       if datastore['RESOLVE_MANAGERS']
         begin
-          managedby_cn = result[2][:value].split(',')[0]
+          managedby_cn = result[2][:value].split(/,(?<!\\,)/)[0]
           m = query("(&(objectClass=user)(objectCategory=person)(#{managedby_cn}))", 1, ['sAMAccountName'])
           if !m.nil? && !m[:results].empty?
             row << m[:results][0][0][:value]

--- a/modules/post/windows/gather/enum_ad_managedby_groups.rb
+++ b/modules/post/windows/gather/enum_ad_managedby_groups.rb
@@ -37,8 +37,8 @@ class Metasploit3 < Msf::Post
 
     register_options([
       OptString.new('ADDITIONAL_FIELDS', [false, 'Additional group fields to retrieve, comma separated.', nil]),
-      OptBool.new('RESOLVE_MANAGERS', [true, 'Query LDAP to get the account name of group managers.', true]),
-      OptBool.new('SECURITY_GROUPS_ONLY', [true, 'Only include security groups.', true])
+      OptBool.new('RESOLVE_MANAGERS', [true, 'Query LDAP to get the account name of group managers.', TRUE]),
+      OptBool.new('SECURITY_GROUPS_ONLY', [true, 'Only include security groups.', TRUE])
     ], self.class)
   end
 

--- a/modules/post/windows/gather/enum_ad_managedby_groups.rb
+++ b/modules/post/windows/gather/enum_ad_managedby_groups.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
       'Description'  => %{
         This module will enumerate AD groups on the specified domain which are managed by users.
         It will also identify whether those groups have the 'Manager can update membership list'
-        option set; if so, it would allow that member to update the contents of that group. This 
+        option set; if so, it would allow that member to update the contents of that group. This
         could either be used as a persistence mechanism (for example, set your user as the 'Domain
         Admins' group manager) or could be used to detect privilege escalation opportunities
         without having domain admin privileges.
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Post
       if datastore['SECURITY_GROUPS_ONLY']
         qs = '(&(objectClass=group)(managedBy=*)(groupType:1.2.840.113556.1.4.803:=2147483648))'
       end
-      q = query('(&(objectClass=group)(managedBy=*))', max_search, @user_fields) 
+      q = query('(&(objectClass=group)(managedBy=*))', max_search, @user_fields)
     rescue ::RuntimeError, ::Rex::Post::Meterpreter::RequestError => e
       # Can't bind or in a network w/ limited accounts
       print_error(e.message)

--- a/modules/post/windows/gather/enum_ad_managedby_groups.rb
+++ b/modules/post/windows/gather/enum_ad_managedby_groups.rb
@@ -20,8 +20,8 @@ class Metasploit3 < Msf::Post
       info,
       'Name'         => 'Windows Gather Active Directory Managed Groups',
       'Description'  => %{
-        This module will enumerate AD groups on the specified domain which are managed by users.
-        It will also identify whether those groups have the 'Manager can update membership list'
+        This module will enumerate AD groups on the specified domain which are specifically managed.
+        It cannot at the moment identify whether the 'Manager can update membership list' option
         option set; if so, it would allow that member to update the contents of that group. This
         could either be used as a persistence mechanism (for example, set your user as the 'Domain
         Admins' group manager) or could be used to detect privilege escalation opportunities


### PR DESCRIPTION
# Overview

This module identifies AD groups which have the 'managedBy' attribute set (which will be the DN of a user who is allowed to manage the group). It will also optionally retrieve the sAMAccountName (username) of the user.

AD groups can be managed by otherwise low privileged users by setting the 'Managed By' attribute:

![managed_by_tab](https://cloud.githubusercontent.com/assets/12296344/11920337/03377940-a764-11e5-952d-1ef8184238e0.png)

This is routinely used for distribution groups, but it turns out that security groups also support this option. If the 'manager can update membership list' option is set, it allows that user to add members to the group. This has two implications:
1. If your user happens to be the manager of a group with this option set, you can add yourself or any other user to the group. 
2. You could maintain Domain Admins persistence by setting the Domain Admins group (or any group which is also a member of the Domain Admins group) to be managed by your user. You would then have the ability to gain domain administrator privileges whenever you wished to acquire them.

This module is concerned with Implication 1; identifying AD groups which have a manager set. 
# Explanation of Impact

On a test domain (goat.stu), an unprivileged user has been created with default privileges. As can be seen, this user does not have sufficient privileges to manipulate the domain admins group.

![unprivileged_user](https://cloud.githubusercontent.com/assets/12296344/11920380/5994ea74-a765-11e5-9782-1ff96aaede62.png)

Executing this module initially shows no results.

```
msf > use post/windows/gather/enum_ad_managedby_groups 
msf post(enum_ad_managedby_groups) > set SESSION 4
SESSION => 4
msf post(enum_ad_managedby_groups) > show options

Module options (post/windows/gather/enum_ad_managedby_groups):

   Name                  Current Setting  Required  Description
   ----                  ---------------  --------  -----------
   ADDITIONAL_FIELDS                      no        Additional group fields to retrieve, comma separated.
   DOMAIN                                 no        The domain to query or distinguished name (e.g. DC=test,DC=com)
   MAX_SEARCH            500              yes       Maximum values to retrieve, 0 for all.
   RESOLVE_MANAGERS      true             yes       Query LDAP to get the account name of group managers.
   SECURITY_GROUPS_ONLY  TRUE             yes       Only include security groups.
   SESSION               4                yes       The session to run this module on.

msf post(enum_ad_managedby_groups) > run

[*] No results returned.
[*] Post module execution completed
msf post(enum_ad_managedby_groups) >
```

However, if a domain admin user sets the unprivileged user to be the manager of the Domain Admins group and sets the 'Manager can update membership list' option:

![domain_admin_set_managed](https://cloud.githubusercontent.com/assets/12296344/11920390/e3d3cebc-a765-11e5-8909-f72681b6b3e4.png)

The module now shows the presence of a managed group:

```
msf post(enum_ad_managedby_groups) > run

Groups with Managers
====================

 cn             distinguishedname                         managedBy                                     description                              Manager Account Name
 --             -----------------                         ---------                                     -----------                              --------------------
 Domain Admins  CN=Domain Admins,CN=Users,DC=goat,DC=stu  CN=Unprivileged User,CN=Users,DC=goat,DC=stu  Designated administrators of the domain  unprivileged.user

[*] Post module execution completed
msf post(enum_ad_managedby_groups) >
```

This then allows the unprivileged.user to add themselves (or any other user) to the Domain Admins group.

![manipulated_groups](https://cloud.githubusercontent.com/assets/12296344/11920402/5c36a30c-a766-11e5-8898-907f6c646562.png)
# Module

The purpose of this module is simply to identify any groups that have managers. It cannot at the moment determine whether the 'Manager can update membership list' is set because this is encoded into the nTSecurityDescriptor attribute which will need more work to obtain and parse. However, if a compromised user is the manager of a particular group which itself can access sensitive information, this would be a useful way of laterally moving, especially as the manager does not have to be a permanent member of the group. As per the example above, it could also be a sneaky way of persisting once privileged access has been obtained, because the presence of this setting is not obvious. 

This is not something that is regularly seen but is worth checking for.
# Options

| Option | Value |
| --- | --- |
| ADDITIONAL_FIELDS | Include additional fields in the group LDAP search. cn, managedBy, distinguishedName and description will always be included. |
| RESOLVE_MANAGERS | If this is TRUE, the module will loop through each of the groups with a manager set and launch another query to get the sAMAccountName (logon name) of the manager. The managedBy field returns a distinguished name. |
| SECURITY_GROUPS_ONLY | If this is TRUE, the module will restrict the search for managedBy groups to security groups rather than distribution groups. |
# Conclusion

This module is not likely to be regularly used, but could reveal an otherwise hidden horizontal privilege escalation vulnerability. It is unusual for groups to be managed by non-domain admins but is not unheard of.
# Further Work

The main improvement that this module needs is to be able to obtain and parse the nTSecurityDescriptor attribute which will allow results to be filtered to only include those for who the 'manager can update membership list' options is set.
