### PR TITLE
Fix meterpreter platform to include OS in the tuple for all meterpreters

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -50,6 +50,7 @@ class CommandShell
   def initialize(*args)
     self.platform ||= ""
     self.arch     ||= ""
+    self.max_threads = 1
     super
   end
 
@@ -235,6 +236,7 @@ class CommandShell
 
   attr_accessor :arch
   attr_accessor :platform
+  attr_accessor :max_threads
 
 protected
 

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -336,8 +336,10 @@ class Meterpreter < Rex::Post::Meterpreter::Client
         Msf::Module::Platform::OSX
       when /freebsd/i
         Msf::Module::Platform::FreeBSD
-      when /openbsd/i, /netbsd/i
-        Msf::Module::Platform::BSD
+      when /netbsd/i
+        Msf::Module::Platform::NetBSD
+      when /openbsd/i
+        Msf::Module::Platform::OpenBSD
       when /sunos/i
         Msf::Module::Platform::Solaris
       else

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -323,6 +323,20 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
 
+    self.platform = self.platform.split('/')[0] + '/' +
+      case self.sys.config.sysinfo['OS']
+      when /windows/i
+        Msf::Module::Platform::Windows
+      when /darwin/i
+        Msf::Module::Platform::OSX
+      when /freebsd/i
+        Msf::Module::Platform::FreeBSD
+      when /openbsd/i, /netbsd/i
+        Msf::Module::Platform::BSD
+      else
+        Msf::Module::Platform::Linux
+      end.realname.downcase
+
     safe_info = "#{username} @ #{sysinfo['Computer']}"
     safe_info.force_encoding("ASCII-8BIT") if safe_info.respond_to?(:force_encoding)
     # Should probably be using Rex::Text.ascii_safe_hex but leave

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -326,7 +326,9 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
 
-    self.platform = self.platform.split('/')[0] + '/' +
+    self.platform =
+      self.sys.config.sysinfo["Architecture"].downcase + '/' +
+      self.platform.split('/')[0] +'/' +
       case self.sys.config.sysinfo['OS']
       when /windows/i
         Msf::Module::Platform::Windows

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -338,9 +338,12 @@ class Meterpreter < Rex::Post::Meterpreter::Client
         Msf::Module::Platform::FreeBSD
       when /openbsd/i, /netbsd/i
         Msf::Module::Platform::BSD
+      when /sunos/i
+        Msf::Module::Platform::Solaris
       else
         Msf::Module::Platform::Linux
       end.realname.downcase
+
 
     safe_info = "#{username} @ #{sysinfo['Computer']}"
     safe_info.force_encoding("ASCII-8BIT") if safe_info.respond_to?(:force_encoding)

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -69,6 +69,9 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     # Don't pass the datastore into the init_meterpreter method
     opts.delete(:datastore)
 
+    # Assume by default that 10 threads is a safe number for this session
+    self.max_threads ||= 10
+
     #
     # Initialize the meterpreter client
     #
@@ -488,6 +491,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   attr_accessor :skip_ssl
   attr_accessor :skip_cleanup
   attr_accessor :target_id
+  attr_accessor :max_threads
 
 protected
 

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -409,6 +409,10 @@ class Msf::Module::Platform
       Rank = 700
       Alias = "10"
     end
+    class V11
+      Rank = 800
+      Alias = "11"
+    end
   end
 
   #

--- a/modules/post/multi/gather/ping_sweep.rb
+++ b/modules/post/multi/gather/ping_sweep.rb
@@ -40,21 +40,8 @@ class MetasploitModule < Msf::Post
         end
         iplst << ipa
       end
-      if session.type =~ /shell/
-        # Only one thread possible when shell
-        thread_num = 1
-        # Use the shell platform for selecting the command
-        platform = session.platform
-      else
-        # When in Meterpreter the safest thread number is 10
-        thread_num = 10
-        # For Meterpreter use the sysinfo OS since java Meterpreter returns java as platform
-        platform = session.sys.config.sysinfo['OS']
-      end
 
-      platform = session.platform
-
-      case platform
+      case session.platform
       when /win/i
         count = " -n 1 "
         cmd = "ping"
@@ -69,10 +56,10 @@ class MetasploitModule < Msf::Post
 
       while(not iplst.nil? and not iplst.empty?)
         a = []
