### PR TITLE
Initial implementation of Rex::Proto::DNS

### DIFF
--- a/lib/rex/proto.rb
+++ b/lib/rex/proto.rb
@@ -7,6 +7,7 @@ require 'rex/proto/drda'
 require 'rex/proto/iax2'
 require 'rex/proto/kerberos'
 require 'rex/proto/rmi'
+require 'rex/proto/dns'
 
 module Rex
 module Proto

--- a/lib/rex/proto/dns.rb
+++ b/lib/rex/proto/dns.rb
@@ -1,0 +1,16 @@
+# -*- coding: binary -*-
+
+module Rex
+module Proto
+module DNS
+
+  module Constants
+    MATCH_HOSTNAME=/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]\.*)$/
+  end
+  
+end
+end
+end
+
+require 'rex/proto/dns/resolver'
+require 'rex/proto/dns/server'

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -1,0 +1,289 @@
+require 'net/dns/resolver'
+
+module Rex
+module Proto
+module DNS
+
+  ##
+  # Provides Rex::Sockets compatible version of Net::DNS::Resolver
+  ##
+  class Resolver < Net::DNS::Resolver
+
+    Defaults = {
+      :config_file => "/dev/null", # default can lead to info leaks
+      :log_file => "/dev/null", # formerly $stdout, should be tied in with our loggers
+      :port => 53,
+      :searchlist => [],
+      :nameservers => [IPAddr.new("127.0.0.1")],
+      :domain => "",
+      :source_port => 0,
+      :source_address => IPAddr.new("0.0.0.0"),
+      :retry_interval => 5,
+      :retry_number => 4,
+      :recursive => true,
+      :defname => true,
+      :dns_search => true,
+      :use_tcp => false,
+      :ignore_truncated => false,
+      :packet_size => 512,
+      :tcp_timeout => TcpTimeout.new(30),
+      :udp_timeout => UdpTimeout.new(30)
+    }
+
+    #
+    # Provide override for initializer to use local Defaults constant
+    #
+    # @param config [Hash] Configuration options as conusumed by parent class
+    def initialize(config = {})
+      raise ResolverArgumentError, "Argument has to be Hash" unless config.kind_of? Hash
+      # config.key_downcase!
+      @config = Defaults.merge config
+      @raw = false
+
+      # New logger facility
+      @logger = Logger.new(@config[:log_file])
+      @logger.level = $DEBUG ? Logger::DEBUG : Logger::WARN
+
+      #------------------------------------------------------------
+      # Resolver configuration will be set in order from:
+      # 1) initialize arguments
+      # 2) ENV variables
+      # 3) config file
+      # 4) defaults (and /etc/resolv.conf for config)
+      #------------------------------------------------------------
+
+
+
+      #------------------------------------------------------------
+      # Parsing config file
+      #------------------------------------------------------------
+      parse_config_file
+
+      #------------------------------------------------------------
+      # Parsing ENV variables
+      #------------------------------------------------------------
+      parse_environment_variables
+
+      #------------------------------------------------------------
+      # Parsing arguments
+      #------------------------------------------------------------
+      config.each do |key,val|
+        next if key == :log_file or key == :config_file
+        begin
+          eval "self.#{key.to_s} = val"
+        rescue NoMethodError
+          raise ResolverArgumentError, "Option #{key} not valid"
+        end
+      end
+    end
+    #
+    # Provides current proxy setting if configured
+    #
+    # @return [String] Current proxy configuration
+    def proxies
+      @config[:proxies].inspect if @config[:proxies]
+    end
+
+    #
+    # Configure proxy setting and additional timeout
+    #
+    # @param prox [String] SOCKS proxy connection string
+    # @param timeout_added [Fixnum] Added TCP timeout to account for proxy
+    def proxies=(prox, timeout_added = 250)
+      return if prox.nil?
+      if prox.is_a?(String) and prox.strip =~ /^socks/i
+        @config[:proxies] = prox.strip
+        @config[:use_tcp] = true
+        self.tcp_timeout = self.tcp_timeout.to_s.to_i + timeout_added
+        @logger.info "SOCKS proxy set, using TCP, increasing timeout"
+      else
+        raise ResolverError, "Only socks proxies supported"
+      end
+    end
+
+    #
+    # Send DNS request over appropriate transport and process response
+    #
+    # @param argument
+    # @param type [Fixnum] Type of record to look up
+    # @param cls [Fixnum] Class of question to look up
+    def send(argument,type=Net::DNS::A,cls=Net::DNS::IN)
+      if @config[:nameservers].size == 0
+        raise ResolverError, "No nameservers specified!"
+      end
+
+      method = self.use_tcp? ? :send_tcp : :send_udp
+
+      if argument.kind_of? Net::DNS::Packet
+        packet = argument
+      elsif argument.kind_of? Resolv::DNS::Message
+        packet = Net::DNS::Packet.parse(argument.encode)
+      else
+        packet = make_query_packet(argument,type,cls)
+      end
+
+      # Store packet_data for performance improvements,
+      # so methods don't keep on calling Packet#data
+      packet_data = packet.data
+      packet_size = packet_data.size
+
+      # Choose whether use TCP, UDP
+      if packet_size > @config[:packet_size] # Must use TCP
+        @logger.info "Sending #{packet_size} bytes using TCP due to size"
+        method = :send_tcp
+      else # Packet size is inside the boundaries
+        if use_tcp? or !(proxies.nil? or proxies.empty?) # User requested TCP
+          @logger.info "Sending #{packet_size} bytes using TCP due to tcp flag"
+          method = :send_tcp
+        else # Finally use UDP
+          @logger.info "Sending #{packet_size} bytes using UDP"
+          method = :send_udp unless method == :send_tcp 
+        end
+      end
+
+      if type == Net::DNS::AXFR
+        @logger.warn "AXFR query, switching to TCP" unless method == :send_tcp
+        method = :send_tcp
+      end
+
+      ans = self.__send__(method,packet_data)
+
+      unless (ans and ans[0].length > 0)
+        @logger.fatal "No response from nameservers list: aborting"
+        raise NoResponseError
+        return nil
+      end
+
+      @logger.info "Received #{ans[0].size} bytes from #{ans[1][2]+":"+ans[1][1].to_s}"
+      response = Net::DNS::Packet.parse(ans[0],ans[1])
+
+      if response.header.truncated? and not ignore_truncated?
+        @logger.warn "Packet truncated, retrying using TCP"
+        self.use_tcp = true
+        begin
+          return send(argument,type,cls)
+        ensure
+          self.use_tcp = false
+        end
+      end
+
+      return response
+    end
+
+    #
+    # Send request over TCP
+    #
+    # @param packet_data [String] Data segment of DNS request packet
+    # @param prox [String] Proxy configuration for TCP socket
+    #
+    # @return ans [String] Raw DNS reply
+    def send_tcp(packet_data,prox = @config[:proxies])
+      ans = nil
+      length = [packet_data.size].pack("n")
+      @config[:nameservers].each do |ns|
+        begin
+          socket = nil
+          @config[:tcp_timeout].timeout do
+            catch(:next_ns) do
+              begin
+                socket = Rex::Socket::Tcp.create(
+                  'PeerHost' => ns.to_s,
+                  'PeerPort' => @config[:port].to_i,
+                  'Proxies' => prox
+                )
+              rescue
+                @logger.warn "TCP Socket could not be established to #{ns}:#{@config[:port]} #{@config[:proxies]}"
+                throw :next_ns
+              end
+              next unless socket #
+              @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
+              socket.write(length+packet_data)
+              got_something = false
+              loop do
+                buffer = ""
+                ans = socket.recv(Net::DNS::INT16SZ)
+                if ans.size == 0
+                  if got_something
+                    break #Proper exit from loop
+                  else
+                    @logger.warn "Connection reset to nameserver #{ns}, trying next."
+                    throw :next_ns
+                  end
+                end
+                got_something = true
+                len = ans.unpack("n")[0]
+
+                @logger.info "Receiving #{len} bytes..."
+
+                if len.nil? or len == 0
+                  @logger.warn "Receiving 0 length packet from nameserver #{ns}, trying next."
+                  throw :next_ns
+                end
+
+                while (buffer.size < len)
+                  left = len - buffer.size
+                  temp,from = socket.recvfrom(left)
+                  buffer += temp
+                end
+
+                unless buffer.size == len
+                  @logger.warn "Malformed packet from nameserver #{ns}, trying next."
+                  throw :next_ns
+                end
+                if block_given?
+                  yield [buffer,["",@config[:port],ns.to_s,ns.to_s]]
+                else
+                  return [buffer,["",@config[:port],ns.to_s,ns.to_s]]
+                end
+              end
+            end
+  			end
+		  rescue Timeout::Error
+			  @logger.warn "Nameserver #{ns} not responding within TCP timeout, trying next one"
+			  next
+		  ensure
+			  socket.close if socket
+		  end
+		end
+		return nil
+	  end
+
+    #
+    # Send request over UDP
+    #
+    # @param packet_data [String] Data segment of DNS request packet
+    #
+    # @return ans [String] Raw DNS reply
+    def send_udp(packet_data)
+      ans = nil
+      response = ""
+      @config[:nameservers].each do |ns|
+        begin
+          @config[:udp_timeout].timeout do
+            begin
+              socket = Rex::Socket::Udp.create(
+                'PeerHost' => ns.to_s,
+                'PeerPort' => @config[:port].to_i
+              )
+            rescue
+              @logger.warn "UDP Socket could not be established to #{ns}:#{@config[:port]}"
+              return nil
+            end
+            @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
+            #socket.sendto(packet_data, ns.to_s, @config[:port].to_i, 0)
+            socket.write(packet_data)
+            ans = socket.recvfrom(@config[:packet_size])
+          end
+          break if ans
+        rescue Timeout::Error
+          @logger.warn "Nameserver #{ns} not responding within UDP timeout, trying next one"
+          next
+        end
+      end
+      return ans
+    end
+  end
+
+end
+end
+end

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -192,7 +192,7 @@ module DNS
                   'PeerHost' => ns.to_s,
                   'PeerPort' => @config[:port].to_i,
                   'Proxies' => prox,
