### PR TITLE
add auxiliary/scanner/redis/redis_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/redis.rb
+++ b/lib/metasploit/framework/login_scanner/redis.rb
@@ -1,0 +1,89 @@
+require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/login_scanner/rex_socket'
+require 'metasploit/framework/tcp/client'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # This is the LoginScanner class for dealing with REDIS.
+      # It is responsible for taking a single target, and a list of credentials
+      # and attempting them. It then saves the results.
+
+      class REDIS
+        include Metasploit::Framework::LoginScanner::Base
+        include Metasploit::Framework::LoginScanner::RexSocket
+        include Metasploit::Framework::Tcp::Client
+
+        DEFAULT_PORT         = 6379
+        LIKELY_PORTS         = [ DEFAULT_PORT ]
+        LIKELY_SERVICE_NAMES = [ 'redis' ]
+        PRIVATE_TYPES        = [ :password ]
+        REALM_KEY            = nil
+
+        # This method can create redis command which can be read by redis server
+        def redis_proto(command_parts)
+          return if command_parts.blank?
+          command = "*#{command_parts.length}\r\n"
+          command_parts.each do |p|
+            command << "$#{p.length}\r\n#{p}\r\n"
+          end
+          command
+        end
+
+        # This method attempts a single login with a single credential against the target
+        # @param credential [Credential] The credential object to attempt to login with
+        # @return [Metasploit::Framework::LoginScanner::Result] The LoginScanner Result object
+        def attempt_login(credential)
+          result_options = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            host: host,
+            port: port,
+            protocol: 'tcp',
+            service_name: 'redis'
+          }
+
+          disconnect if self.sock
+
+          begin
+            connect
+            select([sock], nil, nil, 0.4)
+
+            command = redis_proto(['PING'])
+            sock.put(command)
+            result_options[:proof] = sock.get_once
+
+            if result_options[:proof] && result_options[:proof] =~ /(?<auth_response>ERR operation not permitted|NOAUTH Authentication required)/i
+              command = redis_proto(['AUTH', "#{credential.private}"])
+              sock.put(command)
+              result_options[:proof] = sock.get_once(-1, 16)
+
+              if result_options[:proof] && result_options[:proof][/^\+OK/]
+                result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
+              end
+            end
+
+          rescue Rex::ConnectionError, EOFError, Timeout::Error, Errno::EPIPE => e
+            result_options.merge!(
+              proof: e,
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            )
+          end
+          disconnect if self.sock
+          ::Metasploit::Framework::LoginScanner::Result.new(result_options)
+        end
+
+        private
+
+        # (see Base#set_sane_defaults)
+        def set_sane_defaults
+          self.connection_timeout  ||= 30
+          self.port                ||= DEFAULT_PORT
+          self.max_send_size       ||= 0
+          self.send_delay          ||= 0
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -9,6 +9,7 @@ require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Redis
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
@@ -27,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(6379),
         OptPath.new('PASS_FILE',
           [
             false,

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -35,10 +35,9 @@ class Metasploit3 < Msf::Auxiliary
             File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_passwords.txt')
           ])
       ], self.class)
-  end
 
-  def target
-    "#{rhost}:#{rport}"
+    # redis does not have an username, there's only password
+    deregister_options('USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
   end
 
   def run_host(ip)
@@ -46,10 +45,9 @@ class Metasploit3 < Msf::Auxiliary
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file: datastore['PASS_FILE'],
       password: datastore['PASSWORD'],
-      user_file: datastore['USER_FILE'],
-      userpass_file: datastore['USERPASS_FILE'],
-      username: datastore['USERNAME'],
-      user_as_pass: datastore['USER_AS_PASS']
+      # The LoginScanner API refuses to run if there's no username, so we give it a fake one.
+      # But we will not be reporting this to the database.
+      username: 'redis'
     )
 
     cred_collection = prepend_db_passwords(cred_collection)

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -68,7 +68,8 @@ class Metasploit3 < Msf::Auxiliary
         workspace_id: myworkspace_id
       )
 
-      if result.success?
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
@@ -78,6 +79,9 @@ class Metasploit3 < Msf::Auxiliary
         else
           print_good "#{peer} - LOGIN SUCCESSFUL: #{result.credential}"
         end
