### PR TITLE
Make advanced and evasion options readable

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -400,8 +400,7 @@ class ReadableText
           'Description'
         ])
 
-    mod.options.sorted.each { |entry|
-      name, opt = entry
+    mod.options.sorted.each do |name, opt|
       val = mod.datastore[name] || opt.default
 
       next if (opt.advanced?)
@@ -409,7 +408,7 @@ class ReadableText
       next if (missing && opt.valid?(val))
 
       tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
-    }
+    end
 
     return tbl.to_s
   end
@@ -420,24 +419,23 @@ class ReadableText
   # @param indent [String] the indentation to use.
   # @return [String] the string form of the information.
   def self.dump_advanced_options(mod, indent = '')
-    output = ''
-    pad    = indent
+    tbl = Rex::Ui::Text::Table.new(
+      'Indent'  => indent.length,
+      'Columns' =>
+        [
+          'Name',
+          'Current Setting',
+          'Required',
+          'Description'
+        ])
 
-    mod.options.sorted.each { |entry|
-      name, opt = entry
+    mod.options.sorted.each do |name, opt|
+      next unless opt.advanced?
+      val = mod.datastore[name] || opt.default
+      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
+    end
 
-      next if (!opt.advanced?)
-
-      val = mod.datastore[name] || opt.default.to_s
-      desc = word_wrap(opt.desc, indent.length + 3)
-      desc = desc.slice(indent.length + 3, desc.length)
-
-      output << pad + "Name           : #{name}\n"
-      output << pad + "Current Setting: #{val}\n"
-      output << pad + "Description    : #{desc}\n"
-    }
-
-    return output
+    return tbl.to_s
   end
 
   # Dumps the evasion options associated with the supplied module.
@@ -446,25 +444,23 @@ class ReadableText
   # @param indent [String] the indentation to use.
   # @return [String] the string form of the information.
   def self.dump_evasion_options(mod, indent = '')
-    output = ''
-    pad    = indent
+    tbl = Rex::Ui::Text::Table.new(
+      'Indent'  => indent.length,
+      'Columns' =>
+        [
+          'Name',
+          'Current Setting',
+          'Required',
+          'Description'
+        ])
 
-    mod.options.sorted.each { |entry|
-      name, opt = entry
+    mod.options.sorted.each do |name, opt|
+      next unless opt.evasion?
+      val = mod.datastore[name] || opt.default
+      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
+    end
 
-      next if (!opt.evasion?)
-
-      val = mod.datastore[name] || opt.default || ''
-
-      desc = word_wrap(opt.desc, indent.length + 3)
-      desc = desc.slice(indent.length + 3, desc.length)
-
-      output << pad + "Name           : #{name}\n"
-      output << pad + "Current Setting: #{val}\n"
-      output << pad + "Description    : #{desc}\n"
-    }
-
-    return output
+    return tbl.to_s
   end
 
   # Dumps the references associated with the supplied module.

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -828,7 +828,7 @@ class Core
       end
     end
 
-    args.each { |name|
+    args.each do |name|
       mod = framework.modules.create(name)
 
       if (mod == nil)
@@ -836,7 +836,7 @@ class Core
       else
         show_options(mod)
       end
-    }
+    end
   end
 
   #
@@ -2600,9 +2600,9 @@ class Core
   # Tab completion for the unset command
   #
   # @param str [String] the string currently being typed before tab was hit
-  # @param words [Array<String>] the previously completed words on the command line.  words is always
-  # at least 1 when tab completion has reached this stage since the command itself has been completed
-
+  # @param words [Array<String>] the previously completed words on the command
+  #   line. `words` is always at least 1 when tab completion has reached this
+  #   stage since the command itself has been completed.
   def cmd_unset_tabs(str, words)
     datastore = active_module ? active_module.datastore : self.framework.datastore
     datastore.keys


### PR DESCRIPTION
Advanced and evasion options currently dump out a long scroll of text that is difficult for human brains to parse quickly. This patch makes them look like regular options, i.e. a nice compact table. 
## Verification
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] `show advanced`
- [x] **Verify** prints a table that is much easier to read than the wall of text
## New Output

Advanced options:

