### PR TITLE
Backport net-ssh AES CTR ciphers

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -29,7 +29,7 @@ module Net; module SSH; module Transport
       :encryption  => %w(aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
                          aes192-cbc aes256-cbc rijndael-cbc@lysator.liu.se
                          idea-cbc none arcfour128 arcfour256
-                         aes256-ctr),
+                         aes192-ctr aes256-ctr),
       :hmac        => %w(hmac-sha1 hmac-md5 hmac-sha1-96 hmac-md5-96 none),
       :compression => %w(none zlib@openssh.com zlib),
       :language    => %w() 

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -29,7 +29,7 @@ module Net; module SSH; module Transport
       :encryption  => %w(aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
                          aes192-cbc aes256-cbc rijndael-cbc@lysator.liu.se
                          idea-cbc none arcfour128 arcfour256
-                         aes192-ctr aes256-ctr),
+                         aes128-ctr aes192-ctr aes256-ctr),
       :hmac        => %w(hmac-sha1 hmac-md5 hmac-sha1-96 hmac-md5-96 none),
       :compression => %w(none zlib@openssh.com zlib),
       :language    => %w() 

--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -28,7 +28,8 @@ module Net; module SSH; module Transport
                          diffie-hellman-group1-sha1),
       :encryption  => %w(aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
                          aes192-cbc aes256-cbc rijndael-cbc@lysator.liu.se
-                         idea-cbc none arcfour128 arcfour256),
+                         idea-cbc none arcfour128 arcfour256
+                         aes256-ctr),
       :hmac        => %w(hmac-sha1 hmac-md5 hmac-sha1-96 hmac-md5-96 none),
       :compression => %w(none zlib@openssh.com zlib),
       :language    => %w() 

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -13,6 +13,7 @@ module Net; module SSH; module Transport
       "aes256-cbc"                  => "aes-256-cbc",
       "aes192-cbc"                  => "aes-192-cbc",
       "aes128-cbc"                  => "aes-128-cbc",
+      "aes256-ctr"                  => "aes-256-ecb",
       "idea-cbc"                    => "idea-cbc",
       "cast128-cbc"                 => "cast-cbc",
       "rijndael-cbc@lysator.liu.se" => "aes-256-cbc",

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -13,6 +13,7 @@ module Net; module SSH; module Transport
       "aes256-cbc"                  => "aes-256-cbc",
       "aes192-cbc"                  => "aes-192-cbc",
       "aes128-cbc"                  => "aes-128-cbc",
+      "aes192-ctr"                  => "aes-192-ecb",
       "aes256-ctr"                  => "aes-256-ecb",
       "idea-cbc"                    => "idea-cbc",
       "cast128-cbc"                 => "cast-cbc",

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 require 'openssl'
 require 'net/ssh/transport/identity_cipher'
+require 'net/ssh/transport/ctr.rb'
 
 module Net; module SSH; module Transport
 
@@ -43,6 +44,8 @@ module Net; module SSH; module Transport
 
       cipher = OpenSSL::Cipher::Cipher.new(ossl_name)
       cipher.send(options[:encrypt] ? :encrypt : :decrypt)
+
+      cipher.extend(Net::SSH::Transport::CTR) if (name =~ /-ctr$/)
 
       cipher.padding = 0
       cipher.iv      = make_key(cipher.iv_len, options[:iv], options) if ossl_name != "rc4"

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -13,6 +13,7 @@ module Net; module SSH; module Transport
       "aes256-cbc"                  => "aes-256-cbc",
       "aes192-cbc"                  => "aes-192-cbc",
       "aes128-cbc"                  => "aes-128-cbc",
+      "aes128-ctr"                  => "aes-128-ecb",
       "aes192-ctr"                  => "aes-192-ecb",
       "aes256-ctr"                  => "aes-256-ecb",
       "idea-cbc"                    => "idea-cbc",

