### PR TITLE
Fix msfenv requirement

### DIFF
--- a/tools/exploit/egghunter.rb
+++ b/tools/exploit/egghunter.rb
@@ -4,10 +4,10 @@ msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
+
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
+require 'msfenv'
 require 'rex'
-require 'msf/core'
-require 'msf/base'
 require 'optparse'
 
 module Egghunter


### PR DESCRIPTION
On 100% Stock Kali 2.0, running the following command without this change would result in:

root@kali:/usr/share/metasploit-framework# ruby tools/exploit/egghunter.rb 
/usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rkelly (LoadError)
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from /usr/share/metasploit-framework/lib/rex/proto/http/response.rb:5:in `<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/share/metasploit-framework/lib/rex/proto/http.rb:4:in`<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from /usr/share/metasploit-framework/lib/rex/proto.rb:2:in `<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/share/metasploit-framework/lib/rex.rb:79:in`<top (required)>'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
    from tools/exploit/egghunter.rb:8:in `<main>'
