### PR TITLE
Implement native DNS for Msf Namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.6)
+    rex-socket (0.1.7)
       rex-core
     rex-sslscan (0.1.4)
       rex-socket

--- a/lib/msf/core/exploit/dns.rb
+++ b/lib/msf/core/exploit/dns.rb
@@ -15,5 +15,6 @@ module Exploit::Remote::DNS
 end
 end
 
+require 'msf/core/exploit/dns/common'
 require 'msf/core/exploit/dns/client'
 require 'msf/core/exploit/dns/server'

--- a/lib/msf/core/exploit/dns.rb
+++ b/lib/msf/core/exploit/dns.rb
@@ -1,0 +1,19 @@
+# -*- coding: binary -*-
+require 'msf/core'
+require 'rex/proto/dns'
+
+
+module Msf
+
+###
+#
+# This namespace exposes methods for interacting with and providing services
+#
+###
+module Exploit::Remote::DNS
+
+end
+end
+
+require 'msf/core/exploit/dns/client'
+require 'msf/core/exploit/dns/server'

--- a/lib/msf/core/exploit/dns/client.rb
+++ b/lib/msf/core/exploit/dns/client.rb
@@ -47,8 +47,8 @@ module Client
       ], Exploit::Remote::DNS::Client
     )
 
-    register_autofilter_ports([ 53 ])
-    register_autofilter_services(%W{ dns })
+    register_autofilter_ports([ 53 ]) if respond_to?(:register_autofilter_ports)
+    register_autofilter_services(%W{ dns }) if respond_to?(:register_autofilter_services)
   end
 
 
@@ -58,7 +58,7 @@ module Client
   # @param domain [String] Domain for which to request a record
   # @param type [String] Type of record to request for domain
   #
-  # @return [Net::DNS::RR] DNS response
+  # @return [Dnsruby::RR] DNS response
   def query(domain = datastore['DOMAIN'], type = 'A')
     client.query(domain, type)
   end
@@ -110,7 +110,7 @@ module Client
     if datastore['NS'].blank?
       resp_soa = client.query(target, "SOA")
       if (resp_soa)
-        (resp_soa.answer.select { |i| i.class == Net::DNS::RR::SOA}).each do |rr|
+        (resp_soa.answer.select { |i| i.is_a?(Dnsruby::RR::SOA)}).each do |rr|
           resp_1_soa = client.search(rr.mname)
           if (resp_1_soa and resp_1_soa.answer[0])
             set_nameserver(resp_1_soa.answer.map(&:address).compact.map(&:to_s))
@@ -139,7 +139,7 @@ module Client
     if response.answer.length != 0
       vprint_status("This domain has wildcards enabled!!")
       response.answer.each do |rr|
-        print_status("Wildcard IP for #{rendsub}.#{target} is: #{rr.address.to_s}") if rr.class != Net::DNS::RR::CNAME
+        print_status("Wildcard IP for #{rendsub}.#{target} is: #{rr.address.to_s}") if rr.class != Dnsruby::RR::CNAME
         addr = rr.address.to_s
       end
     end

--- a/lib/msf/core/exploit/dns/client.rb
+++ b/lib/msf/core/exploit/dns/client.rb
@@ -82,7 +82,7 @@ module Client
           query(domain,type)
         end
       end
-      while running.map(:alive?).count >= threadmax
+      while running.select(&:alive?).count >= threadmax
         Rex::ThreadSafe.sleep(1)
       end
     end
@@ -107,10 +107,7 @@ module Client
   #
   # @param domain [String] Domain for which to find SOA
   def switchdns(domain)
-    if not datastore['NS'].blank?
-      vprint_status("Using DNS Server: #{client.nameserver.join(', ')}")
-      client.nameserver = process_nameservers
-    else
+    if datastore['NS'].blank?
       resp_soa = client.query(target, "SOA")
       if (resp_soa)
         (resp_soa.answer.select { |i| i.class == Net::DNS::RR::SOA}).each do |rr|
@@ -122,6 +119,9 @@ module Client
           end
         end
       end
+    else
+      vprint_status("Using DNS Server: #{client.nameserver.join(', ')}")
+      client.nameserver = process_nameservers
     end
   end
 
@@ -144,41 +144,6 @@ module Client
       end
     end
     return addr
-  end
-
-  #
-  # Returns the resolver
-  #
-  def client
-    @dns_resolver
-  end
-
-  #
-  # Returns the target host
-  #
-  def rhost
-    datastore['RHOST']
-  end
-
-  #
-  # Returns the remote port
-  #
-  def rport
-    datastore['RPORT']
-  end
-
-  #
-  # Returns the Host and Port as a string
-  #
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
-  #
-  # Returns the configured proxy list
-  #
-  def proxies
-    datastore['Proxies']
   end
 
   #
@@ -224,23 +189,18 @@ module Client
   # Uses explicitly defined NS option if set
   # Uses RHOSTS if not explicitly defined
   def process_nameservers
-    unless datastore['NS'].blank?
-      if datastore['NS'].split(/\s|,/).all? do |nameserver|
-        Rex::Socket.it_ip_addr?(nameserver)
-      end
-        return datastore['NS'].split(/\s|,/)
-      else
-        raise "Nameservers must be proper IP addresses"
-      end
+    if datastore['NS'].blank?
+      nameservers = datastore['DnsClientDefaultNS'].split(/\s|,/)
     else
-      ns = []
-      rw = Rex::Socket::RangeWalker.new(datastore['DnsClientDefaultNS'].split(/\s|,/))
-      while addr = rw.next_ip
-        # break if addr.nil?
-        ns << addr
-      end
-      return ns.compact
+      nameservers = datastore['NS'].split(/\s|,/)
     end
+
+    invalid = nameservers.select { |ns| !Rex::Socket.dotted_ip?(ns) } 
+    if !invalid.empty?
+      raise "Nameservers must be IP addresses. The following were invalid: #{invalid.join(", ")}"
+    end
+
+    nameservers
   end
 
 end

--- a/lib/msf/core/exploit/dns/client.rb
+++ b/lib/msf/core/exploit/dns/client.rb
@@ -17,8 +17,6 @@ module Client
   include Exploit::Remote::Udp
   include Exploit::Remote::Tcp
 
-  MATCH_HOSTNAME = Rex::Proto::DNS::Constants::MATCH_HOSTNAME
-
   #
   # Initializes an exploit module that interacts with a DNS server.
   #
