### PR TITLE
Verify the correct netmask for autoroute before adding

### DIFF
--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -184,10 +184,9 @@ class MetasploitModule < Msf::Post
 
     session.net.config.each_route do | route |
       next unless is_routable?(route)
-
-      if !switch_board.route_exists?(route.subnet, route.netmask)
+      netmask = route.netmask == '255.255.255.255' ? '255.255.255.0' : route.netmask
+      if !switch_board.route_exists?(route.subnet, netmask)
         begin
-          netmask = route.netmask == '255.255.255.255' ? '255.255.255.0' : route.netmask
           if Rex::Socket::SwitchBoard.add_route(route.subnet, netmask, session)
             print_good("Route added to subnet #{route.subnet}/#{netmask}")
             found = true


### PR DESCRIPTION
Sometimes the module has to modify the netmask to be able to talk to other hosts on the network, but this modification is not done correctly. It needs to happen before switch_board.route_exists is called to avoid the same routes being added again.
## Verification
- [ ] Start msfconsole
- [ ] Get a Windows meterpreter session
- [ ] Run the  post/windows/manage/autoroute module
- [ ] Run it again
- [ ] No routes should be repeated
## Demo

It should be doing something like this:

```
msf post(autoroute) > run

[*] Running module against WIN-6NH0Q8CJQVM
[*] Searching for subnets to autoroute.
[+] Route added to subnet 192.168.146.133/255.255.255.0
[+] Route added to subnet 192.168.146.255/255.255.255.0
[*] Post module execution completed
msf post(autoroute) > run

[*] Running module against WIN-6NH0Q8CJQVM
[*] Searching for subnets to autoroute.
[*] Did not find any new subnets to add.
[*] Post module execution completed
```
