### PR TITLE
Implement consistent socket abstraction

### DIFF
--- a/lib/rex/io/datagram_abstraction.rb
+++ b/lib/rex/io/datagram_abstraction.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 
-require 'socket'
+require 'rex/io/socket_abstraction'
 
 module Rex
 module IO
@@ -12,23 +12,13 @@ module IO
 #
 ###
 module DatagramAbstraction
-
+  include Rex::IO::SocketAbstraction
   #
   # Creates a streaming socket pair
   #
   def initialize_abstraction
-    self.lsock, self.rsock = Rex::Socket.udp_socket_pair()
+    self.lsock, self.rsock = Rex::Socket.udp_socket_pair
   end
-
-
-  # The left side of the stream (local)
-  attr_reader :lsock
-  # The right side of the stream (remote)
-  attr_reader :rsock
-
-protected
-  attr_writer :lsock
-  attr_writer :rsock
 
 end
 

--- a/lib/rex/io/socket_abstraction.rb
+++ b/lib/rex/io/socket_abstraction.rb
@@ -1,0 +1,205 @@
+# -*- coding: binary -*-
+
+require 'socket'
+require 'fcntl'
+
+module Rex
+module IO
+
+###
+#
+# This class provides an abstraction to a stream based
+# connection through the use of a streaming socketpair.
+#
+###
+module SocketAbstraction
+
+  ###
+  #
+  # Extension information for required Stream interface.
+  #
+  ###
+  module Ext
+
+    #
+    # Initializes peer information.
+    #
+    def initinfo(peer,local)
+      @peer = peer
+      @local = local
+    end
+
+    #
+    # Symbolic peer information.
+    #
+    def peerinfo
+      (@peer || "Remote Pipe")
+    end
+
+    #
+    # Symbolic local information.
+    #
+    def localinfo
+      (@local || "Local Pipe")
+    end
+  end
+
+  #
+  # Override this method to init the abstraction
+  #
+  def initialize_abstraction
+    self.lsock, self.rsock = Rex::Compat.pipe
+  end
+
+  #
+  # This method cleans up the abstraction layer.
+  #
+  def cleanup_abstraction
+    self.lsock.close if (self.lsock and !self.lsock.closed?)
+    self.rsock.close if (self.rsock and !self.rsock.closed?)
+
+    self.lsock = nil
+    self.rsock = nil
+  end
+
+  #
+  # Low-level write to the local side.
+  #
+  def syswrite(buffer)
+    lsock.syswrite(buffer)
+  end
+
+  #
+  # Low-level read from the local side.
+  #
+  def sysread(length)
+    lsock.sysread(length)
+  end
+
+  #
+  # Shuts down the local side of the stream abstraction.
+  #
+  def shutdown(how)
+    lsock.shutdown(how)
+  end
+
+  #
+  # Closes both sides of the stream abstraction.
+  #
+  def close
+    cleanup_abstraction
+    super
+  end
+
+  #
+  # Symbolic peer information.
+  #
+  def peerinfo
+    "Remote-side of Pipe"
+  end
+
+  #
+  # Symbolic local information.
+  #
+  def localinfo
+    "Local-side of Pipe"
+  end
+
+  #
+  # The left side of the stream.
+  #
+  attr_reader :lsock
+  #
+  # The right side of the stream.
+  #
+  attr_reader :rsock
+
+protected
+
+  def monitor_rsock(threadname = "SocketMonitorRemote")
+    self.monitor_thread = Rex::ThreadFactory.spawn(threadname, false) {
+      loop do
+        closed = false
+        buf    = nil
+
+        if not self.rsock
+          wlog("monitor_rsock: the remote socket is nil, exiting loop")
+          break
+        end
+
+        begin
+          s = Rex::ThreadSafe.select( [ self.rsock ], nil, nil, 0.2 )
+          if( s == nil || s[0] == nil )
+            next
+          end
+        rescue Exception => e
+          wlog("monitor_rsock: exception during select: #{e.class} #{e}")
+          closed = true
+        end
+
+        if( closed == false )
+          begin
+            buf = self.rsock.sysread( 32768 )
+            if buf == nil
+              closed = true
+              wlog("monitor_rsock: closed remote socket due to nil read")
+            end
+          rescue EOFError => e
+            closed = true
+            dlog("monitor_rsock: EOF in rsock")
+          rescue ::Exception => e
+            closed = true
+            wlog("monitor_rsock: exception during read: #{e.class} #{e}")
+          end
+        end
+
+        if( closed == false )
+          total_sent   = 0
+          total_length = buf.length
+          while( total_sent < total_length )
+            begin
+              data = buf[total_sent, buf.length]
+
+              # Note that this must be write() NOT syswrite() or put() or anything like it.
+              # Using syswrite() breaks SSL streams.
+              sent = self.write( data )
+
+              # sf: Only remove the data off the queue is write was successfull.
+              #     This way we naturally perform a resend if a failure occured.
+              #     Catches an edge case with meterpreter TCP channels where remote send
+              #     failes gracefully and a resend is required.
+              if (sent.nil?)
+                closed = true
+                wlog("monitor_rsock: failed writing, socket must be dead")
+                break
+              elsif (sent > 0)
+                total_sent += sent
+              end
+            rescue ::IOError, ::EOFError => e
+              closed = true
+              wlog("monitor_rsock: exception during write: #{e.class} #{e}")
+              break
+            end
+          end
+        end
+
+        if( closed )
+          begin
+            self.close_write if self.respond_to?('close_write')
+          rescue IOError
+          end
+          break
+        end
+      end
+    }
+  end
+
+protected
+  attr_accessor :monitor_thread
+  attr_writer :lsock
+  attr_writer :rsock
+
+end
+
+end; end
+

