### PR TITLE
Add individual contacts to Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,12 +35,14 @@ This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at msfdev@metasploit.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. Maintainers are
-obligated to maintain confidentiality with regard to the reporter of an
-incident.
+reported by contacting the project maintainers at msfdev@metasploit.com. If
+the incident involves a committer, you may report directly to
+egypt@metasploit.com or todb@metasploit.com.
 
+All complaints will be reviewed and investigated and will result in a
+response that is deemed necessary and appropriate to the circumstances.
+Maintainers are obligated to maintain confidentiality with regard to the
+reporter of an incident.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.3.0, available at


### PR DESCRIPTION
See #6439 

This adds @todb-r7 and me as specific responsible parties for individual contact for the case when someone reporting an incident doesn't feel comfortable sending to a list.
