### PR TITLE
Fix PACKETSTORM warnings; improve msftidy to catch more

### DIFF
--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'OSVDB', '90733' ],
           [ 'BID', '58231' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/120591/dlinkdir645-bypass.txt' ]
+          [ 'PACKETSTORM', '120591' ]
         ],
       'Author'      =>
         [

--- a/modules/auxiliary/admin/http/intersil_pass_reset.rb
+++ b/modules/auxiliary/admin/http/intersil_pass_reset.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'BID', '25676'],
-          [ 'URL', 'http://packetstormsecurity.org/files/59347/boa-bypass.txt.html']
+          [ 'PACKETSTORM', '59347']
         ],
       'DisclosureDate' => 'Sep 10 2007'))
 

--- a/modules/auxiliary/scanner/http/goahead_traversal.rb
+++ b/modules/auxiliary/scanner/http/goahead_traversal.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           ['CVE', '2014-9707'],
-          ['URL', 'http://packetstormsecurity.com/files/131156/GoAhead-3.4.1-Heap-Overflow-Traversal.html']
+          ['PACKETSTORM', '131156']
         ],
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
           ['EDB', '31262'],
           ['OSVDB', '102656'],
           ['BID', '65199'],
-          ['URL', 'http://packetstormsecurity.com/files/124975/ManageEngine-Support-Center-Plus-7916-Directory-Traversal.html']
+          ['PACKETSTORM', '124975']
         ],
       'DisclosureDate' => "Jan 28 2014"
     ))

--- a/modules/auxiliary/scanner/http/wp_mobile_pack_info_disclosure.rb
+++ b/modules/auxiliary/scanner/http/wp_mobile_pack_info_disclosure.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           ['WPVDB', '8107'],
-          ['URL', 'https://packetstormsecurity.com/files/132750/']
+          ['PACKETSTORM', '132750']
         ],
       'Author'         =>
         [

--- a/modules/exploits/linux/http/linksys_themoon_exec.rb
+++ b/modules/exploits/linux/http/linksys_themoon_exec.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'EDB', '31683' ],
           [ 'BID', '65585' ],
           [ 'OSVDB', '103321' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/125253/linksyseseries-exec.txt' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/125252/Linksys-Worm-Remote-Root.html' ],
+          [ 'PACKETSTORM', '125253' ],
+          [ 'PACKETSTORM', '125252' ],
           [ 'URL', 'https://isc.sans.edu/diary/Linksys+Worm+%22TheMoon%22+Summary%3A+What+we+know+so+far/17633' ],
           [ 'URL', 'https://isc.sans.edu/forums/diary/Linksys+Worm+TheMoon+Captured/17630' ]
         ],

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          ['URL', 'http://packetstormsecurity.com/files/125754/Loadbalancer.org-Enterprise-VA-7.5.2-Static-SSH-Key.html']
+          ['PACKETSTORM', '125754']
         ],
       'DisclosureDate' => "Mar 17 2014",
       'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          ['URL', 'http://packetstormsecurity.com/files/125755/quantum-root.txt']
+          ['PACKETSTORM', '125755']
         ],
       'DisclosureDate' => "Mar 17 2014",
       'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['URL', 'http://packetstormsecurity.com/files/125760/quantumvmpro-backdoor.txt']
+          ['PACKETSTORM', '125760']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/multi/browser/java_storeimagearray.rb
+++ b/modules/exploits/multi/browser/java_storeimagearray.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2013-2465' ],
           [ 'OSVDB', '96269' ],
           [ 'EDB', '27526' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/122777/' ],
+          [ 'PACKETSTORM', '122777' ],
           [ 'URL', 'http://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/rev/2a9c79db0040' ]
         ],
       'Platform'      => %w{ java linux win },

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '104652'],
           ['OSVDB', '104653'],
           ['OSVDB', '104654'],
