### PR TITLE
Fix #5197, Fixed yard doc errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,3 @@ DEPENDENCIES
   simplecov
   timecop
   yard
-
-BUNDLED WITH
-   1.11.2

--- a/lib/metasploit/framework/community_string_collection.rb
+++ b/lib/metasploit/framework/community_string_collection.rb
@@ -5,7 +5,7 @@ module Metasploit
 
     # This class is responsible for taking datastore options from the snmp_login module
     # and yielding appropriate {Metasploit::Framework::Credential}s to the {Metasploit::Framework::LoginScanner::SNMP}.
-    # This one has to be different from {credentialCollection} as it will only have a {Metasploit::Framework::Credential#public}
+    # This one has to be different from credentialCollection as it will only have a {Metasploit::Framework::Credential#public}
     # It may be slightly confusing that the attribues are called password and pass_file, because this is what the legacy
     # module used. However, community Strings are now considered more to be public credentials than private ones.
     class CommunityStringCollection

--- a/lib/metasploit/framework/database.rb
+++ b/lib/metasploit/framework/database.rb
@@ -18,10 +18,10 @@ module Metasploit
       # Module Methods
       #
 
-      # Returns first configuration pathname from {configuration_pathnames} or the overridding `:path`.
+      # Returns first configuration pathname from configuration_pathnames or the overridding `:path`.
       #
       # @param options [Hash{Symbol=>String}]
-      # @option options [String] :path Path to use instead of first element of {configurations_pathnames}
+      # @option options [String] :path Path to use instead of first element of configurations_pathnames
       # @return [Pathname] if configuration pathname exists.
       # @return [nil] if configuration pathname does not exist.
       def self.configurations_pathname(options={})

--- a/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
+++ b/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
@@ -29,7 +29,7 @@ module Metasploit
 
         # Returns the latest sid from MSP
         #
-        # @param [Rex::Proto::Http::Response] 
+        # @param res [Rex::Proto::Http::Response] 
         # @return [String] The session ID for MSP
         def get_sid(res)
           cookies = res.get_cookies
@@ -41,7 +41,7 @@ module Metasploit
 
         # Returns the hidden inputs
         #
-        # @param [Rex::Proto::Http::Response]
+        # @param res [Rex::Proto::Http::Response]
         # @return [Hash] Input fields
         def get_hidden_inputs(res)
           found_inputs = {}

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -60,7 +60,7 @@ module Metasploit
           end
         end
 
-        # Attempt to login with every {Credential credential} in # {#cred_details}.
+        # Attempt to login with every {Credential credential} in # #cred_details.
         #
         # @yieldparam result [Result] The {Result} object for each attempt
         # @yieldreturn [void]

--- a/lib/metasploit/framework/spec/constants.rb
+++ b/lib/metasploit/framework/spec/constants.rb
@@ -42,7 +42,7 @@ module Metasploit::Framework::Spec::Constants
   # Adds actions to `spec` task so that `rake spec` fails if any of the following:
   #
   # # `log/leaked-constants.log` exists after printing out the leaked constants.
-  # # {Each.configured!} is unnecessary in `spec/spec_helper.rb` and should be removed.
+  # # Each.configured! is unnecessary in `spec/spec_helper.rb` and should be removed.
   #
   # @return [void]
   def self.define_task

--- a/lib/metasploit/framework/spec/constants/each.rb
+++ b/lib/metasploit/framework/spec/constants/each.rb
@@ -19,7 +19,7 @@ module Metasploit::Framework::Spec::Constants::Each
     attr_accessor :leaks_cleaned
   end
 
-  # Is {Metasploit::Framework::Spec::Constants::Each.configure!} still necessary or should it be removed?
+  # Is Metasploit::Framework::Spec::Constants::Each.configure! still necessary or should it be removed?
   #
   # @return [true] if {configure!}'s `before(:each)` cleaned up leaked constants
   # @return [false] otherwise
@@ -91,7 +91,7 @@ module Metasploit::Framework::Spec::Constants::Each
     !!@configured
   end
 