--- a/lib/rex/io/stream_abstraction.rb
+++ b/lib/rex/io/stream_abstraction.rb
@@ -1,7 +1,6 @@
 # -*- coding: binary -*-
 
-require 'socket'
-require 'fcntl'
+require 'rex/io/socket_abstraction'
 
 module Rex
 module IO
@@ -13,36 +12,7 @@ module IO
 #
 ###
 module StreamAbstraction
-
-  ###
-  #
-  # Extension information for required Stream interface.
-  #
-  ###
-  module Ext
-
-    #
-    # Initializes peer information.
-    #
-    def initinfo(peer,local)
-      @peer = peer
-      @local = local
-    end
-
-    #
-    # Symbolic peer information.
-    #
-    def peerinfo
-      (@peer || "Remote Pipe")
-    end
-
-    #
-    # Symbolic local information.
-    #
-    def localinfo
-      (@local || "Local Pipe")
-    end
-  end
+  include Rex::IO::SocketAbstraction
 
   #
   # This method creates a streaming socket pair and initializes it.
@@ -53,155 +23,8 @@ module StreamAbstraction
     self.lsock.extend(Ext)
     self.rsock.extend(Rex::IO::Stream)
 
-    self.monitor_rsock
+    self.monitor_rsock("StreamMonitorRemote")
   end
