### PR TITLE
Update .mailmap for the latest R7 Metasploit employees

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,45 +1,48 @@
-bcook-r7 <bcook-r7@github>         <busterb@gmail.com>
-bcook-r7 <bcook-r7@github>         Brent Cook <bcook@rapid7.com>
-bturner-r7 <bturner-r7@github>     Brandon Turner <brandon_turner@rapid7.com>
-cdoughty-r7 <cdoughty-r7@github>   Chris Doughty <chris_doughty@rapid7.com>
-dheiland-r7 <dheiland-r7@github>   Deral Heiland <dh@layereddefense.com>
-dmaloney-r7 <dmaloney-r7@github>   David Maloney <DMaloney@rapid7.com>
-dmaloney-r7 <dmaloney-r7@github>   David Maloney <David_Maloney@rapid7.com>
-dmaloney-r7 <dmaloney-r7@github>   dmaloney-r7 <DMaloney@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>   Dev Mohanty <Dev_Mohanty@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>   Dev Mohanty <Dev_Mohanty@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>   dmohanty-r7 <Dev_Mohanty@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>   dmohanty-r7 <Dev_Mohanty@rapid7.com>
-ecarey-r7 <ecarey-r7@github>       Erran Carey <e@ipwnstuff.com>
-farias-r7 <farias-r7@github>       Fernando Arias <fernando_arias@rapid7.com>
-gmikeska-r7 <gmikeska-r7@github>   Greg Mikeska <greg_mikeska@rapid7.com>
-gmikeska-r7 <gmikeska-r7@github>   Gregory Mikeska <greg_mikeska@rapid7.com>
-hdm <hdm@github>                   HD Moore <hd_moore@rapid7.com>
-hdm <hdm@github>                   HD Moore <hdm@digitaloffense.net>
-hdm <hdm@github>                   HD Moore <x@hdm.io>
-jhart-r7 <jhart-r7@github>         Jon Hart <jon_hart@rapid7.com>
-jlee-r7 <jlee-r7@github>           <egypt@metasploit.com> # aka egypt
-jlee-r7 <jlee-r7@github>           <james_lee@rapid7.com>
-kgray-r7 <kgray-r7@github>         Kyle Gray <kyle_gray@rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance.sanchez+github@gmail.com>
-lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance.sanchez@rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance@AUS-MAC-1041.local>
-lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance@aus-mac-1041.aus.rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>   darkbushido <lance.sanchez@gmail.com>
-lsato-r7 <lsato-r7@github>         Louis Sato <lsato@rapid7.com>
+acammack-r7 <acammack-r7@github>     Adam Cammack <Adam_Cammack@rapid7.com>
+bcook-r7 <bcook-r7@github>           <busterb@gmail.com>
+bcook-r7 <bcook-r7@github>           Brent Cook <bcook@rapid7.com>
+bturner-r7 <bturner-r7@github>       Brandon Turner <brandon_turner@rapid7.com>
+bpatterson-r7 <bpatterson-r7@github> Brian Patterson <Brian_Patterson@rapid7.com>
+cdoughty-r7 <cdoughty-r7@github>     Chris Doughty <chris_doughty@rapid7.com>
+dheiland-r7 <dheiland-r7@github>     Deral Heiland <dh@layereddefense.com>
+dmaloney-r7 <dmaloney-r7@github>     David Maloney <DMaloney@rapid7.com>
+dmaloney-r7 <dmaloney-r7@github>     David Maloney <David_Maloney@rapid7.com>
+dmaloney-r7 <dmaloney-r7@github>     dmaloney-r7 <DMaloney@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>     Dev Mohanty <Dev_Mohanty@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>     Dev Mohanty <Dev_Mohanty@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>     dmohanty-r7 <Dev_Mohanty@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>     dmohanty-r7 <Dev_Mohanty@rapid7.com>
+ecarey-r7 <ecarey-r7@github>         Erran Carey <e@ipwnstuff.com>
+farias-r7 <farias-r7@github>         Fernando Arias <fernando_arias@rapid7.com>
+gmikeska-r7 <gmikeska-r7@github>     Greg Mikeska <greg_mikeska@rapid7.com>
+gmikeska-r7 <gmikeska-r7@github>     Gregory Mikeska <greg_mikeska@rapid7.com>
+hdm <hdm@github>                     HD Moore <hd_moore@rapid7.com>
+hdm <hdm@github>                     HD Moore <hdm@digitaloffense.net>
+hdm <hdm@github>                     HD Moore <x@hdm.io>
+jhart-r7 <jhart-r7@github>           Jon Hart <jon_hart@rapid7.com>
+jlee-r7 <jlee-r7@github>             <egypt@metasploit.com> # aka egypt
+jlee-r7 <jlee-r7@github>             <james_lee@rapid7.com>
+kgray-r7 <kgray-r7@github>           Kyle Gray <kyle_gray@rapid7.com>
+lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance.sanchez+github@gmail.com>
+lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance.sanchez@rapid7.com>
+lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance@AUS-MAC-1041.local>
+lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance@aus-mac-1041.aus.rapid7.com>
+lsanchez-r7 <lsanchez-r7@github>     darkbushido <lance.sanchez@gmail.com>
+lsato-r7 <lsato-r7@github>           Louis Sato <lsato@rapid7.com>
 pdeardorff-r7 <pdeardorff-r7@github> Paul Deardorff <Paul_Deardorff@rapid7.com>
 pdeardorff-r7 <pdeardorff-r7@github> pdeardorff-r7 <paul_deardorff@rapid7.com>
