### PR TITLE
Feature/ms 1330/dep updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,14 +34,14 @@ end
 
 group :development, :test do
   # automatically include factories from spec/factories
-  gem 'factory_girl_rails', '~> 4.5.0'
+  gem 'factory_girl_rails'
   # Make rspec output shorter and more useful
-  gem 'fivemat', '~> 1.3.1'
+  gem 'fivemat'
   # running documentation generation tasks and rspec tasks
-  gem 'rake', '~> 10.5'
+  gem 'rake'
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the
   # environment is development
-  gem 'rspec-rails' , '~> 3.3'
+  gem 'rspec-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,26 +87,26 @@ PATH
       activesupport (>= 4.1.0, < 4.2.0)
       bcrypt
       filesize
-      jsobfu (~> 0.4.1)
+      jsobfu
       json
-      metasm (~> 1.0.2)
-      metasploit-model (= 1.1.0)
+      metasm
+      metasploit-model
       metasploit-payloads (= 1.1.6)
       msgpack
-      network_interface (~> 0.0.1)
+      network_interface
       nokogiri
       octokit
-      openssl-ccm (= 1.2.1)
-      packetfu (= 1.1.11)
-      patch_finder (>= 1.0.2)
+      openssl-ccm
+      packetfu
+      patch_finder
       pcaprub
-      pg (>= 0.11)
+      pg
       railties
       rb-readline-r7
-      recog (= 2.0.14)
+      recog
       redcarpet
       robots
-      rubyzip (~> 1.1)
+      rubyzip
       sqlite3
       tzinfo
 
@@ -182,7 +182,7 @@ GEM
     erubis (2.7.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.5.0)
+    factory_girl_rails (4.6.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     faraday (0.9.2)
@@ -241,9 +241,9 @@ GEM
       activesupport (= 4.1.15)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.5.0)
+    rake (11.1.2)
     rb-readline-r7 (0.5.2.0)
-    recog (2.0.14)
+    recog (2.0.19)
       nokogiri
     redcarpet (3.3.4)
     rkelly-remix (0.0.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,8 +295,8 @@ PLATFORMS
 DEPENDENCIES
   aruba
   cucumber-rails
-  factory_girl_rails (~> 4.5.0)
-  fivemat (~> 1.3.1)
+  factory_girl_rails
+  fivemat
   metasploit-concern!
   metasploit-credential!
   metasploit-erd!
@@ -306,9 +306,9 @@ DEPENDENCIES
   metasploit_data_models!
   octokit (~> 4.0)
   pry
-  rake (~> 10.5)
+  rake
   redcarpet
-  rspec-rails (~> 3.3)
+  rspec-rails
   shoulda-matchers
   simplecov
   timecop

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,11 +55,11 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.4.1'
+  spec.add_runtime_dependency 'jsobfu'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasm compiler/decompiler/assembler
-  spec.add_runtime_dependency 'metasm', '~> 1.0.2'
+  spec.add_runtime_dependency 'metasm'
   # Metasploit::Concern hooks
   #spec.add_runtime_dependency 'metasploit-concern'
   # Metasploit::Credential database models
@@ -68,32 +68,32 @@ Gem::Specification.new do |spec|
   #spec.add_runtime_dependency 'metasploit_data_models', '1.3.0'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
-  spec.add_runtime_dependency 'metasploit-model', '1.1.0'
+  spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.1.6'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.
-  spec.add_runtime_dependency 'network_interface', '~> 0.0.1'
+  spec.add_runtime_dependency 'network_interface'
   # Needed by anemone crawler
   spec.add_runtime_dependency 'nokogiri'
   # Needed by db.rb and Msf::Exploit::Capture
-  spec.add_runtime_dependency 'packetfu', '1.1.11'
+  spec.add_runtime_dependency 'packetfu'
   # For sniffer and raw socket modules
   spec.add_runtime_dependency 'pcaprub'
   # Needed for module caching in Mdm::ModuleDetails
-  spec.add_runtime_dependency 'pg', '>= 0.11'
+  spec.add_runtime_dependency 'pg'
   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
   spec.add_runtime_dependency 'railties'
   # required for OS fingerprinting
-  spec.add_runtime_dependency 'recog', '2.0.14'
+  spec.add_runtime_dependency 'recog'
   # required for bitlocker fvek extraction
-  spec.add_runtime_dependency 'openssl-ccm', '1.2.1'
+  spec.add_runtime_dependency 'openssl-ccm'
   # Needed for documentation generation
   spec.add_runtime_dependency 'octokit'
   spec.add_runtime_dependency 'redcarpet'
   # Needed for Microsoft patch finding tool (msu_finder)
-  spec.add_runtime_dependency 'patch_finder', '>= 1.0.2'
+  spec.add_runtime_dependency 'patch_finder'
 
   # rb-readline doesn't work with Ruby Installer due to error with Fiddle:
   #   NoMethodError undefined method `dlopen' for Fiddle:Module
@@ -106,7 +106,7 @@ Gem::Specification.new do |spec|
   # Needed by anemone crawler
   spec.add_runtime_dependency 'robots'
   # Needed by some modules
-  spec.add_runtime_dependency 'rubyzip', '~> 1.1'
+  spec.add_runtime_dependency 'rubyzip'
   # Needed for some post modules
   spec.add_runtime_dependency 'sqlite3'
   # required for Time::TZInfo in ActiveSupport


### PR DESCRIPTION
Unlock version constraints on gem deps in framework

PRE_VERIFICATION
Land the following PRs first:
https://github.com/rapid7/metasploit-erd/pull/9
https://github.com/rapid7/metasploit-concern/pull/23
https://github.com/rapid7/metasploit-model/pull/49
https://github.com/rapid7/metasploit_data_models/pull/157
https://github.com/rapid7/metasploit-credential/pull/117

VERIFICATION STEPS
- [x] `bundle install`
- [x] `rake db:drop db:create db:migrate`
- [x] `rake spec`
- [x] VERIFY all specs pass
