### PR TITLE
Fix display issue when SESSION is -1

### DIFF
--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Post
     end
 
     if !paths.empty?
-      print_good("Found FileZilla Server on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
+      print_good("Found FileZilla Server on #{sysinfo['Computer']} via session ID: #{session.sid}")
       print_line
       return paths
     end


### PR DESCRIPTION
## Verification
- [ ] get a session on something with a filezilla server that stores its creds (we have one in the lab)
- [ ] `use post/windows/gather/credentials/filezilla_server`
- [ ] `set SESSION -1`
- [ ] `run`
- [ ] **VERIFY** shows the actual session number instead of "-1"