```
15:06:20 default j:0 s:0 exploit(psexec) > advanced

Module advanced options (exploit/windows/smb/psexec):

   Name                          Current Setting                                         Required  Description
   ----                          ---------------                                         --------  -----------
   ALLOW_GUEST                   false                                                   yes       Keep trying if only given guest access
   CHOST                                                                                 no        The local client address
   CPORT                         0                                                       no        The local client port
   ConnectTimeout                10                                                      yes       Maximum number of seconds to establish a TCP connection
   ContextInformationFile                                                                no        The information file that contains context information
   DCERPC::ReadTimeout           10                                                      yes       The number of seconds to wait for DCERPC responses
   DisablePayloadHandler         false                                                   no        Disable the handler code for the selected payload
   EXE::Custom                                                                           no        Use custom exe instead of automatically generating a payload exe
   EXE::EICAR                    false                                                   no        Generate an EICAR file instead of regular payload exe
   EXE::FallBack                 false                                                   no        Use the default template in case the specified one is missing
   EXE::Inject                   false                                                   no        Set to preserve the original EXE function
   EXE::OldMethod                false                                                   no        Set to use the substitution EXE generation method.
   EXE::Path                                                                             no        The directory in which to look for the executable template
   EXE::Template                                                                         no        The executable template file name.
   EnableContextEncoding         false                                                   no        Use transient context when encoding payloads
   MSI::Custom                                                                           no        Use custom msi instead of automatically generating a payload msi
   MSI::EICAR                    false                                                   no        Generate an EICAR file instead of regular payload msi
   MSI::Path                                                                             no        The directory in which to look for the msi template
   MSI::Template                                                                         no        The msi template file name
   MSI::UAC                      false                                                   no        Create an MSI with a UAC prompt (elevation to SYSTEM if accepted)
   NTLM::SendLM                  true                                                    yes       Always send the LANMAN response (except when NTLMv2_session is specified)
   NTLM::SendNTLM                true                                                    yes       Activate the 'Negotiate NTLM key' flag, indicating the use of NTLM responses
   NTLM::SendSPN                 true                                                    yes       Send an avp of type SPN in the ntlmv2 client blob, this allows authentication on Windows 7+/Server 2008 R2+ when SPN is required
   NTLM::UseLMKey                false                                                   yes       Activate the 'Negotiate Lan Manager Key' flag, using the LM key when the LM response is sent
   NTLM::UseNTLM2_session        true                                                    yes       Activate the 'Negotiate NTLM2 key' flag, forcing the use of a NTLMv2_session
   NTLM::UseNTLMv2               true                                                    yes       Use NTLMv2 instead of NTLM2_session when 'Negotiate NTLM2' key is true
   PSH_PATH                      Windows\System32\WindowsPowerShell\v1.0\powershell.exe  no        Path to powershell.exe
   Powershell::method            reflection                                              yes       Payload delivery method (Accepted: net, reflection, old, msil)
   Powershell::persist           false                                                   yes       Run the payload in a loop
   Powershell::prepend_sleep     0                                                       no        Prepend seconds of sleep
   Powershell::strip_comments    true                                                    yes       Strip comments
   Powershell::strip_whitespace  false                                                   yes       Strip whitespace
   Powershell::sub_funcs         false                                                   yes       Substitute function names
   Powershell::sub_vars          false                                                   yes       Substitute variable names
   Proxies                                                                               no        A proxy chain of format type:host:port[,type:host:port][...]
   SERVICE_FILENAME                                                                      no        Filename to to be used on target for the service binary
   SERVICE_PERSIST               false                                                   yes       Create an Auto run service and do not remove it.
   SMB::ChunkSize                500                                                     yes       The chunk size for SMB segments, bigger values will increase speed but break NT 4.0 and SMB signing
   SMB::Native_LM                Windows 2000 5.0                                        yes       The Native LM to send during authentication
   SMB::Native_OS                Windows 2000 2195                                       yes       The Native OS to send during authentication
   SMB::VerifySignature          false                                                   yes       Enforces client-side verification of server response signatures
   SMBDirect                     true                                                    no        The target port is a raw SMB service (not NetBIOS)
   SMBName                       *SMBSERVER                                              yes       The NetBIOS hostname (required for port 139 connections)
   SSL                           false                                                   no        Negotiate SSL/TLS for outgoing connections
   SSLCipher                                                                             no        String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"
   SSLVerifyMode                 PEER                                                    no        SSL verification method (Accepted: CLIENT_ONCE, FAIL_IF_NO_PEER_CERT, NONE, PEER)
   SSLVersion                    TLS1                                                    no        Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate) (Accepted: Auto, SSL2, SSL3, SSL23, TLS, TLS1, TLS1.1, TLS1.2)
   VERBOSE                       false                                                   no        Enable detailed status messages
   WORKSPACE                                                                             no        Specify the workspace for this module
   WfsDelay                      10                                                      no        Additional delay when waiting for a session


Payload advanced options (windows/meterpreter/bind_tcp):

   Name                         Current Setting  Required  Description
   ----                         ---------------  --------  -----------
   AutoLoadStdapi               true             yes       Automatically load the Stdapi extension
   AutoRunScript                                 no        A script to run automatically on session creation.
   AutoSystemInfo               true             yes       Automatically capture system information on initialization.
   AutoVerifySession            true             yes       Automatically verify and drop invalid sessions
   AutoVerifySessionTimeout     30               no        Timeout period to wait for session validation to occur, in seconds
   EnableStageEncoding          false            no        Encode the second stage payload
   EnableUnicodeEncoding        false            yes       Automatically encode UTF-8 strings as hexadecimal
   HandlerSSLCert                                no        Path to a SSL certificate in unified PEM format, ignored for HTTP transports
   InitialAutoRunScript                          no        An initial script to run on session creation (before AutoRunScript)
   PayloadUUIDName                               no        A human-friendly name to reference this unique payload (requires tracking)
   PayloadUUIDRaw                                no        A hex string representing the raw 8-byte PUID value for the UUID
   PayloadUUIDSeed                               no        A string to use when generating the payload UUID (deterministic)
   PayloadUUIDTracking          false            yes       Whether or not to automatically register generated UUIDs
   PrependMigrate               false            yes       Spawns and runs shellcode in new process
   PrependMigrateProc                            no        Process to spawn and run shellcode in
   SessionCommunicationTimeout  300              no        The number of seconds of no activity before this session should be killed
   SessionExpirationTimeout     604800           no        The number of seconds before this session should be forcibly shut down
   SessionRetryTotal            3600             no        Number of seconds try reconnecting for on network failure
   SessionRetryWait             10               no        Number of seconds to wait between reconnect attempts
   StageEncoder                                  no        Encoder to use if EnableStageEncoding is set
   StageEncoderSaveRegisters                     no        Additional registers to preserve in the staged payload if EnableStageEncoding is set
   StageEncodingFallback        true             no        Fallback to no encoding if the selected StageEncoder is not compatible
   VERBOSE                      false            no        Enable detailed status messages
   WORKSPACE                                     no        Specify the workspace for this module
```

