### PR TITLE
Adding a json formatting option to the info command

### DIFF
--- a/lib/msf/base.rb
+++ b/lib/msf/base.rb
@@ -29,6 +29,7 @@ require 'msf/base/sessions/tty'
 
 # Serialization
 require 'msf/base/serializer/readable_text'
+require 'msf/base/serializer/json'
 
 # Persistent Storage
 require 'msf/base/persistent_storage'

--- a/lib/msf/base/serializer/json.rb
+++ b/lib/msf/base/serializer/json.rb
@@ -1,0 +1,256 @@
+# -*- coding: binary -*-
+module Msf
+module Serializer
+
+# This class formats information in a json format that
+# is meant to be displayed on a console or some other non-GUI
+# medium.
+class Json
+
+  #Default number of characters to wrap at.
+  DefaultColumnWrap = 70
+  #Default number of characters to indent.
+  DefaultIndent     = 2
+
+  # Returns a formatted string that contains information about
+  # the supplied module instance.
+  #
+  # @param mod [Msf::Module] the module to dump information for.
+  # @param indent [String] the indentation to use.
+  # @return [String] formatted text output of the dump.
+  def self.dump_module(mod, indent = "  ")
+    case mod.type
+      when Msf::MODULE_PAYLOAD
+        return dump_payload_module(mod)
+      when Msf::MODULE_NOP
+        return dump_basic_module(mod)
+      when Msf::MODULE_ENCODER
+        return dump_basic_module(mod)
+      when Msf::MODULE_EXPLOIT
+        return dump_exploit_module(mod)
+      when Msf::MODULE_AUX
+        return dump_auxiliary_module(mod)
+      when Msf::MODULE_POST
+        return dump_post_module(mod)
+      else
+        return dump_generic_module(mod)
+    end
+  end
+
+  # Dumps an exploit's targets.
+  #
+  # @param mod [Msf::Exploit] the exploit module to dump targets
+  #   for.
+  # @return [Array] the exploit targets
+  def self.dump_exploit_targets(mod)
+    list = []
+
+    mod.targets.each_with_index { |target, idx|
+      list.push(target.name || 'All')
+    }
+
+    list
+  end
+
+  # Dumps a module's actions
+  #
+  # @param mod [Msf::Module] the module.
+  # @return [Array] the module actions
+  def self.dump_module_actions(mod)
+    list = []
+      mod.actions.each_with_index { |target, idx|
+        list.push('name' => (target.name || 'All') , 'description' => (target.description || ''))
+    }
+
+    list
+  end
+
+  # Dumps the module's selected action
+  #
+  # @param mod [Msf::Module] the module.
+  # @return [Array] the module options
+  def self.dump_module_action(mod)
+    list = []
+
+    list.push('name' => (mod.action.name || 'All'), 'description' => (mod.action.description || ''))
+
+    list
+  end
+
+  # Dumps information common to all modules
+  def self.dump_common_module_info(mod)
+    {
+      'Name' => mod.name,
+      'Module' => mod.fullname,
+      'Provided by' => dump_authors(mod),
+      'Rank' => mod.rank_to_s.capitalize,
+      'description' => Rex::Text.compress(mod.description),
+      'Basic options' =>  dump_options(mod),
+    }
+  end
+
+  # Dumps information about an exploit module.
+  #
+  # @param mod [Msf::Exploit] the exploit module.
+  # @return [String] the json string form of the information.
+  def self.dump_exploit_module(mod)
+   # Return a json dump of exploit module data
+    {
+    'Platform' => mod.platform_to_s,
+    'Privileged' => (mod.privileged? ? "Yes" : "No"),
+    'License' => mod.license,
+    'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
+    'Payload information'=> {
+      'Space' => (mod.payload_space.to_s if mod.payload_space),
+      'Avoid' => (mod.payload_badchars.length.to_s if mod.payload_badchars)
+    },
+    'references' => dump_references(mod)
+
+    }.merge(dump_common_module_info(mod)).to_json
+  end
+
+  # Dumps information about an auxiliary module.
+  #
+  # @param mod [Msf::Auxiliary] the auxiliary module.
+  # @return [String] the string form of the information.
+  def self.dump_auxiliary_module(mod)
+    # Return a json dump of auxiliary module data
+    {
+      'License' => mod.license,
+      'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
+      'Available actions' => dump_module_actions(mod),
+      'References' => dump_references(mod)
+    }.merge(dump_common_module_info(mod)).to_json
+  end
+
+  # Dumps information about a post module.
+  #
+  # @param mod [Msf::Post] the post module.
+  # @return [String] the string form of the information.
+  def self.dump_post_module(mod)
+    # Return a json dump of post module data
+    {
+      'Platform' => mod.platform_to_s,
+      'Arch' => mod.arch_to_s,
+      'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
+      'Available actions' => dump_module_actions(mod),
+      'References' => dump_references(mod)
+    }.merge(dump_common_module_info(mod)).to_json
+  end
+
+  # Dumps information about a payload module.
+  #
+  # @param mod [Msf::Payload] the payload module.
+  # @return [String] the string form of the information.
+  def self.dump_payload_module(mod)
+    # Return a json dump of post module data
+    {
+      'Platform' => mod.platform_to_s,
+      'Arch' => mod.arch_to_s,
+      'Needs Admin' => (mod.privileged? ? "Yes" : "No"),
+      'Total size' => mod.size,
+    }.merge(dump_common_module_info(mod)).to_json
+
+  end
+
+  # Returns an array of all authors
+  #
+  # @param mod [Msf::Module]
+  # @return [Array] an array of all authors
+  def self.dump_authors(mod)
+    # Authors
+    authors = []
+    mod.each_author { |author|
+      authors.push(author.to_s)
+    }
+    authors
+  end
+
+  # Dumps information about a module, just the basics.
+  #
+  # @param mod [Msf::Module] the module.
+  # @return [String] the string form of the information.
+  def self.dump_basic_module(mod)
+    {
+      'Platform' => mod.platform_to_s,
+      'Arch' => mod.arch_to_s,
+      'References' => dump_references(mod)
+    }.merge(dump_common_module_info(mod)).to_json
+  end
+
+  # Dumps the list of options associated with the
+  # supplied module.
+  #
+  # @param mod [Msf::Module] the module.
+  # @return [Array] the array of the information.
+  def self.dump_options(mod)
+    list = []
+    mod.options.sorted.each { |entry|
+      name, opt = entry
+      val = mod.datastore[name] || opt.default
+
+      next if (opt.advanced?)
+      next if (opt.evasion?)
+      next if (opt.valid?(val))
+
+      list.push('name' => name, 'display_value' => opt.display_value(val), 'required' => opt.required? ? 'yes' : 'no', 'description' => opt.desc)
+    }
+
+    list
+  end
+
+  # Dumps the advanced options associated with the supplied module.
+  #
+  # @param mod [Msf::Module] the module.
+  # @return [Array] the array of the information.
+  def self.dump_advanced_options(mod)
+    list = []
+    mod.options.sorted.each { |entry|
+      name, opt = entry
+
+      next if (!opt.advanced?)
+
+      val = mod.datastore[name] || opt.default.to_s
+
+      list.push("Name" => name, "Current Setting" => val, "Description" => opt.desc)
+    }
+    list
+  end
+
+  # Dumps the evasion options associated with the supplied module.
+  #
+  # @param mod [Msf::Module] the module.
+  # @return [Array] the array of the information.
+  def self.dump_evasion_options(mod)
+    list = []
+    mod.options.sorted.each { |entry|
+      name, opt = entry
+
+      next if (!opt.evasion?)
+
+      val = mod.datastore[name] || opt.default || ''
+
+      list.push("Name" => name, "Current Setting" => val, "Description" => opt.desc)
+    }
+
+    list
+  end
+
+  # Dumps the references associated with the supplied module.
+  #
+  # @param mod [Msf::Module] the module.
+  # @return [Array] the array of the information.
+  def self.dump_references(mod)
+    if (mod.respond_to? :references and mod.references and mod.references.length > 0)
+      refs = []
+      mod.references.each { |ref|
+        refs.push(ref.to_s)
+      }
+    end
+    refs
+  end
+
+end
+
+end end
+

