### PR TITLE
update to nokogiri 1.6.7.1 - security update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     multi_json (1.11.2)
     multi_test (0.1.2)
     network_interface (0.0.1)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     openssl-ccm (1.2.1)
     packetfu (1.1.11)


### PR DESCRIPTION
This fixes a few issues in libxml2 if you are building with the bundled gem library:

https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
