### PR TITLE
update database.yml.example to be something reasonable

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,9 +1,9 @@
-# Please only use postgresql bound to a TCP port.
-# Only postgresql is supportable for metasploit-framework
-# these days. (No SQLite, no MySQL).
-#
 # To set up a metasploit database, follow the directions hosted at:
 # http://r-7.co/MSF-DEV#set-up-postgresql
+#
+# Kali Linux and the Omnibus installers both include an easy wrapper script for
+# managing your database, which may be more convenient than rolling your own.
+
 development: &pgsql
   adapter: postgresql
   database: metasploit_framework_development
@@ -11,7 +11,7 @@ development: &pgsql
   password: __________________________________
   host: localhost
   port: 5432
-  pool: 5
+  pool: 200
   timeout: 5
 
 # You will often want to seperate your databases between dev


### PR DESCRIPTION
Currently, we suggest to users a fairly unrealistic database configuration with a pool of just 5. It doesn't take a lot of threads in a brute force scanner to overwhelm this config. This just changes the example to be big enough to cover basic usage. No other functional change.
