### PR TITLE
End of year .mailmap update

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,34 +1,32 @@
-bcook-r7 <bcook-r7@github>         Brent Cook <bcook@rapid7.com>
 bcook-r7 <bcook-r7@github>         <busterb@gmail.com>
+bcook-r7 <bcook-r7@github>         Brent Cook <bcook@rapid7.com>
 bturner-r7 <bturner-r7@github>     Brandon Turner <brandon_turner@rapid7.com>
-ccatalan-r7 <ccatalan-r7@github>   Christian Catalan <ccatalan@rapid7.com>
 cdoughty-r7 <cdoughty-r7@github>   Chris Doughty <chris_doughty@rapid7.com>
 dheiland-r7 <dheiland-r7@github>   Deral Heiland <dh@layereddefense.com>
 dmaloney-r7 <dmaloney-r7@github>   David Maloney <DMaloney@rapid7.com>
 dmaloney-r7 <dmaloney-r7@github>   David Maloney <David_Maloney@rapid7.com>
 dmaloney-r7 <dmaloney-r7@github>   dmaloney-r7 <DMaloney@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>   Dev Mohanty <Dev_Mohanty@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>   Dev Mohanty <Dev_Mohanty@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>   dmohanty-r7 <Dev_Mohanty@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>   dmohanty-r7 <Dev_Mohanty@rapid7.com>
 ecarey-r7 <ecarey-r7@github>       Erran Carey <e@ipwnstuff.com>
 farias-r7 <farias-r7@github>       Fernando Arias <fernando_arias@rapid7.com>
-hdm <hdm@github>       HD Moore <hd_moore@rapid7.com>
-hdm <hdm@github>       HD Moore <hdm@digitaloffense.net>
-hdm <hdm@github>       HD Moore <x@hdm.io>
+gmikeska-r7 <gmikeska-r7@github>   Greg Mikeska <greg_mikeska@rapid7.com>
+gmikeska-r7 <gmikeska-r7@github>   Gregory Mikeska <greg_mikeska@rapid7.com>
+hdm <hdm@github>                   HD Moore <hd_moore@rapid7.com>
+hdm <hdm@github>                   HD Moore <hdm@digitaloffense.net>
+hdm <hdm@github>                   HD Moore <x@hdm.io>
 jhart-r7 <jhart-r7@github>         Jon Hart <jon_hart@rapid7.com>
-jlee-r7 <jlee-r7@github>           <james_lee@rapid7.com>
 jlee-r7 <jlee-r7@github>           <egypt@metasploit.com> # aka egypt
-jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan.vazquez@metasploit.com>
-jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan_vazquez@rapid7.com>
+jlee-r7 <jlee-r7@github>           <james_lee@rapid7.com>
 kgray-r7 <kgray-r7@github>         Kyle Gray <kyle_gray@rapid7.com>
-limhoff-r7 <limhoff-r7@github>     Luke Imhoff <luke_imhoff@rapid7.com>
 lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance.sanchez+github@gmail.com>
 lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance.sanchez@rapid7.com>
 lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance@AUS-MAC-1041.local>
 lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance@aus-mac-1041.aus.rapid7.com>
 lsanchez-r7 <lsanchez-r7@github>   darkbushido <lance.sanchez@gmail.com>
-mbuck-r7 <mbuck-r7@github>         Matt Buck <Matthew_Buck@rapid7.com>
-mbuck-r7 <mbuck-r7@github>         Matt Buck <techpeace@gmail.com>
-mschloesser-r7 <mschloesser-r7@github> Mark Schloesser <mark_schloesser@rapid7.com>
-mschloesser-r7 <mschloesser-r7@github> mschloesser-r7 <mark_schloesser@rapid7.com>
-parzamendi-r7 <parzamendi-r7@github> parzamendi-r7 <peter_arzamendi@rapid7.com>
+lsato-r7 <lsato-r7@github>         Louis Sato <lsato@rapid7.com>
 pdeardorff-r7 <pdeardorff-r7@github> Paul Deardorff <Paul_Deardorff@rapid7.com>
 pdeardorff-r7 <pdeardorff-r7@github> pdeardorff-r7 <paul_deardorff@rapid7.com>
 sgonzalez-r7 <sgonzalez-r7@github> Sonny Gonzalez <sonny_gonzalez@rapid7.com>
