### PR TITLE
Fix importing with Acunetix

### DIFF
--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -43,6 +43,7 @@ module Msf::DBManager::Service
   # opts may contain
   # +:name+::  the application layer protocol (e.g. ssh, mssql, smb)
   # +:sname+:: an alias for the above
+  # +:workspace+:: the workspace for the service
   #
   def report_service(opts)
     return if not active

--- a/lib/rex/parser/acunetix_nokogiri.rb
+++ b/lib/rex/parser/acunetix_nokogiri.rb
@@ -59,6 +59,8 @@ module Rex
         @text = nil
       when "StartURL" # Populates @state[:starturl_uri], we use this a lot
         @state[:has_text] = false
+        # StartURL does not always include the scheme
+        @text.prepend("http://") unless URI.parse(@text).scheme
         collect_host
         collect_service
         @text = nil


### PR DESCRIPTION
Add a default scheme of `http://` to URIs without a scheme. Also update some documentation.
