### PR TITLE
pin rake version to 1.x line

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ group :development, :test do
   # Make rspec output shorter and more useful
   gem 'fivemat', '~> 1.3.1'
   # running documentation generation tasks and rspec tasks
-  gem 'rake', '>= 10.0.0'
+  gem 'rake', '~> 10.5'
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the
   # environment is development
   gem 'rspec-rails' , '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
       activesupport (= 4.1.15)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (11.0.1)
+    rake (10.5.0)
     rb-readline-r7 (0.5.2.0)
     recog (2.0.14)
       nokogiri
@@ -305,7 +305,7 @@ DEPENDENCIES
   metasploit-yard!
   metasploit_data_models!
   pry
-  rake (>= 10.0.0)
+  rake (~> 10.5)
   redcarpet
   rspec-rails (~> 3.3)
   shoulda-matchers


### PR DESCRIPTION
rake 11 remvoes the last_comment method which
causes a error when trying to run rake jobs
current guidance is to pin the version back to
before the change

MS-1230

VERIFICATION STEPS
- [x] `bundle install`
- [x] `rake spec`
- [x] VERIFY you don't get NoMethod error on 'last_comment'
- [x] VERIFY all specs pass
