### PR TITLE
fix the path quoting in open_webrtc_browser

### DIFF
--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -167,7 +167,7 @@ def self.open_webrtc_browser(url='http://google.com/')
       paths.each do |path|
         if File.exists?(path)
           args = (path =~ /chrome\.exe/) ? "--allow-file-access-from-files" : ""
-          system("#{path} #{args} #{url}")
+          system("\"#{path}\" #{args} \"#{url}\"")
           return true
         end
       end


### PR DESCRIPTION
This allows open_webrtc_browser to work on Windows, which in turn allows info -d to open the resulting html document.
## Verification

List the steps needed to make sure this thing works
- [x] Install the latest metasploit omnibus package (http://windows.metasploit.com)
- [x] Add this change to c:\metasploit-framework\embedded\framework\lib\rex\compat.rb
- [x] run msfconsole.bat from c:\metasploit-framework\bin
- [x] `use exploit/windows/smb/psexec`
- [x] `info -d`
- [x] **Verify** that a browser pops up (in my case, Chrome)

Tested on Windows 10.
