### PR TITLE
Add Windows 10 entry to the version check regex

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -90,7 +90,7 @@ module Msf::Post::Windows::Priv
     uac = false
     winversion = session.sys.config.sysinfo['OS']
 
-    if winversion =~ /Windows (Vista|7|8|2008|2012)/
+    if winversion =~ /Windows (Vista|7|8|2008|2012|10)/
       unless is_system?
         begin
           enable_lua = registry_getvaldata(


### PR DESCRIPTION
This fixes the issue logged in #6775 where the UAC check doesn't work on Windows 10 because of an out of date regex.
## Verification

List the steps needed to make sure this thing works
- [x] Kick off `msfconsole` and create a listener and meterpreter payload.
- [x] Launch the payload on a Windows 10 box.
- [x] run `run post/windows/gather/win_privs`
- [ ] **Verify** It works (returns `True` if it's enabled)

Fixes #6775
