### PR TITLE
Preserve default types for datastore options

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -216,7 +216,7 @@ class CommandShell
       end
     end
 
-    if (datastore['InitialAutoRunScript'] && datastore['InitialAutoRunScript'].empty? == false)
+    if datastore['InitialAutoRunScript'] && !datastore['InitialAutoRunScript'].empty?
       args = Shellwords.shellwords( datastore['InitialAutoRunScript'] )
       print_status("Session ID #{sid} (#{tunnel_to_s}) processing InitialAutoRunScript '#{datastore['InitialAutoRunScript']}'")
       execute_script(args.shift, *args)

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -37,13 +37,13 @@ module MeterpreterOptions
     framework.sessions.schedule Proc.new {
 
     # Configure unicode encoding before loading stdapi
-    session.encode_unicode = ( datastore['EnableUnicodeEncoding'] ? true : false )
+    session.encode_unicode = datastore['EnableUnicodeEncoding']
 
     session.init_ui(self.user_input, self.user_output)
 
     valid = true
 
-    if datastore['AutoVerifySession'] == true
+    if datastore['AutoVerifySession']
       if not session.is_valid_session?(datastore['AutoVerifySessionTimeout'].to_i)
         print_error("Meterpreter session #{session.sid} is not valid and will be closed")
         valid = false
@@ -52,7 +52,7 @@ module MeterpreterOptions
 
     if valid
 
-      if datastore['AutoLoadStdapi'] == true
+      if datastore['AutoLoadStdapi']
 
         session.load_stdapi
 
@@ -72,7 +72,7 @@ module MeterpreterOptions
       end
 
       [ 'InitialAutoRunScript', 'AutoRunScript' ].each do |key|
-        if (datastore[key].empty? == false)
+        if !datastore[key].empty?
           args = Shellwords.shellwords( datastore[key] )
           print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
           session.execute_script(args.shift, *args)

--- a/lib/msf/base/sessions/vncinject_options.rb
+++ b/lib/msf/base/sessions/vncinject_options.rb
@@ -84,7 +84,7 @@ module VncInjectOptions
     print_status("Local TCP relay started.")
 
     # If the AUTOVNC flag is set, launch VNC viewer.
-    if (datastore['AUTOVNC'] == true)
+    if datastore['AUTOVNC']
       if (session.autovnc(datastore['ViewOnly']))
         print_status("Launched vncviewer.")
       else

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -13,6 +13,7 @@ class DataStore < Hash
   # Initializes the data store's internal state.
   #
   def initialize()
+    @options     = Hash.new
     @imported    = Hash.new
     @imported_by = Hash.new
   end
@@ -25,6 +26,14 @@ class DataStore < Hash
     k = find_key_case(k)
     @imported[k] = false
     @imported_by[k] = nil
+
+    opt = @options[k]
+    unless opt.nil?
+      unless opt.valid?(v)
+        raise OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'#{['', ', try harder'].sample}"])
+      end
+      v = opt.normalize(v)
+    end
 
     super(k,v)
   end
@@ -65,12 +74,12 @@ class DataStore < Hash
   # all of the supplied options
   #
   def import_options(options, imported_by = nil, overwrite = false)
-    options.each_option { |name, opt|
+    options.each_option do |name, opt|
       # Skip options without a default or if is already a value defined
       if !opt.default.nil? && (!self.has_key?(name) || overwrite)
-        import_option(name, opt.default, true, imported_by)
+        import_option(name, opt.default, true, imported_by, opt)
       end
-    }
+    end
   end
 
   #
@@ -119,13 +128,14 @@ class DataStore < Hash
   #
   def import_options_from_hash(option_hash, imported = true, imported_by = nil)
     option_hash.each_pair { |key, val|
-      import_option(key, val.to_s, imported, imported_by)
+      import_option(key, val, imported, imported_by)
     }
   end
 
-  def import_option(key, val, imported=true, imported_by=nil)
+  def import_option(key, val, imported=true, imported_by=nil, option=nil)
     self.store(key, val)
 
+    @options[key] = option
     @imported[key]    = imported
     @imported_by[key] = imported_by
   end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -66,14 +66,9 @@ class DataStore < Hash
   #
   def import_options(options, imported_by = nil, overwrite = false)
     options.each_option { |name, opt|
-      # If there's already a value defined for this option, then skip it
-      # and don't import it.
-      next if self.has_key?(name) and overwrite == false
-
-      # If the option has a default value, import it, but only if the
-      # datastore doesn't already have a value set for it.
-      if ((opt.default != nil) and (overwrite or self[name] == nil))
-        import_option(name, opt.default.to_s, true, imported_by)
+      # Skip options without a default or if is already a value defined
+      if !opt.default.nil? && (!self.has_key?(name) || overwrite)
+        import_option(name, opt.default, true, imported_by)
       end
     }
   end

--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -537,7 +537,7 @@ protected
   #
   def find_context_key(buf, badchars, state)
     # Make sure our context information file is sane
-    if File.exists?(datastore['ContextInformationFile']) == false
+    if !File.exists?(datastore['ContextInformationFile'])
       raise NoKeyError, "A context information file must specified when using context encoding", caller
     end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1506,7 +1506,7 @@ protected
   # required when wanting to support context keyed encoding
   #
   def define_context_encoding_reqs(reqs)
-    return if datastore['EnableContextEncoding'] != true
+    return unless datastore['EnableContextEncoding']
 
     # At present, we don't support any automatic methods of obtaining
     # context information.  In the future, we might support obtaining

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -86,7 +86,7 @@ module Exploit::Remote::HttpServer
   # set.
   #
   def use_zlib
-    if (!Rex::Text.zlib_present? and datastore['HTTP::compression'] == true)
+    if !Rex::Text.zlib_present? && datastore['HTTP::compression']
       raise RuntimeError, "zlib support was not detected, yet the HTTP::compression option was set.  Don't do that!"
     end
   end
@@ -530,16 +530,16 @@ module Exploit::Remote::HttpServer
       response.compress = datastore['HTTP::compression']
     end
 
-    if (datastore['HTTP::chunked'] == true)
+    if datastore['HTTP::chunked']
       response.auto_cl = false
       response.transfer_chunked = true
     end
 
-    if (datastore['HTTP::header_folding'] == true)
+    if datastore['HTTP::header_folding']
       response.headers.fold = 1
     end
 
-    if (datastore['HTTP::junk_headers'] == true)
+    if datastore['HTTP::junk_headers']
       response.headers.junk_headers = 1
     end
 

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -588,7 +588,7 @@ module Msf
         if profile.nil?
           print_status("Browsing directly to the exploit URL is forbidden.")
           send_not_found(cli)
-        elsif profile[:tried] and datastore['Retries'] == false
+        elsif profile[:tried] && !datastore['Retries']
           print_status("Target with tag \"#{tag}\" wants to retry the module, not allowed.")
           send_not_found(cli)
         else

--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -65,7 +65,7 @@ module Exploit::Remote::SunRPC
       }
     )
 
