### PR TITLE
post/windows/manage/autoroute Improvements

### DIFF
--- a/documentation/modules/post/windows/manage/autoroute.md
+++ b/documentation/modules/post/windows/manage/autoroute.md
@@ -1,0 +1,27 @@
+## Overview
+
+This module is used to add routes associated with the specified Meterpreter session to the Metasploit routing table. These routes can be used to pivot to private networks and resources that can be accessed by the compromised machine. This module can search for routes and add them automatically. Routes can also be added manually, deleted, or displayed.
+
+## CMD Options
+This module has several command "CMD" options that are used to control the module’s behavior.
+
+### autoadd
+This is the default behavior for this module. When this CMD option is used, the module searches the compromised machine's routing table and network interface list looking for networks that the machine can access. Once found, the module automatically adds routes to the networks to Metasploit’s routing table. Duplicate routes from new sessions are not added.
+
+### add
+This CMD option is used to manually add routes to the Metasploit routing table. An IPv4 subnet and netmask (IPv4 or CIDR) are required to add routes manually. The session number of the Meterpreter session to run the module on is also required.
+
+Subnet Example `set SUBNET 192.168.1.0`
+
+Netmask Examples `set NETMASK 255.255.255.0` or `set NETMASK /24`
+
+### delete
+This CMD option is used to remove a route from the Metasploit routing table. The IPv4 subnet and netmask (IPv4 or CIDR) of the route to be removed are required. The session number of the Meterpreter session to run the module on is also required. Use `route print` or the 'view' CMD option to display the current Metasploit routing table.
+
+### print
+This CMD option is used to display the current Metasploit routing table. This option has the same functionality as the `route print` command.
+
+### default
+This CMD option is used to add a default route to the Metasploit routing table that routes all TCP/IP traffic not otherwise covered in other routes through the specified session when pivoting. **Use this option with caution.**
+
+This option is useful in special situations. An example would be when the compromised host is using a full traffic VPN where the VPN server does the routing to private networks. In this case, the routing table of the compromised host would likely not have entries for these private networks. Adding a default route would push the routing off to the VPN server, and those networks would likely become accessible.

--- a/documentation/modules/post/windows/manage/autoroute.md
+++ b/documentation/modules/post/windows/manage/autoroute.md
@@ -1,27 +1,121 @@
 ## Overview
 
-This module is used to add routes associated with the specified Meterpreter session to the Metasploit routing table. These routes can be used to pivot to private networks and resources that can be accessed by the compromised machine. This module can search for routes and add them automatically. Routes can also be added manually, deleted, or displayed.
+This module is used to add routes associated with the specified Meterpreter session to Metasploit's routing table. These routes can be used to pivot to private networks and resources that can be accessed by the compromised machine. This module can search for routes and add them automatically. Routes can also be added manually, deleted, or displayed.
 
 ## CMD Options
-This module has several command "CMD" options that are used to control the module’s behavior.
+This module has several command "CMD" options that are used to control the module's behavior.
 
 ### autoadd
-This is the default behavior for this module. When this CMD option is used, the module searches the compromised machine's routing table and network interface list looking for networks that the machine can access. Once found, the module automatically adds routes to the networks to Metasploit’s routing table. Duplicate routes from new sessions are not added.
+This is the default behavior for this module. When this CMD option is used, the module searches the compromised machine's routing table and network interface list looking for networks that the machine can access. Once found, the module automatically adds routes to the networks to Metasploit's routing table. Duplicate routes from new sessions are not added.
 
 ### add
-This CMD option is used to manually add routes to the Metasploit routing table. An IPv4 subnet and netmask (IPv4 or CIDR) are required to add routes manually. The session number of the Meterpreter session to run the module on is also required.
+This CMD option is used to manually add routes to Metasploit's routing table. An IPv4 subnet and netmask (IPv4 or CIDR) are required to add routes manually. The session number of the Meterpreter session to run the module on is also required.
 
 Subnet Example `set SUBNET 192.168.1.0`
 
 Netmask Examples `set NETMASK 255.255.255.0` or `set NETMASK /24`
 
 ### delete