-                  'Context' => @config[:context]
+                  'Context' => @config[:context],
                   'Comm' => @config[:comm]
                 }
                 if @config[:source_port] > 0

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -27,7 +27,9 @@ module DNS
       :ignore_truncated => false,
       :packet_size => 512,
       :tcp_timeout => TcpTimeout.new(30),
-      :udp_timeout => UdpTimeout.new(30)
+      :udp_timeout => UdpTimeout.new(30),
+      :context => {},
+      :comm => nil
     }
 
     #
@@ -191,6 +193,7 @@ module DNS
                   'PeerPort' => @config[:port].to_i,
                   'Proxies' => prox,
                   'Context' => @config[:context]
+                  'Comm' => @config[:comm]
                 }
                 if @config[:source_port] > 0
                   config['LocalPort'] = @config[:source_port]
@@ -272,7 +275,8 @@ module DNS
               config = {
                 'PeerHost' => ns.to_s,
                 'PeerPort' => @config[:port].to_i,
-                'Context' => @config[:context]
+                'Context' => @config[:context],
+                'Comm' => @config[:comm]
               }
               if @config[:source_port] > 0
                 config['LocalPort'] = @config[:source_port]

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -186,11 +186,19 @@ module DNS
           @config[:tcp_timeout].timeout do
             catch(:next_ns) do
               begin