@@ -39,13 +37,13 @@ module Client
 
     register_advanced_options(
       [
-        OptString.new('DNS_CLIENT_DEFAULT_NS', [ false, "Specify the default to use for queries, space separated", '8.8.8.8 8.8.4.4' ]),   
-        OptInt.new('DNS_CLIENT_RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
-        OptInt.new('DNS_CLIENT_RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
-        OptBool.new('DNS_CLIENT_REPORT_A_RECORDS', [false, "Add hosts found via BRT and RVL to DB", true]),
-        OptBool.new('DNS_CLIENT_RVL_EXISTING_ONLY', [false, "Only perform lookups on hosts in DB", true]),
-        OptBool.new('DNS_CLIENT_TCP_DNS', [false, "Run queries over TCP", false]),
-        OptPath.new('DNS_CLIENT_RESOLVCONF', [true, "Resolvconf formatted configuration file to use for Resolver", "/dev/null"])
+        OptString.new('DnsClientDefaultNS', [ false, "Specify the default to use for queries, space separated", '8.8.8.8 8.8.4.4' ]),   
+        OptInt.new('DnsClientRetry', [ false, "Number of times to try to resolve a record if no response is received", 2]),
+        OptInt.new('DnsClientRetryInterval', [ false, "Number of seconds to wait before doing a retry", 2]),
+        OptBool.new('DnsClientReportARecords', [false, "Add hosts found via BRT and RVL to DB", true]),
+        OptBool.new('DnsClientRVLExistingOnly', [false, "Only perform lookups on hosts in DB", true]),
+        OptBool.new('DnsClientTcpDns', [false, "Run queries over TCP", false]),
+        OptPath.new('DnsClientResolvconf', [true, "Resolvconf formatted configuration file to use for Resolver", "/dev/null"])
       ], Exploit::Remote::DNS::Client
     )
 
@@ -109,7 +107,7 @@ module Client
   #
   # @param domain [String] Domain for which to find SOA
   def switchdns(domain)
-    if not datastore['NS'].nil?
+    if not datastore['NS'].blank?
       vprint_status("Using DNS Server: #{client.nameserver.join(', ')}")
       client.nameserver = process_nameservers
     else
@@ -189,12 +187,12 @@ module Client
   def setup_resolver
     options.validate(datastore) # This is a hack, DS values should not be Strings prior to this
     config = {
-      :config_file => datastore['DNS_CLIENT_RESOLVCONF'],
+      :config_file => datastore['DnsClientResolvconf'],
       :nameservers => process_nameservers,
       :port => datastore['RPORT'],
-      :retry_number => datastore['DNS_CLIENT_RETRY'].to_i,
-      :retry_interval => datastore['DNS_CLIENT_RETRY_INTERVAL'].to_i,
-      :use_tcp => datastore['DNS_CLIENT_TCP_DNS'],
+      :retry_number => datastore['DnsClientRetry'].to_i,
+      :retry_interval => datastore['DnsClientRetryInterval'].to_i,
+      :use_tcp => datastore['DnsClientTcpDns'],
       :context => {'Msf' => framework, 'MsfExploit' => self}
     }
     if datastore['SEARCHLIST']
@@ -226,7 +224,7 @@ module Client
   # Uses explicitly defined NS option if set
   # Uses RHOSTS if not explicitly defined
   def process_nameservers
-    if datastore['NS'] and !datastore['NS'].empty?
+    unless datastore['NS'].blank?
       if datastore['NS'].split(/\s|,/).all? do |nameserver|
         Rex::Socket.it_ip_addr?(nameserver)
       end
@@ -236,7 +234,7 @@ module Client
       end
     else
       ns = []
-      rw = Rex::Socket::RangeWalker.new(datastore['DNS_CLIENT_DEFAULT_NS'].split(/\s|,/))
+      rw = Rex::Socket::RangeWalker.new(datastore['DnsClientDefaultNS'].split(/\s|,/))
       while addr = rw.next_ip
         # break if addr.nil?
         ns << addr

--- a/lib/msf/core/exploit/dns/client.rb
+++ b/lib/msf/core/exploit/dns/client.rb
@@ -13,6 +13,7 @@ module Msf
 module Exploit::Remote::DNS
 module Client
 
+  include Common
   include Exploit::Remote::Udp
   include Exploit::Remote::Tcp
 

--- a/lib/msf/core/exploit/dns/client.rb
+++ b/lib/msf/core/exploit/dns/client.rb
@@ -38,13 +38,13 @@ module Client
 
     register_advanced_options(
       [
-        OptString.new('DNS::Client::DEFAULT_NS', [ false, "Specify the default to use for queries, space separated", '8.8.8.8 8.8.4.4' ]),   
-        OptInt.new('DNS::Client::RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
-        OptInt.new('DNS::Client::RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
-        OptBool.new('DNS::Client::REPORT_A_RECORDS', [false, "Add hosts found via BRT and RVL to DB", true]),
-        OptBool.new('DNS::Client::RVL_EXISTING_ONLY', [false, "Only perform lookups on hosts in DB", true]),
-        OptBool.new('DNS::Client::TCP_DNS', [false, "Run queries over TCP", false]),
-        OptPath.new('DNS::Client::RESOLVCONF', [true, "Resolvconf formatted configuration file to use for Resolver", "/dev/null"])
+        OptString.new('DNS_CLIENT_DEFAULT_NS', [ false, "Specify the default to use for queries, space separated", '8.8.8.8 8.8.4.4' ]),   
+        OptInt.new('DNS_CLIENT_RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
+        OptInt.new('DNS_CLIENT_RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
+        OptBool.new('DNS_CLIENT_REPORT_A_RECORDS', [false, "Add hosts found via BRT and RVL to DB", true]),
+        OptBool.new('DNS_CLIENT_RVL_EXISTING_ONLY', [false, "Only perform lookups on hosts in DB", true]),
+        OptBool.new('DNS_CLIENT_TCP_DNS', [false, "Run queries over TCP", false]),
+        OptPath.new('DNS_CLIENT_RESOLVCONF', [true, "Resolvconf formatted configuration file to use for Resolver", "/dev/null"])
       ], Exploit::Remote::DNS::Client
     )
 
@@ -188,12 +188,12 @@ module Client
   def setup_resolver
     options.validate(datastore) # This is a hack, DS values should not be Strings prior to this
     config = {
-      :config_file => datastore['DNS::Client::RESOLVCONF'],
+      :config_file => datastore['DNS_CLIENT_RESOLVCONF'],
       :nameservers => process_nameservers,
       :port => datastore['RPORT'],
-      :retry_number => datastore['DNS::Client::RETRY'].to_i,
-      :retry_interval => datastore['DNS::Client::RETRY_INTERVAL'].to_i,
-      :use_tcp => datastore['DNS::Client::TCP_DNS'],
+      :retry_number => datastore['DNS_CLIENT_RETRY'].to_i,
+      :retry_interval => datastore['DNS_CLIENT_RETRY_INTERVAL'].to_i,
+      :use_tcp => datastore['DNS_CLIENT_TCP_DNS'],
       :context => {'Msf' => framework, 'MsfExploit' => self}
     }
     if datastore['SEARCHLIST']
@@ -235,7 +235,7 @@ module Client
       end
     else
       ns = []
-      rw = Rex::Socket::RangeWalker.new(datastore['DNS::Client::DEFAULT_NS'].split(/\s|,/))
+      rw = Rex::Socket::RangeWalker.new(datastore['DNS_CLIENT_DEFAULT_NS'].split(/\s|,/))
       while addr = rw.next_ip
         # break if addr.nil?
         ns << addr

--- a/lib/msf/core/exploit/dns/client.rb
+++ b/lib/msf/core/exploit/dns/client.rb
@@ -1,0 +1,249 @@
+# -*- coding: binary -*-
+require 'msf/core'
+require 'rex/proto/dns'
+
+
+module Msf
+
+###
+#
+# This module exposes methods for querying a remote DNS service
+#
+###
+module Exploit::Remote::DNS
+module Client
+
+  include Exploit::Remote::Udp
+  include Exploit::Remote::Tcp
+
+  MATCH_HOSTNAME = Rex::Proto::DNS::Constants::MATCH_HOSTNAME
+
+  #
+  # Initializes an exploit module that interacts with a DNS server.
+  #
+  def initialize(info = {})
+    super
+
+    deregister_options('RHOST')
+    register_options(
+      [
+        Opt::RPORT(53),
+        Opt::Proxies,
+        OptString.new('DOMAIN', [ false, "The target domain name"]),
+        OptString.new('NS', [ false, "Specify the nameservers to use for queries, space separated" ]),
+        OptString.new('SEARCHLIST', [ false, "DNS domain search list, comma separated"]),
+        OptInt.new('THREADS', [true, "Number of threads to use in threaded queries", 1])
+      ], Exploit::Remote::DNS::Client
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('DNS::Client::DEFAULT_NS', [ false, "Specify the default to use for queries, space separated", '8.8.8.8 8.8.4.4' ]),   
+        OptInt.new('DNS::Client::RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
+        OptInt.new('DNS::Client::RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
+        OptBool.new('DNS::Client::REPORT_A_RECORDS', [false, "Add hosts found via BRT and RVL to DB", true]),
+        OptBool.new('DNS::Client::RVL_EXISTING_ONLY', [false, "Only perform lookups on hosts in DB", true]),
+        OptBool.new('DNS::Client::TCP_DNS', [false, "Run queries over TCP", false]),
+        OptPath.new('DNS::Client::RESOLVCONF', [true, "Resolvconf formatted configuration file to use for Resolver", "/dev/null"])
+      ], Exploit::Remote::DNS::Client
+    )
+
+    register_autofilter_ports([ 53 ])
+    register_autofilter_services(%W{ dns })
+  end
+
+
+  #
+  # Convenience wrapper around Resolver's query method - send DNS request
+  #
+  # @param domain [String] Domain for which to request a record
+  # @param type [String] Type of record to request for domain
+  #
+  # @return [Net::DNS::RR] DNS response
+  def query(domain = datastore['DOMAIN'], type = 'A')
+    client.query(domain, type)
+  end
+
+  #
+  # Performs a set of asynchronous lookups for an array of domain,type pairs
+  #
+  # @param queries [Array] Set of domain,type pairs to pass into #query
+  # @param threadmax [Fixnum] Max number of running threads at a time
+  # @param block [Proc] Code block to execute with the query result
+  #
+  # @return [Array] Resulting set of responses or responses processed by passed blocks
+  def query_async(queries = [], threadmax = datastore['THREADS'], &block)
+    running = []
+    while !queries.empty?
+      domain, type = queries.shift
+      running << framework.threads.spawn("Module(#{self.refname})-#{domain} #{type}", false) do |qat|
+        if block
+          block.call(query(domain,type))
+        else
+          query(domain,type)
+        end
+      end
+      while running.map(:alive?).count >= threadmax
+        Rex::ThreadSafe.sleep(1)
+      end
+    end
+    return running.join
+  end
+
+  #
+  # Switch DNS forwarders in resolver with thread safety
+  #
+  # @param ns [Array, String] List of (or single) nameservers to use
+  def set_nameserver(ns = [])
+    if ns.respond_to?(:split)
+      ns = [ns]
+    end
+    @lock.synchronize do
+      @dns_resolver.nameserver = ns.flatten
+    end
+  end
+
+  #
+  # Switch nameservers to use explicit NS or SOA for target
+  #
+  # @param domain [String] Domain for which to find SOA
+  def switchdns(domain)
+    if not datastore['NS'].nil?
+      vprint_status("Using DNS Server: #{client.nameserver.join(', ')}")
+      client.nameserver = process_nameservers
+    else
+      resp_soa = client.query(target, "SOA")
+      if (resp_soa)
+        (resp_soa.answer.select { |i| i.class == Net::DNS::RR::SOA}).each do |rr|
+          resp_1_soa = client.search(rr.mname)
+          if (resp_1_soa and resp_1_soa.answer[0])
+            set_nameserver(resp_1_soa.answer.map(&:address).compact.map(&:to_s))
+            print_status("Set DNS Server to #{target} NS: #{client.nameserver.join(', ')}")
+            break
+          end
+        end
+      end
+    end
+  end
+
+  #
+  # Detect if target has wildcards enabled for a record type
+  #
+  # @param target [String] Domain to test
+  # @param type [String] Record type to test
+  #
+  # @return [String] Address which is returned for wildcard requests
+  def wildcard(domain, type = "A")
+    addr = false
+    rendsub = rand(10000).to_s
+    response = query("#{rendsub}.#{target}", type)
+    if response.answer.length != 0
+      vprint_status("This domain has wildcards enabled!!")
+      response.answer.each do |rr|
+        print_status("Wildcard IP for #{rendsub}.#{target} is: #{rr.address.to_s}") if rr.class != Net::DNS::RR::CNAME
+        addr = rr.address.to_s
+      end
+    end
+    return addr
+  end
+
+  #
+  # Returns the resolver
+  #
+  def client
+    @dns_resolver
+  end
+
+  #
+  # Returns the target host
+  #
+  def rhost
+    datastore['RHOST']
+  end
+
+  #
+  # Returns the remote port
+  #
+  def rport
+    datastore['RPORT']
+  end
+
+  #
+  # Returns the Host and Port as a string
+  #
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
+  #
+  # Returns the configured proxy list
+  #
+  def proxies
+    datastore['Proxies']
+  end
+
+  #
+  # Create and configure Resolver object
+  #
+  def setup_resolver
+    options.validate(datastore) # This is a hack, DS values should not be Strings prior to this
+    config = {
+      :config_file => datastore['DNS::Client::RESOLVCONF'],
+      :nameservers => process_nameservers,
+      :port => datastore['RPORT'],
+      :retry_number => datastore['DNS::Client::RETRY'].to_i,
+      :retry_interval => datastore['DNS::Client::RETRY_INTERVAL'].to_i,
+      :use_tcp => datastore['DNS::Client::TCP_DNS'],
+      :context => {'Msf' => framework, 'MsfExploit' => self}
+    }
+    if datastore['SEARCHLIST']
+      if datastore['SEARCHLIST'].split(',').all? do |search|
+        search.match(MATCH_HOSTNAME)
+      end
+        config[:search_list] = datastore['SEARCHLIST'].split(',')
+      else
+        raise 'Domain search list must consist of valid domains'
+      end
+    end
+    if datastore['CHOST']
+      config[:source_address] = IPAddr.new(datastore['CHOST'].to_s)
+    end
+    if datastore['CPORT']
+      config[:source_port] = datastore['CPORT'] unless datastore['CPORT'] == 0
+    end
+    if datastore['Proxies']
+      vprint_status("Using DNS/TCP resolution for proxy config")
+      config[:use_tcp] = true
+      config[:proxies] = datastore['Proxies']
+    end
+    @dns_resolver = Rex::Proto::DNS::Resolver.new(config)
+    @dns_resolver_lock = Mutex.new unless @dns_resolver_lock
+  end
+
+  #
+  # Sets the resolver's nameservers
+  # Uses explicitly defined NS option if set
+  # Uses RHOSTS if not explicitly defined
+  def process_nameservers
+    if datastore['NS'] and !datastore['NS'].empty?
+      if datastore['NS'].split(/\s|,/).all? do |nameserver|
+        Rex::Socket.it_ip_addr?(nameserver)
+      end
+        return datastore['NS'].split(/\s|,/)
+      else
+        raise "Nameservers must be proper IP addresses"
+      end
+    else
+      ns = []
+      rw = Rex::Socket::RangeWalker.new(datastore['DNS::Client::DEFAULT_NS'].split(/\s|,/))
+      while addr = rw.next_ip
+        # break if addr.nil?
+        ns << addr
+      end
+      return ns.compact
+    end
+  end
+
+end
+end
+end

--- a/lib/msf/core/exploit/dns/client.rb
+++ b/lib/msf/core/exploit/dns/client.rb
@@ -180,8 +180,17 @@ module Client
       config[:use_tcp] = true
       config[:proxies] = datastore['Proxies']
     end
-    @dns_resolver = Rex::Proto::DNS::Resolver.new(config)
     @dns_resolver_lock = Mutex.new unless @dns_resolver_lock
+    @dns_resolver = Rex::Proto::DNS::Resolver.new(config)
+  end
+
+  #
+  # Convenience method for DNS resolver as client
+  # Executes setup_resolver if none exists
+  #
+  def client
+    setup_resolver unless @dns_resolver
+    @dns_resolver
   end
 
   #

--- a/lib/msf/core/exploit/dns/common.rb
+++ b/lib/msf/core/exploit/dns/common.rb
@@ -1,0 +1,22 @@
+# -*- coding: binary -*-
+require 'msf/core'
+require 'rex/proto/dns'
+
+
+module Msf
+
+###
+#
+# This module exposes methods for querying a remote DNS service
+#
+###
+module Exploit::Remote::DNS
+module Common
+
+  MATCH_HOSTNAME = Rex::Proto::DNS::Constants::MATCH_HOSTNAME
+
+  Packet = Rex::Proto::DNS::Packet
+  
+end
+end
+end

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 require 'msf/core'
 require 'rex/proto/dns'
-
+require 'msf/core/exploit/dns/common'
 
 module Msf
 
@@ -12,7 +12,7 @@ module Msf
 ###
 module Exploit::Remote::DNS
 module Server
-  include Common
+  include Exploit::Remote::DNS::Common
   include Exploit::Remote::SocketServer
 
   #
@@ -110,7 +110,8 @@ module Server
     begin
 
       comm = _determine_server_comm
-      self.service = Rex::Proto::DNS::Server.new(
+      self.service = Rex::ServiceManager.start(
+        Rex::Proto::DNS::Server,
         datastore['SRVHOST'],
         datastore['SRVPORT'],
         datastore['DnsServerUdp'],
@@ -154,7 +155,7 @@ module Server
   # Stops the server
   # @param destroy [TrueClass,FalseClass] Dereference the server object
   def stop_service(destroy = false)
-    self.service.stop unless self.service.nil?
+    Rex::ServiceManager.stop_service(self.service) if self.service
     if destroy
       @dns_resolver = nil
       self.service = nil

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -166,6 +166,13 @@ module Server
     start_service
   end
 
+  #
+  # Determines if resolver is available and configured for use
+  #
+  def use_resolver?
+    !datastore['DISABLE_RESOLVER'] and self.respond_to?(:setup_resolver)
+  end
+
 end
 end
 end

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -38,7 +38,7 @@ module Server
     )
   end
 
-  attr_accessor :service
+  attr_accessor :service # :nodoc:
 
   #
   # Process static entries
@@ -103,10 +103,6 @@ module Server
   # Starts the server
   #
   def start_service
-    options.validate(datastore) # This is a hack, DS values should not be Strings prior to this
-    if !datastore['DISABLE_RESOLVER'] and self.respond_to?(:setup_resolver)
-      setup_resolver
-    end
     begin
 
       comm = _determine_server_comm
@@ -116,10 +112,10 @@ module Server
         datastore['SRVPORT'],
         datastore['DnsServerUdp'],
         datastore['DnsServerTcp'],
-        (datastore['DISABLE_RESOLVER'] ? false : @dns_resolver),
+        (use_resolver? ? setup_resolver : false),
         comm,
         {'Msf' => framework, 'MsfExploit' => self}
-      ) if self.service.nil?
+      )
 
       self.service.dispatch_request_proc = Proc.new do |cli, data|
         on_dispatch_request(cli,data)
@@ -157,8 +153,8 @@ module Server
   def stop_service(destroy = false)
     Rex::ServiceManager.stop_service(self.service) if self.service
     if destroy
-      @dns_resolver = nil
-      self.service = nil
+      @dns_resolver = nil if @dns_resolver
+      self.service = nil if self.service
     end
   end
 

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -12,9 +12,8 @@ module Msf
 ###
 module Exploit::Remote::DNS
 module Server
+  include Common
   include Exploit::Remote::SocketServer
-
-  MATCH_HOSTNAME = Rex::Proto::DNS::Constants::MATCH_HOSTNAME
 
   #
   # Initializes an exploit module that serves DNS requests
@@ -156,7 +155,10 @@ module Server
   # @param destroy [TrueClass,FalseClass] Dereference the server object
   def stop_service(destroy = false)
     self.service.stop unless self.service.nil?
-    self.service = nil if destroy
+    if destroy
+      @dns_resolver = nil
+      self.service = nil
+    end
   end
 
   #

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -58,7 +58,7 @@ module Server
       next if entry.gsub(/\s/,'').empty?
       addr, names = entry.split(' ', 2)
       names.split.each do |name|
-        name << '.' unless name[-1] == '.'
+        name << '.' unless name[-1] == '.' or name == '*'
         service.cache.add_static(name, addr, type)
       end
     end

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -1,0 +1,176 @@
+# -*- coding: binary -*-
+require 'msf/core'
+require 'rex/proto/dns'
+
+
+module Msf
+
+###
+#
+# This module exposes methods for querying a remote DNS service
+#
+###
+module Exploit::Remote::DNS
+module Server
+
+  MATCH_HOSTNAME = Rex::Proto::DNS::Constants::MATCH_HOSTNAME
+
+  #
+  # Initializes an exploit module that serves DNS requests
+  #
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        OptAddress.new('SRVHOST', [ true, "The local host to listen on.", '0.0.0.0' ]),
+        OptPort.new('SRVPORT', [true, 'The local port to listen on.', 53]),
+        OptString.new('STATIC_ENTRIES', [ false, "DNS domain search list (hosts file or space/semicolon separate entries)"]),
+        OptBool.new('DISABLE_RESOLVER', [ false, "Disable DNS request forwarding", false]),
+        OptBool.new('DISABLE_NS_CACHE', [ false, "Disable DNS response caching", false])
+      ], Exploit::Remote::DNS::Server
+    )
+
+    register_advanced_options(
+      [
+        OptBool.new('DNS::Server::UDP_DNS', [true, "Serve UDP DNS requests", true]),
+        OptBool.new('DNS::Server::TCP_DNS', [true, "Serve TCP DNS requests", false])
+      ], Exploit::Remote::DNS::Server
+    )
+  end
+
+  attr_accessor :service
+
+  #
+  # Process static entries
+  #
+  # @param entries [String] Filename or String containing static entries
+  # @param type [String] Type of record for which to add static entries
+  #
+  # @return [Array] List of static entries in the cache
+  def add_static_hosts(entries = datastore['STATIC_ENTRIES'], type = 'A')
+    if File.file?(File.expand_path(entries))
+      data = File.read(File.expand_path(entries)).split("\n")
+    else
+      data = entries.split(';')
+    end
+    data.each do |entry|
+      next if data.gsub(/\s/,'').empty?
+      addr, names = entry.split(' ', 2)
+      names.split.each do |name|
+        server.cache.add_static(name, addr, type)
+      end
+    end
+    data.cache.records.select {|r,e| e == 0}
+  end
+
+  #
+  # Flush all static entries
+  #
+  def flush_static_hosts
+    data.cache.records.select {|r,e| e == 0}.each do |flush|
+      data.cache.delete(flush)
+    end
+  end
+
+  #
+  # Flush cache entries
+  # @param static [TrueClass, FalseClass] flush static hosts
+  def flush_cache(static = false)
+    self.service.cache.stop(true)
+    flush_static_hosts if static
+    self.service.cache.start
+  end
+
+  #
+  # Starts the server
+  #
+  def start_service
+    setup_server
+    self.service = @dns_server
+    self.service.start(!datastore['DISABLE_NS_CACHE'])
+  end
+
+  #
+  # Stops the server
+  # @param destroy [TrueClass,FalseClass] Dereference the server object
+  def stop_service(destroy = false)
+    self.service.stop unless self.service.nil?
+    self.service = nil
+    @dns_server = nil if destroy
+  end
+
+  #
+  # Resets the DNS server
+  #
+  def reset_service
+    stop_service
+    @dns_server = nil
+    start_service
+  end
+
+  #
+  # Returns the server
+  #
+  def service
+    @dns_server
+  end
+
+  #
+  # Returns the local host that is being listened on.
+  #
+  def srvhost
+    datastore['SRVHOST']
+  end
+
+  #
+  # Returns the local port that is being listened on.
+  #
+  def srvport
+    datastore['SRVPORT']
+  end
+
+  #
+  # Handle incoming requests
+  # Override this method in modules to take flow control
+  #
+  def handle_request
+    nil
+  end
+
+  #
+  # Handle incoming requests
+  # Override this method in modules to take flow control
+  #
+  def handle_response
+    nil
+  end
+
+  #
+  # Create and configure Server object unless one exists
+  # Pass in existing resolver if available and allowed
+  # Create Procs for request and response handlers if defined
+  #
+  def setup_server
+    return if @dns_server
+    options.validate(datastore) # This is a hack, DS values should not be Strings prior to this
+    if !datastore['DISABLE_RESOLVER'] and self.respond_to?(:setup_resolver)
+      setup_resolver
+    end
+    @dns_server = Rex::Proto::DNS::Server.new(
+      datastore['SRVHOST'],
+      datastore['SRVPORT'],
+      datastore['DNS::Server::UDP_DNS'],
+      datastore['DNS::Server::TCP_DNS'],
+      (datastore['DISABLE_RESOLVER'] ? false : @dns_resolver),
+      nil,
+      {'Msf' => framework, 'MsfExploit' => self},
+      handle_request,
+      handle_response
+    )
+  end
+
+
+end
+end
+end

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -12,6 +12,7 @@ module Msf
 ###
 module Exploit::Remote::DNS
 module Server
+  include Exploit::Remote::SocketServer
 
   MATCH_HOSTNAME = Rex::Proto::DNS::Constants::MATCH_HOSTNAME
 
@@ -23,7 +24,6 @@ module Server
 
     register_options(
       [
-        OptAddress.new('SRVHOST', [ true, "The local host to listen on.", '0.0.0.0' ]),
         OptPort.new('SRVPORT', [true, 'The local port to listen on.', 53]),
         OptString.new('STATIC_ENTRIES', [ false, "DNS domain search list (hosts file or space/semicolon separate entries)"]),
         OptBool.new('DISABLE_RESOLVER', [ false, "Disable DNS request forwarding", false]),
@@ -33,8 +33,8 @@ module Server
 
     register_advanced_options(
       [
-        OptBool.new('DNS::Server::UDP_DNS', [true, "Serve UDP DNS requests", true]),
-        OptBool.new('DNS::Server::TCP_DNS', [true, "Serve TCP DNS requests", false])
+        OptBool.new('DNS_SERVER_UDP', [true, "Serve UDP DNS requests", true]),
+        OptBool.new('DNS_SERVER_TCP', [true, "Serve TCP DNS requests", false])
       ], Exploit::Remote::DNS::Server
     )
   end
@@ -85,13 +85,70 @@ module Server
   end
 
   #
+  # Handle incoming requests
+  # Override this method in modules to take flow control
+  #
+  def on_dispatch_request(cli, data)
+    service.default_dispatch_request(cli,data)
+  end
+
+  #
+  # Handle incoming requests
+  # Override this method in modules to take flow control
+  #
+  def on_send_response(cli, data)
+    cli.write(data)
+  end
+
+  #
   # Starts the server
   #
   def start_service
-    setup_server
-    self.service = @dns_server
-    add_static_hosts
-    self.service.start(!datastore['DISABLE_NS_CACHE'])
+    options.validate(datastore) # This is a hack, DS values should not be Strings prior to this
+    if !datastore['DISABLE_RESOLVER'] and self.respond_to?(:setup_resolver)
+      setup_resolver
+    end
+    begin
+
+      comm = _determine_server_comm
+      self.service = Rex::Proto::DNS::Server.new(
+        datastore['SRVHOST'],
+        datastore['SRVPORT'],
+        datastore['DNS_SERVER_UDP'],
+        datastore['DNS_SERVER_TCP'],
+        (datastore['DISABLE_RESOLVER'] ? false : @dns_resolver),
+        comm,
+        {'Msf' => framework, 'MsfExploit' => self}
+      ) if self.service.nil?
+
+      self.service.dispatch_request_proc = Proc.new do |cli, data|
+        on_dispatch_request(cli,data)
+      end
+      self.service.send_response_proc = Proc.new do |cli, data|
+        on_send_response(cli,data)
+      end
+      
+      add_static_hosts
+      self.service.start(!datastore['DISABLE_NS_CACHE'])
+
+    rescue ::Errno::EACCES => e
+      if (srvport.to_i < 1024)
+        print_line(" ")
+        print_error("Could not start the DNS server: #{e}.")
+        print_error(
+          "This module is configured to use a privileged port (#{srvport}). " +
+          "On Unix systems, only the root user account is allowed to bind to privileged ports." +
+          "Please run the framework as root to use this module."
+        )
+        print_error(
+          "On Microsoft Windows systems, this error is returned when a process attempts to "+
+          "listen on a host/port combination that is already in use. For example, Windows XP "+
+          "will return this error if a process attempts to bind() over the system SMB/NetBIOS services."
+        )
+        print_line(" ")
+      end
+      raise e
+    end
   end
 
   #
@@ -99,80 +156,16 @@ module Server
   # @param destroy [TrueClass,FalseClass] Dereference the server object
   def stop_service(destroy = false)
     self.service.stop unless self.service.nil?
-    self.service = nil
-    @dns_server = nil if destroy
+    self.service = nil if destroy
   end
 
   #
   # Resets the DNS server
   #
   def reset_service
-    stop_service
-    @dns_server = nil
+    stop_service(true)
     start_service
   end
-
-  #
-  # Returns the server
-  #
-  def service
-    @dns_server
-  end
-
-  #
-  # Returns the local host that is being listened on.
-  #
-  def srvhost
-    datastore['SRVHOST']
-  end
-
-  #
-  # Returns the local port that is being listened on.
-  #
-  def srvport
-    datastore['SRVPORT']
-  end
-
-  #
-  # Handle incoming requests
-  # Override this method in modules to take flow control
-  #
-  def handle_request
-    nil
-  end
-
-  #
-  # Handle incoming requests
-  # Override this method in modules to take flow control
-  #
-  def handle_response
-    nil
-  end
-
-  #
-  # Create and configure Server object unless one exists
-  # Pass in existing resolver if available and allowed
-  # Create Procs for request and response handlers if defined
-  #
-  def setup_server
-    return if @dns_server
-    options.validate(datastore) # This is a hack, DS values should not be Strings prior to this
-    if !datastore['DISABLE_RESOLVER'] and self.respond_to?(:setup_resolver)
-      setup_resolver
-    end
-    @dns_server = Rex::Proto::DNS::Server.new(
-      datastore['SRVHOST'],
-      datastore['SRVPORT'],
-      datastore['DNS::Server::UDP_DNS'],
-      datastore['DNS::Server::TCP_DNS'],
-      (datastore['DISABLE_RESOLVER'] ? false : @dns_resolver),
-      nil,
-      {'Msf' => framework, 'MsfExploit' => self},
-      handle_request,
-      handle_response
-    )
-  end
-
 
 end
 end

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -32,8 +32,8 @@ module Server
 
     register_advanced_options(
       [
-        OptBool.new('DNS_SERVER_UDP', [true, "Serve UDP DNS requests", true]),
-        OptBool.new('DNS_SERVER_TCP', [true, "Serve TCP DNS requests", false])
+        OptBool.new('DnsServerUdp', [true, "Serve UDP DNS requests", true]),
+        OptBool.new('DnsServerTcp', [true, "Serve TCP DNS requests", false])
       ], Exploit::Remote::DNS::Server
     )
   end
@@ -113,8 +113,8 @@ module Server
       self.service = Rex::Proto::DNS::Server.new(
         datastore['SRVHOST'],
         datastore['SRVPORT'],
-        datastore['DNS_SERVER_UDP'],
-        datastore['DNS_SERVER_TCP'],
+        datastore['DnsServerUdp'],
+        datastore['DnsServerTcp'],
         (datastore['DISABLE_RESOLVER'] ? false : @dns_resolver),
         comm,
         {'Msf' => framework, 'MsfExploit' => self}

--- a/lib/msf/core/exploit/dns/server.rb
+++ b/lib/msf/core/exploit/dns/server.rb
@@ -49,19 +49,21 @@ module Server
   #
   # @return [Array] List of static entries in the cache
   def add_static_hosts(entries = datastore['STATIC_ENTRIES'], type = 'A')
+    return if entries.nil? or entries.empty?
     if File.file?(File.expand_path(entries))
       data = File.read(File.expand_path(entries)).split("\n")
     else
       data = entries.split(';')
     end
     data.each do |entry|
-      next if data.gsub(/\s/,'').empty?
+      next if entry.gsub(/\s/,'').empty?
       addr, names = entry.split(' ', 2)
       names.split.each do |name|
-        server.cache.add_static(name, addr, type)
+        name << '.' unless name[-1] == '.'
+        service.cache.add_static(name, addr, type)
       end
     end
-    data.cache.records.select {|r,e| e == 0}
+    service.cache.records.select {|r,e| e == 0}
   end
 
   #
@@ -88,6 +90,7 @@ module Server
   def start_service
     setup_server
     self.service = @dns_server
+    add_static_hosts
     self.service.start(!datastore['DISABLE_NS_CACHE'])
   end
 

--- a/lib/msf/core/exploit/socket_server.rb
+++ b/lib/msf/core/exploit/socket_server.rb
@@ -147,13 +147,21 @@ protected
   #
   # Determines appropriate listener comm
   #
-  def _determine_server_comm(comm = datastore['ListenerComm'])
-    if comm == "local"
+  def _determine_server_comm(srv_comm = datastore['ListenerComm'].to_s)
+    case srv_comm
+    when 'local'
       comm = ::Rex::Socket::Comm::Local
+    when /\A[0-9]+\Z/
+      comm = framework.sessions[srv_comm.to_i]
+      raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not exist") unless comm
+      raise(RuntimeError, "Socket Server Comm (Session #{srv_comm}) does not implement Rex::Socket::Comm") unless comm.is_a? ::Rex::Socket::Comm
+    when nil, ''
+      comm = nil 
     else
-      comm = nil
-    end
-    return comm
+      raise(RuntimeError, "SocketServer Comm '#{srv_comm}' is invalid")
+    end 
+
+    comm
   end
 
   attr_accessor :service # :nodoc:

--- a/lib/msf/core/exploit/socket_server.rb
+++ b/lib/msf/core/exploit/socket_server.rb
@@ -1,0 +1,164 @@
+# -*- coding: binary -*-
+
+module Msf
+
+###
+#
+# This mixin provides a generic interface for running a socket server of some
+# sort that is designed to exploit clients.  Exploits that include this mixin
+# automatically take a passive stance.
+#
+###
+
+module Exploit::Remote::SocketServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Stance' => Msf::Exploit::Stance::Passive))
+
+    register_options(
+      [
+        OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
+        OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),
+
+      ], Msf::Exploit::Remote::SocketServer
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('ListenerComm', [ false, 'The specific communication channel to use for this service'])
+      ], Msf::Exploit::Remote::SocketServer
+    )
+  end
+
+  #
+  # This mixin overrides the exploit method so that it can initiate the
+  # service that corresponds with what the client has requested.
+  #
+  def exploit
+
+    start_service()
+    print_status("Server started.")
+
+    # Call the exploit primer
+    primer
+
+    # Wait on the service to stop
+    self.service.wait
+  end
+
+  #
+  # Primer method to call after starting service but before handling connections
+  #
+  def primer
+  end
+
+  #
+  # Stops the service, if one was created.
+  #
+  def cleanup
+    super
+    if(service)
+      stop_service()
+      print_status("Server stopped.")
+    end
+  end
+
+  #
+  # Called when a client has data available for reading.
+  #
+  def on_client_data(client)
+  end
+
+  #
+  # Starts the service. Override this method in consumers
+  #
+  def start_service(*args)
+  end
+
+  #
+  # Stops the service.
+  #
+  def stop_service
+    if (service)
+      begin
+        self.service.deref if self.service.kind_of?(Rex::Service)
+        if self.service.kind_of?(Rex::Socket)
+          self.service.close
+          self.service.stop
+        end
+
+        self.service = nil
+      rescue ::Exception
+      end
+    end
+  end
+
+  #
+  # Returns the local host that is being listened on.
+  #
+  def srvhost
+    datastore['SRVHOST']
+  end
+
+  #
+  # Returns the local port that is being listened on.
+  #
+  def srvport
+    datastore['SRVPORT']
+  end
+
+  #
+  # Re-generates the payload, substituting the current RHOST and RPORT with
+  # the supplied client host and port from the socket.
+  #
+  def regenerate_payload(cli, arch = nil, platform = nil, target = nil)
+
+    ohost = datastore['RHOST']
+    oport = datastore['RPORT']
+    p = nil
+
+    begin
+      # Update the datastore with the supplied client peerhost/peerport
+      datastore['RHOST'] = cli.peerhost
+      datastore['RPORT'] = cli.peerport
+
+      if ((p = super(arch, platform, target)) == nil)
+        print_error("Failed to generate payload")
+        return nil
+      end
+
+      # Allow the payload to start a new handler
+      add_handler({
+        'RHOST' => datastore['RHOST'],
+        'RPORT' => datastore['RPORT']
+      })
+
+    ensure
+      datastore['RHOST'] = ohost
+      datastore['RPORT'] = oport
+    end
+
+    p
+  end
+
+protected
+
+  #
+  # Determines appropriate listener comm
+  #
+  def _determine_server_comm(comm = datastore['ListenerComm'])
+    if comm == "local"
+      comm = ::Rex::Socket::Comm::Local
+    else
+      comm = nil
+    end
+    return comm
+  end
+
+  attr_accessor :service # :nodoc:
+
+end
+
+end
+

--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'msf/core/exploit/socket_server'
+
 module Msf
 
 ###
@@ -10,20 +12,18 @@ module Msf
 #
 ###
 module Exploit::Remote::TcpServer
+  include Exploit::Remote::SocketServer
 
   def initialize(info = {})
-    super(update_info(info,
-      'Stance' => Msf::Exploit::Stance::Passive))
+    super
 
     register_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for incoming connections', false]),
         # SSLVersion is currently unsupported for TCP servers (only supported by clients at the moment)
-        OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
-        OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
-        OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),
-
-      ], Msf::Exploit::Remote::TcpServer)
+        OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)'])
+      ], Msf::Exploit::Remote::TcpServer
+    )
 
     register_advanced_options(
       [
@@ -40,49 +40,9 @@ module Exploit::Remote::TcpServer
     )
   end
 
-  #
-  # This mixin overrides the exploit method so that it can initiate the
-  # service that corresponds with what the client has requested.
-  #
-  def exploit
-
-    start_service()
-    print_status("Server started.")
-
-    # Call the exploit primer
-    primer
-
-    # Wait on the service to stop
-    self.service.wait
-  end
-
-  #
-  # Primer method to call after starting service but before handling connections
-  #
-  def primer
-  end
-
-  #
-  # Stops the service, if one was created.
-  #
-  def cleanup
-    super
-    if(service)
-      stop_service()
-      print_status("Server stopped.")
-    end
-  end
-
-  #
   # Called when a client connects.
   #
   def on_client_connect(client)
-  end
-
-  #
-  # Called when a client has data available for reading.
-  #
-  def on_client_data(client)
   end
 
   #
@@ -97,12 +57,7 @@ module Exploit::Remote::TcpServer
   def start_service(*args)
     begin
 
-      comm = datastore['ListenerComm']
-      if comm == "local"
-        comm = ::Rex::Socket::Comm::Local
-      else
-        comm = nil
-      end
+      comm = _determine_server_comm
 
       self.service = Rex::Socket::TcpServer.create(
         'LocalHost' => srvhost,
@@ -152,38 +107,6 @@ module Exploit::Remote::TcpServer
   end
 
   #
-  # Stops the service.
-  #
-  def stop_service
-    if (service)
-      begin
-        self.service.deref if self.service.kind_of?(Rex::Service)
-        if self.service.kind_of?(Rex::Socket)
-          self.service.close
-          self.service.stop
-        end
-
-        self.service = nil
-      rescue ::Exception
-      end
-    end
-  end
-
-  #
-  # Returns the local host that is being listened on.
-  #
-  def srvhost
-    datastore['SRVHOST']
-  end
-
-  #
-  # Returns the local port that is being listened on.
-  #
-  def srvport
-    datastore['SRVPORT']
-  end
-
-  #
   # Returns the SSL option
   #
   def ssl
@@ -208,44 +131,6 @@ module Exploit::Remote::TcpServer
   def ssl_compression
     datastore['SSLCompression']
   end
-
-  #
-  # Re-generates the payload, substituting the current RHOST and RPORT with
-  # the supplied client host and port from the socket.
-  #
-  def regenerate_payload(cli, arch = nil, platform = nil, target = nil)
-
-    ohost = datastore['RHOST']
-    oport = datastore['RPORT']
-    p = nil
-
-    begin
-      # Update the datastore with the supplied client peerhost/peerport
-      datastore['RHOST'] = cli.peerhost
-      datastore['RPORT'] = cli.peerport
-
-      if ((p = super(arch, platform, target)) == nil)
-        print_error("Failed to generate payload")
-        return nil
-      end
-
-      # Allow the payload to start a new handler
-      add_handler({
-        'RHOST' => datastore['RHOST'],
-        'RPORT' => datastore['RPORT']
-      })
-
-    ensure
-      datastore['RHOST'] = ohost
-      datastore['RPORT'] = oport
-    end
-
-    p
-  end
-
-protected
-
-  attr_accessor :service # :nodoc:
 
 end
 

--- a/lib/net/dns/packet.rb
+++ b/lib/net/dns/packet.rb
@@ -184,6 +184,7 @@ module Net # :nodoc:
           nscount += 1
         end
         @additional.each do |rr|
+          next if rr.nil?
           data += rr.data#(data.length)
           arcount += 1
         end

--- a/lib/rex/io/gram_server.rb
+++ b/lib/rex/io/gram_server.rb
@@ -1,0 +1,94 @@
+# -*- coding: binary -*-
+require 'thread'
+
+module Rex
+module IO
+
+###
+#
+# This mixin provides the framework and interface for implementing a datagram
+# server that can handle incoming datagrams. Datagram servers include this mixin
+#
+###
+module GramServer
+
+  ##
+  #
+  # Abstract methods
+  #
+  ##
+
+  ##
+  #
+  # Default server monitoring and client management implementation follows
+  # below.
+  #
+  ##
+
+
+  #
+  # This callback is notified when a client connection has data that needs to
+  # be processed.
+  #
+  def dispatch_request(client, data)
+    if (dispatch_request_proc)
+      dispatch_request_proc.call(client, data)
+    end
+  end
+
+  #
+  # This callback is notified when data must be returned to the client
+  # @param client [Socket] Client/Socket to receive data
+  # @param data [String] Data to be sent to client/socket
+  def send_response(client, data)
+    if (send_response_proc)
+      send_response_proc.call(client, data)
+    else
+      client.write(data)
+    end
+  end
+
+  #
+  # Start monitoring the listener socket for connections and keep track of
+  # all client connections.
+  #
+  def start
+    self.listener_thread = Rex::ThreadFactory.spawn("GramServerListener", false) {
+      monitor_listener
+    }
+  end
+
+  #
+  # Terminates the listener monitoring threads and closes all active clients.
+  #
+  def stop
+    self.listener_thread.kill
+  end
+
+  #
+  # This method waits on the server listener thread
+  #
+  def wait
+    self.listener_thread.join if self.listener_thread
+  end
+
+  ##
+  #
+  # Callback procedures.
+  #
+  ##
+
+  #
+  # This callback procedure can be set and will be called when clients
+  # have data to be processed.
+  #
+  attr_accessor :dispatch_request_proc, :send_response_proc
+
+  attr_accessor :listener_thread# :nodoc:
+
+
+end
+
+end
+end
+

--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -251,6 +251,13 @@ class Channel
   end
 
   #
+  # Wrapper around check for self.cid
+  #
+  def closed?
+    self.cid.nil?
+  end
+
+  #
   # Wrapper around the low-level close.
   #
   def close(addends = nil)

--- a/lib/rex/proto.rb
+++ b/lib/rex/proto.rb
@@ -9,6 +9,7 @@ require 'rex/proto/kerberos'
 require 'rex/proto/rmi'
 require 'rex/proto/sms'
 require 'rex/proto/mms'
+require 'rex/proto/dns'
 
 module Rex
 module Proto

--- a/lib/rex/proto/dns.rb
+++ b/lib/rex/proto/dns.rb
@@ -1,0 +1,16 @@
+# -*- coding: binary -*-
+
+module Rex
+module Proto
+module DNS
+
+  module Constants
+    MATCH_HOSTNAME=/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]\.*)$/
+  end
+  
+end
+end
+end
+
+require 'rex/proto/dns/resolver'
+require 'rex/proto/dns/server'