@@ -36,8 +34,6 @@ shuckins-r7 <shuckins-r7@github>   Samuel Huckins <samuel_huckins@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <tod_beardsley@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@metasploit.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@packetfu.com>
-trosen-r7 <trosen-r7@github>       Trevor Rosen <Trevor_Rosen@rapid7.com>
-trosen-r7 <trosen-r7@github>       Trevor Rosen <trevor@catapult-creative.com>
 wchen-r7 <wchen-r7@github>         <msfsinn3r@gmail.com> # aka sinn3r
 wchen-r7 <wchen-r7@github>         <wei_chen@rapid7.com>
 wvu-r7 <wvu-r7@github>             William Vu <William_Vu@rapid7.com>
@@ -55,6 +51,8 @@ wvu-r7 <wvu-r7@github>             wvu-r7 <William_Vu@rapid7.com>
 bannedit <bannedit@github>             David Rude <bannedit0@gmail.com>
 bcoles <bcoles@github>                 bcoles <bcoles@gmail.com>
 bcoles <bcoles@github>                 Brendan Coles <bcoles@gmail.com>
+bokojan <bokojan@github>               parzamendi-r7 <peter_arzamendi@rapid7.com>
+brandonprry <brandonprry@github>       <bperry@brandons-mbp.attlocal.net>
 brandonprry <brandonprry@github>       Brandon Perry <bperry.volatile@gmail.com>
 brandonprry <brandonprry@github>       Brandon Perry <bperry@bperry-rapid7.(none)>
 brandonprry <brandonprry@github>       Brandon Perry <brandon.perry@zenimaxonline.com>
@@ -66,30 +64,46 @@ Chao-mu <Chao-Mu@github>               chao-mu <chao.mu@minorcrash.com>
 Chao-mu <Chao-Mu@github>               chao-mu <chao@confusion.(none)>
 ChrisJohnRiley <ChrisJohnRiley@github> Chris John Riley <chris.riley@c22.cc>
 ChrisJohnRiley <ChrisJohnRiley@github> Chris John Riley <reg@c22.cc>
+claudijd <claudijd@github>             Jonathan Claudius <claudijd@yahoo.com>
+claudijd <claudijd@github>             Jonathan Claudius <jclaudius@trustwave.com>
 corelanc0d3r <corelanc0d3r@github>     corelanc0d3r <peter.ve@corelan.be>
 corelanc0d3r <corelanc0d3r@github>     Peter Van Eeckhoutte (corelanc0d3r) <peter.ve@corelan.be>
+crcatala <crcatala@github>             Christian Catalan <ccatalan@rapid7.com>
 darkoperator <darkoperator@github>     Carlos Perez <carlos_perez@darkoperator.com>
 efraintorres <efraintorres@github>     efraintorres <etlownoise@gmail.com>
 efraintorres <efraintorres@github>     et <>
+espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
+espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
+espreto <espreto@github>               Roberto Soares Espreto <robertoespreto@gmail.com>
+espreto <espreto@github>               Roberto Soares Espreto <robertoespreto@gmail.com>
 fab <fab@???>                          fab <> # fab at revhosts.net (Fabrice MOURRON)
-FireFart <FireFart@github>             Christian Mehlmauer <firefart@gmail.com>
 FireFart <FireFart@github>             <FireFart@users.noreply.github.com>
+FireFart <FireFart@github>             Christian Mehlmauer <firefart@gmail.com>
+g0tmi1k <g0tmi1k@github>               <g0tmi1k@users.noreply.github.com>
+g0tmi1k <g0tmi1k@github>               <have.you.g0tmi1k@gmail.com>
 h0ng10 <h0ng10@github>                 h0ng10 <hansmartin.muench@googlemail.com>
 h0ng10 <h0ng10@github>                 Hans-Martin Münch <hansmartin.muench@googlemail.com>
-jcran <jcran@github>                   <jcran@pwnieexpress.com>
-jcran <jcran@github>                   <jcran@pentestify.com>
+jabra <jabra@github>                   Josh Abraham <jabra@spl0it.org>
+jabra <jabra@github>                   Joshua Abraham <jabra@spl0it.org>
 jcran <jcran@github>                   <jcran@0x0e.org>
+jcran <jcran@github>                   <jcran@pentestify.com>
+jcran <jcran@github>                   <jcran@pwnieexpress.com>
 jcran <jcran@github>                   <jcran@rapid7.com>
 jduck <jduck@github>                   <github.jdrake@qoop.org>
 jduck <jduck@github>                   <jdrake@qoop.org>
 jgor <jgor@github>                     jgor <jgor@indiecom.org>
 joevennix <joevennix@github>           <Joe_Vennix@rapid7.com>
 joevennix <joevennix@github>           <joev@metasploit.com>
