### PR TITLE
Fix #6615, fix typo "format" in auxiliary/analyze/jtr_linux.rb

### DIFF
--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
 
     formats = [ 'md5', 'des', 'bsdi']
     if datastore['Crypt']
-      format << 'crypt'
+      formats << 'crypt'
     end
 
     cracker = new_john_cracker


### PR DESCRIPTION
Fix #6615 
## What this patches

`format` is not an an array, `formats` is.
## Verification
- [ ] Code review should be enough for this.