-This CMD option is used to remove a route from the Metasploit routing table. The IPv4 subnet and netmask (IPv4 or CIDR) of the route to be removed are required. The session number of the Meterpreter session to run the module on is also required. Use `route print` or the 'view' CMD option to display the current Metasploit routing table.
+This CMD option is used to remove a route from Metasploit's routing table. The IPv4 subnet and netmask (IPv4 or CIDR) of the route to be removed are required. The session number of the Meterpreter session to run the module on is also required. Use `route print` or the print CMD option to display the current Metasploit routing table.
 
 ### print
-This CMD option is used to display the current Metasploit routing table. This option has the same functionality as the `route print` command.
+This CMD option is used to display Metasploit's routing table. This option has the same functionality as the `route print` command.
 
 ### default
-This CMD option is used to add a default route to the Metasploit routing table that routes all TCP/IP traffic not otherwise covered in other routes through the specified session when pivoting. **Use this option with caution.**
+This CMD option is used to add a default route to Metasploit's routing table that routes all TCP/IP traffic; not otherwise covered in other routes, through the specified session when pivoting.
+
+**Use this option with caution.**
 
 This option is useful in special situations. An example would be when the compromised host is using a full traffic VPN where the VPN server does the routing to private networks. In this case, the routing table of the compromised host would likely not have entries for these private networks. Adding a default route would push the routing off to the VPN server, and those networks would likely become accessible.
+
+Additionally, the default route combined with a Socks proxy server and Proxychains can be used to browse the Internet as the compromised host. Instructions for this are below.
+
+## Pivoting
+Once routes are established, Metasploit modules can access the IP range specified in the routes. Scans and exploits can be directed at machines that would otherwise be unreachable from the outside. For other applications to access the routes, a little bit more setup is necessary. This involves setting up the Socks4a Metasploit module and using Proxychains in conjunction with the other applications.
+
+### Socks 4a Server Module Setup
+Metasploit can launch a Socks 4a Proxy server using the module: auxiliary/server/socks4a. When set up to bind to a local loopback adapter, applications can be directed to use the proxy to route TCP/IP traffic through Metasploit's routing tables. Below are the steps to initiate this module.
+
+```
+use auxiliary/server/socks4a
+set SRVHOST 127.0.0.1
+set LPORT 1080
+exploit -j
+```
+
+### Proxychains Setup
+First, make sure that you have Proxychains.
+
+```
+sudo apt-get update
+sudo apt-get install proxychains
+```
+
+Now edit the Proxychains configuration file located at /etc/proxychains.conf. Add the below line to the end of the file to set Proxychains to use the Socks 4a server that you just set up.
+
+```
+socks4 127.0.0.1 1080
+```
+
+Note: If there are other proxy entries in the configuration file, you may need to comment them out as they may interfere with proper routing.
+
+### Using Proxychains
+Now you can combine Proxychains with other application like Nmap, Nessus, Firefox and more to scan or access machines and resources through the Metasploit routes. All you need to do is call proxychains before the needed application. No need to change the proxy settings in Firefox of Iceweasel.
+
+
+```
+$ proxychains firefox
+```
+
+### Scanning
+For scanning with Nmap, Zenmap, Nessus and others, keep in mind that ICMP and UPD traffic cannot  tunnel through the proxy. So you cannot perform ping or UDP scans.
+
+For Nmap and Zenmap, the below example shows the commands can be used. It is best to be selective on ports to scan since scanning through the proxy tunnel can be slow.
+
+```
+$ sudo proxychains nmap -n -sT- sV -PN -p 445 10.10.125.0/24
+```
+
+### Combined With Default Route
+Using the default route option along with the Socks proxy and Proxychains, you can browse the internet as the compromised host. This is possible because adding a default route to a Meterpeter session will cause all TCP/IP traffic; that is not otherwise specified in Metasploit's routing table, to route through that session. This is easy to set up and test.
+
+You need a Windows Meterpreter session on a host that has a different public IP address than your attacking machine.
+
+First set up a default route for the Meterpreter session.
+
+```
+meterpreter > run post/windows/manage/autoroute CMD=default
+```
+
+or
+
+```
+msf > use post/windows/manage/autoroute
+msf post(autoroute) > set SESSION session-id
+msf post(autoroute) > set CMD default
+msf post(autoroute) > exploit
+```
+
+Then open Firefox or Iceweasel without invoking Proxychains.
+
+```
+$ firefox
+```
+
+Go to `www.ipchicken.com`
+
+This displays your current public IP address. The one that is logged when you visit a website.
+
+Now open Firefox or Iceweasel with Proxychains.
+
+```
+$ proxychains firefox
+```
+
+Go to `www.ipchicken.com`
+
+Now you will see the public IP address of the compromised host. You are essentially using the compromised host as a proxy to browse the Internet.
+
+**This does not guarantee anonymity! Your browser, and its setting may still give you away.**
+
+

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -211,15 +211,55 @@ class MetasploitModule < Msf::Post
   # @return [void] A useful return value is not expected here
   def autoadd_interface_routes
     session.net.config.each_interface do | interface |