-        1.upto(thread_num) do
+        1.upto session.max_threads do
           a << framework.threads.spawn("Module(#{self.refname})", false, iplst.shift) do |ip_add|
             next if ip_add.nil?
-            if platform =~ /solaris/i
+            if session.platform =~ /solaris/i
               r = cmd_exec(cmd, "-n #{ip_add} 1")
             else
               r = cmd_exec(cmd, count + ip_add)

--- a/modules/post/multi/gather/skype_enum.rb
+++ b/modules/post/multi/gather/skype_enum.rb
@@ -7,18 +7,11 @@ require 'msf/core'
 require 'rex'
 require 'csv'
 
-
-
-
-
 class MetasploitModule < Msf::Post
 
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
-
   include Msf::Post::OSX::System
-
-
 
   def initialize(info={})
     super( update_info( info,
@@ -52,9 +45,9 @@ class MetasploitModule < Msf::Post
       return
     end
 
-      if (session.platform =~ /java/) || (session.platform =~ /osx/)
-        # Make sure a Java Meterpreter on anything but OSX will exit
-        if session.platform =~ /java/ and sysinfo['OS'] !~ /Mac OS X/
+      if session.platform =~ /java/
+        # Make sure that Java Meterpreter on anything but OSX will exit
+        if session.platform !~ /osx/
           print_error("This session type and platform are not supported.")
           return
         end
@@ -105,7 +98,7 @@ class MetasploitModule < Msf::Post
   # Download file using Meterpreter functionality and returns path in loot for the file
   def download_db(profile)
     if session.type =~ /meterpreter/
-      if sysinfo['OS'] =~ /Mac OS X/
+      if session.platform =~ /osx/
         file = session.fs.file.search("#{profile['dir']}/Library/Application Support/Skype/","main.db",true)
       else
         file = session.fs.file.search("#{profile['AppData']}\\Skype","main.db",true)

--- a/modules/post/multi/gather/wlan_geolocate.rb
+++ b/modules/post/multi/gather/wlan_geolocate.rb
@@ -108,18 +108,8 @@ class MetasploitModule < Msf::Post
 
   # Run Method for when run command is issued
   def run
-    if session.type =~ /shell/
-      # Use the shell platform for selecting the command
-      platform = session.platform
-    else
-      # For Meterpreter use the sysinfo OS since java Meterpreter returns java as platform
-      platform = session.sys.config.sysinfo['OS']
-      platform = 'osx' if platform =~ /darwin/i
-    end
-
-    case platform
+    case session.platform
     when /win/i
-
       listing = cmd_exec('netsh wlan show networks mode=bssid')
       if listing.nil?
         print_error("Unable to generate wireless listing.")
@@ -136,7 +126,6 @@ class MetasploitModule < Msf::Post
       end
 
     when /osx/i
-
       listing = cmd_exec('/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -s')
       if listing.nil?
         print_error("Unable to generate wireless listing.")
@@ -152,7 +141,6 @@ class MetasploitModule < Msf::Post
       end
 
     when /linux/i
-
       listing = cmd_exec('iwlist scanning')
       if listing.nil?
         print_error("Unable to generate wireless listing.")
@@ -169,7 +157,6 @@ class MetasploitModule < Msf::Post
       end
 
     when /solaris/i
-
       listing = cmd_exec('dladm scan-wifi')
       if listing.blank?
         print_error("Unable to generate wireless listing.")
@@ -182,7 +169,6 @@ class MetasploitModule < Msf::Post
       end
 
     when /bsd/i
-
       interface = cmd_exec("dmesg | grep -i wlan | cut -d ':' -f1 | uniq")
       # Printing interface as this platform requires the interface to be specified
       # it might not be detected correctly.

--- a/modules/post/multi/manage/set_wallpaper.rb
+++ b/modules/post/multi/manage/set_wallpaper.rb
@@ -71,12 +71,7 @@ class MetasploitModule < Msf::Post
   end
 
   def os_set_wallpaper(file)
-    if session.type =~ /meterpreter/ && session.sys.config.sysinfo['OS'] =~ /darwin/i
-      platform = 'osx'
-    else
-      platform = session.platform
-    end
-    case platform
+    case session.platform
     when /osx/
       osx_set_wallpaper(file)
     when /win/

--- a/modules/post/osx/gather/enum_osx.rb
+++ b/modules/post/osx/gather/enum_osx.rb
@@ -53,7 +53,6 @@ class MetasploitModule < Msf::Post
 
   #parse the dslocal plist in lion
   def read_ds_xml_plist(plist_content)
-
     require "rexml/document"
 
     doc  = REXML::Document.new(plist_content)
@@ -132,11 +131,7 @@ class MetasploitModule < Msf::Post
     when /shell/
       osx_ver = cmd_exec("/usr/bin/sw_vers -productName").chomp
     end
-    if osx_ver =~/Server/
-      return true
-    else
-      return false
-    end
+    return osx_ver =~/Server/
   end
 
   # Enumerate the OS Version
@@ -148,13 +143,10 @@ class MetasploitModule < Msf::Post
     when /shell/
       osx_ver_num = cmd_exec('/usr/bin/sw_vers -productVersion').chomp
     end
-
     return osx_ver_num
   end
 
   def enum_conf(log_folder)
-
-    session_type = session.type
     profile_datatypes = {
       'OS' => 'SPSoftwareDataType',
       'Network' => 'SPNetworkDataType',
@@ -188,11 +180,11 @@ class MetasploitModule < Msf::Post
     profile_datatypes.each do |name, profile_datatypes|
       print_status("\tEnumerating #{name}")
       # Run commands according to the session type
-        if session_type =~ /meterpreter/
+        if session.type =~ /meterpreter/
           returned_data = cmd_exec('system_profiler', profile_datatypes)
           # Save data lo log folder
           file_local_write(log_folder+"//#{name}.txt",returned_data)
-        elsif session_type =~ /shell/
+        elsif session.type =~ /shell/
           begin
             returned_data = cmd_exec("/usr/sbin/system_profiler #{profile_datatypes}", 15)
             # Save data lo log folder
@@ -207,11 +199,11 @@ class MetasploitModule < Msf::Post
       print_status("\tEnumerating #{name}")
       # Run commands according to the session type
       begin
-        if session_type =~ /meterpreter/
+        if session.type =~ /meterpreter/
           command_output = cmd_exec(command[0],command[1])
           # Save data lo log folder
           file_local_write(log_folder+"//#{name}.txt",command_output)
-        elsif session_type =~ /shell/
+        elsif session.type =~ /shell/
           command_output = cmd_exec(command[0], command[1])
           # Save data lo log folder
           file_local_write(log_folder+"//#{name}.txt",command_output)
@@ -222,9 +214,7 @@ class MetasploitModule < Msf::Post
     end
   end
 
-
   def enum_accounts(log_folder,ver_num)
-
     # Specific commands for Leopard and Snow Leopard
     leopard_commands = {
       'Users' => ['/usr/bin/dscacheutil', '-q user'],
@@ -261,13 +251,11 @@ class MetasploitModule < Msf::Post
         file_local_write(log_folder + "//#{name}.txt", command_output)
       end
     end
-
   end
 
 
   # Method for getting SSH and GPG Keys
   def get_crypto_keys(log_folder)
-
     # Run commands according to the session type
     if session.type =~ /shell/
 
@@ -349,7 +337,6 @@ class MetasploitModule < Msf::Post
             end
           end
         end
-
       end
     end
   end
@@ -381,7 +368,6 @@ class MetasploitModule < Msf::Post
         end
       end
       print_status("Screenshot Captured")
-
     end
   end
 


### PR DESCRIPTION
This change updates the OS from sysinfo into the platform tuple, enabling multi-platform meterpreters to have the expected OS string inside of session.platform. This fixes modules that expect things like 'session.platform =~ /osx/` to work consistently. For instance, currently python meterpreter gets reported as 'python/python' for session platform, which breaks a few post modules that do not have meterpreter-specific code working around it.

This also pushes some notions around how many threads a session should be able to support at once. I'm on the fence about removing some of these threaded cases from modules entirely.

This is still a bit of a WiP since it also includes changes to modules. I also need to factor out the OS string match function so it's defined in a single place.
## Verification

List the steps needed to make sure this thing works
- [x] Verify that old modules trying to match platform to an OS work on multi-OS meterpreters
- [x] Verify that updated modules with workarounds continue to work as before.
- [x] Verify that OS-specific meterpreters continue to report platform as before
