### PR TITLE
MS10-58 Call super in #set_sane_defaults for caidao login scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/caidao.rb
+++ b/lib/metasploit/framework/login_scanner/caidao.rb
@@ -43,6 +43,7 @@ module Metasploit
 
         def set_sane_defaults
           self.method = "POST" if self.method.nil?
+          super
         end
 
         # Actually doing the login. Called by #attempt_login


### PR DESCRIPTION
## What This Patch Does

This fixes a problem where we are hitting a backtrace due to a missing default connection timeout value, also URI.

For MS10-58
## Verification
- [ ] Test this module
- [ ] There should be no backtrace
