### PR TITLE
Backport net-ssh Diffie-Hellman Group Exchange SHA-256 key exchange

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -25,7 +25,8 @@ module Net; module SSH; module Transport
     ALGORITHMS = {
       :host_key    => %w(ssh-rsa ssh-dss),
       :kex         => %w(diffie-hellman-group-exchange-sha1
-                         diffie-hellman-group1-sha1),
+                         diffie-hellman-group1-sha1 
+                         diffie-hellman-group-exchange-sha256),
       :encryption  => %w(aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
                          aes192-cbc aes256-cbc rijndael-cbc@lysator.liu.se
                          idea-cbc none arcfour128 arcfour256),

--- a/lib/net/ssh/transport/kex.rb
+++ b/lib/net/ssh/transport/kex.rb
@@ -10,7 +10,9 @@ module Net::SSH::Transport
     MAP = {
       'diffie-hellman-group-exchange-sha1'   => DiffieHellmanGroupExchangeSHA1,
       'diffie-hellman-group1-sha1'           => DiffieHellmanGroup1SHA1,
-      'diffie-hellman-group-exchange-sha256' => DiffieHellmanGroupExchangeSHA256
     }
+    if defined?(DiffieHellmanGroupExchangeSHA256)
+      MAP['diffie-hellman-group-exchange-sha256'] = DiffieHellmanGroupExchangeSHA256
+    end
   end
 end

--- a/lib/net/ssh/transport/kex.rb
+++ b/lib/net/ssh/transport/kex.rb
@@ -8,8 +8,8 @@ module Net::SSH::Transport
     # Maps the supported key-exchange algorithms as named by the SSH protocol
     # to their corresponding implementors.
     MAP = {
-      'diffie-hellman-group-exchange-sha1'   => DiffieHellmanGroupExchangeSHA1,
-      'diffie-hellman-group1-sha1'           => DiffieHellmanGroup1SHA1,
+      'diffie-hellman-group-exchange-sha1' => DiffieHellmanGroupExchangeSHA1,
+      'diffie-hellman-group1-sha1'         => DiffieHellmanGroup1SHA1,
     }
     if defined?(DiffieHellmanGroupExchangeSHA256)
       MAP['diffie-hellman-group-exchange-sha256'] = DiffieHellmanGroupExchangeSHA256

--- a/lib/net/ssh/transport/kex.rb
+++ b/lib/net/ssh/transport/kex.rb
@@ -1,14 +1,16 @@
 # -*- coding: binary -*-
 require 'net/ssh/transport/kex/diffie_hellman_group1_sha1'
 require 'net/ssh/transport/kex/diffie_hellman_group_exchange_sha1'
+require 'net/ssh/transport/kex/diffie_hellman_group_exchange_sha256'
 
 module Net::SSH::Transport
   module Kex
     # Maps the supported key-exchange algorithms as named by the SSH protocol
     # to their corresponding implementors.
     MAP = {
-      'diffie-hellman-group-exchange-sha1' => DiffieHellmanGroupExchangeSHA1,
-      'diffie-hellman-group1-sha1'         => DiffieHellmanGroup1SHA1
+      'diffie-hellman-group-exchange-sha1'   => DiffieHellmanGroupExchangeSHA1,
+      'diffie-hellman-group1-sha1'           => DiffieHellmanGroup1SHA1,
+      'diffie-hellman-group-exchange-sha256' => DiffieHellmanGroupExchangeSHA256
     }
   end
 end

--- a/lib/net/ssh/transport/kex.rb
+++ b/lib/net/ssh/transport/kex.rb
@@ -9,7 +9,7 @@ module Net::SSH::Transport
     # to their corresponding implementors.
     MAP = {
       'diffie-hellman-group-exchange-sha1' => DiffieHellmanGroupExchangeSHA1,
-      'diffie-hellman-group1-sha1'         => DiffieHellmanGroup1SHA1,
+      'diffie-hellman-group1-sha1'         => DiffieHellmanGroup1SHA1
     }
     if defined?(DiffieHellmanGroupExchangeSHA256)
       MAP['diffie-hellman-group-exchange-sha256'] = DiffieHellmanGroupExchangeSHA256