--- a/lib/rex/proto/dns.rb
+++ b/lib/rex/proto/dns.rb
@@ -12,5 +12,6 @@ end
 end
 end
 
+require 'rex/proto/dns/packet'
 require 'rex/proto/dns/resolver'
 require 'rex/proto/dns/server'

--- a/lib/rex/proto/dns/packet.rb
+++ b/lib/rex/proto/dns/packet.rb
@@ -117,10 +117,10 @@ module Packet
     # Set answer count header section
     packet.header.anCount = packet.answer.count
     # Set error code for NXDomain or unset it if reprocessing a response
-    if packet.answer.count < 1
+    if packet.header.anCount < 1
       packet.header.rCode = 3
     else
-      if packet.header.response? and packet.header.rCode == 3
+      if packet.header.response? and packet.header.rCode.code == 3
         packet.header.rCode = 0
       end
     end

--- a/lib/rex/proto/dns/packet.rb
+++ b/lib/rex/proto/dns/packet.rb
@@ -1,0 +1,136 @@
+require 'net/dns'
+require 'resolv'
+
+module Rex
+module Proto
+module DNS
+
+module Packet
+
+  #
+  # Reconstructs a packet with both standard DNS libraries
+  # Ensures that headers match the payload
+  #
+  # @param packet [String, Net::DNS::Packet] Data to be validated
+  #
+  # @return [Net::DNS::Packet]
+  def self.validate(packet)
+    Net::DNS::Packet.parse(
+      Resolv::DNS::Message.decode(
+        packet.respond_to?(:data) ? packet.data : packet
+      ).encode
+    )
+  end
+
+  #
+  # Reads a packet into the Net::DNS::Packet format
+  #
+  # @param data [String, Net::DNS::Packet, Resolv::DNS::Message] Input data
+  #
+  # @return [Net::DNS::Packet]
+  def self.encode_net(packet)
+    return packet if packet.respond_to?(:data)
+    Net::DNS::Packet.parse(
+      packet.respond_to?(:decode) ? packet.encode : packet
+    )
+  end
+
+  # Reads a packet into the Resolv::DNS::Message format
+  #
+  # @param data [String, Net::DNS::Packet, Resolv::DNS::Message] Input data
+  #
+  # @return [Resolv::DNS::Message]
+  def self.encode_res(packet)
+    return packet if packet.respond_to?(:decode)
+    Resolv::DNS::Message.decode(
+      packet.respond_to?(:data) ? packet.data : packet
+    )
+  end
+
+  # Reads a packet into the raw String format
+  #
+  # @param data [String, Net::DNS::Packet, Resolv::DNS::Message] Input data
+  #
+  # @return [Resolv::DNS::Message]
+  def self.encode_raw(packet)
+    return packet unless packet.respond_to?(:decode) or packet.respond_to?(:data)
+    packet.respond_to?(:data) ? packet.data : packet.encode
+  end
+
+  module Raw
+
+    #
+    # Convert data to big endian unsigned short
+    #
+    # @param data [Fixnum, Float, Array] Input for conversion
+    #
+    # @return [String] Raw output
+    def self.to_dw(data)
+      [data].flatten.pack('S>*')
+    end
+
+    #
+    # Convert data from big endian unsigned short
+    #
+    # @param data [String] Input for conversion
+    #
+    # @return [Array] Integer array output
+    def self.from_dw(data)
+      data.unpack('S>*')
+    end
+
+    #
+    # Convert data to big endian unsigned int
+    #
+    # @param data [Fixnum, Float, Array] Input for conversion
+    #
+    # @return [String] Raw output
+    def self.to_dd(data)
+      [data].flatten.pack('I>*')
+    end
+
+    #
+    # Convert data from big endian unsigned int
+    #
+    # @param data [String] Input for conversion
+    #
+    # @return [Array] Integer array output
+    def self.from_dd(data)
+      data.unpack('I>*')
+    end
+
+    #
+    # Convert data to big endian unsigned long
+    #
+    # @param data [Fixnum, Float, Array] Input for conversion
+    #
+    # @return [String] Raw output
+    def self.to_dl(data)
+      [data].flatten.pack('L>*')
+    end
+
+    #
+    # Convert data from big endian unsigned long
+    #
+    # @param data [String] Input for conversion
+    #
+    # @return [Array] Integer array output
+    def self.from_dl(data)
+      data.unpack('L>*')
+    end
+
+    #
+    # Returns request ID from raw packet skipping parsing
+    #
+    # @param data [String] Request data
+    #
+    # @return [Fixnum] Request ID
+    def self.request_id(data)
+      self.from_dw(data[0..1])[0]
+    end
+  end
+end
+
+end
+end
+end

