### PR TITLE
Address ActiveRecord deprecation warning

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -463,7 +463,7 @@ class Db
         if search_term
           next unless (
             host.attribute_names.any? { |a| host[a.intern].to_s.match(search_term) } ||
-            !Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", framework.db.workspace.id, host.address, search_term.source).order("tags.id DESC").empty?
+            !Mdm::Tag.includes(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", framework.db.workspace.id, host.address, search_term.source).references(:hosts).order("tags.id DESC").empty?
           )
         end
 


### PR DESCRIPTION
AR will start to complain about eager loading in command_dispatcher
/db.rb:519 because it references hosts as string without explicitly
stating that the table is being referenced.

Add a call .references in the AR call chain after the where clause
to silence this abysmal warning.
