### PR TITLE
Shrink the size of ms08_067 so that it again works with bind_tcp

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => true,
       'Payload'        =>
         {
-          'Space'    => 410,
+          'Space'    => 408,
           'BadChars' => "\x00\x0a\x0d\x5c\x5f\x2f\x2e\x40",
           'Prepend'  => "\x81\xE4\xF0\xFF\xFF\xFF", # stack alignment
           'StackAdjustment' => -3500,


### PR DESCRIPTION
In #6283, we discovered that ms08_067 was busted with reverse_tcp. The solution was to bump the amount of space needed to help with encoding. However, we flew a little too close to the sun, and introduced a regression with bind_tcp on Windows XP SP2 EN where the payload stages
but does not run.

This shrinks the payload just enough to make bind_tcp work again, but reverse_tcp also continues to work as expected. I should have included this in the original validation steps.
# Validation
- [x] Verify that reverse_tcp stagers work with ms08_067 on Windows XP (shell and meterpreter)
- [x] Verify that bind_tcp stagers work with ms08_067 on Windows XP (shell and meterpreter)
- [x] Verify that reverse_tcp stagers work with ms08_067 on Windows 2003 (shell and meterpreter)
- [x] Verify that bind_tcp stagers work with ms08_067 on Windows 2003 (shell and meterpreter)
  
  @lsanchez-r7 might have some more testing ideas here