--- a/lib/rex/proto/dns/packet.rb
+++ b/lib/rex/proto/dns/packet.rb
@@ -13,7 +13,7 @@ module Packet
   # @param subject [String] Subject name to check
   #
   # @return [TrueClass,FalseClass] Disposition on name match
-  def valid_hostname?(subject = '')
+  def self.valid_hostname?(subject = '')
     !subject.match(Rex::Proto::DNS::Constants::MATCH_HOSTNAME).nil?
   end
 

--- a/lib/rex/proto/dns/packet.rb
+++ b/lib/rex/proto/dns/packet.rb
@@ -60,12 +60,72 @@ module Packet
   module Raw
 
     #
+    # Convert data to little endian unsigned short
+    #
+    # @param data [Fixnum, Float, Array] Input for conversion
+    #
+    # @return [String] Raw output
+    def self.to_short_le(data)
+      [data].flatten.pack('S*')
+    end
+
+    #
+    # Convert data from little endian unsigned short
+    #
+    # @param data [String] Input for conversion
+    #
+    # @return [Array] Integer array output
+    def self.from_short_le(data)
+      data.unpack('S*')
+    end
+
+    #
+    # Convert data to little endian unsigned int
+    #
+    # @param data [Fixnum, Float, Array] Input for conversion
+    #
+    # @return [String] Raw output
+    def self.to_int_le(data)
+      [data].flatten.pack('I*')
+    end
+
+    #
+    # Convert data from little endian unsigned int
+    #
+    # @param data [String] Input for conversion
+    #
+    # @return [Array] Integer array output
+    def self.from_int_le(data)
+      data.unpack('I*')
+    end
+
+    #
+    # Convert data to little endian unsigned long
+    #
+    # @param data [Fixnum, Float, Array] Input for conversion
+    #
+    # @return [String] Raw output
+    def self.to_long_le(data)
+      [data].flatten.pack('L*')
+    end
+
+    #
+    # Convert data from little endian unsigned long
+    #
+    # @param data [String] Input for conversion
+    #
+    # @return [Array] Integer array output
+    def self.from_long_le(data)
+      data.unpack('L*')
+    end
+
+    #
     # Convert data to big endian unsigned short
     #
     # @param data [Fixnum, Float, Array] Input for conversion
     #
     # @return [String] Raw output
