### PR TITLE
remove more regex-style bool checks

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Auxiliary
       'Cookie' => 'PBack=0'
     }
 
-    if (datastore['SSL'].to_s.match(/^(t|y|1)/i))
+    if datastore['SSL']
       if action.name == "OWA_2013"
         data = 'destination=https://' << vhost << '/owa&flags=4&forcedownlevel=0&username=' << user << '&password=' << pass << '&isUtf8=1'
       else

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -70,11 +70,11 @@ class MetasploitModule < Msf::Auxiliary
     @log_console  = false
     @log_database = false
 
-    if (datastore['LogConsole'].to_s.match(/^(t|y|1)/i))
+    if datastore['LogConsole']
       @log_console = true
     end
 
-    if (datastore['LogDatabase'].to_s.match(/^(t|y|1)/i))
+    if datastore['LogDatabase']
       @log_database = true
     end
 


### PR DESCRIPTION
This removes a few more datastore type-confusion checks we should no longer need, now that default value types are preserved.
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/owa_login`
- [x] configure as normal, but **ensure** that the SSL parameter works as expected
- [x] `use auxiliary/server/fakedns`
- [x] **Verify** that enabling / disabling LogDatabase and LogConsole work as expected

Looking more closely at fake_dns, I feel we should drop LogConsole and just replace with vprint_\* instead. Any opinions?
