### PR TITLE
Bump metasploit-payloads to 1.0.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       metasploit-concern (= 1.0.0)
       metasploit-credential (= 1.0.1)
       metasploit-model (= 1.0.0)
-      metasploit-payloads (= 1.0.21)
+      metasploit-payloads (= 1.0.22)
       metasploit_data_models (= 1.2.10)
       msgpack
       network_interface (~> 0.0.1)
@@ -124,7 +124,7 @@ GEM
       activemodel (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
-    metasploit-payloads (1.0.21)
+    metasploit-payloads (1.0.22)
     metasploit_data_models (1.2.10)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '1.0.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.0.21'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.0.22'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module Metasploit4
 
-  CachedSize = 26203
+  CachedSize = 26205
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
This PR bumps the metasploit-payloads version to 1.0.22. It contains a patch for this issue: https://github.com/rapid7/metasploit-framework/issues/6414
