### PR TITLE
reimplement HD's session interrupt handler

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1197,9 +1197,15 @@ class Exploit < Msf::Module
   # value can be one of the Handler::constants.
   #
   def handler(*args)
-    return if not payload_instance
-    return if not handler_enabled?
-    return payload_instance.handler(*args)
+    unless payload_instance && handler_enabled?
+      payload_instance.handler(*args)
+    end
+  end
+
+  def interrupt_handler
+    if payload_instance && handler_enabled? && payload_instance.respond_to?(:interrupt_wait_for_session)
+      payload_instance.interrupt_wait_for_session()
+    end
   end
 
   ##
@@ -1351,6 +1357,9 @@ class Exploit < Msf::Module
 
     # Report the failure (and attempt) in the database
     self.report_failure
+
+    # Interrupt any session waiters in the handler
+    self.interrupt_handler
   end
 
   def report_failure

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -164,6 +164,14 @@ module Handler
   end
 
   #
+  # Interrupts a wait_for_session call by notifying with a nil event
+  #
+  def interrupt_wait_for_session
+    return unless session_waiter_event
+    session_waiter_event.notify(nil)
+  end
+
+  #
   # Set by the exploit module to configure handler
   #
   attr_accessor :exploit_config


### PR DESCRIPTION
reimplement HD's work on a session interrupt handler so that if an exploit fails the handler does not continue waiting for a session that will never come.

MS-385
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec`
- [x] **Verify** you get a shell
