### PR TITLE
remove "Engines is deprecated" warning from Metasploit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'metasploit-concern', :git => "https://github.com/rapid7/metasploit-concern.git", :branch => "staging/MS-888/engines-is-deprecated"
   # automatically include factories from spec/factories
   gem 'factory_girl_rails', '~> 4.5.0'
   # Make rspec output shorter and more useful

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/rapid7/metasploit-concern.git
+  revision: cf2dbfc0cf0b60c9561357d00de4ece34058e13b
+  branch: staging/MS-888/engines-is-deprecated
+  specs:
+    metasploit-concern (1.0.1.pre.engines.pre.is.pre.deprecated)
+      activerecord (>= 4.0.9, < 4.1.0)
+      activesupport (>= 4.0.9, < 4.1.0)
+      railties (>= 4.0.9, < 4.1.0)
+
 PATH
   remote: .
   specs:
@@ -108,10 +118,6 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     metasm (1.0.2)
-    metasploit-concern (1.0.0)
-      activerecord (>= 4.0.9, < 4.1.0)
-      activesupport (>= 4.0.9, < 4.1.0)
-      railties (>= 4.0.9, < 4.1.0)
     metasploit-credential (1.0.1)
       metasploit-concern (~> 1.0)
       metasploit-model (~> 1.0)
@@ -237,6 +243,7 @@ DEPENDENCIES
   cucumber-rails
   factory_girl_rails (~> 4.5.0)
   fivemat (~> 1.3.1)
+  metasploit-concern!
   metasploit-framework!
   pry
   rake (>= 10.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       jsobfu (~> 0.4.1)
       json
       metasm (~> 1.0.2)
-      metasploit-concern (= 1.0.0)
+      metasploit-concern
       metasploit-credential (= 1.0.1)
       metasploit-model (= 1.0.0)
       metasploit-payloads (= 1.1.0)

--- a/lib/msf/base/simple/framework/module_paths.rb
+++ b/lib/msf/base/simple/framework/module_paths.rb
@@ -21,7 +21,7 @@ module Msf
             allowed_module_paths << Msf::Config.user_module_directory
           end
 
-          Rails.application.railties.engines.each do |engine|
+          ::Rails::Engine.subclasses.map(&:instance).each do |engine|
             extract_engine_module_paths(engine).each do |path|
               allowed_module_paths << path
             end

--- a/lib/msf/core/db_manager/migration.rb
+++ b/lib/msf/core/db_manager/migration.rb
@@ -10,7 +10,7 @@ module Msf::DBManager::Migration
            "the .bundle/config manually and then `bundle install`"
     end
 
-    Rails.application.railties.engines.each do |engine|
+    ::Rails::Engine.subclasses.map(&:instance).each.each do |engine|
       migrations_paths = engine.paths['db/migrate'].existent_directories
 
       migrations_paths.each do |migrations_path|

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   # Metasm compiler/decompiler/assembler
   spec.add_runtime_dependency 'metasm', '~> 1.0.2'
   # Metasploit::Concern hooks
-  spec.add_runtime_dependency 'metasploit-concern', '1.0.0'
+  spec.add_runtime_dependency 'metasploit-concern'
   # Metasploit::Credential database models
   spec.add_runtime_dependency 'metasploit-credential', '1.0.1'
   # Database models shared between framework and Pro.


### PR DESCRIPTION
This is the first in a series of PRs to fix Rails deprecations in Metasploit so we can eventually upgrade to supported versions 4.2 / 5.0.
# Verification Steps

This pr eliminates the "Engines is deprecated" warning in Rails 4.0
- [ ] `bundle`
- [ ] `rake spec`
- [ ] verify no failures
- [ ] merge into `staging/rails-4-deprecations`
- [ ] modify the Gemfile's pointer to metasploit-concern so that it points to `staging/rails-4-deprecations` of metasploit-concern.
