### PR TITLE
Add TLS Server Name Indication (SNI) Support, unify SSLVersion options

### DIFF
--- a/lib/msf/core/auxiliary/crawler.rb
+++ b/lib/msf/core/auxiliary/crawler.rb
@@ -44,7 +44,7 @@ module Auxiliary::HttpCrawler
         OptString.new('BasicAuthPass', [false, 'The HTTP password to specify for basic authentication']),
         OptString.new('HTTPAdditionalHeaders', [false, "A list of additional headers to send (separated by \\x01)"]),
         OptString.new('HTTPCookie', [false, "A HTTP cookie header to send with each request"]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL23', 'SSL3', 'TLS1']]),
+        Opt::SSLVersion
       ], self.class
     )
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -50,7 +50,7 @@ module Exploit::Remote::HttpClient
         OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
         OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', '']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),
+        Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
         OptInt.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout'])

--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -64,7 +64,7 @@ module Exploit::Remote::Tcp
     register_advanced_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL/TLS for outgoing connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL/TLS to be used (TLS and SSL23 are auto-negotiate)', 'TLS1', ['SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']]),
+        Opt::SSLVersion,
         OptEnum.new('SSLVerifyMode',  [ false, 'SSL verification method', 'PEER', %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}]),
         OptString.new('SSLCipher',    [ false, 'String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"']),
         Opt::Proxies,

--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -19,7 +19,6 @@ module Exploit::Remote::TcpServer
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for incoming connections', false]),
         # SSLVersion is currently unsupported for TCP servers (only supported by clients at the moment)
-        # OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
         OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
         OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -51,6 +51,13 @@ module Msf
       Msf::OptPort.new(__method__.to_s, [ required, desc, default ])
     end
 
+    # @return [OptEnum]
+    def self.SSLVersion
+      Msf::OptEnum.new('SSLVersion', [ false,
+        'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)', 'Auto',
+        ['Auto', 'SSL2', 'SSL3', 'SSL23', 'TLS', 'TLS1', 'TLS1.1', 'TLS1.2']])
+    end
+
     # These are unused but remain for historical reasons
     class << self
       alias builtin_chost CHOST
@@ -69,6 +76,7 @@ module Msf
     Proxies = Proxies()
     RHOST = RHOST()
     RPORT = RPORT()
+    SSLVersion = SSLVersion()
   end
 
 end

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -65,7 +65,7 @@ begin
       when 'SSL2', :SSLv2
         version = :SSLv2
       # 'TLS' will be the new name for autonegotation with newer versions of OpenSSL
-      when 'SSL23', :SSLv23, 'TLS'
+      when 'SSL23', :SSLv23, 'TLS', 'Auto'
         version = :SSLv23
       when 'SSL3', :SSLv3
         version = :SSLv3

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -124,6 +124,11 @@ begin
     # Tie the context to a socket
     self.sslsock = OpenSSL::SSL::SSLSocket.new(self, self.sslctx)
 
+    # If peerhost looks like a hostname, set the undocumented 'hostname'
+    # attribute on sslsock, which enables the Server Name Indication (SNI)
+    # extension
+    self.sslsock.hostname = self.peerhost if !Rex::Socket.dotted_ip?(self.peerhost)
+
     # Force a negotiation timeout
     begin
     Timeout.timeout(params.timeout) do

--- a/modules/auxiliary/dos/http/f5_bigip_apm_max_sessions.rb
+++ b/modules/auxiliary/dos/http/f5_bigip_apm_max_sessions.rb
@@ -37,7 +37,6 @@ class Metasploit3 < Msf::Auxiliary
       'DefaultOptions' =>
         {
           'SSL' => true,
-          'SSLVersion' => 'TLS1',
           'RPORT' => 443
         }
     ))

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'DefaultOptions' =>
         {
-          'SSLVersion' => 'TLS1',
           'SSL'        => true
         }
     ))

