### PR TITLE
Add -x flag to session list to show checkin time

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -524,6 +524,7 @@ class ReadableText
   def self.dump_sessions(framework, opts={})
     ids = (opts[:session_ids] || framework.sessions.keys).sort
     verbose = opts[:verbose] || false
+    extended = opts[:extended] || false
     indent = opts[:indent] || DefaultIndent
     col = opts[:col] || DefaultColumnWrap
 
@@ -536,6 +537,7 @@ class ReadableText
         'Information',
         'Connection'
       ]
+    columns << 'Checkin?' if extended
 
     tbl = Rex::Ui::Text::Table.new(
       'Indent'  => indent,
@@ -552,8 +554,16 @@ class ReadableText
       end
 
       row = [ session.sid.to_s, session.type.to_s, sinfo, session.tunnel_to_s + " (#{session.session_host})" ]
-      if session.respond_to? :platform
+      if session.respond_to?(:platform)
         row[1] << (" " + session.platform)
+      end
+
+      if extended
+        if session.respond_to?(:last_checkin) && session.last_checkin
+          row << "#{(Time.now.to_i - session.last_checkin.to_i)}s ago"
+        else
+          row << '?'
+        end
       end
 
       tbl << row

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -524,20 +524,18 @@ class ReadableText
   def self.dump_sessions(framework, opts={})
     ids = (opts[:session_ids] || framework.sessions.keys).sort
     verbose = opts[:verbose] || false
-    extended = opts[:extended] || false
+    show_checkin = opts[:show_checkin] || false
     indent = opts[:indent] || DefaultIndent
     col = opts[:col] || DefaultColumnWrap
 
     return dump_sessions_verbose(framework, opts) if verbose
 
-    columns =
-      [
-        'Id',
-        'Type',
-        'Information',
-        'Connection'
-      ]
-    columns << 'Checkin?' if extended
+    columns = []
+    columns << 'Id'
+    columns << 'Type'
+    columns << 'Checkin?' if show_checkin
+    columns << 'Information'
+    columns << 'Connection'
 
     tbl = Rex::Ui::Text::Table.new(
       'Indent'  => indent,
@@ -553,18 +551,21 @@ class ReadableText
         sinfo = sinfo[0,77] + "..."
       end
 
-      row = [ session.sid.to_s, session.type.to_s, sinfo, session.tunnel_to_s + " (#{session.session_host})" ]
-      if session.respond_to?(:platform)
-        row[1] << (" " + session.platform)
-      end
+      row = []
+      row << session.sid.to_s
+      row << session.type.to_s
+      row[-1] << (" " + session.platform) if session.respond_to?(:platform)
 
-      if extended
+      if show_checkin
         if session.respond_to?(:last_checkin) && session.last_checkin
           row << "#{(Time.now.to_i - session.last_checkin.to_i)}s ago"
         else
           row << '?'
         end
       end
+
+      row << sinfo
+      row << session.tunnel_to_s + " (#{session.session_host})"
 
       tbl << row
     }

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -34,18 +34,19 @@ class Core
 
   # Session command options
   @@sessions_opts = Rex::Parser::Arguments.new(
-    "-c" => [ true,  "Run a command on the session given with -i, or all"],
-    "-h" => [ false, "Help banner"                                    ],
-    "-i" => [ true,  "Interact with the supplied session ID"          ],
-    "-l" => [ false, "List all active sessions"                       ],
-    "-v" => [ false, "List verbose fields"                            ],
-    "-q" => [ false, "Quiet mode"                                     ],
-    "-k" => [ true,  "Terminate sessions by session ID and/or range"  ],
-    "-K" => [ false, "Terminate all sessions"                         ],
-    "-s" => [ true,  "Run a script on the session given with -i, or all"],
-    "-r" => [ false, "Reset the ring buffer for the session given with -i, or all"],
-    "-u" => [ true,  "Upgrade a shell to a meterpreter session on many platforms" ],
-    "-t" => [ true,  "Set a response timeout (default: 15)"])
+    "-c"  => [ true,  "Run a command on the session given with -i, or all"          ],
+    "-h"  => [ false, "Help banner"                                                 ],
+    "-i"  => [ true,  "Interact with the supplied session ID   "                    ],
+    "-l"  => [ false, "List all active sessions"                                    ],
+    "-v"  => [ false, "List extended fields"                                        ],
+    "-vv" => [ false, "Render in verbose mode"                                      ],
+    "-q"  => [ false, "Quiet mode"                                                  ],
+    "-k"  => [ true,  "Terminate sessions by session ID and/or range"               ],
+    "-K"  => [ false, "Terminate all sessions"                                      ],
+    "-s"  => [ true,  "Run a script on the session given with -i, or all"           ],
+    "-r"  => [ false, "Reset the ring buffer for the session given with -i, or all" ],
+    "-u"  => [ true,  "Upgrade a shell to a meterpreter session on many platforms"  ],
+    "-t"  => [ true,  "Set a response timeout (default: 15)"                        ])
 
   @@jobs_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -1757,12 +1758,13 @@ class Core
   #
   def cmd_sessions(*args)
     begin
