### PR TITLE
Fix an error in the OpenVas and Burp Issue importers

### DIFF
--- a/lib/rex/parser/burp_issue_nokogiri.rb
+++ b/lib/rex/parser/burp_issue_nokogiri.rb
@@ -99,7 +99,7 @@ module Rex
         return unless @state[:port]
         return unless @state[:proto]
         return unless @state[:service_name]
-        service_info = {}
+        service_info = {:workspace => @args[:wspace]}
         service_info[:host] = @state[:host]
         service_info[:port] = @state[:port]
         service_info[:proto] = @state[:proto]
@@ -112,7 +112,7 @@ module Rex
         return unless @state[:vuln_name]
         return unless @state[:issue_detail]
         return unless @state[:refs]
-        vuln_info = {}
+        vuln_info = {:workspace => @args[:wspace]}
         vuln_info[:service_id] = @state[:service_object].id
         vuln_info[:host] = @state[:host]
         vuln_info[:name] = @state[:vuln_name]

--- a/lib/rex/parser/burp_issue_nokogiri.rb
+++ b/lib/rex/parser/burp_issue_nokogiri.rb
@@ -88,7 +88,7 @@ module Rex
       def report_web_host_info
         return unless @state[:host]
         address = Rex::Socket.resolv_to_dotted(@state[:host]) rescue nil
-        host_info = {:workspace => @args[:wspace]}
+        host_info = {workspace: @args[:wspace]}
         host_info[:address] = address
         host_info[:name] = @state[:host]
         db_report(:host, host_info)
@@ -99,7 +99,7 @@ module Rex
         return unless @state[:port]
         return unless @state[:proto]
         return unless @state[:service_name]
-        service_info = {:workspace => @args[:wspace]}
+        service_info = {workspace: @args[:wspace]}
         service_info[:host] = @state[:host]
         service_info[:port] = @state[:port]
         service_info[:proto] = @state[:proto]
@@ -112,7 +112,7 @@ module Rex
         return unless @state[:vuln_name]
         return unless @state[:issue_detail]
         return unless @state[:refs]
-        vuln_info = {:workspace => @args[:wspace]}
+        vuln_info = {workspace: @args[:wspace]}
         vuln_info[:service_id] = @state[:service_object].id
         vuln_info[:host] = @state[:host]
         vuln_info[:name] = @state[:vuln_name]

--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -132,6 +132,7 @@ module Parser
         vuln_info[:info] = @state[:vuln_desc]
         vuln_info[:port] = @state[:port]
         vuln_info[:proto] = @state[:proto]
+        vuln_info[:workspace] = @args[:wspace]
 
         db_report(:vuln, vuln_info)
       end
@@ -145,6 +146,7 @@ module Parser
         vuln_info[:info] = @state[:vuln_desc]
         vuln_info[:port] = @state[:port]
         vuln_info[:proto] = @state[:proto]
+        vuln_info[:workspace] = @args[:wspace]
 
         db_report(:vuln, vuln_info)
       end
@@ -157,11 +159,13 @@ module Parser
     service_info[:name] = @state[:name]
     service_info[:port] = @state[:port]
     service_info[:proto] = @state[:proto]
+    service_info[:workspace] = @args[:wspace]
 
     db_report(:service, service_info)
 
     host_info = {}
     host_info[:host] = @state[:host]
+    host_info[:workspace] = @args[:wspace]
 
     db_report(:host, host_info)
   end


### PR DESCRIPTION
This change fixes the issue where the vuln and host info would import into the default workspace instead of the current workspace for OpenVas and Burp Issue importers
## Verification

List the steps needed to make sure this thing works
- [x] Clear your db
- [x] Start `msfconsole`
- [x] Using the workspace command, add a new workspace and switch to it
  (workspace -a NewWorkspace  for example)
- [x] Then, using the db_import command import the open_vas.xml file provided
- [x] Check that you're in the new workspace and not the default using the workspace command
- [x] Check that there are hosts and vulns imported into this workspace
- [x] Ensure that there are no hosts or vulns in the default workspace
- [x] Repeat with the burp_issue.xml file

[openvas_report.txt](https://github.com/rapid7/metasploit-framework/files/204746/openvas_report.txt)
[burp_issue.txt](https://github.com/rapid7/metasploit-framework/files/204762/burp_issue.txt)

Remember to convert these to xml files because the importers are expecting xml files, while github doesn't let me import xml files. Also, the IP's in these files have been changed.