-  # Adds action to `spec` task so that `rake spec` fails if {configured!} is unnecessary in `spec/spec_helper.rb` and
+  # Adds action to `spec` task so that `rake spec` fails if configured! is unnecessary in `spec/spec_helper.rb` and
   # should be removed
   #
   # @return [void]

--- a/lib/metasploit/framework/spec/constants/suite.rb
+++ b/lib/metasploit/framework/spec/constants/suite.rb
@@ -6,7 +6,7 @@ module Metasploit::Framework::Spec::Constants::Suite
 
   LOGS_PATHNAME = Pathname.new('log/metasploit/framework/spec/constants/suite')
 
-  # Logs leaked constants to {LOG_PATHNAME} and prints `message` to stderr.
+  # Logs leaked constants to LOG_PATHNAME and prints `message` to stderr.
   #
   # @param hook (see log_pathname)
   # @param message [String] additional message printed to stderr when there is at least one leaked constant.

--- a/lib/metasploit/framework/thread_factory_provider.rb
+++ b/lib/metasploit/framework/thread_factory_provider.rb
@@ -1,5 +1,5 @@
 # Wraps {Msf::Framework} so that {Msf::Framework#threads} is only created on the first call to {#spawn} by
-# {Rex::ThreadFactory#spawn}, which allows the threads used by {Msf::ThreadManager} to be created lazily.
+# Rex::ThreadFactory#spawn, which allows the threads used by {Msf::ThreadManager} to be created lazily.
 #
 # @example Setting Rex::ThreadFactory.provider and spawning threads
 #   Rex::ThreadFactory.provider = Metasploit::Framework::ThreadFactoryProvider.new(framework: framework)

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -49,7 +49,7 @@ module Auxiliary::AuthBrute
     @@max_per_service = nil
   end
 
-  # Yields each {Metasploit::Credential::Core} in the {Mdm::Workspace} with
+  # Yields each Metasploit::Credential::Core in the Mdm::Workspace with
   # a private type of 'ntlm_hash'
   #
   # @yieldparam [Metasploit::Credential::Core]
@@ -60,7 +60,7 @@ module Auxiliary::AuthBrute
     end
   end
 
-  # Yields each {Metasploit::Credential::Core} in the {Mdm::Workspace} with
+  # Yields each Metasploit::Credential::Core in the Mdm::Workspace with
   # a private type of 'password'
   #
   # @yieldparam [Metasploit::Credential::Core]
@@ -71,7 +71,7 @@ module Auxiliary::AuthBrute
     end
   end
 
-  # Yields each {Metasploit::Credential::Core} in the {Mdm::Workspace} with
+  # Yields each Metasploit::Credential::Core in the Mdm::Workspace with
   # a private type of 'ssh_key'
   #
   # @yieldparam [Metasploit::Credential::Core]
@@ -90,7 +90,7 @@ module Auxiliary::AuthBrute
     (datastore['DB_ALL_CREDS'] || datastore['DB_ALL_PASS'] || datastore['DB_ALL_USERS']) && framework.db.active
   end
 
-  # This method takes a {Metasploit::Framework::CredentialCollection} and prepends existing NTLMHashes
+  # This method takes a Metasploit::Framework::CredentialCollection and prepends existing NTLMHashes
   # from the database. This allows the users to use the DB_ALL_CREDS option.
   #
   # @param cred_collection [Metasploit::Framework::CredentialCollection]
@@ -105,7 +105,7 @@ module Auxiliary::AuthBrute
     cred_collection
   end
 
-  # This method takes a {Metasploit::Framework::CredentialCollection} and prepends existing SSHKeys
+  # This method takes a Metasploit::Framework::CredentialCollection and prepends existing SSHKeys
   # from the database. This allows the users to use the DB_ALL_CREDS option.
   #
   # @param [Metasploit::Framework::CredentialCollection] cred_collection
@@ -120,7 +120,7 @@ module Auxiliary::AuthBrute
     cred_collection
   end
 
-  # This method takes a {Metasploit::Framework::CredentialCollection} and prepends existing Password Credentials
+  # This method takes a Metasploit::Framework::CredentialCollection and prepends existing Password Credentials
   # from the database. This allows the users to use the DB_ALL_CREDS option.
   #
   # @param cred_collection [Metasploit::Framework::CredentialCollection]