--- a/lib/msf/base/serializer/json.rb
+++ b/lib/msf/base/serializer/json.rb
@@ -1,256 +1,208 @@
 # -*- coding: binary -*-
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/ClassLength
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Style/BlockDelimiters
 module Msf
-module Serializer
+  module Serializer
+    #
+    # This class formats information in a json format that
+    # is meant to be displayed on a console or some other non-GUI
+    # medium.
+    class Json
+      #
+      # Returns a formatted string that contains information about
+      # the supplied module instance.
+      #
+      # @param mod [Msf::Module] the module to dump information for.
+      # @param indent [String] the indentation to use.
+      # @return [String] formatted text output of the dump.
+      def self.dump_module(mod, _indent = "")
+        case mod.type
+        when Msf::MODULE_PAYLOAD
+          return dump_payload_module(mod)
+        when Msf::MODULE_NOP
+          return dump_basic_module(mod)
+        when Msf::MODULE_ENCODER
+          return dump_basic_module(mod)
+        when Msf::MODULE_EXPLOIT
+          return dump_exploit_module(mod)
+        when Msf::MODULE_AUX
+          return dump_auxiliary_module(mod)
+        when Msf::MODULE_POST
+          return dump_post_module(mod)
+        else
+          return dump_basic_module(mod)
+        end
+      end
 
