### PR TITLE
Backport net-ssh ECDH SHA2 NIST key exchange algorithms

### DIFF
--- a/lib/net/ssh/transport/algorithms.rb
+++ b/lib/net/ssh/transport/algorithms.rb
@@ -34,6 +34,12 @@ module Net; module SSH; module Transport
       :language    => %w() 
     }
 
+    if defined?(OpenSSL::PKey::EC)
+      ALGORITHMS[:kex] += %w(ecdh-sha2-nistp256
+                             ecdh-sha2-nistp384
+                             ecdh-sha2-nistp521)
+    end
+
     # The underlying transport layer session that supports this object
     attr_reader :session
 

--- a/lib/net/ssh/transport/constants.rb
+++ b/lib/net/ssh/transport/constants.rb
@@ -27,5 +27,7 @@ module Net; module SSH; module Transport
     KEXDH_INIT                = 30
     KEXDH_REPLY               = 31
 
+    KEXECDH_INIT              = 30
+    KEXECDH_REPLY             = 31
   end
 end; end; end

--- a/lib/net/ssh/transport/kex.rb
+++ b/lib/net/ssh/transport/kex.rb
@@ -10,5 +10,14 @@ module Net::SSH::Transport
       'diffie-hellman-group-exchange-sha1' => DiffieHellmanGroupExchangeSHA1,
       'diffie-hellman-group1-sha1'         => DiffieHellmanGroup1SHA1
     }
+    if defined?(OpenSSL::PKey::EC)
+      require 'net/ssh/transport/kex/ecdh_sha2_nistp256'
+      require 'net/ssh/transport/kex/ecdh_sha2_nistp384'
+      require 'net/ssh/transport/kex/ecdh_sha2_nistp521'
+
+      MAP['ecdh-sha2-nistp256'] = EcdhSHA2NistP256
+      MAP['ecdh-sha2-nistp384'] = EcdhSHA2NistP384
+      MAP['ecdh-sha2-nistp521'] = EcdhSHA2NistP521
+    end
   end
 end

--- a/lib/net/ssh/transport/kex/ecdh_sha2_nistp256.rb
+++ b/lib/net/ssh/transport/kex/ecdh_sha2_nistp256.rb
@@ -1,0 +1,94 @@
+# -*- coding: binary -*-
+require 'net/ssh/transport/constants'
+require 'net/ssh/transport/kex/diffie_hellman_group1_sha1'
+
+module Net; module SSH; module Transport; module Kex
+
+  # A key-exchange service implementing the "ecdh-sha2-nistp256"
+  # key-exchange algorithm. (defined in RFC 5656)
+  class EcdhSHA2NistP256 < DiffieHellmanGroup1SHA1
+    include Constants, Loggable
+
+    attr_reader :ecdh
+
+    def digester
+      OpenSSL::Digest::SHA256
+    end
+
+    def curve_name
+      OpenSSL::PKey::EC::CurveNameAlias['nistp256']
+    end
+
+    def initialize(algorithms, connection, data)
+      @algorithms = algorithms
+      @connection = connection
+
+      @digester = digester
+      @data = data.dup
+      @ecdh = generate_key
+      @logger = @data.delete(:logger)
+    end
+
+    private
+
+    def get_message_types
+      [KEXECDH_INIT, KEXECDH_REPLY]
+    end
+
+    def build_signature_buffer(result)
+      response = Net::SSH::Buffer.new
+      response.write_string data[:client_version_string],
+                            data[:server_version_string],
+                            data[:client_algorithm_packet],
+                            data[:server_algorithm_packet],
+                            result[:key_blob],
+                            ecdh.public_key.to_bn.to_s(2),
+                            result[:server_ecdh_pubkey]
+      response.write_bignum result[:shared_secret]
+      response
+    end
+
+    def generate_key #:nodoc:
+      OpenSSL::PKey::EC.new(curve_name).generate_key
+    end
+
+    def send_kexinit #:nodoc:
+      init, reply = get_message_types
+
+      # send the KEXECDH_INIT message
+      ## byte     SSH_MSG_KEX_ECDH_INIT
+      ## string   Q_C, client's ephemeral public key octet string
+      buffer = Net::SSH::Buffer.from(:byte, init, :string, ecdh.public_key.to_bn.to_s(2))
+      connection.send_message(buffer)
+
+      # expect the following KEXECDH_REPLY message
+      ## byte     SSH_MSG_KEX_ECDH_REPLY
+      ## string   K_S, server's public host key
+      ## string   Q_S, server's ephemeral public key octet string
+      ## string   the signature on the exchange hash
+      buffer = connection.next_message
+      raise Net::SSH::Exception, "expected REPLY" unless buffer.type == reply
+
+      result = Hash.new
+      result[:key_blob] = buffer.read_string
+      result[:server_key] = Net::SSH::Buffer.new(result[:key_blob]).read_key
+      result[:server_ecdh_pubkey] = buffer.read_string
+
+      # compute shared secret from server's public key and client's private key
+      pk = OpenSSL::PKey::EC::Point.new(OpenSSL::PKey::EC.new(curve_name).group,
+                                        OpenSSL::BN.new(result[:server_ecdh_pubkey], 2))
+      result[:shared_secret] = OpenSSL::BN.new(ecdh.dh_compute_key(pk), 2)
+
+      sig_buffer = Net::SSH::Buffer.new(buffer.read_string)
+      sig_type = sig_buffer.read_string
+      if sig_type != algorithms.host_key
+        raise Net::SSH::Exception,
+        "host key algorithm mismatch for signature " +
+          "'#{sig_type}' != '#{algorithms.host_key}'"
+      end
+      result[:server_sig] = sig_buffer.read_string
+
+      return result
+    end
+  end
+end; end; end; end

