### PR TITLE
Fix RegExp evaluation in is_routable? function post/windows/manage/autoroute

### DIFF
--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Post
   # @return [true]  If good to add
   # @return [false] If not
   def is_routable?(subnet, netmask)
-    if subnet =~ /^224\.|127\./
+    if subnet =~ /^224\.|^127\./
       return false
     elsif subnet == '0.0.0.0'
       return false


### PR DESCRIPTION
## Fix

This PR is to fix a problem with the regular expression in the is_routable? function in post/windows/manage/autoroute. @void-in noticed that the 127 exclusion was being applied to all four IPv4 octets instead of just the first one to determine rotatability. Thank you! 

Without this fix, any IPv4 subnet with 127 in any of the octets would be excluded. After the fix, only IPv4 subnets with 127 in the first octet will be excluded, which is as it should be.
