### PR TITLE
Deprecate dns_bruteforce / dns_cache_scraper / dns_info / dns_reverse_lookup / dns_srv_enum

### DIFF
--- a/modules/auxiliary/gather/dns_bruteforce.rb
+++ b/modules/auxiliary/gather/dns_bruteforce.rb
@@ -8,8 +8,10 @@ require "net/dns/resolver"
 require 'rex'
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Module::Deprecated
   include Msf::Auxiliary::Report
 
+  deprecated(Date.new(2016, 6, 12), 'auxiliary/gather/enum_dns')
   def initialize(info = {})
     super(update_info(info,
       'Name'		   => 'DNS Brutefoce Enumeration',

--- a/modules/auxiliary/gather/dns_cache_scraper.rb
+++ b/modules/auxiliary/gather/dns_cache_scraper.rb
@@ -7,7 +7,10 @@ require 'msf/core'
 require 'net/dns/resolver'
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Module::Deprecated
   include Msf::Auxiliary::Report
+
+  deprecated(Date.new(2016, 6, 12), 'auxiliary/gather/enum_dns')
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/gather/dns_info.rb
+++ b/modules/auxiliary/gather/dns_info.rb
@@ -8,7 +8,10 @@ require "net/dns/resolver"
 require 'rex'
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Module::Deprecated
   include Msf::Auxiliary::Report
+
+  deprecated(Date.new(2016, 6, 12), 'auxiliary/gather/enum_dns')
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -8,7 +8,10 @@ require "net/dns/resolver"
 require 'rex'
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Module::Deprecated
   include Msf::Auxiliary::Report
+
+  deprecated(Date.new(2016, 6, 12), 'auxiliary/gather/enum_dns')
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/gather/dns_srv_enum.rb
+++ b/modules/auxiliary/gather/dns_srv_enum.rb
@@ -8,7 +8,10 @@ require "net/dns/resolver"
 require 'rex'
 
 class MetasploitModule < Msf::Auxiliary
+  include Msf::Module::Deprecated
   include Msf::Auxiliary::Report
+
+  deprecated(Date.new(2016, 6, 12), 'auxiliary/gather/enum_dns')
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
[**enum_dns**](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/gather/enum_dns.rb) can finish what the following modules can do:
- [x] [auxiliary/gather/dns_bruteforce](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/gather/dns_bruteforce.rb) 
- [x] [auxiliary/gather/dns_cache_scraper](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/gather/dns_cache_scraper.rb)
- [x] [auxiliary/gather/dns_info](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/gather/dns_info.rb)
- [x] [auxiliary/gather/dns_reverse_lookup](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/gather/dns_reverse_lookup.rb)
- [x] [auxiliary/gather/dns_srv_enum](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/gather/dns_srv_enum.rb)  

```
msf auxiliary(enum_dns) > show options 

Module options (auxiliary/gather/enum_dns):

   Name         Current Setting                                                             Required  Description
   ----         ---------------                                                             --------  -----------
   DOMAIN                                                                                   yes       The target domain
   ENUM_A       true                                                                        yes       Enumerate DNS A record
   ENUM_AXFR    true                                                                        yes       Initiate a zone transfer against each NS record
   ENUM_BRT     false                                                                       yes       Brute force subdomains and hostnames via the supplied wordlist
   ENUM_CNAME   true                                                                        yes       Enumerate DNS CNAME record
   ENUM_MX      true                                                                        yes       Enumerate DNS MX record
   ENUM_NS      true                                                                        yes       Enumerate DNS NS record
   ENUM_RVL     false                                                                       yes       Reverse lookup a range of IP addresses
   ENUM_SOA     true                                                                        yes       Enumerate DNS SOA record
   ENUM_SRV     true                                                                        yes       Enumerate the most common SRV records
   ENUM_TLD     false                                                                       yes       Perform a TLD expansion by replacing the TLD with the IANA TLD list
   ENUM_TXT     true                                                                        yes       Enumerate DNS TXT record
   IPRANGE                                                                                  no        The target address range or CIDR identifier
   NS                                                                                       no        Specify the nameserver to use for queries (default is system DNS)
   STOP_WLDCRD  false                                                                       yes       Stops bruteforce enumeration if wildcard resolution is detected
   THREADS      1                                                                           no        Threads for ENUM_BRT
   WORDLIST     /Users/Open-Security/Code/metasploit-framework/data/wordlists/namelist.txt  no        Wordlist of subdomains


```

I advise us to deprecate all of the above.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use auxiliary/gather/enum_dns`
- [x] `show options`
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