--- a/lib/net/ssh/transport/kex/ecdh_sha2_nistp384.rb
+++ b/lib/net/ssh/transport/kex/ecdh_sha2_nistp384.rb
@@ -1,0 +1,14 @@
+# -*- coding: binary -*-
+module Net; module SSH; module Transport; module Kex
+
+  # A key-exchange service implementing the "ecdh-sha2-nistp384"
+  # key-exchange algorithm. (defined in RFC 5656)
+  class EcdhSHA2NistP384 < EcdhSHA2NistP256
+    def digester
+      OpenSSL::Digest::SHA384
+    end
+    def curve_name
+      OpenSSL::PKey::EC::CurveNameAlias['nistp384']
+    end
+  end
+end; end; end; end

--- a/lib/net/ssh/transport/kex/ecdh_sha2_nistp521.rb
+++ b/lib/net/ssh/transport/kex/ecdh_sha2_nistp521.rb
@@ -1,0 +1,14 @@
+# -*- coding: binary -*-
+module Net; module SSH; module Transport; module Kex
+
+  # A key-exchange service implementing the "ecdh-sha2-nistp521"
+  # key-exchange algorithm. (defined in RFC 5656)
+  class EcdhSHA2NistP521 < EcdhSHA2NistP256
+    def digester
+      OpenSSL::Digest::SHA512
+    end
+    def curve_name
+      OpenSSL::PKey::EC::CurveNameAlias['nistp521']
+    end
+  end
+end; end; end; end

--- a/lib/net/ssh/transport/openssl.rb
+++ b/lib/net/ssh/transport/openssl.rb
@@ -124,6 +124,19 @@ module OpenSSL
       end
     end
 
+    if defined?(OpenSSL::PKey::EC)
+      # This class is originally defined in the OpenSSL module. As needed, methods
+      # have been added to it by the Net::SSH module for convenience in dealing
+      # with SSH funcationality.
+      class EC
+        CurveNameAlias = {
+          "nistp256" => "prime256v1",
+          "nistp384" => "secp384r1",
+          "nistp521" => "secp521r1",
+        }
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
# Purpose

