### PR TITLE
Remove dead version check in db_manager.rb

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -163,14 +163,4 @@ class Msf::DBManager
 
     true
   end
-
-  # Mainly, it's Ruby 1.9.1 that cause a lot of problems now, along with Ruby 1.8.6.
-  # Ruby 1.8.7 actually seems okay, but why tempt fate? Let's say 1.9.3 and beyond.
-  def warn_about_rubies
-    if ::RUBY_VERSION =~ /^1\.9\.[012]($|[^\d])/
-      $stderr.puts "**************************************************************************************"
-      $stderr.puts "Metasploit requires at least Ruby 1.9.3. For an easy upgrade path, see https://rvm.io/"
-      $stderr.puts "**************************************************************************************"
-    end
-  end
 end

--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -52,5 +52,4 @@ RSpec.describe Msf::DBManager do
   it { is_expected.to respond_to :error }
   it { is_expected.to respond_to :initialize_database_support }
   it { is_expected.to respond_to :service_name_map }
-  it { is_expected.to respond_to :warn_about_rubies }
 end


### PR DESCRIPTION
The check appears to have been orphaned in the db_manager refactor, but
I can't track down the exact commit.
## Verification
- [x] The specs should pass
- [x] `msfconsole` should start
