### PR TITLE
Fix crash when tab-completing LHOST and Ifaddr#addr is nil

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1169,7 +1169,7 @@ class Core
           output += "\n"
         end
 
-        print(output +"\n")
+        print(output + "\n")
       else
         print_line("Invalid Thread ID")
       end
@@ -1251,7 +1251,7 @@ class Core
         print_status("Successfully loaded plugin: #{inst.name}")
       end
     rescue ::Exception => e
-      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", src = 'core', level = 0, from = caller)
+      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0, caller)
       print_error("Failed to load plugin from #{path}: #{e}")
     end
   end
@@ -2222,7 +2222,7 @@ class Core
     end
 
     mod.options.sorted.each { |e|
-      name, opt = e
+      name, _opt = e
       res << name
     }
 
@@ -2244,7 +2244,7 @@ class Core
       p = framework.payloads.create(mod.datastore['PAYLOAD'])
       if (p)
         p.options.sorted.each { |e|
-          name, opt = e
+          name, _opt = e
           res << name
         }
       end
@@ -2454,7 +2454,7 @@ class Core
     return tabs
   end
 
- def cmd_get_help
+  def cmd_get_help
     print_line "Usage: get var1 [var2 ...]"
     print_line
     print_line "The get command is used to get the value of one or more variables."

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3090,7 +3090,9 @@ class Core
           # getifaddrs was introduced in 2.1.2
           if Socket.respond_to?(:getifaddrs)
             ifaddrs = Socket.getifaddrs.find_all do |ifaddr|
-              ((ifaddr.flags & Socket::IFF_LOOPBACK) == 0) && ifaddr.addr.ip?
+              ((ifaddr.flags & Socket::IFF_LOOPBACK) == 0) &&
+                ifaddr.addr &&
+                ifaddr.addr.ip?
             end
             res += ifaddrs.map { |ifaddr| ifaddr.addr.ip_address }
           end


### PR DESCRIPTION
See http://ruby-doc.org/stdlib-2.2.2/libdoc/socket/rdoc/Socket/Ifaddr.html#method-i-addr
Which says:

> Returns the address of _ifaddr_. nil is returned if address is not
>   available in _ifaddr_.

I ran into this with a teql interface, but who knows what else might
trigger it.