-      (0..interface.addrs.size).each do | index |
+
+      (0..(interface.addrs.size - 1)).each do | index |
+
         ip_addr = interface.addrs[index]
         netmask = interface.netmasks[index]
 
         next unless ip_addr =~ /\./
         next unless is_routable?(ip_addr, netmask)
-        print_status("Interface: #{interface.mac_name}  =  #{interface.addrs[index]} : #{interface.netmasks[index]}")
+
+        print_status("Interface: #{interface.mac_name}  =  #{ip_addr} : #{netmask}")
+        get_subnet(ip_addr, netmask)
+
       end
     end
+  end
+
+  # This function will take an IP address and a netmask and return
+  # the appropreate subnet "Network"
+  # This function only checks address ranges on IP and Netmask
+  #
+  # @ip_addr [string class] Input IPv4 Address
+  # @netmask [string class] Input IPv4 Netmask
+  #
+  # @return [nil class] Something is out of range
+  # @return [string class] The subnet related to the IP address and netmask
+  def get_subnet(ip_addr, netmask)
+    nets = ip_addr.split('.')
+    masks = netmask.split('.')
+
+    return nil if nets.size != 4 || masks.size != 4 # Some intial checking
+
+    nets.each do | net |
+      print_good("\t\tString: #{net}    Int + 1:#{int_or_nil(net) + 1}")
+    end
+
+    
+    masks.each do | mask |
+      print_good("\t\t#{mask}    Int + 1:#{int_or_nil(mask) + 1}")
+    end
+    
+  end
+
+  # This function takes a string of numbers and converts it to an integer.
+  #
+  # @return [integer class] Integer representation of the number string
+  # @return [nil class] string contains non-numbers, cannot convert
+  def int_or_nil(string)
+    num = string.to_i
+    num if num.to_s == string
   end
 
   # Validates the command options

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -171,8 +171,11 @@ class MetasploitModule < Msf::Post
 
   # This function will exclude loopback, multicast, and default routes
   #
-  # @return [true]  if routable
-  # @return [false] if not
+  # @subnet [string class] IPv4 subnet or address to check
+  # @netmask [string class] IPv4 netmask to check
+  #
+  # @return [true]  If good to add
+  # @return [false] If not
   def is_routable?(subnet, netmask)
     if subnet =~ /^224\.|127\./
       return false
@@ -281,8 +284,8 @@ class MetasploitModule < Msf::Post
     return output
   end
 
