### PR TITLE
IPv6 Neighbor Router Advertisement Enhancement

### DIFF
--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Auxiliary
   def listen_for_neighbor_solicitation(opts = {})
     hosts = []
     timeout = opts['TIMEOUT'] || datastore['TIMEOUT']
-    prefix = generate_prefix()
+    prefix = @prefix
 
     max_epoch = ::Time.now.to_i + timeout
     autoconf_prefix = IPAddr.new(prefix).to_string().slice(0..19)
@@ -96,7 +96,7 @@ class Metasploit3 < Msf::Auxiliary
     smac = @smac
     shost = opts['SHOST'] || datastore['SHOST'] || ipv6_link_address
     lifetime = opts['LIFETIME'] || datastore['TIMEOUT']
-    prefix = generate_prefix()
+    prefix = @prefix
     plen = 64
     dmac = "33:33:00:00:00:01"
 
@@ -154,6 +154,7 @@ class Metasploit3 < Msf::Auxiliary
     # Start capture
     open_pcap({'FILTER' => "icmp6"})
 
+    @prefix = generate_prefix()
     @netifaces = true
     if not netifaces_implemented?
       print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
         the host portion of the IPv6 address.  Use NDP host solicitation to
         determine if the IP address is valid'
     },
-    'Author'      => 'wuntee',
+    'Author'      => 'wuntee, d0lph1n98',
     'License'     => MSF_LICENSE,
     'References'    =>
     [
@@ -33,20 +33,22 @@ class Metasploit3 < Msf::Auxiliary
       OptInt.new('TIMEOUT_NEIGHBOR', [true, "Time (seconds) to listen for a solicitation response.", 1])
     ], self.class)
 
-    register_advanced_options(
-      [
-        OptString.new('PREFIX', [true, "Prefix that each host should get an IPv6 address from",
-          "2001:1234:DEAD:BEEF::"]
-        )
-      ], self.class)
-
     deregister_options('SNAPLEN', 'FILTER', 'RHOST', 'PCAPFILE')
+  end
+
+  def generate_prefix(opts = {})
+    max = 16 ** 4
+    prefix = "2001::"
+    (0..2).each do
+        prefix << "%x::" % Random.rand(0..max)
+    end
+    return prefix
   end
 
   def listen_for_neighbor_solicitation(opts = {})
     hosts = []
     timeout = opts['TIMEOUT'] || datastore['TIMEOUT']
-    prefix = opts['PREFIX'] || datastore['PREFIX']
+    prefix = generate_prefix()
 
     max_epoch = ::Time.now.to_i + timeout
     autoconf_prefix = IPAddr.new(prefix).to_string().slice(0..19)
@@ -94,7 +96,7 @@ class Metasploit3 < Msf::Auxiliary
     smac = @smac
     shost = opts['SHOST'] || datastore['SHOST'] || ipv6_link_address
     lifetime = opts['LIFETIME'] || datastore['TIMEOUT']
-    prefix = opts['PREFIX'] || datastore['PREFIX']
+    prefix = generate_prefix()
     plen = 64
     dmac = "33:33:00:00:00:01"
 
@@ -141,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
     checksum = 0
     hop_limit = 0
     flags = 0x08
-    lifetime = 1800
+    lifetime = 0
     reachable = 0
     retrans = 0
     [type, code, checksum, hop_limit, flags,


### PR DESCRIPTION
http://seclists.org/nmap-dev/2011/q2/79
1. Shorten router advertisement payload lifetime.
2. Randomize the address prefix.
3. Prevent from getting into default router list.
