### PR TITLE
Update to latest Rspec 3 Conventions

### DIFF
--- a/spec/lib/active_record/connection_adapters/abstract_adapter/connection_pool_spec.rb
+++ b/spec/lib/active_record/connection_adapters/abstract_adapter/connection_pool_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe ActiveRecord::ConnectionAdapters::ConnectionPool do
 
   # Not all specs require a database connection, and railties aren't being
   # used, so have to manually establish connection.
-  before(:each) do
+  before(:example) do
     ActiveRecord::Base.configurations = database_configurations
     spec = ActiveRecord::Base.configurations[Rails.env]
     ActiveRecord::Base.establish_connection(spec)
   end
 
-  after(:each) do
+  after(:example) do
     ActiveRecord::Base.clear_all_connections!
   end
 
@@ -39,7 +39,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::ConnectionPool do
       Thread.current
     end
 
-    before(:each) do
+    before(:example) do
       ActiveRecord::Base.connection_pool.connection
     end
 
@@ -92,7 +92,7 @@ RSpec.describe ActiveRecord::ConnectionAdapters::ConnectionPool do
         connection_pool.connection
       end
 
-      after(:each) do
+      after(:example) do
         connection_pool.checkin connection
       end
 

--- a/spec/lib/metasploit/framework/credential_spec.rb
+++ b/spec/lib/metasploit/framework/credential_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Metasploit::Framework::Credential do
     end
 
     context 'when not paired' do
-      before(:each) do
+      before(:example) do
         cred_detail.paired = false
       end
 
@@ -53,7 +53,7 @@ RSpec.describe Metasploit::Framework::Credential do
     end
 
     context 'when paired' do
-      before(:each) do
+      before(:example) do
         cred_detail.paired = true
       end
 

--- a/spec/lib/metasploit/framework/database_spec.rb
+++ b/spec/lib/metasploit/framework/database_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Metasploit::Framework::Database do
       described_class.configurations_pathnames
     }
 
-    before(:each) do
+    before(:example) do
       allow(described_class).to receive(:environment_configurations_pathname).and_return(
                                     environment_configurations_pathname
                                 )
@@ -119,7 +119,7 @@ RSpec.describe Metasploit::Framework::Database do
         # Callbacks
         #
 
-        before(:each) do
+        before(:example) do
           allow(described_class).to receive(:user_configurations_pathname).and_return(
                                         user_configurations_pathname
                                     )
@@ -143,7 +143,7 @@ RSpec.describe Metasploit::Framework::Database do
             # Callbacks
             #
 
-            before(:each) do
+            before(:example) do
               allow(described_class).to receive(:project_configurations_pathname).and_return(
                                             project_configurations_pathname
                                         )
@@ -224,7 +224,7 @@ RSpec.describe Metasploit::Framework::Database do
             # Callbacks
             #
 
-            before(:each) do
+            before(:example) do
               allow(described_class).to receive(:project_configurations_pathname).and_return(
                                             project_configurations_pathname
                                         )
@@ -306,7 +306,7 @@ RSpec.describe Metasploit::Framework::Database do
           # Callbacks
           #
 
-          before(:each) do
+          before(:example) do
             allow(described_class).to receive(:project_configurations_pathname).and_return(
                                           project_configurations_pathname
                                       )
@@ -346,7 +346,7 @@ RSpec.describe Metasploit::Framework::Database do
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         allow(described_class).to receive(:user_configurations_pathname).and_return(
                                       user_configurations_pathname
                                   )
@@ -370,7 +370,7 @@ RSpec.describe Metasploit::Framework::Database do
           # Callbacks
           #
 
-          before(:each) do
+          before(:example) do
             allow(described_class).to receive(:project_configurations_pathname).and_return(
                                           project_configurations_pathname
                                       )
@@ -451,7 +451,7 @@ RSpec.describe Metasploit::Framework::Database do
           # Callbacks
           #
 
-          before(:each) do
+          before(:example) do
             allow(described_class).to receive(:project_configurations_pathname).and_return(
                                           project_configurations_pathname
                                       )
@@ -524,7 +524,7 @@ RSpec.describe Metasploit::Framework::Database do
         # Callbacks
         #
 
-        before(:each) do
+        before(:example) do
           allow(described_class).to receive(:project_configurations_pathname).and_return(
                                         project_configurations_pathname
                                     )
@@ -584,7 +584,7 @@ RSpec.describe Metasploit::Framework::Database do
       described_class.environment_configurations_pathname
     }
 
-    around(:each) do |example|
+    around(:example) do |example|
       env_before = ENV.to_hash
 
       begin
@@ -595,7 +595,7 @@ RSpec.describe Metasploit::Framework::Database do
     end
 
     context 'with MSF_DATABASE_CONFIG' do
-      before(:each) do
+      before(:example) do
         ENV['MSF_DATABASE_CONFIG'] = msf_database_config
       end
 
@@ -619,7 +619,7 @@ RSpec.describe Metasploit::Framework::Database do
     end
 
     context 'without MSF_DATABASE_CONFIG' do
-      before(:each) do
+      before(:example) do
         ENV.delete('MSF_DATABASE_CONFIG')
       end
 
@@ -655,7 +655,7 @@ RSpec.describe Metasploit::Framework::Database do
     # Callbacks
     #
 
-    around(:each) do |example|
+    around(:example) do |example|
       begin
         example.run
       ensure
@@ -663,7 +663,7 @@ RSpec.describe Metasploit::Framework::Database do
       end
     end
 
-    before(:each) do
+    before(:example) do
       allow(Msf::Config).to receive(:get_config_root).and_return(config_root)
     end
 

--- a/spec/lib/metasploit/framework/jtr/cracker_spec.rb
+++ b/spec/lib/metasploit/framework/jtr/cracker_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Metasploit::Framework::JtR::Cracker do
 
 
     context 'when the user supplied a john_path' do
-      before(:each) do
+      before(:example) do
         cracker.john_path = john_path
       end
 
@@ -54,7 +54,7 @@ RSpec.describe Metasploit::Framework::JtR::Cracker do
   end
 
   describe '#crack_command' do
-    before(:each) do
+    before(:example) do
       expect(cracker).to receive(:binary_path).and_return john_path
       expect(cracker).to receive(:john_session_id).and_return session_id
     end
@@ -123,7 +123,7 @@ RSpec.describe Metasploit::Framework::JtR::Cracker do
   end
 
   describe '#show_command' do
-    before(:each) do
+    before(:example) do
       expect(cracker).to receive(:binary_path).and_return john_path
     end
 
@@ -159,7 +159,7 @@ RSpec.describe Metasploit::Framework::JtR::Cracker do
   describe 'validations' do
     context 'failures' do
       context 'file_path validators' do
-        before(:each) do
+        before(:example) do
           expect(File).to receive(:file?).and_return false
         end
 
@@ -189,7 +189,7 @@ RSpec.describe Metasploit::Framework::JtR::Cracker do
       end
 
       context 'executable_path validators' do
-        before(:each) do
+        before(:example) do
           expect(File).to receive(:executable?).and_return false
         end
 
@@ -203,7 +203,7 @@ RSpec.describe Metasploit::Framework::JtR::Cracker do
 
     context 'successes' do
       context 'file_path validators' do
-        before(:each) do
+        before(:example) do
           expect(File).to receive(:file?).and_return true
         end
 
@@ -233,7 +233,7 @@ RSpec.describe Metasploit::Framework::JtR::Cracker do
       end
 
       context 'executable_path validators' do
-        before(:each) do
+        before(:example) do
           expect(File).to receive(:executable?).and_return true
         end
 

--- a/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::ChefWebUI do
       'New password for the User'
     end
 
-    before :each do
+    before :example do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
         if req.opts['uri'] && req.opts['uri'].include?('/users/login_exec') &&
             req.opts['data'] &&

--- a/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::FTP do
   end
 
   context '#attempt_login' do
-    before(:each) do
+    before(:example) do
       ftp_scanner.host = '127.0.0.1'
       ftp_scanner.port = 21
       ftp_scanner.connection_timeout = 30

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Glassfish do
       '<title>Deploy Enterprise Applications/Modules</title>'
     end
 
-    before :each do
+    before :example do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
         if req.opts['uri'] && req.opts['uri'].include?('j_security_check') &&
             req.opts['data'] &&
@@ -158,7 +158,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Glassfish do
       '<title>Deploy Enterprise Applications/Modules</title>'
     end
 
-    before :each do
+    before :example do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
         if req.opts['uri'] && req.opts['uri'].include?('j_security_check') &&
             req.opts['data'] &&

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
 
   let(:response) { Rex::Proto::Http::Response.new(200, 'OK') }
 
-  before(:each) do
+  before(:example) do
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
     allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)

--- a/spec/lib/metasploit/framework/login_scanner/ipboard_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ipboard_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::IPBoard do
 
     context "when invalid IPBoard application" do
       let(:not_found_warning) { 'Server nonce not present, potentially not an IP Board install or bad URI.' }
-      before :each do
+      before :example do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
           Rex::Proto::Http::Response.new(200)
         end
@@ -70,7 +70,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::IPBoard do
     end
 
     context "when valid IPBoard application" do
-      before :each do
+      before :example do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
 
           if req.opts['uri'] && req.opts['uri'].include?('index.php') &&

--- a/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::ManageEngineDesktopCentral d
       Rex::Proto::Http::Response.new(200, 'OK')
     end
 
-    before(:each) do
+    before(:example) do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)

--- a/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Nessus do
       Rex::Proto::Http::Response.new(200, 'OK')
     end
 
-    before(:each) do
+    before(:example) do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)

--- a/spec/lib/metasploit/framework/login_scanner/pop3_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/pop3_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::POP3 do
     context "Open Connection" do
       let(:sock) {double('socket')}
 
-      before(:each) do
+      before(:example) do
         allow(sock).to receive(:shutdown)
         allow(sock).to receive(:close)
         allow(sock).to receive(:closed?)

--- a/spec/lib/metasploit/framework/login_scanner/smb_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smb_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SMB do
   end
 
   context '#attempt_login' do
-    before(:each) do
+    before(:example) do
       allow(login_scanner).to receive_message_chain(:simple, :client, :auth_user, :nil?).and_return false
     end
     context 'when there is a connection error' do
@@ -119,7 +119,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SMB do
 
     context 'when the login succeeds' do
       context 'and the user is local admin' do
-        before(:each) do
+        before(:example) do
           login_scanner.simple = double
           allow(login_scanner.simple).to receive(:connect).with(/.*admin\$/i)
           allow(login_scanner.simple).to receive(:connect).with(/.*ipc\$/i)
@@ -135,7 +135,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SMB do
       end
 
       context 'and the user is NOT local admin' do
-        before(:each) do
+        before(:example) do
           login_scanner.simple = double
           allow(login_scanner.simple).to receive(:connect).with(/.*admin\$/i).and_raise(
             # STATUS_ACCESS_DENIED

--- a/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Smh do
     end
 
     context "when valid HP System Management application" do
-      before :each do
+      before :example do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
 
           if req.opts['uri'] &&

--- a/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SSH do
   end
 
   context '#attempt_login' do
-    before(:each) do
+    before(:example) do
       ssh_scanner.host = '127.0.0.1'
       ssh_scanner.port = 22
       ssh_scanner.connection_timeout = 30

--- a/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SymantecWebGateway do
       Rex::Proto::Http::Response.new(200, 'OK')
     end
 
-    before(:each) do
+    before(:example) do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)

--- a/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Zabbix do
       '<title>Zabbix 2.4 Appliance: User profile</title>'
     end
 
-    before :each do
+    before :example do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv) do |cli, req|
         if req.opts['uri'] && req.opts['uri'].include?('index.php') &&
             req.opts['data'] &&

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Msf::EncodedPayload do
 
     context 'when passed a valid payload instance' do
       # don't ever actually generate payload bytes
-      before(:each) do
+      before(:example) do
         allow_any_instance_of(described_class).to receive(:generate)
       end
 

--- a/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
     req
   end
 
-  before(:each) do
+  before(:example) do
     framework = double('Msf::Framework', datastore: {})
 
     # Prepare fake notes
@@ -437,7 +437,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
 
 
   describe '#init_exploits' do
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:set_exploit_options)
       subject.instance_variable_set(:@bap_exploits, [])
     end
@@ -452,7 +452,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
 
   context 'when removing jobs' do
     describe '#rm_exploit_jobs' do
-      before(:each) do
+      before(:example) do
         subject.instance_variable_set(:@exploit_job_ids, job_ids)
       end
 
@@ -464,7 +464,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
     end
 
     describe '#rm_payload_jobs' do
-      before(:each) do
+      before(:example) do
         subject.instance_variable_set(:@payload_job_ids, job_ids)
       end
 
@@ -477,7 +477,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   end
 
   describe '#set_exploit_options' do
-    before(:each) do
+    before(:example) do
       payload_info = {
         payload_name: windows_meterpreter_reverse_tcp,
         payload_lport: 4444
@@ -491,7 +491,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
     end
 
     context 'when a module is given' do
-      before(:each) do
+      before(:example) do
         subject.instance_variable_set(:@bap_exploits, [])
         subject.init_exploits
         subject.set_exploit_options(xploit)
@@ -505,7 +505,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   end
 
   describe '#is_resource_taken?' do
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:set_exploit_options)
       subject.instance_variable_set(:@bap_exploits, [])
       subject.init_exploits
@@ -537,7 +537,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
 
 
   context 'when sorting' do
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:set_exploit_options)
       subject.instance_variable_set(:@bap_exploits, [])
       subject.init_exploits
@@ -619,7 +619,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
       }]
     end
 
-    before(:each) do
+    before(:example) do
       subject.instance_variable_set(:@wanted_payloads, wanted_payloads)
       subject.instance_variable_set(:@payload_job_ids, [])
     end
@@ -726,7 +726,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   end
 
   describe '#select_payload' do
-    before(:each) do
+    before(:example) do
       subject.instance_variable_set(:@wanted_payloads, [])
     end
 
@@ -742,7 +742,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
   end
 
   describe '#start_exploits' do
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:set_exploit_options)
       subject.instance_variable_set(:@exploit_job_ids, [])
       subject.instance_variable_set(:@bap_exploits, [])
@@ -772,7 +772,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
       fake.string
     end
 
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:print_status) { |arg| $stdout.puts arg }
       allow(subject).to receive(:print_line) { |arg| $stdout.puts arg }
       allow(subject).to receive(:print) { |arg| $stdout.puts arg }