Backport support for ECDH SHA2 NIST (256-, 384- and 521-bit) key exchange algorithms from https://github.com/net-ssh/net-ssh.

Console output below is of auxiliary/scanner/ssh/ssh_login being run against an OpenSSH instance configured to support only the 521-bit version of the algorithm (256- and 384-bit similarly verified).
## Before code changes:

```
       =[ metasploit v4.11.7-dev-88ef307                  ]
+ -- --=[ 1518 exploits - 877 auxiliary - 257 post        ]
+ -- --=[ 437 payloads - 38 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

RHOSTS => 192.168.2.111
USERNAME => pi
PASSWORD => letmein
SSH_DEBUG => true
[*] 192.168.2.111:22 SSH - Starting bruteforce
[-] 192.168.2.111:22 SSH - Failed: 'pi:letmein'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed


SSH_DEBUG OUTPUT:
=================
D, [2016-01-10T18:32:46.686844 #27404] DEBUG -- net.ssh.transport.session[1edf368]: establishing connection to 192.168.2.111:22
D, [2016-01-10T18:32:46.689810 #27404] DEBUG -- net.ssh.transport.session[1edf368]: connection established
I, [2016-01-10T18:32:46.690002 #27404]  INFO -- net.ssh.transport.server_version[1edb358]: negotiating protocol version
D, [2016-01-10T18:32:46.756998 #27404] DEBUG -- net.ssh.transport.server_version[1edb358]: remote is `SSH-2.0-OpenSSH_6.7p1 Raspbian-5'
D, [2016-01-10T18:32:46.757172 #27404] DEBUG -- net.ssh.transport.server_version[1edb358]: local is `SSH-2.0-OpenSSH_5.0'
D, [2016-01-10T18:32:46.763779 #27404] DEBUG -- socket[1ede2c4]: read 616 bytes
D, [2016-01-10T18:32:46.764030 #27404] DEBUG -- socket[1ede2c4]: received packet nr 0 type 20 len 612
I, [2016-01-10T18:32:46.764177 #27404]  INFO -- net.ssh.transport.algorithms[1ed5e08]: got KEXINIT from server
I, [2016-01-10T18:32:46.764355 #27404]  INFO -- net.ssh.transport.algorithms[1ed5e08]: sending KEXINIT
D, [2016-01-10T18:32:46.764587 #27404] DEBUG -- socket[1ede2c4]: queueing packet nr 0 type 20 len 556
D, [2016-01-10T18:32:46.764821 #27404] DEBUG -- socket[1ede2c4]: sent 560 bytes
I, [2016-01-10T18:32:46.764857 #27404]  INFO -- net.ssh.transport.algorithms[1ed5e08]: negotiating algorithms
```
## After code changes:

```
       =[ metasploit v4.11.7-dev-8102fc2                  ]
+ -- --=[ 1518 exploits - 877 auxiliary - 257 post        ]
+ -- --=[ 437 payloads - 38 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

RHOSTS => 192.168.2.111
USERNAME => pi
PASSWORD => letmein
SSH_DEBUG => true
[*] 192.168.2.111:22 SSH - Starting bruteforce
[+] 192.168.2.111:22 SSH - Success: 'pi:letmein' 'uid=1000(pi) gid=1000(pi) groups=1000(pi),108(docker),119(wireshark) Linux pi 3.18.11-hypriotos-v7+ #2 SMP PREEMPT Sun Apr 12 16:34:20 UTC 2015 armv7l GNU/Linux '
[*] Command shell session 1 opened (192.168.2.105:33052 -> 192.168.2.111:22) at 2016-01-10 18:34:26 +0000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed


SSH_DEBUG OUTPUT:
=================                                                  
D, [2016-01-10T18:34:24.353877 #28950] DEBUG -- net.ssh.transport.session[1c3633c]: establishing connection to 192.168.2.111:22
D, [2016-01-10T18:34:24.356951 #28950] DEBUG -- net.ssh.transport.session[1c3633c]: connection established
I, [2016-01-10T18:34:24.357144 #28950]  INFO -- net.ssh.transport.server_version[1c275f8]: negotiating protocol version
D, [2016-01-10T18:34:24.423757 #28950] DEBUG -- net.ssh.transport.server_version[1c275f8]: remote is `SSH-2.0-OpenSSH_6.7p1 Raspbian-5'
D, [2016-01-10T18:34:24.423925 #28950] DEBUG -- net.ssh.transport.server_version[1c275f8]: local is `SSH-2.0-OpenSSH_5.0'
D, [2016-01-10T18:34:24.430980 #28950] DEBUG -- socket[1c324e4]: read 616 bytes
D, [2016-01-10T18:34:24.431311 #28950] DEBUG -- socket[1c324e4]: received packet nr 0 type 20 len 612
I, [2016-01-10T18:34:24.431446 #28950]  INFO -- net.ssh.transport.algorithms[1bfce0c]: got KEXINIT from server
I, [2016-01-10T18:34:24.431698 #28950]  INFO -- net.ssh.transport.algorithms[1bfce0c]: sending KEXINIT
D, [2016-01-10T18:34:24.432059 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 0 type 20 len 612
D, [2016-01-10T18:34:24.432344 #28950] DEBUG -- socket[1c324e4]: sent 616 bytes
I, [2016-01-10T18:34:24.432391 #28950]  INFO -- net.ssh.transport.algorithms[1bfce0c]: negotiating algorithms
D, [2016-01-10T18:34:24.432613 #28950] DEBUG -- net.ssh.transport.algorithms[1bfce0c]: negotiated:
* kex: ecdh-sha2-nistp521
* host_key: ssh-rsa
* encryption_server: aes192-cbc
* encryption_client: aes192-cbc
* hmac_client: hmac-sha1
* hmac_server: hmac-sha1
* compression_client: none
* compression_server: none
* language_client: 
* language_server: 
D, [2016-01-10T18:34:24.432668 #28950] DEBUG -- net.ssh.transport.algorithms[1bfce0c]: exchanging keys
D, [2016-01-10T18:34:24.433709 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 1 type 30 len 148
D, [2016-01-10T18:34:24.433788 #28950] DEBUG -- socket[1c324e4]: sent 152 bytes
D, [2016-01-10T18:34:24.657654 #28950] DEBUG -- socket[1c324e4]: read 728 bytes
D, [2016-01-10T18:34:24.657895 #28950] DEBUG -- socket[1c324e4]: received packet nr 1 type 31 len 708
D, [2016-01-10T18:34:24.660228 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 2 type 21 len 20
D, [2016-01-10T18:34:24.660544 #28950] DEBUG -- socket[1c324e4]: sent 24 bytes
D, [2016-01-10T18:34:24.660638 #28950] DEBUG -- socket[1c324e4]: received packet nr 2 type 21 len 12
D, [2016-01-10T18:34:24.661028 #28950] DEBUG -- net.ssh.authentication.session[1b1cc30]: beginning authentication of `pi'
D, [2016-01-10T18:34:24.661344 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 3 type 5 len 28
D, [2016-01-10T18:34:24.661466 #28950] DEBUG -- socket[1c324e4]: sent 52 bytes
D, [2016-01-10T18:34:24.662440 #28950] DEBUG -- socket[1c324e4]: read 52 bytes
D, [2016-01-10T18:34:24.662702 #28950] DEBUG -- socket[1c324e4]: received packet nr 3 type 6 len 28
D, [2016-01-10T18:34:24.662891 #28950] DEBUG -- net.ssh.authentication.session[1b1cc30]: trying password
D, [2016-01-10T18:34:24.663129 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 4 type 50 len 60
D, [2016-01-10T18:34:24.663357 #28950] DEBUG -- socket[1c324e4]: sent 84 bytes
D, [2016-01-10T18:34:25.009183 #28950] DEBUG -- socket[1c324e4]: read 36 bytes
D, [2016-01-10T18:34:25.009449 #28950] DEBUG -- socket[1c324e4]: received packet nr 4 type 52 len 12
D, [2016-01-10T18:34:25.009595 #28950] DEBUG -- net.ssh.authentication.methods.password[1b18810]: password succeeded
D, [2016-01-10T18:34:25.010051 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 5 type 90 len 44
D, [2016-01-10T18:34:25.010389 #28950] DEBUG -- socket[1c324e4]: sent 68 bytes
D, [2016-01-10T18:34:25.114880 #28950] DEBUG -- socket[1c324e4]: read 52 bytes
D, [2016-01-10T18:34:25.115174 #28950] DEBUG -- socket[1c324e4]: received packet nr 5 type 91 len 28
I, [2016-01-10T18:34:25.115324 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_open_confirmation: 0 0 0 32768
I, [2016-01-10T18:34:25.115486 #28950]  INFO -- net.ssh.connection.channel[1b1488c]: sending channel request "exec"
D, [2016-01-10T18:34:25.115648 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 6 type 98 len 28
D, [2016-01-10T18:34:25.115964 #28950] DEBUG -- socket[1c324e4]: sent 52 bytes
D, [2016-01-10T18:34:25.119447 #28950] DEBUG -- socket[1c324e4]: read 88 bytes
D, [2016-01-10T18:34:25.119730 #28950] DEBUG -- socket[1c324e4]: received packet nr 6 type 93 len 28
I, [2016-01-10T18:34:25.119823 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_window_adjust: 0 +2097152
D, [2016-01-10T18:34:25.120007 #28950] DEBUG -- socket[1c324e4]: received packet nr 7 type 99 len 12
I, [2016-01-10T18:34:25.120065 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_success: 0
D, [2016-01-10T18:34:25.144480 #28950] DEBUG -- socket[1c324e4]: read 152 bytes
D, [2016-01-10T18:34:25.144782 #28950] DEBUG -- socket[1c324e4]: received packet nr 8 type 94 len 92
I, [2016-01-10T18:34:25.144872 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_data: 0 69b
D, [2016-01-10T18:34:25.145006 #28950] DEBUG -- socket[1c324e4]: received packet nr 9 type 96 len 12
I, [2016-01-10T18:34:25.145048 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_eof: 0
D, [2016-01-10T18:34:25.145356 #28950] DEBUG -- socket[1c324e4]: read 172 bytes
D, [2016-01-10T18:34:25.145442 #28950] DEBUG -- socket[1c324e4]: received packet nr 10 type 98 len 44
I, [2016-01-10T18:34:25.145516 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_request: 0 exit-status false
D, [2016-01-10T18:34:25.145627 #28950] DEBUG -- socket[1c324e4]: received packet nr 11 type 98 len 44
I, [2016-01-10T18:34:25.145748 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_request: 0 eow@openssh.com false
D, [2016-01-10T18:34:25.145819 #28950] DEBUG -- socket[1c324e4]: received packet nr 12 type 97 len 12
I, [2016-01-10T18:34:25.145858 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_close: 0
D, [2016-01-10T18:34:25.145974 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 7 type 97 len 28
D, [2016-01-10T18:34:25.146148 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 8 type 90 len 44
D, [2016-01-10T18:34:25.146321 #28950] DEBUG -- socket[1c324e4]: sent 120 bytes
D, [2016-01-10T18:34:25.147522 #28950] DEBUG -- socket[1c324e4]: read 52 bytes
D, [2016-01-10T18:34:25.147752 #28950] DEBUG -- socket[1c324e4]: received packet nr 13 type 91 len 28
I, [2016-01-10T18:34:25.147836 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_open_confirmation: 1 1 0 32768
I, [2016-01-10T18:34:25.147900 #28950]  INFO -- net.ssh.connection.channel[1af6558]: sending channel request "exec"
D, [2016-01-10T18:34:25.148032 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 9 type 98 len 44
D, [2016-01-10T18:34:25.148219 #28950] DEBUG -- socket[1c324e4]: sent 68 bytes
D, [2016-01-10T18:34:25.151273 #28950] DEBUG -- socket[1c324e4]: read 88 bytes
D, [2016-01-10T18:34:25.151556 #28950] DEBUG -- socket[1c324e4]: received packet nr 14 type 93 len 28
I, [2016-01-10T18:34:25.151683 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_window_adjust: 1 +2097152
D, [2016-01-10T18:34:25.151812 #28950] DEBUG -- socket[1c324e4]: received packet nr 15 type 99 len 12
I, [2016-01-10T18:34:25.151857 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_success: 1
D, [2016-01-10T18:34:25.169833 #28950] DEBUG -- socket[1c324e4]: read 132 bytes
D, [2016-01-10T18:34:25.170126 #28950] DEBUG -- socket[1c324e4]: received packet nr 16 type 94 len 108
I, [2016-01-10T18:34:25.170210 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_data: 1 92b
D, [2016-01-10T18:34:25.170429 #28950] DEBUG -- socket[1c324e4]: read 208 bytes
D, [2016-01-10T18:34:25.170502 #28950] DEBUG -- socket[1c324e4]: received packet nr 17 type 96 len 12
I, [2016-01-10T18:34:25.170544 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_eof: 1
D, [2016-01-10T18:34:25.170609 #28950] DEBUG -- socket[1c324e4]: received packet nr 18 type 98 len 44
I, [2016-01-10T18:34:25.170666 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_request: 1 exit-status false
D, [2016-01-10T18:34:25.170827 #28950] DEBUG -- socket[1c324e4]: received packet nr 19 type 98 len 44
I, [2016-01-10T18:34:25.170879 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_request: 1 eow@openssh.com false
D, [2016-01-10T18:34:25.170950 #28950] DEBUG -- socket[1c324e4]: received packet nr 20 type 97 len 12
I, [2016-01-10T18:34:25.170990 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_close: 1
D, [2016-01-10T18:34:25.171084 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 10 type 97 len 28
D, [2016-01-10T18:34:25.605224 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 11 type 90 len 44
D, [2016-01-10T18:34:25.605646 #28950] DEBUG -- socket[1c324e4]: sent 120 bytes
D, [2016-01-10T18:34:25.608416 #28950] DEBUG -- socket[1c324e4]: read 52 bytes
D, [2016-01-10T18:34:25.608689 #28950] DEBUG -- socket[1c324e4]: received packet nr 21 type 91 len 28
I, [2016-01-10T18:34:25.608804 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_open_confirmation: 2 0 0 32768
I, [2016-01-10T18:34:25.608879 #28950]  INFO -- net.ssh.connection.channel[68070f4]: sending channel request "exec"
D, [2016-01-10T18:34:25.608998 #28950] DEBUG -- socket[1c324e4]: queueing packet nr 12 type 98 len 44
D, [2016-01-10T18:34:25.609257 #28950] DEBUG -- socket[1c324e4]: sent 68 bytes
D, [2016-01-10T18:34:25.612440 #28950] DEBUG -- socket[1c324e4]: read 88 bytes
D, [2016-01-10T18:34:25.612772 #28950] DEBUG -- socket[1c324e4]: received packet nr 22 type 93 len 28
I, [2016-01-10T18:34:25.612858 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_window_adjust: 2 +2097152
D, [2016-01-10T18:34:25.612923 #28950] DEBUG -- socket[1c324e4]: received packet nr 23 type 99 len 12
I, [2016-01-10T18:34:25.612964 #28950]  INFO -- net.ssh.connection.session[1b14cc4]: channel_success: 2
```
