### PR TITLE
Move android_stock_browser_iframe_dos_cve_2012_6301 and make it passive

### DIFF
--- a/modules/auxiliary/dos/android/android_stock_browser_iframe.rb
+++ b/modules/auxiliary/dos/android/android_stock_browser_iframe.rb
@@ -7,9 +7,6 @@ require 'msf/core'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpServer
-  include Msf::Module::Deprecated
-
-  deprecated(Date.new(2016, 4, 23), 'auxiliary/dos/android/android_stock_browser_iframe')
 
   def initialize(info = {})
     super(
@@ -31,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DisclosureDate' => "Dec 1 2012",
         'Actions'        => [[ 'WebServer' ]],
-        'PassiveActions' => [[ 'WebServer' ]],
+        'PassiveActions' => [ 'WebServer' ],
         'DefaultAction'  => 'WebServer'
       )
     )


### PR DESCRIPTION
## What This PR Does

This PR actually addresses two things:
1. It moves the module. dos/http is for http servers, not browsers.
2. It should be passive, but the PassiveActions syntax is wrong, so it's not being treated as passive.
## Verification
- [x] Start msfconsole
- [x] Do: `use auxiliary/dos/http/android_stock_browser_iframe_dos_cve_2012_6301`
- [x] You should see a deprecation message
- [x] Do: `use auxiliary/dos/android/android_stock_browser_iframe`
- [x] The auxiliary/dos/android/android_stock_browser_iframe module should be loaded
- [x] In the msf prompt, go to irb
- [x] In irb, do: `framework.modules.create('auxiliary/dos/android/android_stock_browser_iframe').passive?`
- [x] It should return true