--- a/modules/auxiliary/gather/ssllabs_scan.rb
+++ b/modules/auxiliary/gather/ssllabs_scan.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 
       name = name.to_s.camelize(:lower)
       uri = api_path + name
-      cli = Rex::Proto::Http::Client.new(api_host, api_port, {}, true, 'TLS1')
+      cli = Rex::Proto::Http::Client.new(api_host, api_port, {}, true, 'TLS')
       cli.connect
       req = cli.request_cgi({
           'uri' => uri,
@@ -430,7 +430,6 @@ class Metasploit3 < Msf::Auxiliary
           {
             'RPORT'      => 443,
             'SSL'        => true,
-            'SSLVersion' => 'TLS1'
           }
     ))
     register_options(

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Auxiliary
       'DefaultOptions' =>
       {
         'SSL'         => true,
-        'SSLVersion'  => 'TLS1'
       }
     )
 

--- a/modules/auxiliary/scanner/http/f5_mgmt_scanner.rb
+++ b/modules/auxiliary/scanner/http/f5_mgmt_scanner.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
       'DefaultOptions' =>
         {
           'SSL' => true,
-          'SSLVersion' => 'TLS1',
           'RPORT' => 443
         }
     ))

--- a/modules/auxiliary/scanner/http/ssl_version.rb
+++ b/modules/auxiliary/scanner/http/ssl_version.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Auxiliary
       {
         'SSL' => true,
         'RPORT' => 443,
-        'SSLVersion' => 'SSL3'
       },
       'References'  =>
       [
@@ -43,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptEnum.new('SSLVersion', [true, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']])
+        Opt::SSLVersion
       ]
     )
 

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
         {
           'RPORT'      => 443,
           'SSL'        => true,
-          'SSLVersion' => 'TLS1'
         }
     ))
   end

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
       'DefaultOptions' =>
       {
         'SSL'        => true,
-        'SSLVersion' => 'TLS1'
       }
     ))
     register_options(

--- a/modules/exploits/linux/http/symantec_web_gateway_restore.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_restore.rb
@@ -47,7 +47,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' => {
         'RPORT'      => 443,
         'SSL'        => true,
-        'SSLVersion' => 'TLS1'
       },
       'Platform'       => ['unix'],
       'Arch'           => ARCH_CMD,

--- a/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
+++ b/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'SSL' => true,
-          'SSLVersion' => 'SSL3',
           'PrependMigrate' => true
         },
       'Payload'        =>

--- a/modules/exploits/windows/misc/hp_magentservice.rb
+++ b/modules/exploits/windows/misc/hp_magentservice.rb
@@ -37,7 +37,6 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'seh',
           'SSL' => true,
-          'SSLVersion' => 'SSL3'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/ibm_cognos_tm1admsd_bof.rb
+++ b/modules/exploits/windows/misc/ibm_cognos_tm1admsd_bof.rb
@@ -38,7 +38,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'SSL' => true,
-          'SSLVersion' => 'TLS1'
         },
       'Payload'        =>
         {


### PR DESCRIPTION
Noted on IRC today, our SSL/TLS support does not set the Server Name Indication field on client hello, which is required for many modern TLS servers to connect, especially when going through a TLS proxy. This patch automatically adds the required parameter if the peername is a hostname rather than an IP address.

This patch also unifies the SSLVersion option, removing inconsistencies between various modules and mixins. It also removes the copy/pasted defaults and instead defers to the default embedded in the SSLVersion option itself, which is to auto-negotiate. This makes things work automatically for the most part.
# Verification steps
- [x] Verify that travis is green
- [x] run any web client exploit, set RHOST to a hostname, e.g. google.com, and capture the traffic with wireshark
- [x] verify that the server_name extension shows up in the client hello packet
- [x] alternately, connect to a server that requires SNI and validate that you can now connect
- [x] Verify that the web scanner has the same SSLVersion field as an HTTP client exploit, etc.
