### PR TITLE
fix rspec + rake errors without database

### DIFF
--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -49,7 +49,7 @@ module Metasploit
       #
       # @return [void]
       def self.optionally_active_record_railtie
-        if ::File.exist?(Rails.application.config.paths['config/database'].first)
+        if ::File.exist?('config/database.yml')
           optionally(
             'active_record/railtie',
             'activerecord not in the bundle, so database support will be disabled.'

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -49,7 +49,7 @@ module Metasploit
       #
       # @return [void]
       def self.optionally_active_record_railtie
-        if ::File.exist?('config/database.yml')
+        if ::Rails.application.config.paths['config/database'].any?
           optionally(
             'active_record/railtie',
             'activerecord not in the bundle, so database support will be disabled.'

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -49,8 +49,7 @@ module Metasploit
       #
       # @return [void]
       def self.optionally_active_record_railtie
-        conf = ::Rails.application.config.paths['config/database']
-        if conf.any? && ::File.exist?(conf.first)
+        if ::Rails.application.config.paths['config/database'].any?
           optionally(
             'active_record/railtie',
             'activerecord not in the bundle, so database support will be disabled.'

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -49,7 +49,8 @@ module Metasploit
       #
       # @return [void]
       def self.optionally_active_record_railtie
-        if ::Rails.application.config.paths['config/database'].any?
+        conf = ::Rails.application.config.paths['config/database']
+        if conf.any? && ::File.exist?(conf.first)
           optionally(
             'active_record/railtie',
             'activerecord not in the bundle, so database support will be disabled.'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ end
 # Must be explicit as activerecord is optional dependency
 require 'active_record/railtie'
 
+unless File.exist?('config/database.yml')
+  fail 'RSPEC currently needs a configured database'
+end
+
 require File.expand_path('../../config/environment', __FILE__)
 
 # Don't `require 'rspec/rails'` as it includes support for pieces of rails that metasploit-framework doesn't use

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,9 @@ end
 # Must be explicit as activerecord is optional dependency
 require 'active_record/railtie'
 
-unless File.exist?('config/database.yml') || File.exist?(File.expand_path('~/.msf4/database.yml'))
+require 'metasploit/framework/database'
+# check if database.yml is present
+unless Metasploit::Framework::Database.configurations_pathname.try(:to_path)
   fail 'RSPEC currently needs a configured database'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ end
 # Must be explicit as activerecord is optional dependency
 require 'active_record/railtie'
 
-unless File.exist?('config/database.yml')
+unless File.exist?('config/database.yml') || File.exist?(File.expand_path('~/.msf4/database.yml'))
   fail 'RSPEC currently needs a configured database'
 end
 


### PR DESCRIPTION
Currently rspec fails when no database connection is present (just delete database.yml). The cause is `Rails::Paths::Path` (http://api.rubyonrails.org/classes/Rails/Paths/Path.html) methods not checking for nil and passing the value to other APIs thus all fails badly.
# Before
## RSPEC

```
macbook:metasploit-framework firefart$ rspec
Coverage report generated for RSpec to /Users/firefart/Coding/metasploit-framework/coverage. 17583 / 92557 LOC (19.0%) covered.
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:189:in `expand_path': no implicit conversion of nil into String (TypeError)
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:189:in `block in expanded'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:163:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:163:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:188:in `expanded'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:139:in `first'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/application/configuration.rb:103:in `database_configuration'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activerecord-4.0.13/lib/active_record/railtie.rb:175:in `block (2 levels) in <class:Railtie>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:38:in `instance_eval'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:38:in `execute_hook'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:45:in `block in run_load_hooks'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:44:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/lazy_load_hooks.rb:44:in `run_load_hooks'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activerecord-4.0.13/lib/active_record/base.rb:322:in `<module:ActiveRecord>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activerecord-4.0.13/lib/active_record/base.rb:22:in `<top (required)>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/metasploit_data_models-1.2.10/config/initializers/arel_helper.rb:4:in `<top (required)>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:223:in `load'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:223:in `block in load'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:214:in `load_dependency'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/activesupport-4.0.13/lib/active_support/dependencies.rb:223:in `load'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/engine.rb:609:in `block (2 levels) in <class:Engine>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/engine.rb:608:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/engine.rb:608:in `block in <class:Engine>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/initializable.rb:30:in `instance_exec'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/initializable.rb:30:in `run'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/initializable.rb:55:in `block in run_initializers'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:226:in `block in tsort_each'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:418:in `block (2 levels) in each_strongly_connected_component_from'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:427:in `each_strongly_connected_component_from'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:417:in `block in each_strongly_connected_component_from'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/initializable.rb:44:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/initializable.rb:44:in `tsort_each_child'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:411:in `call'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:411:in `each_strongly_connected_component_from'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:347:in `block in each_strongly_connected_component'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:345:in `each'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:345:in `call'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:345:in `each_strongly_connected_component'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:224:in `tsort_each'
    from /Users/firefart/.rvm/rubies/ruby-2.1.7/lib/ruby/2.1.0/tsort.rb:205:in `tsort_each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/initializable.rb:54:in `run_initializers'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/application.rb:215:in `initialize!'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/railtie/configurable.rb:30:in `method_missing'
    from /Users/firefart/Coding/metasploit-framework/config/environment.rb:5:in `<top (required)>'
    from /Users/firefart/Coding/metasploit-framework/spec/spec_helper.rb:14:in `require'
    from /Users/firefart/Coding/metasploit-framework/spec/spec_helper.rb:14:in `<top (required)>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `require'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `block in requires='
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `requires='
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:109:in `block in process_options_into'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:108:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:108:in `process_options_into'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:21:in `configure'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:101:in `setup'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/exe/rspec:4:in `<top (required)>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/rspec:23:in `load'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/rspec:23:in `<main>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/ruby_executable_hooks:15:in `eval'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/ruby_executable_hooks:15:in `<main>'
```
## RAKE

```
macbook:metasploit-framework firefart$ rake -T
rake aborted!
TypeError: no implicit conversion of nil into String
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:189:in `expand_path'
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:189:in `block in expanded'
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:163:in `each'
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:163:in `each'
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:188:in `expanded'
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/railties-4.0.13/lib/rails/paths.rb:139:in `first'
/Users/firefart/Coding/metasploit-framework/lib/metasploit/framework/require.rb:52:in `optionally_active_record_railtie'
/Users/firefart/Coding/metasploit-framework/Rakefile:10:in `<top (required)>'
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/ruby_executable_hooks:15:in `eval'
/Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```
# After
## RSPEC

```
macbook:metasploit-framework firefart$ rspec
Coverage report generated for RSpec to /Users/firefart/Coding/metasploit-framework/coverage. 0.0 / 0.0 LOC (100.0%) covered.
/Users/firefart/Coding/metasploit-framework/spec/spec_helper.rb:15:in `<top (required)>': RSPEC currently needs a configured database (RuntimeError)
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `require'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `block in requires='
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1280:in `requires='
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:109:in `block in process_options_into'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:108:in `each'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:108:in `process_options_into'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/configuration_options.rb:21:in `configure'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:101:in `setup'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/gems/rspec-core-3.3.2/exe/rspec:4:in `<top (required)>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/rspec:23:in `load'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/rspec:23:in `<main>'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/ruby_executable_hooks:15:in `eval'
    from /Users/firefart/.rvm/gems/ruby-2.1.7@metasploit-framework/bin/ruby_executable_hooks:15:in `<main>'
```
## RAKE

```
macbook:metasploit-framework firefart$ rake -T
Could not find database.yml, so database support will be disabled.
rake about                                             # List versions of all Rails frameworks and the environment
rake cache_digests:dependencies                        # Lookup first-level dependencies for TEMPLATE (like messages/show or comments/_comment.html)
rake cache_digests:nested_dependencies                 # Lookup nested dependencies for TEMPLATE (like messages/show or comments/_comment.html)
rake cucumber                                          # Alias for cucumber:ok
rake cucumber:all                                      # Run all features
rake cucumber:boot                                     # Run features that should pass
rake cucumber:ok                                       # Run features that should pass
rake cucumber:rerun                                    # Record failing features and run only them if any exist
rake cucumber:wip                                      # Run features that are being worked on
rake doc:app                                           # Generate docs for the app -- also available doc:rails, doc:guides (options: TEMPLATE=/rdoc-template.rb, TITLE="Custom Title")
rake log:clear                                         # Truncates all *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)
rake metasploit_credential_engine:install:migrations   # Copy migrations from metasploit_credential_engine to application
rake metasploit_data_models_engine:install:migrations  # Copy migrations from metasploit_data_models_engine to application
rake middleware                                        # Prints out your Rack middleware stack
rake notes                                             # Enumerate all annotations (use notes:optimize, :fixme, :todo for focus)
rake notes:custom                                      # Enumerate a custom annotation, specify with ANNOTATION=CUSTOM
rake rails:template                                    # Applies the template supplied by LOCATION=(/path/to/template) or URL
rake rails:update                                      # Update configs and some other initially generated files (or use just update:configs, update:bin, or update:application_controller)
rake routes                                            # Print out all defined routes in match order, with names
rake secret                                            # Generate a cryptographically secure secret key (this is typically used to generate a secret for cookie sessions)
rake spec                                              # Run all specs in spec directory (excluding plugin specs)
rake spec:lib                                          # Run the code examples in spec/lib
rake spec:models                                       # Run the code examples in spec/models
rake spec:modules                                      # Run the code examples in spec/modules
rake spec:tools                                        # Run the code examples in spec/tools
rake stats                                             # Report code statistics (KLOCs, etc) from the application
rake time:zones:all                                    # Displays all time zones, also available: time:zones:us, time:zones:local -- filter with OFFSET parameter, e.g., OFFSET=-6
rake tmp:clear                                         # Clear session, cache, and socket files from tmp/ (narrow w/ tmp:sessions:clear, tmp:cache:clear, tmp:sockets:clear)
rake tmp:create                                        # Creates tmp directories for sessions, cache, sockets, and pids
rake yard                                              # Generate YARD documentation
rake yard:doc                                          # Generate YARD Documentation
rake yard:stats                                        # Shows stats for YARD Documentation including listing undocumented modules, classes, constants, and methods
```