+joevennix <joevennix@github>           Joe Vennix <joevennix@gmail.com>
+joevennix <joevennix@github>           jvennix-r7 <Joe_Vennix@rapid7.com>
+juanvazquez <juanvazquez@github>       jvazquez-r7 <juan.vazquez@metasploit.com>
+juanvazquez <juanvazquez@github>       jvazquez-r7 <juan_vazquez@rapid7.com>
 kernelsmith <kernelsmith@github>       Joshua Smith <kernelsmith@kernelsmith.com>
 kernelsmith <kernelsmith@github>       Joshua Smith <kernelsmith@metasploit.com>
 kernelsmith <kernelsmith@github>       kernelsmith <kernelsmith@kernelsmith>
 kost <kost@github>                     Vlatko Kosturjak <kost@linux.hr>
 kris <kris@???>                        kris <>
+KronicDeth <KronicDeth@github>         Luke Imhoff <luke_imhoff@rapid7.com>
 m-1-k-3 <m-1-k-3@github>               m-1-k-3 <github@s3cur1ty.de>
 m-1-k-3 <m-1-k-3@github>               m-1-k-3 <m1k3@s3cur1ty.de>
 m-1-k-3 <m-1-k-3@github>               m-1-k-3 <michael.messner@integralis.com>
@@ -106,6 +120,8 @@ oj <oj@github>                         <oj@buffered.io>
 r3dy <r3dy@github>                     Royce Davis <r3dy@Royces-MacBook-Pro.local>
 r3dy <r3dy@github>                     Royce Davis <rdavis@Royces-MacBook-Pro-2.local>
 r3dy <r3dy@github>                     Royce Davis <royce.e.davis@gmail.com>
+rep <mschloesser-r7@github>            Mark Schloesser <mark_schloesser@rapid7.com>
+rep <mschloesser-r7@github>            mschloesser-r7 <mark_schloesser@rapid7.com>
 Rick Flores <0xnanoquetz9l@gmail.com>  Rick Flores (nanotechz9l) <0xnanoquetz9l@gmail.com>
 rsmudge <rsmudge@github>               Raphael Mudge <rsmudge@gmail.com> # Aka `butane
 schierlm <schierlm@github>             Michael Schierl <schierlm@gmx.de> # Aka mihi
@@ -113,12 +129,24 @@ scriptjunkie <scriptjunkie@github>     Matt Weeks <scriptjunkie@scriptjunkie.us>
 scriptjunkie <scriptjunkie@github>     scriptjunkie <scriptjunkie@scriptjunkie.us>
 skape <skape@???>                      Matt Miller <mmiller@hick.org>
 spoonm <spoonm@github>                 Spoon M <spoonm@gmail.com>
+stufus <stufus@github>                 Stuart <stufus@users.noreply.github.com>
+stufus <stufus@github>                 Stuart Morgan <stuart.morgan@mwrinfosecurity.com>
 swtornio <swtornio@github>             Steve Tornio <swtornio@gmail.com>
 Tasos Laskos <Tasos_Laskos@rapid7.com> Tasos Laskos <Tasos_Laskos@rapid7.com>
+techpeace <techpeace@github>           Matt Buck <Matthew_Buck@rapid7.com>
+techpeace <techpeace@github>           Matt Buck <techpeace@gmail.com>
 timwr <timwr@github>                   <timrlw@gmail.com>
 TomSellers <TomSellers@github>         Tom Sellers <tom@fadedcode.net>
+trevrosen <trevrosen@github>           Trevor Rosen <trevor@catapult-creative.com>
+trevrosen <trevrosen@github>           Trevor Rosen <Trevor_Rosen@rapid7.com>
 TrustedSec <davek@trustedsec.com>      trustedsec <davek@trustedsec.com>
+void-in <void-in@github>               root <void-in@users.noreply.github.com>
+void-in <void-in@github>               void-in <root@localhost.localdomain>
+void-in <void-in@github>               void-in <waqas.bsquare@gmail.com>
+void-in <void-in@github>               void_in <root@localhost.localdomain>
+void-in <void-in@github>               Waqas Ali <waqas.bsquare@gmail.com>
 zeroSteiner <zeroSteiner@github>       Spencer McIntyre <zeroSteiner@gmail.com>
+
 
 # Aliases for utility author names. Since they're fake, typos abound
 


### PR DESCRIPTION
I'm currently writing the Metasploit commit stats blog posts, and that means I need to refresh the .mailmap so I can have a reasonably accurate committer count. There's some movement and sorting going on in here as people change github aliases or have slightly different e-mail addresses and the like.
## Verification
- [x] Look up all of @void-in's attributions with `git log --format="%aN <%aE>" | grep -ie void | sort | uniq -c`
- [x] Before this change, see that @void-in has 4 different committer aliases.
- [x] After this change, see that it's normalized to just one.
