### PR TITLE
Fix a few issues with the SSL scanner

### DIFF
--- a/modules/auxiliary/scanner/http/ssl.rb
+++ b/modules/auxiliary/scanner/http/ssl.rb
@@ -38,56 +38,65 @@ class MetasploitModule < Msf::Auxiliary
 
       connect(true, {"SSL" => true}) #Force SSL
 
-      cert = OpenSSL::X509::Certificate.new(sock.peer_cert)
+      if sock.respond_to? :peer_cert
+        cert = OpenSSL::X509::Certificate.new(sock.peer_cert)
+      end
 
       disconnect
 
       if cert
-        print_status("#{ip}:#{rport} Subject: #{cert.subject}")
-        print_status("#{ip}:#{rport} Issuer: #{cert.issuer}")
-        print_status("#{ip}:#{rport} Signature Alg: #{cert.signature_algorithm}")
-        public_key_size = cert.public_key.n.num_bytes * 8
-        print_status("#{ip}:#{rport} Public Key Size: #{public_key_size} bits")
-        print_status("#{ip}:#{rport} Not Valid Before: #{cert.not_before}")
-        print_status("#{ip}:#{rport} Not Valid After: #{cert.not_after}")
+        print_status("Subject: #{cert.subject}")
+        print_status("Issuer: #{cert.issuer}")
+        print_status("Signature Alg: #{cert.signature_algorithm}")
+
+        # If we use ECDSA rather than RSA, our metrics for key size are different
+        public_key_size = 0
+        if cert.public_key.respond_to? :n
+          public_key_size = cert.public_key.n.num_bytes * 8
+          print_status("Public Key Size: #{public_key_size} bits")
+        end
+        print_status("Not Valid Before: #{cert.not_before}")
+        print_status("Not Valid After: #{cert.not_after}")
 
         # Checks for common properties of self signed certificates
         caissuer = (/CA Issuers - URI:(.*?),/i).match(cert.extensions.to_s)
 
         if caissuer.to_s.empty?
-          print_good("#{ip}:#{rport} Certificate contains no CA Issuers extension... possible self signed certificate")
+          print_good("Certificate contains no CA Issuers extension... possible self signed certificate")
         else
-          print_status("#{ip}:#{rport} " +caissuer.to_s[0..-2])
+          print_status(caissuer.to_s[0..-2])
         end
 
         if cert.issuer.to_s == cert.subject.to_s
-          print_good("#{ip}:#{rport} Certificate Subject and Issuer match... possible self signed certificate")
+          print_good("Certificate Subject and Issuer match... possible self signed certificate")
         end
 
         alg = cert.signature_algorithm
 
         if alg.downcase.include? "md5"
-          print_status("#{ip}:#{rport} WARNING: Signature algorithm using MD5 (#{alg})")
+          print_status("WARNING: Signature algorithm using MD5 (#{alg})")
         end
 
         vhostn = nil
         cert.subject.to_a.each do |n|
           vhostn = n[1] if n[0] == 'CN'
         end
-        if public_key_size == 1024
-          print_status("#{ip}:#{rport} WARNING: Public Key only 1024 bits")
-        elsif public_key_size < 1024
-          print_status("#{ip}:#{rport} WARNING: Weak Public Key: #{public_key_size} bits")
+        if public_key_size > 0
+          if public_key_size == 1024
+            print_status("WARNING: Public Key only 1024 bits")
+          elsif public_key_size < 1024
+            print_status("WARNING: Weak Public Key: #{public_key_size} bits")
+          end
         end
         if cert.not_after < Time.now
-          print_status("#{ip}:#{rport} WARNING: Certificate not valid anymore")
+          print_status("WARNING: Certificate not valid anymore")
         end
         if cert.not_before > Time.now
-          print_status("#{ip}:#{rport} WARNING: Certificate not valid yet")
+          print_status("WARNING: Certificate not valid yet")
         end
 
         if vhostn
