### PR TITLE
Move apache_karaf_command_execution to the SSH directory

### DIFF
--- a/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
+++ b/modules/auxiliary/scanner/ssh/apache_karaf_command_execution.rb
@@ -9,9 +9,6 @@ require 'net/ssh'
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
-  include Msf::Module::Deprecated
-
-  deprecated(Date.new(2016, 4, 14), 'auxiliary/scanner/ssh/apache_karaf_command_execution')
 
   def initialize(info={})
     super(update_info(info,


### PR DESCRIPTION
## What This Does

This PR moves the apache_karaf_command_execution module to the SSH directory, because it does not gather data.

Related to https://github.com/rapid7/metasploit-framework/pull/6564#issuecomment-196140191
## Verification
- [x] Start msfconsole
- [x] Do: `use auxiliary/gather/apache_karaf_command_execution`
- [x] You should see a deprecation message
- [x] Do: `auxiliary/scanner/ssh/apache_karaf_command_execution`
- [x] You should be able to load the module