+      when Metasploit::Model::Login::Status::NO_AUTH_REQUIRED
+        vprint_error "#{peer} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        break
       else
         invalidate_login(credential_data)
         vprint_error "#{peer} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -55,19 +55,10 @@ class Metasploit3 < Msf::Auxiliary
     scanner = Metasploit::Framework::LoginScanner::REDIS.new(
       host: ip,
       port: rport,
-      ssl: datastore['SSL'],
+      proxies: datastore['PROXIES'],
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],
-      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-      max_send_size: datastore['TCP::max_send_size'],
-      send_delay: datastore['TCP::send_delay'],
-      framework: framework,
-      framework_module: self,
-      ssl_version: datastore['SSLVersion'],
-      ssl_verify_mode: datastore['SSLVerifyMode'],
-      ssl_cipher: datastore['SSLCipher'],
-      local_port: datastore['CPORT'],
-      local_host: datastore['CHOST']
+      connection_timeout: 30
     )
 
     scanner.scan! do |result|

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -1,0 +1,94 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'metasploit/framework/login_scanner/redis'
+require 'metasploit/framework/credential_collection'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'         => 'Redis Login Utility',
+        'Description'  => 'This module attempts to authenticate to an REDIS service.',
+        'Author'       => [ 'Nixawk' ],
+        'References'   => [
+          ['URL', 'http://redis.io/topics/protocol']
+        ],
+        'License'      => MSF_LICENSE))
+
+    register_options(
+      [
+        Opt::RPORT(6379),
+        OptPath.new('PASS_FILE',
+          [
+            false,
+            'The file that contains a list of of probable passwords.',
+            File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_passwords.txt')
+          ])
+      ], self.class)
+  end
+
+  def target
+    "#{rhost}:#{rport}"
+  end
+
+  def run_host(ip)
+    cred_collection = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
+    )
+
+    cred_collection = prepend_db_passwords(cred_collection)
+
+    scanner = Metasploit::Framework::LoginScanner::REDIS.new(
+      host: ip,
+      port: rport,
+      ssl: datastore['SSL'],
+      cred_details: cred_collection,
+      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+      max_send_size: datastore['TCP::max_send_size'],
+      send_delay: datastore['TCP::send_delay'],
+      framework: framework,
+      framework_module: self,
+      ssl_version: datastore['SSLVersion'],
+      ssl_verify_mode: datastore['SSLVerifyMode'],
+      ssl_cipher: datastore['SSLCipher'],
+      local_port: datastore['CPORT'],
+      local_host: datastore['CHOST']
+    )
+
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+        module_fullname: self.fullname,
+        workspace_id: myworkspace_id
+      )
+
+      if result.success?
+        credential_core = create_credential(credential_data)
+        credential_data[:core] = credential_core
+        create_credential_login(credential_data)
+
+        print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential}"
+      else
+        invalidate_login(credential_data)
+        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/redis/redis_login.rb
+++ b/modules/auxiliary/scanner/redis/redis_login.rb
@@ -82,10 +82,14 @@ class Metasploit3 < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential}"
+        if datastore['VERBOSE']
+          vprint_good "#{peer} - LOGIN SUCCESSFUL: #{result.credential} (#{result.status}: #{result.proof})"
+        else
+          print_good "#{peer} - LOGIN SUCCESSFUL: #{result.credential}"
+        end
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        vprint_error "#{peer} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
       end
     end
   end


### PR DESCRIPTION
```
msf auxiliary(redis_login) > show options 

Module options (auxiliary/scanner/redis/redis_login):

   Name              Current Setting                                                                   Required  Description
   ----              ---------------                                                                   --------  -----------
   BLANK_PASSWORDS   false                                                                             no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                                                                                 yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false                                                                             no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false                                                                             no        Add all passwords in the current database to the list
   PASSWORD                                                                                            no        A specific password to authenticate with
   PASS_FILE         /Users/Open-Security/Code/metasploit-framework/data/wordlists/unix_passwords.txt  no        The file that contains a list of of probable passwords.
   RHOSTS            192.168.199.249                                                                   yes       The target address range or CIDR identifier
   RPORT             6379                                                                              yes       The target port
   STOP_ON_SUCCESS   false                                                                             yes       Stop guessing when a credential works for a host
   THREADS           1                                                                                 yes       The number of concurrent threads
   VERBOSE           true                                                                              yes       Whether to print output for all attempts

msf auxiliary(redis_login) > run 

[-] 192.168.199.249:6379 REDIS - LOGIN FAILED: redis:123456 (Incorrect: -ERR invalid password
[-] 192.168.199.249:6379 REDIS - LOGIN FAILED: redis:12345 (Incorrect: -ERR invalid password
[-] 192.168.199.249:6379 REDIS - LOGIN FAILED: redis:123456789 (Incorrect: -ERR invalid password
[+] 192.168.199.249:6379 - LOGIN SUCCESSFUL: redis:password
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(redis_login) > creds 
Credentials
===========

host             origin           service           public  private   realm  private_type
----             ------           -------           ------  -------   -----  ------------
192.168.199.249  192.168.199.249  6379/tcp (redis)  redis   password         Password
```

If **`No Auth Required`**, messages show as follow just once:

```
msf auxiliary(redis_login) > run 

[-] 192.168.1.102:6379 REDIS - LOGIN FAILED: redis:password (No Auth Required: -ERR Client sent AUTH, but no password is set
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
