### PR TITLE
Update msftidy to error when module super class is incorrect

### DIFF
--- a/spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb
+++ b/spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb
@@ -1,0 +1,22 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'            => 'Tidy Auxiliary Module for RSpec'
+        'Description'     => 'Test!'
+        },
+        'Author'         => %w(Unknown),
+        'License'        => MSF_LICENSE,
+      )
+    )
+  end
+end
+

--- a/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb
+++ b/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 # XXX: invalid super class for an auxiliary module
 class Metasploit4 < Msf::Exploit
+  # XXX: auxiliary modules don't use Rank
+  Rank = LowRanking
   def initialize(info = {})
     super(
       update_info(

--- a/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb
+++ b/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb
@@ -1,0 +1,23 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+# XXX: invalid super class for an auxiliary module
+class Metasploit4 < Msf::Exploit
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'            => 'Untidy Auxiliary Module for RSpec'
+        'Description'     => 'Test!'
+        },
+        'Author'         => %w(Unknown),
+        'License'        => MSF_LICENSE,
+      )
+    )
+  end
+end
+

--- a/spec/file_fixtures/modules/payloads/payload_tidy.rb
+++ b/spec/file_fixtures/modules/payloads/payload_tidy.rb
@@ -1,0 +1,17 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+module Metasploit4
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name'          => 'Unix Command Shell, Bind TCP (via AWK)',
+        'Description'   => 'Listen for a connection and spawn a command shell via GNU AWK',
+      )
+    )
+  end
+end

--- a/spec/file_fixtures/modules/payloads/payload_tidy.rb
+++ b/spec/file_fixtures/modules/payloads/payload_tidy.rb
@@ -9,8 +9,8 @@ module Metasploit4
     super(
       merge_info(
         info,
-        'Name'          => 'Unix Command Shell, Bind TCP (via AWK)',
-        'Description'   => 'Listen for a connection and spawn a command shell via GNU AWK',
+        'Name'          => 'Tidy Payload for RSpec',
+        'Description'   => 'Test!'
       )
     )
   end

--- a/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
@@ -1,4 +1,5 @@
 require 'msf/core'
+require 'spec_helper'
 
 RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
 
@@ -758,19 +759,6 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   end
 
   describe 'when outputing' do
-
-    # Get stdout:
-    # http://stackoverflow.com/questions/11349270/test-output-to-command-line-with-rspec
-    def get_stdout(&block)
-      out = $stdout
-      $stdout = fake = StringIO.new
-      begin
-        yield
-      ensure
-        $stdout = out
-      end
-      fake.string
-    end
 
     before(:each) do
       allow(subject).to receive(:print_status) { |arg| $stdout.puts arg }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 # -*- coding: binary -*-
+require 'stringio'
+
 ENV['RAILS_ENV'] = 'test'
 
 unless Bundler.settings.without.include?(:coverage)
@@ -97,3 +99,25 @@ end
 
 Metasploit::Framework::Spec::Constants::Suite.configure!
 Metasploit::Framework::Spec::Threads::Suite.configure!
+
+def get_stdout(&block)
+  out = $stdout
+  $stdout = tmp = StringIO.new
+  begin
+    yield
+  ensure
+    $stdout = out
+  end
+  tmp.string
+end
+
+def get_stderr(&block)
+  out = $stderr
+  $stderr = tmp = StringIO.new
+  begin
+    yield
+  ensure
+    $stderr = out
+  end
+  tmp.string
+end

--- a/spec/tools/dev/msftidy_spec.rb
+++ b/spec/tools/dev/msftidy_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe 'msftidy utility' do
+  let(:msftidy) { File.expand_path('tools/dev/msftidy.rb') }
+
+  it "shows Usage if invalid arguments are provided" do
+    expect { system(msftidy) }.to output(/Usage/).to_stderr_from_any_process
+  end
+
+  context "with a tidy auxiliary module" do
+    let(:auxiliary_tidy) { File.expand_path('modules/auxiliary/auxiliary_tidy.rb', FILE_FIXTURES_PATH) }
+
+    it "outputs nothing" do
+      expect { system("#{msftidy} #{auxiliary_tidy}") }.to_not output.to_stdout_from_any_process
+    end
+  end
+
+  context "with an untidy auxiliary module" do
+    let(:auxiliary_untidy) { File.expand_path('modules/auxiliary/auxiliary_untidy.rb', FILE_FIXTURES_PATH) }
+
+    it "outputs expected errors and warnings" do
+      expect { system("#{msftidy} #{auxiliary_untidy}") }.to \
+        output(/ERROR.*Invalid super class for auxiliary module/).to_stdout_from_any_process
+    end
+  end
+
+  context "with a tidy payload module" do
+    let(:payload_tidy) { File.expand_path('modules/payloads/payload_tidy.rb', FILE_FIXTURES_PATH) }
+
+    it "outputs nothing" do
+      expect { system("#{msftidy} #{payload_tidy}") }.to_not output.to_stdout_from_any_process
+    end
+  end
+end

