### PR TITLE
Fix: badchars.present? is false for whitespace

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -376,7 +376,7 @@ module Msf
           encoders << e if e
         end
         encoders.sort_by { |my_encoder| my_encoder.rank }.reverse
-      elsif badchars.present?
+      elsif !badchars.empty? && !badchars.nil?
         framework.encoders.each_module_ranked('Arch' => [arch], 'Platform' => platform_list) do |name, mod|
           e = framework.encoders.create(name)
           e.datastore.import_options_from_hash(datastore)


### PR DESCRIPTION
`.present?` considers strings containing only whitespace chars to be `false`, and so `badchars.present?` is `false` in the case of badchars containing only whitespace.

Instead check for is not blank and is not nil.

Pre-patch: msfvenom kicks out "No encoder or badchars specified" in the case of badchars containing only whitespace chars, and generated shellcode contains badchars.

```
% ./msfvenom -p linux/x86/exec CMD="/bin/bash" -b '\x0a' -f python
No platform was selected, choosing Msf::Module::Platform::Linux from the payload 
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 45 bytes
buf =  ""  
buf += "\x6a\x0b\x58\x99\x52\x66\x68\x2d\x63\x89\xe7\x68\x2f"
buf += "\x73\x68\x00\x68\x2f\x62\x69\x6e\x89\xe3\x52\xe8\x0a"
buf += "\x00\x00\x00\x2f\x62\x69\x6e\x2f\x62\x61\x73\x68\x00"
buf += "\x57\x53\x89\xe1\xcd\x80"
```

Post-patch: Not the above

```
% ./msfvenom -p linux/x86/exec CMD="/bin/bash" -b '\x0a' -f python
No platform was selected, choosing Msf::Module::Platform::Linux from the payload 
No Arch selected, selecting Arch: x86 from the payload
Found 10 compatible encoders
Attempting to encode payload with 1 iterations of x86/shikata_ga_nai
x86/shikata_ga_nai succeeded with size 72 (iteration=0)
x86/shikata_ga_nai chosen with final size 72
Payload size: 72 bytes
buf =  ""  
buf += "\xdd\xc2\xbf\x08\x4e\xdb\x0e\xd9\x74\x24\xf4\x5e\x31"
buf += "\xc9\xb1\x0c\x31\x7e\x18\x83\xc6\x04\x03\x7e\x1c\xac"
buf += "\x2e\x64\x17\x68\x48\x2b\x41\xe0\x47\xaf\x04\x17\xff"
buf += "\x00\x65\xb0\x00\x37\xa6\x22\x68\xa9\x31\x41\x38\xdd"
buf += "\x4b\x86\xbd\x1d\x64\xe4\xd4\x73\x55\x8a\x47\xff\xc1"
buf += "\x4a\xdf\xac\x98\xaa\x12\xd2"
```
## Verification
- [x] Generate payloads without badchars. Should work as before.
- [x] Generate payloads with non-whitespace badchars. Should work as before.
- [x] Generate payloads with whitespace badchars. Should be fixed as shown above.
- [x] Generate payloads with non-whitespace and whitespace badchars. Should work as before.
