### PR TITLE
Feature: Autoadd for /post/windows/manage/autoroute.rb

### DIFF
--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -164,17 +164,20 @@ class Metasploit3 < Msf::Post
   # @return [void] A useful return value is not expected here
   def autoadd_routes
     switch_board = Rex::Socket::SwitchBoard.instance
-    print_status("Searcing for subnets to auto route.")
+    print_status("Searcing for subnets to autoroute.")
+    found = false
+
     session.net.config.each_route do | route |
       # Remove multicast and loopback interfaces
       next if route.subnet =~ /^(224\.|127\.)/
       next if route.subnet == '0.0.0.0'
       next if route.netmask == '255.255.255.255'
 
-      if not switch_board.route_exists?(route.subnet, route.netmask)
+      if !switch_board.route_exists?(route.subnet, route.netmask)
         begin
           if Rex::Socket::SwitchBoard.add_route(route.subnet, route.netmask, session)
             print_good("Route added to subnet #{route.subnet}/#{route.netmask}")
+            found = true
           else
             print_error("Could not add route to subnet #{route.subnet}/#{route.netmask}")
           end
@@ -184,6 +187,7 @@ class Metasploit3 < Msf::Post
         end
       end
     end
+    print_status("Did not find any new subnets to add.") if !found
   end
 
   # Validates the command options

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -15,7 +15,8 @@ class Metasploit3 < Msf::Post
         'Name'          => 'Windows Manage Network Route via Meterpreter Session',
         'Description'   => %q{This module manages session routing via an existing
           Meterpreter session. It enables other modules to 'pivot' through a
-          compromised host when connecting to the named NETWORK and SUBMASK.},
+          compromised host when connecting to the named NETWORK and SUBMASK.
+          Autoadd will search session for valid subnets and route to them.},
         'License'       => MSF_LICENSE,
         'Author'        => [ 'todb'],
         'Platform'      => [ 'win' ],


### PR DESCRIPTION
# Background

While working on a project demonstration, I noticed that the auto_add_route plugin wasn't wanting to work for Meterpreter Reverse HTTPS payloads.  It was even preventing the running of AutoRunScripts after session creation.  So I turned to the /post/windows/manage/autoroute module as a different option.  However, it didn't have the same functionality to search for subnets and add them to routing automatically.
# Work

I took the core functionality of the auto_add_route plugin and added it to the autoroute post module.  Cleaned up the code from the plugin and added some error handling.  Added an "autoadd" switch to the "CMD" datastore.  In this PR the "autoadd" switch is set to default, but the default can be switched back to "add" if it looks like it may break people's scripts.
# Testing
### The added feature was successfully tested on the following:

(Using both Reverse TCP and Reverse HTTPS payloads)
Win XP
Win Vista
Win 7
Win 8.1
Win 10
Server 2008 R2
Server 2012 RT
### Testing method
- Run post module on sessions with additional subnets.
- See if pivoting is available.
- Start another session with same additional subnets to make sure it doesn't double up routes.
- Start a session with no additional subnets, make sure it reports back that no additional subnets were found.
# Screenshots
### Operation with session that has additional subnets.

![usage1](https://cloud.githubusercontent.com/assets/12484685/12698953/986ec3ac-c770-11e5-9bdb-39696a870db9.jpg)
### Operation with session that has no new subnets.

![usage2](https://cloud.githubusercontent.com/assets/12484685/12698957/ae8f2ce4-c770-11e5-8a29-86802feccf57.jpg)
### Pivot test - Attack WinXP SP0 machine on internal subnet.

![pivottest](https://cloud.githubusercontent.com/assets/12484685/12698965/eccab60e-c770-11e5-8a26-10da90ab9a75.jpg)
