### PR TITLE
move SSL to the default options

### DIFF
--- a/lib/msf/core/auxiliary/crawler.rb
+++ b/lib/msf/core/auxiliary/crawler.rb
@@ -25,7 +25,8 @@ module Auxiliary::HttpCrawler
         OptInt.new('MAX_THREADS', [ true, 'The maximum number of concurrent requests', 4]),
         OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication']),
         OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication']),
-        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentication', 'WORKSTATION'])
+        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentication', 'WORKSTATION']),
+        OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false])
 
       ], self.class
     )
@@ -43,7 +44,6 @@ module Auxiliary::HttpCrawler
         OptString.new('BasicAuthPass', [false, 'The HTTP password to specify for basic authentication']),
         OptString.new('HTTPAdditionalHeaders', [false, "A list of additional headers to send (separated by \\x01)"]),
         OptString.new('HTTPCookie', [false, "A HTTP cookie header to send with each request"]),
-        OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL23', 'SSL3', 'TLS1']]),
       ], self.class
     )

--- a/lib/msf/core/auxiliary/crawler.rb
+++ b/lib/msf/core/auxiliary/crawler.rb
@@ -26,7 +26,7 @@ module Auxiliary::HttpCrawler
         OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication']),
         OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication']),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentication', 'WORKSTATION']),
-        OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false])
+        OptBool.new('SSL', [ false, 'Negotiate SSL/TLS for outgoing connections', false])
 
       ], self.class
     )

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -37,7 +37,7 @@ module Exploit::Remote::HttpClient
         Opt::RHOST,
         Opt::RPORT(80),
         OptString.new('VHOST', [ false, "HTTP server virtual host" ]),
-        OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
+        OptBool.new('SSL', [ false, 'Negotiate SSL/TLS for outgoing connections', false]),
         Opt::Proxies
       ], self.class
     )

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -37,6 +37,7 @@ module Exploit::Remote::HttpClient
         Opt::RHOST,
         Opt::RPORT(80),
         OptString.new('VHOST', [ false, "HTTP server virtual host" ]),
+        OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
         Opt::Proxies
       ], self.class
     )
@@ -49,7 +50,6 @@ module Exploit::Remote::HttpClient
         OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', '']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
-        OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),

--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -63,7 +63,7 @@ module Exploit::Remote::Tcp
 
     register_advanced_options(
       [
-        OptBool.new('SSL',        [ false, 'Negotiate SSL for outgoing connections', false]),
+        OptBool.new('SSL',        [ false, 'Negotiate SSL/TLS for outgoing connections', false]),
         OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL/TLS to be used (TLS and SSL23 are auto-negotiate)', 'TLS1', ['SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']]),
         OptEnum.new('SSLVerifyMode',  [ false, 'SSL verification method', 'PEER', %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}]),
         OptString.new('SSLCipher',    [ false, 'String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"']),

--- a/modules/auxiliary/admin/vmware/poweroff_vm.rb
+++ b/modules/auxiliary/admin/vmware/poweroff_vm.rb
@@ -20,7 +20,8 @@ class Metasploit3 < Msf::Auxiliary
         This module will log into the Web API of VMWare and try to power off
         a specified Virtual Machine.},
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -30,8 +31,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ]),
         OptString.new('VM', [true, "The VM to try to Power Off"])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
   def run

--- a/modules/auxiliary/admin/vmware/poweron_vm.rb
+++ b/modules/auxiliary/admin/vmware/poweron_vm.rb
@@ -21,7 +21,8 @@ class Metasploit3 < Msf::Auxiliary
         a specified Virtual Machine.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -31,8 +32,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ]),
         OptString.new('VM', [true, "The VM to try to Power On"])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
   def run

--- a/modules/auxiliary/admin/vmware/tag_vm.rb
+++ b/modules/auxiliary/admin/vmware/tag_vm.rb
@@ -22,7 +22,8 @@ class Metasploit3 < Msf::Auxiliary
         logging a user event with user supplied text
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -33,8 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('VM', [true, "The VM to try to Power On"]),
         OptString.new('MSG', [true, "The message to put in the log", 'Pwned by Metasploit'])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
   def run