@@ -135,9 +135,9 @@ module Auxiliary::AuthBrute
     cred_collection
   end
 
-  # Takes a {Metasploit::Credential::Core} and converts it into a
-  # {Metasploit::Framework::Credential} and processes it into the
-  # {Metasploit::Framework::CredentialCollection} as dictated by the
+  # Takes a Metasploit::Credential::Core and converts it into a
+  # Metasploit::Framework::Credential and processes it into the
+  # Metasploit::Framework::CredentialCollection as dictated by the
   # selected datastore options.
   #
   # @param [Metasploit::Framework::CredentialCollection] cred_collection the credential collection to add to

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -70,7 +70,7 @@ module Auxiliary::Report
   # This method safely get the workspace ID. It handles if the db is not active
   #
   # @return [NilClass] if there is no DB connection
-  # @return [Fixnum] the ID of the current {Mdm::Workspace}
+  # @return [Fixnum] the ID of the current Mdm::Workspace
   def myworkspace_id
     if framework.db.active
       myworkspace.id
@@ -169,7 +169,7 @@ module Auxiliary::Report
   # should be used directly instead.
   #
   # @param opts [Hash] the option hash
-  # @option opts [String] :host the address of the host (also takes a {Mdm::Host})
+  # @option opts [String] :host the address of the host (also takes a Mdm::Host)
   # @option opts [Fixnum] :port the port of the connected service
   # @option opts [Mdm::Service] :service an optional Service object to build the cred for
   # @option opts [String] :type What type of private credential this is (e.g. "password", "hash", "ssh_key")

--- a/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/xml.rb
@@ -88,7 +88,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
     report_note(note_data)
   end
 
-  # Imports web_form element using {Msf::DBManager#report_web_form}.
+  # Imports web_form element using Msf::DBManager#report_web_form.
   #
   # @param element [REXML::Element] web_form element.
   # @param options [Hash{Symbol => Object}] options
@@ -124,7 +124,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
     end
   end
 
-  # Imports web_page element using {Msf::DBManager#report_web_page}.
+  # Imports web_page element using Msf::DBManager#report_web_page.
   #
   # @param element [REXML::Element] web_page element.
   # @param options [Hash{Symbol => Object}] options
@@ -171,7 +171,7 @@ module Msf::DBManager::Import::MetasploitFramework::XML
     end
   end
 
-  # Imports web_vuln element using {Msf::DBManager#report_web_vuln}.
+  # Imports web_vuln element using Msf::DBManager#report_web_vuln.
   #
   # @param element [REXML::Element] web_vuln element.
   # @param options [Hash{Symbol => Object}] options
@@ -577,8 +577,8 @@ module Msf::DBManager::Import::MetasploitFramework::XML
   end
 
   # Imports web_form, web_page, or web_vuln element using
-  # {Msf::DBManager#report_web_form}, {Msf::DBManager#report_web_page}, and
-  # {Msf::DBManager#report_web_vuln}, respectively.
+  # Msf::DBManager#report_web_form, Msf::DBManager#report_web_page, and
+  # Msf::DBManager#report_web_vuln, respectively.
   #
   # @param element [REXML::Element] the web_form, web_page, or web_vuln
   #   element.

--- a/lib/msf/core/db_manager/import/nexpose/raw.rb
+++ b/lib/msf/core/db_manager/import/nexpose/raw.rb
@@ -196,8 +196,8 @@ module Msf::DBManager::Import::Nexpose::Raw
   # Takes an array of vuln hashes, as returned by the NeXpose rawxml stream
   # parser, like:
   #   [
-  #     {"id"=>"winreg-notes-protocol-handler", severity="8", "refs"=>[{"source"=>"BID", "value"=>"10600"}, ...]}
-  #     {"id"=>"windows-zotob-c", severity="8", "refs"=>[{"source"=>"BID", "value"=>"14513"}, ...]}
+  #     "id"=>"winreg-notes-protocol-handler", severity="8", "refs"=>["source"=>"BID", "value"=>"10600", ...]
+  #     "id"=>"windows-zotob-c", severity="8", "refs"=>["source"=>"BID", "value"=>"14513", ...]
   #   ]
   # and transforms it into a struct, containing :id, :refs, :title, and :severity
   #

