### PR TITLE
Fix #6539, correct a typo in report_cred

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -225,7 +225,7 @@ class Metasploit3 < Msf::Auxiliary
 
         do_logout(resp.get_cookies)
 
-        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.body)
+        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: resp.body)
         report_note(ip: rhost, type: 'cisco.cred.group', data: "User: #{user} / Group: #{group}")
         return :next_user
 


### PR DESCRIPTION
Fix #6539 
## What This Patch Does

This patch fixes a typo in cisco_ssl_vpn.rb. When the module calls `report_cred`, it passes the wrong object name for the credential proof. Instead of `res.body`, it should be `resp.body`
## Verification
- [x] This is very easy to verify, so code review should be sufficient to verify this typo.
