### PR TITLE
Fixup finalizers to not double-close Meterpreter objects

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
@@ -30,7 +30,8 @@ class RegistryKey
     self.perm     = perm
     self.hkey     = hkey
 
-    ObjectSpace.define_finalizer( self, self.class.finalize(self.client, self.hkey) )
+    # Ensure the remote object is closed when all references are removed
+    ObjectSpace.define_finalizer(self, self.class.finalize(client, hkey))
   end
 
   def self.finalize(client,hkey)
@@ -115,7 +116,11 @@ class RegistryKey
 
   # Instance method for the same
   def close()
-    self.class.close(self.client, self.hkey)
+    unless self.hkey.nil?
+      ObjectSpace.undefine_finalizer(self)
+      self.class.close(self.client, self.hkey)
+      self.hkey = nil
+    end
   end
 
   ##

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/remote_registry_key.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/remote_registry_key.rb
@@ -29,11 +29,12 @@ class RemoteRegistryKey
     self.target_host = target_host
     self.hkey     = hkey
 
-    ObjectSpace.define_finalizer( self, self.class.finalize(self.client, self.hkey) )
+    # Ensure the remote object is closed when all references are removed
+    ObjectSpace.define_finalizer(self, self.class.finalize(client, hkey))
   end
 
-  def self.finalize(client,hkey)
-    proc { self.close(client,hkey) }
+  def self.finalize(client, hkey)
+    proc { self.close(client, hkey) }
   end
 
   ##
@@ -113,8 +114,12 @@ class RemoteRegistryKey
   end
 
   # Instance method for the same
-  def close()
-    self.class.close(self.client, self.hkey)
+  def close
+    unless self.hkey.nil?
+      ObjectSpace.undefine_finalizer(self)
+      self.class.close(self.client, self.hkey)
+      self.hkey = nil
+    end
   end
 
   ##


### PR DESCRIPTION
We add finalizers to an assortment of Meterpreter-managed objects in order to clean things up in the event that a post module crashes and does not clean things up. However, this also means that even a properly-written post module can lead to an object getting double-closed on the Meterpreter session when the garbage collector kicks in. This can lead to quite non-deterministic behavior and crashes.

This change modifies the instance close methods to unregister the finalizer on close, ensuring we cannot do a double-close automatically if one is requested explicitly first. As an additional measure, we check an instance variable to see if we called close directly twice as well. This is not sufficient in itself, since we do not have a reference to 'self' in the finalizer proc to check the close state.

fixes #6634 
# Verification steps
- [x] establish a windows meterpreter session
- [x] run 'loadpath test/modules' to load the test modules
- [x] use post/test/meterpreter; run a few times
- [x] use post/test/registry; run a few times
- [x] downgrade the metasploit-payloads gem back to 1.1.1 to recreate the python channel double-close bug #6593,
- [x] establish a python meterpreter session
- [x] verify that you can download a large file multiple times without truncation

Probably more to test here as well.
