### PR TITLE
Update the msftidy warning for module class names

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -511,7 +511,7 @@ class Msftidy
 
   def check_bad_class_name
     if @source =~ /^\s*class (Metasploit\d+)\s*</
-      warn("Please use Metasploit as a class name (you used #{Regexp.last_match(1)})")
+      warn("Please use 'MetasploitModule' as the class name (you used #{Regexp.last_match(1)})")
     end
   end
 


### PR DESCRIPTION
This change updates the warning from msftidy that is generated when a module uses a class name such as `Metasploit4`. Prior to this, msftidy was suggesting the module name `Metasploit` be used.
## Verification
- [x] Pick a module and change the class name to `Metasploit4`
- [x] Run msftidy on the module you updated
- [x] See msftidy suggest that you use `MetasploitModule` instead of `Metasploit4`
