### PR TITLE
Fix #6643, Pcap.lookupaddrs does not exist

### DIFF
--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Auxiliary
       raise RuntimeError ,'Source MAC is not in correct format' unless is_mac?(@smac)
 
       @sip = datastore['LOCALSIP']
-      @sip ||= Pcap.lookupaddrs(@interface)[0] if @netifaces
+      @sip ||= get_ipv4_addr(@interface)[0] if @netifaces
       raise "LOCALSIP is not defined and can not be guessed" unless @sip
       raise "LOCALSIP is not an ipv4 address" unless Rex::Socket.is_ipv4?(@sip)
 


### PR DESCRIPTION
This fixes #6643 by using the proper way to see ip addresses on an interface these days.
# Verification steps
- [x] use auxiliary/spoof/arp/arp_poisoning
- [x] set SHOSTS, DHOSTS, LOCALSIP
- [x] run the module, verify no backtrace

OTOH, this module has been busted for at least 2 years. Maybe we should just delete it!
