### PR TITLE
Fixed timeout warning with newer Ruby in Net::SSH

### DIFF
--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -65,9 +65,10 @@ module Net; module SSH; module Transport
       factory = options[:proxy]
 
       if (factory)
-        @socket = timeout(options[:timeout] || 0) { factory.open(@host, @port) }
+        @socket = ::Timeout.timeout(options[:timeout] || 0) { factory.open(@host, 
+@port) }
       else
-        @socket = timeout(options[:timeout] || 0) {
+        @socket = ::Timeout.timeout(options[:timeout] || 0) {
           Rex::Socket::Tcp.create(
           	'PeerHost' => @host,
           	'PeerPort' => @port,


### PR DESCRIPTION
In newer versions of ruby Object#timeout is deprecated:

```
>> transport = Net::SSH::Transport::Session.new('127.0.0.1')
/Users/bcook/projects/metasploit-framework/lib/net/ssh/transport/session.rb:70:in `initialize': Object#timeout is deprecated, use Timeout.timeout instead.
```
