### PR TITLE
Add unicode test examples

### DIFF
--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -126,7 +126,6 @@ class MetasploitModule < Msf::Post
       ret
     end
 
-
     it "should write REG_DWORD values" do
       ret = true
       registry_setvaldata(%q#HKCU\test_key#, "test_val_dword", 1234, "REG_DWORD")
@@ -149,6 +148,41 @@ class MetasploitModule < Msf::Post
       ret &&= registry_deletekey(%q#HKCU\test_key#)
       # Deleting the key should delete all its values
       valinfo = registry_getvalinfo(%q#HKCU\test_key#, "test_val_dword")
+      ret &&= (valinfo.nil?)
+
+      ret
+    end
+
+    it "should create unicode keys" do
+      ret = registry_createkey(%q#HKCU\σονσλυσιονεμκυε#)
+    end
+
+    it "should write REG_SZ unicode values" do
+      ret = true
+      registry_setvaldata(%q#HKCU\σονσλυσιονεμκυε#, "test_val_str", "дэлььякатезшимя", "REG_SZ")
+      registry_setvaldata(%q#HKCU\σονσλυσιονεμκυε#, "test_val_dword", 1234, "REG_DWORD")
+      valinfo = registry_getvalinfo(%q#HKCU\σονσλυσιονεμκυε#, "test_val_str")
+      if (valinfo.nil?)
+        ret = false
+      else
+        # type == REG_SZ means string
+        ret &&= !!(valinfo["Type"] == 1)
+        ret &&= !!(valinfo["Data"].kind_of? String)
+        ret &&= !!(valinfo["Data"] == "дэлььякатезшимя")
+      end
+
+      ret
+    end
+
+
+    it "should delete unicode keys" do
+      ret = registry_deleteval(%q#HKCU\σονσλυσιονεμκυε#, "test_val_str")
+      valinfo = registry_getvalinfo(%q#HKCU\σονσλυσιονεμκυε#, "test_val_str")
+      # getvalinfo should return nil for a non-existent key
+      ret &&= (valinfo.nil?)
+      ret &&= registry_deletekey(%q#HKCU\σονσλυσιονεμκυε#)
+      # Deleting the key should delete all its values
+      valinfo = registry_getvalinfo(%q#HKCU\σονσλυσιονεμκυε#, "test_val_dword")
       ret &&= (valinfo.nil?)
 
       ret


### PR DESCRIPTION
Add Unicode testing to test/modules/post/test/registry.rb

As part of [landing](https://github.com/rapid7/metasploit-payloads/commit/73d548be48b50a4886ed45f0a51cab95fc8c736b) rapid7/metasploit-payloads#85, add tests to the already-existing
automated testing script to verify Unicode registry key names and values are
created and deleted properly.
## Verification
- [x] Create a meterpreter session running on a windows client 
- [x] Background the session
- [x] Load the registry test module ((post/test/registry)
- [x] Set the proper session for the test script
- [x] Run the registry test module
- [x] Verify the output indicates success in writing Unicode keys
- [x] Verify the output indicates success in writing Unicode key values
- [x] Verify the output indicates success in deleting Unicode keys
## Example run:

```
msf post(registry) > loadpath test/modules
Loaded 1 modules:
    1 post
msf post(registry) > use post/test/registry 
msf post(registry) > set session -1
session => -1
msf post(registry) > run

[*] Running against session -1
[*] Session type is meterpreter and platform is x86/win32
[+] should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should return normalized values
[+] should enumerate keys and values
[+] should create keys
[+] should write REG_SZ values
[+] should write REG_DWORD values
[+] should delete keys
[+] should create unicode keys
[+] should write REG_SZ unicode values
[+] should delete unicode keys
[*] Passed: 11; Failed: 0
[*] Post module execution completed
```
