### PR TITLE
Fix autoadd problem in post/windows/manage/autoroute

### DIFF
--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -162,11 +162,9 @@ class MetasploitModule < Msf::Post
   def is_routable?(route)
     if route.subnet =~ /^224\.|127\./
       return false
-    elsif route.subnet =~ /[\d\.]+\.0$/
-      return false
     elsif route.subnet == '0.0.0.0'
       return false
-    elsif route.subnet == '255.255.255.255'
+    elsif route.netmask == '255.255.255.255'
       return false
     end
 


### PR DESCRIPTION
## Error Description

In PR #6515, I submitted the "autoadd" feature. A function called is_routable? was added that was different from the original code that was submitted. This function contains errors that are causing invalid routes to be added.

 Running a test using the current code, this is the output:

```
[*]     Running command run post/windows/manage/autoroute
[*] Running module against SHADOW
[*] Searching for subnets to autoroute.
[+] Route added to subnet 192.168.1.145/255.255.255.0
[+] Route added to subnet 192.168.1.255/255.255.255.0
[+] Route added to subnet 192.168.14.1/255.255.255.0
[+] Route added to subnet 192.168.14.255/255.255.255.0
[+] Route added to subnet 192.168.179.1/255.255.255.0
[+] Route added to subnet 192.168.179.255/255.255.255.0
[+] Route added to subnet 192.168.202.1/255.255.255.0
[+] Route added to subnet 192.168.202.255/255.255.255.0
```

These routes are incorrect and do not work.
## Fix

The routing check `elsif route.subnet =~ /[\d\.]+\.0$/` is causing part of the error and was removed for the fix.

Also, this line: `elsif route.subnet == '255.255.255.255'` should be: `elseif route.netmask == '255.255.255.255'`

Once these changes are made the output is:

```
[*]     Running command run post/windows/manage/autoroute
[*] Running module against SHADOW
[*] Searching for subnets to autoroute.
[+] Route added to subnet 192.168.1.0/255.255.255.0
[+] Route added to subnet 192.168.14.0/255.255.255.0
[+] Route added to subnet 192.168.179.0/255.255.255.0
[+] Route added to subnet 192.168.202.0/255.255.255.0
```

Which are correct routes.