--- a/lib/msf/core/db_manager/session.rb
+++ b/lib/msf/core/db_manager/session.rb
@@ -33,7 +33,7 @@ module Msf::DBManager::Session
   #     :session host is contained.  Also used as the workspace for the
   #     Mdm::ExploitAttempt and Mdm::Vuln.  Defaults to Mdm::Worksapce with
   #     Mdm::Workspace#name equal to +session.workspace+.
-  #   @return [nil] if {Msf::DBManager#active} is +false+.
+  #   @return [nil] if Msf::DBManager#active is +false+.
   #   @return [Mdm::Session] if session is saved
   #   @raise [ArgumentError] if :session is not an {Msf::Session}.
   #   @raise [ActiveRecord::RecordInvalid] if session is invalid and cannot be
@@ -68,7 +68,7 @@ module Msf::DBManager::Session
   #     exploit that was used to open the session.
   #   @option option [String] :via_payload the {MSf::Module#fullname} of the
   #     payload sent to the host when the exploit was successful.
-  #   @return [nil] if {Msf::DBManager#active} is +false+.
+  #   @return [nil] if Msf::DBManager#active is +false+.
   #   @return [Mdm::Session] if session is saved.
   #   @raise [ArgumentError] if :host is not an Mdm::Host.
   #   @raise [ActiveRecord::RecordInvalid] if session is invalid and cannot be
@@ -103,7 +103,7 @@ module Msf::DBManager::Session
 
   protected
 
-  # @param session [Msf::Session] A session with a {db_record Msf::Session#db_record}
+  # @param session [Msf::Session] A session with a db_record Msf::Session#db_record
   # @param wspace [Mdm::Workspace]
   # @return [void]
   def infer_vuln_from_session(session, wspace)

--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -409,8 +409,8 @@ module Msf
     # Checks if the module is multi-platform based on the directory path.
     #
     # @param m [Object] Module.
-    # @return Module [TrueClass] is multi-platform.
-    # @return Module [FalseClass] is not multi-platform.
+    # @return [TrueClass] is multi-platform.
+    # @return [FalseClass] is not multi-platform.
     def is_multi_platform_exploit?(m)
       m.fullname.include?('multi/')
     end

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -73,10 +73,10 @@ module Msf
       'vuln_test',    # Example: "if(window.MyComponentIsInstalled)return true;",
       # :activex is a special case.
       # When you set this requirement in your module, this is how it should be:
-      # [{:clsid=>'String', :method=>'String'}]
+      # [:clsid=>'String', :method=>'String']
       # Where each Hash is a test case
       # But when BES receives this information, the JavaScript will return this format:
-      # "{CLSID}=>Method=>Boolean;"
+      # "CLSID=>Method=>Boolean;"
       # Also see: #has_bad_activex?
       'activex'
     ])
@@ -216,7 +216,7 @@ module Msf
 
     # Returns true if there's a bad ActiveX, otherwise false.
     # @param ax [String] The raw activex the JavaScript detection will return in this format:
-    #                    "{CLSID}=>Method=>Boolean;"
+    #                    "CLSID=>Method=>Boolean;"
     # @return [Boolean] True if there's a bad ActiveX, otherwise false
     def has_bad_activex?(ax)
       ax.to_s.split(';').each do |a|

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -106,7 +106,7 @@ module ReverseHttp
     "#{scheme}://#{callback_host}/"
   end
 
-  # Use the {#refname} to determine whether this handler uses SSL or not
+  # Use the #refname to determine whether this handler uses SSL or not
   #
   def ssl?
     !!(self.refname.index('https'))

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -183,8 +183,8 @@ class Msf::ModuleSet < Hash
   # @option info [Array<String>] 'files' List of paths to files that defined
   #   +klass+.
   # @return [Class] The klass parameter modified to have