-    def self.to_dw(data)
+    def self.to_short_be(data)
       [data].flatten.pack('S>*')
     end
 
@@ -75,7 +135,7 @@ module Packet
     # @param data [String] Input for conversion
     #
     # @return [Array] Integer array output
-    def self.from_dw(data)
+    def self.from_short_be(data)
       data.unpack('S>*')
     end
 
@@ -85,7 +145,7 @@ module Packet
     # @param data [Fixnum, Float, Array] Input for conversion
     #
     # @return [String] Raw output
-    def self.to_dd(data)
+    def self.to_int_be(data)
       [data].flatten.pack('I>*')
     end
 
@@ -95,7 +155,7 @@ module Packet
     # @param data [String] Input for conversion
     #
     # @return [Array] Integer array output
-    def self.from_dd(data)
+    def self.from_int_be(data)
       data.unpack('I>*')
     end
 
@@ -105,7 +165,7 @@ module Packet
     # @param data [Fixnum, Float, Array] Input for conversion
     #
     # @return [String] Raw output
-    def self.to_dl(data)
+    def self.to_long_be(data)
       [data].flatten.pack('L>*')
     end
 
@@ -115,7 +175,7 @@ module Packet
     # @param data [String] Input for conversion
     #
     # @return [Array] Integer array output
-    def self.from_dl(data)
+    def self.from_long_be(data)
       data.unpack('L>*')
     end
 
@@ -126,7 +186,17 @@ module Packet
     #
     # @return [Fixnum] Request ID
     def self.request_id(data)
-      self.from_dw(data[0..1])[0]
+      self.from_short_be(data[0..1])[0]
+    end
+
+    #
+    # Returns request length from raw packet skipping parsing
+    #
+    # @param data [String] Request data
+    #
+    # @return [Fixnum] Request Length
+    def self.request_length(data)
+      self.from_short_le(data[0..2])[0]
     end
   end
 end

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -70,6 +70,8 @@ module DNS
       #------------------------------------------------------------
       # Parsing arguments
       #------------------------------------------------------------