--- a/lib/net/ssh/transport/ctr.rb
+++ b/lib/net/ssh/transport/ctr.rb
@@ -1,0 +1,95 @@
+require 'openssl'
+
+module Net::SSH::Transport
+
+  # Pure-Ruby implementation of Stateful Decryption Counter(SDCTR) Mode
+  # for Block Ciphers. See RFC4344 for detail.
+  module CTR
+    def self.extended(orig)
+      orig.instance_eval {
+        @remaining = ""
+        @counter = nil
+        @counter_len = orig.block_size
+        orig.encrypt
+        orig.padding = 0
+      }
+
+      class <<orig
+        alias :_update :update
+        private :_update
+        undef :update
+
+        def iv
+          @counter
+        end
+
+        def iv_len
+          block_size
+        end
+
+        def iv=(iv_s)
+          @counter = iv_s if @counter.nil?
+        end
+
+        def encrypt
+          # DO NOTHING (always set to "encrypt")
+        end
+
+        def decrypt
+          # DO NOTHING (always set to "encrypt")
+        end
+
+        def padding=(pad)
+          # DO NOTHING (always 0)
+        end
+
+        def reset
+          @remaining = ""
+        end
+
+        def update(data)
+          @remaining += data
+
+          encrypted = ""
+
+          while @remaining.bytesize >= block_size
+            encrypted += xor!(@remaining.slice!(0, block_size),
+                              _update(@counter))
+            increment_counter!
+          end
+
+          encrypted
+        end
+
+        def final
+          unless @remaining.empty?
+            s = xor!(@remaining, _update(@counter))
+          else
+            s = ""
+          end
+
+          @remaining = ""
+
+          s
+        end
+
+        private
+
+        def xor!(s1, s2)
+          s = []
+          s1.unpack('Q*').zip(s2.unpack('Q*')) {|a,b| s.push(a^b) }
+          s.pack('Q*')
+        end
+
+        def increment_counter!
+          c = @counter_len
+          while ((c -= 1) > 0)
+            if @counter.setbyte(c, (@counter.getbyte(c) + 1) & 0xff) != 0
+              break
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ssh/transport/ctr.rb
+++ b/lib/net/ssh/transport/ctr.rb
@@ -36,7 +36,7 @@ module Net::SSH::Transport
         end
 
         def decrypt
-          # DO NOTHING (always set to "encrypt")
+          # DO NOTHING (always set to "decrypt")
         end
 
         def padding=(pad)

--- a/lib/net/ssh/transport/ctr.rb
+++ b/lib/net/ssh/transport/ctr.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'openssl'
 
 module Net::SSH::Transport


### PR DESCRIPTION
# Purpose

Backport support for AES CTR (128-, 192- and 256-bit) ciphers from https://github.com/net-ssh/net-ssh.

Console output below is of auxiliary/scanner/ssh/ssh_login being run against an OpenSSH instance configured to support only AES CTR (128-bit shown below, others similarly verified).
## Before code changes:

