### PR TITLE
Add new cmd mainframe payload (generic_jcl) for z/OS

### DIFF
--- a/modules/payloads/singles/cmd/mainframe/generic_jcl.rb
+++ b/modules/payloads/singles/cmd/mainframe/generic_jcl.rb
@@ -1,0 +1,64 @@
+##
+# This is a prototype JCL command payload for z/OS - mainframe.
+#   It submits the IEFBR14 standard z/OS program, which does nothing
+#   but complete successfully and return code 0.
+#
+#   See http://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.ieab500/hpropr.htm?lang=en
+#   for more information on IEFBR14
+##
+
+
+require 'msf/core'
+require 'msf/core/handler/find_shell'
+require 'msf/base/sessions/mainframe_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Payload::Mainframe
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+         'Name'          => 'Generic JCL Test for Mainframe Exploits',
+         'Description'   => 'Provide JCL which can be used to submit
+              a job to JES2 on z/OS which will exit and return 0.  This
+              can be used as a template for other JCL based payloads',
+          'Author'        => 'Bigendian Smalls',
+          'License'       => MSF_LICENSE,
+          'Platform'      => 'mainframe',
+          'Arch'          => ARCH_CMD,
+          'Handler'       => Msf::Handler::None,
+          'Session'       => Msf::Sessions::MainframeShell,
+          'PayloadType'   => 'cmd',
+          'RequiredCmd'   => 'jcl',
+          'Payload'       =>
+            {
+              'Offsets' => { },
+              'Payload' => ''
+            }
+  ))
+  end
+
+  ##
+  # Construct the paload
+  ##
+  def generate
+    return super + command_string
+  end
+
+  ##
+  # Build the command string for JCL submission
+  ##
+  def command_string
+    return "//DUMMY  JOB (MFUSER),'dummy job',\n" +
+           "//   NOTIFY=&SYSUID,\n" +
+           "//   MSGCLASS=H,\n" +
+           "//   MSGLEVEL=(1,1),\n" +
+           "//   REGION=0M\n" +
+           "//   EXEC PGM=IEFBR14\n"
+  end
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -398,9 +398,19 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'bsdi/x86/shell_reverse_tcp'
   end
 
-  context 'cmd/unix/bind_awk' do
+  context 'cmd/mainframe/generic_jcl' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
+                              'singles/cmd/mainframe/generic_jcl'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/mainframe/generic_jcl'
+  end
+
+  context 'cmd/unix/bind_awk' do
+    it_should_behave_like 'payload cached size is consistent',
+                         ancestor_reference_names: [
                               'singles/cmd/unix/bind_awk'
                           ],
                           dynamic_size: false,


### PR DESCRIPTION
#### New Generic Mainframe (z/OS) JCL (Job Control Language - mainframe "scripting") cmd payload.

This payload does nothing but return successfully.  It can be used to
test exploits and as a basis for other JCL cmd payloads.  JCL is used to submit jobs (i.e. run programs) on the mainframe.
##### Testing the module with MSFVENOM should yield the following:

```
$ ./msfvenom -p cmd/mainframe/generic_jcl
No platform was selected, choosing Msf::Module::Platform::Mainframe from the payload
No Arch selected, selecting Arch: cmd from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 131 bytes
//DUMMY  JOB (MFUSER),'dummy job',
//   NOTIFY=&SYSUID,
//   MSGCLASS=H,
//   MSGLEVEL=(1,1),
//   REGION=0M
//   EXEC PGM=IEFBR14
$
```

Notes:
- there is no exploit that uses this payload yet
- it is the first of 3 PRs to complete an exploit which uses JCL
