### PR TITLE
Use bind_addresses rather than bind_address; fixes #6394

### DIFF
--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -50,9 +50,7 @@ module ReverseTcpSsl
 
     comm = select_comm
     local_port = bind_port
-    addrs = bind_address
-
-    addrs.each { |ip|
+    bind_addresses.each { |ip|
       begin
 
         self.listener_sock = Rex::Socket::SslTcpServer.create(


### PR DESCRIPTION
Fixes #6394.

Before:

```
[*] Processing /tmp/6394.rc for ERB directives.
resource (/tmp/6394.rc)> use exploit/windows/mssql/mssql_payload
resource (/tmp/6394.rc)> set PAYLOAD windows/powershell_reverse_tcp
PAYLOAD => windows/powershell_reverse_tcp
resource (/tmp/6394.rc)> set LHOST localhost
LHOST => localhost
resource (/tmp/6394.rc)> set RHOST localhost
RHOST => localhost
resource (/tmp/6394.rc)> run
[-] Exploit failed: NameError undefined local variable or method `bind_address' for #<#<Class:0x007fb53cc706c0>:0x007fb53e4b2490>
[*] Exploit completed, but no session was created.
```

After:

```
[*] Processing /tmp/6394.rc for ERB directives.
resource (/tmp/6394.rc)> use exploit/windows/mssql/mssql_payload
resource (/tmp/6394.rc)> set PAYLOAD windows/powershell_reverse_tcp
PAYLOAD => windows/powershell_reverse_tcp
resource (/tmp/6394.rc)> set LHOST localhost
LHOST => localhost
resource (/tmp/6394.rc)> set RHOST localhost
RHOST => localhost
resource (/tmp/6394.rc)> run
[*] Started reverse SSL handler on 127.0.0.1:4444 
[-] Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (localhost:1433).
[*] Exploit completed, but no session was created.
```
