### PR TITLE
Fix datastore stickiness and validations

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -76,7 +76,7 @@ class DataStore < Hash
   def import_options(options, imported_by = nil, overwrite = false)
     options.each_option do |name, opt|
       # Skip options without a default or if is already a value defined
-      if !opt.default.nil? && (!self.has_key?(name) || overwrite)
+      if !opt.default.nil? && (self[name].nil? || overwrite)
         import_option(name, opt.default, true, imported_by, opt)
       end
     end

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -75,8 +75,7 @@ class DataStore < Hash
   #
   def import_options(options, imported_by = nil, overwrite = false)
     options.each_option do |name, opt|
-      # Skip options without a default or if is already a value defined
-      if !opt.default.nil? && (self[name].nil? || overwrite)
+      if self[name].nil? || overwrite
         import_option(name, opt.default, true, imported_by, opt)
       end
     end

--- a/lib/msf/core/opt_port.rb
+++ b/lib/msf/core/opt_port.rb
@@ -7,24 +7,13 @@ module Msf
 # Network port option.
 #
 ###
-class OptPort < OptBase
+class OptPort < OptInt
   def type
     return 'port'
   end
 
-  def normalize(value)
-    value.to_i
-  end
-
   def valid?(value)
-    return false if empty_required_value?(value)
-
-    if ((value != nil and value.to_s.empty? == false) and
-        ((value.to_s.match(/^\d+$/) == nil or value.to_i < 0 or value.to_i > 65535)))
-      return false
-    end
-
-    return super
+    super && normalize(value) <= 65535 && normalize(value) > 0
   end
 end
 

--- a/lib/msf/core/opt_port.rb
+++ b/lib/msf/core/opt_port.rb
@@ -13,7 +13,11 @@ class OptPort < OptInt
   end
 
   def valid?(value)
-    super && normalize(value) <= 65535 && normalize(value) > 0
+    if !required? and value.to_s.empty?
+      super
+    else
+      super && normalize(value) <= 65535 && normalize(value) >= 0
+    end
   end
 end
 


### PR DESCRIPTION
The first commit restores the old behavior of the datastore when setting options. The second magically extends validation on assignment to options without a default. The third changes `OptPort` to be a variation of `OptInt`.
# Verification
- [x] Run `./msfconsole -qx 'set lport 1234; use exploit/multi/handler; set lport 443; set payload windows/meterpreter/reverse_tcp; set lport 4433; show options'`
- [x] Verify that `LPORT` is set to `4433`
- [x] Exit msfconsole
- [x] Run `./msfconsole -qx 'set lport doge; use auxiliary/admin/backupexec/dump; set lport wow'`
- [x] Verify that msfconsole complains at you and leaves the value at `doge`
- [x] `set lport 10000`
- [x] `show options`
- [x] Verify that `LPORT` is set to `10000`