-# This class formats information in a json format that
-# is meant to be displayed on a console or some other non-GUI
-# medium.
-class Json
+      # Dumps an exploit's targets.
+      #
+      # @param mod [Msf::Exploit] the exploit module to dump targets
+      #   for.
+      # @return [Array] the exploit targets
+      def self.dump_exploit_targets(mod)
+        list = []
 
-  #Default number of characters to wrap at.
-  DefaultColumnWrap = 70
-  #Default number of characters to indent.
-  DefaultIndent     = 2
+        mod.targets.each { |target| list.push(target.name || 'All') }
 
-  # Returns a formatted string that contains information about
-  # the supplied module instance.
-  #
-  # @param mod [Msf::Module] the module to dump information for.
-  # @param indent [String] the indentation to use.
-  # @return [String] formatted text output of the dump.
-  def self.dump_module(mod, indent = "  ")
-    case mod.type
-      when Msf::MODULE_PAYLOAD
-        return dump_payload_module(mod)
-      when Msf::MODULE_NOP
-        return dump_basic_module(mod)
-      when Msf::MODULE_ENCODER
-        return dump_basic_module(mod)
-      when Msf::MODULE_EXPLOIT
-        return dump_exploit_module(mod)
-      when Msf::MODULE_AUX
-        return dump_auxiliary_module(mod)
-      when Msf::MODULE_POST
-        return dump_post_module(mod)
-      else
-        return dump_generic_module(mod)
+        list
+      end
+
+      # Dumps a module's actions
+      #
+      # @param mod [Msf::Module] the module.
+      # @return [Array] the module actions
+      def self.dump_module_actions(mod)
+        list = []
+
+        mod.actions.each { |target| list.push('name' => (target.name || 'All'), 'description' => (target.description || '')) }
+
+        list
+      end
+
+      # Dumps the module's selected action
+      #
+      # @param mod [Msf::Module] the module.
+      # @return [Array] the module options
+      def self.dump_module_action(mod)
+        list = []
+
+        list.push('name' => (mod.action.name || 'All'), 'description' => (mod.action.description || ''))
+
+        list
+      end
+
+      # Dumps information common to all modules
+      def self.dump_common_module_info(mod)
+        {
+          'Name' => mod.name,
+          'Module' => mod.fullname,
+          'Provided by' => dump_authors(mod),
+          'Rank' => mod.rank_to_s.capitalize,
+          'description' => Rex::Text.compress(mod.description),
+          'Basic options' =>  dump_options(mod)
+        }
+      end
+
+      # Dumps information about an exploit module.
+      #
+      # @param mod [Msf::Exploit] the exploit module.
+      # @return [String] the json string form of the information.
+      def self.dump_exploit_module(mod)
+        # Return a json dump of exploit module data
+        {
+          'Platform' => mod.platform_to_s,
+          'Privileged' => (mod.privileged? ? "Yes" : "No"),
+          'License' => mod.license,
+          'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
+          'Payload information' => {
+            'Space' => (mod.payload_space.to_s if mod.payload_space),
+            'Avoid' => (mod.payload_badchars.length.to_s if mod.payload_badchars)
+          },
+          'references' => dump_references(mod)
+        }.merge(dump_common_module_info(mod)).to_json
+      end
+
+      # Dumps information about an auxiliary module.
+      #
+      # @param mod [Msf::Auxiliary] the auxiliary module.
+      # @return [String] the string form of the information.
+      def self.dump_auxiliary_module(mod)
+        # Return a json dump of auxiliary module data
+        {
+          'License' => mod.license,
+          'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
+          'Available actions' => dump_module_actions(mod),
+          'References' => dump_references(mod)
+        }.merge(dump_common_module_info(mod)).to_json
+      end
+
+      # Dumps information about a post module.
+      #
+      # @param mod [Msf::Post] the post module.
+      # @return [String] the string form of the information.
+      def self.dump_post_module(mod)
+        # Return a json dump of post module data
+        {
+          'Platform' => mod.platform_to_s,
+          'Arch' => mod.arch_to_s,
+          'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
+          'Available actions' => dump_module_actions(mod),
+          'References' => dump_references(mod)
+        }.merge(dump_common_module_info(mod)).to_json
+      end
+
+      # Dumps information about a payload module.
+      #
+      # @param mod [Msf::Payload] the payload module.
+      # @return [String] the string form of the information.
+      def self.dump_payload_module(mod)
+        # Return a json dump of post module data
+        {
+          'Platform' => mod.platform_to_s,
+          'Arch' => mod.arch_to_s,
+          'Needs Admin' => (mod.privileged? ? "Yes" : "No"),
+          'Total size' => mod.size
+        }.merge(dump_common_module_info(mod)).to_json
+      end
+
+      # Returns an array of all authors
+      #
+      # @param mod [Msf::Module]
+      # @return [Array] an array of all authors
+      def self.dump_authors(mod)
+        # Authors
+        authors = []
+        mod.each_author { |author| authors.push(author.to_s) }
+        authors
+      end
+
+      # Dumps information about a module, just the basics.
+      #
+      # @param mod [Msf::Module] the module.
+      # @return [String] the string form of the information.
+      def self.dump_basic_module(mod)
+        {
+          'Platform' => mod.platform_to_s,
+          'Arch' => mod.arch_to_s,
+          'References' => dump_references(mod)
+        }.merge(dump_common_module_info(mod)).to_json
+      end
+
+      # Dumps the list of options associated with the
+      # supplied module.
+      #
+      # @param mod [Msf::Module] the module.
+      # @return [Array] the array of the information.
+      def self.dump_options(mod)
+        list = []
+        mod.options.sorted.each { |entry|
+          name, opt = entry
+          val = mod.datastore[name] || opt.default
+
+          next if opt.advanced?
+          next if opt.evasion?
+          next if opt.valid?(val)
+
+          list.push('name' => name, 'display_value' => opt.display_value(val), 'required' => opt.required? ? 'yes' : 'no', 'description' => opt.desc)
+        }
+
+        list
+      end
+
+      # Dumps the references associated with the supplied module.
+      #
+      # @param mod [Msf::Module] the module.
+      # @return [Array] the array of the information.
+      def self.dump_references(mod)
+        if (mod.respond_to? :references) && mod.references && (mod.references.length > 0)
+          refs = []
+          mod.references.each { |ref| refs.push(ref.to_s) }
+        end
+
+        refs
+      end
     end
   end