-  # Get an octet of an IPv4 address and the cooresponding octet of the
-  # IPv4 netmask and returns the appropreate subnet octet.
+  # Input an octet of an IPv4 address and the cooresponding octet of the
+  # IPv4 netmask then return the appropreate subnet octet.
   #
   # @net  [integer class] IPv4 address octet
   # @mask [integer class] Ipv4 netmask octet

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Post
           Meterpreter session. It enables other modules to 'pivot' through a
           compromised host when connecting to the named NETWORK and SUBMASK.
           Autoadd will search a session for valid subnets from the routing table
-          and interface list then add routes to them. Default will add a default 
+          and interface list then add routes to them. Default will add a default
           route so that all TCP/IP traffic not specified in the MSF routing table
           will be routed through the session when pivoting. See documentation for more
           'info -d' and click 'Knowledge Base'},

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -229,7 +229,6 @@ class MetasploitModule < Msf::Post
 
   # This function will take an IP address and a netmask and return
   # the appropreate subnet "Network"
-  # This function only checks address ranges on IP and Netmask
   #
   # @ip_addr [string class] Input IPv4 Address
   # @netmask [string class] Input IPv4 Netmask
@@ -237,24 +236,36 @@ class MetasploitModule < Msf::Post
   # @return [nil class] Something is out of range
   # @return [string class] The subnet related to the IP address and netmask
   def get_subnet(ip_addr, netmask)
+    return nil if !validate_cmd(ip_addr, netmask)
+
     nets = ip_addr.split('.')
     masks = netmask.split('.')
 
-    return nil if nets.size != 4 || masks.size != 4 # Some intial checking
-
-    nets.each do | net |
-      print_good("\t\tString: #{net}    Int + 1:#{int_or_nil(net) + 1}")
+    (0..3).each do | index |
+      get_subnet_octet(int_or_nil(nets[index]), int_or_nil(masks[index]))
     end
+  end
 
-    
-    masks.each do | mask |
-      print_good("\t\t#{mask}    Int + 1:#{int_or_nil(mask) + 1}")
-    end
-    
+  # This function an octet of an IPv4 address and the cooresponding octet of the
+  # IPv4 netmask and returns the appropreate subnet octet.
+  #
+  # @net  [integer class] IPv4 address octet
+  # @mask [integer class] Ipv4 netmask octet
+  #
+  # @return [integer class] Integer representation of the number string
+  # @return [nil class] string contains non-numbers, cannot convert
+  def get_subnet_octet(net, mask)
+    subnet_range = 256 - mask  #This is the address space of the coorisponding subnet octet
+
+    multi = net / subnet_range #Integer division to get the multiplier needed to deturmine subnet octet
+
+    octet = subnet_range * multi
+    print_status("\tSubnet_Range: #{subnet_range}    Multi: #{multi}   Octet:#{octet}")
   end
 
   # This function takes a string of numbers and converts it to an integer.
   #
+  # @string [string class] Input string, needs to be all numbers (0..9)
   # @return [integer class] Integer representation of the number string
   # @return [nil class] string contains non-numbers, cannot convert
   def int_or_nil(string)

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -159,6 +159,10 @@ class MetasploitModule < Msf::Post
     Rex::Socket::SwitchBoard.remove_route(subnet, netmask, session)
   end
 
+  # This function will check if a subnet is routable
+  #
+  # @return [true]  if routable
+  # @return [false] if not
   def is_routable?(route)
     if route.subnet =~ /^224\.|127\./
       return false
@@ -197,11 +201,21 @@ class MetasploitModule < Msf::Post
         end
       end
     end
-
-    session.net.config.each_interface do | interface |
-      print_status("Interface: #{interface.mac_name}  =  #{interface.addrs[1]} : #{interface.netmasks[1]}") if interface.addrs[1]
-    end
+    autoadd_interface_routes
     print_status("Did not find any new subnets to add.") if !found
