### PR TITLE
Print response fix for HTTP NTLM

### DIFF
--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -310,7 +310,7 @@ class MetasploitModule < Msf::Auxiliary
       else
         print_status("Auth successful, saving server response in database")
       end
-      vprint_status(resp)
+      vprint_status(resp.to_s)
     end
     return [resp, ser_sock]
   end


### PR DESCRIPTION
This fixes a bug when trying the print the HTTP response at HTTP NTLM relaying. More details can be found here: 

https://github.com/rapid7/metasploit-framework/issues/6682