--- a/spec/lib/msf/core/exploit/capture_spec.rb
+++ b/spec/lib/msf/core/exploit/capture_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Msf::Exploit::Capture do
   context '#capture_sendto' do
     let(:payload) { Rex::Text::rand_text_alphanumeric(100 + rand(1024)) }
 
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:capture).and_return(true)
     end
 

--- a/spec/lib/msf/core/exploit/http/jboss/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/base_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::Base do
   end
 
   describe "#deploy" do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do
         if res_code.nil?
           res = nil
@@ -59,7 +59,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::Base do
   end
 
   describe "#query_serverinfo" do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do
         if res_code.nil?
           res = nil

--- a/spec/lib/msf/core/exploit/http/jboss/bean_shell_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/bean_shell_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::BeanShell do
     mod
   end
 
-  before :each do
+  before :example do
     allow(subject).to receive(:send_request_cgi) do
       case res_code
       when nil

--- a/spec/lib/msf/core/exploit/http/jboss/deployment_file_repository_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/deployment_file_repository_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::DeploymentFileRepository do
     '<%@page import="java.io.*%>'
   end
 
-  before :each do
+  before :example do
     allow(subject).to receive(:send_request_cgi) do
       case res_code
       when nil

--- a/spec/lib/msf/core/exploit/http/joomla/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/joomla/base_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Joomla::Base do
     res
   end
 
-  before(:each) do
+  before(:example) do
     allow(subject).to receive(:send_request_cgi) do |opts|
       rex_http_response
     end

--- a/spec/lib/msf/core/exploit/http/joomla/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/joomla/version_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Joomla::Version do
     res
   end
 
-  before(:each) do
+  before(:example) do
     allow(subject).to receive(:send_request_cgi) do |opts|
       rex_http_response
     end

--- a/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Base do
   end
 
   describe '#wordpress_and_online?' do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do
         res = Rex::Proto::Http::Response.new
         res.code = wp_code

--- a/spec/lib/msf/core/exploit/http/wordpress/login_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/login_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Login do
   end
 
   describe '#wordpress_login' do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do |opts|
         res = Rex::Proto::Http::Response.new
         res.code = 301

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
   end
 
   describe '#wordpress_version' do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do |opts|
         res = Rex::Proto::Http::Response.new
         res.code = 200
@@ -67,7 +67,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
   end
 
   describe '#check_version_from_readme' do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do |opts|
         res = Rex::Proto::Http::Response.new
         res.code = wp_code
@@ -153,7 +153,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
   end
 
   describe '#check_theme_version_from_style' do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do |opts|
         res = Rex::Proto::Http::Response.new
         res.code = wp_code
@@ -239,7 +239,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
   end
 
   describe '#check_version_from_custom_file' do
-    before :each do
+    before :example do
       allow(subject).to receive(:send_request_cgi) do |opts|
         res = Rex::Proto::Http::Response.new
         res.code = wp_code

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
   end
 
 
-  before(:each) do
+  before(:example) do
     allow_any_instance_of(described_class).to receive(:vprint_status)
     allow_any_instance_of(described_class).to receive(:vprint_line)
     @notes = [create_fake_note(first_profile_tag, in_memory_profile)]
@@ -117,7 +117,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
     allow(Rex::ServiceManager).to receive(:start).and_return(service_double)
   end
 
-  before(:each) do
+  before(:example) do
     server.start_service
   end
 
@@ -203,7 +203,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
   end
 
   describe '#on_request_uri' do
-    before(:each) do
+    before(:example) do
       allow(server).to receive(:process_browser_info)
       allow(server).to receive(:send_response)      { @send_response_called = true }
       allow(server).to receive(:send_redirect)      { @send_redirect_called = true }
@@ -212,7 +212,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
       allow(server).to receive(:on_request_exploit) { @on_request_exploit_called = true }
     end
 
-    after(:each) do
+    after(:example) do
       @send_response_called      = false
       @send_redirect_called      = false
       @on_request_exploit_called = false
@@ -245,7 +245,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
   end
 
   describe '#get_payload' do
-    before(:each) do
+    before(:example) do
       target = double('Msf::Module::Target')
       allow(target).to receive(:arch).and_return(nil)
       allow(server).to receive(:get_target).and_return(target)
@@ -280,7 +280,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
       'http://example.com'
     end
 
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:datastore).and_return({'Custom404'=>custom_404})
     end
 
@@ -296,7 +296,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
       'exploit_receiver_page'
     end
 
-    before(:each) do
+    before(:example) do
       subject.instance_variable_set(:@exploit_receiver_page, exploit_receiver_page)
       allow(subject).to receive(:get_uri).and_return('')
     end
@@ -371,7 +371,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
   end
 
   describe '#process_browser_info' do
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:report_client) { |args| @report_client = args }
       allow(subject).to receive(:browser_profile).and_return(Hash.new)
     end
@@ -404,7 +404,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserExploitServer do
   end
 
   describe '#cookie_name' do
-    before(:each) do
+    before(:example) do
       subject.datastore.merge!({'CookieName'=>cookie})
     end
 

--- a/spec/lib/msf/core/exploit/remote/browser_profile_manager_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_profile_manager_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserProfileManager do
     }
   end
 
-  before(:each) do
+  before(:example) do
     framework = double('framework', browser_profiles: default_profile)
     allow(exploit_remmote).to receive(:framework).and_return(framework)
   end
@@ -26,7 +26,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserProfileManager do
   end
 
   describe '#browser_profile' do
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:browser_profile_prefix).and_return('PREFIX')
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserProfileManager do
   end
 
   describe '#clear_browser_profiles' do
-    before(:each) do
+    before(:example) do
       allow(subject).to receive(:browser_profile_prefix).and_return('PREFIX')
     end
 

--- a/spec/lib/msf/core/exploit/smb/client/local_paths_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/client/local_paths_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Client::LocalPaths do
     mod
   end
 
-  before(:all) do
+  before(:context) do
     prefix = "local_#{Rex::Text.rand_text_alpha(10)}"
     # create a single random file to be used for LPATH
     @lpath = prefix
@@ -55,7 +55,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Client::LocalPaths do
     end
   end
 
-  after(:all) do
+  after(:context) do
     @file_lpaths.unlink
   end
 end

--- a/spec/lib/msf/core/exploit/smb/client/remote_paths_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/client/remote_paths_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Client::RemotePaths do
     mod
   end
 
-  before(:all) do
+  before(:context) do
     prefix = "remote_#{Rex::Text.rand_text_alpha(10)}"
     # create a single random file to be used for RPATH
     @rpath = prefix
@@ -55,7 +55,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Client::RemotePaths do
     end
   end
 
-  after(:all) do
+  after(:context) do
     @file_rpaths.unlink
   end
 end

--- a/spec/lib/msf/core/exploit/smb/server/share/command/close_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/close_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
     "\x00\x00\x44\x43\x00\x00\x00"
   end
 