-  #   {Msf::Module#framework}, {Msf::Module#refname}, {Msf::Module#file_path},
-  #   and {Msf::Module#orig_cls} set.
+  #   Msf::Module.framework, Msf::Module#refname, Msf::Module#file_path,
+  #   and Msf::Module#orig_cls set.
   def add_module(klass, reference_name, info = {})
     # Set the module's reference_name so that it can be referenced when
     # instances are created.

--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -53,7 +53,7 @@ class Msf::Post < Msf::Module
     mod
   end
 
-  # This method returns the ID of the {Mdm::Session} that the post module
+  # This method returns the ID of the Mdm::Session that the post module
   # is currently running against.
   #
   # @return [NilClass] if there is no database record for the session

--- a/lib/rex/parser/fs/bitlocker.rb
+++ b/lib/rex/parser/fs/bitlocker.rb
@@ -1,10 +1,13 @@
 # -*- coding: binary -*-
+
+require 'openssl/ccm'
+require 'metasm'
+
 ##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-require 'openssl/ccm'
-require 'metasm'
+
 module Rex
   module Parser
     ###
@@ -112,7 +115,7 @@ module Rex
 
       # Parse the metadata_entries and return a hashmap using the
       # following format:
-      # {metadata_entry_type => {metadata_value_type => [fve_entry,...]}}
+      # metadata_entry_type => metadata_value_type => [fve_entry,...]
       def fve_entries(metadata_entries)
         offset_entry = 0
         entry_size = metadata_entries[0, 2].unpack('v')[0]
@@ -215,7 +218,7 @@ module Rex
       end
 
       # Produce a hash map using the following format:
-      # {PROTECTION_TYPE => [fve_entry, fve_entry...]}
+      # PROTECTION_TYPE => [fve_entry, fve_entry...]
       def vmk_entries
         res = {}
         (@fve_metadata_entries[ENTRY_TYPE_VMK][VALUE_TYPE_VMK]).each do |vmk|

--- a/lib/rex/proto/adb/client.rb
+++ b/lib/rex/proto/adb/client.rb
@@ -1,9 +1,5 @@
 # -*- coding: binary -*-
 
-##
-# ADB protocol support
-##
-
 require 'rex/proto/adb/message'
 
 module Rex

--- a/lib/rex/proto/steam/message.rb
+++ b/lib/rex/proto/steam/message.rb
@@ -52,7 +52,7 @@ module Steam
 
   # Decodes an A2S_INFO response message
   #
-  # @parameter response [String] the A2S_INFO resposne to decode
+  # @param response [String] the A2S_INFO resposne to decode
   # @return [Hash] the fields extracted from the response
   def a2s_info_decode(response)
     # abort if it is impossibly short

--- a/plugins/request.rb
+++ b/plugins/request.rb
@@ -216,7 +216,7 @@ class Plugin::Requests < Msf::Plugin
     #   response.
     # @option opts [Boolean] :print_headers Whether or not to print the headers
     #   of the response.
-    # @options opts [String] :ssl_version The version of SSL to use if the
+    # @option opts [String] :ssl_version The version of SSL to use if the
     #   request scheme is HTTPS.
     # @option opts [String] :uri The target uri to request.
     # @option opts [String] :user_agent The value to use in the User-Agent
@@ -247,7 +247,7 @@ class Plugin::Requests < Msf::Plugin
     #   response.
     # @option opts [Boolean] :print_headers Whether or not to print the headers
     #   of the response.
-    # @options opts [String] :ssl_version The version of SSL to use if the
+    # @option opts [String] :ssl_version The version of SSL to use if the
     #   request scheme is HTTPS.
     # @option opts [String] :uri The target uri to request.
     # @option opts [String] :user_agent The value to use in the User-Agent


### PR DESCRIPTION
Several errors and linking issues were occurring when generating yard docs. Some errors were purely typos, such as misnaming a param, others were x-ref errors because the links couldn't be resolved.  

This fixes most of those errors. 
## Verification
- [x] From the Framework directory, run `rake yard`.
- [x] Verify that the docs generate without error. The one error that you still may see is "Unknown tag @probe".

Fix #5197 Fixed issues that caused errors during yard doc generation
