### PR TITLE
fix post/multi/manage/set_wallpaper

### DIFF
--- a/modules/post/multi/manage/set_wallpaper.rb
+++ b/modules/post/multi/manage/set_wallpaper.rb
@@ -73,6 +73,8 @@ class MetasploitModule < Msf::Post
   def os_set_wallpaper(file)
     if session.type =~ /meterpreter/ && session.sys.config.sysinfo['OS'] =~ /darwin/i
       platform = 'osx'
+    else
+      platform = session.platform
     end
     case platform
     when /osx/


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/pull/6598
The platform variable is currently nil if you're not targetting an OS X box.
## Verification
- [ ] Get an Android or Windows meterpreter session
- [ ] Run the `post/multi/manage/set_wallpaper` module

```
wget http://img.wonderhowto.com/img/58/65/63545252017877/0/hack-like-pro-metasploit-for-aspiring-hacker-part-3-payloads.1280x600.jpg -O wallpaper.jpeg
use post/multi/manage/set_wallpaper 
set SESSION 1
set WALLPAPER_FILE wallpaper.jpeg
run
```
- [ ] **Verify** the wallpaper is set.