-
-  # Dumps an exploit's targets.
-  #
-  # @param mod [Msf::Exploit] the exploit module to dump targets
-  #   for.
-  # @return [Array] the exploit targets
-  def self.dump_exploit_targets(mod)
-    list = []
-
-    mod.targets.each_with_index { |target, idx|
-      list.push(target.name || 'All')
-    }
-
-    list
-  end
-
-  # Dumps a module's actions
-  #
-  # @param mod [Msf::Module] the module.
-  # @return [Array] the module actions
-  def self.dump_module_actions(mod)
-    list = []
-      mod.actions.each_with_index { |target, idx|
-        list.push('name' => (target.name || 'All') , 'description' => (target.description || ''))
-    }
-
-    list
-  end
-
-  # Dumps the module's selected action
-  #
-  # @param mod [Msf::Module] the module.
-  # @return [Array] the module options
-  def self.dump_module_action(mod)
-    list = []
-
-    list.push('name' => (mod.action.name || 'All'), 'description' => (mod.action.description || ''))
-
-    list
-  end
-
-  # Dumps information common to all modules
-  def self.dump_common_module_info(mod)
-    {
-      'Name' => mod.name,
-      'Module' => mod.fullname,
-      'Provided by' => dump_authors(mod),
-      'Rank' => mod.rank_to_s.capitalize,
-      'description' => Rex::Text.compress(mod.description),
-      'Basic options' =>  dump_options(mod),
-    }
-  end
-
-  # Dumps information about an exploit module.
-  #
-  # @param mod [Msf::Exploit] the exploit module.
-  # @return [String] the json string form of the information.
-  def self.dump_exploit_module(mod)
-   # Return a json dump of exploit module data
-    {
-    'Platform' => mod.platform_to_s,
-    'Privileged' => (mod.privileged? ? "Yes" : "No"),
-    'License' => mod.license,
-    'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
-    'Payload information'=> {
-      'Space' => (mod.payload_space.to_s if mod.payload_space),
-      'Avoid' => (mod.payload_badchars.length.to_s if mod.payload_badchars)
-    },
-    'references' => dump_references(mod)
-
-    }.merge(dump_common_module_info(mod)).to_json
-  end
-
-  # Dumps information about an auxiliary module.
-  #
-  # @param mod [Msf::Auxiliary] the auxiliary module.
-  # @return [String] the string form of the information.
-  def self.dump_auxiliary_module(mod)
-    # Return a json dump of auxiliary module data
-    {
-      'License' => mod.license,
-      'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
-      'Available actions' => dump_module_actions(mod),
-      'References' => dump_references(mod)
-    }.merge(dump_common_module_info(mod)).to_json
-  end
-
-  # Dumps information about a post module.
-  #
-  # @param mod [Msf::Post] the post module.
-  # @return [String] the string form of the information.
-  def self.dump_post_module(mod)
-    # Return a json dump of post module data
-    {
-      'Platform' => mod.platform_to_s,
-      'Arch' => mod.arch_to_s,
-      'Disclosed' => (mod.disclosure_date if mod.disclosure_date),
-      'Available actions' => dump_module_actions(mod),
-      'References' => dump_references(mod)
-    }.merge(dump_common_module_info(mod)).to_json
-  end
-
-  # Dumps information about a payload module.
-  #
-  # @param mod [Msf::Payload] the payload module.
-  # @return [String] the string form of the information.
-  def self.dump_payload_module(mod)
-    # Return a json dump of post module data
-    {
-      'Platform' => mod.platform_to_s,
-      'Arch' => mod.arch_to_s,
-      'Needs Admin' => (mod.privileged? ? "Yes" : "No"),
-      'Total size' => mod.size,
-    }.merge(dump_common_module_info(mod)).to_json
-
-  end
-
-  # Returns an array of all authors
-  #
-  # @param mod [Msf::Module]
-  # @return [Array] an array of all authors
-  def self.dump_authors(mod)
-    # Authors
-    authors = []
-    mod.each_author { |author|
-      authors.push(author.to_s)
-    }
-    authors
-  end
-
-  # Dumps information about a module, just the basics.
-  #
-  # @param mod [Msf::Module] the module.
-  # @return [String] the string form of the information.
-  def self.dump_basic_module(mod)
-    {
-      'Platform' => mod.platform_to_s,
-      'Arch' => mod.arch_to_s,
-      'References' => dump_references(mod)
-    }.merge(dump_common_module_info(mod)).to_json
-  end
-
-  # Dumps the list of options associated with the
-  # supplied module.
-  #
-  # @param mod [Msf::Module] the module.
-  # @return [Array] the array of the information.
-  def self.dump_options(mod)
-    list = []
-    mod.options.sorted.each { |entry|
-      name, opt = entry
-      val = mod.datastore[name] || opt.default
-
-      next if (opt.advanced?)
-      next if (opt.evasion?)
-      next if (opt.valid?(val))
-
-      list.push('name' => name, 'display_value' => opt.display_value(val), 'required' => opt.required? ? 'yes' : 'no', 'description' => opt.desc)
-    }
-
-    list
-  end
-
-  # Dumps the advanced options associated with the supplied module.
-  #
-  # @param mod [Msf::Module] the module.
-  # @return [Array] the array of the information.
-  def self.dump_advanced_options(mod)
-    list = []
-    mod.options.sorted.each { |entry|
-      name, opt = entry
-
-      next if (!opt.advanced?)
-
-      val = mod.datastore[name] || opt.default.to_s
-
-      list.push("Name" => name, "Current Setting" => val, "Description" => opt.desc)
-    }
-    list
-  end
-
-  # Dumps the evasion options associated with the supplied module.
-  #
-  # @param mod [Msf::Module] the module.
-  # @return [Array] the array of the information.
-  def self.dump_evasion_options(mod)
-    list = []
-    mod.options.sorted.each { |entry|
-      name, opt = entry
-
-      next if (!opt.evasion?)
-
-      val = mod.datastore[name] || opt.default || ''
-
-      list.push("Name" => name, "Current Setting" => val, "Description" => opt.desc)
-    }
-
-    list
-  end
-
-  # Dumps the references associated with the supplied module.
-  #
-  # @param mod [Msf::Module] the module.
-  # @return [Array] the array of the information.
-  def self.dump_references(mod)
-    if (mod.respond_to? :references and mod.references and mod.references.length > 0)
-      refs = []
-      mod.references.each { |ref|
-        refs.push(ref.to_s)
-      }
-    end
-    refs
-  end
-
 end
