### PR TITLE
Bugfix: specify scripting language

### DIFF
--- a/modules/exploits/multi/elasticsearch/search_groovy_script.rb
+++ b/modules/exploits/multi/elasticsearch/search_groovy_script.rb
@@ -185,7 +185,8 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       "script_fields" => {
         "msf_result" => {
-          "script" => java
+          "script" => java,
+          "lang" => "groovy"
         }
       }
     }


### PR DESCRIPTION
An Elasticsearch instance that I tested the module on interpreted scripts as "mvel" by default, unless otherwise specified. This is an error (plus, mvel scripting was disabled on the instance) and the exploit failed. Explicitly stating the scripting language as "groovy" fixed that and made the exploit module work.
