### PR TITLE
deprecate auxiliary/scanner/misc/redis_server

### DIFF
--- a/modules/auxiliary/scanner/misc/redis_server.rb
+++ b/modules/auxiliary/scanner/misc/redis_server.rb
@@ -7,6 +7,9 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2016, 3, 5), 'auxiliary/scanner/redis/redis_server')
+
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::Tcp


### PR DESCRIPTION
```
msf > use auxiliary/scanner/misc/redis_server 

[!] ************************************************************************
[!] *         The module scanner/misc/redis_server is deprecated!          *
[!] *              It will be removed on or about 2016-03-05               *
[!] *           Use auxiliary/scanner/redis/redis_server instead           *
[!] ************************************************************************
```