-    if datastore['ONCRPC::tcp_request_fragmentation'] == true
+    if datastore['ONCRPC::tcp_request_fragmentation']
       self.rpcobj.should_fragment = 1
     end
 

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -266,11 +266,10 @@ class Module
   end
 
   #
-  # Returns true if this module is being debugged.  The debug flag is set
-  # by setting datastore['DEBUG'] to 1|true|yes
+  # Returns true if this module is being debugged.
   #
   def debugging?
-    (datastore['DEBUG'] || '') =~ /^(1|t|y)/i
+    datastore['DEBUG']
   end
 
   #

--- a/lib/msf/core/module/ui/message.rb
+++ b/lib/msf/core/module/ui/message.rb
@@ -14,9 +14,8 @@ module Msf::Module::UI::Message
 
   def print_prefix
     prefix = ''
-    if (datastore['TimestampOutput'] =~ /^(t|y|1)/i) || (
-      framework && framework.datastore['TimestampOutput'] =~ /^(t|y|1)/i
-    )
+    if datastore['TimestampOutput'] ||
+        (framework && framework.datastore['TimestampOutput'])
       prefix << "[#{Time.now.strftime("%Y.%m.%d-%H:%M:%S")}] "
 
       xn ||= datastore['ExploitNumber']

--- a/lib/msf/core/module/ui/message/verbose.rb
+++ b/lib/msf/core/module/ui/message/verbose.rb
@@ -1,21 +1,21 @@
 module Msf::Module::UI::Message::Verbose
   # Verbose version of #print_error
   def vprint_error(msg='')
