### PR TITLE
Add aux module to gather browser information.

### DIFF
--- a/modules/auxiliary/gather/browser_info.rb
+++ b/modules/auxiliary/gather/browser_info.rb
@@ -64,8 +64,8 @@ class MetasploitModule < Msf::Auxiliary
   def print_target_info(cli, target_info)
     print_status("#{cli.peerhost} - We have found the following interesting information:")
     report_host_info(target_info)
+    ignore_items!(target_info)
     target_info.each_pair do |key, value|
-      ignore_items!(target_info)
       if key == :source
         value = translate_script_meaning(value)
       end

--- a/modules/auxiliary/gather/browser_info.rb
+++ b/modules/auxiliary/gather/browser_info.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "HTTP Client Information Gather",
+      'Description'    => %q{
+        This module gathers information about a browser that exploits might be interested in, such
+        as OS name, browser version, plugins, etc. By default, the module will return a fake 404,
+        but you can customize this output by changing the Custom404 datastore option, and
+        redirect to an external web page.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'sinn3r' ],
+      'DisclosureDate' => "Mar 22 2016",
+      'Actions'     =>
+        [
+          [
+            'WebServer', {
+              'Description' => 'A web that collects information about the browser.'
+          }]
+        ],
+      'PassiveActions' => [ 'WebServer' ],
+      'DefaultAction'  => 'WebServer'
+    ))
+  end
+
+  def is_key_wanted?(key)
+    ![:module, :created_at, :tried, :vuln_test, :address].include?(key)
+  end
+
+  def is_value_wanted?(value)
+    !(value.nil? || value =~ /^undefined|false/ || !value)
+  end
+
+  def ignore_items!(target_info)
+    target_info.delete_if do |key, value|
+      !is_key_wanted?(key) || !is_value_wanted?(value)
+    end
+  end
+
+  def report_host_info(target_info)
+    opts = { host: target_info[:address] }
+    opts.merge!(target_info)
+    report_host(opts)
+  end
+
+  def translate_script_meaning(value)
+    case value
+    when 'script'
+      'Browser allows JavaScript'
+    when 'headers'
+      'Browser does not allow JavaScript'
+    end
+  end
+
+  def print_target_info(cli, target_info)
+    print_status("#{cli.peerhost} - We have found the following interesting information:")
+    report_host_info(target_info)
+    target_info.each_pair do |key, value|
+      ignore_items!(target_info)
+      if key == :source
+        value = translate_script_meaning(value)
+      end
+      print_status("#{cli.peerhost} - #{key} = #{value}")
+    end
+  end
+
+  def on_request_exploit(cli, req, target_info)
+    print_target_info(cli, target_info)
+    send_not_found(cli)
+  end
+
+  def run
+    exploit
+  end
+
+end


### PR DESCRIPTION
## What This Module Does

This module relies on the BrowserExploitServer mixin to gather browser information.

I created this module because during an internal training, I wanted to demonstrate information gathering via a web server, but nothing was available at the time from Metasploit. The BES mixin is used to gather info because it detects what we could actually exploit with Metasploit.
## Verification Steps
- [x] Start msfconsole
- [x] Do: `auxiliary/gather/browser_info`
- [x] Do: `run`. The module will give you an URL you should go to.
- [x] Open a browser, and go to the URL.
- [x] The module should collect some information about the target (browser, OS, maybe interesting plugins, etc)
