### PR TITLE
Make ms09_065_eot_integer passive

### DIFF
--- a/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
+++ b/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
@@ -28,6 +28,9 @@ class MetasploitModule < Msf::Auxiliary
           [ 'MSB', 'MS09-065' ],
           [ 'OSVDB', '59869']
         ],
+      'Actions'        => [[ 'WebServer' ]],
+      'PassiveActions' => [ 'WebServer' ],
+      'DefaultAction'  => 'WebServer',
       'DisclosureDate' => 'Nov 10 2009'
     ))
     register_options([


### PR DESCRIPTION
MS-932
## What This Patch Does

This patch makes ms09_065_eot_integer passive, otherwise it cannot be run from Pro.
## Verification Steps
- [x] Start msfconsole
- [x] Go to `irb`
- [x] In irb, do this:

``` ruby
framework.modules.create('auxiliary/dos/windows/browser/ms09_065_eot_integer').passive?
```
- [x] You should see that it returns true