-
-  #
-  # This method cleans up the abstraction layer.
-  #
-  def cleanup_abstraction
-    self.lsock.close if (self.lsock)
-    self.rsock.close if (self.rsock)
-
-    self.lsock = nil
-    self.rsock = nil
-  end
-
-  #
-  # Low-level write to the local side.
-  #
-  def syswrite(buffer)
-    lsock.syswrite(buffer)
-  end
-
-  #
-  # Low-level read from the local side.
-  #
-  def sysread(length)
-    lsock.sysread(length)
-  end
-
-  #
-  # Shuts down the local side of the stream abstraction.
-  #
-  def shutdown(how)
-    lsock.shutdown(how)
-  end
-
-  #
-  # Closes both sides of the stream abstraction.
-  #
-  def close
-    cleanup_abstraction
-  end
-
-  #
-  # Symbolic peer information.
-  #
-  def peerinfo
-    "Remote-side of Pipe"
-  end
-
-  #
-  # Symbolic local information.
-  #
-  def localinfo
-    "Local-side of Pipe"
-  end
-
-  #
-  # The left side of the stream.
-  #
-  attr_reader :lsock
-  #
-  # The right side of the stream.
-  #
-  attr_reader :rsock
-
-protected
-
-  def monitor_rsock
-    self.monitor_thread = Rex::ThreadFactory.spawn("StreamMonitorRemote", false) {
-      loop do
-        closed = false
-        buf    = nil
-
-        if not self.rsock
-          wlog("monitor_rsock: the remote socket is nil, exiting loop")
-          break
-        end
-
-        begin
-          s = Rex::ThreadSafe.select( [ self.rsock ], nil, nil, 0.2 )
-          if( s == nil || s[0] == nil )
-            next
-          end
-        rescue Exception => e
-          wlog("monitor_rsock: exception during select: #{e.class} #{e}")
-          closed = true
-        end
-
-        if( closed == false )
-          begin
-            buf = self.rsock.sysread( 32768 )
-            if buf == nil
-              closed = true
-              wlog("monitor_rsock: closed remote socket due to nil read")
-            end
-          rescue EOFError => e
-            closed = true
-            dlog("monitor_rsock: EOF in rsock")
-          rescue ::Exception => e
-            closed = true
-            wlog("monitor_rsock: exception during read: #{e.class} #{e}")
-          end
-        end
-
-        if( closed == false )
-          total_sent   = 0
-          total_length = buf.length
-          while( total_sent < total_length )
-            begin
-              data = buf[total_sent, buf.length]
-
-              # Note that this must be write() NOT syswrite() or put() or anything like it.
-              # Using syswrite() breaks SSL streams.
-              sent = self.write( data )
-
-              # sf: Only remove the data off the queue is write was successfull.
-              #     This way we naturally perform a resend if a failure occured.
-              #     Catches an edge case with meterpreter TCP channels where remote send
-              #     failes gracefully and a resend is required.
-              if (sent.nil?)
-                closed = true
-                wlog("monitor_rsock: failed writing, socket must be dead")
-                break
-              elsif (sent > 0)
-                total_sent += sent
-              end
-            rescue ::IOError, ::EOFError => e
-              closed = true
-              wlog("monitor_rsock: exception during write: #{e.class} #{e}")
-              break
-            end
-          end
-        end
-
-        if( closed )
-          begin
-            self.close_write if self.respond_to?('close_write')
-          rescue IOError
-          end
-          break
-        end
-      end
-    }
-  end
-
-protected
-  attr_accessor :monitor_thread
-  attr_writer :lsock
-  attr_writer :rsock
 
 end
 

--- a/lib/rex/post/meterpreter/channels/datagram.rb
+++ b/lib/rex/post/meterpreter/channels/datagram.rb
@@ -1,0 +1,75 @@
+# -*- coding: binary -*-
+
+require 'rex/io/datagram_abstraction'
+require 'rex/post/meterpreter/channels/socket_abstraction'
+
+module Rex
+module Post
+module Meterpreter
+
+###
+#
+# Stream
+# ------
+#
+# This class represents a channel that is streaming.  This means
+# that sequential data is flowing in either one or both directions.
+#
+###
+class Datagram < Rex::Post::Meterpreter::Channel
+
+  include Rex::Post::Meterpreter::SocketAbstraction
+  include Rex::IO::DatagramAbstraction
+
+  class << self
+    def cls
+      return CHANNEL_CLASS_DATAGRAM
+    end
+  end
+
+  module SocketInterface
+    include Rex::Post::Meterpreter::SocketAbstraction::SocketInterface
+    def type?
+      'udp'
+    end
+
+    def recvfrom_nonblock(length,flags = nil)
+      return [super(length, flags)[0], super(length, flags)[0]]
+    end
+
+    def send( buf, flags, saddr )
+      channel.send( buf, flags, saddr)
+    end
+  end
+
+  def dio_write_handler( packet, data )
+    @recvd ||= []
+    @recvd << [packet, data]
+    peerhost = packet.get_tlv_value(
+      Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_PEER_HOST
+    )
+    peerport = packet.get_tlv_value(
+      Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_PEER_PORT
+    )
+
+    if( peerhost and peerport )
+      # Maxlen here is 65507, to ensure we dont overflow, we need to write twice
+      # If the other side has a full 64k, handle by splitting up the datagram and
+      # writing multiple times along with the sockaddr. Consumers calling recvfrom
+      # repeatedly will buffer up all the pieces.
+      while data.length > 65507
+        rsock.syswrite(data[0..65506])
+        rsock.syswrite(Rex::Socket.to_sockaddr(peerhost,peerport))
+        data = data - data[0..65506]
+      end
+      rsock.syswrite(data)
+      rsock.syswrite(Rex::Socket.to_sockaddr(peerhost,peerport))
+      return true
+    else
+      return false
+    end
+  end
+
+end
+
+end; end; end

