### PR TITLE
Msf::Exploit::Remote::HttpServer print_* fix

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -73,7 +73,7 @@ module Exploit::Remote::HttpServer
   end
 
   def print_prefix
-    if cli && !aggressive?
+    if cli && (respond_to?(:aggressive) && !aggressive?)
       super + "#{cli.peerhost.ljust(16)} #{self.shortname} - "
     else
       super


### PR DESCRIPTION
Exploit::Remote::HttpServer and every descendant utilizes the
print_prefix method which checks whether the module which mixes in
these modules is aggressive. This is done in a proc context most
of the time since its a callback on the underlying Rex HTTP server.

When modules do not define :aggressive? the resulting exceptions
are quietly swallowed, and requestors get an empty response as the
client object dies off.

Add check for response to :aggressive? in :print_prefix to address
this issue.
