### PR TITLE
Fix priv_migrate user migration issue

### DIFF
--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -61,8 +61,8 @@ class Metasploit3 < Msf::Post
   def get_pid(proc_name)
     processes = client.sys.process.get_processes
     processes.each do |proc|
-      if proc['name'] == proc_name
-        return proc['pid'] if proc['user'] != ""
+      if proc['name'] == proc_name && proc['user'] != ""
+        return proc['pid']
       end
     end
     return nil

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
          It will do everything it can to migrate, including spawing a new User level process.
          For sessions with Admin rights: It will try to migrate into a System level process in the following
          order: ANAME (if specified), services.exe, winlogon.exe, wininit.exe, lsm.exe, and lsass.exe.
-         If al these fail, it will fall back to User level migration. For sessions with User level rights:
+         If all these fail, it will fall back to User level migration. For sessions with User level rights:
          It will try to migrate to a user level process, if that fails it will attempt to spawn the process
          then migrate to it. It will attempt the User level processes in the following order:
          NAME (if specified), explorer.exe, then notepad.exe.},

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -53,6 +53,7 @@ class Metasploit3 < Msf::Post
   end
 
   # This function returns the first process id of a process with the name provided.
+  # It will make sure that the process has a visible user meaning that the session has rights to that process.
   # Note: "target_pid = session.sys.process[proc_name]" will not work when "include Msf::Post::Windows::Priv" is in the module.
   #
   # @return [Fixnum] the PID if one is found
@@ -60,7 +61,9 @@ class Metasploit3 < Msf::Post
   def get_pid(proc_name)
     processes = client.sys.process.get_processes
     processes.each do |proc|
-      return proc['pid'] if proc['name'] == proc_name
+      if proc['name'] == proc_name
+        return proc['pid'] if proc['user'] != ""
+      end
     end
     return nil
   end


### PR DESCRIPTION
## Bug

I discovered an issued that we missed during the initial testing of this module. This issue occurs for user level migration. When multiple users are logged in to the target system, the module will fail if it attempts to migrate in to an explorer.exe instance that belongs to a user other than the one associated with the Meterpreter session.
## Fix

The fix for this issue was very simple. For user level sessions, the 'user' attribute for processes that the session does not have access to returns a blank string. So the get_pid function was modified to make sure that the process it locates does not have a blank string for the 'user' attribute. This insures that the session has access to that process.

This had an added benefit that it speeds up Admin level migration in Windows 10 where services.exe is protected and cannot be migrated in to.
## Additional

I also fixed a minor grammar issue in the module description where the word "all" as missing a letter.

All intended priv_migrate functions remain the same.
