### PR TITLE
add some preuath fps for postgres 9.4

### DIFF
--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -292,6 +292,8 @@ module Exploit::Remote::Postgres
     when "Fauth.c:L302:Rauth_failed"          ; return {:preauth => "9.1.6"} # Bad password, good database
     when "Fpostinit.c:L718:RInitPostgres"     ; return {:preauth => "9.1.6"} # Good creds, non-existent but allowed database
     when "Fauth.c:L483:RClientAuthentication" ; return {:preauth => "9.1.6"} # Bad user
+    when "Fauth.c:L285:Rauth_failed"          ; return {:preauth => "9.4.1-5"} # Bad creds, good database
+    when "Fauth.c:L481:RClientAuthentication" ; return {:preauth => "9.4.1-5"} # bad user or host
 
     # Windows
 


### PR DESCRIPTION
the preauth fingerprinting for postgres is somewhat
unmaintainable, but due to a specific customer request
i have added these two FPs for 9.4.1-5

MS-1102
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/postgres/postgres_login`
- [x]  set username and password to something invalid
- [x]  set RHOST to target a postgres 9.4.1 - 9.4.5 server that youcan reach
- [x] `run`
- [ ] VERIFY it identifies the server as 9.4.1-5