+  end
+
+  # This function will look at network interfaces as options for additional routes.
+  # If the routes are not already included they will be added.
+  #
+  # @return [void] A useful return value is not expected here
+  def autoadd_interface_routes
+    session.net.config.each_interface do | interface |
+      (0..interface.addrs.size).each do | index |
+        next unless interface.addrs[index] =~ /\./
+        print_status("Interface: #{interface.mac_name}  =  #{interface.addrs[index]} : #{interface.netmasks[index]}") if interface.addrs[1]
+      end
+    end
   end
 
   # Validates the command options

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -200,13 +200,13 @@ class MetasploitModule < Msf::Post
       if !switch_board.route_exists?(route.subnet, route.netmask)
         begin
           if Rex::Socket::SwitchBoard.add_route(route.subnet, route.netmask, session)
-            print_good("Route added to subnet #{route.subnet}/#{route.netmask} from routing table.")
+            print_good("Route added to subnet #{route.subnet}/#{route.netmask} from host's routing table.")
             found = true
           else
-            print_error("Could not add route to subnet #{route.subnet}/#{route.netmask}")
+            print_error("Could not add route to subnet #{route.subnet}/#{route.netmask} from host's routing table.")
           end
         rescue ::Rex::Post::Meterpreter::RequestError => error
-          print_error("Could not add route to subnet #{route.subnet}/(#{route.netmask})")
+          print_error("Could not add route to subnet #{route.subnet}/(#{route.netmask}) from host's routing table.")
           print_error(error.to_s)
         end
       end
@@ -242,13 +242,13 @@ class MetasploitModule < Msf::Post
           if !switch_board.route_exists?(subnet, netmask)
             begin
               if Rex::Socket::SwitchBoard.add_route(subnet, netmask, session)
-                print_good("Route added to subnet #{subnet}/#{netmask} from interface list.")
+                print_good("Route added to subnet #{subnet}/#{netmask} from #{interface.mac_name}.")
                 found = true
               else
-                print_error("Could not add route to subnet #{subnet}/#{netmask}")
+                print_error("Could not add route to subnet #{subnet}/#{netmask} from #{interface.mac_name}")
               end
             rescue ::Rex::Post::Meterpreter::RequestError => error
-              print_error("Could not add route to subnet #{subnet}/(#{netmask})")
+              print_error("Could not add route to subnet #{subnet}/(#{netmask}) from #{interface.mac_name}")
               print_error(error.to_s)
             end
           end

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Post
       return false
     end
 
-    true
+    return true
   end
 
   # This function will search for valid subnets on the target and attempt
@@ -185,18 +185,21 @@ class MetasploitModule < Msf::Post
 
       if !switch_board.route_exists?(route.subnet, route.netmask)
         begin
-          netmask = route.netmask == '255.255.255.255' ? '255.255.255.0' : route.netmask
           if Rex::Socket::SwitchBoard.add_route(route.subnet, netmask, session)
-            print_good("Route added to subnet #{route.subnet}/#{netmask}")
+            print_good("Route added to subnet #{route.subnet}/#{route.netmask}")
             found = true
           else
-            print_error("Could not add route to subnet #{route.subnet}/#{netmask}")
+            print_error("Could not add route to subnet #{route.subnet}/#{route.netmask}")
           end
         rescue ::Rex::Post::Meterpreter::RequestError => error
-          print_error("Could not add route to subnet #{route.subnet}/(#{netmask})")
+          print_error("Could not add route to subnet #{route.subnet}/(#{route.netmask})")
           print_error(error.to_s)
         end
       end
+    end
+
+    session.net.config.each_interface do | interface |
+      print_status("Interface: #{interface.mac_name}  =  #{interface.addrs[1]} : #{interface.netmasks[1]}") if interface.addrs[1]
     end
     print_status("Did not find any new subnets to add.") if !found
   end


