### PR TITLE
Fix a couple of missing requires in payloads.

### DIFF
--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 require 'rex/socket'
 require 'thread'
+require 'msf/core/handler/reverse_tcp'
 
 module Msf
 module Handler

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -3,6 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'metasploit-payloads'
 require 'msf/core'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'


### PR DESCRIPTION
This pops up occasionally. This fixes a couple of anecdotal reports of missing requires that cause the loader to fail, depending on the directory sort order.

It also fixes the problem as reported in #6460 . Note that normally you will not see any issues at all, so verification is difficult if you don't test on the system that it was happening on.
# Verification Steps
- [x] msfconsole starts as expected
