### PR TITLE
Add linux/x86/meterpreter/reverse_tcp to the preference list

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -225,6 +225,7 @@ class Exploit
     # A list of preferred payloads in the best-first order
     pref = [
       'windows/meterpreter/reverse_tcp',
+      'linux/x86/meterpreter/reverse_tcp',
       'java/meterpreter/reverse_tcp',
       'php/meterpreter/reverse_tcp',
       'php/meterpreter_reverse_tcp',


### PR DESCRIPTION
linux/x86/meterpreter/reverse_tcp was not added to the preference list, because at the time it was not reliable. For example: it would crash while running a post module. This is not the case anymore, so it looks like linux/x86/meterpreter/reverse_tcp is ready to serve.

@bcook-r7 Could you please handle this PR? You know about linux/x86/meterpreter/reverse_tcp better than I do.