-          print_status("#{ip}:#{rport} has common name #{vhostn}")
+          print_status("Has common name #{vhostn}")
 
           # Store the virtual hostname for HTTP
           report_note(
@@ -125,7 +134,7 @@ class MetasploitModule < Msf::Auxiliary
 
         end
       else
-        print_status("#{ip}:#{rport}] No certificate subject or common name found")
+        print_status("No certificate subject or common name found")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE


### PR DESCRIPTION
@mubix said this was busted on IRC, so I thought I'd fix it.

First, we need to handle public keys with strength not measured on the same bit scale as RSA keys. This fixes handshakes for ECDSA and others.

Second, depending on the host we are talking to, we may not have a peer cert. Handle this properly by checking first on the socket before using the peer cert.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/ssl`
- [x] `set RHOSTS lwn.net`
- [x] Verify that you get something like this:

```
[*] 45.33.94.129:443      - Subject: /OU=GT50021565/OU=See www.rapidssl.com/resources/cps (c)15/OU=Domain Control Validated - RapidSSL(R)/CN=*.lwn.net
[*] 45.33.94.129:443      - Issuer: /C=US/O=GeoTrust Inc./CN=RapidSSL SHA256 CA - G3
[*] 45.33.94.129:443      - Signature Alg: sha256WithRSAEncryption
[*] 45.33.94.129:443      - Public Key Size: 2048 bits
[*] 45.33.94.129:443      - Not Valid Before: 2015-10-12 18:06:09 UTC
[*] 45.33.94.129:443      - Not Valid After: 2018-10-14 20:24:37 UTC
[+] 45.33.94.129:443      - Certificate contains no CA Issuers extension... possible self signed certificate
[*] 45.33.94.129:443      - Have common name *.lwn.net
[*] google.com:443        - Scanned 1 of 2 hosts (50% complete)
[*] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Subject: /OU=GT50021565/OU=See www.rapidssl.com/resources/cps (c)15/OU=Domain Control Validated - RapidSSL(R)/CN=*.lwn.net
[*] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Issuer: /C=US/O=GeoTrust Inc./CN=RapidSSL SHA256 CA - G3
[*] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Signature Alg: sha256WithRSAEncryption
[*] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Public Key Size: 2048 bits
[*] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Not Valid Before: 2015-10-12 18:06:09 UTC
[*] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Not Valid After: 2018-10-14 20:24:37 UTC
[+] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Certificate contains no CA Issuers extension... possible self signed certificate
[*] 2600:3c03::f03c:91ff:fe61:5c5b:443 - Have common name *.lwn.net
[*] google.com:443        - Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
- [x] `set RHOSTS stackexchange.com`
- [x] Verify that you see something like this:

```
msf auxiliary(ssl) > set RHOSTS stackexchange.com
RHOSTS => stackexchange.com
msf auxiliary(ssl) > run

[*] 104.16.119.182:443    - Subject: /OU=Domain Control Validated/OU=PositiveSSL Multi-Domain/CN=ssl333133.cloudflaressl.com
[*] 104.16.119.182:443    - Issuer: /C=GB/ST=Greater Manchester/L=Salford/O=COMODO CA Limited/CN=COMODO ECC Domain Validation Secure Server CA 2
[*] 104.16.119.182:443    - Signature Alg: ecdsa-with-SHA256
[*] 104.16.119.182:443    - Not Valid Before: 2016-01-04 00:00:00 UTC
[*] 104.16.119.182:443    - Not Valid After: 2016-12-31 23:59:59 UTC
[+] 104.16.119.182:443    - Certificate contains no CA Issuers extension... possible self signed certificate
[*] 104.16.119.182:443    - Have common name ssl333133.cloudflaressl.com
[*] google.com:443        - Scanned 1 of 5 hosts (20% complete)
[*] 104.16.117.182:443    - Subject: /OU=Domain Control Validated/OU=PositiveSSL Multi-Domain/CN=ssl333133.cloudflaressl.com
[*] 104.16.117.182:443    - Issuer: /C=GB/ST=Greater Manchester/L=Salford/O=COMODO CA Limited/CN=COMODO ECC Domain Validation Secure Server CA 2
[*] 104.16.117.182:443    - Signature Alg: ecdsa-with-SHA256
[*] 104.16.117.182:443    - Not Valid Before: 2016-01-04 00:00:00 UTC
[*] 104.16.117.182:443    - Not Valid After: 2016-12-31 23:59:59 UTC
[+] 104.16.117.182:443    - Certificate contains no CA Issuers extension... possible self signed certificate
[*] 104.16.117.182:443    - Have common name ssl333133.cloudflaressl.com
[*] google.com:443        - Scanned 2 of 5 hosts (40% complete)
....
```
