### PR TITLE
Add tab completion for ReverseListenerBindAddress values

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3081,7 +3081,7 @@ class Core
         option_values_target_addrs().each do |addr|
           res << addr
         end
-      when 'LHOST', 'SRVHOST'
+      when 'LHOST', 'SRVHOST', 'REVERSELISTENERBINDADDRESS'
         rh = self.active_module.datastore['RHOST'] || framework.datastore['RHOST']
         if rh and not rh.empty?
           res << Rex::Socket.source_address(rh)


### PR DESCRIPTION
This has been bugging me for a while now.
- [x] `use exploit/multi/handler`
- [x] Pick a `reverse` payload
- [x] Try to tab-complete `ReverseListenerBindAddress` (case-sensitive)
#4998, #6065