-
-end end
-

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -762,7 +762,7 @@ class Core
     if (args.length == 0)
       if (active_module)
         if dump_json
-          print(Serializer::Json.dump_module(active_module))
+          print(Serializer::Json.dump_module(active_module) + "\n")
         else
           print(Serializer::ReadableText.dump_module(active_module))
         end
@@ -782,7 +782,7 @@ class Core
       if (mod == nil)
         print_error("Invalid module: #{name}")
       elsif dump_json
-        print(Serializer::Json.dump_module(mod))
+        print(Serializer::Json.dump_module(mod) + "\n")
       else
         print(Serializer::ReadableText.dump_module(mod))
       end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -743,6 +743,7 @@ class Core
   def cmd_info_help
     print_line "Usage: info <module name> [mod2 mod3 ...]"
     print_line
+    print_line "Optionally the flag '-j' will print the data in json format"
     print_line "Queries the supplied module or modules for information. If no module is given,"
     print_line "show info for the currently active module."
     print_line
@@ -752,9 +753,16 @@ class Core
   # Displays information about one or more module.
   #
   def cmd_info(*args)
+    dump_json = false
+    if args.include?('-j')
+      args.delete('-j')
+      dump_json = true
+    end
+
     if (args.length == 0)
       if (active_module)
-        print(Serializer::ReadableText.dump_module(active_module))
+        print(Serializer::Json.dump_module(active_module)) if dump_json
+        print(Serializer::ReadableText.dump_module(active_module)) if dump_json
         return true
       else
         cmd_info_help