-  before(:each) do
+  before(:example) do
     mod.instance_variable_set('@state', {
       msf_io => {
         :multiplex_id => 0x41424344,

--- a/spec/lib/msf/core/exploit/smb/server/share/command/negotiate_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/negotiate_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   let(:valid_response_length) { 81 }
   let(:challenge_length) { 8 }
 
-  before(:each) do
+  before(:example) do
     mod.instance_variable_set('@state', {
       msf_io => {
         :multiplex_id => 0x41424344,

--- a/spec/lib/msf/core/exploit/smb/server/share/command/nt_create_andx_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/nt_create_andx_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   end
   let(:smb_error_length) { 39 }
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {

--- a/spec/lib/msf/core/exploit/smb/server/share/command/read_andx_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/read_andx_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   end
   let(:empty_response_length) { 63 }
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {

--- a/spec/lib/msf/core/exploit/smb/server/share/command/session_setup_andx_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/session_setup_andx_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
 
   let(:opts) { {} }
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {
@@ -96,7 +96,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
     end
 
     context "when extra SMB_COM_TREE_CONNECT_ANDX command" do
-      before(:each) do
+      before(:example) do
         tree_connect_response = Rex::Proto::SMB::Constants::SMB_TREE_CONN_ANDX_RES_PKT.make_struct
         opts[:andx_command] = tree_connect_response
       end

--- a/spec/lib/msf/core/exploit/smb/server/share/command/trans2/find_first2_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/trans2/find_first2_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   end
   let(:find_file_both_directory_info_res_length) { 179 }
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {

--- a/spec/lib/msf/core/exploit/smb/server/share/command/trans2/query_file_information_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/trans2/query_file_information_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   end
   let(:query_file_standard_info_res_length) { 83 }
 
-  before(:each) do
+  before(:example) do
     mod.instance_variable_set('@state', {
       msf_io => {
         :multiplex_id => 0x41424344,

--- a/spec/lib/msf/core/exploit/smb/server/share/command/trans2/query_path_information_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/trans2/query_path_information_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   end
   let(:not_found_res_length) { 39 }
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {

--- a/spec/lib/msf/core/exploit/smb/server/share/command/trans2_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/command/trans2_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   let(:empty_query) { "\x00\x00\x00\x00" }
   let(:empty_query_res_length) { 39 }
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {

--- a/spec/lib/msf/core/exploit/smb/server/share/information_level/find_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/information_level/find_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   let(:existent_folder_file_full_res_length) { 139 }
 
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {

--- a/spec/lib/msf/core/exploit/smb/server/share/information_level/query_spec.rb
+++ b/spec/lib/msf/core/exploit/smb/server/share/information_level/query_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Msf::Exploit::Remote::SMB::Server::Share do
   let(:existent_path_info_standard_res_length) { 83 }
   let(:existent_path_info_network_res_length) { 117 }
 
-  before(:each) do
+  before(:example) do
     msf_io.string = ''
     mod.instance_variable_set('@state', {
       msf_io => {

--- a/spec/lib/msf/core/module_set_spec.rb
+++ b/spec/lib/msf/core/module_set_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Msf::ModuleSet do
     }
 
     context 'with Msf::SymbolicModule' do
-      before(:each) do
+      before(:example) do
         module_set['a'] = Msf::SymbolicModule
         module_set['b'] = Msf::SymbolicModule
         module_set['c'] = Msf::SymbolicModule
@@ -35,7 +35,7 @@ RSpec.describe Msf::ModuleSet do
         }
 
         context 'returns nil' do
-          before(:each) do
+          before(:example) do
             hide_const('A::Rank')
             allow(module_set).to receive(:create).with('a').and_return(nil)
 
@@ -78,14 +78,14 @@ RSpec.describe Msf::ModuleSet do
           # Callbacks
           #
 
-          before(:each) do
+          before(:example) do
             allow(module_set).to receive(:create).with('a').and_return(a_class.new)
             allow(module_set).to receive(:create).with('b').and_return(b_class.new)
             allow(module_set).to receive(:create).with('c').and_return(c_class.new)
           end
 
           context 'with Rank' do
-            before(:each) do
+            before(:example) do
               stub_const('A', a_class)
               stub_const('A::Rank', Msf::LowRanking)
 
@@ -108,7 +108,7 @@ RSpec.describe Msf::ModuleSet do
           end
 
           context 'without Rank' do
-            before(:each) do
+            before(:example) do
               stub_const('A', a_class)
               hide_const('A::Rank')
 
@@ -154,14 +154,14 @@ RSpec.describe Msf::ModuleSet do
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         module_set['a'] = a_class
         module_set['b'] = b_class
         module_set['c'] = c_class
       end
 
       context 'with Rank' do
-        before(:each) do
+        before(:example) do
               stub_const('A', a_class)
               stub_const('A::Rank', Msf::LowRanking)
 
@@ -184,7 +184,7 @@ RSpec.describe Msf::ModuleSet do
       end
 
       context 'without Rank' do
-        before(:each) do
+        before(:example) do
           stub_const('A', a_class)
           hide_const('A::Rank')
 

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Msf::Module do
 
     describe "#perform_extensions" do
       describe "when there are extensions registered" do
-        before(:each) do
+        before(:example) do
           msf_module.register_extensions(MsfExtensionTestFoo, MsfExtensionTestBar)
         end
 
@@ -63,7 +63,7 @@ RSpec.describe Msf::Module do
       end
 
       describe "when the datastore key has invalid data" do
-        before(:each) do
+        before(:example) do
           msf_module.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY] = "invalid"
         end
 

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         Msf::MODULE_AUX
       end
 
-      before(:each) do
+      before(:example) do
         allow(subject).to receive(:module_path).and_return(module_path)
       end
 
@@ -265,7 +265,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       end
 
       context 'without file changed' do
-        before(:each) do
+        before(:example) do
           allow(module_manager).to receive(:file_changed?).and_return(false)
         end
 
@@ -294,7 +294,7 @@ RSpec.describe Msf::Modules::Loader::Base do
           'Mod617578696c696172792f72737065632f6d6f636b'
         end
 
-        before(:each) do
+        before(:example) do
           # capture in a local so that instance_eval can access it
           relative_name = self.relative_name
 
@@ -362,7 +362,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         end
 
         context 'with empty module content' do
-          before(:each) do
+          before(:example) do
             allow(subject).to receive(:read_module_content).with(parent_path, type, module_reference_name).and_return('')
           end
 
@@ -377,7 +377,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         end
 
         context 'with errors from namespace_module_eval_with_lexical_scope' do
-          before(:each) do
+          before(:example) do
             @namespace_module = double('Namespace Module', :'parent_path=' => nil)
             module_content = double('Module Content', empty?: false)
 
@@ -415,7 +415,7 @@ RSpec.describe Msf::Modules::Loader::Base do
               'This is rspec.  Your argument is invalid.'
             end
 
-            before(:each) do
+            before(:example) do
               allow(@namespace_module).to receive(:module_eval_with_lexical_scope).and_raise(error)
 
               @module_load_error_by_path = {}
@@ -425,7 +425,7 @@ RSpec.describe Msf::Modules::Loader::Base do
             end
 
             context 'with version compatibility' do
-              before(:each) do
+              before(:example) do
                 expect(@namespace_module).to receive(:version_compatible!).with(module_path, module_reference_name)
               end
 
@@ -449,7 +449,7 @@ RSpec.describe Msf::Modules::Loader::Base do
                 0.0 / 0.0
               end
 
-              before(:each) do
+              before(:example) do
                 allow(@namespace_module).to receive(
                     :version_compatible!
                 ).with(
@@ -475,7 +475,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         end
 
         context 'without module_eval errors' do
-          before(:each) do
+          before(:example) do
             @namespace_module = double('Namespace Module')
             allow(@namespace_module).to receive(:parent_path=)
             allow(@namespace_module).to receive(:module_eval_with_lexical_scope).with(module_content, module_path)
@@ -512,7 +512,7 @@ RSpec.describe Msf::Modules::Loader::Base do
               0.0 / 0.0
             end
 
-            before(:each) do
+            before(:example) do
               allow(@namespace_module).to receive(
                   :version_compatible!
               ).with(
@@ -538,7 +538,7 @@ RSpec.describe Msf::Modules::Loader::Base do
           end
 
           context 'with version compatibility' do
-            before(:each) do
+            before(:example) do
               allow(@namespace_module).to receive(:version_compatible!).with(module_path, module_reference_name)
 
               allow(module_manager).to receive(:on_module_load)
@@ -552,7 +552,7 @@ RSpec.describe Msf::Modules::Loader::Base do
                 )
               end
 
-              before(:each) do
+              before(:example) do
                 expect(@namespace_module).to receive(:metasploit_class!).with(module_path, module_reference_name).and_raise(error)
               end
 
@@ -582,7 +582,7 @@ RSpec.describe Msf::Modules::Loader::Base do
                 double('Metasploit Class')
               end
 
-              before(:each) do
+              before(:example) do
                 allow(@namespace_module).to receive(:metasploit_class!).and_return(metasploit_class)
               end
 
@@ -592,7 +592,7 @@ RSpec.describe Msf::Modules::Loader::Base do
               end
 
               context 'without usable metasploit_class' do
-                before(:each) do
+                before(:example) do
                   expect(subject).to receive(:usable?).and_return(false)
                 end
 
@@ -613,7 +613,7 @@ RSpec.describe Msf::Modules::Loader::Base do
               end
 
               context 'with usable metasploit_class' do
-                before(:each) do
+                before(:example) do
                   # remove the mocked namespace_module since happy-path/real loading is occurring in this context
                   allow(subject).to receive(:namespace_module_transaction).and_call_original
                 end
@@ -714,7 +714,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         'Mod0'
       end
 
-      before(:each) do
+      before(:example) do
         # capture in local variable so it works in instance_eval
         relative_name = self.relative_name
 
@@ -805,7 +805,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         'Mod0'
       end
 
-      before(:each) do
+      before(:example) do
         # copy to local variable so it is accessible in instance_eval
         relative_name = self.relative_name
 
@@ -940,7 +940,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       end
 
       context 'with pre-existing namespace module' do
-        before(:each) do
+        before(:example) do
           module Msf
             module Modules
               module Mod617578696c696172792f72737065632f6d6f636b
@@ -1071,7 +1071,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       end
 
       context 'without pre-existing namespace module' do
-        before(:each) do
+        before(:example) do
           relative_name = self.relative_name
 
           if Msf::Modules.const_defined? relative_name
@@ -1217,7 +1217,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         # Callbacks
         #
 
-        before(:each) do
+        before(:example) do
           parent_module.const_set(relative_name, Module.new)
         end
 
@@ -1235,7 +1235,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       end
 
       context 'with parent_module and namespace_module' do
-        before(:each) do
+        before(:example) do
           module Msf
             module Modules
               module Mod0
@@ -1252,7 +1252,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         end
 
         context 'with relative_name being a defined constant' do
-          before(:each) do
+          before(:example) do
             module Msf
               module Modules
                 module Mod0

--- a/spec/lib/msf/core/modules/loader/directory_spec.rb
+++ b/spec/lib/msf/core/modules/loader/directory_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Msf::Modules::Loader::Directory do
         end
 
         context 'with module previously loaded' do
-          before(:each) do
+          before(:example) do
             subject.load_module(parent_path, type, module_reference_name)
           end
 
@@ -106,7 +106,7 @@ RSpec.describe Msf::Modules::Loader::Directory do
           Errno::ENOENT.new(module_path)
         end
 
-        before(:each) do
+        before(:example) do
           allow(module_manager).to receive(:file_changed?).and_return(true)
           allow(module_manager).to receive(:module_load_error_by_path).and_return({})
         end
@@ -133,7 +133,7 @@ RSpec.describe Msf::Modules::Loader::Directory do
           'osx/armle/safari_libtiff'
         end
 
-        before(:each) do
+        before(:example) do
           allow(subject).to receive(:load_error).with(module_path, kind_of(Errno::ENOENT))
         end
 

--- a/spec/lib/msf/core/modules/namespace_spec.rb
+++ b/spec/lib/msf/core/modules/namespace_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Msf::Modules::Namespace do
   end
 
   context 'metasploit_class' do
-    before(:each) do
+    before(:example) do
       if major
         subject.const_set("Metasploit#{major}", Class.new)
       end
@@ -128,7 +128,7 @@ RSpec.describe Msf::Modules::Namespace do
         Class.new
       end
 
-      before(:each) do
+      before(:example) do
         allow(subject).to receive(:metasploit_class).and_return(metasploit_class)
       end
 
@@ -138,7 +138,7 @@ RSpec.describe Msf::Modules::Namespace do
     end
 
     context 'without metasploit_class' do
-      before(:each) do
+      before(:example) do
         allow(subject).to receive(:metasploit_class)
       end
 
@@ -198,7 +198,7 @@ RSpec.describe Msf::Modules::Namespace do
         1
       end
 
-      before(:each) do
+      before(:example) do
         subject.const_set(
             :RequiredVersions,
             [

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe Msf::PayloadGenerator do
     context 'when nops are set to 0' do
       let(:nops) { 0 }
 
-      before(:each) do
+      before(:example) do
         load_and_create_module(
             module_type: 'nop',
             reference_name: 'x86/opty2'
@@ -367,7 +367,7 @@ RSpec.describe Msf::PayloadGenerator do
       let(:nops) { 20 }
 
       context 'when payload is x86' do
-        before(:each) do
+        before(:example) do
           load_and_create_module(
             module_type: 'nop',
             reference_name: 'x86/opty2'
@@ -398,7 +398,7 @@ RSpec.describe Msf::PayloadGenerator do
           )
         }
 
-        before(:each) do
+        before(:example) do
           load_and_create_module(
               module_type: 'nop',
               reference_name: 'x64/simple'
@@ -456,7 +456,7 @@ RSpec.describe Msf::PayloadGenerator do
       # Callbacks
       #
 
-      before(:each) do
+      before(:example) do
         encoder_reference_names.each do |reference_name|
           load_and_create_module(
               module_type: 'encoder',

--- a/spec/lib/msf/core/post/linux/busy_box_spec.rb
+++ b/spec/lib/msf/core/post/linux/busy_box_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Msf::Post::Linux::BusyBox do
 
   describe "#busy_box_file_exist?" do
     describe "when file exists" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           'test data'
         end
@@ -24,7 +24,7 @@ RSpec.describe Msf::Post::Linux::BusyBox do
     end
 
     describe "when file doesn't exist" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           ''
         end
@@ -37,14 +37,14 @@ RSpec.describe Msf::Post::Linux::BusyBox do
   end
 
   describe "#busy_box_is_writable_dir?" do
-    before :each do
+    before :example do
       allow(subject).to receive(:cmd_exec) do
         ''
       end
     end
 
     describe "when dir is writable" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           "#{'A' * 16}XXX#{'A' * 16}"
         end
@@ -60,7 +60,7 @@ RSpec.describe Msf::Post::Linux::BusyBox do
     end
 
     describe "when dir isn't writable" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           ''
         end
@@ -74,14 +74,14 @@ RSpec.describe Msf::Post::Linux::BusyBox do
 
 
   describe "#busy_box_writable_dir" do
-    before :each do
+    before :example do
       allow(subject).to receive(:cmd_exec) do
         ''
       end
     end
 
     describe "when a writable directory doesn't exist" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           ''
         end
@@ -93,7 +93,7 @@ RSpec.describe Msf::Post::Linux::BusyBox do
     end
 
     describe "when a writable directory exists" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           "#{'A' * 16}XXX#{'A' * 16}"
         end
@@ -111,14 +111,14 @@ RSpec.describe Msf::Post::Linux::BusyBox do
 
 
   describe "#busy_box_write_file" do
-    before :each do
+    before :example do
       allow(subject).to receive(:cmd_exec) do
         ''
       end
     end
 
     describe "when the file isn't writable" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           ''
         end
@@ -130,7 +130,7 @@ RSpec.describe Msf::Post::Linux::BusyBox do
     end
 
     describe "when the file is writable" do
-      before :each do
+      before :example do
         allow(subject).to receive(:read_file) do
           "#{'A' * 16}XXX#{'A' * 16}"
         end
@@ -148,7 +148,7 @@ RSpec.describe Msf::Post::Linux::BusyBox do
     describe "when prepend is true" do
       describe "when there is a writable dir" do
         describe "when the target file is writable" do
-          before :each do
+          before :example do
             allow(subject).to receive(:busy_box_writable_dir) do
               '/tmp/'
             end
@@ -169,7 +169,7 @@ RSpec.describe Msf::Post::Linux::BusyBox do
       end
 
       describe "when there isn't a writable dir" do
-        before :each do
+        before :example do
           allow(subject).to receive(:busy_box_writable_dir) do
             nil
           end

--- a/spec/lib/msf/core/post/windows/mssql_spec.rb
+++ b/spec/lib/msf/core/post/windows/mssql_spec.rb
@@ -293,7 +293,7 @@ RSpec.describe Msf::Post::Windows::MSSQL do
     end
 
     context 'user has privs to impersonate' do
-      before(:each) do
+      before(:example) do
         allow(subject).to receive_message_chain('session.sys.config.getuid').and_return('Superman')
         allow(subject).to receive_message_chain('client.sys.config.getprivs').and_return(['SeAssignPrimaryTokenPrivilege'])
         allow(subject).to receive_message_chain('session.sys.process.each_process').and_yield(process)
@@ -316,7 +316,7 @@ RSpec.describe Msf::Post::Windows::MSSQL do
     end
 
     context 'user does not have privs to impersonate' do
-      before(:each) do
+      before(:example) do
         allow(subject).to receive_message_chain('session.sys.config.getuid').and_return('Superman')
         allow(subject).to receive_message_chain('client.sys.config.getprivs').and_return([])
       end
@@ -375,7 +375,7 @@ RSpec.describe Msf::Post::Windows::MSSQL do
       'blah'
     end
 
-    before(:each) do
+    before(:example) do
       subject.sql_client = sqlclient
     end
 

--- a/spec/lib/msf/db_manager/export_spec.rb
+++ b/spec/lib/msf/db_manager/export_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Msf::DBManager::Export do
         )
       end
 
-      before(:each) do
+      before(:example) do
         report_file.write("<root>")
         extract_module_detail_info
         report_file.write("</root>")

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
 
       let!(:origin) { FactoryGirl.create(:metasploit_credential_origin_import) }
 
-      before(:each) do
+      before(:example) do
         priv = FactoryGirl.create(:metasploit_credential_password, data: password)
         pub = FactoryGirl.create(:metasploit_credential_username, username: username)
         FactoryGirl.create(:metasploit_credential_core,
@@ -245,7 +245,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
         end
 =end
 
-        after(:each) do
+        after(:example) do
           #ntlm_core.destroy
           password_core.destroy
           #nonreplayable_core.destroy
@@ -295,7 +295,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
         end
       end
       context "when a core already exists" do
-        before(:each) do
+        before(:example) do
           priv = FactoryGirl.create(:metasploit_credential_password, data: password)
           pub = FactoryGirl.create(:metasploit_credential_username, username: username)
           FactoryGirl.create(:metasploit_credential_core,
@@ -468,7 +468,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
       end
     end
     describe "-p" do
-      before(:each) do
+      before(:example) do
         host = FactoryGirl.create(:mdm_host, :workspace => framework.db.workspace, :address => "192.168.0.1")
         FactoryGirl.create(:mdm_service, :host => host, :port => 1024, name: 'Service1', proto: 'udp')
         FactoryGirl.create(:mdm_service, :host => host, :port => 1025, name: 'Service2', proto: 'tcp')
@@ -488,7 +488,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
       end
     end
     describe "-np" do
-      before(:each) do
+      before(:example) do
         host = FactoryGirl.create(:mdm_host, :workspace => framework.db.workspace, :address => "192.168.0.1")
         FactoryGirl.create(:mdm_service, :host => host, :port => 1024)
         FactoryGirl.create(:mdm_service, :host => host, :port => 1025)
@@ -535,7 +535,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
   end
 
   describe "#cmd_workspace" do
-    before(:each) do
+    before(:example) do
       db.cmd_workspace "-D"
       @output = []
     end

--- a/spec/lib/rex/ole/clsid_spec.rb
+++ b/spec/lib/rex/ole/clsid_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rex/ole'
 
 RSpec.describe Rex::OLE::CLSID do
-  before(:each) do
+  before(:example) do
     Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
   end
 

--- a/spec/lib/rex/ole/difat_spec.rb
+++ b/spec/lib/rex/ole/difat_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rex/ole'
 
 RSpec.describe Rex::OLE::DIFAT do
-  before(:each) do
+  before(:example) do
     Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
   end
 

--- a/spec/lib/rex/ole/direntry_spec.rb
+++ b/spec/lib/rex/ole/direntry_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rex/ole'
 
 RSpec.describe Rex::OLE::DirEntry do
-  before(:each) do
+  before(:example) do
     Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
   end
 

--- a/spec/lib/rex/ole/header_spec.rb
+++ b/spec/lib/rex/ole/header_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rex/ole'
 
 RSpec.describe Rex::OLE::Header do
-  before(:each) do
+  before(:example) do
     Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
   end
 

--- a/spec/lib/rex/ole/minifat_spec.rb
+++ b/spec/lib/rex/ole/minifat_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rex/ole'
 
 RSpec.describe Rex::OLE::MiniFAT do
-  before(:each) do
+  before(:example) do
     Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
   end
 

--- a/spec/lib/rex/ole/util_spec.rb
+++ b/spec/lib/rex/ole/util_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 require 'rex/ole'
 
 RSpec.describe Rex::OLE::Util do
-  before(:each) do
+  before(:example) do
     Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
   end
 

--- a/spec/lib/rex/post/meterpreter/client_core_spec.rb
+++ b/spec/lib/rex/post/meterpreter/client_core_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rex::Post::Meterpreter::ClientCore do
 
   describe "#use" do
 
-    before(:each) do
+    before(:example) do
       @response = double("response")
       allow(@response).to receive(:result) { 0 }
       allow(@response).to receive(:each) { [:help] }

--- a/spec/lib/rex/post/meterpreter/extensions/priv/priv_spec.rb
+++ b/spec/lib/rex/post/meterpreter/extensions/priv/priv_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rex::Post::Meterpreter::Extensions::Priv::Priv do
   end
 
   describe "#getsystem" do
-    before(:each) do
+    before(:example) do
       @client = double("client")
       allow(@client).to receive(:register_extension_aliases) { [] }
     end

--- a/spec/lib/rex/post/meterpreter/extensions/stdapi/ui_spec.rb
+++ b/spec/lib/rex/post/meterpreter/extensions/stdapi/ui_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Rex::Post::Meterpreter::Extensions::Stdapi::UI do
 
   describe "#screenshot" do
 
-    before(:each) do
+    before(:example) do
       @client = double("client")
     end
 

--- a/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
+++ b/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Rex::Post::Meterpreter::PacketParser do
   subject(:parser){
     Rex::Post::Meterpreter::PacketParser.new
   }
-  before(:each) do
+  before(:example) do
     @req_packt = Rex::Post::Meterpreter::Packet.new(
           Rex::Post::Meterpreter::PACKET_TYPE_REQUEST,
           "test_method")

--- a/spec/lib/rex/post/meterpreter/packet_spec.rb
+++ b/spec/lib/rex/post/meterpreter/packet_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe Rex::Post::Meterpreter::GroupTlv do
   end
 
   context "with TLVs added" do
-    before(:each) do
+    before(:example) do
       group_tlv.reset
       tlv_array = [
         {'type' => Rex::Post::Meterpreter::TLV_TYPE_STRING, 'value' => "test"},
@@ -454,7 +454,7 @@ RSpec.describe Rex::Post::Meterpreter::Packet do
         "test_method"
       )
     }
-    before(:each) do
+    before(:example) do
       packet.add_tlv(Rex::Post::Meterpreter::TLV_TYPE_RESULT, "a-ok")
     end
 

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -5,7 +5,7 @@ require 'rex/proto/http/client_request'
 
 
 RSpec.shared_context "with no evasions" do
-  before(:each) do
+  before(:example) do
     client_request.opts['uri_dir_self_reference'] = false
     client_request.opts['uri_fake_params_start'] = false
     client_request.opts['uri_full_url'] = false
@@ -18,7 +18,7 @@ end
 
 
 RSpec.shared_context "with 'uri_dir_self_reference'" do
-  before(:each) do
+  before(:example) do
     client_request.opts['uri_dir_self_reference'] = true
   end
 
@@ -30,7 +30,7 @@ end
 
 
 RSpec.shared_context "with 'uri_dir_fake_relative'" do
-  before(:each) do
+  before(:example) do
     client_request.opts['uri_dir_fake_relative'] = true
   end
 
@@ -44,11 +44,11 @@ end
 
 RSpec.shared_context "with 'uri_full_url'" do
 
-  before(:each) do
+  before(:example) do
     client_request.opts['uri_full_url'] = true
   end
 
-  before(:each) do
+  before(:example) do
     client_request.opts['vhost'] = host
   end
 

--- a/spec/lib/rex/proto/http/response_spec.rb
+++ b/spec/lib/rex/proto/http/response_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Rex::Proto::Http::Response do
       res
     end
 
-    before(:each) do
+    before(:example) do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
@@ -234,7 +234,7 @@ RSpec.describe Rex::Proto::Http::Response do
         res
       end
 
-      before(:each) do
+      before(:example) do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
       end
 
@@ -252,7 +252,7 @@ RSpec.describe Rex::Proto::Http::Response do
         res
       end
 
-      before(:each) do
+      before(:example) do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(response)
       end
 

--- a/spec/lib/rex/proto/kerberos/client_spec.rb
+++ b/spec/lib/rex/proto/kerberos/client_spec.rb
@@ -15,7 +15,7 @@ class MyStringIO < StringIO
 end
 
 RSpec.describe Rex::Proto::Kerberos::Client do
-  before :each do
+  before :example do
     allow(Rex::Socket::Tcp).to receive(:create) do
       s = ''
       io = MyStringIO.new(s, 'w+b')

--- a/spec/lib/rex/socket_spec.rb
+++ b/spec/lib/rex/socket_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Rex::Socket do
 
     subject { described_class.getaddress('whatever') }
 
-    before(:each) do
+    before(:example) do
       expect(Socket).to receive(:gethostbyname).and_return(['name', ['aliases'], response_afamily, *response_addresses])
     end
 
@@ -123,7 +123,7 @@ RSpec.describe Rex::Socket do
 
     subject { described_class.getaddresses('whatever') }
 
-    before(:each) do
+    before(:example) do
       expect(Socket).to receive(:gethostbyname).and_return(['name', ['aliases'], response_afamily, *response_addresses])
     end
 

--- a/spec/lib/rex/sslscan/result_spec.rb
+++ b/spec/lib/rex/sslscan/result_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe Rex::SSLScan::Result do
   end
 
   context "enumerating all accepted ciphers" do
-    before(:each) do
+    before(:example) do
       subject.add_cipher(:SSLv3, "AES256-SHA", 256, :accepted)
       subject.add_cipher(:TLSv1, "AES256-SHA", 256, :accepted)
       subject.add_cipher(:SSLv3, "AES128-SHA", 128, :accepted)
@@ -309,7 +309,7 @@ RSpec.describe Rex::SSLScan::Result do
   end
 
   context "enumerating all rejected ciphers" do
-    before(:each) do
+    before(:example) do
       subject.add_cipher(:SSLv3, "AES256-SHA", 256, :rejected)
       subject.add_cipher(:TLSv1, "AES256-SHA", 256, :rejected)
       subject.add_cipher(:SSLv3, "AES128-SHA", 128, :rejected)
@@ -409,7 +409,7 @@ RSpec.describe Rex::SSLScan::Result do
 
   context "checking for weak ciphers" do
     context "when weak ciphers are supported" do
-      before(:each) do
+      before(:example) do
         subject.add_cipher(:SSLv3, "EXP-RC4-MD5", 40, :accepted)
         subject.add_cipher(:SSLv3, "DES-CBC-SHA", 56, :accepted)
       end
@@ -428,7 +428,7 @@ RSpec.describe Rex::SSLScan::Result do
     end
 
     context "when no weak ciphers are supported" do
-      before(:each) do
+      before(:example) do
         subject.add_cipher(:SSLv3, "AES256-SHA", 256, :accepted)
         subject.add_cipher(:TLSv1, "AES256-SHA", 256, :accepted)
         subject.add_cipher(:SSLv3, "AES128-SHA", 128, :accepted)
@@ -472,7 +472,7 @@ RSpec.describe Rex::SSLScan::Result do
 
   context "when printing the results" do
     context "when OpenSSL is compiled without SSLv2" do
-      before(:each) do
+      before(:example) do
         subject.add_cipher(:SSLv3, "AES256-SHA", 256, :accepted)
         subject.add_cipher(:TLSv1, "AES256-SHA", 256, :accepted)
         subject.add_cipher(:SSLv3, "AES128-SHA", 128, :accepted)
@@ -484,7 +484,7 @@ RSpec.describe Rex::SSLScan::Result do
     end
 
     context "when we have SSL results" do
-      before(:each) do
+      before(:example) do
         subject.add_cipher(:SSLv3, "AES256-SHA", 256, :accepted)
         subject.add_cipher(:TLSv1, "AES256-SHA", 256, :accepted)
         subject.add_cipher(:SSLv3, "AES128-SHA", 128, :accepted)

--- a/spec/lib/rex/sslscan/scanner_spec.rb
+++ b/spec/lib/rex/sslscan/scanner_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Rex::SSLScan::Scanner do
     end
 
     context "if SSLv2 is not available locally" do
-      before(:each) do
+      before(:example) do
         expect(subject).to receive(:check_opensslv2).and_return(false)
         subject.send(:initialize, 'google.com', 443)
       end

--- a/spec/msfupdate_spec.rb
+++ b/spec/msfupdate_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Msfupdate do
     Msfupdate.new(msfbase_dir, stdin, stdout, stderr)
   end
 
-  before(:all) do
+  before(:context) do
     # Create some fake directories to mock our different install environments
     dummy_pathname.mkpath
     dummy_apt_pathname.join('.apt').mkpath
@@ -42,11 +42,11 @@ RSpec.describe Msfupdate do
     FileUtils.touch(dummy_install_pathname.join('..', 'engine', 'update.rb'))
   end
 
-  after(:all) do
+  after(:context) do
     dummy_pathname.rmtree
   end
 
-  before(:each) do
+  before(:example) do
     # By default, we want to ensure tests never actually try to execute any
     # of the update methods unless we are explicitly testing them
     allow(subject).to receive(:update_apt!)
@@ -168,7 +168,7 @@ RSpec.describe Msfupdate do
   end
 
   context "#run!" do
-    before(:each) do
+    before(:example) do
       subject.parse_args(args)
     end
     let(:args) { [] }
@@ -193,7 +193,7 @@ RSpec.describe Msfupdate do
     it { expect(subject.git?).to be_falsey }
 
     context "#validate_args" do
-      before(:each) do
+      before(:example) do
         subject.parse_args(args)
       end
 
@@ -246,7 +246,7 @@ RSpec.describe Msfupdate do
     it { expect(subject.git?).to be_falsey }
 
     context "#validate_args" do
-      before(:each) do
+      before(:example) do
         subject.parse_args(args)
       end
 
@@ -300,7 +300,7 @@ RSpec.describe Msfupdate do
 
 
     context "#validate_args" do
-      before(:each) do
+      before(:example) do
         subject.parse_args(args)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ engines.each do |engine|
 end
 
 RSpec.configure do |config|
-  config.raise_errors_for_deprecations!
+  #config.raise_errors_for_deprecations!
 
   config.expose_dsl_globally = false
 
@@ -93,6 +93,17 @@ RSpec.configure do |config|
     # a real object.
     mocks.verify_partial_doubles = true
   end
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end
 
 Metasploit::Framework::Spec::Constants::Suite.configure!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ engines.each do |engine|
 end
 
 RSpec.configure do |config|
-  #config.raise_errors_for_deprecations!
+  config.raise_errors_for_deprecations!
 
   config.expose_dsl_globally = false
 

--- a/spec/support/shared/contexts/metasploit/framework/spec/constants/cleaner.rb
+++ b/spec/support/shared/contexts/metasploit/framework/spec/constants/cleaner.rb
@@ -1,6 +1,6 @@
 # Use in a context to clean up the constants that are created by the module loader.
 RSpec.shared_context 'Metasploit::Framework::Spec::Constants cleaner' do
-  after(:each) do
+  after(:example) do
     Metasploit::Framework::Spec::Constants.clean
   end
 end

--- a/spec/support/shared/contexts/msf/db_manager.rb
+++ b/spec/support/shared/contexts/msf/db_manager.rb
@@ -9,7 +9,7 @@ RSpec.shared_context 'Msf::DBManager' do
     framework.db
   end
 
-  before(:each) do
+  before(:example) do
     # already connected due to use_transactional_fixtures, but need some of the side-effects of #connect
     framework.db.workspace = framework.db.default_workspace
     allow(db_manager).to receive(:active).and_return(active)

--- a/spec/support/shared/contexts/msf/framework/threads/cleaner.rb
+++ b/spec/support/shared/contexts/msf/framework/threads/cleaner.rb
@@ -1,5 +1,5 @@
 RSpec.shared_context 'Msf::Framework#threads cleaner' do
-  after(:each) do |example|
+  after(:example) do |example|
     unless framework.threads?
       fail RuntimeError.new(
                "framework.threads was never initialized. There are no threads to clean up. " \

--- a/spec/support/shared/contexts/msf/simple/framework.rb
+++ b/spec/support/shared/contexts/msf/simple/framework.rb
@@ -19,11 +19,11 @@ RSpec.shared_context 'Msf::Simple::Framework' do
     dummy_pathname.join('framework', 'config')
   end
 
-  before(:each) do
+  before(:example) do
     framework_config_pathname.mkpath
   end
 
-  after(:each) do
+  after(:example) do
     dummy_pathname.rmtree
   end
 end

--- a/spec/support/shared/contexts/msf/string_io.rb
+++ b/spec/support/shared/contexts/msf/string_io.rb
@@ -21,7 +21,7 @@ RSpec.shared_context 'Msf::StringIO' do
   # Callbacks
   #
 
-  before(:each) do
+  before(:example) do
     def msf_io.get_once
       read
     end

--- a/spec/support/shared/contexts/untested_payloads.rb
+++ b/spec/support/shared/contexts/untested_payloads.rb
@@ -41,7 +41,7 @@ RSpec.shared_context 'untested payloads' do |options={}|
 
   modules_pathname = options.fetch(:modules_pathname)
 
-  before(:all) do
+  before(:context) do
     @expected_ancestor_reference_name_set = Set.new
     @actual_ancestor_reference_name_set = Set.new
 
@@ -56,7 +56,7 @@ RSpec.shared_context 'untested payloads' do |options={}|
     end
   end
 
-  after(:all) do
+  after(:context) do
     missing_ancestor_reference_name_set = @expected_ancestor_reference_name_set - @actual_ancestor_reference_name_set
 
     untested_payloads_pathname = Pathname.new('log/untested-payloads.log')

--- a/spec/support/shared/examples/all_modules_with_module_type_can_be_instantiated.rb
+++ b/spec/support/shared/examples/all_modules_with_module_type_can_be_instantiated.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'all modules with module type can be instantiated' do |options={}|
+RSpec.shared_examples_for 'all modules with module type can be instantiated' do |options={}|
   options.assert_valid_keys(:module_type, :modules_pathname, :type_directory)
 
   module_type = options.fetch(:module_type)

--- a/spec/support/shared/examples/an_option.rb
+++ b/spec/support/shared/examples/an_option.rb
@@ -1,6 +1,6 @@
 # -*- coding:binary -*-
 
-shared_examples_for "an option" do |valid_values, invalid_values, type|
+RSpec.shared_examples_for "an option" do |valid_values, invalid_values, type|
   subject do
     described_class.new("name")
   end

--- a/spec/support/shared/examples/credential/core/to_credential.rb
+++ b/spec/support/shared/examples/credential/core/to_credential.rb
@@ -1,6 +1,6 @@
 require 'metasploit/framework/credential'
 
-shared_examples_for 'Metasploit::Credential::Core::ToCredential' do
+RSpec.shared_examples_for 'Metasploit::Credential::Core::ToCredential' do
   context "methods" do
     context ".to_credential" do
 

--- a/spec/support/shared/examples/hash_with_insensitive_access.rb
+++ b/spec/support/shared/examples/hash_with_insensitive_access.rb
@@ -1,4 +1,4 @@
-shared_examples_for "hash with insensitive keys" do
+RSpec.shared_examples_for "hash with insensitive keys" do
   it "should store with insensitive key" do
     subject["asdf"] = "foo"
     subject["ASDF"] = "bar"

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Framework::LoginScanner::HTTP' do
+RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::HTTP' do
   subject(:http_scanner) { described_class.new }
 
   it { is_expected.to respond_to :uri }

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/login_scanner_base.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/login_scanner_base.rb
@@ -1,5 +1,5 @@
 
-shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
+RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
 
   subject(:login_scanner) { described_class.new }
 
@@ -248,7 +248,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
       )
     }
 
-    before(:each) do
+    before(:example) do
       login_scanner.host = '127.0.0.1'
       login_scanner.port = 22
       login_scanner.connection_timeout = 30
@@ -282,7 +282,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
     end
 
     context 'when stop_on_success is true' do
-      before(:each) do
+      before(:example) do
         login_scanner.host = '127.0.0.1'
         login_scanner.port = 22
         login_scanner.connection_timeout = 30
@@ -307,7 +307,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
     if opts[:has_realm_key]
       context 'when the login_scanner has a REALM_KEY' do
         context 'when the credential has a realm' do
-          before(:each) do
+          before(:example) do
             login_scanner.cred_details = [ad_cred]
           end
           it 'set the realm_key on the credential to that of the scanner' do
@@ -319,7 +319,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
 
         if opts[:has_default_realm]
           context 'when the credential has no realm' do
-            before(:each) do
+            before(:example) do
               login_scanner.cred_details = [pub_pri]
             end
             it 'uses the default realm' do
@@ -335,7 +335,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
     else
       context 'when login_scanner has no REALM_KEY' do
         context 'when the credential has a realm' do
-          before(:each) do
+          before(:example) do
             login_scanner.cred_details = [ad_cred]
           end
           it 'yields the original credential as well as one with the realm in the public' do
@@ -349,7 +349,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts |
         end
 
         context 'when the credential does not have a realm' do
-          before(:each) do
+          before(:example) do
             login_scanner.cred_details = [pub_pri]
           end
           it 'simply yields the original credential' do

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/ntlm.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/ntlm.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Framework::LoginScanner::NTLM' do
+RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::NTLM' do
 
   subject(:login_scanner) { described_class.new }
 

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/rex_socket.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/rex_socket.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Metasploit::Framework::LoginScanner::RexSocket' do
+RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::RexSocket' do
   subject(:login_scanner) { described_class.new }
 
   it { is_expected.to respond_to :ssl }

--- a/spec/support/shared/examples/metasploit/framework/tcp/client.rb
+++ b/spec/support/shared/examples/metasploit/framework/tcp/client.rb
@@ -1,5 +1,5 @@
 
-shared_examples_for 'Metasploit::Framework::Tcp::Client' do
+RSpec.shared_examples_for 'Metasploit::Framework::Tcp::Client' do
   subject(:login_scanner) { described_class.new }
 
   it { is_expected.to respond_to :send_delay }

--- a/spec/support/shared/examples/msf/core/exploit/jsobfu.rb
+++ b/spec/support/shared/examples/msf/core/exploit/jsobfu.rb
@@ -3,7 +3,7 @@ require 'msf/core'
 require 'msf/core/exploit/jsobfu'
 
 
-shared_examples_for 'Msf::Exploit::JSObfu' do
+RSpec.shared_examples_for 'Msf::Exploit::JSObfu' do
 
   subject(:jsobfu) do
     mod = ::Msf::Module.new

--- a/spec/support/shared/examples/msf/db_manager/adapter.rb
+++ b/spec/support/shared/examples/msf/db_manager/adapter.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Adapter' do
+RSpec.shared_examples_for 'Msf::DBManager::Adapter' do
   context 'CONSTANTS' do
     context 'ADAPTER' do
       subject(:adapter) {

--- a/spec/support/shared/examples/msf/db_manager/client.rb
+++ b/spec/support/shared/examples/msf/db_manager/client.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Client' do
+RSpec.shared_examples_for 'Msf::DBManager::Client' do
   it { is_expected.to respond_to :find_or_create_client }
   it { is_expected.to respond_to :get_client }
   it { is_expected.to respond_to :report_client }

--- a/spec/support/shared/examples/msf/db_manager/connection.rb
+++ b/spec/support/shared/examples/msf/db_manager/connection.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Connection' do
+RSpec.shared_examples_for 'Msf::DBManager::Connection' do
   it { is_expected.to respond_to :active }
   it { is_expected.to respond_to :after_establish_connection }
   it { is_expected.to respond_to :connect }

--- a/spec/support/shared/examples/msf/db_manager/cred.rb
+++ b/spec/support/shared/examples/msf/db_manager/cred.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Cred' do
+RSpec.shared_examples_for 'Msf::DBManager::Cred' do
   it { is_expected.to respond_to :creds }
   it { is_expected.to respond_to :each_cred }
   it { is_expected.to respond_to :find_or_create_cred }

--- a/spec/support/shared/examples/msf/db_manager/event.rb
+++ b/spec/support/shared/examples/msf/db_manager/event.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Event' do
+RSpec.shared_examples_for 'Msf::DBManager::Event' do
   it { is_expected.to respond_to :events }
   it { is_expected.to respond_to :report_event }
 end

--- a/spec/support/shared/examples/msf/db_manager/exploit_attempt.rb
+++ b/spec/support/shared/examples/msf/db_manager/exploit_attempt.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::ExploitAttempt' do
+RSpec.shared_examples_for 'Msf::DBManager::ExploitAttempt' do
   it { is_expected.to respond_to :report_exploit }
   it { is_expected.to respond_to :report_exploit_attempt }
   it { is_expected.to respond_to :report_exploit_failure }
@@ -78,7 +78,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_failure
           end
 
@@ -115,7 +115,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_failure
           end
 
@@ -163,7 +163,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_failure
           end
 
@@ -198,7 +198,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_failure
           end
 
@@ -298,7 +298,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_success
           end
 
@@ -335,7 +335,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_success
           end
 
@@ -383,7 +383,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_success
           end
 
@@ -418,7 +418,7 @@ shared_examples_for 'Msf::DBManager::ExploitAttempt' do
         end
 
         context "calling report_exploit_success" do
-          after(:each) do
+          after(:example) do
             report_exploit_success
           end
 

--- a/spec/support/shared/examples/msf/db_manager/exploited_host.rb
+++ b/spec/support/shared/examples/msf/db_manager/exploited_host.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::ExploitedHost' do
+RSpec.shared_examples_for 'Msf::DBManager::ExploitedHost' do
   it { is_expected.to respond_to :each_exploited_host }
   it { is_expected.to respond_to :exploited_hosts }
 end

--- a/spec/support/shared/examples/msf/db_manager/export/extract_module_detail_info_module_detail_child.rb
+++ b/spec/support/shared/examples/msf/db_manager/export/extract_module_detail_info_module_detail_child.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Export#extract_module_detail_info module_detail child' do |child_node_name|
+RSpec.shared_examples_for 'Msf::DBManager::Export#extract_module_detail_info module_detail child' do |child_node_name|
   attribute_name = child_node_name.underscore
 
   subject(:child_node) do

--- a/spec/support/shared/examples/msf/db_manager/host.rb
+++ b/spec/support/shared/examples/msf/db_manager/host.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Host' do
+RSpec.shared_examples_for 'Msf::DBManager::Host' do
   it { is_expected.to respond_to :del_host }
   it { is_expected.to respond_to :each_host }
   it { is_expected.to respond_to :find_or_create_host }

--- a/spec/support/shared/examples/msf/db_manager/host_detail.rb
+++ b/spec/support/shared/examples/msf/db_manager/host_detail.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::HostDetail' do
+RSpec.shared_examples_for 'Msf::DBManager::HostDetail' do
   it { is_expected.to respond_to :report_host_details }
 end

--- a/spec/support/shared/examples/msf/db_manager/host_tag.rb
+++ b/spec/support/shared/examples/msf/db_manager/host_tag.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::HostTag' do
+RSpec.shared_examples_for 'Msf::DBManager::HostTag' do
   it { is_expected.to respond_to :report_host_tag }
 end

--- a/spec/support/shared/examples/msf/db_manager/import.rb
+++ b/spec/support/shared/examples/msf/db_manager/import.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import' do
+RSpec.shared_examples_for 'Msf::DBManager::Import' do
   it { is_expected.to respond_to :dehex }
   it { is_expected.to respond_to :emit }
   it { is_expected.to respond_to :import }

--- a/spec/support/shared/examples/msf/db_manager/import/acunetix.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/acunetix.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Acunetix' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Acunetix' do
   it { is_expected.to respond_to :import_acunetix_noko_stream }
   it { is_expected.to respond_to :import_acunetix_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/amap.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/amap.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Amap' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Amap' do
   it { is_expected.to respond_to :import_amap_log }
   it { is_expected.to respond_to :import_amap_log_file }
   it { is_expected.to respond_to :import_amap_mlog }

--- a/spec/support/shared/examples/msf/db_manager/import/appscan.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/appscan.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Appscan' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Appscan' do
   it { is_expected.to respond_to :import_appscan_noko_stream }
   it { is_expected.to respond_to :import_appscan_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/burp.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/burp.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Burp' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Burp' do
   it { is_expected.to respond_to :import_burp_session_noko_stream }
   it { is_expected.to respond_to :import_burp_session_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/ci.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/ci.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::CI' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::CI' do
   it { is_expected.to respond_to :import_ci_noko_stream }
   it { is_expected.to respond_to :import_ci_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/foundstone.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/foundstone.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Foundstone' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Foundstone' do
   it { is_expected.to respond_to :import_foundstone_noko_stream }
   it { is_expected.to respond_to :import_foundstone_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/fusion_vm.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/fusion_vm.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::Import::FusionVM' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::FusionVM' do
   it { is_expected.to respond_to :import_fusionvm_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/ip360.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/ip360.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::IP360' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::IP360' do
   it_should_behave_like 'Msf::DBManager::Import::IP360::ASPL'
   it_should_behave_like 'Msf::DBManager::Import::IP360::V3'
 end

--- a/spec/support/shared/examples/msf/db_manager/import/ip360/aspl.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/ip360/aspl.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::Import::IP360::ASPL' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::IP360::ASPL' do
   it { is_expected.to respond_to :import_ip360_aspl_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/ip360/v3.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/ip360/v3.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::IP360::V3' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::IP360::V3' do
   it { is_expected.to respond_to :import_ip360_xml_file }
   it { is_expected.to respond_to :import_ip360_xml_v3 }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/ip_list.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/ip_list.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::IPList' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::IPList' do
   it { is_expected.to respond_to :import_ip_list }
   it { is_expected.to respond_to :import_ip_list_file }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/libpcap.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/libpcap.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Libpcap' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Libpcap' do
   it { is_expected.to respond_to :import_libpcap }
   it { is_expected.to respond_to :import_libpcap_file }
   it { is_expected.to respond_to :inspect_single_packet }

--- a/spec/support/shared/examples/msf/db_manager/import/mbsa.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/mbsa.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::MBSA' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::MBSA' do
   it { is_expected.to respond_to :import_mbsa_noko_stream }
   it { is_expected.to respond_to :import_mbsa_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::MetasploitFramework' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework' do
   it { is_expected.to respond_to :nils_for_nulls }
   it { is_expected.to respond_to :unserialize_object }
 

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/credential.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/credential.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::Credential' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::Credential' do
   it { is_expected.to respond_to :import_msf_cred_dump }
   it { is_expected.to respond_to :import_msf_cred_dump_zip }
   it { is_expected.to respond_to :import_msf_pwdump }

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
@@ -1,7 +1,7 @@
 # -*- coding:binary -*-
 require 'builder'
 
-shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
   # Serialized format from pro/modules/auxiliary/pro/report.rb
   def serialize(object)
     # FIXME https://www.pivotaltracker.com/story/show/46578647
@@ -307,7 +307,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
         FactoryGirl.create(:mdm_web_vuln)
       end
 
-      before(:each) do
+      before(:example) do
         allow(db_manager).to receive(
             :report_web_vuln
         ).with(
@@ -322,7 +322,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
           double(':workspace')
         end
 
-        before(:each) do
+        before(:example) do
           options[:workspace] = workspace
         end
 
@@ -348,7 +348,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
           FactoryGirl.create(:mdm_workspace)
         end
 
-        before(:each) do
+        before(:example) do
           db_manager.workspace = workspace
         end
 
@@ -389,7 +389,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
           }
         end
 
-        before(:each) do
+        before(:example) do
           allow(db_manager).to receive(:import_msf_text_element).and_return(returned_hash)
         end
 
@@ -521,7 +521,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
             []
           end
 
-          before(:each) do
+          before(:example) do
             options[:notifier] = notifier
           end
 

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml/check_msf_xml_version_with_root_tag.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml/check_msf_xml_version_with_root_tag.rb
@@ -1,5 +1,5 @@
 # -*- coding:binary -*-
-shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML#check_msf_xml_version! with root tag' do |root_tag, options={}|
+RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML#check_msf_xml_version! with root tag' do |root_tag, options={}|
   options.assert_valid_keys(:allow_yaml)
   allow_yaml = options.fetch(:allow_yaml)
 

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml/import_msf_web_element_specialization.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml/import_msf_web_element_specialization.rb
@@ -1,5 +1,5 @@
 # -*- coding:binary -*-
-shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML#import_msf_web_element specialization' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML#import_msf_web_element specialization' do
   it 'should call #import_msf_web_element with element' do
     expect(db_manager).to receive(:import_msf_web_element).with(element, anything)
 

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/zip.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/zip.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::Zip' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::Zip' do
   it { is_expected.to respond_to :import_msf_collateral }
   it { is_expected.to respond_to :import_msf_zip }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/nessus.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nessus.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Nessus' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nessus' do
   it_should_behave_like 'Msf::DBManager::Import::Nessus::NBE'
   it_should_behave_like 'Msf::DBManager::Import::Nessus::XML'
 end

--- a/spec/support/shared/examples/msf/db_manager/import/nessus/nbe.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nessus/nbe.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Nessus::NBE' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nessus::NBE' do
   it { is_expected.to respond_to :import_nessus_nbe }
   it { is_expected.to respond_to :import_nessus_nbe_file }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/nessus/xml.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nessus/xml.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Nessus::XML' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nessus::XML' do
   it { is_expected.to respond_to :import_nessus_xml_file }
 
   it_should_behave_like 'Msf::DBManager::Import::Nessus::XML::V1'

--- a/spec/support/shared/examples/msf/db_manager/import/nessus/xml/v1.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nessus/xml/v1.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::Import::Nessus::XML::V1' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nessus::XML::V1' do
   it { is_expected.to respond_to :import_nessus_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/nessus/xml/v2.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nessus/xml/v2.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::Import::Nessus::XML::V2' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nessus::XML::V2' do
   it { is_expected.to respond_to :import_nessus_xml_v2 }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/netsparker.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/netsparker.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Netsparker' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Netsparker' do
   it { is_expected.to respond_to :import_netsparker_xml }
   it { is_expected.to respond_to :import_netsparker_xml_file }
   it { is_expected.to respond_to :netsparker_method_map }

--- a/spec/support/shared/examples/msf/db_manager/import/nexpose.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nexpose.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Nexpose' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nexpose' do
   it_should_behave_like 'Msf::DBManager::Import::Nexpose::Raw'
   it_should_behave_like 'Msf::DBManager::Import::Nexpose::Simple'
 end

--- a/spec/support/shared/examples/msf/db_manager/import/nexpose/raw.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nexpose/raw.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Nexpose::Raw' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nexpose::Raw' do
   it { is_expected.to respond_to :import_nexpose_raw_noko_stream }
   it { is_expected.to respond_to :import_nexpose_rawxml }
   it { is_expected.to respond_to :import_nexpose_rawxml_file }

--- a/spec/support/shared/examples/msf/db_manager/import/nexpose/simple.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nexpose/simple.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Nexpose::Simple' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nexpose::Simple' do
   it { is_expected.to respond_to :import_nexpose_noko_stream }
   it { is_expected.to respond_to :import_nexpose_simplexml }
   it { is_expected.to respond_to :import_nexpose_simplexml_file }

--- a/spec/support/shared/examples/msf/db_manager/import/nikto.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nikto.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::Import::Nikto' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nikto' do
   it { is_expected.to respond_to :import_nikto_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/nmap.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/nmap.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Nmap' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Nmap' do
   it { is_expected.to respond_to :import_nmap_noko_stream }
   it { is_expected.to respond_to :import_nmap_xml }
   it { is_expected.to respond_to :import_nmap_xml_file }

--- a/spec/support/shared/examples/msf/db_manager/import/open_vas.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/open_vas.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::OpenVAS' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::OpenVAS' do
   it { is_expected.to respond_to :import_openvas_new_xml }
   it { is_expected.to respond_to :import_openvas_new_xml_file }
   it { is_expected.to respond_to :import_openvas_xml }

--- a/spec/support/shared/examples/msf/db_manager/import/outpost24.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/outpost24.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Outpost24' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Outpost24' do
   it { is_expected.to respond_to :import_outpost24_noko_stream }
   it { is_expected.to respond_to :import_outpost24_xml }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/qualys.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/qualys.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Qualys' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Qualys' do
   it_should_behave_like 'Msf::DBManager::Import::Qualys::Asset'
   it_should_behave_like 'Msf::DBManager::Import::Qualys::Scan'
 end

--- a/spec/support/shared/examples/msf/db_manager/import/qualys/asset.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/qualys/asset.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Qualys::Asset' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Qualys::Asset' do
   it { is_expected.to respond_to :find_qualys_asset_ports }
   it { is_expected.to respond_to :find_qualys_asset_vuln_refs }
   it { is_expected.to respond_to :find_qualys_asset_vulns }

--- a/spec/support/shared/examples/msf/db_manager/import/qualys/scan.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/qualys/scan.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Qualys::Scan' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Qualys::Scan' do
   it { is_expected.to respond_to :import_qualys_scan_xml }
   it { is_expected.to respond_to :import_qualys_scan_xml_file }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/report.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/report.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::Import::Report' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Report' do
   it { is_expected.to respond_to :import_report }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/retina.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/retina.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Retina' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Retina' do
   it { is_expected.to respond_to :import_retina_xml }
   it { is_expected.to respond_to :import_retina_xml_file }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/spiceworks.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/spiceworks.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::Import::Spiceworks' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Spiceworks' do
   it { is_expected.to respond_to :import_spiceworks_csv }
 end

--- a/spec/support/shared/examples/msf/db_manager/import/wapiti.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/wapiti.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Import::Wapiti' do
+RSpec.shared_examples_for 'Msf::DBManager::Import::Wapiti' do
   it { is_expected.to respond_to :import_wapiti_xml }
   it { is_expected.to respond_to :import_wapiti_xml_file }
 end

--- a/spec/support/shared/examples/msf/db_manager/ip_address.rb
+++ b/spec/support/shared/examples/msf/db_manager/ip_address.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::IPAddress' do
+RSpec.shared_examples_for 'Msf::DBManager::IPAddress' do
   it { is_expected.to respond_to :ipv46_validator }
   it { is_expected.to respond_to :ipv4_validator }
   it { is_expected.to respond_to :ipv6_validator }

--- a/spec/support/shared/examples/msf/db_manager/loot.rb
+++ b/spec/support/shared/examples/msf/db_manager/loot.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Loot' do
+RSpec.shared_examples_for 'Msf::DBManager::Loot' do
   it { is_expected.to respond_to :each_loot }
   it { is_expected.to respond_to :find_or_create_loot }
   it { is_expected.to respond_to :loots }

--- a/spec/support/shared/examples/msf/db_manager/migration.rb
+++ b/spec/support/shared/examples/msf/db_manager/migration.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Migration' do
+RSpec.shared_examples_for 'Msf::DBManager::Migration' do
   it { is_expected.to be_a Msf::DBManager::Migration }
 
 
@@ -55,7 +55,7 @@ shared_examples_for 'Msf::DBManager::Migration' do
         "Error during migration"
       end
 
-      before(:each) do
+      before(:example) do
         expect(ActiveRecord::Migrator).to receive(:migrate).and_raise(error)
       end
 

--- a/spec/support/shared/examples/msf/db_manager/module_cache.rb
+++ b/spec/support/shared/examples/msf/db_manager/module_cache.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::ModuleCache' do
+RSpec.shared_examples_for 'Msf::DBManager::ModuleCache' do
   it { is_expected.to respond_to :match_values }
   it { is_expected.to respond_to :module_to_details_hash }
   it { is_expected.to respond_to :modules_cached }
@@ -26,7 +26,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
       )
     end
 
-    before(:each) do
+    before(:example) do
       allow(db_manager).to receive(:migrated).and_return(migrated)
     end
 
@@ -39,7 +39,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
         false
       end
 
-      before(:each) do
+      before(:example) do
         allow(db_manager).to receive(:modules_caching).and_return(modules_caching)
       end
 
@@ -96,7 +96,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
       )
     end
 
-    before(:each) do
+    before(:example) do
       allow(db_manager).to receive(:migrated).and_return(migrated)
     end
 
@@ -157,7 +157,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
         "app:#{app}"
       end
 
-      before(:each) do
+      before(:example) do
         Mdm::Module::Detail::STANCES.each do |stance|
           FactoryGirl.create(:mdm_module_detail, :stance => stance)
         end
@@ -588,7 +588,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
       false
     end
 
-    before(:each) do
+    before(:example) do
       allow(db_manager).to receive(:migrated).and_return(migrated)
     end
 
@@ -601,7 +601,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
         true
       end
 
-      before(:each) do
+      before(:example) do
         allow(db_manager).to receive(:modules_caching).and_return(modules_caching)
       end
 
@@ -804,7 +804,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
       'exploits'
     end
 
-    before(:each) do
+    before(:example) do
       allow(db_manager).to receive(:migrated).and_return(migrated)
     end
 
@@ -849,7 +849,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
           FactoryGirl.generate :mdm_module_detail_stance
         end
 
-        before(:each) do
+        before(:example) do
           allow(db_manager).to receive(
               :module_to_details_hash
           ).with(
@@ -864,7 +864,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
             Mdm::Module::Detail.last
           end
 
-          before(:each) do
+          before(:example) do
             update_module_details
           end
 
@@ -881,7 +881,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
             []
           end
 
-          before(:each) do
+          before(:example) do
             module_to_details_hash[:bits] = bits
           end
 
@@ -914,7 +914,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
                 Mdm::Module::Detail.last
               end
 
-              before(:each) do
+              before(:example) do
                 update_module_details
               end
 
@@ -951,7 +951,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
                 Mdm::Module::Detail.last
               end
 
-              before(:each) do
+              before(:example) do
                 update_module_details
               end
 
@@ -993,7 +993,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
                 Mdm::Module::Detail.last
               end
 
-              before(:each) do
+              before(:example) do
                 update_module_details
               end
 
@@ -1031,7 +1031,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
                 Mdm::Module::Detail.last
               end
 
-              before(:each) do
+              before(:example) do
                 update_module_details
               end
 
@@ -1068,7 +1068,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
                 Mdm::Module::Detail.last
               end
 
-              before(:each) do
+              before(:example) do
                 update_module_details
               end
 
@@ -1110,7 +1110,7 @@ shared_examples_for 'Msf::DBManager::ModuleCache' do
                 Mdm::Module::Detail.last
               end
 
-              before(:each) do
+              before(:example) do
                 update_module_details
               end
 

--- a/spec/support/shared/examples/msf/db_manager/note.rb
+++ b/spec/support/shared/examples/msf/db_manager/note.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Note' do
+RSpec.shared_examples_for 'Msf::DBManager::Note' do
   it { is_expected.to respond_to :each_note }
   it { is_expected.to respond_to :find_or_create_note }
   it { is_expected.to respond_to :notes }

--- a/spec/support/shared/examples/msf/db_manager/ref.rb
+++ b/spec/support/shared/examples/msf/db_manager/ref.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Ref' do
+RSpec.shared_examples_for 'Msf::DBManager::Ref' do
   it { is_expected.to respond_to :find_or_create_ref }
   it { is_expected.to respond_to :get_ref }
   it { is_expected.to respond_to :has_ref? }

--- a/spec/support/shared/examples/msf/db_manager/report.rb
+++ b/spec/support/shared/examples/msf/db_manager/report.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Report' do
+RSpec.shared_examples_for 'Msf::DBManager::Report' do
   it { is_expected.to respond_to :find_or_create_report }
   it { is_expected.to respond_to :report_artifact }
   it { is_expected.to respond_to :report_report }

--- a/spec/support/shared/examples/msf/db_manager/route.rb
+++ b/spec/support/shared/examples/msf/db_manager/route.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Route' do
+RSpec.shared_examples_for 'Msf::DBManager::Route' do
   it { is_expected.to respond_to :report_session_route }
   it { is_expected.to respond_to :report_session_route_remove }
 end

--- a/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_platform_name_or_mdm_module_target_name_keyword.rb
+++ b/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_platform_name_or_mdm_module_target_name_keyword.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Platform#name or Mdm::Module::Target#name keyword' do |keyword|
+RSpec.shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Platform#name or Mdm::Module::Target#name keyword' do |keyword|
   context "with #{keyword} keyword" do
     let(:search_string) do
       "#{keyword}:#{name}"

--- a/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_ref_name_keyword.rb
+++ b/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_ref_name_keyword.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Ref#name keyword' do |keyword|
+RSpec.shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Ref#name keyword' do |keyword|
   context "with #{keyword} keyword" do
     let(keyword) do
       1
@@ -12,7 +12,7 @@ shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Ref#name keyword
       "#{keyword}:#{send(keyword)}"
     end
 
-    before(:each) do
+    before(:example) do
       FactoryGirl.create(:mdm_module_ref, :name => name)
     end
 

--- a/spec/support/shared/examples/msf/db_manager/service.rb
+++ b/spec/support/shared/examples/msf/db_manager/service.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Service' do
+RSpec.shared_examples_for 'Msf::DBManager::Service' do
   it { is_expected.to respond_to :del_service }
   it { is_expected.to respond_to :each_service }
   it { is_expected.to respond_to :find_or_create_service }

--- a/spec/support/shared/examples/msf/db_manager/session.rb
+++ b/spec/support/shared/examples/msf/db_manager/session.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Session' do
+RSpec.shared_examples_for 'Msf::DBManager::Session' do
   it { is_expected.to respond_to :get_session }
 
   context '#report_session' do
@@ -16,7 +16,7 @@ shared_examples_for 'Msf::DBManager::Session' do
       end
 
       context 'with :session' do
-        before(:each) do
+        before(:example) do
           options[:session] = session
         end
 
@@ -98,7 +98,7 @@ shared_examples_for 'Msf::DBManager::Session' do
             FactoryGirl.create(:mdm_workspace)
           end
 
-          before(:each) do
+          before(:example) do
             reference_name = 'multi/handler'
             path = File.join(parent_path, 'exploits', reference_name)
 
@@ -123,7 +123,7 @@ shared_examples_for 'Msf::DBManager::Session' do
           end
 
           context 'with a run_id in user_data' do
-            before(:each) do
+            before(:example) do
               allow(db_manager).to receive(:create_match_for_vuln).and_return(nil)
             end
 
@@ -142,7 +142,7 @@ shared_examples_for 'Msf::DBManager::Session' do
             end
 
             context 'with :workspace' do
-              before(:each) do
+              before(:example) do
                 options[:workspace] = options_workspace
               end
 
@@ -192,7 +192,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                   FactoryGirl.generate :mdm_host_arch
                 end
 
-                before(:each) do
+                before(:example) do
                   allow(session).to receive(:arch).and_return(arch)
                 end
 
@@ -250,7 +250,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     nil
                   end
 
-                  before(:each) do
+                  before(:example) do
                     Timecop.freeze
 
                     session.exploit_datastore['RPORT'] = rport
@@ -258,7 +258,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     report_session
                   end
 
-                  after(:each) do
+                  after(:example) do
                     Timecop.return
                   end
 
@@ -282,7 +282,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                       'windows/smb/ms08_067_netapi'
                     end
 
-                    before(:each) do
+                    before(:example) do
                       path = File.join(
                         parent_path,
                         'exploits',
@@ -339,7 +339,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     nil
                   end
 
-                  before(:each) do
+                  before(:example) do
                     Timecop.freeze
 
                     session.exploit_datastore['RPORT'] = rport
@@ -347,7 +347,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     report_session
                   end
 
-                  after(:each) do
+                  after(:example) do
                     Timecop.return
                   end
 
@@ -369,7 +369,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                   end
 
                   context "without session.via_exploit 'exploit/multi/handler'" do
-                    before(:each) do
+                    before(:example) do
                       session.via_exploit = parent_module_fullname
                     end
 
@@ -379,11 +379,11 @@ shared_examples_for 'Msf::DBManager::Session' do
               end
 
               context 'returned Mdm::Session' do
-                before(:each) do
+                before(:example) do
                   Timecop.freeze
                 end
 
-                after(:each) do
+                after(:example) do
                   Timecop.return
                 end
 
@@ -446,7 +446,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                 end
 
                 context "without session.via_exploit 'exploit/multi/handler'" do
-                  before(:each) do
+                  before(:example) do
                     reference_name = 'windows/smb/ms08_067_netapi'
                     path = File.join(
                       parent_path,
@@ -485,7 +485,7 @@ shared_examples_for 'Msf::DBManager::Session' do
             let(:user_data) { nil }
 
             context 'with :workspace' do
-              before(:each) do
+              before(:example) do
                 options[:workspace] = options_workspace
               end
 
@@ -535,7 +535,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                   FactoryGirl.generate :mdm_host_arch
                 end
 
-                before(:each) do
+                before(:example) do
                   allow(session).to receive(:arch).and_return(arch)
                 end
 
@@ -593,7 +593,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     nil
                   end
 
-                  before(:each) do
+                  before(:example) do
                     Timecop.freeze
 
                     session.exploit_datastore['RPORT'] = rport
@@ -601,7 +601,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     report_session
                   end
 
-                  after(:each) do
+                  after(:example) do
                     Timecop.return
                   end
 
@@ -625,7 +625,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                       'windows/smb/ms08_067_netapi'
                     end
 
-                    before(:each) do
+                    before(:example) do
                       path = File.join(
                           parent_path,
                           'exploits',
@@ -682,7 +682,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     nil
                   end
 
-                  before(:each) do
+                  before(:example) do
                     Timecop.freeze
 
                     session.exploit_datastore['RPORT'] = rport
@@ -690,7 +690,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                     report_session
                   end
 
-                  after(:each) do
+                  after(:example) do
                     Timecop.return
                   end
 
@@ -712,7 +712,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                   end
 
                   context "without session.via_exploit 'exploit/multi/handler'" do
-                    before(:each) do
+                    before(:example) do
                       session.via_exploit = parent_module_fullname
                     end
 
@@ -722,11 +722,11 @@ shared_examples_for 'Msf::DBManager::Session' do
               end
 
               context 'returned Mdm::Session' do
-                before(:each) do
+                before(:example) do
                   Timecop.freeze
                 end
 
-                after(:each) do
+                after(:example) do
                   Timecop.return
                 end
 
@@ -789,7 +789,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                 end
 
                 context "without session.via_exploit 'exploit/multi/handler'" do
-                  before(:each) do
+                  before(:example) do
                     reference_name = 'windows/smb/ms08_067_netapi'
                     path = File.join(
                         parent_path,
@@ -840,7 +840,7 @@ shared_examples_for 'Msf::DBManager::Session' do
 
       context 'without :session' do
         context 'with :host' do
-          before(:each) do
+          before(:example) do
             options[:host] = host
           end
 
@@ -890,7 +890,7 @@ shared_examples_for 'Msf::DBManager::Session' do
                 'Session Type'
               end
 
-              before(:each) do
+              before(:example) do
                 options[:closed_at] = closed_at
                 options[:close_reason] = close_reason
                 options[:desc] = description

--- a/spec/support/shared/examples/msf/db_manager/session_event.rb
+++ b/spec/support/shared/examples/msf/db_manager/session_event.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::SessionEvent' do
+RSpec.shared_examples_for 'Msf::DBManager::SessionEvent' do
   it { is_expected.to respond_to :report_session_event }
 end

--- a/spec/support/shared/examples/msf/db_manager/task.rb
+++ b/spec/support/shared/examples/msf/db_manager/task.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Task' do
+RSpec.shared_examples_for 'Msf::DBManager::Task' do
   it { is_expected.to respond_to :find_or_create_task }
   it { is_expected.to respond_to :report_task }
   it { is_expected.to respond_to :tasks }

--- a/spec/support/shared/examples/msf/db_manager/update_all_module_details_refresh.rb
+++ b/spec/support/shared/examples/msf/db_manager/update_all_module_details_refresh.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager#update_all_module_details refresh' do
+RSpec.shared_examples_for 'Msf::DBManager#update_all_module_details refresh' do
 
   it 'should destroy Mdm::Module::Detail' do
     expect {
@@ -13,7 +13,7 @@ shared_examples_for 'Msf::DBManager#update_all_module_details refresh' do
       framework.exploits
     end
 
-    before(:each) do
+    before(:example) do
       module_set[module_detail.refname] = Msf::SymbolicModule
 
       framework.modules.send(:module_info_by_path)[module_detail.file] = {
@@ -40,7 +40,7 @@ shared_examples_for 'Msf::DBManager#update_all_module_details refresh' do
     end
 
     context 'with exception raised by #update_module_details' do
-      before(:each) do
+      before(:example) do
         expect(db_manager).to receive(:update_module_details).and_raise(Exception)
       end
 

--- a/spec/support/shared/examples/msf/db_manager/update_module_details_with_module_type.rb
+++ b/spec/support/shared/examples/msf/db_manager/update_module_details_with_module_type.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager#update_module_details with module' do |options={}|
+RSpec.shared_examples_for 'Msf::DBManager#update_module_details with module' do |options={}|
   options.assert_valid_keys(:reference_name, :type)
 
   reference_name = options.fetch(:reference_name)

--- a/spec/support/shared/examples/msf/db_manager/vuln.rb
+++ b/spec/support/shared/examples/msf/db_manager/vuln.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Vuln' do
+RSpec.shared_examples_for 'Msf::DBManager::Vuln' do
   it { is_expected.to respond_to :each_vuln }
   it { is_expected.to respond_to :find_or_create_vuln }
   it { is_expected.to respond_to :find_vuln_by_details }

--- a/spec/support/shared/examples/msf/db_manager/vuln_attempt.rb
+++ b/spec/support/shared/examples/msf/db_manager/vuln_attempt.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::DBManager::VulnAttempt' do
+RSpec.shared_examples_for 'Msf::DBManager::VulnAttempt' do
   it { is_expected.to respond_to :report_vuln_attempt }
 end

--- a/spec/support/shared/examples/msf/db_manager/vuln_detail.rb
+++ b/spec/support/shared/examples/msf/db_manager/vuln_detail.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::VulnDetail' do
+RSpec.shared_examples_for 'Msf::DBManager::VulnDetail' do
   it { is_expected.to respond_to :report_vuln_details }
   it { is_expected.to respond_to :update_vuln_details }
 end

--- a/spec/support/shared/examples/msf/db_manager/web.rb
+++ b/spec/support/shared/examples/msf/db_manager/web.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Web' do
+RSpec.shared_examples_for 'Msf::DBManager::Web' do
   it { is_expected.to respond_to :report_web_form }
   it { is_expected.to respond_to :report_web_page }
   it { is_expected.to respond_to :report_web_site }

--- a/spec/support/shared/examples/msf/db_manager/wmap.rb
+++ b/spec/support/shared/examples/msf/db_manager/wmap.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::WMAP' do
+RSpec.shared_examples_for 'Msf::DBManager::WMAP' do
   it { is_expected.to respond_to :create_request }
   it { is_expected.to respond_to :create_target }
   it { is_expected.to respond_to :delete_all_targets }

--- a/spec/support/shared/examples/msf/db_manager/workspace.rb
+++ b/spec/support/shared/examples/msf/db_manager/workspace.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::DBManager::Workspace' do
+RSpec.shared_examples_for 'Msf::DBManager::Workspace' do
   it { is_expected.to respond_to :add_workspace }
   it { is_expected.to respond_to :default_workspace }
   it { is_expected.to respond_to :find_workspace }

--- a/spec/support/shared/examples/msf/module/arch.rb
+++ b/spec/support/shared/examples/msf/module/arch.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Arch' do
+RSpec.shared_examples_for 'Msf::Module::Arch' do
   it { is_expected.to respond_to :arch }
   it { is_expected.to respond_to :arch? }
   it { is_expected.to respond_to :arch_to_s }

--- a/spec/support/shared/examples/msf/module/author.rb
+++ b/spec/support/shared/examples/msf/module/author.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Author' do
+RSpec.shared_examples_for 'Msf::Module::Author' do
   it { is_expected.to respond_to :author }
   it { is_expected.to respond_to :author_to_s }
   it { is_expected.to respond_to :each_author }

--- a/spec/support/shared/examples/msf/module/compatibility.rb
+++ b/spec/support/shared/examples/msf/module/compatibility.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Compatibility' do
+RSpec.shared_examples_for 'Msf::Module::Compatibility' do
   it { is_expected.to respond_to :compat }
   it { is_expected.to respond_to :compatible? }
   it { is_expected.to respond_to_protected :init_compat }

--- a/spec/support/shared/examples/msf/module/data_store.rb
+++ b/spec/support/shared/examples/msf/module/data_store.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::DataStore' do
+RSpec.shared_examples_for 'Msf::Module::DataStore' do
   it { is_expected.to respond_to :datastore }
   it { is_expected.to respond_to :import_defaults }
   it { is_expected.to respond_to :share_datastore }

--- a/spec/support/shared/examples/msf/module/full_name.rb
+++ b/spec/support/shared/examples/msf/module/full_name.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::FullName' do
+RSpec.shared_examples_for 'Msf::Module::FullName' do
   it { is_expected.to respond_to :fullname }
   it { is_expected.to respond_to :refname }
   it { is_expected.to respond_to :shortname }

--- a/spec/support/shared/examples/msf/module/module_info.rb
+++ b/spec/support/shared/examples/msf/module/module_info.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::ModuleInfo' do
+RSpec.shared_examples_for 'Msf::Module::ModuleInfo' do
   context 'CONSTANTS' do
     context 'UpdateableOptions' do
       subject(:updateable_options) {

--- a/spec/support/shared/examples/msf/module/module_store.rb
+++ b/spec/support/shared/examples/msf/module/module_store.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::ModuleStore' do
+RSpec.shared_examples_for 'Msf::Module::ModuleStore' do
   it { is_expected.to respond_to :[] }
   it { is_expected.to respond_to :[]= }
   it { is_expected.to respond_to :module_store }

--- a/spec/support/shared/examples/msf/module/network.rb
+++ b/spec/support/shared/examples/msf/module/network.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Network' do
+RSpec.shared_examples_for 'Msf::Module::Network' do
   it { is_expected.to respond_to :comm }
   it { is_expected.to respond_to :support_ipv6? }
   it { is_expected.to respond_to :target_host }

--- a/spec/support/shared/examples/msf/module/options.rb
+++ b/spec/support/shared/examples/msf/module/options.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Options' do
+RSpec.shared_examples_for 'Msf::Module::Options' do
   it { is_expected.to respond_to_protected :deregister_options }
   it { is_expected.to respond_to :options }
   it { is_expected.to respond_to :validate }

--- a/spec/support/shared/examples/msf/module/privileged.rb
+++ b/spec/support/shared/examples/msf/module/privileged.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Privileged' do
+RSpec.shared_examples_for 'Msf::Module::Privileged' do
   it { is_expected.to respond_to :privileged }
   it { is_expected.to respond_to :privileged? }
 end

--- a/spec/support/shared/examples/msf/module/ranking.rb
+++ b/spec/support/shared/examples/msf/module/ranking.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Ranking' do
+RSpec.shared_examples_for 'Msf::Module::Ranking' do
   it { is_expected.to respond_to :rank }
   it { is_expected.to respond_to :rank_to_h }
   it { is_expected.to respond_to :rank_to_s }

--- a/spec/support/shared/examples/msf/module/search.rb
+++ b/spec/support/shared/examples/msf/module/search.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Search' do
+RSpec.shared_examples_for 'Msf::Module::Search' do
   describe '#search_filter' do
     REF_TYPES = %w(CVE BID OSVDB EDB)
 
@@ -159,7 +159,7 @@ shared_examples_for 'Msf::Module::Search' do
       all_module_types = Msf::MODULE_TYPES
       all_module_types.each do |mtype|
         context "on a #{mtype} module" do
-          before(:each) { allow(subject).to receive(:type).and_return(mtype) }
+          before(:example) { allow(subject).to receive(:type).and_return(mtype) }
 
           accept = ["type:#{mtype}"]
           reject = all_module_types.reject { |t| t == mtype }.map { |t| "type:#{t}" }

--- a/spec/support/shared/examples/msf/module/type.rb
+++ b/spec/support/shared/examples/msf/module/type.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::Type' do
+RSpec.shared_examples_for 'Msf::Module::Type' do
   it { is_expected.to respond_to :auxiliary? }
   it { is_expected.to respond_to :encoder? }
   it { is_expected.to respond_to :exploit? }

--- a/spec/support/shared/examples/msf/module/ui.rb
+++ b/spec/support/shared/examples/msf/module/ui.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::UI' do
+RSpec.shared_examples_for 'Msf::Module::UI' do
   it_should_behave_like 'Msf::Module::UI::Line'
   it_should_behave_like 'Msf::Module::UI::Message'
 end

--- a/spec/support/shared/examples/msf/module/ui/line.rb
+++ b/spec/support/shared/examples/msf/module/ui/line.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::UI::Line' do
+RSpec.shared_examples_for 'Msf::Module::UI::Line' do
   it_should_behave_like 'Msf::Module::UI::Line::Verbose'
 
   it { is_expected.to respond_to :print_line }

--- a/spec/support/shared/examples/msf/module/ui/line/verbose.rb
+++ b/spec/support/shared/examples/msf/module/ui/line/verbose.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::Module::UI::Line::Verbose' do
+RSpec.shared_examples_for 'Msf::Module::UI::Line::Verbose' do
   it { is_expected.to respond_to :vprint_line }
 end

--- a/spec/support/shared/examples/msf/module/ui/message.rb
+++ b/spec/support/shared/examples/msf/module/ui/message.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::UI::Message' do
+RSpec.shared_examples_for 'Msf::Module::UI::Message' do
   it_should_behave_like 'Msf::Module::UI::Message::Verbose'
 
   it { is_expected.to respond_to :print_error }

--- a/spec/support/shared/examples/msf/module/ui/message/verbose.rb
+++ b/spec/support/shared/examples/msf/module/ui/message/verbose.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Module::UI::Message::Verbose' do
+RSpec.shared_examples_for 'Msf::Module::UI::Message::Verbose' do
   it { is_expected.to respond_to :vprint_error }
   it { is_expected.to respond_to :vprint_good }
   it { is_expected.to respond_to :vprint_status }

--- a/spec/support/shared/examples/msf/module/uuid.rb
+++ b/spec/support/shared/examples/msf/module/uuid.rb
@@ -1,3 +1,3 @@
-shared_examples_for 'Msf::Module::UUID' do
+RSpec.shared_examples_for 'Msf::Module::UUID' do
   it { is_expected.to respond_to :uuid }
 end

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::ModuleManager::Cache' do
+RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
   let(:parent_path) do
     parent_pathname.to_path
   end
@@ -35,7 +35,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
       module_manager.cache_empty?
     end
 
-    before(:each) do
+    before(:example) do
       module_manager.send(:module_info_by_path=, module_info_by_path)
     end
 
@@ -92,7 +92,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
           module_manager.send(:module_info_by_path)
         end
 
-        before(:each) do
+        before(:example) do
           cache_in_memory
         end
 
@@ -148,7 +148,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
       module_manager.load_cached_module(type, reference_name)
     end
 
-    before(:each) do
+    before(:example) do
       module_manager.send(:module_info_by_path=, module_info_by_path)
     end
 
@@ -187,7 +187,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
       end
 
       context 'return from load_module' do
-        before(:each) do
+        before(:example) do
           module_manager.send(:loaders).each do |loader|
             expect(loader).to receive(:load_module).and_return(module_loaded)
           end
@@ -221,7 +221,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
   end
 
   context '#refresh_cache_from_module_files' do
-    before(:each) do
+    before(:example) do
       allow(module_manager).to receive(:framework_migrated?).and_return(framework_migrated?)
     end
 
@@ -308,7 +308,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
     end
 
     context 'with framework database' do
-      before(:each) do
+      before(:example) do
         expect(framework.db).to receive(:migrated).and_return(migrated)
       end
 
@@ -330,7 +330,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
     end
 
     context 'without framework database' do
-      before(:each) do
+      before(:example) do
         expect(framework).to receive(:db).and_return(nil)
       end
 
@@ -359,7 +359,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
       module_manager.send(:module_info_by_path_from_database!)
     end
 
-    before(:each) do
+    before(:example) do
       allow(module_manager).to receive(:framework_migrated?).and_return(framework_migrated?)
     end
 
@@ -405,7 +405,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
             module_info_by_path[path]
           end
 
-          before(:each) do
+          before(:example) do
             module_info_by_path_from_database!
           end
 
@@ -421,7 +421,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
           end
 
           context 'with reference_name' do
-            before(:each) do
+            before(:example) do
               typed_module_set[reference_name] = double('Msf::Module')
             end
 

--- a/spec/support/shared/examples/msf/module_manager/loading.rb
+++ b/spec/support/shared/examples/msf/module_manager/loading.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::ModuleManager::Loading' do
+RSpec.shared_examples_for 'Msf::ModuleManager::Loading' do
   context '#file_changed?' do
     let(:module_basename) do
       [basename_prefix, '.rb']
@@ -124,7 +124,7 @@ shared_examples_for 'Msf::ModuleManager::Loading' do
       klass.type
     end
 
-    before(:each) do
+    before(:example) do
       allow(klass).to receive(:parent).and_return(namespace_module)
     end
 

--- a/spec/support/shared/examples/msf/module_manager/module_paths.rb
+++ b/spec/support/shared/examples/msf/module_manager/module_paths.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::ModuleManager::ModulePaths' do
+RSpec.shared_examples_for 'Msf::ModuleManager::ModulePaths' do
   def module_paths
     module_manager.send(:module_paths)
   end

--- a/spec/support/shared/examples/msf/modules/error_subclass_initialize.rb
+++ b/spec/support/shared/examples/msf/modules/error_subclass_initialize.rb
@@ -1,5 +1,5 @@
 # -*- coding:binary -*-
-shared_examples_for 'Msf::Modules::Error subclass #initialize' do
+RSpec.shared_examples_for 'Msf::Modules::Error subclass #initialize' do
   context 'instance methods' do
     context '#initialize' do
       include_context 'Msf::Modules::Error attributes'

--- a/spec/support/shared/examples/msf/modules/version_compatibility_error.rb
+++ b/spec/support/shared/examples/msf/modules/version_compatibility_error.rb
@@ -1,5 +1,5 @@
 # -*- coding:binary -*-
-shared_examples_for 'Msf::Modules::VersionCompatibilityError' do
+RSpec.shared_examples_for 'Msf::Modules::VersionCompatibilityError' do
   let(:error) do
     begin
       subject.version_compatible!(module_path, module_reference_name)

--- a/spec/support/shared/examples/msf/simple/framework/module_paths.rb
+++ b/spec/support/shared/examples/msf/simple/framework/module_paths.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Msf::Simple::Framework::ModulePaths' do
+RSpec.shared_examples_for 'Msf::Simple::Framework::ModulePaths' do
   it { is_expected.to be_a Msf::Simple::Framework::ModulePaths }
 
   context '#init_module_paths' do
@@ -20,7 +20,7 @@ shared_examples_for 'Msf::Simple::Framework::ModulePaths' do
       {}
     end
 
-    before(:each) do
+    before(:example) do
       # create the framework first so that it's initialization's call
       # to init_module_paths doesn't get captured.
       framework
@@ -41,7 +41,7 @@ shared_examples_for 'Msf::Simple::Framework::ModulePaths' do
     end
 
     context 'Msf::Config' do
-      before(:each) do
+      before(:example) do
         allow(Rails.application.paths).to receive(:[]).with('modules').and_return(nil)
       end
 
@@ -64,7 +64,7 @@ shared_examples_for 'Msf::Simple::Framework::ModulePaths' do
     end
 
     context 'datastore' do
-      before(:each) do
+      before(:example) do
         allow(Rails.application.paths).to receive(:[]).with('modules').and_return(nil)
       end
 
@@ -79,7 +79,7 @@ shared_examples_for 'Msf::Simple::Framework::ModulePaths' do
           module_paths
         end
 
-        before(:each) do
+        before(:example) do
           msf_module_paths = module_paths.join(';')
           framework.datastore['MsfModulePaths'] = msf_module_paths
         end

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -69,7 +69,7 @@
 # @option options [String] :reference_name The reference name for payload class that should be instantiated from mixing
 #   `:ancestor_reference_names`.
 # @return [void]
-shared_examples_for 'payload cached size is consistent' do |options|
+RSpec.shared_examples_for 'payload cached size is consistent' do |options|
 
   options.assert_valid_keys(:ancestor_reference_names, :modules_pathname, :reference_name, :dynamic_size)
 

--- a/spec/support/shared/examples/rex/encoder/alpha2/generic.rb
+++ b/spec/support/shared/examples/rex/encoder/alpha2/generic.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'Rex::Encoder::Alpha2::Generic' do
+RSpec.shared_examples_for 'Rex::Encoder::Alpha2::Generic' do
 
   describe ".encode_byte" do
     subject(:encoded_byte) { described_class.encode_byte(block, badchars) }

--- a/spec/support/shared/examples/rex/encoder/ndr/wstring.rb
+++ b/spec/support/shared/examples/rex/encoder/ndr/wstring.rb
@@ -1,4 +1,4 @@
-shared_examples_for "Rex::Encoder::NDR.wstring" do
+RSpec.shared_examples_for "Rex::Encoder::NDR.wstring" do
   let(:string) { "ABCD" }
 
   it "encodes the argument as null-terminated unicode string" do

--- a/spec/support/shared/examples/rex/encoder/ndr/wstring_prebuild.rb
+++ b/spec/support/shared/examples/rex/encoder/ndr/wstring_prebuild.rb
@@ -1,4 +1,4 @@
-shared_examples_for "Rex::Encoder::NDR.wstring_prebuild" do
+RSpec.shared_examples_for "Rex::Encoder::NDR.wstring_prebuild" do
   context "when 2-byte aligned string length" do
     let(:string) { "A\x00B\x00C\x00" }
 

--- a/spec/support/shared/examples/rex/image_source/image_source.rb
+++ b/spec/support/shared/examples/rex/image_source/image_source.rb
@@ -1,4 +1,4 @@
-shared_examples_for "Rex::ImageSource::ImageSource" do
+RSpec.shared_examples_for "Rex::ImageSource::ImageSource" do
 
   describe "#read_asciiz" do
     let(:offset) { 0 }

--- a/spec/support/shared/examples/typed_path.rb
+++ b/spec/support/shared/examples/typed_path.rb
@@ -1,5 +1,5 @@
 # -*- coding:binary -*-
-shared_examples_for 'typed_path' do |map|
+RSpec.shared_examples_for 'typed_path' do |map|
   map ||= {}
   if map.length < 1
     raise ArgumentError,

--- a/spec/support/shared/examples/xor_encoder.rb
+++ b/spec/support/shared/examples/xor_encoder.rb
@@ -1,5 +1,5 @@
 # -*- coding: binary -*-
-shared_examples_for 'an xor encoder' do |keysize|
+RSpec.shared_examples_for 'an xor encoder' do |keysize|
 
   it "should encode one block" do
     # Yup it returns one of its arguments in an array... Because spoon.

--- a/spec/tools/egghunter_spec.rb
+++ b/spec/tools/egghunter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Egghunter do
         { :platform => 'windows', :format => 'c', :eggtag => egg, :arch => 'x86' }
       }
 
-      before(:each) do
+      before(:example) do
         allow(Egghunter::OptsConsole).to receive(:parse).with(any_args).and_return(options)
       end
 

--- a/spec/tools/java_deserializer_spec.rb
+++ b/spec/tools/java_deserializer_spec.rb
@@ -5,7 +5,7 @@ load Metasploit::Framework.root.join('tools/exploit/java_deserializer.rb').to_pa
 
 RSpec.describe JavaDeserializer do
 
-  before(:all) do
+  before(:context) do
     @out = $stdout
     @err = $stderr
 
@@ -13,7 +13,7 @@ RSpec.describe JavaDeserializer do
     $stderr = StringIO.new
   end
 
-  after(:all) do
+  after(:context) do
     $stdout = @out
     $stderr = @err
   end
@@ -47,7 +47,7 @@ RSpec.describe JavaDeserializer do
     end
 
     context "when file contains a valid stream" do
-      before(:each) do
+      before(:example) do
         $stdout.string = ''
       end
 

--- a/spec/tools/jsobfu_spec.rb
+++ b/spec/tools/jsobfu_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Jsobfu do
         { :input => fname, :iteration => 1 }
       }
 
-      before(:each) do
+      before(:example) do
         allow(Jsobfu::OptsConsole).to receive(:parse).with(any_args).and_return(default_opts)
         allow(File).to receive(:open).with(fname, 'rb').and_yield(StringIO.new(js))
         @out = $stdout
@@ -33,7 +33,7 @@ RSpec.describe Jsobfu do
         $stdout.string = ''
       end
 
-      after(:each) do
+      after(:example) do
         $stdout = @out
       end
 

--- a/spec/tools/md5_lookup_spec.rb
+++ b/spec/tools/md5_lookup_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Md5LookupUtility do
       }
     }
 
-    before(:each) do
+    before(:example) do
       expect(Md5LookupUtility::OptsConsole).to receive(:parse).with(any_args).and_return(options)
       allow(File).to receive(:open).with(input_file, 'rb').and_yield(StringIO.new(input_data))
       allow(File).to receive(:new).with(output_file, 'wb').and_return(StringIO.new)
@@ -320,7 +320,7 @@ RSpec.describe Md5LookupUtility do
       context 'when valid arguments are passed' do
         let(:opts) { subject.parse(valid_argv) }
 
-        before(:each) do
+        before(:example) do
           allow(File).to receive(:exists?).and_return(true)
         end
 
@@ -339,7 +339,7 @@ RSpec.describe Md5LookupUtility do
       end
 
       context 'when the required input file is not set' do
-        before(:each) do
+        before(:example) do
           allow(File).to receive(:exists?).and_return(false)
         end
 

--- a/spec/tools/msu_finder_spec.rb
+++ b/spec/tools/msu_finder_spec.rb
@@ -5,7 +5,7 @@ require 'uri'
 
 RSpec.describe MicrosoftPatchFinder do
 
-  before(:each) do
+  before(:example) do
     cli = Rex::Proto::Http::Client.new('127.0.0.1')
     allow(cli).to receive(:connect)
     allow(cli).to receive(:request_cgi)
@@ -204,7 +204,7 @@ RSpec.describe MicrosoftPatchFinder do
       MicrosoftPatchFinder::PatchLinkCollector.new
     end
 
-    before(:each) do
+    before(:example) do
       allow(patch_link_collector).to receive(:print_debug)
     end
 
@@ -369,7 +369,7 @@ RSpec.describe MicrosoftPatchFinder do
       MicrosoftPatchFinder::TechnetMsbSearch.new
     end
 
-    before(:each) do
+    before(:example) do
       allow_any_instance_of(MicrosoftPatchFinder::TechnetMsbSearch).to receive(:print_debug)
       allow_any_instance_of(MicrosoftPatchFinder::TechnetMsbSearch).to receive(:send_http_request) { |info_obj, info_opts, opts|
         case opts['uri']
@@ -556,7 +556,7 @@ RSpec.describe MicrosoftPatchFinder do
         |
     end
 
-    before(:each) do
+    before(:example) do
       allow_any_instance_of(MicrosoftPatchFinder::GoogleMsbSearch).to receive(:print_debug)
       allow_any_instance_of(MicrosoftPatchFinder::GoogleMsbSearch).to receive(:send_http_request) { |info_obj, info_opts, opts|
         res = Rex::Proto::Http::Response.new
@@ -620,7 +620,7 @@ RSpec.describe MicrosoftPatchFinder do
       'http://download.microsoft.com/download/9/0/6/906BC7A4-7DF7-4C24-9F9D-3E801AA36ED3/Windows6.0-KB3087918-x86.msu'
     end
 
-    before(:each) do
+    before(:example) do
       opts = { keyword: msb }
       allow(MicrosoftPatchFinder::OptsConsole).to receive(:get_parsed_options).and_return(opts)
       allow_any_instance_of(MicrosoftPatchFinder::PatchLinkCollector).to receive(:download_advisory).and_return(Rex::Proto::Http::Response.new)

--- a/spec/tools/virustotal_spec.rb
+++ b/spec/tools/virustotal_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe VirusTotalUtility do
             }
           end
 
-          before(:each) do
+          before(:example) do
             @upload_data = vt.send(:_create_upload_data, form_opts)
           end
 


### PR DESCRIPTION
Now that we are on Rspec 3 we should be using the current proper conventions in all of our specs.
This PR adds changes made by the transpec tool to update the specs

VERIFICATION STEPS
- [ ] `rake spec`
- [ ] VERIFY all specs pass
