### PR TITLE
Update egghunter.rb - Add msfenv requirements

### DIFF
--- a/tools/exploit/egghunter.rb
+++ b/tools/exploit/egghunter.rb
@@ -5,9 +5,10 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
-require 'rex'
+require 'msfenv'
 require 'msf/core'
 require 'msf/base'
+require 'rex'
 require 'optparse'
 
 module Egghunter


### PR DESCRIPTION
On Stock Kali 2.0 (after apt-get upgrade), the following command errors **./egghunter.rb --list-formats**  Adding _require 'msfenv'_ to the file alleviates the issue.

**Before:**
_./egghunter.rb --list-formats_

> /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rkelly (LoadError)
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
>     from /usr/share/metasploit-framework/lib/rex/proto/http/response.rb:5:in `<top (required)>'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
>     from /usr/share/metasploit-framework/lib/rex/proto/http.rb:4:in`<top (required)>'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
>     from /usr/share/metasploit-framework/lib/rex/proto.rb:2:in `<top (required)>'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
>     from /usr/share/metasploit-framework/lib/rex.rb:79:in`<top (required)>'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
>     from /usr/share/metasploit-framework/lib/msf/core.rb:17:in `<top (required)>'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
>     from /usr/share/metasploit-framework/lib/msf/base.rb:17:in`<top (required)>'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
>     from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in`require'
>     from ./egghunter.rb:9:in `main'

**After:**
_./egghunter.rb --list-formats_

> [*] Supported output formats:
> bash, c, csharp, dw, dword, hex, java, js_be, js_le, num, perl, pl, powershell, ps1, py, python, raw, rb, ruby, sh, vbapplication, vbscript