--- a/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha256.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha256.rb
@@ -1,0 +1,15 @@
+require 'net/ssh/transport/kex/diffie_hellman_group_exchange_sha1'
+
+module Net::SSH::Transport::Kex
+  if defined?(OpenSSL::Digest::SHA256)
+    # A key-exchange service implementing the
+    # "diffie-hellman-group-exchange-sha256" key-exchange algorithm.
+    class DiffieHellmanGroupExchangeSHA256 < DiffieHellmanGroupExchangeSHA1
+      def initialize(*args)
+        super(*args)
+
+        @digester = OpenSSL::Digest::SHA256
+      end
+    end
+  end
+end

--- a/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha256.rb
+++ b/lib/net/ssh/transport/kex/diffie_hellman_group_exchange_sha256.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'net/ssh/transport/kex/diffie_hellman_group_exchange_sha1'
 
 module Net::SSH::Transport::Kex


### PR DESCRIPTION
# Purpose

Backport support for Diffie-Hellman Group Exchange SHA-256 key exchange from https://github.com/net-ssh/net-ssh.

Console output below is of `auxiliary/scanner/ssh/ssh_login` being run against an OpenSSH instance configured to support only the key exchange algorithm of interest.
## Before code changes:

```
       =[ metasploit v4.11.6-dev-8cead41                  ]
+ -- --=[ 1518 exploits - 877 auxiliary - 257 post        ]
+ -- --=[ 437 payloads - 37 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

RHOSTS => 192.168.2.111
USERNAME => pi
PASSWORD => letmein
SSH_DEBUG => true
[*] 192.168.2.111:22 SSH - Starting bruteforce
[-] 192.168.2.111:22 SSH - Failed: 'pi:letmein'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed


SSH_DEBUG OUTPUT:
=================
D, [2016-01-08T02:18:39.687738 #72862] DEBUG -- net.ssh.transport.session[4d88660]: establishing connection to 192.168.2.111:22
D, [2016-01-08T02:18:39.696526 #72862] DEBUG -- net.ssh.transport.session[4d88660]: connection established
I, [2016-01-08T02:18:39.696713 #72862]  INFO -- net.ssh.transport.server_version[4d7f074]: negotiating protocol version
D, [2016-01-08T02:18:39.763959 #72862] DEBUG -- net.ssh.transport.server_version[4d7f074]: remote is `SSH-2.0-OpenSSH_6.7p1 Raspbian-5'
D, [2016-01-08T02:18:39.764805 #72862] DEBUG -- net.ssh.transport.server_version[4d7f074]: local is `SSH-2.0-OpenSSH_5.0'
D, [2016-01-08T02:18:39.771996 #72862] DEBUG -- socket[4d7f880]: read 744 bytes
D, [2016-01-08T02:18:39.772815 #72862] DEBUG -- socket[4d7f880]: received packet nr 0 type 20 len 740
I, [2016-01-08T02:18:39.773267 #72862]  INFO -- net.ssh.transport.algorithms[4d7c57c]: got KEXINIT from server
I, [2016-01-08T02:18:39.773716 #72862]  INFO -- net.ssh.transport.algorithms[4d7c57c]: sending KEXINIT
D, [2016-01-08T02:18:39.774315 #72862] DEBUG -- socket[4d7f880]: queueing packet nr 0 type 20 len 556
D, [2016-01-08T02:18:39.774810 #72862] DEBUG -- socket[4d7f880]: sent 560 bytes
I, [2016-01-08T02:18:39.775143 #72862]  INFO -- net.ssh.transport.algorithms[4d7c57c]: negotiating algorithms
```
## After code changes:

```
       =[ metasploit v4.11.6-dev-77cd28c                  ]
+ -- --=[ 1518 exploits - 877 auxiliary - 257 post        ]
+ -- --=[ 437 payloads - 37 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

RHOSTS => 192.168.2.111
USERNAME => pi
PASSWORD => letmein
SSH_DEBUG => true
[*] 192.168.2.111:22 SSH - Starting bruteforce
[+] 192.168.2.111:22 SSH - Success: 'pi:letmein' 'uid=1000(pi) gid=1000(pi) groups=1000(pi),108(docker),119(wireshark) Linux pi 3.18.11-hypriotos-v7+ #2 SMP PREEMPT Sun Apr 12 16:34:20 UTC 2015 armv7l GNU/Linux '
[*] Command shell session 1 opened (192.168.2.105:47844 -> 192.168.2.111:22) at 2016-01-08 02:16:22 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed



SSH_DEBUG OUTPUT:
=================
D, [2016-01-08T02:16:20.355759 #70733] DEBUG -- net.ssh.transport.session[244ad98]: establishing connection to 192.168.2.111:22
D, [2016-01-08T02:16:20.361394 #70733] DEBUG -- net.ssh.transport.session[244ad98]: connection established
I, [2016-01-08T02:16:20.362401 #70733]  INFO -- net.ssh.transport.server_version[2441a04]: negotiating protocol version
D, [2016-01-08T02:16:20.428799 #70733] DEBUG -- net.ssh.transport.server_version[2441a04]: remote is `SSH-2.0-OpenSSH_6.7p1 Raspbian-5'
D, [2016-01-08T02:16:20.429546 #70733] DEBUG -- net.ssh.transport.server_version[2441a04]: local is `SSH-2.0-OpenSSH_5.0'
D, [2016-01-08T02:16:20.436570 #70733] DEBUG -- socket[2446d24]: read 744 bytes
D, [2016-01-08T02:16:20.441182 #70733] DEBUG -- socket[2446d24]: received packet nr 0 type 20 len 740
I, [2016-01-08T02:16:20.441405 #70733]  INFO -- net.ssh.transport.algorithms[2431d84]: got KEXINIT from server
I, [2016-01-08T02:16:20.441630 #70733]  INFO -- net.ssh.transport.algorithms[2431d84]: sending KEXINIT
D, [2016-01-08T02:16:20.441951 #70733] DEBUG -- socket[2446d24]: queueing packet nr 0 type 20 len 588
D, [2016-01-08T02:16:20.442243 #70733] DEBUG -- socket[2446d24]: sent 592 bytes
I, [2016-01-08T02:16:20.443407 #70733]  INFO -- net.ssh.transport.algorithms[2431d84]: negotiating algorithms
D, [2016-01-08T02:16:20.443658 #70733] DEBUG -- net.ssh.transport.algorithms[2431d84]: negotiated:
* kex: diffie-hellman-group-exchange-sha256
* host_key: ssh-rsa
* encryption_server: aes128-cbc
* encryption_client: aes128-cbc
* hmac_client: hmac-sha1
* encryption_client: aes128-cbc
* hmac_client: hmac-sha1
* hmac_server: hmac-sha1
* compression_client: none
* compression_server: none
* language_client:
* language_server:
D, [2016-01-08T02:16:20.444578 #70733] DEBUG -- net.ssh.transport.algorithms[2431d84]: exchanging keys
D, [2016-01-08T02:16:20.444976 #70733] DEBUG -- socket[2446d24]: queueing packet nr 1 type 34 len 20
D, [2016-01-08T02:16:20.449201 #70733] DEBUG -- socket[2446d24]: sent 24 bytes
D, [2016-01-08T02:16:20.499143 #70733] DEBUG -- socket[2446d24]: read 152 bytes
D, [2016-01-08T02:16:20.499365 #70733] DEBUG -- socket[2446d24]: received packet nr 1 type 31 len 148
D, [2016-01-08T02:16:20.501101 #70733] DEBUG -- socket[2446d24]: queueing packet nr 2 type 32 len 140
D, [2016-01-08T02:16:20.501307 #70733] DEBUG -- socket[2446d24]: sent 144 bytes
D, [2016-01-08T02:16:20.590883 #70733] DEBUG -- socket[2446d24]: read 720 bytes
D, [2016-01-08T02:16:20.591148 #70733] DEBUG -- socket[2446d24]: received packet nr 2 type 33 len 700
D, [2016-01-08T02:16:20.593511 #70733] DEBUG -- socket[2446d24]: queueing packet nr 3 type 21 len 20
D, [2016-01-08T02:16:20.594470 #70733] DEBUG -- socket[2446d24]: sent 24 bytes
D, [2016-01-08T02:16:20.594911 #70733] DEBUG -- socket[2446d24]: received packet nr 3 type 21 len 12
D, [2016-01-08T02:16:20.595677 #70733] DEBUG -- net.ssh.authentication.session[238ca8c]: beginning authentication of `pi'
D, [2016-01-08T02:16:20.596311 #70733] DEBUG -- socket[2446d24]: queueing packet nr 4 type 5 len 28
D, [2016-01-08T02:16:20.596823 #70733] DEBUG -- socket[2446d24]: sent 52 bytes
D, [2016-01-08T02:16:20.597707 #70733] DEBUG -- socket[2446d24]: read 52 bytes
D, [2016-01-08T02:16:20.598151 #70733] DEBUG -- socket[2446d24]: received packet nr 4 type 6 len 28
D, [2016-01-08T02:16:20.598594 #70733] DEBUG -- net.ssh.authentication.session[238ca8c]: trying password
D, [2016-01-08T02:16:20.599212 #70733] DEBUG -- socket[2446d24]: queueing packet nr 5 type 50 len 60
D, [2016-01-08T02:16:20.599679 #70733] DEBUG -- socket[2446d24]: sent 84 bytes
D, [2016-01-08T02:16:20.934675 #70733] DEBUG -- socket[2446d24]: read 36 bytes
D, [2016-01-08T02:16:20.935591 #70733] DEBUG -- socket[2446d24]: received packet nr 5 type 52 len 12
D, [2016-01-08T02:16:20.936105 #70733] DEBUG -- net.ssh.authentication.methods.password[23886f8]: password succeeded
D, [2016-01-08T02:16:20.936916 #70733] DEBUG -- socket[2446d24]: queueing packet nr 6 type 90 len 44
D, [2016-01-08T02:16:20.937681 #70733] DEBUG -- socket[2446d24]: sent 68 bytes
D, [2016-01-08T02:16:21.058093 #70733] DEBUG -- socket[2446d24]: read 52 bytes
D, [2016-01-08T02:16:21.058413 #70733] DEBUG -- socket[2446d24]: received packet nr 6 type 91 len 28
I, [2016-01-08T02:16:21.058596 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_open_confirmation: 0 0 0 32768
I, [2016-01-08T02:16:21.058718 #70733]  INFO -- net.ssh.connection.channel[23862f4]: sending channel request "exec"
D, [2016-01-08T02:16:21.058876 #70733] DEBUG -- socket[2446d24]: queueing packet nr 7 type 98 len 28
D, [2016-01-08T02:16:21.059217 #70733] DEBUG -- socket[2446d24]: sent 52 bytes
D, [2016-01-08T02:16:21.062349 #70733] DEBUG -- socket[2446d24]: read 88 bytes
D, [2016-01-08T02:16:21.065597 #70733] DEBUG -- socket[2446d24]: received packet nr 7 type 93 len 28
I, [2016-01-08T02:16:21.065920 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_window_adjust: 0 +2097152
D, [2016-01-08T02:16:21.066369 #70733] DEBUG -- socket[2446d24]: received packet nr 8 type 99 len 12
I, [2016-01-08T02:16:21.066761 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_success: 0
D, [2016-01-08T02:16:21.088602 #70733] DEBUG -- socket[2446d24]: read 152 bytes
D, [2016-01-08T02:16:21.089383 #70733] DEBUG -- socket[2446d24]: read 172 bytes
D, [2016-01-08T02:16:21.090026 #70733] DEBUG -- socket[2446d24]: received packet nr 9 type 94 len 92
I, [2016-01-08T02:16:21.090596 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_data: 0 69b
D, [2016-01-08T02:16:21.091163 #70733] DEBUG -- socket[2446d24]: received packet nr 10 type 96 len 12
I, [2016-01-08T02:16:21.091675 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_eof: 0
D, [2016-01-08T02:16:21.092217 #70733] DEBUG -- socket[2446d24]: received packet nr 11 type 98 len 44
I, [2016-01-08T02:16:21.092803 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_request: 0 exit-status false
D, [2016-01-08T02:16:21.093385 #70733] DEBUG -- socket[2446d24]: received packet nr 12 type 98 len 44
I, [2016-01-08T02:16:21.093855 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_request: 0 eow@openssh.com false
D, [2016-01-08T02:16:21.094360 #70733] DEBUG -- socket[2446d24]: received packet nr 13 type 97 len 12
I, [2016-01-08T02:16:21.094763 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_close: 0
D, [2016-01-08T02:16:21.095217 #70733] DEBUG -- socket[2446d24]: queueing packet nr 8 type 97 len 28
D, [2016-01-08T02:16:21.095863 #70733] DEBUG -- socket[2446d24]: queueing packet nr 9 type 90 len 44
D, [2016-01-08T02:16:21.096879 #70733] DEBUG -- socket[2446d24]: sent 120 bytes
D, [2016-01-08T02:16:21.098473 #70733] DEBUG -- socket[2446d24]: read 52 bytes
D, [2016-01-08T02:16:21.099753 #70733] DEBUG -- socket[2446d24]: received packet nr 14 type 91 len 28
I, [2016-01-08T02:16:21.100948 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_open_confirmation: 1 1 0 32768
I, [2016-01-08T02:16:21.101840 #70733]  INFO -- net.ssh.connection.channel[2371c64]: sending channel request "exec"
D, [2016-01-08T02:16:21.102826 #70733] DEBUG -- socket[2446d24]: queueing packet nr 10 type 98 len 44
D, [2016-01-08T02:16:21.103603 #70733] DEBUG -- socket[2446d24]: sent 68 bytes
D, [2016-01-08T02:16:21.107850 #70733] DEBUG -- socket[2446d24]: read 88 bytes
D, [2016-01-08T02:16:21.109296 #70733] DEBUG -- socket[2446d24]: received packet nr 15 type 93 len 28
I, [2016-01-08T02:16:21.110458 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_window_adjust: 1 +2097152
D, [2016-01-08T02:16:21.111913 #70733] DEBUG -- socket[2446d24]: received packet nr 16 type 99 len 12
I, [2016-01-08T02:16:21.114168 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_success: 1
D, [2016-01-08T02:16:21.127346 #70733] DEBUG -- socket[2446d24]: read 340 bytes
D, [2016-01-08T02:16:21.129143 #70733] DEBUG -- socket[2446d24]: received packet nr 17 type 94 len 108
I, [2016-01-08T02:16:21.130268 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_data: 1 92b
D, [2016-01-08T02:16:21.130962 #70733] DEBUG -- socket[2446d24]: received packet nr 18 type 96 len 12
I, [2016-01-08T02:16:21.131522 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_eof: 1
D, [2016-01-08T02:16:21.131990 #70733] DEBUG -- socket[2446d24]: received packet nr 19 type 98 len 44
I, [2016-01-08T02:16:21.132815 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_request: 1 exit-status false
D, [2016-01-08T02:16:21.133646 #70733] DEBUG -- socket[2446d24]: received packet nr 20 type 98 len 44
I, [2016-01-08T02:16:21.134180 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_request: 1 eow@openssh.com false
D, [2016-01-08T02:16:21.134739 #70733] DEBUG -- socket[2446d24]: received packet nr 21 type 97 len 12
I, [2016-01-08T02:16:21.135286 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_close: 1
D, [2016-01-08T02:16:21.135863 #70733] DEBUG -- socket[2446d24]: queueing packet nr 11 type 97 len 28
D, [2016-01-08T02:16:21.513361 #70733] DEBUG -- socket[2446d24]: queueing packet nr 12 type 90 len 44
D, [2016-01-08T02:16:21.515510 #70733] DEBUG -- socket[2446d24]: sent 120 bytes
D, [2016-01-08T02:16:21.520510 #70733] DEBUG -- socket[2446d24]: read 52 bytes
D, [2016-01-08T02:16:21.521446 #70733] DEBUG -- socket[2446d24]: received packet nr 22 type 91 len 28
I, [2016-01-08T02:16:21.521923 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_open_confirmation: 2 0 0 32768
I, [2016-01-08T02:16:21.522335 #70733]  INFO -- net.ssh.connection.channel[19be08c]: sending channel request "exec"
D, [2016-01-08T02:16:21.522866 #70733] DEBUG -- socket[2446d24]: queueing packet nr 13 type 98 len 44
D, [2016-01-08T02:16:21.523461 #70733] DEBUG -- socket[2446d24]: sent 68 bytes
D, [2016-01-08T02:16:21.527181 #70733] DEBUG -- socket[2446d24]: read 88 bytes
D, [2016-01-08T02:16:21.528181 #70733] DEBUG -- socket[2446d24]: received packet nr 23 type 93 len 28
I, [2016-01-08T02:16:21.530458 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_window_adjust: 2 +2097152
D, [2016-01-08T02:16:21.531558 #70733] DEBUG -- socket[2446d24]: received packet nr 24 type 99 len 12
I, [2016-01-08T02:16:21.533176 #70733]  INFO -- net.ssh.connection.session[23867e0]: channel_success: 2
```

This is my first PR against metasploit, so please be as critical as possible :) 

I'm planning on doing a couple more related to this (maybe more KEx's or a few ciphers) if that would be welcomed.
