### PR TITLE
Fix #6609 and #6587 - Change Content-Length behavior in Rex HTTP

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -391,8 +391,9 @@ class ClientRequest
 
   #
   # Return the content length header
+  #
   def set_content_len_header(clen)
-    return "" if opts['chunked_size'] > 0
+    return "" if clen == 0 || opts['chunked_size'] > 0 || (opts['headers'] && opts['headers']['Content-Length'])
     set_formatted_header("Content-Length", clen)
   end
 

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -151,7 +151,26 @@ RSpec.describe Rex::Proto::Http::ClientRequest do
       {
         :set_host_header       => { :result => "Host: [2001:DB8::1]:1234\r\n" },
       }
-    ]
+    ],
+
+    [
+      "with modified Content-Length header",
+      default_options.merge({
+        'headers' => { 'Content-Length' => 1337 }
+      }),
+      {
+        :set_content_len_header => { args: 0, result: ''}
+      }
+    ],
+
+    [
+      "with 1024 bytes of Content-Length",
+      default_options,
+      {
+        :set_content_len_header => { args: 1024, result: "Content-Length: 1024\r\n"}
+      }
+    ],
+  
   ].each do |c, opts, expectations|
     context c do
       subject(:client_request) { Rex::Proto::Http::ClientRequest.new(opts) }


### PR DESCRIPTION
## What This Patch Does

This patches changes two things:
1. If a module has a custom Content-Length, it will respect that instead of forcing its own.
2. If a request does not have anything in the body, the Content-Length header will not be set.

Fix #6609
Fix #6587
## Verification
- [x] Make sure Travis is green
- [x] Download the following test script to your ~/.msf4/modules directory:

``` ruby
load "./lib/rex/proto/http/client_request.rb"

require 'msf/core'
require 'msf/core/exploit/jsobfu'

class Metasploit3 < Msf::Auxiliary

  include Msf::Exploit::Remote::HttpClient

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'HttpClient Test',
      'Description'    => %q{
        HttpClient
      },
      'Author'         => [ 'sinn3r' ],
      'License'        => MSF_LICENSE,
      'DefaultOptions' => {
        'JsObfuscate' => 1
      }
    ))
  end

  def run
    print_status("It should have a Content-Length of 1337 bytes")
    res = send_request_cgi({
      'method' => 'POST',
      'uri'    => '/',
      'vars_post' => {
        'test' => '1'
      },
      'headers' => {
        'Content-Length' => 1337
      }
    })
    print_status(res.request.include?('Content-Length: 1337').inspect)
    print_line

    print_status("It should not have a Content-Length header")
    res = send_request_cgi({
      'method' => 'GET',
      'uri'    => '/'
    })
    print_status((!res.request.include?('Content-Length:')).inspect)
    print_line

    print_status("It should have a Content-Length of 6 bytes")
    res = send_request_cgi({
      'method' => 'POST',
      'uri'    => '/',
      'vars_post' => {
        'test' => '1' # This is 6 bytes
      }
    })
    print_status(res.request.include?('Content-Length: 6').inspect)
  end

end
```
- [x] Start a web server: `ruby -run -e httpd . -p 8181`
- [x] Run the test module against the web server. You should get an output like this:

```
[*] It should have a Content-Length of 1337 bytes
[*] true

[*] It should not have a Content-Length header
[*] true

[*] It should have a Content-Length of 6 bytes
[*] true
[*] Auxiliary module execution completed
```
