### PR TITLE
Improve tomcat_mgr_upload fail undeployment check

### DIFF
--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -200,7 +200,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vars = {}
     unless @csrf_token.nil?
       vars = {
-        "path" => @app_base,
+        "path" => "/" + @app_base,
         "org.apache.catalina.filters.CSRF_NONCE" => @csrf_token
       }
     end

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -396,7 +396,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return false
     end
 
-    if res and (res.code < 200 or res.code >= 300)
+    if res and (res.code < 200 or res.code >= 300 or res.body =~ /FAIL - Invalid context path/)
       vprint_warning("Deletion failed on #{undeploy_url} [#{res.code} #{res.message}]")
       return false
     end

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -200,7 +200,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vars = {}
     unless @csrf_token.nil?
       vars = {
-        "path" => "/" + @app_base,
+        "path" => @app_base,
         "org.apache.catalina.filters.CSRF_NONCE" => @csrf_token
       }
     end


### PR DESCRIPTION
This fixes the undeployment fail detection of the tomcat_mgr_upload module.

The server might respond with HTTP 200 and with message stating "FAIL - Invalid context path evilpayload was specified".

This was tested with Tomcat 7.0.52 running on Windows Server 2008 R2.
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/tomcat_mgr_upload`
- [ ] `exploit`
- [ ] Check from the Tomcat Manager that the payload was actually undeployed properly
