### PR TITLE
Fix psexec 64 w psh

### DIFF
--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -169,7 +169,7 @@ module Exploit::Remote::SMB::Client::Psexec
             vprint_status("Removing the service...")
             svc_status = svc_client.deleteservice(svc_handle)
             if svc_status == ERROR_SUCCESS
-              vprint_good("Successfully removed the sevice")
+              vprint_good("Successfully removed the service")
             else
               print_error("Unable to remove the service, ERROR_CODE: #{svc_status}")
             end

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -59,8 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'        => 3072,
-          'DisableNops'  => true,
-          'StackAdjustment' => -3500
+          'DisableNops'  => true
         },
       'Platform'       => 'win',
       'Arch'           => [ARCH_X86, ARCH_X86_64],


### PR DESCRIPTION
See #6222 , this appears to be a partial fix for 64-bit payloads properly working with with the hybrid psexec module when in powershell mode. I say partial because, while it 'works for me', it seems that this fix is not sufficient for other setups.
## Verification

List the steps needed to make sure this thing works
- [ ] Launch the psexec module against a variety of 32-bit and 64-bit platforms, from XP to Windows 10
     using 32-bit and 64-bit payloads, for targets 0, 1, 2, domain-joined and standalone

The test matrix for this should roughly be:
- 11 OSes (XP, Vista, Windows 7, Windows 8.1, Windows 10, 2003, 2003r2, 2008, 2008r2, 2012, 2012r2)
- 2 modes (With and without domain)
- 3 different targets (auto, classic and powershell)
- 2 different payloads (32 and 64-bit Meterpreter reverse_tcp)

132 permutations! pinging @jbarnett-r7