+      comm = config.delete(:comm)
+      context = context = config.delete(:context)
       config.each do |key,val|
         next if key == :log_file or key == :config_file
         begin

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -1,0 +1,289 @@
+require 'net/dns/resolver'
+
+module Rex
+module Proto
+module DNS
+
+  ##
+  # Provides Rex::Sockets compatible version of Net::DNS::Resolver
+  ##
+  class Resolver < Net::DNS::Resolver
+
+    Defaults = {
+      :config_file => "/dev/null", # default can lead to info leaks
+      :log_file => "/dev/null", # formerly $stdout, should be tied in with our loggers
+      :port => 53,
+      :searchlist => [],
+      :nameservers => [IPAddr.new("127.0.0.1")],
+      :domain => "",
+      :source_port => 0,
+      :source_address => IPAddr.new("0.0.0.0"),
+      :retry_interval => 5,
+      :retry_number => 4,
+      :recursive => true,
+      :defname => true,
+      :dns_search => true,
+      :use_tcp => false,
+      :ignore_truncated => false,
+      :packet_size => 512,
+      :tcp_timeout => TcpTimeout.new(30),
+      :udp_timeout => UdpTimeout.new(30)
+    }
+
+    #
+    # Provide override for initializer to use local Defaults constant
+    #
+    # @param config [Hash] Configuration options as conusumed by parent class
+    def initialize(config = {})
+      raise ResolverArgumentError, "Argument has to be Hash" unless config.kind_of? Hash
+      # config.key_downcase!
+      @config = Defaults.merge config
+      @raw = false
+
+      # New logger facility
+      @logger = Logger.new(@config[:log_file])
+      @logger.level = $DEBUG ? Logger::DEBUG : Logger::WARN
+
+      #------------------------------------------------------------
+      # Resolver configuration will be set in order from:
+      # 1) initialize arguments
+      # 2) ENV variables
+      # 3) config file
+      # 4) defaults (and /etc/resolv.conf for config)
+      #------------------------------------------------------------
+
+
+
+      #------------------------------------------------------------
+      # Parsing config file
+      #------------------------------------------------------------
+      parse_config_file
+
+      #------------------------------------------------------------
+      # Parsing ENV variables
+      #------------------------------------------------------------
+      parse_environment_variables
+
+      #------------------------------------------------------------
+      # Parsing arguments
+      #------------------------------------------------------------
+      config.each do |key,val|
+        next if key == :log_file or key == :config_file
+        begin
+          eval "self.#{key.to_s} = val"
+        rescue NoMethodError
+          raise ResolverArgumentError, "Option #{key} not valid"
+        end
+      end
+    end
+    #
+    # Provides current proxy setting if configured
+    #
+    # @return [String] Current proxy configuration
+    def proxies
+      @config[:proxies].inspect if @config[:proxies]
+    end
+
+    #
+    # Configure proxy setting and additional timeout
+    #
+    # @param prox [String] SOCKS proxy connection string
+    # @param timeout_added [Fixnum] Added TCP timeout to account for proxy
+    def proxies=(prox, timeout_added = 250)
+      return if prox.nil?
+      if prox.is_a?(String) and prox.strip =~ /^socks/i
+        @config[:proxies] = prox.strip
+        @config[:use_tcp] = true
+        self.tcp_timeout = self.tcp_timeout.to_s.to_i + timeout_added
+        @logger.info "SOCKS proxy set, using TCP, increasing timeout"
+      else
+        raise ResolverError, "Only socks proxies supported"
+      end
+    end
+
+    #
+    # Send DNS request over appropriate transport and process response
+    #
+    # @param argument
+    # @param type [Fixnum] Type of record to look up
+    # @param cls [Fixnum] Class of question to look up
+    def send(argument,type=Net::DNS::A,cls=Net::DNS::IN)
+      if @config[:nameservers].size == 0
+        raise ResolverError, "No nameservers specified!"
+      end
+
+      method = self.use_tcp? ? :send_tcp : :send_udp
+
+      if argument.kind_of? Net::DNS::Packet
+        packet = argument
+      elsif argument.kind_of? Resolv::DNS::Message
+        packet = Net::DNS::Packet.parse(argument.encode)
+      else
+        packet = make_query_packet(argument,type,cls)
+      end
+
+      # Store packet_data for performance improvements,
+      # so methods don't keep on calling Packet#data
+      packet_data = packet.data
+      packet_size = packet_data.size
+
+      # Choose whether use TCP, UDP
+      if packet_size > @config[:packet_size] # Must use TCP
+        @logger.info "Sending #{packet_size} bytes using TCP due to size"
+        method = :send_tcp
+      else # Packet size is inside the boundaries
+        if use_tcp? or !(proxies.nil? or proxies.empty?) # User requested TCP
+          @logger.info "Sending #{packet_size} bytes using TCP due to tcp flag"
+          method = :send_tcp
+        else # Finally use UDP
+          @logger.info "Sending #{packet_size} bytes using UDP"
+          method = :send_udp unless method == :send_tcp 
+        end
+      end
+
+      if type == Net::DNS::AXFR
+        @logger.warn "AXFR query, switching to TCP" unless method == :send_tcp
+        method = :send_tcp
+      end
+
+      ans = self.__send__(method,packet_data)
+
+      unless (ans and ans[0].length > 0)
+        @logger.fatal "No response from nameservers list: aborting"
+        raise NoResponseError
+        return nil
+      end
+
+      @logger.info "Received #{ans[0].size} bytes from #{ans[1][2]+":"+ans[1][1].to_s}"
+      response = Net::DNS::Packet.parse(ans[0],ans[1])
+
+      if response.header.truncated? and not ignore_truncated?
+        @logger.warn "Packet truncated, retrying using TCP"
+        self.use_tcp = true
+        begin
+          return send(argument,type,cls)
+        ensure
+          self.use_tcp = false
+        end
+      end
+
+      return response
+    end
+
+    #
+    # Send request over TCP
+    #
+    # @param packet_data [String] Data segment of DNS request packet
+    # @param prox [String] Proxy configuration for TCP socket
+    #
+    # @return ans [String] Raw DNS reply
+    def send_tcp(packet_data,prox = @config[:proxies])
+      ans = nil
+      length = [packet_data.size].pack("n")
+      @config[:nameservers].each do |ns|
+        begin
+          socket = nil
+          @config[:tcp_timeout].timeout do
+            catch(:next_ns) do
+              begin
+                socket = Rex::Socket::Tcp.create(
+                  'PeerHost' => ns.to_s,
+                  'PeerPort' => @config[:port].to_i,
+                  'Proxies' => prox
+                )
+              rescue
+                @logger.warn "TCP Socket could not be established to #{ns}:#{@config[:port]} #{@config[:proxies]}"
+                throw :next_ns
+              end
+              next unless socket #
+              @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
+              socket.write(length+packet_data)
+              got_something = false
+              loop do
+                buffer = ""
+                ans = socket.recv(Net::DNS::INT16SZ)
+                if ans.size == 0
+                  if got_something
+                    break #Proper exit from loop
+                  else
+                    @logger.warn "Connection reset to nameserver #{ns}, trying next."
+                    throw :next_ns
+                  end
+                end
+                got_something = true
+                len = ans.unpack("n")[0]
+
+                @logger.info "Receiving #{len} bytes..."
+
+                if len.nil? or len == 0
+                  @logger.warn "Receiving 0 length packet from nameserver #{ns}, trying next."
+                  throw :next_ns
+                end
+
+                while (buffer.size < len)
+                  left = len - buffer.size
+                  temp,from = socket.recvfrom(left)
+                  buffer += temp
+                end
+
+                unless buffer.size == len
+                  @logger.warn "Malformed packet from nameserver #{ns}, trying next."
+                  throw :next_ns
+                end
+                if block_given?
+                  yield [buffer,["",@config[:port],ns.to_s,ns.to_s]]
+                else
+                  return [buffer,["",@config[:port],ns.to_s,ns.to_s]]
+                end
+              end
+            end
+  			end
+		  rescue Timeout::Error
+			  @logger.warn "Nameserver #{ns} not responding within TCP timeout, trying next one"
+			  next
+		  ensure
+			  socket.close if socket
+		  end
+		end
+		return nil
+	  end
+
+    #
+    # Send request over UDP
+    #
+    # @param packet_data [String] Data segment of DNS request packet
+    #
+    # @return ans [String] Raw DNS reply
+    def send_udp(packet_data)
+      ans = nil
+      response = ""
+      @config[:nameservers].each do |ns|
+        begin
+          @config[:udp_timeout].timeout do
+            begin
+              socket = Rex::Socket::Udp.create(
+                'PeerHost' => ns.to_s,
+                'PeerPort' => @config[:port].to_i
+              )
+            rescue
+              @logger.warn "UDP Socket could not be established to #{ns}:#{@config[:port]}"
+              return nil
+            end
+            @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
+            #socket.sendto(packet_data, ns.to_s, @config[:port].to_i, 0)
+            socket.write(packet_data)
+            ans = socket.recvfrom(@config[:packet_size])
+          end
+          break if ans
+        rescue Timeout::Error
+          @logger.warn "Nameserver #{ns} not responding within UDP timeout, trying next one"
+          next
+        end
+      end
+      return ans
+    end
+  end
+
+end
+end
+end

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -192,7 +192,7 @@ module DNS
                   'PeerHost' => ns.to_s,
                   'PeerPort' => @config[:port].to_i,
                   'Proxies' => prox,
-                  'Context' => @config[:context]
+                  'Context' => @config[:context],
                   'Comm' => @config[:comm]
                 }
                 if @config[:source_port] > 0

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -32,6 +32,7 @@ module DNS
       :comm => nil
     }
 
+    attr_accessor :context, :comm
     #
     # Provide override for initializer to use local Defaults constant
     #

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -27,7 +27,9 @@ module DNS
       :ignore_truncated => false,
       :packet_size => 512,
       :tcp_timeout => TcpTimeout.new(30),
-      :udp_timeout => UdpTimeout.new(30)
+      :udp_timeout => UdpTimeout.new(30),
+      :context => {},
+      :comm => nil
     }
 
     #
@@ -191,6 +193,7 @@ module DNS
                   'PeerPort' => @config[:port].to_i,
                   'Proxies' => prox,
                   'Context' => @config[:context]
+                  'Comm' => @config[:comm]
                 }
                 if @config[:source_port] > 0
                   config['LocalPort'] = @config[:source_port]
@@ -272,7 +275,8 @@ module DNS
               config = {
                 'PeerHost' => ns.to_s,
                 'PeerPort' => @config[:port].to_i,
-                'Context' => @config[:context]
+                'Context' => @config[:context],
+                'Comm' => @config[:comm]
               }
               if @config[:source_port] > 0
                 config['LocalPort'] = @config[:source_port]

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -186,11 +186,19 @@ module DNS
           @config[:tcp_timeout].timeout do
             catch(:next_ns) do
               begin
-                socket = Rex::Socket::Tcp.create(
+                config = {
                   'PeerHost' => ns.to_s,
                   'PeerPort' => @config[:port].to_i,
-                  'Proxies' => prox
-                )
+                  'Proxies' => prox,
+                  'Context' => @config[:context]
+                }
+                if @config[:source_port] > 0
+                  config['LocalPort'] = @config[:source_port]
+                end
+                if @config[:source_host].to_s != '0.0.0.0'
+                  config['LocalHost'] = @config[:source_host] unless @config[:source_host].nil?
+                end
+                socket = Rex::Socket::Tcp.create(config)
               rescue
                 @logger.warn "TCP Socket could not be established to #{ns}:#{@config[:port]} #{@config[:proxies]}"
                 throw :next_ns
@@ -261,10 +269,18 @@ module DNS
         begin
           @config[:udp_timeout].timeout do
             begin
-              socket = Rex::Socket::Udp.create(
+              config = {
                 'PeerHost' => ns.to_s,
-                'PeerPort' => @config[:port].to_i
-              )
+                'PeerPort' => @config[:port].to_i,
+                'Context' => @config[:context]
+              }
+              if @config[:source_port] > 0
+                config['LocalPort'] = @config[:source_port]
+              end
+              if @config[:source_host] != IPAddr.new('0.0.0.0')
+                config['LocalHost'] = @config[:source_host] unless @config[:source_host].nil?
+              end
+              socket = Rex::Socket::Udp.create(config)
             rescue
               @logger.warn "UDP Socket could not be established to #{ns}:#{@config[:port]}"
               return nil

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -247,7 +247,7 @@ class Server
       end
     end
     # Forward remaining requests, cache responses
-    if forward.question.count > 0
+    if forward.question.count > 0 and @fwd_res
       forwarded = @fwd_res.send(validate_packet(forward))
       req.answer = req.answer + forwarded.answer 
       forwarded.answer.each do |ans|

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -222,7 +222,7 @@ class Server
     ensure
       while csock = ensure_close.shift
         csock.stop if csock.respond_to?(:stop)