@@ -771,7 +779,8 @@ class Core
       if (mod == nil)
         print_error("Invalid module: #{name}")
       else
-        print(Serializer::ReadableText.dump_module(mod))
+        print(Serializer::Json.dump_module(mod)) if dump_json
+        print(Serializer::ReadableText.dump_module(mod)) if dump_json
       end
     }
   end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -761,8 +761,11 @@ class Core
 
     if (args.length == 0)
       if (active_module)
-        print(Serializer::Json.dump_module(active_module)) if dump_json
-        print(Serializer::ReadableText.dump_module(active_module)) if dump_json
+        if dump_json
+          print(Serializer::Json.dump_module(active_module))
+        else
+          print(Serializer::ReadableText.dump_module(active_module))
+        end
         return true
       else
         cmd_info_help
@@ -778,9 +781,10 @@ class Core
 
       if (mod == nil)
         print_error("Invalid module: #{name}")
+      elsif dump_json
+        print(Serializer::Json.dump_module(mod))
       else
-        print(Serializer::Json.dump_module(mod)) if dump_json
-        print(Serializer::ReadableText.dump_module(mod)) if dump_json
+        print(Serializer::ReadableText.dump_module(mod))
       end
     }
   end


### PR DESCRIPTION
#### Description:

There are cases, such as when grabbing module information in batch, where module information in a json formatting would be very helpful.
#### Verification:
- [x] Perform a code review
- [x] Verify existing functionality works.  This command should give you output in readable text:

```
./msfconsole -q -x "info exploits/windows/http/oracle_beehive_evaluation"
```
- [x] Verify new functionality works. This command should give you the output in json format:

```
./msfconsole -q -x "info -j exploits/windows/http/oracle_beehive_evaluation"
```
