### PR TITLE
Bump payloads to 1.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       metasploit-concern
       metasploit-credential (= 1.1.0)
       metasploit-model (= 1.1.0)
-      metasploit-payloads (= 1.1.4)
+      metasploit-payloads (= 1.1.5)
       metasploit_data_models (= 1.3.0)
       msgpack
       network_interface (~> 0.0.1)
@@ -130,7 +130,7 @@ GEM
       activemodel (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
-    metasploit-payloads (1.1.4)
+    metasploit-payloads (1.1.5)
     metasploit_data_models (1.3.0)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '1.1.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.1.4'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.1.5'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.


### PR DESCRIPTION
This bumps the version of payloads up to 1.1.5 to include the fixes for the Python extension in the Payloads PR 91.
