### PR TITLE
Fix the help option for vulns command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -745,7 +745,7 @@ class Db
       #	mode = :add
       #when "-d"
       #	mode = :delete
-      when "-h"
+      when "-h","--help"
         cmd_vulns_help
         return
       when "-p","--port"


### PR DESCRIPTION
Actually the command **vulns --help** appears in the options but "--help" is not working because it is not implemented.

This pull request is for add the option "--help" to _vulns_ command.

Regards.