-    method  = nil
-    quiet   = false
-    verbose = false
-    sid     = nil
-    cmds    = []
-    script  = nil
+    method   = nil
+    quiet    = false
+    extended = false
+    verbose  = false
+    sid      = nil
+    cmds     = []
+    script   = nil
     reset_ring = false
     response_timeout = 15
 
@@ -1780,6 +1782,8 @@ class Core
         method = 'cmd'
         cmds << val if val
       when "-v"
+        extended = true
+      when "-vv"
         verbose = true
       # Do something with the supplied session identifier instead of
       # all sessions.
@@ -2041,7 +2045,7 @@ class Core
       end
     when 'list',nil
       print_line
-      print(Serializer::ReadableText.dump_sessions(framework, :verbose => verbose))
+      print(Serializer::ReadableText.dump_sessions(framework, :extended => extended, :verbose => verbose))
       print_line
     end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -35,11 +35,11 @@ class Core
   # Session command options
   @@sessions_opts = Rex::Parser::Arguments.new(
     "-c"  => [ true,  "Run a command on the session given with -i, or all"          ],
+    "-ci" => [ false, "Show the last checkin time in the session table"             ],
     "-h"  => [ false, "Help banner"                                                 ],
     "-i"  => [ true,  "Interact with the supplied session ID   "                    ],
     "-l"  => [ false, "List all active sessions"                                    ],
-    "-v"  => [ false, "List extended fields"                                        ],
-    "-vv" => [ false, "Render in verbose mode"                                      ],
+    "-v"  => [ false, "List sessions in verbose mode"                               ],
     "-q"  => [ false, "Quiet mode"                                                  ],
     "-k"  => [ true,  "Terminate sessions by session ID and/or range"               ],
     "-K"  => [ false, "Terminate all sessions"                                      ],
@@ -1760,7 +1760,7 @@ class Core
     begin
     method   = nil
     quiet    = false
-    extended = false
+    show_checkin = false
     verbose  = false
     sid      = nil
     cmds     = []
@@ -1781,9 +1781,9 @@ class Core
       when "-c"
         method = 'cmd'
         cmds << val if val
+      when "-ci"
+        show_checkin = true
       when "-v"
-        extended = true
-      when "-vv"
         verbose = true
       # Do something with the supplied session identifier instead of
       # all sessions.
@@ -2045,7 +2045,7 @@ class Core
       end
     when 'list',nil
       print_line
-      print(Serializer::ReadableText.dump_sessions(framework, :extended => extended, :verbose => verbose))
+      print(Serializer::ReadableText.dump_sessions(framework, :show_checkin => show_checkin, :verbose => verbose))
       print_line
     end
 


### PR DESCRIPTION
This is a simple PR that changes the `sessions` command to allow for extended information in the sessions list. The default `sessions` command remains the same:

```
msf exploit(handler) > sessions

Active sessions
===============

  Id  Type                   Information                           Connection
  --  ----                   -----------                           ----------
  1   meterpreter x86/win32  WIN-7CH5RT177BA\oj @ WIN-7CH5RT177BA  10.1.10.40:3000 -> 10.1.10.38:61094 (10.1.10.38)
```

Adding the `-v` parameter changes this to `extended`, which at this time includes the last check-in time (which I am constantly wanting to see on gigs):

```
msf exploit(handler) > sessions -v

Active sessions
===============

  Id  Type                   Information                           Connection                                        Checkin?
  --  ----                   -----------                           ----------                                        --------
  1   meterpreter x86/win32  WIN-7CH5RT177BA\oj @ WIN-7CH5RT177BA  10.1.10.40:3000 -> 10.1.10.38:61094 (10.1.10.38)  2s ago
```

Using `-vv` then puts the list into verbose mode, which is what `-v` used to do:

```
msf exploit(handler) > sessions -vv

Active sessions
===============

  Session ID: 1
        Type: meterpreter x86/win32
        Info: WIN-7CH5RT177BA\oj @ WIN-7CH5RT177BA
      Tunnel: 10.1.10.40:3000 -> 10.1.10.38:61094 (10.1.10.38)
         Via: exploit/multi/handler
        UUID: 90d03b78c24ab8f7/x86=1/windows=1/2016-01-25T12:31:07Z
   MachineID: b8cbd32fa758033e81eb1143d24948da
     CheckIn: 1s ago @ 2016-01-25 22:31:36 +1000
  Registered: No
```

Help updated to reflect changes:

```
msf exploit(handler) > sessions -h
Usage: sessions [options]

Active session manipulation and interaction.

OPTIONS:

    -K         Terminate all sessions
    -c  <opt>  Run a command on the session given with -i, or all
    -h         Help banner
    -i  <opt>  Interact with the supplied session ID   
    -k  <opt>  Terminate sessions by session ID and/or range
    -l         List all active sessions
    -q         Quiet mode
    -r         Reset the ring buffer for the session given with -i, or all
    -s  <opt>  Run a script on the session given with -i, or all
    -t  <opt>  Set a response timeout (default: 15)
    -u  <opt>  Upgrade a shell to a meterpreter session on many platforms
    -v         List extended fields
    -vv        Render in verbose mode
```

Thoughts? I think seeing the checkin time in a table is really useful, and makes it easy to know at a glance which sessions are dead and which aren't.
