### PR TITLE
Fix a stack trace with 'set PAYLOAD' in the global context

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -570,7 +570,7 @@ class Driver < Msf::Ui::Driver
 
         if (framework and framework.payloads.valid?(val) == false)
           return false
-        elsif active_module.type == 'exploit' && !active_module.is_payload_compatible?(val)
+        elsif active_module && active_module.type == 'exploit' && !active_module.is_payload_compatible?(val)
           return false
         elsif (active_module)
           active_module.datastore.clear_non_user_defined


### PR DESCRIPTION
The console driver's `on_variable_set` callback handles `PAYLOAD` incorrectly, leading to a stack trace. This PR fixes the stack trace, but it is still not possible to set a global `PAYLOAD` value.

To reproduce the bug:

```
msf> set PAYLOAD anything
```