--- a/lib/rex/post/meterpreter/channels/socket_abstraction.rb
+++ b/lib/rex/post/meterpreter/channels/socket_abstraction.rb
@@ -1,0 +1,161 @@
+# -*- coding: binary -*-
+
+# require 'rex/io/socket_abstraction'
+require 'rex/post/meterpreter/channel'
+
+module Rex
+module Post
+module Meterpreter
+
+###
+#
+# Abstraction
+# ------
+#
+# This class represents a channel that is streaming.  This means
+# that sequential data is flowing in either one or both directions.
+#
+###
+module SocketAbstraction
+
+  # include Rex::IO::SocketAbstraction
+  
+  class << self
+    def cls
+      raise NotImplementedError
+    end
+  end
+
+  module SocketInterface
+    def type?
+      raise NotImplementedError
+    end
+
+    def getsockname
+      return super if not channel
+      # Find the first host in our chain (our address)
+      hops = 0
+      csock = channel.client.sock
+      while(csock.respond_to?('channel'))
+        csock = csock.channel.client.sock
+        hops += 1
+      end
+      tmp,caddr,cport = csock.getsockname
+      tmp,raddr,rport = csock.getpeername
+      maddr,mport = [ channel.params.localhost, channel.params.localport ]
+      [ tmp, "#{caddr}#{(hops > 0) ? "-_#{hops}_" : ""}-#{raddr}", "#{mport}" ]
+    end
+
+    def getpeername
+      return super if not channel
+      tmp,caddr,cport = channel.client.sock.getpeername
+      maddr,mport = [ channel.params.peerhost, channel.params.peerport ]
+      [ tmp, "#{maddr}", "#{mport}" ]
+    end
+
+    %w{localhost localport peerhost peerport}.map do |meth|
+      define_method(meth.to_sym) {
+        return super if not channel
+        channel.params.send(meth.to_sym)
+      }
+    end
+
+    def close
+      super
+      channel.cleanup_abstraction
+      channel.close
+    end
+
+    attr_accessor :channel
+  end
+
+  #
+  # Simple mixin for lsock in order to help avoid a ruby interpreter issue with ::Socket.pair
+  # Instead of writing to the lsock, reading from the rsock and then writing to the channel,
+  # we use this mixin to directly write to the channel.
+  #
+  # Note: This does not work with OpenSSL as OpenSSL is implemented natively and requires a real
+  # socket to write to and we cant intercept the sockets syswrite at a native level.
+  #
+  # Note: The deadlock only seems to effect the Ruby build for cygwin.
+  #
+  module DirectChannelWrite
+
+    def syswrite( buf )
+      channel._write( buf )
+    end
+
+    attr_accessor :channel
+  end
+  ##
+  #
+  # Constructor
+  #
+  ##
+
+  #
+  # Passes the initialization information up to the base class
+  #
+  def initialize(client, cid, type, flags)
+    # sf: initialize_abstraction() before super() as we can get a scenario where dio_write_handler() is called
+    # with data to write to the rsock but rsock has not yet been initialized. This happens if the channel
+    # is registered (client.add_channel(self) in Channel.initialize) to a session and a 'core_channel_write'
+    # request comes in before we have called self.initialize_abstraction()
+    initialize_abstraction
+    super(client, cid, type, flags)
+  end
+
+  ##
+  #
+  # Remote I/O handlers
+  #
+  ##
+
+  #
+  # Performs a write operation on the right side of the local stream.
+  #
+  def dio_write_handler(packet, data)
+    rv = Rex::ThreadSafe.select(nil, [rsock], nil, 0.01)
+    if(rv)
+      rsock.syswrite(data)
+      return true
+    else
+      return false
+    end
+  end
+
+  #
+  # Performs a close operation on the right side of the local stream.
+  #
+  def dio_close_handler(packet)
+    rsock.close
+
+    return super(packet)
+  end
+
+  #
+  # Cleans up the stream abstraction.
+  #
+  def cleanup
+    super
+
+    cleanup_abstraction
+  end
+
+  #
+  # Wrap the _write() call in order to catch some common, but harmless Windows exceptions
+  #
+  def _write(*args)
+    begin
+      super(*args)
+    rescue ::Rex::Post::Meterpreter::RequestError => e
+      case e.code
+      when 10000 .. 10100
+        raise ::Rex::ConnectionError.new
+      end
+    end
+  end
+
+end
+
+end; end; end

--- a/lib/rex/post/meterpreter/channels/stream.rb
+++ b/lib/rex/post/meterpreter/channels/stream.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex/io/stream_abstraction'
-require 'rex/post/meterpreter/channel'
+require 'rex/post/meterpreter/channels/socket_abstraction'
 
 module Rex
 module Post
@@ -18,6 +18,7 @@ module Meterpreter
 ###
 class Stream < Rex::Post::Meterpreter::Channel
 
+  include Rex::Post::Meterpreter::SocketAbstraction
   include Rex::IO::StreamAbstraction
 
   class << self
@@ -26,59 +27,11 @@ class Stream < Rex::Post::Meterpreter::Channel
     end
   end
 
-  ##
-  #
-  # Constructor
-  #
-  ##
-
-  #
-  # Passes the initialization information up to the base class
-  #
-  def initialize(client, cid, type, flags)
-    # sf: initialize_abstraction() before super() as we can get a scenario where dio_write_handler() is called
-    # with data to write to the rsock but rsock has not yet been initialized. This happens if the channel
-    # is registered (client.add_channel(self) in Channel.initialize) to a session and a 'core_channel_write'
-    # request comes in before we have called self.initialize_abstraction()
-    initialize_abstraction
-    super(client, cid, type, flags)
-  end
-
-  ##
-  #
-  # Remote I/O handlers
-  #
-  ##
-
-  #
-  # Performs a write operation on the right side of the local stream.
-  #
-  def dio_write_handler(packet, data)
-    rv = Rex::ThreadSafe.select(nil, [rsock], nil, 0.01)
-    if(rv)
-      rsock.write(data)
-      return true
-    else
-      return false
+  module SocketInterface
+    include Rex::Post::Meterpreter::SocketAbstraction::SocketInterface
+    def type?
+      'tcp'
     end
-  end
-
-  #
-  # Performs a close operation on the right side of the local stream.
-  #
-  def dio_close_handler(packet)
-    rsock.close
-
-    return super(packet)
-  end
-
-  #
-  # Cleans up the stream abstraction.
-  #
-  def cleanup
-    super
-
-    cleanup_abstraction
   end
 
 end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket.rb
@@ -118,7 +118,11 @@ class Socket
   #
   def create_udp_channel(params)
     begin
-      return SocketSubsystem::UdpChannel.open(client, params)
+      channel = SocketSubsystem::UdpChannel.open(client, params)
+      if( channel != nil )
+        return channel.lsock
+      end
+      return nil
     rescue ::Rex::Post::Meterpreter::RequestError => e
       case e.code
         when 10000 .. 10100

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
@@ -5,6 +5,7 @@ require 'rex/socket/udp'
 require 'rex/socket/parameters'
 require 'rex/post/meterpreter/extensions/stdapi/tlv'
 require 'rex/post/meterpreter/channel'
+require 'rex/post/meterpreter/channels/datagram'
 
 module Rex
 module Post
@@ -14,12 +15,7 @@ module Stdapi
 module Net
 module SocketSubsystem
 
-class UdpChannel < Rex::Post::Meterpreter::Channel
-
-  #
-  # We inclue Rex::Socket::Udp as this channel is effectivly a UDP socket.
-  #
-  include Rex::Socket::Udp
+class UdpChannel < Rex::Post::Meterpreter::Datagram
 
   #
   # We are a datagram channel.
@@ -64,89 +60,19 @@ class UdpChannel < Rex::Post::Meterpreter::Channel
   #
   # Simply initialize this instance.
   #
-  def initialize(client, cid, type, flags)
-    super(client, cid, type, flags)
-    # the instance variable that holds all incoming datagrams.
-    @datagrams = []
-  end
+  def initialize( client, cid, type, flags )
+    super( client, cid, type, flags )
 
-  #
-  # We overwrite Rex::Socket::Udp.timed_read in order to avoid the call to Kernel.select
-  # which wont be of use as we are not a natively backed ::Socket or ::IO instance.
-  #
-  def timed_read( length=65535, timeout=def_read_timeout )
-    result = ''
+    lsock.extend( Rex::Socket::Udp )
+    lsock.initsock
+    lsock.extend( SocketInterface )
+    lsock.extend( DirectChannelWrite )
+    lsock.channel = self
 
-    begin
-      Timeout.timeout( timeout ) {
-        while( true )
-          if( @datagrams.empty? )
-            Rex::ThreadSafe.sleep( 0.2 )
-            next
-          end
-          result = self.read( length )
-          break
-        end
-      }
-    rescue Timeout::Error
-      result = ''
-    end
+    # rsock.extend( Rex::Socket::Udp )
+    rsock.extend( SocketInterface )
+    rsock.channel = self
 
-    return result
-  end
-
-  #
-  # We overwrite Rex::Socket::Udp.recvfrom in order to correctly hand out the
-  # datagrams which the remote end of this channel has received and are in the
-  # queue.
-  #
-  def recvfrom( length=65535, timeout=def_read_timeout )
-    result = nil
-    # force a timeout on the wait for an incoming datagram
-    begin
-      Timeout.timeout( timeout ) {
-        while( true )
-          # wait untill we have at least one datagram in the queue
-          if( @datagrams.empty? )
-            Rex::ThreadSafe.sleep( 0.2 )
-            next
-          end
-          # grab the oldest datagram we have received...
-          result = @datagrams.shift
-          # break as we have a result...
-          break
-        end
-      }
-    rescue Timeout::Error
-      result = nil
-    end
-    # if no result return nothing
-    if( result == nil )
-      return [ '', nil, nil ]
-    end
-    # get the data from this datagram
-    data = result[0]
-    # if its only a partial read of this datagram, slice it, loosing the remainder.
-    result[0] = data[0,length-1] if data.length > length
-    # return the result in the form [ data, host, port ]
-    return result
-  end
-
-  #
-  # Overwrite the low level sysread to read data off our datagram queue. Calls
-  # to read() will end up calling this.
-  #
-  def sysread( length )
-    result = self.recvfrom( length )
-    return result[0]
-  end
-
-  #
-  # Overwrite the low level syswrite to write data to the remote end of the channel.
-  # Calls to write() will end up calling this.
-  #
-  def syswrite( buf )
-    return _write( buf )
   end
 
   #
@@ -169,39 +95,6 @@ class UdpChannel < Rex::Post::Meterpreter::Channel
 
     return _write( buf, buf.length, addends )
   end
-
-  #
-  # The channels direct io write handler for any incoming data from the remote end
-  # of the channel. We extract the data and peer host/port, and save this to a queue
-  # of incoming datagrams which are passed out via calls to self.recvfrom()
-  #
-  def dio_write_handler( packet, data )
-
-    peerhost = packet.get_tlv_value( TLV_TYPE_PEER_HOST )
-    peerport = packet.get_tlv_value( TLV_TYPE_PEER_PORT )
-
-    if( peerhost and peerport )
-      @datagrams << [ data, peerhost, peerport ]
-      return true
-    end
-
-    return false
-  end
-
-  #
-  # Wrap the _write() call in order to catch some common, but harmless Windows exceptions
-  #
-  def _write(*args)
-    begin
-      super(*args)
-    rescue ::Rex::Post::Meterpreter::RequestError => e
-      case e.code
-      when 10000 .. 10100
-        raise ::Rex::ConnectionError.new
-      end
-    end
-  end
-
 
 end
 


### PR DESCRIPTION
Background:

In current nomenclature, Rex Sockets are objects created by calls
to Rex::Socket::[Transport].create and Rex::Socket.create_...
When the LocalHost or Comm parameters are set to remotely routed
addresses (currently via Meterpreter sessions), Rex will create a
Channel which will abstract communications with the remote end of
the session. These channel based abstractions are called pivots,
and present in three separate flavors:
1 - TcpClientChannel, a fully abstracted, selectable Socket.
2 - TcpServerChannel, a virtual Channel which distributes client
channels.
3 - UdpChannel, a virtual Channel which provides common methods for
UDP socket operations, but is not a full (selectable) abstraction.

Unfortunately this differentiation results in inconsistent returns
from the aforementioned socket creation calls, as the call chain
creates parameters and supplies them to the create method on the
comm object referenced in the params. The comm object may be a
channel, and produce a virtual representation of a socket with
functional methods analogous to Sockets, but without a kernel FD.

This commit begins the work of ensuring that all calls for socket
creation return selectable Rex::Socket objects with semantics
familiar to Ruby developers who have not read into the details of
Rex::Socket and Rex::Post.

---

Summary of changes:

Convert Rex::IO::StreamAbstraction to SocketAbstraction and use
the new mixin in StreamAbstraction and DatagramAbstraction. This
approach allows for common methods to reuse the abstraction data
flow, while initializing separate types of socket obects and an
optional monitor as needed.

In the Rex::Post::Meterpreter namespace, extract common methods
from Stream to a SocketAbstraction mixin, include that mixin in
Stream, and add Datagram with the dio_write handler override
exported from the current implementation of UdpChannel, also using
the mixin. This relies on the Rex::IO work above to implement the
proper type of socket abstraction to the Channel descendants.

In Rex::Post::Meterpreter::Extensions::Stdapi::Net, convert the
UdpChannel to inherit from the Rex::Post::Meterpreter::Datagram
class, implementing only the send method at this tier. Convert
create_udp_channel to return the local socket side of the datagram
abstraction presented analogous to the TcpClientChannel approach
used before.

---

Notes and intricacies:

In order to implement recvfrom on the UDP abstraction, a shim layer
has been put in place to forward the sockaddr information from the
remote peer to the local UDP socketpair in the abstraction. This
information takes up buffer space in the UDP socket, and in order
to maintain compatibility with consumers, the dio_write_handler
pushes the data buffer, and in a separate send call, he sockaddr
information from the remote socket. On the abstraction side, the
recvfrom_nonblock call of the real UDPSocket has been overriden
via the mixed in module to call the real method twice, once for
the data buffer, and once for the packed sockaddr data. The Rex
level consumer for recvfrom calls the underlying nonblock method
and expects this exact set of returns (as opposed to what standard
library UDPSocket.recvfrom returns, which is a data buffer and an
Array of sockaddr data).

---

Testing:
  Local and lab testing only so far.
  Test RC script to be added in GH comments.

---

Issues:
  RESOLVED - Currently, sendto on a remote socket does not appear
to honor LocalPort which causes DNS responses (#6611) to come
from the wrong port to remote clients being serviced over a pivot socket.
