### PR TITLE
bump travis ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - graphviz
 language: ruby
 rvm:
-  - '2.1.8'
+  - '2.1.9'
 
 env:
   - RAKE_TASKS="cucumber cucumber:boot" CREATE_BINSTUBS=true


### PR DESCRIPTION
See #6735 for details. We need to wait till ruby 2.1.9 becomes available in travis
