### PR TITLE
Change java/reverse_https size to 5931 (expected by Travis... NOT)

### DIFF
--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/uuid/options'
 
 module MetasploitModule
 
-  CachedSize = 5932
+  CachedSize = 5931
 
   include Msf::Payload::Stager
   include Msf::Payload::Java


### PR DESCRIPTION
## What this Patch Does

This PR is meant to resolve the following error:

```
  1) modules/payloads java/meterpreter/reverse_https it should behave like payload cached size is consistent java/meterpreter/reverse_https has a valid cached_size
     Failure/Error: expect(pinst.cached_size).to eq(pinst.generate_simple(opts).size)

       expected: 5931
            got: 5932
```

update_payload_cached_sizes.rb begs to differ, so I'm gonna let @bcook-r7 look at it.
