### PR TITLE
Add original exploit discoverer and exploit-db ref

### DIFF
--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'	=>
         [
-          'Gary @ Sec-1 ltd', # initial discovery
+          'Gary @ Sec-1 ltd', # discovery
           'Marc-Alexandre Montpas', # discovery
           'Christian Mehlmauer' # metasploit module
         ],

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'	=>
         [
-          'Gary @ Sec-1 ltd', # discovery
           'Marc-Alexandre Montpas', # discovery
           'Christian Mehlmauer' # metasploit module
         ],
@@ -32,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2015-8562'],
-          ['EDB', '38977'], # original PoC from Gary
+          ['EDB', '38977'], # PoC from Gary
           ['EDB', '39033'], # Exploit modified to use "X-Forwarded-For" header instead of "User-Agent"
           ['URL', 'https://blog.sucuri.net/2015/12/joomla-remote-code-execution-the-details.html'],
           ['URL', 'https://blog.sucuri.net/2015/12/remote-command-execution-vulnerability-in-joomla.html'],

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -24,6 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'	=>
         [
+          'Gary @ Sec-1 ltd', # initial discovery
           'Marc-Alexandre Montpas', # discovery
           'Christian Mehlmauer' # metasploit module
         ],
@@ -31,6 +32,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['CVE', '2015-8562'],
+          ['EDB', '38977'], # original PoC from Gary
+          ['EDB', '39033'], # Exploit modified to use "X-Forwarded-For" header instead of "User-Agent"
           ['URL', 'https://blog.sucuri.net/2015/12/joomla-remote-code-execution-the-details.html'],
           ['URL', 'https://blog.sucuri.net/2015/12/remote-command-execution-vulnerability-in-joomla.html'],
           ['URL', 'https://developer.joomla.org/security-centre/630-20151214-core-remote-code-execution-vulnerability.html'],


### PR DESCRIPTION
Adding Gary @ Sec-1 ltd for the original exploit and two exploit-db references. Marc-Alexandre Montpas modified Gary's exploit that uses "User-Agent" header. Marc-Alexandre Montpas used "X-FORWARDED-FOR" header to avoid default logged to access.log

See the exploit author reference @ https://www.exploit-db.com/exploits/39033/
