### PR TITLE
Add bf support for meterpreter

### DIFF
--- a/lib/rex/post/meterpreter/extensions/bf/bf.rb
+++ b/lib/rex/post/meterpreter/extensions/bf/bf.rb
@@ -1,0 +1,46 @@
+# -*- coding: binary -*-
+
+require 'rex/post/meterpreter/extensions/bf/tlv'
+
+module Rex
+module Post
+module Meterpreter
+module Extensions
+module BF
+
+###
+#
+# This meterpreter extensions a privilege escalation interface that is capable
+# of doing things like dumping password hashes and performing local
+# exploitation.
+#
+###
+class BF < Extension
+
+
+  def initialize(client)
+    super(client, 'bf')
+
+    client.register_extension_aliases(
+      [
+        {
+          'name' => 'bf',
+          'ext'  => self
+        },
+      ])
+  end
+
+
+  def execute_string(opts={})
+    return nil unless opts[:code]
+
+    request = Packet.create_request('bf_execute')
+    request.add_tlv(TLV_TYPE_BF_CODE, opts[:code])
+
+    response = client.send_request(request)
+    return response.get_tlv_value(TLV_TYPE_BF_RESULT)
+  end
+
+end
+
+end; end; end; end; end

--- a/lib/rex/post/meterpreter/extensions/bf/tlv.rb
+++ b/lib/rex/post/meterpreter/extensions/bf/tlv.rb
@@ -1,0 +1,15 @@
+# -*- coding: binary -*-
+module Rex
+module Post
+module Meterpreter
+module Extensions
+module BF
+
+TLV_TYPE_BF_CODE             = TLV_META_TYPE_STRING | (TLV_EXTENSIONS + 1)
+TLV_TYPE_BF_RESULT           = TLV_META_TYPE_STRING | (TLV_EXTENSIONS + 2)
+
+end
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/bf.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/bf.rb
@@ -34,12 +34,11 @@ class Console::CommandDispatcher::BF
   end
 
   @@bf_execute_opts = Rex::Parser::Arguments.new(
-    '-s' => [true, 'Specify the id/name of the BF session to run the command in.'],
     '-h' => [false, 'Help banner']
   )
 
   def bf_execute_usage
-    print_line('Usage: bf_execute <bf code> [-s session-id]')
+    print_line('Usage: bf_execute <bf code>')
     print_line
     print_line('Runs the given BF string on the target.')
     print_line(@@bf_execute_opts.usage)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/bf.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/bf.rb
@@ -1,0 +1,78 @@
+# -*- coding: binary -*-
+require 'rex/post/meterpreter'
+
+module Rex
+module Post
+module Meterpreter
+module Ui
+
+###
+#
+# BF extension - interact with a BF interpreter
+#
+###
+class Console::CommandDispatcher::BF
+
+  Klass = Console::CommandDispatcher::BF
+
+  include Console::CommandDispatcher
+
+  #
+  # Name for this dispatcher
+  #
+  def name
+    'BF'
+  end
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    {
+      'bf_execute'  => 'Execute a BF command string'
+    }
+  end
+
+  @@bf_execute_opts = Rex::Parser::Arguments.new(
+    '-s' => [true, 'Specify the id/name of the BF session to run the command in.'],
+    '-h' => [false, 'Help banner']
+  )
+
+  def bf_execute_usage
+    print_line('Usage: bf_execute <bf code> [-s session-id]')
+    print_line
+    print_line('Runs the given BF string on the target.')
+    print_line(@@bf_execute_opts.usage)
+  end
+
+  #
+  # Execute a simple BF command string
+  #
+  def cmd_bf_execute(*args)
+    if args.length == 0 || args.include?('-h')
+      bf_execute_usage
+      return false
+    end
+
+    opts = {
+      code: args.shift
+    }
+
+    @@bf_execute_opts.parse(args) { |opt, idx, val|
+      case opt
+      when '-s'
+        opts[:session_id] = val
+      end
+    }
+
+    result = client.bf.execute_string(opts)
+    print_good("Command execution completed:\n#{result}")
+  end
+
+end
+
+end
+end
+end
+end
+


### PR DESCRIPTION
The great new Python and Powershell extensions, while making Meterpreter powerful and extensible, also make it a little to easy. What we need is a powerful language that also challenges a person to think critically. Maybe even whimper a little.

This extension even features a convenient stack overflow in the output buffer, so you can write arbitrary code to extend the language at runtime!
## Verification

List the steps needed to make sure this thing works
- [ ] Land and build https://github.com/rapid7/metasploit-payloads/pull/92
- [ ] Start a meterpreter session on Windows and Linux 32-bit
- [ ] 'use bf'
- [ ] The 'bf_execute' command is then used to simplify and enhance the post-exploitation process

```
meterpreter > load bf 
Loading extension bf...success.
meterpreter > bf_execute ++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.
[+] Command execution completed:
Hello World!

```

Next steps are of course to add Meterpreter, Powershell, and APL bindings.