--- a/modules/auxiliary/admin/vmware/terminate_esx_sessions.rb
+++ b/modules/auxiliary/admin/vmware/terminate_esx_sessions.rb
@@ -20,7 +20,8 @@ class Metasploit3 < Msf::Auxiliary
         This module will log into the Web API of VMWare and try to terminate
         user login sessions as specified by the session keys.},
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -30,8 +31,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ]),
         OptString.new('KEYS', [true, "The session key to terminate"])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
   def run

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -32,14 +32,14 @@ class Metasploit3 < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'DefaultOptions' =>
         {
-          'SSLVersion' => 'TLS1'
+          'SSLVersion' => 'TLS1',
+          'SSL'        => true
         }
     ))
 
     register_options(
       [
         OptInt.new('RPORT', [true, 'The BigIP service port to listen on', 443]),
-        OptBool.new('SSL', [true, "Negotiate SSL for outgoing connections", true]),
         OptString.new('TARGETURI', [true, 'The URI path to test', '/']),
         OptInt.new('REQUESTS', [true, 'The number of requests to send', 10])
       ], self.class)

--- a/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
+++ b/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
@@ -22,12 +22,12 @@ class Metasploit3 < Msf::Auxiliary
           'Deral "Percentx" Heiland',
           'Pete "Bokojan" Arzamendi'
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => false }
     ))
 
     register_options(
       [
-        OptBool.new('SSL', [true, 'Negotiate SSL for outgoing connections', false]),
         OptString.new('PASSWORD', [true, 'Password to access administrative interface. Defaults to 1111', '1111']),
         OptPort.new('RPORT', [true, 'The target port on the remote printer. Defaults to 80', 80]),
         OptInt.new('TIMEOUT', [true, 'Timeout for printer connection probe.', 20]),

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -26,15 +26,18 @@ class Metasploit3 < Msf::Auxiliary
         [
           'hdm'
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' =>
+      {
+        'SSL'         => true,
+        'SSLVersion'  => 'TLS1'
+      }
     )
 
     register_options(
       [
         Opt::RPORT(443),
         OptString.new('TARGETURI', [ true,  'The path to the Chef Web UI application', '/']),
-        OptBool.new('SSL', [true, 'Negotiate SSL for outgoing connections', true]),
-        OptEnum.new('SSLVersion', [false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
+++ b/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
@@ -24,13 +24,13 @@ class Metasploit3 < Msf::Auxiliary
         [
           'Jonathan Claudius <jclaudius[at]trustwave.com>',
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     ))
 
     register_options(
       [
         Opt::RPORT(443),
-        OptBool.new('SSL', [true, "Negotiate SSL for outgoing connections", true]),
         OptString.new('USERNAME', [true, "A specific username to authenticate as", 'cisco']),
         OptString.new('PASSWORD', [true, "A specific password to authenticate with", 'cisco'])
       ], self.class)

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -24,13 +24,13 @@ class Metasploit3 < Msf::Auxiliary
         [
           'Karn Ganeshen <KarnGaneshen[at]gmail.com>',
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     ))
 
     register_options(
       [
         Opt::RPORT(443),
-        OptBool.new('SSL', [true, "Negotiate SSL for outgoing connections", true]),
         OptString.new('USERNAME', [true, "A specific username to authenticate as", "admin"]),
         OptString.new('PASSWORD', [true, "A specific password to authenticate with", "ironport"])
       ], self.class)

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn_priv_esc.rb
@@ -30,13 +30,13 @@ class Metasploit3 < Msf::Auxiliary
           ['URL', 'http://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20140409-asa'],
           ['URL', 'https://www3.trustwave.com/spiderlabs/advisories/TWSL2014-005.txt']
         ],
-      'DisclosureDate' => 'Apr 09 2014'
+      'DisclosureDate' => 'Apr 09 2014',
+      'DefaultOptions' => { 'SSL' => true }
     ))
 
     register_options(
       [
         Opt::RPORT(443),
-        OptBool.new('SSL', [true, "Negotiate SSL for outgoing connections", true]),
         OptString.new('USERNAME', [true, "A specific username to authenticate as", 'clientless']),
         OptString.new('PASSWORD', [true, "A specific password to authenticate with", 'clientless']),
         OptString.new('GROUP', [true, "A specific VPN group to use", 'clientless']),

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -42,8 +42,6 @@ class Metasploit3 < Msf::Auxiliary
         # There is no TARGETURI because when Glassfish is installed, the path is /
         Opt::RPORT(4848),
         OptString.new('USERNAME',[true, 'A specific username to authenticate as','admin']),
-        OptBool.new('SSL', [false, 'Negotiate SSL for outgoing connections', false]),
-        OptEnum.new('SSLVersion', [false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/http_hsts.rb
+++ b/modules/auxiliary/scanner/http/http_hsts.rb
@@ -12,16 +12,16 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info={})
     super(update_info(info,
-      'Name'        => 'HTTP Strict Transport Security (HSTS) Detection',
-      'Description' => %q{
+      'Name'            => 'HTTP Strict Transport Security (HSTS) Detection',
+      'Description'     => %q{
         Display HTTP Strict Transport Security (HSTS) information about each system.
       },
-      'Author'      => 'Matt "hostess" Andreko <mandreko[at]accuvant.com>',
-      'License'     => MSF_LICENSE
+      'Author'          => 'Matt "hostess" Andreko <mandreko[at]accuvant.com>',
+      'License'         => MSF_LICENSE,
+      'DefaultOptions'  => { 'SSL' => true }
     ))
 
     register_options([
-        OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
         Opt::RPORT(443)
       ])
   end

--- a/modules/auxiliary/scanner/http/infovista_enum.rb
+++ b/modules/auxiliary/scanner/http/infovista_enum.rb
@@ -24,13 +24,13 @@ class Metasploit3 < Msf::Auxiliary
         [
           'Karn Ganeshen <KarnGaneshen[at]gmail.com>',
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     ))
 
     register_options(
       [
         Opt::RPORT(443),
-        OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
         OptString.new('TARGETURI', [true, "URI for Web login. Default: /VPortal/mgtconsole/CheckPassword.jsp", "/VPortal/mgtconsole/CheckPassword.jsp"])
       ], self.class)
   end

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -33,8 +33,6 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(80),
         OptString.new('TARGETURI', [ true,  'The path to the Zabbix server application', '/zabbix/']),
-        OptBool.new('SSL', [false, 'Negotiate SSL for outgoing connections', false]),
-        OptEnum.new('SSLVersion', [false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/msf/msf_web_login.rb
+++ b/modules/auxiliary/scanner/msf/msf_web_login.rb
@@ -21,7 +21,8 @@ class Metasploit3 < Msf::Auxiliary
         web interface using a specific user/pass.
       },
       'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -30,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('URILOGIN', [true, "URI for Metasploit Web login. Default is /login", "/login"]),
         OptString.new('URIGUESS', [true, "URI for Metasploit Web login. Default is /user_sessions", "/user_sessions"]),
         OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false]),
-        OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
       ], self.class)
 
     register_autofilter_ports([55553])

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -21,14 +21,17 @@ class Metasploit3 < Msf::Auxiliary
         This module will attempt to authenticate to a Nessus server RPC interface.
       },
       'Author'         => [ 'void_in' ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' =>
+      {
+        'SSL'        => true,
+        'SSLVersion' => 'TLS1'
+      }
     ))
     register_options(
       [
         Opt::RPORT(8834),
         OptString.new('TARGETURI', [ true,  'The path to the Nessus server login API', '/session']),
-        OptBool.new('SSL', [true, 'Negotiate SSL for outgoing connections', true]),
-        OptEnum.new('SSLVersion', [false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
@@ -24,7 +24,8 @@ class Metasploit3 < Msf::Auxiliary
         specific user/pass.
       },
       'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -33,11 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('URI', [true, "URI for Nessus XMLRPC login. Default is /login", "/login"]),
         OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
       ], self.class)
-
-    register_advanced_options(
-    [
-      OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
-    ], self.class)
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/nessus/nessus_xmlrpc_ping.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_xmlrpc_ping.rb
@@ -23,7 +23,8 @@ class Metasploit3 < Msf::Auxiliary
         for Nessus XMLRPC interface.'
       },
       'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -32,11 +33,6 @@ class Metasploit3 < Msf::Auxiliary
         OptInt.new('THREADS', [true, "The number of concurrent threads", 25]),
         OptString.new('URI', [true, "URI for Nessus XMLRPC. Default is /", "/"])
       ], self.class)
