### PR TITLE
Better service reporting for snmp_login

### DIFF
--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -16,8 +16,10 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'SNMP Community Scanner',
-      'Description' => 'Scan for SNMP devices using common community names',
+      'Name'        => 'SNMP Community Login Scanner',
+      'Description' => %q{
+        This module logs in to SNMP devices using common community names.
+      },
       'Author'      => 'hdm',
       'References'     =>
         [
@@ -71,6 +73,14 @@ class Metasploit3 < Msf::Auxiliary
         create_credential_login(credential_data)
 
         print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential} (Access level: #{result.access_level}); Proof (sysDescr.0): #{result.proof}"
+        report_service(
+          :host  => ip,
+          :port  => rport,
+          :proto => 'udp',
+          :name  => 'snmp',
+          :info  => result.proof,
+          :state => 'open'
+        )
       else
         invalidate_login(credential_data)
         print_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"


### PR DESCRIPTION
Report the snmp string and update the module title & description to better clarify what the module really does.
## Test

I tested with Windows, so here's how you would do it:
- [ ] Set up an SNMP service with the following:

<img width="357" alt="screen shot 2016-02-01 at 12 10 01 pm" src="https://cloud.githubusercontent.com/assets/1170914/12726774/03f43f98-c8df-11e5-8b21-c4dedeb11fa5.png">
- [ ] Start msfconsole
- [ ] `workspace -a snmp_test`
- [ ] `use auxiliary/scanner/snmp/snmp_login`
- [ ] `set rhosts [IP]`
- [ ] `run`
- [ ] `services`
- [ ] You should see your SNMP host with some data under the info column