-                socket = Rex::Socket::Tcp.create(
+                config = {
                   'PeerHost' => ns.to_s,
                   'PeerPort' => @config[:port].to_i,
-                  'Proxies' => prox
-                )
+                  'Proxies' => prox,
+                  'Context' => @config[:context]
+                }
+                if @config[:source_port] > 0
+                  config['LocalPort'] = @config[:source_port]
+                end
+                if @config[:source_host].to_s != '0.0.0.0'
+                  config['LocalHost'] = @config[:source_host] unless @config[:source_host].nil?
+                end
+                socket = Rex::Socket::Tcp.create(config)
               rescue
                 @logger.warn "TCP Socket could not be established to #{ns}:#{@config[:port]} #{@config[:proxies]}"
                 throw :next_ns
@@ -261,10 +269,18 @@ module DNS
         begin
           @config[:udp_timeout].timeout do
             begin
-              socket = Rex::Socket::Udp.create(
+              config = {
                 'PeerHost' => ns.to_s,
-                'PeerPort' => @config[:port].to_i
-              )
+                'PeerPort' => @config[:port].to_i,
+                'Context' => @config[:context]
+              }
+              if @config[:source_port] > 0
+                config['LocalPort'] = @config[:source_port]
+              end
+              if @config[:source_host] != IPAddr.new('0.0.0.0')
+                config['LocalHost'] = @config[:source_host] unless @config[:source_host].nil?
+              end
+              socket = Rex::Socket::Udp.create(config)
             rescue
               @logger.warn "UDP Socket could not be established to #{ns}:#{@config[:port]}"
               return nil

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -247,7 +247,7 @@ class Server
       end
     end
     # Forward remaining requests, cache responses