-    print_error(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
+    print_error(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
   end
 
   # Verbose version of #print_good
   def vprint_good(msg='')
-    print_good(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
+    print_good(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
   end
 
   # Verbose version of #print_status
   def vprint_status(msg='')
-    print_status(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
+    print_status(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
   end
 
   # Verbose version of #print_warning
   def vprint_warning(msg='')
-    print_warning(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
+    print_warning(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
   end
 end

--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -147,8 +147,7 @@ module Msf
     # @return [void]
     def auto_subscribe_module(klass)
       # If auto-subscribe has been disabled
-      if (framework.datastore['DisableAutoSubscribe'] and
-          framework.datastore['DisableAutoSubscribe'] =~ /^(y|1|t)/)
+      if framework.datastore['DisableAutoSubscribe']
         return
       end
 

--- a/lib/msf/core/opt_raw.rb
+++ b/lib/msf/core/opt_raw.rb
@@ -13,7 +13,7 @@ class OptRaw < OptBase
   end
 
   def normalize(value)
-    if (value =~ /^file:(.*)/)
+    if (value.to_s =~ /^file:(.*)/)
       path = $1
       begin
         value = File.read(path)

--- a/lib/msf/core/opt_regexp.rb
+++ b/lib/msf/core/opt_regexp.rb
@@ -29,7 +29,7 @@ class OptRegexp < OptBase
 
   def normalize(value)
     return nil if value.nil?
-    return Regexp.compile(value)
+    return Regexp.compile(value.to_s)
   end
 
   def display_value(value)

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -13,7 +13,7 @@ class OptString < OptBase
   end
 
   def normalize(value)
-    if (value =~ /^file:(.*)/)
+    if (value.to_s =~ /^file:(.*)/)
       path = $1
       begin
         value = File.read(path)

--- a/lib/msf/core/payload/windows/prepend_migrate.rb
+++ b/lib/msf/core/payload/windows/prepend_migrate.rb
@@ -28,7 +28,7 @@ module Msf::Payload::Windows::PrependMigrate
   # for discussion.
   #
   def prepend_migrate?
-    !!(datastore['PrependMigrate'] && datastore['PrependMigrate'].to_s.downcase == 'true')
+    datastore['PrependMigrate']
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2171,10 +2171,15 @@ class Core
       return true
     end
 
-    if append
-      datastore[name] = datastore[name] + value
-    else
-      datastore[name] = value
+    begin
+      if append
+        datastore[name] = datastore[name] + value
+      else
+        datastore[name] = value
+      end
+    rescue OptionValidateError => e
+      print_error(e.message)
+      elog(e.message)
     end
 
     print_line("#{name} => #{datastore[name]}")

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3516,7 +3516,7 @@ class Core
       next if not o
 
       # handle a search string, search deep
-      if(
+      if (
         not regex or
         o.name.match(regex) or
         o.description.match(regex) or
@@ -3530,7 +3530,7 @@ class Core
             mod_opt_keys = o.options.keys.map { |x| x.downcase }
 
             opts.each do |opt,val|
-              if mod_opt_keys.include?(opt.downcase) == false or (val != nil and o.datastore[opt] != val)
+              if !mod_opt_keys.include?(opt.downcase) || (val != nil && o.datastore[opt] != val)
                 show = false
               end
             end

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -154,8 +154,7 @@ class Exploit
     else
       # If we didn't run a payload handler for this exploit it doesn't
       # make sense to complain to the user that we didn't get a session
-      disable_handler = /^true$/i === mod.datastore["DisablePayloadHandler"] ? true : false
-      unless disable_handler
+      unless mod.datastore["DisablePayloadHandler"]
         fail_msg = 'Exploit completed, but no session was created.'
         print_status(fail_msg)
         begin

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -139,13 +139,13 @@ class Driver < Msf::Ui::Driver
     self.disable_output = false
 
     # Whether or not command passthru should be allowed
-    self.command_passthru = (opts['AllowCommandPassthru'] == false) ? false : true
+    self.command_passthru = opts['AllowCommandPassthru']
 
     # Whether or not to confirm before exiting
-    self.confirm_exit = (opts['ConfirmExit'] == true) ? true : false
+    self.confirm_exit = opts['ConfirmExit']
 
     # Disables "dangerous" functionality of the console
-    @defanged = opts['Defanged'] == true
+    @defanged = opts['Defanged']
 
     # If we're defanged, then command passthru should be disabled
     if @defanged
@@ -652,7 +652,7 @@ protected
   def unknown_command(method, line)
 
     [method, method+".exe"].each do |cmd|
-      if (command_passthru == true and Rex::FileUtils.find_full_path(cmd))
+      if command_passthru && Rex::FileUtils.find_full_path(cmd)
 
         print_status("exec: #{line}")
         print_line('')

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -139,7 +139,7 @@ class Driver < Msf::Ui::Driver
     self.disable_output = false
 
     # Whether or not command passthru should be allowed
-    self.command_passthru = opts['AllowCommandPassthru']
+    self.command_passthru = opts.fetch('AllowCommandPassthru', true)
 
     # Whether or not to confirm before exiting
     self.confirm_exit = opts['ConfirmExit']

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
   def run
     print_status("Running MS SQL Server Enumeration...")
 
-    if mssql_login_datastore == false
+    if !mssql_login_datastore
       print_error("Login was unsuccessful. Check your credentials.")
       disconnect
       return

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
       OptString.new('SMBSHARE', [true, 'The name of a writeable share on the server', 'C$']),
       OptString.new('VSCPATH', [false, 'The path to the target Volume Shadow Copy', '']),
       OptString.new('WINPATH', [true, 'The name of the Windows directory (examples: WINDOWS, WINNT)', 'WINDOWS']),
-      OptBool.new('CREATE_NEW_VSC', [false, 'If true, attempts to create a volume shadow copy', 'false']),
+      OptBool.new('CREATE_NEW_VSC', [false, 'If true, attempts to create a volume shadow copy', false]),
     ], self.class)
 
   end
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
         print_status("Attempting to copy NTDS.dit from #{datastore['VSCPATH']}")
         vscpath = datastore['VSCPATH']
       else
-        unless datastore['CREATE_NEW_VSC'] == true
+        unless datastore['CREATE_NEW_VSC']
           vscpath = check_vss(text, bat)
         end
         unless vscpath

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -538,7 +538,7 @@ class Metasploit3 < Msf::Auxiliary
               print_status("Done fuzzing fields in form #{thisform[:name].upcase.strip}")
             end
             # fuzz headers ?
-            if datastore['FUZZHEADERS'] == true
+            if datastore['FUZZHEADERS']
               print_status("Fuzzing header fields")
               do_fuzz_headers(thisform,response.headers)
             end

--- a/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
+++ b/modules/auxiliary/gather/apple_safari_ftp_url_cookie_theft.rb
@@ -172,7 +172,7 @@ class Metasploit3 < Msf::Auxiliary
   # set.
   #
   def use_zlib
-    unless Rex::Text.zlib_present? || datastore['HTTP::compression'] == false
+    unless Rex::Text.zlib_present? || !datastore['HTTP::compression']
       fail_with(Failure::Unknown, "zlib support was not detected, yet the HTTP::compression option was set.  Don't do that!")
     end
   end

--- a/modules/auxiliary/gather/safari_file_url_navigation.rb
+++ b/modules/auxiliary/gather/safari_file_url_navigation.rb
@@ -286,7 +286,7 @@ class Metasploit3 < Msf::Auxiliary
   # set.
   #
   def use_zlib
-    if (!Rex::Text.zlib_present? and datastore['HTTP::compression'] == true)
+    if !Rex::Text.zlib_present? && datastore['HTTP::compression']
       fail_with(Failure::Unknown, "zlib support was not detected, yet the HTTP::compression option was set.  Don't do that!")
     end
   end

--- a/modules/auxiliary/gather/ssllabs_scan.rb
+++ b/modules/auxiliary/gather/ssllabs_scan.rb
@@ -437,9 +437,9 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptString.new('HOSTNAME', [true, 'The target hostname']),
         OptInt.new('DELAY', [true, 'The delay in seconds between  API requests', 5]),
-        OptBool.new('USECACHE', [true, 'Use cached results (if available), else force live scan', 'true']),
-        OptBool.new('GRADE', [true, 'Output only the hostname: grade', 'false']),
-        OptBool.new('IGNOREMISMATCH', [true, 'Proceed with assessments even when the server certificate doesn\'t match the assessment hostname', 'true'])
+        OptBool.new('USECACHE', [true, 'Use cached results (if available), else force live scan', true]),
+        OptBool.new('GRADE', [true, 'Output only the hostname: grade', false]),
+        OptBool.new('IGNOREMISMATCH', [true, 'Proceed with assessments even when the server certificate doesn\'t match the assessment hostname', true])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptBool.new('STORE_NOTES', [ true, 'Store the captured information in notes. Use "notes -t http.title" to view', true ]),
-        OptBool.new('SHOW_ERRORS', [ true, 'Show error messages relating to grabbing titles on the console', true ]),
         OptBool.new('SHOW_TITLES', [ true, 'Show the titles on the console as they are grabbed', true ]),
         OptString.new('TARGETURI', [true, 'The base path', '/'])
       ], self.class)
@@ -35,8 +34,8 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    if datastore['STORE_NOTES'] == false && datastore['SHOW_ERRORS'] == false && datastore['SHOW_TITLES'] == false
-      print_error("Notes storage is false, errors have been turned off and titles are not being shown on the console. There isn't much point in running this module.")
+    if !datastore['STORE_NOTES'] && !datastore['SHOW_TITLES']
+      print_error("Notes storage is false and titles are not being shown on the console. There isn't much point in running this module.")
     else
       super
     end
@@ -51,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 
         # If no response, quit now
         if res.nil?
-          print_error("[#{target_host}:#{rport}] No response") if datastore['SHOW_ERRORS'] == true
+          vprint_error("[#{target_host}:#{rport}] No response")
           return
         end
 
@@ -65,12 +64,12 @@ class Metasploit3 < Msf::Auxiliary
             server_header  = val if key.downcase == 'server'
           end
         else
-          print_error("[#{target_host}:#{rport}] No HTTP headers") if datastore['SHOW_ERRORS'] == true
+          vprint_error("[#{target_host}:#{rport}] No HTTP headers")
         end
 
         # If the body is blank, just stop now as there is no chance of a title
         if res.body.nil?
-          print_error("[#{target_host}:#{rport}] No webpage body") if datastore['SHOW_ERRORS'] == true
+          vprint_error("[#{target_host}:#{rport}] No webpage body")
           return
         end
 
@@ -78,7 +77,7 @@ class Metasploit3 < Msf::Auxiliary
         # there is no chance that we will have a title
         rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
         unless rx
-          print_error("[#{target_host}:#{rport}] No webpage title") if datastore['SHOW_ERRORS'] == true
+          vprint_error("[#{target_host}:#{rport}] No webpage title")
           return
         end
 
@@ -86,13 +85,15 @@ class Metasploit3 < Msf::Auxiliary
         rx[:title].strip!
         if rx[:title] != ''
           rx_title = Rex::Text.html_decode(rx[:title])
-          print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}") if datastore['SHOW_TITLES'] == true
-          if datastore['STORE_NOTES'] == true
+          if datastore['SHOW_TITLES']
+            print_status("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}")
+          end
+          if datastore['STORE_NOTES']
             notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header, uri: datastore['TARGETURI'] }
             report_note(host: target_host, port: rport, type: "http.title", data: notedata, update: :unique_data)
           end
         else
-          print_error("[#{target_host}:#{rport}] No webpage title") if datastore['SHOW_ERRORS'] == true
+          vprint_error("[#{target_host}:#{rport}] No webpage title")
         end
       end
 

--- a/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
+++ b/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Auxiliary
       loot = store_loot("tplink.traversal.data","text/plain",rhost, res.body,file)
       vprint_good("#{rhost}:#{rport} - File #{file} downloaded to: #{loot}")
 
-      if datastore['VERBOSE'] == true
+      if datastore['VERBOSE']
         vprint_good("#{rhost}:#{rport} - Response - File #{file}:")
         res.body.each_line do |line|
           # the following is the last line of the useless response
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Auxiliary
         end
         out = false
       end
-    elsif (res and res.code)
+    elsif res && res.code
       vprint_error("#{rhost}:#{rport} - File->#{file} not found")
     end
   end

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
 
-    if (not mssql_login_datastore)
+    if !mssql_login_datastore
       print_error("#{rhost}:#{rport} - Invalid SQL Server credentials")
       return
     end

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
 
-    if (not mssql_login_datastore)
+    if !mssql_login_datastore
       print_error("#{rhost}:#{rport} - Invalid SQL Server credentials")
       return
     end

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -37,12 +37,12 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
     [
       OptInt.new('RETRY', [false, "Number of tries to query the NTP server", 3]),
-      OptBool.new('SHOW_LIST', [false, 'Show the recent clients list', 'false'])
+      OptBool.new('SHOW_LIST', [false, 'Show the recent clients list', false])
     ], self.class)
 
     register_advanced_options(
     [
-      OptBool.new('StoreNTPClients', [true, 'Store NTP clients as host records in the database', 'false'])
+      OptBool.new('StoreNTPClients', [true, 'Store NTP clients as host records in the database', false])
     ], self.class)
   end
 

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -408,7 +408,7 @@ class Metasploit3 < Msf::Auxiliary
         end
         subdirs.shift
       end
-    print_status("#{ip}:#{rport} - Spider #{x} complete.") unless datastore['ShowFiles'] == true
+    print_status("#{ip}:#{rport} - Spider #{x} complete.") unless datastore['ShowFiles']
     end
     unless detailed_tbl.rows.empty?
       if datastore['LogSpider'] == '1'

--- a/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(69),
         OptString.new('FILENAME', [false, 'The file to loot', 'windows\\win.ini']),
-        OptBool.new('SAVE', [false, 'Save the downloaded file to disk', 'false'])
+        OptBool.new('SAVE', [false, 'Save the downloaded file to disk', false])
       ], self.class)
   end
 

--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Encoder
     register_options(
       [
         OptString.new( 'ValidCharSet', [ false, "Specify a known set of valid chars (ALPHA, ALPHANUM, FILEPATH)" ]),
-        OptBool.new( 'OverwriteProtect', [ false, "Indicate if the encoded payload requires protection against being overwritten" ])
+        OptBool.new( 'OverwriteProtect', [ false, "Indicate if the encoded payload requires protection against being overwritten", false])
       ],
       self.class)
   end
@@ -179,10 +179,8 @@ class Metasploit3 < Msf::Encoder
       raise EncodingError, "Unable to find AND-able chars resulting 0 in the valid character set."
     end
 
-    protect_payload = (datastore['OverwriteProtect'] || "").downcase == "true"
-
     # with everything set up, we can now call the encoding routine
-    state.decoder_stub = encode_payload(state.buf, reg_offset, protect_payload)
+    state.decoder_stub = encode_payload(state.buf, reg_offset, datastore['OverwriteProtect'])
 
     state.buf = ""
     state.decoder_stub

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'WfsDelay' => 300,  #5 minutes
-          'DisablePayloadHandler' => 'false',
+          'DisablePayloadHandler' => false,
           'EXITFUNC' => 'thread'
         },
       'Platform'       => ['php'],

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -99,7 +99,7 @@ class Metasploit4 < Msf::Exploit::Remote
     if res.body =~ /Set Default Options for #{printer_name}/
       vprint_good("Added printer successfully")
       delete_printer(printer_name)
