### PR TITLE
Fix #6764, nil SQL error in lib/msf/core/exploit/postgres

### DIFF
--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -166,8 +166,16 @@ module Exploit::Remote::Postgres
           sql_error_msg += " Column does not exist: '#{sql}'"
         when "C42883"
           sql_error_msg += " Function does not exist: '#{sql}'"
+        when nil
+          sql_error_msg = e.inspect
         else # Let the user figure out the rest.
-          sql_error_msg += " SQL statement '#{sql}' returns #{e.inspect}"
+          if e == Timeout::Error
+            sql_error_msg = 'Execution expired'
+          elsif sql_error_msg.nil?
+            sql_error_msg = e.inspect
+          else
+            sql_error_msg += " SQL statement '#{sql}' returns #{e.inspect}"
+          end
         end
         return {:sql_error => sql_error_msg}
       end

--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -166,8 +166,6 @@ module Exploit::Remote::Postgres
           sql_error_msg += " Column does not exist: '#{sql}'"
         when "C42883"
           sql_error_msg += " Function does not exist: '#{sql}'"
-        when nil
-          sql_error_msg = e.inspect
         else # Let the user figure out the rest.
           if e == Timeout::Error
             sql_error_msg = 'Execution expired'

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status "#{peer} - #{language} could not be loaded"
       return false
     else
-      print_error "#{peer} - error occurred loading #{language}"
+      vprint_error "#{peer} - error occurred loading #{language}"
       return false
     end
   end
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error "#{peer} - Connection error"
       return false
     when :sql_error
-      print_error "#{peer} - Exploit failed"
+      print_warning "#{peer} - Unable to execute query: #{query}"
       return false
     when :complete
       print_good "#{peer} - Exploit successful"


### PR DESCRIPTION
## What This Patch Does

This PR fixes a problem with lib/msf/core/exploit/postgres timing out, resulting a nil for the SQL error message. The processing of the SQL error message assumes it is always going to be a string, but if there's a timeout or some sort, the error message is nil, so it can't do `+=` to it.

The PR also changes how the postgres_createlang module outputs some of its errors/warnings to avoid confusion from the user's perspective. (Like if there's a timeout, it would say exploit failed even though there is a working shell)
## Verification
- [x] Get a Ubuntu box, start a terminal
- [x] Do: `apt-get install postgresql postgresql-plperl postgresql-plpython`
- [x] Do the following:

```
sudo -u postgres psql postgres
# \password postgres
Enter new password: 
```
- [x] Modify these files:

```
# /etc/postgresql/9.4/main/postgresql.conf
listen_addresses = '*'

# /etc/postgresql/9.4/main/pg_hba.conf
host    all    all            0.0.0.0/0             md5 
```
- [x] `sudo service postgreql restart`
- [x] Start msfconsole
- [x] Do: `use exploit/multi/postgres/postgres_createlang`
- [x] Set the options for the exploit
- [x] Do: `seft payload cmd/unix/reverse_python`
- [x] Set lhost
- [x] Do: `run`
- [x] You should get a session
