### PR TITLE
failed to unload event_tester / exit msfconsole

### DIFF
--- a/plugins/event_tester.rb
+++ b/plugins/event_tester.rb
@@ -7,10 +7,6 @@ module Msf
 
 class Plugin::EventTester < Msf::Plugin
   class Subscriber
-    def respond_to?(name)
-      # Why yes, I can do that.
-      true
-    end
     def method_missing(name, *args)
       $stdout.puts("Event fired: #{name}(#{args.join(", ")})")
     end


### PR DESCRIPTION
Related to issue [#6522](https://github.com/rapid7/metasploit-framework/issues/6522) .

When event_tester is loaded, we can not unload event_tester, or exit msf console.
