### PR TITLE
remove overwritten keys from hashes

### DIFF
--- a/modules/exploits/multi/http/atutor_sqli.rb
+++ b/modules/exploits/multi/http/atutor_sqli.rb
@@ -243,7 +243,6 @@ class MetasploitModule < Msf::Exploit::Remote
       post_reference_name: self.refname,
       private_data: opts[:password],
       origin_type: :service,
-      private_type: :password,
       private_type: :nonreplayable_hash,
       jtr_format: 'sha512',
       username: opts[:user]

--- a/modules/exploits/windows/http/easyfilesharing_seh.rb
+++ b/modules/exploits/windows/http/easyfilesharing_seh.rb
@@ -25,10 +25,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'EDB', '39008' ],
         ],
       'Privileged'     => true,
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread',
-        },
       'Payload'        =>
         {
           'Space'    => 390,


### PR DESCRIPTION
This fixes #6772. I chose to delete the overwritten hash values, rather than merge, since it was clear that the overwritten values were never tested (since they had no effect.)
## Verification
- [x] Visual code inspection (the fixes are fairly obvious)
- [ ] On an up-to-date Kali-rolling VM, verify that msfconsole does not throw warnings with the system ruby when running a fresh metasploit-framework checkout with this PR, OR....
- [x] You can also simulate Kali's environment with RVM by updating to ruby 2.3.0 by modifying .ruby-version, reentering the directory, following rvm's instructions, then bundling the gems again.
