### PR TITLE
Modify the open_vas importer and the nessus importer

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -254,6 +254,9 @@ module Msf::DBManager::Import
     elsif (firstline.index("<scanJob>"))
       @import_filedata[:type] = "Retina XML"
       return :retina_xml
+    elsif (firstline.index(/<get_results_response status=['"]200['"] status_text=['"]OK['"]>/))
+      @import_filedata[:type] = "OpenVAS XML"
+      return :openvas_new_xml
     elsif (firstline.index(/<get_reports_response status=['"]200['"] status_text=['"]OK['"]>/))
       @import_filedata[:type] = "OpenVAS XML"
       return :openvas_new_xml
@@ -286,7 +289,7 @@ module Msf::DBManager::Import
           @import_filedata[:type] = "Nmap XML"
           return :nmap_xml
         when "openvas-report"
-          @import_filedata[:type] = "OpenVAS Report"
+          @import_filedata[:type] = "OpenVAS"
           return :openvas_xml
         when "NessusClientData"
           @import_filedata[:type] = "Nessus XML (v1)"

--- a/lib/msf/core/db_manager/import/nessus.rb
+++ b/lib/msf/core/db_manager/import/nessus.rb
@@ -12,20 +12,22 @@ module Msf::DBManager::Import::Nessus
   # Nessus NBE and NESSUS v1 methods
   #
   def handle_nessus(wspace, hobj, port, nasl, plugin_name, severity, data,task=nil)
+
     addr = hobj.address
     # The port section looks like:
     #   http (80/tcp)
     p = port.match(/^([^\(]+)\((\d+)\/([^\)]+)\)/)
-    return if not p
 
-    # Unnecessary as the caller should already have reported this host
-    #report_host(:workspace => wspace, :host => addr, :state => Msf::HostState::Alive)
-    name = p[1].strip
-    port = p[2].to_i
-    proto = p[3].downcase
+    if p
+      name = p[1].strip
+      port = p[2].to_i
+      proto = p[3].downcase
+    else
+      port = nil
+    end
 
     info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto, :task => task }
-    if name != "unknown" and name[-1,1] != "?"
+    if name and name != "unknown" and name[-1,1] != "?"
       info[:name] = name
     end
     report_service(info)

--- a/lib/msf/core/db_manager/import/open_vas.rb
+++ b/lib/msf/core/db_manager/import/open_vas.rb
@@ -29,6 +29,6 @@ module Msf::DBManager::Import::OpenVAS
     filename = args[:filename]
     wspace = args[:wspace] || workspace
 
-    raise Msf::DBImportError.new("No OpenVAS XML support. Please submit a patch to msfdev[at]metasploit.com")
+    raise Msf::DBImportError.new("No OpenVas XML support. Please submit a patch to msfdev[at]metasploit.com")
   end
 end

--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -4,7 +4,7 @@ require "rex/parser/nokogiri_doc_mixin"
 module Rex
 module Parser
 
-  # If Nokogiri is available, define OpenVAS document class.
+  # If Nokogiri is available, define OpenVas document class.
   load_nokogiri && class OpenVASDocument < Nokogiri::XML::SAX::Document
 
   include NokogiriDocMixin
@@ -37,8 +37,10 @@ module Parser
         @state[:vuln_name] = @text.strip if @text
       end
     when 'description'
-      @state[:has_text] = true
-      @state[:vuln_desc] = @text.strip if @text
+      if in_tag('result')
+        @state[:has_text] = true
+        @state[:vuln_desc] = @text.strip if @text
+      end
     when 'bid'
       if in_tag('result') && in_tag('nvt')
         @state[:has_text] = true
@@ -62,7 +64,7 @@ module Parser
     when 'subnet'
       @state[:has_text] = true
     when 'result'
-      record_vuln if in_tag('results')
+      record_vuln
     when 'threat'
       @state[:has_text] = true if in_tag('ports') && in_tag('port')
     when 'host'


### PR DESCRIPTION
This change allows you to import open_vas results xml without breaking open_vas reports xml. It also allows nessus.nbe imports to not break if there is a malformed port given, but instead imports what it can.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] Using db_import [filename] ensure that the three given files all import hosts and vulns (I have changed all IP addresses to 192.168.1.1 so you might need to delete the hosts table using `hosts -d` between imports in order to properly verify.
- [x] I've included the three files below as text files because github doesn't support .nbe or .xml filetypes. Change the file extension to the corresponding filetypes before trying to import. (nessus.txt should be nessus.nbe and the other two are xml files)
- [x] Ensure that rspec tests pass
