### PR TITLE
Fix the ARM NOP generator after #6762, #6768, and #6644

### DIFF
--- a/modules/nops/armle/simple.rb
+++ b/modules/nops/armle/simple.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Nop
       0xe1a0b00b
     ]
 
-    if( random and random.match(/^(t|y|1)/i) )
+    if random
       return ([nops[rand(nops.length)]].pack("V*") * (length/4))
     end
 


### PR DESCRIPTION
This fixes another regex-based datastore check that now needs to be boolean instead.
