### PR TITLE
Add `dir` as an alias for `ls`

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -52,6 +52,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'cat'        => 'Read the contents of a file to the screen',
       'cd'         => 'Change directory',
       'del'        => 'Delete the specified file',
+      'dir'        => 'List files (alias for ls)',
       'download'   => 'Download a file or directory',
       'edit'       => 'Edit a file',
       'getlwd'     => 'Print local working directory',
@@ -73,6 +74,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       'cat'        => [],
       'cd'         => ['stdapi_fs_chdir'],
       'del'        => ['stdapi_fs_rm'],
+      'dir'        => ['stdapi_fs_stat', 'stdapi_fs_ls'],
       'download'   => [],
       'edit'       => [],
       'getlwd'     => [],
@@ -597,6 +599,12 @@ class Console::CommandDispatcher::Stdapi::Fs
 
     return true
   end
+
+  #
+  # Alias the ls command to dir, for those of us who have windows muscle-memory
+  #
+  alias cmd_dir cmd_ls
+
 
   #
   # Make one or more directory.


### PR DESCRIPTION
I know I'm not alone with this one. I use `dir` and `ls` all the time on different operating systems during engagements. However, sometimes I forget I'm in Meterp, and I type `dir` instead of `ls` when listing files.

Give that these two commands are effectively the same thing, I thought that aliasing them would make sense in the same way we do for `ifconfig` and `ipconfig`. This PR adds `dir` as an alias to `ls`.
## Sample Run

```
meterpreter > help

Stdapi: File system Commands
============================

    Command       Description
    -------       -----------
    dir           List files (alias for ls)

meterpreter > ls
Listing: C:\
============

Mode              Size      Type  Last modified              Name
----              ----      ----  -------------              ----
40777/rwxrwxrwx   0         dir   2015-11-20 10:37:59 +1000  $Recycle.Bin
100444/r--r--r--  8192      fil   2015-11-21 05:34:08 +1000  BOOTSECT.BAK
40777/rwxrwxrwx   0         dir   2015-11-20 15:40:57 +1000  Boot
40777/rwxrwxrwx   0         dir   2009-07-14 15:08:56 +1000  Documents and Settings
40777/rwxrwxrwx   0         dir   2009-07-14 13:20:08 +1000  PerfLogs
40555/r-xr-xr-x   0         dir   2015-12-02 11:26:29 +1000  Program Files
40555/r-xr-xr-x   0         dir   2015-11-20 16:35:07 +1000  Program Files (x86)
40777/rwxrwxrwx   0         dir   2015-11-27 11:45:43 +1000  ProgramData
40777/rwxrwxrwx   0         dir   2015-11-20 16:18:44 +1000  Python27
40777/rwxrwxrwx   0         dir   2015-11-20 10:37:21 +1000  Recovery
40777/rwxrwxrwx   0         dir   2016-01-27 09:10:49 +1000  System Volume Information
40555/r-xr-xr-x   0         dir   2015-11-20 10:37:22 +1000  Users
40777/rwxrwxrwx   0         dir   2015-11-24 08:04:21 +1000  Windows
100444/r--r--r--  383786    fil   2010-11-21 13:23:51 +1000  bootmgr
0126/--x-w-rw-    40238224  fif   1970-01-01 10:00:00 +1000  pagefile.sys
40777/rwxrwxrwx   0         dir   2015-11-27 11:49:38 +1000  symbols

meterpreter > dir
Listing: C:\
============

Mode              Size      Type  Last modified              Name
----              ----      ----  -------------              ----
40777/rwxrwxrwx   0         dir   2015-11-20 10:37:59 +1000  $Recycle.Bin
100444/r--r--r--  8192      fil   2015-11-21 05:34:08 +1000  BOOTSECT.BAK
40777/rwxrwxrwx   0         dir   2015-11-20 15:40:57 +1000  Boot
40777/rwxrwxrwx   0         dir   2009-07-14 15:08:56 +1000  Documents and Settings
40777/rwxrwxrwx   0         dir   2009-07-14 13:20:08 +1000  PerfLogs
40555/r-xr-xr-x   0         dir   2015-12-02 11:26:29 +1000  Program Files
40555/r-xr-xr-x   0         dir   2015-11-20 16:35:07 +1000  Program Files (x86)
40777/rwxrwxrwx   0         dir   2015-11-27 11:45:43 +1000  ProgramData
40777/rwxrwxrwx   0         dir   2015-11-20 16:18:44 +1000  Python27
40777/rwxrwxrwx   0         dir   2015-11-20 10:37:21 +1000  Recovery
40777/rwxrwxrwx   0         dir   2016-01-27 09:10:49 +1000  System Volume Information
40555/r-xr-xr-x   0         dir   2015-11-20 10:37:22 +1000  Users
40777/rwxrwxrwx   0         dir   2015-11-24 08:04:21 +1000  Windows
100444/r--r--r--  383786    fil   2010-11-21 13:23:51 +1000  bootmgr
0126/--x-w-rw-    40238224  fif   1970-01-01 10:00:00 +1000  pagefile.sys
40777/rwxrwxrwx   0         dir   2015-11-27 11:49:38 +1000  symbols

meterpreter > 
```
## Verification
- [x] Create a meterp session
- [x] Make sure the help contains information on the `dir` alias
- [x] Confirm that `dir` functions the same way as `ls`