-        csock.close csock.respond_to?(:close) and !csock.closed?
+        csock.close unless csock.respond_to?(:close) and csock.closed?
       end
     end
     self.cache.stop(flush_cache)

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -1,0 +1,320 @@
+# -*- coding: binary -*-
+
+require 'rex/socket'
+require 'rex/proto/dns'
+
+module Rex
+module Proto
+module DNS
+
+class Server
+
+  class Cache
+    include Rex::Proto::DNS::Constants
+    # class DNSRecordError < ::Exception
+    #
+    # Create DNS Server cache
+    #
+    def initialize
+      @records = {}
+      @lock = Mutex.new
+    end
+
+    #
+    # Find entries in cache
+    #
+    # @param search [String] Name or address to search for
+    # @param type [String] Record type to search for
+    #
+    # @return [Array] Records found
+    def find(search, type = 'A')
+      @records.select do |record,expire|
+        record.type == type and (expire < 1 or expire > Time.now.to_i) and 
+        (record.name == search or record.address == search)
+      end.keys
+    end
+
+    #
+    # Add record to cache
+    #
+    # @param record [Net::DNS::RR] Record to cache
+    def cache_record(record)
+      if record.class.ancestors.include?(Net::DNS::RR) and
+      Rex::Socket.is_ip_addr?(record.address.to_s) and record.name.to_s.match(MATCH_HOSTNAME)
+        add(record, Time.now.to_i + record.ttl)
+      else
+        raise "Invalid record for cache entry - #{record.inspect}"
+      end
+    end
+
+    #
+    # Add static record to cache
+    #
+    # @param name [String] Name of record
+    # @param address [String] Address of record
+    # @param type [String] Record type to add
+    def add_static(name, address, type = 'A')
+      if Rex::Socket.is_ip_addr?(address.to_s) and name.to_s.match(MATCH_HOSTNAME)
+        find(name, type).each do |found|
+          delete(found)
+        end
+        add(Net::DNS::RR.new(:name => name, :address => address),0)
+      else
+        raise "Invalid parameters for static entry - #{name}, #{address}, #{type}"
+      end
+    end
+
+    #
+    # Prune cache entries
+    #
+    # @param before [Fixnum] Time in seconds before which records are evicted
+    def prune(before = Time.now.to_i)
+      @records.select do |rec, expire|
+        expire > 0 and expire < before
+      end.each {|rec, exp| delete(rec)}
+    end
+
+    #
+    # Start the cache monitor
+    #
+    def start
+      @monitor_thread = Rex::ThreadFactory.spawn("DNSServerCacheMonitor", false) {
+        while true
+          prune
+          Rex::ThreadSafe.sleep(0.5)
+        end
+      } unless @monitor_thread
+    end
+
+    #
+    # Stop the cache monitor
+    #
+    # @param flush [TrueClass,FalseClass] Remove non-static entries
+    def stop(flush = false)
+      @monitor_thread.kill
+      @monitor_thread = nil
+      if flush
+        @records.select do |rec, expire|
+          rec.ttl > 0
+        end.map {|rec| delete(rec)}
+      end
+    end
+
+    protected
+
+    #
+    # Add a record to the cache with thread safety
+    #
+    # @param record [Net::DNS::RR] Record to add
+    # @param expire [Fixnum] Time in seconds when record becomes stale
+    def add(record, expire = 0)
+      @lock.synchronize do
+        @records[record] = expire
+      end
+    end
+
+    #
+    # Delete a record from the cache with thread safety
+    #
+    # @param record [Net::DNS::RR] Record to delete
+    def delete(record)
+      @lock.synchronize do
+        @records.delete(record)
+      end
+    end
+  end # Cache
+
+  #
+  # Create DNS Server
+  #
+  # @param lhost [String] Listener address
+  # @param lport [Fixnum] Listener port
+  # @param udp [TrueClass, FalseClass] Listen on UDP socket
+  # @param tcp [TrueClass, FalseClass] Listen on TCP socket
+  # @param res [Rex::Proto::DNS::Resolver] Resolver to use, nil to create a fresh one
+  # @param ctx [Hash] Framework context for sockets
+  # @param dblock [Proc] Handler for :dispatch_request flow control interception
+  # @param sblock [Proc] Handler for :send_response flow control interception
+  #
+  # @return [Rex::Proto::DNS::Server] DNS Server object
+  def initialize(lhost = '0.0.0.0', lport = 53, udp = true, tcp = false, res = nil, ctx = {}, dblock = nil, sblock = nil)
+    
+    @udp_sock = udp ? Rex::Socket::Udp.create(
+      'LocalHost' => lhost,
+      'LocalPort' => lport,
+      'Context'   => ctx
+    ) : nil
+    @tcp_sock = tcp ? Rex::Socket::TcpServer.create(
+      'LocalHost' => lhost,
+      'LocalPort' => lport,
+      'Context'   => ctx
+    ) : nil
+    @fwd_res = res.nil? ? Rex::Proto::DNS::Resolver.new : res
+    @udp_mon = nil
+    @dispatch_block = dblock
+    @send_block = sblock
+    @cache = Cache.new
+    @lock = Mutex.new
+  end
+
+  #
+  # Switch DNS forwarders in resolver with thread safety
+  #
+  # @param ns [Array, String] List of (or single) nameservers to use
+  def switchns(ns = [])
+    if ns.respond_to?(:split)
+      ns = [ns]
+    end
+    @lock.synchronize do
+      @fwd_res.nameserver = ns
+    end
+  end
+
+  #
+  # Start the DNS server and cache
+  #
+  def start
+    @udp_mon = Rex::ThreadFactory.spawn("DNSServerMonitor", false) {
+      monitor_udp_socket
+    } if @udp_sock
+
+    if @tcp_sock
+
+      @tcp_sock.on_client_data_proc = Proc.new { |cli|
+        on_client_data(cli)
+      }
+      @tcp_sock.start
+    end
+    @cache.start
+  end
+
+  #
+  # Stop the DNS server and cache
+  #
+  # @param flush_cache [TrueClass,FalseClass] Flush DNS cache on stop
+  def stop(flush_cache = false)
+    if @udp_mon
+      @udp_mon.kill
+      @udp_mon = nil
+    end
+    @tcp_sock.stop if @tcp_sock
+    @cache.stop(flush_cache)
+  end
+
+  #
+  # Reconstructs a packet with both standard DNS libraries
+  # Ensures that headers match the payload
+  #
+  # @param packet [String, Net::DNS::Packet] Data to be validated
+  #
+  # @return [Net::DNS::Packet]
+  def validate_packet(packet)
+    Net::DNS::Packet.parse(
+      Resolv::DNS::Message.decode(
+        packet.respond_to?(:data) ? packet.data : packet
+      ).encode
+    )
+  end
+
+  #
+  # Process client request, handled with @dispatch_block if set
+  #
+  # @param cli [Rex::Socket::Tcp, Rex::Socket::Udp] Client sending the request
+  # @param data [String] raw DNS request data
+  def dispatch_request(cli, data)
+    if @dispatch_block
+      @dispatch_block.call(cli,data)
+    else
+      req = Net::DNS::Packet.parse(data)
+      forward = req.dup
+      # Find cached items, remove request from forwarded packet
+      req.question.each do |ques|
+        cached = @cache.find(ques.qName, ques.qType.to_s)
+        if cached.empty?
+          next
+        else
+          req.answer = req.answer + cached
+          forward.question.delete(ques)
+        end
+      end
+      # Forward remaining requests, cache responses
+      if forward.question.count > 0
+        forwarded = @fwd_res.send(validate_packet(forward))
+        req.answer = req.answer + forwarded.answer 
+        forwarded.answer.each do |ans|
+          @cache.cache_record(ans)
+        end
+      end
+      # Finalize answers in response
+      # Check for empty response prior to sending
+      if req.answer.size < 1
+        req.header.rCode = Net::DNS::Header::RCode.new(3)
+      end
+      send_response(cli, validate_packet(req).data)
+    end
+  end
+
+  #
+  # Send response to client, handled with @send_block if set
+  #
+  # @param cli [Rex::Socket::Tcp, Rex::Socket::Udp] Client receiving the response
+  # @param data [String] raw DNS response data
+  def send_response(cli, data)
+    if @send_block
+      @send_block.call(cli, data)
+    else
+      cli.write(data)
+    end
+  end
+
+protected
+
+  #
+  # Monitor UDP socket for incoming requests, create client object from socket
+  #
+  def monitor_udp_socket
+    while true
+      rds = [@udp_sock]
+      wds = []
+      eds = [@udp_sock]
+
+      r,_,_ = ::IO.select(rds,wds,eds,1)
+
+      if (r != nil and r[0] == @udp_sock)
+        buf,host,port = @udp_sock.recvfrom(65535)
+        # Mock up a client object as a Rex Socket for sending back data
+        cli = Rex::Socket::Udp.create(
+          'PeerHost' => host,
+          'PeerPort' => port,
+          'LocalHost' => @udp_sock.localhost,
+          'LocalPort' => @udp_sock.localport
+        )
+        dispatch_request(cli, buf)
+      end
+
+    end
+  end
+
+  #
+  # Processes request coming from client
+  #
+  # @param cli [Rex::Socket::Tcp] Client sending request
+  def on_client_data(cli)
+    begin
+      data = cli.read(65535)
+
+      raise ::EOFError if not data
+      raise ::EOFError if data.empty?
+      from = [cli.peerhost, cli.peerport]
+      dispatch_request(cli, data)
+    rescue EOFError => e
+      close_client(cli)
+      raise e
+    end
+  end
+
+end
+
+end
+end
+end

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -175,6 +175,13 @@ class Server
   end
 
   #
+  # Check if server is running
+  #
+  def running?
+    @running == true
+  end
+
+  #
   # Start the DNS server and cache
   #
   def start
@@ -190,6 +197,7 @@ class Server
       @tcp_sock.start
     end
     @cache.start
+    @running = true
   end
 
   #
@@ -203,6 +211,7 @@ class Server
     end
     @tcp_sock.stop if @tcp_sock
     @cache.stop(flush_cache)
+    @running = false
   end
 
   #

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -40,7 +40,8 @@ class Server
     #
     # @param record [Net::DNS::RR] Record to cache
     def cache_record(record)
-      if record.class.ancestors.include?(Net::DNS::RR) and @monitor_thread and
+      return unless @monitor_thread
+      if record.class.ancestors.include?(Net::DNS::RR) and
       Rex::Socket.is_ip_addr?(record.address.to_s) and record.name.to_s.match(MATCH_HOSTNAME)
         add(record, Time.now.to_i + record.ttl)
       else

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -245,6 +245,7 @@ class Server
         forwarded.answer.each do |ans|
           @cache.cache_record(ans)
         end
+        req.header.ra = 1 # Set recursion bit
       end
       # Finalize answers in response
       # Check for empty response prior to sending
@@ -252,7 +253,6 @@ class Server
         req.header.rCode = Net::DNS::Header::RCode.new(3)
       end
       req.header.qr = 1 # Set response bit
-      req.header.ra = 1 # Set recursion bit
       send_response(cli, validate_packet(req).data)
     end
   end

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -190,7 +190,6 @@ class Server
 
     if self.serve_udp
       @udp_sock = Rex::Socket::Udp.create(self.sock_options)
-      udp_sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
       self.listener_thread = Rex::ThreadFactory.spawn("UDPDNSServerListener", false) {
         monitor_listener
       }
@@ -300,7 +299,6 @@ protected
           'LocalHost' => self.udp_sock.localhost,
           'LocalPort' => self.udp_sock.localport
         )
-        cli.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
         dispatch_request(cli, buf)
       end
     end

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -190,6 +190,7 @@ class Server
 
     if self.serve_udp
       @udp_sock = Rex::Socket::Udp.create(self.sock_options)
+      udp_sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
       self.listener_thread = Rex::ThreadFactory.spawn("UDPDNSServerListener", false) {
         monitor_listener
       }
@@ -221,7 +222,7 @@ class Server
     ensure
       while csock = ensure_close.shift
         csock.stop if csock.respond_to?(:stop)
-        csock.close unless csock.closed?
+        csock.close csock.respond_to?(:close) and !csock.closed?
       end
     end
     self.cache.stop(flush_cache)
@@ -299,6 +300,7 @@ protected
           'LocalHost' => self.udp_sock.localhost,
           'LocalPort' => self.udp_sock.localport
         )
+        cli.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
         dispatch_request(cli, buf)
       end
     end

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -92,7 +92,7 @@ class Server
     #
     # @param flush [TrueClass,FalseClass] Remove non-static entries
     def stop(flush = false)
-      @monitor_thread.kill
+      @monitor_thread.kill unless @monitor_thread.nil?
       @monitor_thread = nil
       if flush
         @records.select do |rec, expire|
@@ -183,8 +183,8 @@ class Server
 
   #
   # Start the DNS server and cache
-  #
-  def start
+  # @param start_cache [TrueClass, FalseClass] stop the cache
+  def start(start_cache = true)
     @udp_mon = Rex::ThreadFactory.spawn("DNSServerMonitor", false) {
       monitor_udp_socket
     } if @udp_sock
@@ -196,14 +196,14 @@ class Server
       }
       @tcp_sock.start
     end
-    @cache.start
+    @cache.start if start_cache
     @running = true
   end
 
   #
   # Stop the DNS server and cache
   #
-  # @param flush_cache [TrueClass,FalseClass] Flush DNS cache on stop
+  # @param flush_cache [TrueClass,FalseClass] Flush eDNS cache on stop
   def stop(flush_cache = false)
     if @udp_mon
       @udp_mon.kill

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -328,10 +328,9 @@ protected
 
       raise ::EOFError if not data
       raise ::EOFError if data.empty?
-      from = [cli.peerhost, cli.peerport]
       dispatch_request(cli, data)
     rescue EOFError => e
-      close_client(cli)
+      self.tcp_socket.close_client(cli) if cli
       raise e
     end
   end

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -32,7 +32,7 @@ class Server
     def find(search, type = 'A')
       self.records.select do |record,expire|
         record.type == type and (expire < 1 or expire > Time.now.to_i) and 
-        (record.name == search or record.address == search)
+        (record.name == search or record.address.to_s == search)
       end.keys
     end
 
@@ -56,11 +56,11 @@ class Server
     # @param name [String] Name of record
     # @param address [String] Address of record
     # @param type [String] Record type to add
