### PR TITLE
Bump Jsobfu version to support preserved_identifiers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       activesupport (>= 4.0.9, < 4.1.0)
       bcrypt
       filesize
-      jsobfu (~> 0.3.0)
+      jsobfu (~> 0.4.1)
       json
       metasm (~> 1.0.2)
       metasploit-concern (= 1.0.0)
@@ -102,7 +102,7 @@ GEM
       multi_json (~> 1.3)
     hike (1.2.3)
     i18n (0.7.0)
-    jsobfu (0.3.0)
+    jsobfu (0.4.1)
       rkelly-remix (= 0.0.6)
     json (1.8.3)
     mail (2.6.3)

--- a/lib/msf/core/exploit/jsobfu.rb
+++ b/lib/msf/core/exploit/jsobfu.rb
@@ -24,7 +24,7 @@ module Msf
     #
     def js_obfuscate(js, opts={})
       iterations = (opts[:iterations] || datastore['JsObfuscate']).to_i
-      identifiers = (opts[:preserved_identifiers] || datastore['JsIdentifiers'] || '').split(',')
+      identifiers = opts[:preserved_identifiers].blank? ? (datastore['JsIdentifiers'] || '').split(',') : opts[:preserved_identifiers]
       obfu = ::Rex::Exploitation::JSObfu.new(js)
       obfu_opts = {}
       obfu_opts.merge!(iterations: iterations)

--- a/lib/msf/core/exploit/jsobfu.rb
+++ b/lib/msf/core/exploit/jsobfu.rb
@@ -9,7 +9,7 @@ module Msf
       super
       register_advanced_options([
         OptInt.new('JsObfuscate', [false, "Number of times to obfuscate JavaScript", 0]),
-        OptString.new('Identifiers', [false, "Identifiers to preserve for JsObfu"])
+        OptString.new('JsIdentifiers', [false, "Identifiers to preserve for JsObfu"])
       ], Exploit::JSObfu)
     end
 
@@ -24,7 +24,7 @@ module Msf
     #
     def js_obfuscate(js, opts={})
       iterations = (opts[:iterations] || datastore['JsObfuscate']).to_i
-      identifiers = (opts[:preserved_identifiers] || datastore['Identifiers'] || '').split(',')
+      identifiers = (opts[:preserved_identifiers] || datastore['JsIdentifiers'] || '').split(',')
       obfu = ::Rex::Exploitation::JSObfu.new(js)
       obfu_opts = {}
       obfu_opts.merge!(iterations: iterations)

--- a/lib/msf/core/exploit/jsobfu.rb
+++ b/lib/msf/core/exploit/jsobfu.rb
@@ -8,7 +8,8 @@ module Msf
     def initialize(info={})
       super
       register_advanced_options([
-        OptInt.new('JsObfuscate', [false, "Number of times to obfuscate JavaScript", 0])
+        OptInt.new('JsObfuscate', [false, "Number of times to obfuscate JavaScript", 0]),
+        OptString.new('Identifiers', [false, "Identifiers to preserve for JsObfu"])
       ], Exploit::JSObfu)
     end
 
@@ -18,12 +19,18 @@ module Msf
     # @param js [String] JavaScript code
     # @param opts [Hash] obfuscation options
     #    * :iterations [FixNum] Number of times to obfuscate
+    #    * :preserved_identifiers [Array] An array of identifiers to preserve during obfuscation
     # @return [::Rex::Exploitation::JSObfu]
     #
     def js_obfuscate(js, opts={})
       iterations = (opts[:iterations] || datastore['JsObfuscate']).to_i
+      identifiers = (opts[:preserved_identifiers] || datastore['Identifiers'] || '').split(',')
       obfu = ::Rex::Exploitation::JSObfu.new(js)
-      obfu.obfuscate(:iterations=>iterations)
+      obfu_opts = {}
+      obfu_opts.merge!(iterations: iterations)
+      obfu_opts.merge!(preserved_identifiers: identifiers)
+
+      obfu.obfuscate(obfu_opts)
       obfu
     end
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.3.0'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.4.1'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasm compiler/decompiler/assembler

--- a/tools/exploit/jsobfu.rb
+++ b/tools/exploit/jsobfu.rb
@@ -32,6 +32,10 @@ module Jsobfu
           options[:output] = v
         end
 
+        opt.on('-p', '--preserved-identifiers id1,id2', 'The identifiers to preserve') do |v|
+          options[:preserved_identifiers] = v.split(',')
+        end
+
         opt.on_tail('-h', '--help', 'Show this message') do
           $stdout.puts opt
           exit
@@ -67,7 +71,10 @@ module Jsobfu
     def run
       original_js = read_js(@opts[:input])
       js = ::Rex::Exploitation::JSObfu.new(original_js)
-      js.obfuscate(:iterations=>@opts[:iteration].to_i)
+      obfu_opts = {}
+      obfu_opts.merge!(iterations: @opts[:iteration].to_i)
+      obfu_opts.merge!(preserved_identifiers: @opts[:preserved_identifiers] || [])
+      js.obfuscate(obfu_opts)
       js = js.to_s
 
       output_stream = $stdout


### PR DESCRIPTION
This PR bumps the JsObfu version to 0.4.1 in order to support the preserved_identifiers flag.
## Testing
- [x] Do: `ruby tools/exploit/jsobfu.rb -h`
- [x] You should see the -p option in the help menu
- [x] Do: `echo "alert(1)" > /tmp/js.js`
- [x] Do: `ruby tools/exploit/jsobfu.rb -p alert -i /tmp/js.js`
- [x] You should see `alert` not being obfuscated like the following demo:

```
$ ruby tools/exploit/jsobfu.rb -p alert -i /tmp/js.js
alert('f'.length);
```
- [x] Do: `ruby tools/exploit/jsobfu.rb -i /tmp/js.js`
- [x] You should see `alert` being obfuscated like the following demo:

```
$ ruby tools/exploit/jsobfu.rb -i /tmp/js.js
window[(function () { var lf="t",J="er",q="al"; return q+J+lf })()]('W'.length);
```
- [x] Save this script as ~/.msf4/modules/auxiliary/test.rb

``` ruby
require 'msf/core'
require 'msf/core/exploit/jsobfu'

class Metasploit3 < Msf::Auxiliary

  include Msf::Exploit::JSObfu

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'Jsobfu test',
      'Description'    => %q{
        Tests Jsobfu
      },
      'Author'         => [ 'sinn3r' ],
      'License'        => MSF_LICENSE,
      'DefaultOptions' => {
        'JsObfuscate' => 1
      }
    ))
  end

  def js
    %Q|alert(1)|
  end

  def run
    j = js_obfuscate(js, preserved_identifiers: ['alert'])
    print_status("This should not obfuscate 'alert'")
    print_line j.to_s

    print_line

    j = js_obfuscate(js)
    print_status("This should obfuscate 'alert'")
    print_line j.to_s
  end

end
```
- [x] Start msfconsole and run the above script. The first obfuscate should not change `alert`, and the second should like the following example:

```
msf auxiliary(test) > rerun
[*] Reloading module...

[*] This should not obfuscate 'alert'
alert('e'.length);

[*] This should obfuscate 'alert'
window[(function () { var i="t",W="r",V="a",Q="le"; return V+Q+W+i })()]('m'.length);
[*] Auxiliary module execution completed
msf auxiliary(test) > 
```