And evasions:

```
15:12:43 default j:0 s:0 exploit(psexec) > show evasion 

Module evasion options:

   Name                             Current Setting  Required  Description
   ----                             ---------------  --------  -----------
   DCERPC::fake_bind_multi          true             no        Use multi-context bind calls
   DCERPC::fake_bind_multi_append   0                no        Set the number of UUIDs to append the target
   DCERPC::fake_bind_multi_prepend  0                no        Set the number of UUIDs to prepend before the target
   DCERPC::max_frag_size            4096             yes       Set the DCERPC packet fragmentation size
   DCERPC::smb_pipeio               rw               no        Use a different delivery method for accessing named pipes (Accepted: rw, trans)
   SMB::obscure_trans_pipe_level    0                yes       Obscure PIPE string in TransNamedPipe (level 0-3)
   SMB::pad_data_level              0                yes       Place extra padding between headers and data (level 0-3)
   SMB::pad_file_level              0                yes       Obscure path names used in open/create (level 0-3)
   SMB::pipe_evasion                false            yes       Enable segmented read/writes for SMB Pipes
   SMB::pipe_read_max_size          1024             yes       Maximum buffer size for pipe reads
   SMB::pipe_read_min_size          1                yes       Minimum buffer size for pipe reads
   SMB::pipe_write_max_size         1024             yes       Maximum buffer size for pipe writes
   SMB::pipe_write_min_size         1                yes       Minimum buffer size for pipe writes
   TCP::max_send_size               0                no        Maxiumum tcp segment size.  (0 = disable)
   TCP::send_delay                  0                no        Delays inserted before every send.  (0 = disable)


Payload evasion options (windows/meterpreter/bind_tcp):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------

15:12:46 default j:0 s:0 exploit(psexec) > 
```
