### PR TITLE
replace deprecated 'ignore' with 'transient'

### DIFF
--- a/spec/factories/mdm/module_details.rb
+++ b/spec/factories/mdm/module_details.rb
@@ -1,6 +1,6 @@
 FactoryGirl.modify do
   factory :mdm_module_detail do
-    ignore do
+    transient do
       root {
         Metasploit::Framework.root
       }


### PR DESCRIPTION
# Verification Steps
- [ ] `bundle install`
- [ ] `RAILS_ENV=test rake db:drop db:create db:migrate`
- [ ] `rake spec`
- [ ] verify that you see no deprecation messages about `#ignore`