```
       =[ metasploit v4.11.6-dev-8cead41                  ]
+ -- --=[ 1518 exploits - 877 auxiliary - 257 post        ]
+ -- --=[ 437 payloads - 37 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

RHOSTS => 192.168.2.111
USERNAME => pi
PASSWORD => letmein
SSH_DEBUG => true
[*] 192.168.2.111:22 SSH - Starting bruteforce
[-] 192.168.2.111:22 SSH - Failed: 'pi:letmein'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed


SSH_DEBUG OUTPUT:
=================                                     
D, [2016-01-09T15:02:22.568989 #114994] DEBUG -- net.ssh.transport.session[1419370]: establishing connection to 192.168.2.111:22
D, [2016-01-09T15:02:22.571794 #114994] DEBUG -- net.ssh.transport.session[1419370]: connection established
I, [2016-01-09T15:02:22.571990 #114994]  INFO -- net.ssh.transport.server_version[1416d78]: negotiating protocol version
D, [2016-01-09T15:02:22.639406 #114994] DEBUG -- net.ssh.transport.server_version[1416d78]: remote is `SSH-2.0-OpenSSH_6.7p1 Raspbian-5'
D, [2016-01-09T15:02:22.639547 #114994] DEBUG -- net.ssh.transport.server_version[1416d78]: local is `SSH-2.0-OpenSSH_5.0'
D, [2016-01-09T15:02:22.646486 #114994] DEBUG -- socket[1417ebc]: read 624 bytes
D, [2016-01-09T15:02:22.646701 #114994] DEBUG -- socket[1417ebc]: received packet nr 0 type 20 len 620
I, [2016-01-09T15:02:22.646822 #114994]  INFO -- net.ssh.transport.algorithms[1411940]: got KEXINIT from server
I, [2016-01-09T15:02:22.646993 #114994]  INFO -- net.ssh.transport.algorithms[1411940]: sending KEXINIT
D, [2016-01-09T15:02:22.647176 #114994] DEBUG -- socket[1417ebc]: queueing packet nr 0 type 20 len 556
D, [2016-01-09T15:02:22.647382 #114994] DEBUG -- socket[1417ebc]: sent 560 bytes
I, [2016-01-09T15:02:22.647422 #114994]  INFO -- net.ssh.transport.algorithms[1411940]: negotiating algorithms
```
## After code changes:

```
       =[ metasploit v4.11.6-dev-3a5805f                  ]
+ -- --=[ 1518 exploits - 877 auxiliary - 257 post        ]
+ -- --=[ 437 payloads - 37 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

RHOSTS => 192.168.2.111
USERNAME => pi
PASSWORD => letmein
SSH_DEBUG => true
[*] 192.168.2.111:22 SSH - Starting bruteforce
[+] 192.168.2.111:22 SSH - Success: 'pi:letmein' 'uid=1000(pi) gid=1000(pi) groups=1000(pi),108(docker),119(wireshark) Linux pi 3.18.11-hypriotos-v7+ #2 SMP PREEMPT Sun Apr 12 16:34:20 UTC 2015 armv7l GNU/Linux '
[*] Command shell session 1 opened (192.168.2.105:52090 -> 192.168.2.111:22) at 2016-01-09 15:00:22 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed


SSH_DEBUG OUTPUT:
=================
D, [2016-01-09T15:00:20.513180 #113164] DEBUG -- net.ssh.transport.session[1845bd8]: establishing connection to 192.168.2.111:22
D, [2016-01-09T15:00:20.516428 #113164] DEBUG -- net.ssh.transport.session[1845bd8]: connection established
I, [2016-01-09T15:00:20.516667 #113164]  INFO -- net.ssh.transport.server_version[1841498]: negotiating protocol version
D, [2016-01-09T15:00:20.583844 #113164] DEBUG -- net.ssh.transport.server_version[1841498]: remote is `SSH-2.0-OpenSSH_6.7p1 Raspbian-5'
D, [2016-01-09T15:00:20.583988 #113164] DEBUG -- net.ssh.transport.server_version[1841498]: local is `SSH-2.0-OpenSSH_5.0'
D, [2016-01-09T15:00:20.591774 #113164] DEBUG -- socket[1844148]: read 624 bytes
D, [2016-01-09T15:00:20.591959 #113164] DEBUG -- socket[1844148]: received packet nr 0 type 20 len 620
I, [2016-01-09T15:00:20.592048 #113164]  INFO -- net.ssh.transport.algorithms[183e504]: got KEXINIT from server
I, [2016-01-09T15:00:20.592171 #113164]  INFO -- net.ssh.transport.algorithms[183e504]: sending KEXINIT
D, [2016-01-09T15:00:20.592372 #113164] DEBUG -- socket[1844148]: queueing packet nr 0 type 20 len 620
D, [2016-01-09T15:00:20.592546 #113164] DEBUG -- socket[1844148]: sent 624 bytes
I, [2016-01-09T15:00:20.592578 #113164]  INFO -- net.ssh.transport.algorithms[183e504]: negotiating algorithms
D, [2016-01-09T15:00:20.592709 #113164] DEBUG -- net.ssh.transport.algorithms[183e504]: negotiated:
* kex: diffie-hellman-group1-sha1
* host_key: ssh-rsa
* encryption_server: aes128-ctr
* encryption_client: aes128-ctr
* hmac_client: hmac-sha1
* hmac_server: hmac-sha1
* compression_client: none
* compression_server: none
* language_client: 
* language_server: 
D, [2016-01-09T15:00:20.592734 #113164] DEBUG -- net.ssh.transport.algorithms[183e504]: exchanging keys
D, [2016-01-09T15:00:20.593814 #113164] DEBUG -- socket[1844148]: queueing packet nr 1 type 30 len 140
D, [2016-01-09T15:00:20.593879 #113164] DEBUG -- socket[1844148]: sent 144 bytes
D, [2016-01-09T15:00:20.706850 #113164] DEBUG -- socket[1844148]: read 720 bytes
D, [2016-01-09T15:00:20.707124 #113164] DEBUG -- socket[1844148]: received packet nr 1 type 31 len 700
D, [2016-01-09T15:00:20.708815 #113164] DEBUG -- socket[1844148]: queueing packet nr 2 type 21 len 20
D, [2016-01-09T15:00:20.709196 #113164] DEBUG -- socket[1844148]: sent 24 bytes
D, [2016-01-09T15:00:20.709357 #113164] DEBUG -- socket[1844148]: received packet nr 2 type 21 len 12
D, [2016-01-09T15:00:20.710021 #113164] DEBUG -- net.ssh.authentication.session[1803ecc]: beginning authentication of `pi'
D, [2016-01-09T15:00:20.710509 #113164] DEBUG -- socket[1844148]: queueing packet nr 3 type 5 len 28
D, [2016-01-09T15:00:20.710730 #113164] DEBUG -- socket[1844148]: sent 52 bytes
D, [2016-01-09T15:00:20.711606 #113164] DEBUG -- socket[1844148]: read 52 bytes
D, [2016-01-09T15:00:20.711814 #113164] DEBUG -- socket[1844148]: received packet nr 3 type 6 len 28
D, [2016-01-09T15:00:20.711995 #113164] DEBUG -- net.ssh.authentication.session[1803ecc]: trying password
D, [2016-01-09T15:00:20.712288 #113164] DEBUG -- socket[1844148]: queueing packet nr 4 type 50 len 60
D, [2016-01-09T15:00:20.712535 #113164] DEBUG -- socket[1844148]: sent 84 bytes
D, [2016-01-09T15:00:21.051521 #113164] DEBUG -- socket[1844148]: read 36 bytes
D, [2016-01-09T15:00:21.051804 #113164] DEBUG -- socket[1844148]: received packet nr 4 type 52 len 12
D, [2016-01-09T15:00:21.051974 #113164] DEBUG -- net.ssh.authentication.methods.password[17ff91c]: password succeeded
D, [2016-01-09T15:00:21.052599 #113164] DEBUG -- socket[1844148]: queueing packet nr 5 type 90 len 44
D, [2016-01-09T15:00:21.052945 #113164] DEBUG -- socket[1844148]: sent 68 bytes
D, [2016-01-09T15:00:21.158793 #113164] DEBUG -- socket[1844148]: read 52 bytes
D, [2016-01-09T15:00:21.159107 #113164] DEBUG -- socket[1844148]: received packet nr 5 type 91 len 28
I, [2016-01-09T15:00:21.159347 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_open_confirmation: 0 0 0 32768
I, [2016-01-09T15:00:21.159425 #113164]  INFO -- net.ssh.connection.channel[17fc7a8]: sending channel request "exec"
D, [2016-01-09T15:00:21.159571 #113164] DEBUG -- socket[1844148]: queueing packet nr 6 type 98 len 28
D, [2016-01-09T15:00:21.159828 #113164] DEBUG -- socket[1844148]: sent 52 bytes
D, [2016-01-09T15:00:21.163233 #113164] DEBUG -- socket[1844148]: read 88 bytes
D, [2016-01-09T15:00:21.163612 #113164] DEBUG -- socket[1844148]: received packet nr 6 type 93 len 28
I, [2016-01-09T15:00:21.163694 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_window_adjust: 0 +2097152
D, [2016-01-09T15:00:21.163776 #113164] DEBUG -- socket[1844148]: received packet nr 7 type 99 len 12
I, [2016-01-09T15:00:21.163816 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_success: 0
D, [2016-01-09T15:00:21.188989 #113164] DEBUG -- socket[1844148]: read 152 bytes
D, [2016-01-09T15:00:21.189375 #113164] DEBUG -- socket[1844148]: received packet nr 8 type 94 len 92
I, [2016-01-09T15:00:21.189463 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_data: 0 69b
D, [2016-01-09T15:00:21.189632 #113164] DEBUG -- socket[1844148]: read 172 bytes
D, [2016-01-09T15:00:21.189741 #113164] DEBUG -- socket[1844148]: received packet nr 9 type 96 len 12
I, [2016-01-09T15:00:21.189783 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_eof: 0
D, [2016-01-09T15:00:21.189875 #113164] DEBUG -- socket[1844148]: received packet nr 10 type 98 len 44
I, [2016-01-09T15:00:21.189941 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_request: 0 exit-status false
D, [2016-01-09T15:00:21.190118 #113164] DEBUG -- socket[1844148]: received packet nr 11 type 98 len 44
I, [2016-01-09T15:00:21.190172 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_request: 0 eow@openssh.com false
D, [2016-01-09T15:00:21.190273 #113164] DEBUG -- socket[1844148]: received packet nr 12 type 97 len 12
I, [2016-01-09T15:00:21.190313 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_close: 0
D, [2016-01-09T15:00:21.190431 #113164] DEBUG -- socket[1844148]: queueing packet nr 7 type 97 len 28
D, [2016-01-09T15:00:21.190691 #113164] DEBUG -- socket[1844148]: queueing packet nr 8 type 90 len 44
D, [2016-01-09T15:00:21.190926 #113164] DEBUG -- socket[1844148]: sent 120 bytes
D, [2016-01-09T15:00:21.192341 #113164] DEBUG -- socket[1844148]: read 52 bytes
D, [2016-01-09T15:00:21.192736 #113164] DEBUG -- socket[1844148]: received packet nr 13 type 91 len 28
I, [2016-01-09T15:00:21.192850 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_open_confirmation: 1 1 0 32768
I, [2016-01-09T15:00:21.192929 #113164]  INFO -- net.ssh.connection.channel[17500e8]: sending channel request "exec"
D, [2016-01-09T15:00:21.193087 #113164] DEBUG -- socket[1844148]: queueing packet nr 9 type 98 len 44
D, [2016-01-09T15:00:21.193366 #113164] DEBUG -- socket[1844148]: sent 68 bytes
D, [2016-01-09T15:00:21.196493 #113164] DEBUG -- socket[1844148]: read 88 bytes
D, [2016-01-09T15:00:21.196857 #113164] DEBUG -- socket[1844148]: received packet nr 14 type 93 len 28
I, [2016-01-09T15:00:21.196934 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_window_adjust: 1 +2097152
D, [2016-01-09T15:00:21.197015 #113164] DEBUG -- socket[1844148]: received packet nr 15 type 99 len 12
I, [2016-01-09T15:00:21.197056 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_success: 1
D, [2016-01-09T15:00:21.215332 #113164] DEBUG -- socket[1844148]: read 132 bytes
D, [2016-01-09T15:00:21.215779 #113164] DEBUG -- socket[1844148]: read 208 bytes
D, [2016-01-09T15:00:21.216016 #113164] DEBUG -- socket[1844148]: received packet nr 16 type 94 len 108
I, [2016-01-09T15:00:21.216098 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_data: 1 92b
D, [2016-01-09T15:00:21.216181 #113164] DEBUG -- socket[1844148]: received packet nr 17 type 96 len 12
I, [2016-01-09T15:00:21.216251 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_eof: 1
D, [2016-01-09T15:00:21.216362 #113164] DEBUG -- socket[1844148]: received packet nr 18 type 98 len 44
I, [2016-01-09T15:00:21.216416 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_request: 1 exit-status false
D, [2016-01-09T15:00:21.216551 #113164] DEBUG -- socket[1844148]: received packet nr 19 type 98 len 44
I, [2016-01-09T15:00:21.216628 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_request: 1 eow@openssh.com false
D, [2016-01-09T15:00:21.216706 #113164] DEBUG -- socket[1844148]: received packet nr 20 type 97 len 12
I, [2016-01-09T15:00:21.216744 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_close: 1
D, [2016-01-09T15:00:21.216852 #113164] DEBUG -- socket[1844148]: queueing packet nr 10 type 97 len 28
D, [2016-01-09T15:00:21.564739 #113164] DEBUG -- socket[1844148]: queueing packet nr 11 type 90 len 44
D, [2016-01-09T15:00:21.565143 #113164] DEBUG -- socket[1844148]: sent 120 bytes
D, [2016-01-09T15:00:21.568150 #113164] DEBUG -- socket[1844148]: read 52 bytes
D, [2016-01-09T15:00:21.568457 #113164] DEBUG -- socket[1844148]: received packet nr 21 type 91 len 28
I, [2016-01-09T15:00:21.568608 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_open_confirmation: 2 0 0 32768
I, [2016-01-09T15:00:21.568697 #113164]  INFO -- net.ssh.connection.channel[605c390]: sending channel request "exec"
D, [2016-01-09T15:00:21.568876 #113164] DEBUG -- socket[1844148]: queueing packet nr 12 type 98 len 44
D, [2016-01-09T15:00:21.569043 #113164] DEBUG -- socket[1844148]: sent 68 bytes
D, [2016-01-09T15:00:21.576480 #113164] DEBUG -- socket[1844148]: read 88 bytes
D, [2016-01-09T15:00:21.576882 #113164] DEBUG -- socket[1844148]: received packet nr 22 type 93 len 28
I, [2016-01-09T15:00:21.576973 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_window_adjust: 2 +2097152
D, [2016-01-09T15:00:21.577052 #113164] DEBUG -- socket[1844148]: received packet nr 23 type 99 len 12
I, [2016-01-09T15:00:21.577092 #113164]  INFO -- net.ssh.connection.session[17fccd0]: channel_success: 2
```

Between this PR and https://github.com/rapid7/metasploit-framework/pull/6451, there should now be support for running SSH modules against OpenSSH server v6.7 under its default configuration.