-
-    register_advanced_options(
-    [
-      OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
-    ], self.class)
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
+++ b/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
@@ -24,7 +24,8 @@ class Metasploit3 < Msf::Auxiliary
         specific user/pass.
       },
       'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -33,11 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('URI', [true, "URI for NeXpose API. Default is /api/1.1/xml", "/api/1.1/xml"]),
         OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false])
       ], self.class)
-
-    register_advanced_options(
-    [
-      OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
-    ], self.class)
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
@@ -15,13 +15,14 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'OpenVAS gsad Web Interface Login Utility',
-      'Description' => %q{
+      'Name'           => 'OpenVAS gsad Web Interface Login Utility',
+      'Description'    => %q{
         This module simply attempts to login to a OpenVAS gsad interface
         using a specific user/pass.
       },
-      'Author'      => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
-      'License'     => MSF_LICENSE
+      'Author'         => [ 'Vlatko Kosturjak <kost[at]linux.hr>' ],
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -29,7 +30,6 @@ class Metasploit3 < Msf::Auxiliary
         Opt::RPORT(443),
         OptString.new('URI', [true, "URI for OpenVAS omp login. Default is /omp", "/omp"]),
         OptBool.new('BLANK_PASSWORDS', [false, "Try blank passwords for all users", false]),
-        OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
       ], self.class)
 
     register_advanced_options(

--- a/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
+++ b/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
@@ -22,14 +22,13 @@ class Metasploit3 < Msf::Auxiliary
         and attempts to identify version information for that server.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options([Opt::RPORT(443),
       OptString.new('URI', [false, 'The uri path to test against' , '/sdk'])
     ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
@@ -24,7 +24,8 @@ class Metasploit3 < Msf::Auxiliary
         the VMware product
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -33,8 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('USERNAME', [ true, "The username to Authenticate with.", 'root' ]),
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
@@ -22,7 +22,8 @@ class Metasploit3 < Msf::Auxiliary
         all the login sessions.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -31,8 +32,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('USERNAME', [ true, "The username to Authenticate with.", 'root' ]),
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
@@ -23,7 +23,8 @@ class Metasploit3 < Msf::Auxiliary
         more domains, it will try to enumerate domain users as well.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -32,8 +33,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('USERNAME', [ true, "The username to Authenticate with.", 'root' ]),
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
@@ -22,7 +22,8 @@ class Metasploit3 < Msf::Auxiliary
         running the web interface. This would include ESX/ESXi and VMWare Server.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -32,8 +33,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ]),
         OptBool.new('SCREENSHOT', [true, "Wheter or not to try to take a screenshot", true])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/vmware/vmware_host_details.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_host_details.rb
@@ -22,7 +22,8 @@ class Metasploit3 < Msf::Auxiliary
         This can include information about the hardware installed on the host machine.
       },
       'Author'         => ['theLightCosine'],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -32,8 +33,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('PASSWORD', [ true, "The password to Authenticate with.", 'password' ]),
         OptBool.new('HW_DETAILS', [true, "Enumerate the Hardware on the system as well?", false])
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -25,7 +25,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '1999-0502'] # Weak password
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true }
     )
 
     register_options(
@@ -33,8 +34,6 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('URI', [true, "The default URI to login with", "/sdk"]),
         Opt::RPORT(443)
       ], self.class)
-
-    register_advanced_options([OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', true]),])
   end
 
   def report_cred(opts)


### PR DESCRIPTION
Since more and more sites are switching to SSL / TLS move the `SSL` datastore option to the normal options for HTTP based modules. This makes it clearer for the end user to also set `SSL = true` when testing SSL enabled servers.
