### PR TITLE
Correct proftp version check at module runtime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-g    metasploit-framework (4.11.20)
+    metasploit-framework (4.11.20)
       actionpack (>= 4.0.9, < 4.1.0)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metasploit-framework (4.11.20)
+g    metasploit-framework (4.11.20)
       actionpack (>= 4.0.9, < 4.1.0)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
@@ -260,3 +260,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,3 @@ DEPENDENCIES
   simplecov
   timecop
   yard
-
-BUNDLED WITH
-   1.11.2

--- a/modules/exploits/linux/ftp/proftp_sreplace.rb
+++ b/modules/exploits/linux/ftp/proftp_sreplace.rb
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
       mytarget = nil
 
       print_status("Automatically detecting the target...")
-      if (banner and (m = banner.match(/ProFTPD (1\.3\.[23][^ ]) Server/i))) then
+      if (banner and (m = banner.match(/ProFTPD (1\.[23]\.[^ ])/i))) then
         print_status("FTP Banner: #{banner.strip}")
         version = m[1]
       else


### PR DESCRIPTION
As mentioned in issue #6606, proftp_sreplace.rb was improperly rejecting any version string that wasn't either '1.3.2' or '1.3.3' at time of exploit. This pr changes the version check to properly verify that the version string is between '1.2.0' - '1.3.0'
## Verification

List the steps needed to make sure this thing works
- [x] have proftpd v 1.2.0-1.3.0 running on a linux vm. (I got the same version mentioned in the aforementioned issue from http://pkgs.fedoraproject.org/repo/pkgs/proftpd/proftpd-1.3.0rc3.tar.bz2/050c3e2caec0d930f8a331e7b3ec0931/proftpd-1.3.0rc3.tar.bz2)
- [x] start 'msfconsole'
- [x] `use exploit/linux/ftp/proftp_sreplace`
- [x] `set  FTPPASS Your_Password`
- [x] `set FTPUSER Your_Username`
- [x] `set RHOST [IP]`
- [x] `set rport 2121`
- [x] `set writable /writable_drectory/on_ftp`
- [x]  `exploit`
- [x] After you see `Automatically detecting the target...` in the terminal
- [x] verify that you see `Selected Target: ProFTPD [Version_Number]`
- [x] Verify that the module doesn't fail with "No matching target"