-          ['URL', 'http://packetstormsecurity.com/files/125761/Array-Networks-vxAG-xAPV-Privilege-Escalation.html']
+          ['PACKETSTORM', '125761']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
+++ b/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '69352' ],
           [ 'CVE', '2010-4335' ],
           [ 'BID', '44852'  ],
-          [ 'URL', 'http://packetstormsecurity.org/files/view/95847/burnedcake.py.txt' ]
+          [ 'PACKETSTORM', '95847' ]
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
+++ b/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          [ 'URL', 'http://packetstormsecurity.com/files/123480/ClipBucket-Remote-Code-Execution.html' ]
+          [ 'PACKETSTORM', '123480' ]
         ],
       'Platform'        => ['php'],
       'Arch'            => ARCH_PHP,

--- a/modules/exploits/unix/webapp/instantcms_exec.rb
+++ b/modules/exploits/unix/webapp/instantcms_exec.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'BID', '60816' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/122176/InstantCMS-1.6-Code-Execution.html' ]
+          [ 'PACKETSTORM', '122176' ]
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/unix/webapp/nagios_graph_explorer.rb
+++ b/modules/exploits/unix/webapp/nagios_graph_explorer.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '83552' ],
           [ 'BID', '54263' ],
-          [ 'URL', 'http://packetstormsecurity.org/files/118497/Nagios-XI-Network-Monitor-2011R1.9-OS-Command-Injection.html' ]
+          [ 'PACKETSTORM', '118497' ]
         ],
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['OSVDB', '85881'],
           ['EDB', '21929'],
-          ['URL', 'http://packetstormsecurity.org/files/117070/ProjectPier-0.8.8-Shell-Upload.html']
+          ['PACKETSTORM', '117070']
         ],
       'Platform'       => %w{ linux php },
       'Targets'        =>

--- a/modules/exploits/unix/webapp/skybluecanvas_exec.rb
+++ b/modules/exploits/unix/webapp/skybluecanvas_exec.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '102586'],
           ['BID', '65129'],
           ['EDB', '31183'],
-          ['URL', 'http://packetstormsecurity.com/files/124948/SkyBlueCanvas-CMS-1.1-r248-03-Command-Injection.html']
+          ['PACKETSTORM', '124948']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/zeroshell_exec.rb
+++ b/modules/exploits/unix/webapp/zeroshell_exec.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          [ 'URL', 'http://packetstormsecurity.com/files/122799/ZeroShell-2.0RC2-File-Disclosure-Command-Execution.html' ]
+          [ 'PACKETSTORM', '122799' ]
         ],
       'Platform'        => ['linux'],
       'Arch'            => ARCH_X86,

--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '62793' ],
           [ 'MSB', 'MS13-022' ],
           [ 'MSB', 'MS13-087' ],
-          [ 'URL', 'http://packetstormsecurity.com/files/123731/' ]
+          [ 'PACKETSTORM', '123731' ]
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/windows/http/miniweb_upload_wbem.rb
+++ b/modules/exploits/windows/http/miniweb_upload_wbem.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['OSVDB', '92198'],
           ['OSVDB', '92200'],
-          ['URL',   'http://dl.packetstormsecurity.net/1304-exploits/miniweb-shelltraversal.txt']
+          ['PACKETSTORM', '121168']
         ],
       'Payload'        =>
         {

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -210,7 +210,7 @@ class Msftidy
             warn("Please use 'US-CERT-VU' for '#{value}'")
           elsif value =~ /^https:\/\/wpvulndb\.com\/vulnerabilities\//
             warn("Please use 'WPVDB' for '#{value}'")
-          elsif value =~ /^http:\/\/packetstormsecurity\.com\/files\//
+          elsif value =~ /^https?:\/\/(?:[^\.]+\.)?packetstormsecurity\.(?:com|net|org)\//
             warn("Please use 'PACKETSTORM' for '#{value}'")
           end
         end


### PR DESCRIPTION
This has been annoying me while landing PRs, merging locally and working with several modules.  This cleans up the affected modules and `msftidy` should give a clean bill of health for all modules again.