-sgonzalez-r7 <sgonzalez-r7@github> Sonny Gonzalez <sonny_gonzalez@rapid7.com>
-shuckins-r7 <shuckins-r7@github>   Samuel Huckins <samuel_huckins@rapid7.com>
-todb-r7 <todb-r7@github>           Tod Beardsley <tod_beardsley@rapid7.com>
-todb-r7 <todb-r7@github>           Tod Beardsley <todb@metasploit.com>
-todb-r7 <todb-r7@github>           Tod Beardsley <todb@packetfu.com>
-wchen-r7 <wchen-r7@github>         <msfsinn3r@gmail.com> # aka sinn3r
-wchen-r7 <wchen-r7@github>         <wei_chen@rapid7.com>
-wvu-r7 <wvu-r7@github>             William Vu <William_Vu@rapid7.com>
-wvu-r7 <wvu-r7@github>             William Vu <wvu@metasploit.com>
-wvu-r7 <wvu-r7@github>             William Vu <wvu@nmt.edu>
-wvu-r7 <wvu-r7@github>             wvu-r7 <William_Vu@rapid7.com>
+sgonzalez-r7 <sgonzalez-r7@github>   Sonny Gonzalez <sonny_gonzalez@rapid7.com>
+shuckins-r7 <shuckins-r7@github>     Samuel Huckins <samuel_huckins@rapid7.com>
+todb-r7 <todb-r7@github>             Tod Beardsley <tod_beardsley@rapid7.com>
+todb-r7 <todb-r7@github>             Tod Beardsley <todb@metasploit.com>
+todb-r7 <todb-r7@github>             Tod Beardsley <todb@packetfu.com>
+wchen-r7 <wchen-r7@github>           <msfsinn3r@gmail.com> # aka sinn3r
+wchen-r7 <wchen-r7@github>           <wei_chen@rapid7.com>
+wvu-r7 <wvu-r7@github>               William Vu <William_Vu@rapid7.com>
+wvu-r7 <wvu-r7@github>               William Vu <wvu@metasploit.com>
+wvu-r7 <wvu-r7@github>               William Vu <wvu@nmt.edu>
+wvu-r7 <wvu-r7@github>               wvu-r7 <William_Vu@rapid7.com>
+wwebb-r7 <wwebb-r7@github>           William Webb <William_Webb@rapid7.com>
 
 # Above this line are current Rapid7 employees. Below this paragraph are
 # volunteers, former employees, and potential Rapid7 employees who, at


### PR DESCRIPTION
## What This Patch Does

This updates the .mailmap file for new hires: Adam Cammack, Brian Patterson, and William Webb.
## Verification
- [x] Verify employment, I guess.
