### PR TITLE
avoid validating file-based datastore options on assignment

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -29,10 +29,12 @@ class DataStore < Hash
 
     opt = @options[k]
     unless opt.nil?
-      unless opt.valid?(v)
-        raise OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'#{['', ', try harder'].sample}"])
+      if opt.validate_on_assignment?
+        unless opt.valid?(v)
+          raise OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'"])
+        end
+        v = opt.normalize(v)
       end
-      v = opt.normalize(v)
     end
 
     super(k,v)

--- a/lib/msf/core/opt_address_range.rb
+++ b/lib/msf/core/opt_address_range.rb
@@ -12,6 +12,10 @@ class OptAddressRange < OptBase
     return 'addressrange'
   end
 
+  def validate_on_assignment?
+    false
+  end
+
   def normalize(value)
     return nil unless value.kind_of?(String)
     if (value =~ /^file:(.*)/)

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -76,6 +76,13 @@ module Msf
     end
 
     #
+    # Returns true if this option can be validated on assignment
+    #
+    def validate_on_assignment?
+      true
+    end
+
+    #
     # If it's required and the value is nil or empty, then it's not valid.
     #
     def valid?(value)

--- a/lib/msf/core/opt_path.rb
+++ b/lib/msf/core/opt_path.rb
@@ -12,6 +12,10 @@ class OptPath < OptBase
     return 'path'
   end
 
+  def validate_on_assignment?
+    false
+  end
+
   # Generally, 'value' should be a file that exists.
   def valid?(value)
     return false if empty_required_value?(value)

--- a/lib/msf/core/opt_raw.rb
+++ b/lib/msf/core/opt_raw.rb
@@ -12,6 +12,10 @@ class OptRaw < OptBase
     return 'raw'
   end
 
+  def validate_on_assignment?
+    false
+  end
+
   def normalize(value)
     if (value.to_s =~ /^file:(.*)/)
       path = $1

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -12,6 +12,10 @@ class OptString < OptBase
     return 'string'
   end
 
+  def validate_on_assignment?
+    false
+  end
+
   def normalize(value)
     if (value.to_s =~ /^file:(.*)/)
       path = $1


### PR DESCRIPTION
file:/ strings are special with some datastore options, causing them to read a file rather than emitting the exact string. This causes a couple of problems.
1. the valid? check needs to be special on assignment, since normalization really means normalizing the path, not playing with the value as we would do for other types
2. there are races or simply out-of-order assignments when running commands like 'services -p 80 -R', where the datastore option is assigned before the file is actually written.

This is the 'easy' fix of disabling assignment validation (which we didn't have before anyway) for types that can expect a file:/ prefix. Future refinements might make a loose validation that a file exists, and fix the underlying out-of-order operation - who knows how many others are lurking in the codebase. That we have to write a file that gets read again is also an odd pattern!

fix #6718 
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/x11/open_x11`
- [x] ensure that you have some hosts and service in your local database
- [x] run `services -p 80 -R`
- [x] ensure there is no backtrace
- [x] run `show options`
- [x] ensure that RHOSTS preserves the file name, rather than a list of IP addresses