-    elsif res.code == 401 || (res.code == 426 && datastore['SSL'] == true)
+    elsif res.code == 401 || (res.code == 426 && datastore['SSL'])
       vprint_error("Authentication failed")
     elsif res.code == 426
       vprint_error("SSL required - set SSL true")
@@ -129,7 +129,7 @@ class Metasploit4 < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "#{peer} - Could not add printer - Connection failed.")
     elsif res.body =~ /Set Default Options for #{printer_name}/
       print_good("Added printer successfully")
-    elsif res.code == 401 || (res.code == 426 && datastore['SSL'] == true)
+    elsif res.code == 401 || (res.code == 426 && datastore['SSL'])
       fail_with(Failure::NoAccess, "#{peer} - Could not add printer - Authentication failed.")
     elsif res.code == 426
       fail_with(Failure::BadConfig, "#{peer} - Could not add printer - SSL required - set SSL true.")
@@ -145,7 +145,7 @@ class Metasploit4 < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "#{peer} - Could not add test page to print queue - Connection failed.")
     elsif res.body =~ /Test page sent; job ID is/
       vprint_good("Added test page to printer queue")
-    elsif res.code == 401 || (res.code == 426 && datastore['SSL'] == true)
+    elsif res.code == 401 || (res.code == 426 && datastore['SSL'])
       fail_with(Failure::NoAccess, "#{peer} - Could not add test page to print queue - Authentication failed.")
     elsif res.code == 426
       fail_with(Failure::BadConfig, "#{peer} - Could not add test page to print queue - SSL required - set SSL true.")
