### PR TITLE
Fix Nexpose import to truncate long vuln names

### DIFF
--- a/lib/rex/parser/nexpose_raw_nokogiri.rb
+++ b/lib/rex/parser/nexpose_raw_nokogiri.rb
@@ -193,6 +193,13 @@ module Rex
       vuln_instances = @report_data[:vuln][:matches].size
       db.emit(:vuln, [refs.last,vuln_instances], &block) if block
 
+      # TODO: potential remove the size limit on this field, might require
+      # some additional UX
+      if @report_data[:vuln]['title'].length > 255
+        db.emit :warning, 'Vulnerability name longer than 255 characters, truncating.', &block if block
+        @report_data[:vuln]['title'] = @report_data[:vuln]['title'][0..254]
+      end
+
       vuln_ids = @report_data[:vuln][:matches].map{ |v| v[0] }
       vdet_ids = @report_data[:vuln][:matches].map{ |v| v[1] }
 


### PR DESCRIPTION
A warning is emitted since there is a potential for data loss, but since
we reference vulns by their ID, the data-integrity risk is small.
Initially triggered by some Nexpose data, this should probably be
properly fixed by removing the length bound on the field.

MS-1184
# Verification
- [x] Obtain or modify a Nexpose XML report with a vulnerability tag that has a `title` attribute longer than 255 characters
- [x] `db_import` the report in msfconsole
- [x] You should see a warning
- [x] The import should complete
