### PR TITLE
remove duplicate key warning from Ruby 2.2.x

### DIFF
--- a/modules/exploits/multi/http/uptime_file_upload_2.rb
+++ b/modules/exploits/multi/http/uptime_file_upload_2.rb
@@ -280,7 +280,6 @@ class Metasploit4 < Msf::Exploit::Remote
           'isonvacation' => '0',
           'receivealerts' => '0',
           'activexgraphs' => '0',
-          'newuser' => 'on',
           'newuser' => '1',
           'userroleid' => '1',
           'usergroupid[]' => '1'


### PR DESCRIPTION
This gets rid of the warning:

modules/exploits/multi/http/uptime_file_upload_2.rb:283: warning: duplicated key at line 284 ignored: "newuser"
# Verification Steps
- [x] Verify that uptime_file_upload_2 works as expected
- [x] Verify no startup warning with msfconsole  running ruby 2.2.x