@@ -159,7 +159,7 @@ class Metasploit4 < Msf::Exploit::Remote
       fail_with(Failure::Unreachable, "#{peer} - Could not delete printer - Connection failed.")
     elsif res.body =~ /has been deleted successfully/
       print_status("Deleted printer '#{printer_name}' successfully")
-    elsif res.code == 401 || (res.code == 426 && datastore['SSL'] == true)
+    elsif res.code == 401 || (res.code == 426 && datastore['SSL'])
       vprint_warning("Could not delete printer '#{printer_name}' - Authentication failed.")
     elsif res.code == 426
       vprint_warning("Could not delete printer '#{printer_name}' - SSL required - set SSL true.")

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -155,7 +155,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    if check == Exploit::CheckCode::Safe && datastore['FORCE']
+    if check == Exploit::CheckCode::Safe && !datastore['FORCE']
       print_error('Target seems safe, so we will not continue.')
       return
     end

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -155,7 +155,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    if check == Exploit::CheckCode::Safe && datastore['FORCE'] == false
+    if check == Exploit::CheckCode::Safe && datastore['FORCE']
       print_error('Target seems safe, so we will not continue.')
       return
     end

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -168,7 +168,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # msf/core/exploit/http/server.rb
   #
   def start_http(opts={})
-    # Ensture all dependencies are present before initializing HTTP
+    # Ensure all dependencies are present before initializing HTTP
     use_zlib
 
     comm = datastore['ListenerComm']
@@ -255,7 +255,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # set.
   #
   def use_zlib
-    if (!Rex::Text.zlib_present? and datastore['HTTP::compression'] == true)
+    if !Rex::Text.zlib_present? && datastore['HTTP::compression']
       fail_with(Failure::Unknown, "zlib support was not detected, yet the HTTP::compression option was set.  Don't do that!")
     end
   end

--- a/modules/exploits/unix/webapp/php_vbulletin_template.rb
+++ b/modules/exploits/unix/webapp/php_vbulletin_template.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
       b = /#{wrapper}[\s\r\n]*(.*)[\s\r\n]*#{wrapper}/sm.match(res.body)
       if b
         return b.captures[0]
-      elsif datastore['HTTP::chunked'] == true
+      elsif datastore['HTTP::chunked']
         b = /chunked Transfer-Encoding forbidden/.match(res.body)
         if b
           fail_with(Failure::Unknown, 'Target PHP installation does not support chunked encoding. Support for chunked encoded requests was added to PHP on 12/15/2005. Try disabling HTTP::chunked and trying again.')

--- a/modules/exploits/unix/webapp/php_xmlrpc_eval.rb
+++ b/modules/exploits/unix/webapp/php_xmlrpc_eval.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
       b = /#{wrapper}(.*)#{wrapper}/sm.match(res.body)
       if b
         return b.captures[0]
-      elsif datastore['HTTP::chunked'] == true
+      elsif datastore['HTTP::chunked']
         b = /chunked Transfer-Encoding forbidden/.match(res.body)
         if b
           fail_with(Failure::BadConfig, 'Target PHP installation does not support chunked encoding. Support for chunked encoded requests was added to PHP on 12/15/2005. Try disabling HTTP::chunked and trying again.')

--- a/modules/exploits/unix/webapp/sixapart_movabletype_storable_exec.rb
+++ b/modules/exploits/unix/webapp/sixapart_movabletype_storable_exec.rb
@@ -110,7 +110,7 @@ print "LFI test for storable flaw is: $frozen\n";
   end
 
   def exploit
-    if datastore['DESTRUCTIVE'] == true
+    if datastore['DESTRUCTIVE']
       exploit_destructive
     else
       exploit_nondestructive

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return p
     end
 