--- a/spec/tools/egghunter_spec.rb
+++ b/spec/tools/egghunter_spec.rb
@@ -1,6 +1,5 @@
 load Metasploit::Framework.root.join('tools/exploit/egghunter.rb').to_path
-
-require 'stringio'
+require 'spec_helper'
 
 RSpec.describe Egghunter do
 
@@ -15,17 +14,6 @@ RSpec.describe Egghunter do
     }
 
     describe '#run' do
-
-      def get_stdout(&block)
-        out = $stdout
-        $stdout = fake = StringIO.new
-        begin
-          yield
-        ensure
-          $stdout = out
-        end
-        fake.string
-      end
 
       let(:default_opts) {
         { :platform => 'windows', :format => 'c', :eggtag => egg, :arch => 'x86' }

--- a/spec/tools/md5_lookup_spec.rb
+++ b/spec/tools/md5_lookup_spec.rb
@@ -1,4 +1,5 @@
 load Metasploit::Framework.root.join('tools/password/md5_lookup.rb').to_path
+require 'spec_helper'
 
 require 'rex/proto/http/response'
 require 'stringio'
@@ -68,17 +69,6 @@ RSpec.describe Md5LookupUtility do
     allow(subject).to receive(:send_request_cgi) do |opts|
       set_expected_response(body)
     end
-  end
-
-  def get_stdout(&block)
-    out = $stdout
-    $stdout = fake = StringIO.new
-    begin
-      yield
-    ensure
-      $stdout = out
-    end
-    fake.string
   end
 
   #

--- a/spec/tools/msu_finder_spec.rb
+++ b/spec/tools/msu_finder_spec.rb
@@ -2,6 +2,7 @@ load Metasploit::Framework.root.join('tools/exploit/msu_finder.rb').to_path
 
 require 'nokogiri'
 require 'uri'
+require 'spec_helper'
 
 RSpec.describe MicrosoftPatchFinder do
 
@@ -60,29 +61,6 @@ RSpec.describe MicrosoftPatchFinder do
   end
 
   describe MicrosoftPatchFinder::Helper do
-
-    def get_stdout(&block)
-      out = $stdout
-      $stdout = fake = StringIO.new
-      begin
-        yield
-      ensure
-        $stdout = out
-      end
-      fake.string
-    end
-
-    def get_stderr(&block)
-      out = $stderr
-      $stderr = fake = StringIO.new
-      begin
-        yield
-      ensure
-        $stderr = out
-      end
-      fake.string
-    end
-
     subject(:object_helper) do
       mod = Object.new
       mod.extend MicrosoftPatchFinder::Helper

--- a/spec/tools/virustotal_spec.rb
+++ b/spec/tools/virustotal_spec.rb
@@ -172,19 +172,6 @@ RSpec.describe VirusTotalUtility do
 
 
     describe VirusTotalUtility::Driver do
-      # Get stdout:
-      # http://stackoverflow.com/questions/11349270/test-output-to-command-line-with-rspec
-      def get_stdout(&block)
-        out = $stdout
-        $stdout = fake = StringIO.new
-        begin
-          yield
-        ensure
-          $stdout = out
-        end
-        fake.string
-      end
-
       before do
         $stdin = StringIO.new("Y\n")
       end

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -483,8 +483,8 @@ class Msftidy
     end
 
     prefix_super_map = {
-      'auxiliary' => /Msf::Auxiliary$/,
-      'exploits' => /Msf::Exploit(?:::Local|::Remote)?$/,
+      'auxiliary' => /^Msf::Auxiliary$/,
+      'exploits' => /^Msf::Exploit(?:::Local|::Remote)?$/,
       'encoders' => /^(?:Msf|Rex)::Encoder/,
       'nops' => /^Msf::Nop$/,
       'post' => /^Msf::Post$/

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -465,9 +465,9 @@ class Msftidy
   def check_bad_terms
     # "Stack overflow" vs "Stack buffer overflow" - See explanation:
     # http://blogs.technet.com/b/srd/archive/2009/01/28/stack-overflow-stack-exhaustion-not-the-same-as-stack-buffer-overflow.aspx
-    if @source =~ /class Metasploit\d < Msf::Exploit::Remote/ and @source.gsub("\n", "") =~ /stack[[:space:]]+overflow/i
+    if @module_type == 'exploit' && @source.gsub("\n", "") =~ /stack[[:space:]]+overflow/i
       warn('Contains "stack overflow" You mean "stack buffer overflow"?')
-    elsif @source =~ /class Metasploit\d < Msf::Auxiliary/ and @source.gsub("\n", "") =~ /stack[[:space:]]+overflow/i
+    elsif @module_type == 'auxiliary' && @source.gsub("\n", "") =~ /stack[[:space:]]+overflow/i
       warn('Contains "stack overflow" You mean "stack exhaustion"?')
     end
   end
@@ -585,7 +585,7 @@ class Msftidy
       end
 
       # Auxiliary modules do not have a rank attribute
-      if ln =~ /^\s*Rank\s*=\s*/ and @source =~ /<\sMsf::Auxiliary/
+      if ln =~ /^\s*Rank\s*=\s*/ && @module_type == 'auxiliary'
         warn("Auxiliary modules have no 'Rank': #{ln}", idx)
       end
 
@@ -680,6 +680,40 @@ class Msftidy
     end
   end
 
+  #
+  # Run all the msftidy checks.
+  #
+  def run_checks
+    check_mode
+    check_shebang
+    check_nokogiri
+    check_rubygems
+    check_ref_identifiers
+    check_old_keywords
+    check_verbose_option
+    check_badchars
+    check_extname
+    check_old_rubies
+    check_ranking
+    check_disclosure_date
+    check_title_casing
+    check_bad_terms
+    check_bad_super_class
+    check_function_basics
+    check_lines
+    check_snake_case_filename
+    check_comment_splat
+    check_vuln_codes
+    check_vars_get
+    check_newline_eof
+    check_sock_get
+    check_udp_sock_get
+    check_invalid_url_scheme
+    check_print_debug
+    check_register_datastore_debug
+    check_use_datastore_debug
+  end
+
   private
 
   def load_file(file)
@@ -698,72 +732,37 @@ class Msftidy
   end
 end
 
-#
-# Run all the msftidy checks.
-#
-# @param full_filepath [String] The full file path to check
-# @return status [Integer] A status code suitable for use as an exit status
-def run_checks(full_filepath)
-  tidy = Msftidy.new(full_filepath)
-  tidy.check_mode
-  tidy.check_shebang
-  tidy.check_nokogiri
-  tidy.check_rubygems
-  tidy.check_ref_identifiers
-  tidy.check_old_keywords
-  tidy.check_verbose_option
-  tidy.check_badchars
-  tidy.check_extname
-  tidy.check_old_rubies
-  tidy.check_ranking
-  tidy.check_disclosure_date
-  tidy.check_title_casing
-  tidy.check_bad_terms
-  tidy.check_bad_super_class
-  tidy.check_function_basics
-  tidy.check_lines
-  tidy.check_snake_case_filename
-  tidy.check_comment_splat
-  tidy.check_vuln_codes
-  tidy.check_vars_get
-  tidy.check_newline_eof
-  tidy.check_sock_get
-  tidy.check_udp_sock_get
-  tidy.check_invalid_url_scheme
-  tidy.check_print_debug
-  tidy.check_register_datastore_debug
-  tidy.check_use_datastore_debug
-  return tidy
-end
-
 ##
 #
 # Main program
 #
 ##
 
-dirs = ARGV
+if __FILE__ == $PROGRAM_NAME
+  dirs = ARGV
 
-@exit_status = 0
+  @exit_status = 0
 
-if dirs.length < 1
-  $stderr.puts "Usage: #{File.basename(__FILE__)} <directory or file>"
-  @exit_status = 1
-  exit(@exit_status)
-end
-
-dirs.each do |dir|
-  begin
-    Find.find(dir) do |full_filepath|
-      next if full_filepath =~ /\.git[\x5c\x2f]/
-      next unless File.file? full_filepath
-      next unless full_filepath =~ /\.rb$/
-      msftidy = run_checks(full_filepath)
-      @exit_status = msftidy.status if (msftidy.status > @exit_status.to_i)
-    end
-  rescue Errno::ENOENT
-    $stderr.puts "#{File.basename(__FILE__)}: #{dir}: No such file or directory"
+  if dirs.length < 1
+    $stderr.puts "Usage: #{File.basename(__FILE__)} <directory or file>"
+    @exit_status = 1
+    exit(@exit_status)
   end
-end
 
-exit(@exit_status.to_i)
+  dirs.each do |dir|
+    begin
+      Find.find(dir) do |full_filepath|
+        next if full_filepath =~ /\.git[\x5c\x2f]/
+        next unless File.file? full_filepath
+        next unless full_filepath =~ /\.rb$/
+        msftidy = Msftidy.new(full_filepath)
+        msftidy.run_checks
+        @exit_status = msftidy.status if (msftidy.status > @exit_status.to_i)
+      end
+    rescue Errno::ENOENT
+      $stderr.puts "#{File.basename(__FILE__)}: #{dir}: No such file or directory"
+    end
+  end
+
+  exit(@exit_status.to_i)
+end


### PR DESCRIPTION
Fixes #6365.

Currently all modules pass this check, but when I modified one to be invalid, I get this:

```
modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb - [ERROR] Invalid super class for auxiliary module (found 'Msf::Exploit::Remote', expected something like (?-mix:Msf::Auxiliary$)
```

This also refactors msftidy to be testable and adds some initial tests for it, which seems necessary given what we use it for.
