### PR TITLE
Changed .all to .load in workspace.rb

### DIFF
--- a/lib/msf/core/db_manager/workspace.rb
+++ b/lib/msf/core/db_manager/workspace.rb
@@ -30,7 +30,7 @@ module Msf::DBManager::Workspace
 
   def workspaces
   ::ActiveRecord::Base.connection_pool.with_connection {
-    ::Mdm::Workspace.order('updated_at asc').all
+    ::Mdm::Workspace.order('updated_at asc').load
   }
   end
 end


### PR DESCRIPTION
 In order to eager load the relation and fix the 4.0 rails deprecation.
- [x] In metasploit-framework, run rake spec.
- [x] Search your terminal for Relation#all. There should be no results.
- [ ] Alternately you can try this initializer https://gist.github.com/farias-r7/5a49383ffcd659e628c8 to log it to a file which you can search.
- [x] Point your gemfile in pro to your local framework repository by setting the gem :path to the path to the repository
- [x] Run rake spec in pro/ui to make sure this fix doesn't break anything else and that there are no deprecations there for Relation#all.
