### PR TITLE
Speed up the datastore

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -58,7 +58,7 @@ module Exploit::Powershell
   # @return [String] Encoded script
   def encode_script(script_in, eof = nil)
     opts = {}
-    datastore.select { |k, v| k =~ /^Powershell::(strip|sub)/ && v }.keys.map do |k|
+    datastore.select { |k, v| k =~ /^Powershell::(strip|sub)/i && v }.keys.map do |k|
       mod_method = k.split('::').last.intern
       opts[mod_method.to_sym] = true
     end
@@ -76,7 +76,7 @@ module Exploit::Powershell
   # @return [String] Compressed script with decompression stub
   def compress_script(script_in, eof=nil)
     opts = {}
-    datastore.select { |k, v| k =~ /^Powershell::(strip|sub)/ && v }.keys.map do |k|
+    datastore.select { |k, v| k =~ /^Powershell::(strip|sub)/i && v }.keys.map do |k|
       mod_method = k.split('::').last.intern
       opts[mod_method.to_sym] = true
     end

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Post
 
 
   def set_module_options(mod)
-    self.datastore.each_pair do |k,v|
+    self.datastore.each do |k,v|
       mod.datastore[k] = v
     end
     if !mod.datastore['SESSION'] && session.present?


### PR DESCRIPTION
Before, the datastore would store options case-sensitive, but would access them case-insensitive, resulting is a number of string compares. This commit stores options in their downcase form to reduce update/lookup time. This adds up to reducing msfconsole boot time by about 10% and rspec time by about 45 sec. (!) on my box.

One tricky part of this conversion is that there are several places (in pro and framework) where we export or otherwise access the datastore as a plain hash (case-sensitive). I believe I have caught all the ways we access the datastore that are case-sensitive and substituted the original key capitalization in those cases.

Ideally, I would like to not have to keep track of case in the datastore, but that would require wide, coordinated changes.

The now removed `#find_key_case` from the call graph generated by `./msfconsole -qx "exit"`:
<img width="662" alt="screen shot 2016-03-29 at 18 25 31" src="https://cloud.githubusercontent.com/assets/16652544/14156299/4921a63a-f68b-11e5-8ba3-70f78d498487.png">
(absolute and relative times slightly skewed by tracing)
# Verification
- [x] The specs should be green
- [x] Your favorite modules should accept options as before
