### PR TITLE
Fix inverted logic introduced by #6734

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1197,7 +1197,7 @@ class Exploit < Msf::Module
   # value can be one of the Handler::constants.
   #
   def handler(*args)
-    unless payload_instance && handler_enabled?
+    if payload_instance && handler_enabled?
       payload_instance.handler(*args)
     end
   end


### PR DESCRIPTION
The fix for MS-385 inverted the logic of whether a handler gets run when an exploit calls `Exploit#handler`, causing explicit handlers never to be run, thus preventing successful exploits from creating sessions. This affects all exploits compatible with find-type payloads and the special `cmd/unix/interact`.
## Verification
- [x] copy the ssh key out of `exploit/linux/ssh/f5_bigip_known_privkey` onto a Linux VM as f5.priv
- [x] in the VM: `ssh-keygen -y -f f5.priv >> /root/.ssh/authorized_keys`
- [x] make sure `PermitRootLogin` is `yes` in /etc/ssh/sshd_config
- [x] Start `msfconsole`
- [x] `use exploit/linux/ssh/f5_bigip_known_privkey`
- [x] set RHOST to the VM from above
- [x] `run`
- [x] **Verify** root shell
- [x] Clean up your VM
  - [x] remove f5 key from /root/.ssh/authorized_keys file
  - [x] set `PermitRootLogin` back to what it was before (ideally `no`).
