### PR TITLE
Fix reverse_http{,s} LHOST bind address

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -63,28 +63,11 @@ module ReverseHttp
       ], Msf::Handler::ReverseHttp)
   end
 
-  # Determine where to bind the server
-  #
-  # @return [String]
-  def listener_address
-    if datastore['ReverseListenerBindAddress']
-      bindaddr = datastore['ReverseListenerBindAddress']
-    else
-      begin
-        bindaddr = Rex::Socket.getaddress(datastore['LHOST'])
-      rescue SocketError
-        bindaddr = Rex::Socket.is_ipv6?(datastore['LHOST']) ? '::' : '0.0.0.0'
-      end
-    end
-
-    bindaddr
-  end
-
   # Return a URI suitable for placing in a payload
   #
   # @return [String] A URI of the form +scheme://host:port/+
-  def listener_uri
-    uri_host = Rex::Socket.is_ipv6?(listener_address) ? "[#{listener_address}]" : listener_address
+  def listener_uri(addr)
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
     "#{scheme}://#{uri_host}:#{bind_port}/"
   end
 
@@ -133,20 +116,33 @@ module ReverseHttp
   #
   def setup_handler
 
+    local_addr = nil
     local_port = bind_port
+    ex = false
 
     # Start the HTTPS server service on this host/port
-    self.service = Rex::ServiceManager.start(Rex::Proto::Http::Server,
-      local_port,
-      listener_address,
-      ssl?,
-      {
-        'Msf'        => framework,
-        'MsfExploit' => self,
-      },
-      nil,
-      (ssl?) ? datastore['HandlerSSLCert'] : nil
-    )
+    bind_addresses.each do |ip|
+      begin
+        self.service = Rex::ServiceManager.start(Rex::Proto::Http::Server,
+          local_port, ip, ssl?,
+          {
+            'Msf'        => framework,
+            'MsfExploit' => self,
+          },
+          nil,
+          (ssl?) ? datastore['HandlerSSLCert'] : nil
+        )
+        local_addr = ip
+      rescue
+        ex = $!
+        print_error("Handler failed to bind to #{ip}:#{local_port}")
+      else
+        ex = false
+        break
+      end
+    end
+
+    raise ex if (ex)
 
     self.service.server_name = datastore['MeterpreterServerName']
 
@@ -160,7 +156,7 @@ module ReverseHttp
       },
       'VirtualDirectory' => true)
 
-    print_status("Started #{scheme.upcase} reverse handler on #{listener_uri}")
+    print_status("Started #{scheme.upcase} reverse handler on #{listener_uri(local_addr)}")
     lookup_proxy_settings
 
     if datastore['IgnoreUnknownPayloads']

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -67,10 +67,14 @@ module ReverseHttp
   #
   # @return [String]
   def listener_address
-    if datastore['ReverseListenerBindAddress'].to_s == ''
-      bindaddr = Rex::Socket.is_ipv6?(datastore['LHOST']) ? '::' : '0.0.0.0'
-    else
+    if datastore['ReverseListenerBindAddress']
       bindaddr = datastore['ReverseListenerBindAddress']
+    else
+      begin
+        bindaddr = Rex::Socket.getaddress(datastore['LHOST'])
+      rescue SocketError
+        bindaddr = Rex::Socket.is_ipv6?(datastore['LHOST']) ? '::' : '0.0.0.0'
+      end
     end
 
     bindaddr


### PR DESCRIPTION
This pull request modifies the reverse_http{,s} handler to only bind to a particular LHOST address if the one specified matches an address on the local machine. Otherwise, it attempts to bind to the wildcard address.

The previous behavior was to always bind to the wildcard, which creates problems when one wants to run multiple handlers on the same machine on the same port but for different payloads or protocols.

Fixes #6519.
# Verification steps
- [x] Start a local reverse_http handler and set LHOST to a non-local address

```
msf > use exploit/multi/handler 
msf exploit(handler) > set payload python/meterpreter/reverse_http
payload => python/meterpreter/reverse_http
msf exploit(handler) > set lhost 1.2.3.4
lhost => 1.2.3.4
msf exploit(handler) > run

[-] Handler failed to bind to 1.2.3.4:8080
[*] Started HTTP reverse handler on http://0.0.0.0:8080/
[*] Starting the payload handler...
```
- [x] Verify that the first bind fails, but the second one binds to the wildcard handler
- [x] Try the same with a non-local IPv6 address
- [x] Verify that we bind to the IPv6 wildcard address
- [x] Try the same with a non-local IPv4 hostname (e.g. google.com)
- [x] Verify that we bind to the IPv4 wildcard address
- [x] Try the same with a non-local IPv6 hostname (e.g. ipv6.google.com)
- [x] Verify that we bind to the IPv6 wildcard address
- [x] Verify that local IPv4 / IPv6 addresses bind as well as local IPv4 / IPv6 hostnames