-    if forward.question.count > 0
+    if forward.question.count > 0 and @fwd_res
       forwarded = @fwd_res.send(validate_packet(forward))
       req.answer = req.answer + forwarded.answer 
       forwarded.answer.each do |ans|

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -1,0 +1,320 @@
+# -*- coding: binary -*-
+
+require 'rex/socket'
+require 'rex/proto/dns'
+
+module Rex
+module Proto
+module DNS
+
+class Server
+
+  class Cache
+    include Rex::Proto::DNS::Constants
+    # class DNSRecordError < ::Exception
+    #
+    # Create DNS Server cache
+    #
+    def initialize
+      @records = {}
+      @lock = Mutex.new
+    end
+
+    #
+    # Find entries in cache
+    #
+    # @param search [String] Name or address to search for
+    # @param type [String] Record type to search for
+    #
+    # @return [Array] Records found
+    def find(search, type = 'A')
+      @records.select do |record,expire|
+        record.type == type and (expire < 1 or expire > Time.now.to_i) and 
+        (record.name == search or record.address == search)
+      end.keys
+    end
+
+    #
+    # Add record to cache
+    #
+    # @param record [Net::DNS::RR] Record to cache
+    def cache_record(record)
+      if record.class.ancestors.include?(Net::DNS::RR) and
+      Rex::Socket.is_ip_addr?(record.address.to_s) and record.name.to_s.match(MATCH_HOSTNAME)
+        add(record, Time.now.to_i + record.ttl)
+      else
+        raise "Invalid record for cache entry - #{record.inspect}"
+      end
+    end
+
+    #
+    # Add static record to cache
+    #
+    # @param name [String] Name of record
+    # @param address [String] Address of record
+    # @param type [String] Record type to add
+    def add_static(name, address, type = 'A')
+      if Rex::Socket.is_ip_addr?(address.to_s) and name.to_s.match(MATCH_HOSTNAME)
+        find(name, type).each do |found|
+          delete(found)
+        end
+        add(Net::DNS::RR.new(:name => name, :address => address),0)
+      else
+        raise "Invalid parameters for static entry - #{name}, #{address}, #{type}"
+      end
+    end
+
+    #
+    # Prune cache entries
+    #
+    # @param before [Fixnum] Time in seconds before which records are evicted
+    def prune(before = Time.now.to_i)
+      @records.select do |rec, expire|
+        expire > 0 and expire < before
+      end.each {|rec, exp| delete(rec)}
+    end
+
+    #
+    # Start the cache monitor
+    #
+    def start
+      @monitor_thread = Rex::ThreadFactory.spawn("DNSServerCacheMonitor", false) {
+        while true
+          prune
+          Rex::ThreadSafe.sleep(0.5)
+        end
+      } unless @monitor_thread
+    end
+
+    #
+    # Stop the cache monitor
+    #
+    # @param flush [TrueClass,FalseClass] Remove non-static entries
+    def stop(flush = false)
+      @monitor_thread.kill
+      @monitor_thread = nil
+      if flush
+        @records.select do |rec, expire|
+          rec.ttl > 0
+        end.map {|rec| delete(rec)}
+      end
+    end
+
+    protected
+
+    #
+    # Add a record to the cache with thread safety
+    #
+    # @param record [Net::DNS::RR] Record to add
+    # @param expire [Fixnum] Time in seconds when record becomes stale
+    def add(record, expire = 0)
+      @lock.synchronize do
+        @records[record] = expire
+      end
+    end
+
+    #
+    # Delete a record from the cache with thread safety
+    #
+    # @param record [Net::DNS::RR] Record to delete
+    def delete(record)
+      @lock.synchronize do
+        @records.delete(record)
+      end
+    end
+  end # Cache
+
+  #
+  # Create DNS Server
+  #
+  # @param lhost [String] Listener address
+  # @param lport [Fixnum] Listener port
+  # @param udp [TrueClass, FalseClass] Listen on UDP socket
+  # @param tcp [TrueClass, FalseClass] Listen on TCP socket
+  # @param res [Rex::Proto::DNS::Resolver] Resolver to use, nil to create a fresh one
+  # @param ctx [Hash] Framework context for sockets
+  # @param dblock [Proc] Handler for :dispatch_request flow control interception
+  # @param sblock [Proc] Handler for :send_response flow control interception
+  #
+  # @return [Rex::Proto::DNS::Server] DNS Server object
+  def initialize(lhost = '0.0.0.0', lport = 53, udp = true, tcp = false, res = nil, ctx = {}, dblock = nil, sblock = nil)
+    
+    @udp_sock = udp ? Rex::Socket::Udp.create(
+      'LocalHost' => lhost,
+      'LocalPort' => lport,
+      'Context'   => ctx
+    ) : nil
+    @tcp_sock = tcp ? Rex::Socket::TcpServer.create(
+      'LocalHost' => lhost,
+      'LocalPort' => lport,
+      'Context'   => ctx
+    ) : nil
+    @fwd_res = res.nil? ? Rex::Proto::DNS::Resolver.new : res
+    @udp_mon = nil
+    @dispatch_block = dblock
+    @send_block = sblock
+    @cache = Cache.new
+    @lock = Mutex.new
+  end
+
+  #
+  # Switch DNS forwarders in resolver with thread safety
+  #
+  # @param ns [Array, String] List of (or single) nameservers to use
+  def switchns(ns = [])
+    if ns.respond_to?(:split)
+      ns = [ns]
+    end
+    @lock.synchronize do
+      @fwd_res.nameserver = ns
+    end
+  end
+
+  #
+  # Start the DNS server and cache
+  #
+  def start
+    @udp_mon = Rex::ThreadFactory.spawn("DNSServerMonitor", false) {
+      monitor_udp_socket
+    } if @udp_sock
+
+    if @tcp_sock
+
+      @tcp_sock.on_client_data_proc = Proc.new { |cli|
+        on_client_data(cli)
+      }
+      @tcp_sock.start
+    end
+    @cache.start
+  end
+
+  #
+  # Stop the DNS server and cache
+  #
+  # @param flush_cache [TrueClass,FalseClass] Flush DNS cache on stop
+  def stop(flush_cache = false)
+    if @udp_mon
+      @udp_mon.kill
+      @udp_mon = nil
+    end
+    @tcp_sock.stop if @tcp_sock
+    @cache.stop(flush_cache)
+  end
+
+  #
+  # Reconstructs a packet with both standard DNS libraries
+  # Ensures that headers match the payload
+  #
+  # @param packet [String, Net::DNS::Packet] Data to be validated
+  #
+  # @return [Net::DNS::Packet]
+  def validate_packet(packet)
+    Net::DNS::Packet.parse(
+      Resolv::DNS::Message.decode(
+        packet.respond_to?(:data) ? packet.data : packet
+      ).encode
+    )
+  end
+
+  #
+  # Process client request, handled with @dispatch_block if set
+  #
+  # @param cli [Rex::Socket::Tcp, Rex::Socket::Udp] Client sending the request
+  # @param data [String] raw DNS request data
+  def dispatch_request(cli, data)
+    if @dispatch_block
+      @dispatch_block.call(cli,data)
+    else
+      req = Net::DNS::Packet.parse(data)
+      forward = req.dup
+      # Find cached items, remove request from forwarded packet
+      req.question.each do |ques|
+        cached = @cache.find(ques.qName, ques.qType.to_s)
+        if cached.empty?
+          next
+        else
+          req.answer = req.answer + cached
+          forward.question.delete(ques)
+        end
+      end
+      # Forward remaining requests, cache responses
+      if forward.question.count > 0
+        forwarded = @fwd_res.send(validate_packet(forward))
+        req.answer = req.answer + forwarded.answer 
+        forwarded.answer.each do |ans|
+          @cache.cache_record(ans)
+        end
+      end
+      # Finalize answers in response
+      # Check for empty response prior to sending
+      if req.answer.size < 1
+        req.header.rCode = Net::DNS::Header::RCode.new(3)
+      end
+      send_response(cli, validate_packet(req).data)
+    end
+  end
+
+  #
+  # Send response to client, handled with @send_block if set
+  #
+  # @param cli [Rex::Socket::Tcp, Rex::Socket::Udp] Client receiving the response
+  # @param data [String] raw DNS response data
+  def send_response(cli, data)
+    if @send_block
+      @send_block.call(cli, data)
+    else
+      cli.write(data)
+    end
+  end
+
+protected
+
+  #
+  # Monitor UDP socket for incoming requests, create client object from socket
+  #
+  def monitor_udp_socket
+    while true
+      rds = [@udp_sock]
+      wds = []
+      eds = [@udp_sock]
+
+      r,_,_ = ::IO.select(rds,wds,eds,1)
+
+      if (r != nil and r[0] == @udp_sock)
+        buf,host,port = @udp_sock.recvfrom(65535)
+        # Mock up a client object as a Rex Socket for sending back data
+        cli = Rex::Socket::Udp.create(
+          'PeerHost' => host,
+          'PeerPort' => port,
+          'LocalHost' => @udp_sock.localhost,
+          'LocalPort' => @udp_sock.localport
+        )
+        dispatch_request(cli, buf)
+      end
+
+    end
+  end
+
+  #
+  # Processes request coming from client
+  #
+  # @param cli [Rex::Socket::Tcp] Client sending request
+  def on_client_data(cli)
+    begin
+      data = cli.read(65535)
+
+      raise ::EOFError if not data
+      raise ::EOFError if data.empty?
+      from = [cli.peerhost, cli.peerport]
+      dispatch_request(cli, data)
+    rescue EOFError => e
+      close_client(cli)
+      raise e
+    end
+  end
+
+end
+
+end
+end
+end

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -245,6 +245,7 @@ class Server
         forwarded.answer.each do |ans|
           @cache.cache_record(ans)
         end
