### PR TITLE
Resolve #6553, remove unnecessary content-length header

### DIFF
--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
@@ -121,7 +121,6 @@ class Metasploit3 < Msf::Exploit::Remote
         'Keep-Alive' => '300',
         'Connection' => 'Keep-Alive',
         'Cache-Control' => 'max-age=0',
-        'Content-Length' => data.length,
         'Content-Type' => 'application/x-www-form-urlencoded',
       }
     }, 3)

--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
@@ -82,7 +82,6 @@ class Metasploit3 < Msf::Exploit::Remote
         'Keep-Alive'      => '300',
         'Connection'      => 'Keep-Alive',
         'Cache-Control'   => 'mag-age=0',
-        'Content-Length'  => data.length,
         'Content-Type'    => 'application/x-www-form-urlencoded',
       }
     }, 3)


### PR DESCRIPTION
## What This Patch Does

Rex will always generate a content-length header, so the module doesn't have to do this anymore. This patch is considered a little ghetto, but the [user is in the middle of testing](https://github.com/rapid7/metasploit-framework/issues/6553) so it probably doesn't really hurt to change these two first.

Resolve #6553
## Verification
- [x] Are the modules still manually generating the content-length? No? Okay, then you're good to go.