### PR DESCRIPTION
## Overview

This PR is in response to Issue #6781 where @wchen-r7 noticed that the autoadd CMD option was not adding all possible routes. As previously programmed, autoadd was only looking at the host's routing table to gather potential routes. In certain situations, this would miss other potential routes. The issue is observed in the case of a full traffic VPN that does not put a route to its subnet in the host's routing table since all traffic goes through the VPN's network adapter.
## Fix

The issue was fixed by adding functionality for autoadd to search through the host's network interface list to find additional potential routes. If these routes are not already included in Metasploit's routing table, they are added.

Note: Since I was unable to locate functions to convert an IPv4 address and netmask to a corresponding subnet "network" in the Framework, I wrote them for this module. If they do exist in the Framework, I will drop off the ones in this module. Or if they do not exist in the Framework, and it is desirable to move them to a Framework library for other modules to use, I am good with that. I would need to know which library is best for them.
## Additional Improvements

A new CMD option "default" was added to this module. This option will add a default route (0.0.0.0/0.0.0.0) to Metasploit's routing table for the associated Meterpreter session. This forces all TCP/IP traffic; not otherwise covered in the routing table, to be routed through that session. A default route useful in situations where a full traffic VPN is used and the VPN server does the routing to private networks. In this situation, it is likely that the compromised host's routing table and interface list would not include routes or references to these networks. The default route will push the routing off to the server allowing those networks to be accessed, pending you know where to look. The default route can also be used to browse the Internet as the compromised host using a Socks4a proxy and Proxychains.

Also, included in this PR is the addition of a documentation file for this module (autoroute.md). The file contains information on using this module and information on pivoting using a Socks4a server and Proxychains.
## Verification of Fix for Issue

A Meterpreter session was initiated on a machine running Windows 10. This host has NetMotion's Mobility VPN installed and set up for full traffic. (Also tested on Windows 7 using the same VPN.)

Before this update the results of this module using autoadd were as follows:

```
[*]     Running command run post/windows/manage/autoroute
[*] Running module against SURFACE
[*] Searching for subnets to autoroute.
[+] Route added to subnet 192.168.1.0/255.255.255.0
[+] Route added to subnet 192.168.86.0/255.255.255.0
[+] Route added to subnet 192.168.184.0/255.255.255.0
```

This is missing a route to the subnet associated with the VPN since it is not in the routing table as can be seen from the NetMotion interface.

```
Interface 18
============
Name         : NetMotion Virtual Network Adapter (NMVNIC)
Hardware MAC : 4e:4d:a5:91:ea:8e
MTU          : 1500
IPv4 Address : 10.10.239.210
IPv4 Netmask : 255.255.255.0
IPv6 Address : fe80::3107:4f8f:74dd:5555
IPv6 Netmask : ffff:ffff:ffff:ffff::
```

After this update the results of autoadd are as follows:

```
[*]     Running command run post/windows/manage/autoroute
[*] Running module against SURFACE
[*] Searching for subnets to autoroute.
[+] Route added to subnet 192.168.1.0/255.255.255.0 from host's routing table.
[+] Route added to subnet 192.168.86.0/255.255.255.0 from host's routing table.
[+] Route added to subnet 192.168.184.0/255.255.255.0 from host's routing table.
[+] Route added to subnet 10.10.239.0/255.255.255.0 from NetMotion Virtual Network Adapter (NMVNIC).
```

Testing on other VPN solutions is requested. Since this looks at all of the network interfaces, it should find the routes regardless of which VPN solution is used.
## Verification of Default Route

For this, I started a Windows Meterpreter session on a host with a different public IP address from my Kali machine. The module was run on the session using the "default" CMD option. A default route was added. I used the Socks4a module with Proxychains and Firefox to visit www.ipchicken.com to verify that the reported external IP address belonged to the compromised host. A description of how to set this up is in the documentation file included in this PR.