+        req.header.ra = 1 # Set recursion bit
       end
       # Finalize answers in response
       # Check for empty response prior to sending
@@ -252,7 +253,6 @@ class Server
         req.header.rCode = Net::DNS::Header::RCode.new(3)
       end
       req.header.qr = 1 # Set response bit
-      req.header.ra = 1 # Set recursion bit
       send_response(cli, validate_packet(req).data)
     end
   end


### PR DESCRIPTION
Add Rex::Proto::DNS and Rex::Proto::DNS::Constants namespaces
Create Rex::Proto::DNS::Resolver from Net::DNS::Resolver
Create Rex::Proto::DNS::Server and Rex::Proto::DNS::Server::Cache

Constants -
  A Rex::Socket style MATCH_HOSTNAME regex has been added to
help validate DNS names.

Resolver -
  Based off of old work creating Rex socket overrides in the
Net::DNS::Resolver as well as allowing for proxying and making
automatic adjustments to use TCP for proxied connections. This
resolver pivots with MSF, uses proxies, and doesnt pull in the
default /etc/resolv.conf information which can lead to info leak.
  Automatically sends Net::DNS::Packet and Resolv::DNS::Message
objects to the appropriate nameservers.
  TODO: Review for potential low level concurrent resolution impl.

Server::Cache -
  Threadsafe wrapper around a Hash which holds Net::DNS::RR keys
