### PR TITLE
Fix dns labels/names size limits

### DIFF
--- a/lib/net/dns/names/names.rb
+++ b/lib/net/dns/names/names.rb
@@ -46,8 +46,8 @@ module Net # :nodoc:
       end
       
       def pack_name(name)
-        if name.size > 63
-          raise ArgumentError, "Label data cannot exceed 63 chars"
+        if name.size > 255
+          raise ArgumentError, "Name data cannot exceed 255 chars"
         end
         arr = name.split(".")
         str = ""

--- a/lib/net/dns/names/names.rb
+++ b/lib/net/dns/names/names.rb
@@ -52,6 +52,9 @@ module Net # :nodoc:
         arr = name.split(".")
         str = ""
         arr.each do |elem|
+          if elem.size > 63
+            raise ArgumentError, "Label data cannot exceed 63 chars"
+          end
           str += [elem.size,elem].pack("Ca*")
         end
         str += [0].pack("C")

--- a/spec/lib/net/dns/names/names_spec.rb
+++ b/spec/lib/net/dns/names/names_spec.rb
@@ -1,0 +1,129 @@
+require 'msf/core'
+
+RSpec.describe Net::DNS::Names do
+  subject do
+    obj = Object.new
+    obj.extend(described_class)
+  end
+
+  describe '#dn_expand' do
+    context 'when offset is great than packet length' do
+      let(:packet) do
+        'AAAAA'
+      end
+
+      let(:offset) do
+        10
+      end
+
+      it 'raises an ExpandError exception' do
+        expect { subject.dn_expand(packet, offset) }.to raise_exception(ExpandError)
+      end
+    end
+
+    context 'when packet length is less than offset + INT16SZ' do
+      let(:packet) do
+        "\xc0"
+      end
+
+      let(:offset) do
+        0
+      end
+
+      it 'raises an ExpandError exception' do
+        expect { subject.dn_expand(packet, offset) }.to raise_exception(ExpandError)
+      end
+    end
+
+    context 'when packet length is less than offset + packet length' do
+      let(:packet) do
+        'AAAAA'
+      end
+
+      let(:offset) do
+        4
+      end
+
+      it 'raises an ExpandError exception' do
+        expect { subject.dn_expand(packet, offset) }.to raise_exception(ExpandError)
+      end
+    end
+  end
+
+  describe '#pack_name' do
+    context 'when name data size is larger than 255 bytes' do
+      let(:name) do
+        'A' * (255+1)
+      end
+
+      it 'raises an ArgumentError exception' do
+        expect { subject.pack_name(name) }.to raise_exception(ArgumentError)
+      end
+    end
+
+    context 'when label data is larger than 63 bytes' do
+      let(:name) do
+        'A' * (63+1) + '.'
+      end
+
+      it 'raises an ArgumentError exception' do
+        expect { subject.pack_name(name) }.to raise_exception(ArgumentError)
+      end 
+    end
+  end
+
+  describe '#names_array' do
+    let(:name) do
+      "AAA.AAA"
+    end
+
+    it 'returns an Array' do
+      expect(subject.names_array(name)).to be_kind_of(Array)
+    end
+  end
+
+  describe '#dn_comp' do
+    let(:name) do
+      'AAAA'
+    end
+
+    let(:offset) do
+      0
+    end
+
+    let(:compnames) do
+      {}
+    end
+
+    it 'returns 3 values' do
+      v = subject.dn_comp(name, offset, compnames)
+      expect(v.length).to eq(3)
+      expect(v[0]).to be_kind_of(String)
+      expect(v[1]).to be_kind_of(Fixnum)
+      expect(v[2]).to be_kind_of(Hash)
+    end
+  end
+
+  describe '#valid?' do
+    context 'when FQDN is valid' do
+      let(:fqdn) do
+        'example.com'
+      end
+
+      it 'returns the FQDN' do
+        expect(subject.valid?(fqdn)).to eq(fqdn)
+      end
+
+    end
+
+    context 'when FQDN is not valid' do
+      let(:fqdn) do
+        'INVALID'
+      end
+
+      it 'raises ArgumentError exception' do
+        expect { subject.valid?(fqdn) }.to raise_exception(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- #6187 - [Clean up and enhance enum_dns](https://github.com/rapid7/metasploit-framework/pull/6187)
- #6447 - [Net::DNS improperly (?) handles CNAMEs > 63 characters](https://github.com/rapid7/metasploit-framework/issues/6447)

When @jhart-r7 tests [**enum_dns**](https://github.com/rapid7/metasploit-framework/pull/6187), he finds that:

```
>> Net::DNS::Packet.parse(IO.read("/home/jhart/dns.bin"))
ArgumentError: Label data cannot exceed 63 chars
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/names/names.rb:50:in `pack_name'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/rr/cname.rb:31:in `build_pack'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/rr.rb:335:in `new_from_binary'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/rr.rb:176:in `parse_packet'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/rr.rb:327:in `new_from_binary'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/rr.rb:176:in `parse_packet'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/packet.rb:522:in `block in new_from_data'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/packet.rb:521:in `times'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/packet.rb:521:in `new_from_data'
    from /home/jhart/rapid7/metasploit-framework/lib/net/dns/packet.rb:153:in `parse'
    from (irb):6:in `cmd_irb'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:53:in `block in run'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `catch'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `run'
    from /home/jhart/rapid7/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:882:in `cmd_irb'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
    from /home/jhart/rapid7/metasploit-framework/lib/rex/ui/text/shell.rb:203:in `run'
    from /home/jhart/rapid7/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
    from /home/jhart/rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
```

the RFC makes this restriction because of how DNS labels are compressed, but this was also the same RFC which prohibited DNS names from starting with numbers which has since been relaxed. It also appears that other tools seem to handle these longer names without issue:

```
$  host spoofed.co                                                                       
spoofed.co is an alias for pr-co-suspensions.neuweb.biz.
pr-co-suspensions.neuweb.biz is an alias for WS-PR-WEB-suspensionpages-1962938698.us-east-1.elb.amazonaws.com.
WS-PR-WEB-suspensionpages-1962938698.us-east-1.elb.amazonaws.com has address 54.174.168.184
WS-PR-WEB-suspensionpages-1962938698.us-east-1.elb.amazonaws.com has address 52.22.183.58
$  echo -n WS-PR-WEB-suspensionpages-1962938698.us-east-1.elb.amazonaws.com |wc -c  
      64
```

---

From [**RFC 1035**](http://www.faqs.org/rfcs/rfc1035.html) , we can learn that:

```
2.3.4. Size limits

Various objects and parameters in the DNS have size limits.  They are
listed below.  Some could be easily changed, others are more
fundamental.

labels          63 octets or less

names           255 octets or less

TTL             positive values of a signed 32 bit number.

UDP messages    512 octets or less

3. DOMAIN NAME SPACE AND RR DEFINITIONS

3.1. Name space definitions

Domain names in messages are expressed in terms of a sequence of labels.
Each label is represented as a one octet length field followed by that
number of octets.  Since every domain name ends with the null label of
the root, a domain name is terminated by a length byte of zero.  The
high order two bits of every length octet must be zero, and the
remaining six bits of the length field limit the label to 63 octets or
less.

To simplify implementations, the total length of a domain name (i.e.,
label octets and label length octets) is restricted to 255 octets or
less.
```

We should make a name split into serval labels, ex:

**Name**: dev.rapid7.com (size <= 255)
**Label-1**: dev  (size <= 63)
**Label-2**: rapid7 (size <= 63)
**Label-3**: com (size <= 63)
**Label-4**: null (size <= 63)

If we fix size limits of name, everything goes well. Please read [**RFC 1035**](http://www.faqs.org/rfcs/rfc1035.html) for more details. Thanks @jhart-r7.
