### PR TITLE
Add a rescue to catch method missing for stage_payload

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -331,29 +331,34 @@ protected
 
         resp['Content-Type'] = 'application/octet-stream'
 
-        # generate the stage, but pass in the existing UUID and connection id so that
-        # we don't get new ones generated.
-        blob = obj.stage_payload(
-          uuid: uuid,
-          uri:  conn_id,
-          lhost: uri.host,
-          lport: uri.port
-        )
+        begin
+          # generate the stage, but pass in the existing UUID and connection id so that
+          # we don't get new ones generated.
+          blob = obj.stage_payload(
+            uuid: uuid,
+            uri:  conn_id,
+            lhost: uri.host,
+            lport: uri.port
+          )
 
-        resp.body = encode_stage(blob)
+          resp.body = encode_stage(blob)
 
-        # Short-circuit the payload's handle_connection processing for create_session
-        create_session(cli, {
-          :passive_dispatcher => obj.service,
-          :conn_id            => conn_id,
-          :url                => url,
-          :expiration         => datastore['SessionExpirationTimeout'].to_i,
-          :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
-          :retry_total        => datastore['SessionRetryTotal'].to_i,
-          :retry_wait         => datastore['SessionRetryWait'].to_i,
-          :ssl                => ssl?,
-          :payload_uuid       => uuid
-        })
+          # Short-circuit the payload's handle_connection processing for create_session
+          create_session(cli, {
+            :passive_dispatcher => obj.service,
+            :conn_id            => conn_id,
+            :url                => url,
+            :expiration         => datastore['SessionExpirationTimeout'].to_i,
+            :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
+            :retry_total        => datastore['SessionRetryTotal'].to_i,
+            :retry_wait         => datastore['SessionRetryWait'].to_i,
+            :ssl                => ssl?,
+            :payload_uuid       => uuid
+          })
+        rescue NoMethodError
+          print_error("Staging failed. This can occur when stageless listeners are used with staged payloads.")
+          return
+        end
 
       when :connect
         print_status("#{cli.peerhost}:#{cli.peerport} (UUID: #{uuid.to_s}) Attaching orphaned/stageless session ...")


### PR DESCRIPTION
Handlers are still not universal, and hence are still in some ways tied to a payload type. In the case of stageless vs staged `reverse_http/s` we have a bit of a unique scenario.

The staged listener (ie. one that has a payload set to `meterepreter/reverse_https`) is able to not only handle staged connections, but stageless connections too. This is rather useful as it means that we can have a single listener for staged and stageless payloads so long as they are the same architecture.

For the most part, the equivalent of a stageless handler (one that had a payload set to `meterpreter_reverse_https`) will work as well, except for one key aspect: staging!

If a stageless listener is used and a staged payload fires, then this nastiness ensues:

```
[*] 10.1.10.34:49491 (UUID: 4dd2d69127ae75e6/x86=1/windows=1/2016-03-28T22:43:06Z) Staging Native payload ...
[-] Exception handling request: undefined method `stage_payload' for #<#<Class:0x0000000394bd00>:0x00000008dfcf70>
```

This isn't exactly intuitive and makes us look a little unprofessional. This PR includes a small change to cover this one case, so that we can at least inform the user of the issue. While we can't assume we know how to stage the payload thanks to the lack of configuration, we can at least give them an idea of what's going on:

```
[*] 10.1.10.34:49575 (UUID: 4dd2d69127ae75e6/x86=1/windows=1/2016-03-28T22:43:06Z) Staging Native payload ...
[-] Staging failed. This can occur when stageless listeners are used with staged payloads.
```
## Verification
- [x] Start `msfconsole`
- [x] Set up a stageless handler (payload set to `windows/meterpreter_reverse_https`)
- [x] Create a staged payload with `windows/meterpreter/reverse_https` that points to the stageless handler.
- [x] Run the payload on any windows machine.
- [x] **Verify** the message that appears is a little more sensible and helpful compared to before.