with Time.to_i values for counting eviction/stale time without
altering the original record.
  Takes records with a TTL of < 1 as static entries which are not
flushed or pruned by the monitor thread.

Server -
  A standard Rex level server allowing for client connections with
TCP and UDP listeners. Provides common framework for handling the
different transports by creating a "client" type object as a Rex
UDP socket and passing it back to the dispatch/sender methods.
This server can host listeners on remote pivot targets since it
utilizes Rex sockets, and should not leak internal information
from the resolver as easily either.
  Can be configured with a custom resolver regardless of its own
listener configuration (UDP/TCP mix is fine), and carries a
threadsafe wrapper for swapping the resolvers nameservers under
a Mutex.synchronize. Since listeners and resolvers can pivot,
a compromised host in one environment can serve DNS information
obtained by the resolver pivoting through a completely different
target.
  The server takes blocks for dispatch and send functions which
when defined, will intercept the standard execution flow which is
to parse the request, check the cache for corresponding records,
then forward the remaining questions in a request via the resolver,
and build + send a response back to the client.
  The accessors for dispatch and send, resolver, and cache are
accessible at runtime, though it is likely unsafe to replace the
cache and resolver while they are accessed from other threads.

---

Testing:
  Initial testing performed in IRB/Pry generating manual requests.
  Subsequent checks performed using the running server as the sys
resolver.
  Additional testing is needed - the default dispatch_request
behavior may not be correct (i need to check the RFCs for this) as
it handles multiple questions for A records. This should be tuned
to be RFC compliant, with inheriting classes changing behavior as
needed. We also need to ensure that we're not leaking our own DNS
information to our targets, so all sorts of abuse is in order.

---

TODO:
  Create Msf::Exploit::DNS namespace utilizing this functionality.
- Move the threaded enum_dns work, as well as work from https://github.com/rapid7/metasploit-framework/pull/6187,
  into the namespace
- Review existing modules for functional overlap and move here
  as needed. This should be done in separate commits/PRs.
  Create specific DNS servers for spoofing, exploit delivery, and
  finally handling DNS tunnels (the primary reason for this work).
  Write spec
- Convince/coerce a friendly soul in the community to handle
  spec for this fiasco while building further functionality.