-    if !t['ASLR'] && datastore['ROP'] == 'SWF' && flash_version =~ /11,3,300,257/
+    if t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,257/
       print_status("Using Rop Chain For Flash: #{flash_version}")
       pivot = [
         0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       p = generate_rop_payload('flash', payload.encoded, {'target'=>'11.3.300.257', 'pivot'=>pivot})
 
-    elsif !t['ASLR'] && datastore['ROP'] == 'SWF' && flash_version =~ /11,3,300,265/
+    elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,265/
       print_status("Using Rop Chain For Flash: #{flash_version}")
       pivot = [
         0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       p = generate_rop_payload('flash', payload.encoded, {'target'=>'11.3.300.265', 'pivot'=>pivot})
 
-    elsif !t['ASLR'] && datastore['ROP'] == 'SWF' && flash_version =~ /11,3,300,268/
+    elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,268/
       print_status("Using Rop Chain For Flash: #{flash_version}")
       pivot = [
         0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return p
     end
 
-    if t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,257/
+    if !t['ASLR'] && datastore['ROP'] == 'SWF' && flash_version =~ /11,3,300,257/
       print_status("Using Rop Chain For Flash: #{flash_version}")
       pivot = [
         0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       p = generate_rop_payload('flash', payload.encoded, {'target'=>'11.3.300.257', 'pivot'=>pivot})
 
-    elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,265/
+    elsif !t['ASLR'] && datastore['ROP'] == 'SWF' && flash_version =~ /11,3,300,265/
       print_status("Using Rop Chain For Flash: #{flash_version}")
       pivot = [
         0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       p = generate_rop_payload('flash', payload.encoded, {'target'=>'11.3.300.265', 'pivot'=>pivot})
 
-    elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,268/
+    elsif !t['ASLR'] && datastore['ROP'] == 'SWF' && flash_version =~ /11,3,300,268/
       print_status("Using Rop Chain For Flash: #{flash_version}")
       pivot = [
         0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'false',
+          'DisablePayloadHandler' => false,
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Payload'        =>

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'false',
+          'DisablePayloadHandler' => false,
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Payload'        =>

--- a/modules/exploits/windows/browser/winamp_playlist_unc.rb
+++ b/modules/exploits/windows/browser/winamp_playlist_unc.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_evasion_options(
       [
-        OptBool.new('PlaylistSpaceInjection', [false, 'Add junk spaces in between each entry item in the playlist"', 'false'])
+        OptBool.new('PlaylistSpaceInjection', [false, 'Add junk spaces in between each entry item in the playlist"', false])
       ])
   end
 
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def generate_space
-    if datastore['PlaylistSpaceInjection'] == true
+    if datastore['PlaylistSpaceInjection']
       return rand_text(rand(100)+1, nil, " \t")
     else
       return ''

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
@@ -334,7 +334,7 @@ class Metasploit3 < Msf::Exploit::Remote
     msg.to = datastore['MAILTO']
     msg.from = datastore['MAILFROM']
 
-    if datastore['HTML'] == true
+    if datastore['HTML']
       body = create_email_body_html(datastore['MESSAGE'], msg.subject)
       content_type = "text/html; charset=\"iso-8859-1\""
       msg.add_part(body, content_type, 'quoted-printable')

--- a/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/foxit_reader_launch.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_launch.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
+++ b/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
+++ b/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload' =>
         {

--- a/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
+++ b/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
+++ b/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => "none",
           #'InitialAutoRunScript' => 'migrate -f',
-          'DisablePayloadHandler' => 'false',
+          'DisablePayloadHandler' => false,
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/mediajukebox.rb
+++ b/modules/exploits/windows/fileformat/mediajukebox.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload' =>
         {

--- a/modules/exploits/windows/fileformat/microp_mppl.rb
+++ b/modules/exploits/windows/fileformat/microp_mppl.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'thread',
-          'DisablePayloadHandler' => 'false'
+          'DisablePayloadHandler' => false
         },
       'Platform'       => 'win',
       'Targets'        =>
@@ -234,7 +234,7 @@ class Metasploit3 < Msf::Exploit::Remote
 end
 
 =begin
-mbp:win7_diff sinn3r$ diff patch/GetCurrentIcon.c vuln/GetCurrentIcon.c 
+mbp:win7_diff sinn3r$ diff patch/GetCurrentIcon.c vuln/GetCurrentIcon.c
 1c1
 < void *__thiscall CPackage::_GetCurrentIcon(void *this, int a2)
 ---

--- a/modules/exploits/windows/fileformat/ms13_071_theme.rb
+++ b/modules/exploits/windows/fileformat/ms13_071_theme.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' => 'false'
+          'DisablePayloadHandler' => false
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/ms15_100_mcl_exe.rb
+++ b/modules/exploits/windows/fileformat/ms15_100_mcl_exe.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' => 'false'
+          'DisablePayloadHandler' => false
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'DisablePayloadHandler' => 'false',
+          'DisablePayloadHandler' => false,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
+++ b/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
       "<?xml version=\"1.0\"?>\r\n<g:searchrequest xmlns:g=\"DAV:\">\r\n" +
       "<g:sql>\r\nSelect \"DAV:displayname\" from scope()\r\n</g:sql>\r\n</g:searchrequest>\r\n"
 
-    if datastore['InvalidSearchRequest'] == true
+    if datastore['InvalidSearchRequest']
       xml = rand_text(rand(1024) + 32)
     end
 

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
@@ -377,7 +377,7 @@ exec sp_executesql @z|
     runme.gsub!(/%STUFF%/, enc)
 
     # go!
-    if (not mssql_login_datastore)
+    if !mssql_login_datastore
       fail_with(Failure::NoAccess, "Unable to log in!")
     end
     begin
@@ -452,7 +452,7 @@ exec sp_executesql @z|
       return nil
     end
 
-    if (not logged_in)
+    if !logged_in
       fail_with(Failure::NoAccess, "Invalid SQL Server credentials")
     end
     res = mssql_query("select @@version", datastore['VERBOSE'])

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptBool.new('DEPLOY',       [false, 'Deploy payload via the sysadmin links', 'false']),
+        OptBool.new('DEPLOY',       [false, 'Deploy payload via the sysadmin links', false]),
         OptString.new('DEPLOYLIST', [false,'Comma seperated list of systems to deploy to']),
         OptString.new('PASSWORD',   [true, 'The password for the specified username'])
       ], self.class)
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Check if credentials are correct
     print_status("Attempting to connect to SQL Server at #{rhost}:#{rport}...")
 
-    if (not mssql_login_datastore)
+    if !mssql_login_datastore
       print_error("Invalid SQL Server credentials")
       print_status("-------------------------------------------------")
       return
@@ -137,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }
       if masterList.length == 1
         print_good("Successfully connected to #{server["name"]}")
-        if datastore['VERBOSE'] == true
+        if datastore['VERBOSE']
           show_configs(server["name"],parse_results,true)
         elsif server["db_sysadmin"] == 1
           print_good("Sysadmin on #{server["name"]}")
@@ -185,7 +185,7 @@ class Metasploit3 < Msf::Exploit::Remote
               write_to_report(name,server,parse_results,linked_server_table,link_status)
 
               # Display link server information in verbose mode
-              if datastore['VERBOSE'] == true
+              if datastore['VERBOSE']
                 show_configs(name,parse_results)
                 print_status("  o Link path: #{masterList.first["name"]} -> #{temppath.join(" -> ")}")
               else
@@ -219,7 +219,7 @@ class Metasploit3 < Msf::Exploit::Remote
               linked_server_table << [server["name"],server["db_version"],server["db_os"],name,'NA','NA','NA','NA','Connection Failed']
 
               # Display status to user
-              if datastore['VERBOSE'] == true
+              if datastore['VERBOSE']
                 print_status(" ")
                 print_error("Linked Server: #{name} ")
                 print_error("  o Link Path: #{masterList.first["name"]} -> #{temppath.join(" -> ")} - Connection Failed")
@@ -435,14 +435,14 @@ class Metasploit3 < Msf::Exploit::Remote
         if datastore['DEPLOYLIST']==""
           datastore['DEPLOYLIST'] = nil
         end
-        if datastore['DEPLOYLIST'] != nil and datastore["VERBOSE"] == true
+        if !datastore['DEPLOYLIST'].nil? && datastore["VERBOSE"]
           print_status("\t - Checking if #{name} is on the deploy list...")
         end
         if datastore['DEPLOYLIST'] != nil
           deploylist = datastore['DEPLOYLIST'].upcase.split(',')
         end
         if datastore['DEPLOYLIST'] == nil or deploylist.include? name.upcase
-          if datastore['DEPLOYLIST'] != nil and datastore["VERBOSE"] == true
+          if !datastore['DEPLOYLIST'].nil? && datastore["VERBOSE"]
             print_status("\t - #{name} is on the deploy list.")
           end
           unless shelled.include?(name)
@@ -451,7 +451,7 @@ class Metasploit3 < Msf::Exploit::Remote
           else
             print_status("Payload already deployed on #{name}")
           end
-        elsif datastore['DEPLOYLIST'] != nil and datastore["VERBOSE"] == true
+        elsif !datastore['DEPLOYLIST'].nil? && datastore["VERBOSE"]
           print_status("\t - #{name} is not on the deploy list")
         end
       end

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    if (not mssql_login_datastore)
+    if !mssql_login_datastore
       vprint_status("Invalid SQL Server credentials")
       return Exploit::CheckCode::Detected
     end
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
 
-    if (not mssql_login_datastore)
+    if !mssql_login_datastore
       print_status("Invalid SQL Server credentials")
       return
     end

--- a/modules/exploits/windows/scada/codesys_web_server.rb
+++ b/modules/exploits/windows/scada/codesys_web_server.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'false',
+          'DisablePayloadHandler' => false,
         },
       'Platform'        => 'win',
       'Payload'         =>

--- a/modules/payloads/stages/osx/x86/isight.rb
+++ b/modules/payloads/stages/osx/x86/isight.rb
@@ -80,7 +80,7 @@ module Metasploit3
 
     print_status("Photo saved as #{dest}")
 
-    if (datastore['AUTOVIEW'] == true)
+    if datastore['AUTOVIEW']
       print_status("Opening photo in a web browser...")
       Rex::Compat.open_browser(File.expand_path(dest))
     end

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -321,17 +321,14 @@ class Metasploit3 < Msf::Post
     end
     settings['ftp_bindip'] = "0.0.0.0" if settings['ftp_bindip'] == "*" || settings['ftp_bindip'].empty?
 
-    if settings['ssl'] == "1"
-      settings['ssl'] = "true"
-    else
-      if datastore['SSLCERT']
-        print_error("Cannot loot the SSL Certificate, SSL is disabled in the configuration file")
-      end
-      settings['ssl'] = "false"
+    settings['ssl'] = settings['ssl'] == "1"
+    if !settings['ssl'] && datastore['SSLCERT']
+      print_error("Cannot loot the SSL Certificate, SSL is disabled in the configuration file")
     end
 
     settings['ssl_certfile'] = items[45].text rescue "<none>"
-    if settings['ssl_certfile'] != "<none>" and settings['ssl'] == "true" and datastore['SSLCERT'] # lets get the file if its there could be useful in MITM attacks
+    # Get the file if it is there. It could be useful in MITM attacks
+    if settings['ssl_certfile'] != "<none>" && settings['ssl'] and datastore['SSLCERT']
       sslfile = session.fs.file.new(settings['ssl_certfile'])
       until sslfile.eof?
         sslcert << sslfile.read
@@ -386,7 +383,7 @@ class Metasploit3 < Msf::Post
 
       account['host'] = settings['ftp_bindip']
       account['port'] = settings['ftp_port']
-      account['ssl']  = settings['ssl']
+      account['ssl']  = settings['ssl'].to_s
       creds << account
 
       vprint_status("    Username: #{account['user']}")

--- a/modules/post/windows/gather/credentials/imail.rb
+++ b/modules/post/windows/gather/credentials/imail.rb
@@ -191,7 +191,7 @@ class Metasploit3 < Msf::Post
     imail_user = datastore['IMAILUSER']
     imail_domain = datastore['IMAILDOMAIN']
 
-    print_status("Download iMail user information...") if datastore['VERBOSE'] == false
+    vprint_status("Download iMail user information...")
 
     #Download user data.  If no user specified, we dump it all.
     users = download_info(imail_user, imail_domain)

--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -278,7 +278,7 @@ class Metasploit3 < Msf::Post
     # If we can impersonate a token, we use that first.
     # If we can't, we'll try to MIGRATE (more aggressive) if the user wants to
     got_token = steal_token
-    if not got_token and datastore["MIGRATE"]
+    if !got_token && datastore["MIGRATE"]
       migrate_success = migrate
     end
 
@@ -330,7 +330,7 @@ class Metasploit3 < Msf::Post
     end
 
     # Migrate back to the original process
-    if datastore["MIGRATE"] and @old_pid and migrate_success == true
+    if datastore["MIGRATE"] && @old_pid && migrate_success
       print_status("Migrating back...")
       migrate(@old_pid)
     end

--- a/modules/post/windows/manage/add_user_domain.rb
+++ b/modules/post/windows/manage/add_user_domain.rb
@@ -223,12 +223,11 @@ class Metasploit3 < Msf::Post
     end
 
     ## steal token if neccessary
-    if (datastore['TOKEN'] == '')
-      token_found,token_user,current_user = token_hunter(domain)
-
-      return if token_found == false
-
-      datastore['TOKEN'] = token_user if current_user == false
+    if datastore['TOKEN'] == ''
+      token_found, token_user, current_user = token_hunter(domain)
+      if token_found && current_user == false
+        datastore['TOKEN'] = token_user
+      end
     end
 
     ## steal token
@@ -247,7 +246,7 @@ class Metasploit3 < Msf::Post
     already_member_group = false
 
     ## Add user to the domain
-    if (datastore['ADDTODOMAIN'] == true)
+    if datastore['ADDTODOMAIN']
       user_add_res = run_cmd("net user \"#{datastore['USERNAME']}\" /domain",false)
 
       if (user_add_res =~ /The command completed successfully/ and user_add_res =~ /Domain Users/)
@@ -261,7 +260,7 @@ class Metasploit3 < Msf::Post
     end
 
     ## Add user to a domain group
-    if datastore['ADDTOGROUP'] == true
+    if datastore['ADDTOGROUP']
       ## check if user is already a member of the group
       group_add_res = run_cmd("net groups \"#{datastore['GROUP']}\" /domain",false)
 
@@ -291,7 +290,7 @@ class Metasploit3 < Msf::Post
     end
 
     ## verify user was added to domain or domain group
-    if datastore['ADDTOGROUP'] == true
+    if datastore['ADDTOGROUP']
       if already_member_group == false
         net_groups_res = run_cmd("net groups \"#{datastore['GROUP']}\" /domain",false)
 

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Post
         OptString.new('DB_USERNAME',  [true, 'New sysadmin login', '']),
         OptString.new('DB_PASSWORD',  [true, 'Password for new sysadmin login', '']),
         OptString.new('INSTANCE',  [false, 'Name of target SQL Server instance', nil]),
-        OptBool.new('REMOVE_LOGIN',  [true, 'Remove DB_USERNAME login from database', 'false'])
+        OptBool.new('REMOVE_LOGIN',  [true, 'Remove DB_USERNAME login from database', false])
       ], self.class)
   end
 

--- a/modules/post/windows/manage/rpcapd_start.rb
+++ b/modules/post/windows/manage/rpcapd_start.rb
@@ -52,8 +52,8 @@ class Metasploit3 < Msf::Post
           print_status("Setting rpcapd as 'auto' service")
           service_change_startup("rpcapd", START_TYPE_AUTO)
         end
-        if datastore['ACTIVE']==true
-          if datastore['RHOST']==nil
+        if datastore['ACTIVE']
+          if datastore['RHOST'].nil?
             print_error("RHOST is not set ")
             return
           else
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Post
           print_status("Installing rpcap in PASSIVE mode (local port: #{datastore['PORT']}) ")
           p = prog << " -d -p #{datastore['PORT']} "
         end
-        if datastore['NULLAUTH']==true
+        if datastore['NULLAUTH']
           p<< "-n"
         end
         run_rpcapd(p)

--- a/modules/post/windows/manage/sdel.rb
+++ b/modules/post/windows/manage/sdel.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Post
     n = datastore['ITERATIONS']
     file = datastore['FILE']
 
-    if datastore['ZERO']==true
+    if datastore['ZERO']
       type = 0
       print_status("The file will be overwritten with null bytes")
     end

--- a/spec/lib/msf/core/exploit/powershell_spec.rb
+++ b/spec/lib/msf/core/exploit/powershell_spec.rb
@@ -323,14 +323,12 @@ RSpec.describe Msf::Exploit::Powershell do
     end
 
     context 'when method is unknown' do
-      before do
-        subject.datastore['Powershell::method'] = 'blah'
-      end
       it 'should raise an exception' do
         except = false
         begin
+          subject.datastore['Powershell::method'] = 'blah'
           subject.cmd_psh_payload(payload, arch)
-        rescue RuntimeError
+        rescue Msf::OptionValidateError
           except = true
         end
         expect(except).to be_truthy


### PR DESCRIPTION
As a funny historical nit, we convert all default datastore options to strings before storing them. This means that false becomes 'false', which is 'truthy' when used in a normal boolean-expecting expression. This is what has been holding up #5393 for some time, so I thought I would try to fix the problem.

Removing the default behavior was easy, but funny enough, lots of rspec started failing because datastore['VERBOSE'] was actually false by default, leading to a nil dereference in the vprint_\* functions. I then excised all of the truthy workarounds in lib and modules. I can't decide if the PrependMigrate hack or the DisablePayloadHandler hack was my favorite way to extract meaning from the datastore :) 

This will need a careful eye and a good bit of testing, but I think it is on the right track.
## Verification
- [ ] `use exploit/windows/smb/psexec`
  - [ ] `set RPORT -1` **Verify** displays an error
  - [ ] `set RPORT 9999999` **Verify** displays an error
  - [ ] `set RPORT asdf` **Verify** displays an error
  - [ ] `set RPORT 1234` **Verify** sets the thing
  - [ ] `save`
  - [ ] exit msfconsole and restart
  - [ ] `set RPORT` **Verify** has the value 1234
  - [ ] `unset RPORT` **Verify** reverts to the default (445)