-    def add_static(name, address, type = 'A')
+    def add_static(name, address, type = 'A', replace = false)
       if Rex::Socket.is_ip_addr?(address.to_s) and name.to_s.match(MATCH_HOSTNAME)
         find(name, type).each do |found|
           delete(found)
-        end
+        end if replace
         add(Net::DNS::RR.new(:name => name, :address => address),0)
       else
         raise "Invalid parameters for static entry - #{name}, #{address}, #{type}"

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -175,4 +175,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nessus_rest'
   # Nexpose Gem
   spec.add_runtime_dependency 'nexpose'
+  # Dnsruby Gem
+  spec.add_runtime_dependency 'dnsruby'
 end

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core/exploit/dns'
 
-class Metasploit3 < Msf::Auxiliary
+class Metasploit < Msf::Auxiliary
 
   include Msf::Exploit::Remote::DNS::Client
   include Msf::Exploit::Remote::DNS::Server

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
       },
       'Author'         => 'RageLtMan <rageltman[at]sempervictus>',
       'License'        => MSF_LICENSE,
-      'References'     => [],
-      'DisclosureDate' => 'November 1987' # RFC 1035
+      'References'     => []
     ))
   end
 

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -1,0 +1,63 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/dns'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::DNS::Client
+  include Msf::Exploit::Remote::DNS::Server
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Native DNS Server (Example)',
+      'Description'    => %q{
+        This module provides a Rex based DNS service which can store static entries,
+        resolve names over pivots, and serve DNS requests across routed session comms.
+        DNS tunnels can operate across the the Rex switchboard, and DNS other modules
+        can use this as a template. Setting static records via hostfile allows for DNS
+        spoofing attacks without direct traffic manipulation at the handlers.
+      },
+      'Author'         => 'RageLtMan <rageltman[at]sempervictus>',
+      'License'        => MSF_LICENSE,
+      'References'     => [],
+      'DisclosureDate' => 'November 1987' # RFC 1035
+    ))
+  end
+
+  #
+  # Wrapper for service execution and cleanup
+  #
+  def run
+    begin
+      setup_server
+      start_service
+      while service.running?
+        Rex::ThreadSafe.sleep(1)
+      end
+    ensure
+      stop_service
+    end
+  end
+
+  #
+  # Creates Proc to handle incoming requests
+  #
+  def handle_request
+    nil
+  end
+
+
+  #
+  # Creates Proc to handle outbound responses
+  #
+  def handle_response
+    Proc.new do |cli, data|
+      cli.write(data)
+    end
+  end
+
+
+end

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -58,8 +58,12 @@ class MetasploitModule < Msf::Auxiliary
       else
         req.answer = req.answer + cached
         forward.question.delete(ques)
-        hits = cached.map do |hit|
-          hit.name + ':' + hit.address.to_s + ' ' + hit.type
+        cached.map do |hit|
+          if hit.respond_to?(:address)
+            hit.name + ':' + hit.address.to_s + ' ' + hit.type
+          else
+            hit.name + ' ' + hit.type
+          end
         end.each {|h| vprint_status("Cache hit for #{h}")}
       end
     end unless service.cache.nil?
@@ -70,7 +74,8 @@ class MetasploitModule < Msf::Auxiliary
       else
         forwarded = service.fwd_res.send(Packet.validate(forward))
         forwarded.answer.each do |ans|
-          vprint_status("Caching response #{ans.name}:#{ans.address} #{ans.type}")
+          rstring = ans.respond_to?(:address) ? "#{ans.name}:#{ans.address}" : ans.name
+          vprint_status("Caching response #{rstring} #{ans.type}")
           service.cache.cache_record(ans)
         end unless service.cache.nil?
         # Merge the answers and use the upstream response

--- a/modules/auxiliary/server/dns/native_server.rb
+++ b/modules/auxiliary/server/dns/native_server.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core/exploit/dns'
 
-class Metasploit < Msf::Auxiliary
+class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::DNS::Client
   include Msf::Exploit::Remote::DNS::Server

--- a/modules/auxiliary/spoof/dns/native_spoofer.rb
+++ b/modules/auxiliary/spoof/dns/native_spoofer.rb
@@ -118,7 +118,6 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Could not spoof any domains for #{peer} request #{asked}")
       return
     end
-    req.header.qr = 1
     service.send_response(cli, Packet.validate(Packet.generate_response(req)).data)
   end
 
@@ -128,7 +127,7 @@ class MetasploitModule < Msf::Auxiliary
   def on_send_response(cli,data)
     cli.payload = data
     cli.recalc
-    inject cli
+    inject cli.to_s
   end
 
 

--- a/modules/auxiliary/spoof/dns/native_spoofer.rb
+++ b/modules/auxiliary/spoof/dns/native_spoofer.rb
@@ -79,9 +79,14 @@ class MetasploitModule < Msf::Auxiliary
     open_pcap({'FILTER' => datastore['FILTER']})
     @capture_thread = Rex::ThreadFactory.spawn("DNSSpoofer", false) do
       each_packet do |pack|
-        parsed = PacketFu::Packet.parse(pack)
-        reply = reply_packet(parsed)
-        service.dispatch_request(reply, parsed.payload)
+        begin
+          parsed = PacketFu::Packet.parse(pack)
+          reply = reply_packet(parsed)
+          service.dispatch_request(reply, parsed.payload)
+        rescue => e
+          vprint_status("PacketFu could not parse captured packet")
+          dlog(e.backtrace)
+        end
       end
     end
   end

--- a/modules/auxiliary/spoof/dns/native_spoofer.rb
+++ b/modules/auxiliary/spoof/dns/native_spoofer.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/dns'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Capture
+  include Msf::Exploit::Remote::DNS::Client
+  include Msf::Exploit::Remote::DNS::Server
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Native DNS Spoofer (Example)',
+      'Description'    => %q{
+        This module provides a Rex based DNS service to resolve queries intercepted
+        via the capture mixin. Configure STATIC_ENTRIES to contain host-name mappings
+        desired for spoofing using a hostsfile or space/semicolon separated entries.
+      },
+      'Author'         => 'RageLtMan <rageltman[at]sempervictus>',
+      'License'        => MSF_LICENSE,
+      'References'     => []
+    ))
+
+    register_options(
+      [
+        OptString.new('FILTER', [false, 'The filter string for capturing traffic', 'dst port 53']),
+        OptAddress.new('SRVHOST', [true, 'The local host to listen on for DNS services.', '127.0.2.2'])
+      ], self.class)
+
+    deregister_options('PCAPFILE')
+  end
+
+  #
+  # Wrapper for service execution and cleanup
+  #
+  def run
+    begin
+      start_service
+      capture_traffic
+      service.wait
+    ensure
+      @capture_thread.kill if @capture_thread
+      close_pcap
+      stop_service(true)
+    end
+  end
+
+  #
+  # Generates reply with src and dst reversed
+  # Maintains original packet structure, proto, etc
+  #
+  def reply_packet(pack)
+    rep = pack.dup
+    rep.eth_dst, rep.eth_src = rep.eth_src, rep.eth_dst
+    rep.ip_dst, rep.ip_src = rep.ip_src, rep.ip_dst
+    if pack.is_udp?
+      rep.udp_dst, rep.udp_src = rep.udp_src, rep.udp_dst
+    else
+      rep.tcp_dst, rep.tcp_src = rep.tcp_src, rep.tcp_dst
+    end
+    return rep
+  end
+
+  #
+  # Configures capture and handoff
+  #
+  def capture_traffic
+    check_pcaprub_loaded()
+    ::Socket.do_not_reverse_lookup = true  # Mac OS X workaround
+    open_pcap({'FILTER' => datastore['FILTER']})
+    @capture_thread = Rex::ThreadFactory.spawn("DNSSpoofer", false) do
+      each_packet do |pack|
+        parsed = PacketFu::Packet.parse(pack)
+        reply = reply_packet(parsed)
+        service.dispatch_request(reply, parsed.payload)
+      end
+    end
+  end
+
+  #
+  # Creates Proc to handle incoming requests
+  #
+  def on_dispatch_request(cli,data)
+    peer = "#{cli.ip_daddr}:"
+    if cli.is_udp?
+      peer << "#{cli.udp_dst}"
+    else
+      peer << "#{cli.tcp_dst}"
+    end
+    # Deal with non DNS traffic
+    begin
+      req = Packet.encode_net(data)
+    rescue => e
+      print_error("Could not decode payload segment of packet from #{peer}")
+      dlog e.backtrace
+      return
+    end
+    asked = req.question.map(&:qName).join(', ')
+    vprint_status("Received request for #{asked} from #{peer}")
+    forward = req.dup
+    # Find cached items, remove request from forwarded packet
+    req.question.each do |ques|
+      cached = service.cache.find(ques.qName, ques.qType.to_s)
+      if cached.empty?
+        next
+      else
+        req.answer = req.answer + cached
+        forward.question.delete(ques)
+        hits = cached.map do |hit|
+          hit.name + ':' + hit.address.to_s + ' ' + hit.type
+        end.each {|h| vprint_status("Cache hit for #{h}")}
+      end
+    end
+    if req.answer.size < 1
+      print_status("Could not spoof any domains for #{peer} request #{asked}")
+      return
+    end
+    req.header.qr = 1
+    service.send_response(cli, Packet.validate(Packet.generate_response(req)).data)
+  end
+
+  #
+  # Creates Proc to handle outbound responses
+  #
+  def on_send_response(cli,data)
+    cli.payload = data
+    cli.recalc
+    inject cli
+  end
+
+
+end


### PR DESCRIPTION
Built atop the Rex::Proto::DNS work to implement mixins for client
and server functionality, providing common interfaces for querying
domain name servers, and providing domain name services to clients
across Rex sockets. Fully functional native DNS server module is
included to demonstrate functionality, serve as a spoofing DNS
server, a collecting proxy, or any other number of DNS functions.

---

At the core of this work is a Rex::Proto::DNS::Resolver object
descended from Net::DNS::Resolver with overrides and alterations
for using Rex sockets. The sockets implementation has been in use
internally for a number of years and is well tested. Changes have
been made to provider better interface for higher level components.

The resolver provides forward lookup capability for the server
(Rex::Proto::DNS::Server) which also implements a self-pruning
Cache subclass capable of holding static entries. The server can
operate in TCP or UDP mode, and provides a common abstraction for
addressing TCP and UDP clients by passing a Rex::Socket::Udp
mock client around with the data object to higher level consumers.
Finally, as is standard practice when building full service objects
from Rex to Msf, the server allows consumers to efficiently take
execution control at the request and response handlers by passing
Procs into the constructor (or manually assigning at runtime) for
execution instead of the default call chain.

The service, lookup, and caching functionality is encapsulated and
stands on its own to be used by consumers other than the standard
Msf::Exploit::Remote namespaces. It is intended to serve as the
driver and transport handler for pending DNS tunnel transports,
and can be used by exploit and auxiliary modules directly.

---

The Msf::Exploit::Remote namespace receives DNS, DNS::Client, and
DNS::Server mixins providing common interfaces for Rex::Proto::DNS
objects. These mixins create convenience methods for executing
queries, serving requests, and configuring the Rex providers.

DNS::Client mixin attempts to "intelligently" configure the client
resolver's name servers and options from the data store. Accessor,
query, and configuration methods are provided in this mixin. Of
note are the wildcard and switchdns methods which were adapted
from prior work by others (likely Carlos Perez) which can be used
by numerous consumer modules. Consumers should use setup_client
during their run call to ensure the resolver is appropriately
configured.

DNS::Server mixin creates common service wrappers for modules to
utilize along with a configuration mechanism analagous to the
one used by the Client mixin, called setup_server, and calling
the setup_client method if present. Note that when setup_server
is called, the consumer does not need to call setup_resolver.

---

At the framework module level, a native dns server is provided
to showcase the mixin functionality and provide everything from
normal DNS services, to tunneling proxies (with cache disabled),
spoofing services, and MITM functionality via the handler Procs
for requests and responses.

Use auxiliary/server/dns/native_server to get started.

---

Testing:
  Basic local testing completed.
  Needs to be checked for info leaks - we used to leak a lot.
  Needs to be checked for functionality under varying configs.

Notes:
  We have a serious problem with the datastore somewhere in the
Msf namespace. Datastore options must be validated with
options.validate(datastore) or they are all Strings, which
completely destroys any type-dependent logic consuming
datastore values. This must be addressed separately and all
calls to options.validate(datastore) should be removed (other
work has included such calls as well, this just proved that
the problem exists upstream).

Future work:
  Implement sessions transports atop the DNS infrastructure in
order to provide native DNS tunneling.
