### PR TITLE
Don't require username in wrt110 cmd exec module

### DIFF
--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
       ))
 
     register_options([
-      OptString.new('USERNAME', [ true, 'Valid router administrator username', 'admin']),
+      OptString.new('USERNAME', [ false, 'Valid router administrator username', 'admin']),
       OptString.new('PASSWORD', [ false, 'Password to login with', 'admin']),
       OptAddress.new('RHOST', [true, 'The address of the router', '192.168.1.1']),
       OptInt.new('TIMEOUT', [false, 'The timeout to use in every request', 20])


### PR DESCRIPTION
I was demoing this module and found a stray bug. On my device, the router's default admin username is the empty string `""`. If you try to use that as the username, the module will fail validation and will not run.

A/C:
- You can run this module with a username of `""`
