### PR TITLE
fix play_youtube to work on Android

### DIFF
--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -94,6 +94,19 @@ class Metasploit3 < Msf::Post
     true
   end
 
+  #
+  # The Android version is launched via an Intent
+  #
+  def android_start_video(id)
+    intenturl = "intent://youtube.com/watch?v=#{id}&autoplay=1#Intent;scheme=http;action=android.intent.action.VIEW;end"
+    begin
+      session.android.activity_start(intenturl)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      return false
+    end
+    true
+  end
+
   def start_video(id)
     case session.platform
     when /osx/
@@ -102,6 +115,8 @@ class Metasploit3 < Msf::Post
       win_start_video(id)
     when /linux/
       linux_start_video(id)
+    when /android/
+      android_start_video(id)
     end
   end
 


### PR DESCRIPTION
 This change fixes the play_youtube post module to work on Android using the new activity_start command. If the youtube app is not installed it falls back to a browser, which unfortunately doesn't (and can't) autoplay.
- [x] Get an android meterpreter session, e.g:
- [x] Ensure the module post/multi/manage/play_youtube launches the youtube video
