### PR TITLE
File.exists? must die

### DIFF
--- a/data/exploits/capture/http/forms/grabforms.rb
+++ b/data/exploits/capture/http/forms/grabforms.rb
@@ -28,7 +28,7 @@ File.readlines(sitelist).each do |site|
   next if site =~ /^#/
 
   out = File.join(output, site + ".txt")
-  File.unlink(out) if File.exists?(out)
+  File.unlink(out) if File.exist?(out)
 
   fd  = File.open(out, "a")
 

--- a/lib/anemone/storage/pstore.rb
+++ b/lib/anemone/storage/pstore.rb
@@ -9,7 +9,7 @@ module Anemone
       def_delegators :@keys, :has_key?, :keys, :size
 
       def initialize(file)
-        File.delete(file) if File.exists?(file)
+        File.delete(file) if File.exist?(file)
         @store = ::PStore.new(file)
         @keys = {}
       end

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -27,7 +27,7 @@ module Scriptable
 
       # Scan all of the path combinations
       check_paths.each { |path|
-        if ::File.exists?(path)
+        if ::File.exist?(path)
           full_path = path
           break
         end

--- a/lib/msf/base/simple/framework.rb
+++ b/lib/msf/base/simple/framework.rb
@@ -30,7 +30,7 @@ module Framework
     def load(path, opts = {})
       def_path = Msf::Config.plugin_directory + File::SEPARATOR + path
 
-      if (File.exists?(def_path) or File.exists?(def_path + ".rb"))
+      if (File.exist?(def_path) or File.exist?(def_path + ".rb"))
         super(def_path, opts)
       else
         super

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -65,10 +65,10 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
 
       # Only report loot if we actually have it.
       # TODO: Copypasta. Separate this out.
-      if ::File.exists? loot_info[:orig_path]
+      if ::File.exist? loot_info[:orig_path]
         loot_dir = ::File.join(basedir,"loot")
         loot_file = ::File.split(loot_info[:orig_path]).last
-        if ::File.exists? loot_dir
+        if ::File.exist? loot_dir
           unless (::File.directory?(loot_dir) && ::File.writable?(loot_dir))
             raise Msf::DBImportError.new("Could not move files to #{loot_dir}")
           end
@@ -77,7 +77,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
         end
         new_loot = ::File.join(loot_dir,loot_file)
         loot_info[:path] = new_loot
-        if ::File.exists?(new_loot)
+        if ::File.exist?(new_loot)
           ::File.unlink new_loot # Delete it, and don't report it.
         else
           report_loot(loot_info) # It's new, so report it.
@@ -115,10 +115,10 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
 
       # Only report a task if we actually have it.
       # TODO: Copypasta. Separate this out.
-      if ::File.exists? task_info[:orig_path]
+      if ::File.exist? task_info[:orig_path]
         tasks_dir = ::File.join(basedir,"tasks")
         task_file = ::File.split(task_info[:orig_path]).last
-        if ::File.exists? tasks_dir
+        if ::File.exist? tasks_dir
           unless (::File.directory?(tasks_dir) && ::File.writable?(tasks_dir))
             raise Msf::DBImportError.new("Could not move files to #{tasks_dir}")
           end
@@ -127,7 +127,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
         end
         new_task = ::File.join(tasks_dir,task_file)
         task_info[:path] = new_task
-        if ::File.exists?(new_task)
+        if ::File.exist?(new_task)
           ::File.unlink new_task # Delete it, and don't report it.
         else
           report_task(task_info) # It's new, so report it.
@@ -156,7 +156,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
     new_tmp = ::File.join(Dir::tmpdir,"msf","imp_#{Rex::Text::rand_text_alphanumeric(4)}",@import_filedata[:zip_basename])
-    if ::File.exists? new_tmp
+    if ::File.exist? new_tmp
       unless (::File.directory?(new_tmp) && ::File.writable?(new_tmp))
         raise Msf::DBImportError.new("Could not extract zip file to #{new_tmp}")
       end
@@ -172,7 +172,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     # already exist
     @import_filedata[:zip_tmp_subdirs].each {|sub|
       tmp_subdirs = ::File.join(@import_filedata[:zip_tmp],sub)
-      if File.exists? tmp_subdirs
+      if File.exist? tmp_subdirs
         unless (::File.directory?(tmp_subdirs) && File.writable?(tmp_subdirs))
           # if it exists but we can't write to it, give up
           raise Msf::DBImportError.new("Could not extract zip file to #{tmp_subdirs}")
@@ -198,7 +198,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     Dir.entries(@import_filedata[:zip_tmp]).each do |entry|
       if entry =~ /^.*#{Regexp.quote(Metasploit::Credential::Exporter::Core::CREDS_DUMP_FILE_IDENTIFIER)}.*/
         manifest_file_path = File.join(@import_filedata[:zip_tmp], entry, Metasploit::Credential::Importer::Zip::MANIFEST_FILE_NAME)
-        if File.exists? manifest_file_path
+        if File.exist? manifest_file_path
           import_msf_cred_dump(manifest_file_path, wspace)
         end
       end

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -329,7 +329,7 @@ module Msf::DBManager::ModuleCache
           next
         end
 
-        unless md.file and ::File.exists?(md.file)
+        unless md.file and ::File.exist?(md.file)
           refresh << md
           next
         end

--- a/lib/msf/core/db_manager/report.rb
+++ b/lib/msf/core/db_manager/report.rb
@@ -23,7 +23,7 @@ module Msf::DBManager::Report
     created = opts.delete(:created_at)
     updated = opts.delete(:updated_at)
 
-    unless File.exists? tmp_path
+    unless File.exist? tmp_path
       raise Msf::DBImportError 'Report artifact file to be imported does not exist.'
     end
 
@@ -31,7 +31,7 @@ module Msf::DBManager::Report
       raise Msf::DBImportError "Could not move report artifact file to #{artifacts_dir}."
     end
 
-    if File.exists? new_path
+    if File.exist? new_path
       unique_basename = "#{(Time.now.to_f*1000).to_i}_#{artifact_name}"
       new_path = File.join(artifacts_dir, unique_basename)
     end

--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -537,7 +537,7 @@ protected
   #
   def find_context_key(buf, badchars, state)
     # Make sure our context information file is sane
-    if !File.exists?(datastore['ContextInformationFile'])
+    if !File.exist?(datastore['ContextInformationFile'])
       raise NoKeyError, "A context information file must specified when using context encoding", caller
     end
 

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -110,7 +110,7 @@ module Msf
         cap = datastore['PCAPFILE'] || ''
 
         if (not cap.empty?)
-          if (not File.exists?(cap))
+          if (not File.exist?(cap))
             raise RuntimeError, "The PCAP file #{cap} could not be found"
           end
           self.capture = ::Pcap.open_offline(cap)
@@ -216,7 +216,7 @@ module Msf
           raise RuntimeError, "Could not access the capture process (remember to open_pcap first!)"
         end
 
-        if (not File.exists?(pcap_file))
+        if (not File.exist?(pcap_file))
           raise RuntimeError, "The PCAP file #{pcap_file} could not be found"
         end
 

--- a/lib/msf/core/exploit/java.rb
+++ b/lib/msf/core/exploit/java.rb
@@ -47,7 +47,7 @@ module Exploit::Java
     end
 
     toolsjar = File.join(ENV['JAVA_HOME'], "lib", "tools.jar")
-    if (not File.exists? toolsjar)
+    if (not File.exist? toolsjar)
       raise RuntimeError, 'JAVA_HOME does not point to a valid JDK installation.'
     end
 
@@ -69,7 +69,7 @@ module Exploit::Java
   def save_to_file(classnames, codez, location)
     path = File.join( Msf::Config.install_root, "external", "source", location )
 
-    if not File.exists? path
+    if not File.exist? path
       Dir.mkdir(path)
     end
 
@@ -96,7 +96,7 @@ module Exploit::Java
     compile_options = [] if compile_options.nil?
 
     # Create the directory if it doesn't exist
-    Dir.mkdir(datastore['JavaCache']) if !File.exists? datastore['JavaCache']
+    Dir.mkdir(datastore['JavaCache']) if !File.exist? datastore['JavaCache']
 
     # For compatibility, some exploits need to have the target and source version
     # set to a previous JRE version.
@@ -157,7 +157,7 @@ module Exploit::Java
 
     # Check if the keystore exists from previous run.  If it does, delete it.
     msf_keystore	= File.join(datastore['JavaCache'], msf_keystore)
-    File.delete msf_keystore if File.exists? msf_keystore
+    File.delete msf_keystore if File.exist? msf_keystore
 
     # Rjb pukes on a CN with a comma in it so bad that it crashes to shell
     # and turns input echoing off.  Simple fix for this ugly bug is

--- a/lib/msf/core/opt_address_range.rb
+++ b/lib/msf/core/opt_address_range.rb
@@ -20,7 +20,7 @@ class OptAddressRange < OptBase
     return nil unless value.kind_of?(String)
     if (value =~ /^file:(.*)/)
       path = $1
-      return false if not File.exists?(path) or File.directory?(path)
+      return false if not File.exist?(path) or File.directory?(path)
       return File.readlines(path).map{ |s| s.strip}.join(" ")
     elsif (value =~ /^rand:(.*)/)
       count = $1.to_i

--- a/lib/msf/core/opt_path.rb
+++ b/lib/msf/core/opt_path.rb
@@ -23,7 +23,7 @@ class OptPath < OptBase
       if value =~ /^memory:\s*([0-9]+)/i
         return false unless check_memory_location($1)
       else
-        unless File.exists?(value)
+        unless File.exist?(value)
           return false
         end
       end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -143,7 +143,7 @@ module Msf::Post::File
   # @param data [String]
   # @return [void]
   def file_local_write(local_file_name, data)
-    unless ::File.exists?(local_file_name)
+    unless ::File.exist?(local_file_name)
       ::FileUtils.touch(local_file_name)
     end
 
@@ -160,7 +160,7 @@ module Msf::Post::File
   # @param local_file_name [String] Local file name
   # @return [String] Hex digest of file contents
   def file_local_digestmd5(local_file_name)
-    if ::File.exists?(local_file_name)
+    if ::File.exist?(local_file_name)
       require 'digest/md5'
       chksum = nil
       chksum = Digest::MD5.hexdigest(::File.open(local_file_name, "rb") { |f| f.read})
@@ -191,7 +191,7 @@ module Msf::Post::File
   # @param local_file_name [String] Local file name
   # @return [String] Hex digest of file contents
   def file_local_digestsha1(local_file_name)
-    if ::File.exists?(local_file_name)
+    if ::File.exist?(local_file_name)
       require 'digest/sha1'
       chksum = nil
       chksum = Digest::SHA1.hexdigest(::File.open(local_file_name, "rb") { |f| f.read})
@@ -222,7 +222,7 @@ module Msf::Post::File
   # @param local_file_name [String] Local file name
   # @return [String] Hex digest of file contents
   def file_local_digestsha2(local_file_name)
-    if ::File.exists?(local_file_name)
+    if ::File.exist?(local_file_name)
       require 'digest/sha2'
       chksum = nil
       chksum = Digest::SHA256.hexdigest(::File.open(local_file_name, "rb") { |f| f.read})

--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -30,7 +30,7 @@ class RPC_Plugin < RPC_Base
 
       # If the plugin isn't in the user direcotry (~/.msf3/plugins/), use the base
       path = Msf::Config.user_plugin_directory + File::SEPARATOR + plugin_file_name
-      if not File.exists?( path  + ".rb" )
+      if not File.exist?( path  + ".rb" )
         # If the following "path" doesn't exist it will be caught when we attempt to load
         path = Msf::Config.plugin_directory + File::SEPARATOR + plugin_file_name
       end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -249,7 +249,7 @@ class Core
 
     args.each do |res|
       good_res = nil
-      if ::File.exists?(res)
+      if ::File.exist?(res)
         good_res = res
       elsif
         # let's check to see if it's in the scripts/resource dir (like when tab completed)
@@ -258,7 +258,7 @@ class Core
           ::Msf::Config.user_script_directory + ::File::SEPARATOR + "resource"
         ].each do |dir|
           res_path = dir + ::File::SEPARATOR + res
-          if ::File.exists?(res_path)
+          if ::File.exist?(res_path)
             good_res = res_path
             break
           end
@@ -1254,7 +1254,7 @@ class Core
 
       # If the plugin isn't in the user directory (~/.msf3/plugins/), use the base
       path = Msf::Config.user_plugin_directory + File::SEPARATOR + plugin_file_name
-      if not File.exists?( path  + ".rb" )
+      if not File.exist?( path  + ".rb" )
         # If the following "path" doesn't exist it will be caught when we attempt to load
         path = Msf::Config.plugin_directory + File::SEPARATOR + plugin_file_name
       end
@@ -3291,7 +3291,7 @@ class Core
 
   # Determines if this is an apt-based install
   def is_apt
-    File.exists?(File.expand_path(File.join(Msf::Config.install_root, '.apt')))
+    File.exist?(File.expand_path(File.join(Msf::Config.install_root, '.apt')))
   end
 
   # Determines if we're a Metasploit Pro/Community/Express

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1469,7 +1469,7 @@ class Db
             print_error("Can't make loot with no filename")
             return
           end
-          if (!File.exists?(filename) or !File.readable?(filename))
+          if (!File.exist?(filename) or !File.readable?(filename))
             print_error("Can't read file")
             return
           end
@@ -1979,13 +1979,13 @@ class Db
       return
     end
     if (args[0] == "-y")
-      if (args[1] and not ::File.exists? ::File.expand_path(args[1]))
+      if (args[1] and not ::File.exist? ::File.expand_path(args[1]))
         print_error("File not found")
         return
       end
       file = args[1] || ::File.join(Msf::Config.get_config_root, "database.yml")
       file = ::File.expand_path(file)
-      if (::File.exists? file)
+      if (::File.exist? file)
         db = YAML.load(::File.read(file))['production']
         framework.db.connect(db)
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -220,7 +220,7 @@ class Driver < Msf::Ui::Driver
     if opts['Resource'].blank?
       # None given, load the default
       default_resource = ::File.join(Msf::Config.config_directory, 'msfconsole.rc')
-      load_resource(default_resource) if ::File.exists?(default_resource)
+      load_resource(default_resource) if ::File.exist?(default_resource)
     else
       opts['Resource'].each { |r|
         load_resource(r)
@@ -279,7 +279,7 @@ class Driver < Msf::Ui::Driver
 
     fname = ::File.join(@junit_output_path, "#{bname}.xml")
     cnt   = 0
-    while ::File.exists?( fname )
+    while ::File.exist?( fname )
       cnt  += 1
       fname = ::File.join(@junit_output_path, "#{bname}_#{cnt}.xml")
     end
@@ -314,7 +314,7 @@ class Driver < Msf::Ui::Driver
     # Generate the output path, allow multiple test with the same name
     fname = ::File.join(@junit_output_path, "#{bname}.xml")
     cnt   = 0
-    while ::File.exists?( fname )
+    while ::File.exist?( fname )
       cnt  += 1
       fname = ::File.join(@junit_output_path, "#{bname}_#{cnt}.xml")
     end
@@ -416,7 +416,7 @@ class Driver < Msf::Ui::Driver
     if path == '-'
       resource_file = $stdin.read
       path = 'stdin'
-    elsif ::File.exists?(path)
+    elsif ::File.exist?(path)
       resource_file = ::File.read(path)
     else
       print_error("Cannot find resource script: #{path}")

--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -37,7 +37,7 @@ module Msf
         kb_path = File.join(PullRequestFinder::MANUAL_BASE_PATH, "#{mod.fullname}.md")
         kb = ''
 
-        if File.exists?(kb_path)
+        if File.exist?(kb_path)
           File.open(kb_path, 'rb') { |f| kb = f.read }
         end
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -2253,9 +2253,9 @@ require 'msf/core/exe/segment_appender'
     path = ::File.expand_path(::File.join(
       ::File.dirname(__FILE__),"..", "..", "..", "data", "eicar.com")
     )
-    return true unless ::File.exists?(path)
+    return true unless ::File.exist?(path)
     ret = false
-    if ::File.exists?(path)
+    if ::File.exist?(path)
       begin
         data = ::File.read(path)
         unless Digest::SHA1.hexdigest(data) == "3395856ce81f2b7382dee72602f798b642f14140"

--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -138,7 +138,7 @@ def self.open_browser(url='http://google.com/')
       ['xdg-open', 'sensible-browser', 'firefox', 'firefox-bin', 'opera', 'konqueror', 'chromium-browser'].each do |browser|
         ENV['PATH'].split(':').each do |path|
           # Does the browser exists?
-          if File.exists?("#{path}/#{browser}")
+          if File.exist?("#{path}/#{browser}")
             system("#{browser} #{url} &")
             return
           end
@@ -165,7 +165,7 @@ def self.open_webrtc_browser(url='http://google.com/')
       paths << "#{app_data}\\Google\\Chrome\\Application\\chrome.exe"
 
       paths.each do |path|
-        if File.exists?(path)
+        if File.exist?(path)
           args = (path =~ /chrome\.exe/) ? "--allow-file-access-from-files" : ""
           system("\"#{path}\" #{args} \"#{url}\"")
           return true
@@ -187,7 +187,7 @@ def self.open_webrtc_browser(url='http://google.com/')
       ['google-chrome', 'chrome', 'chromium', 'firefox' , 'firefox', 'opera'].each do |browser|
         ENV['PATH'].split(':').each do |path|
           browser_path = "#{path}/#{browser}"
-          if File.exists?(browser_path)
+          if File.exist?(browser_path)
             args = (browser_path =~ /Chrome/) ? "--allow-file-access-from-files" : ""
             system("#{browser_path} #{args} #{url} &")
             return true

--- a/lib/rex/exploitation/ropdb.rb
+++ b/lib/rex/exploitation/ropdb.rb
@@ -24,7 +24,7 @@ class RopDb
   # Returns true if a ROP chain is available, otherwise false
   #
   def has_rop?(rop_name)
-    File.exists?(File.join(@base_path, "#{rop_name}.xml"))
+    File.exist?(File.join(@base_path, "#{rop_name}.xml"))
   end
 
   #

--- a/lib/rex/file.rb
+++ b/lib/rex/file.rb
@@ -82,7 +82,7 @@ module FileUtils
   def self.find_full_path(file_name)
 
     # Check for the absolute fast first
-    if (file_name[0,1] == "/" and ::File.exists?(file_name) and ::File::Stat.new(file_name))
+    if (file_name[0,1] == "/" and ::File.exist?(file_name) and ::File::Stat.new(file_name))
       return file_name
     end
 

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -132,7 +132,7 @@ class Client
 
     # The SSL certificate is being passed down as a file path
     if opts[:ssl_cert]
-      if ! ::File.exists? opts[:ssl_cert]
+      if ! ::File.exist? opts[:ssl_cert]
         elog("SSL certificate at #{opts[:ssl_cert]} does not exist and will be ignored")
       else
         # Load the certificate the same way that SslTcpServer does it

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -184,7 +184,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   #
   # Returns true if the remote file +name+ exists, false otherwise
   #
-  def File.exists?(name)
+  def File.exist?(name)
     r = client.fs.filestat.new(name) rescue nil
     r ? true : false
   end
@@ -302,7 +302,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
 
     # Check for changes
     src_stat = client.fs.filestat.new(src_file)
-    if ::File.exists?(dest_file)
+    if ::File.exist?(dest_file)
       dst_stat = ::File.stat(dest_file)
       if src_stat.size == dst_stat.size && src_stat.mtime == dst_stat.mtime
         return 'skipped'

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -240,7 +240,7 @@ class Rex::Socket::Comm::Local
         if @@ip6_lla_scopes.length == 0 and retry_scopes
 
           # Linux specific interface lookup code
-          if ::File.exists?( "/proc/self/net/igmp6" )
+          if ::File.exist?( "/proc/self/net/igmp6" )
             ::File.open("/proc/self/net/igmp6") do |fd|
               fd.each_line do |line|
                 line = line.strip

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -57,7 +57,7 @@ module Shell
   def init_tab_complete
     if (self.input and self.input.supports_readline)
       self.input = Input::Readline.new(lambda { |str| tab_complete(str) })
-      if Readline::HISTORY.length == 0 and histfile and File.exists?(histfile)
+      if Readline::HISTORY.length == 0 and histfile and File.exist?(histfile)
         File.readlines(histfile).each { |e|
           Readline::HISTORY << e.chomp
         }

--- a/modules/auxiliary/fuzzers/ftp/client_ftp.rb
+++ b/modules/auxiliary/fuzzers/ftp/client_ftp.rb
@@ -325,11 +325,11 @@ class MetasploitModule < Msf::Auxiliary
       return
 
     when 'RNFR'
-      send_response(c,arg,"RNRF",350," File exists")
+      send_response(c,arg,"RNRF",350," File.exist")
       return
 
     when 'RNTO'
-      send_response(c,arg,"RNTO",350," File exists")
+      send_response(c,arg,"RNTO",350," File.exist")
       return
     else
       send_response(c,arg,cmd.upcase,200," Command not understood")

--- a/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
           save_source.puts(res.body.to_s)
           save_source.close
 
-          print_status("#{full_uri} - nginx - File successfully saved: #{path_save}#{uri}") if (File.exists?("#{path_save}#{uri}"))
+          print_status("#{full_uri} - nginx - File successfully saved: #{path_save}#{uri}") if (File.exist?("#{path_save}#{uri}"))
 
         else
           print_error("http://#{vhost}:#{rport} - nginx - Unrecognized #{res.code} response")

--- a/modules/auxiliary/server/ftp.rb
+++ b/modules/auxiliary/server/ftp.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     path = ::File.join(datastore['FTPROOT'], Rex::FileUtils.clean_path(arg))
-    if(not ::File.exists?(path))
+    if(not ::File.exist?(path))
       c.put "550 File does not exist\r\n"
       return
     end
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     path = ::File.join(datastore['FTPROOT'], Rex::FileUtils.clean_path(arg))
-    if(not ::File.exists?(path))
+    if(not ::File.exist?(path))
       c.put "550 File does not exist\r\n"
       return
     end
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     npath = ::File.expand_path(::File.join(datastore['FTPROOT'], bpath))
-    if not (::File.exists?(npath) and ::File.directory?(npath))
+    if not (::File.exist?(npath) and ::File.directory?(npath))
       c.put "550 Directory does not exist\r\n"
       return
     end

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
     filename = datastore['FILENAME']
     verbose = datastore['VERBOSE']
     count = 0
-    unless File.exists? filename and File.file? filename
+    unless File.exist? filename and File.file? filename
       print_error("Pcap File does not exist")
       return
     end

--- a/modules/post/cisco/gather/enum_cisco.rb
+++ b/modules/post/cisco/gather/enum_cisco.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Post
       end
     else
       if pass_file
-        if not ::File.exists?(pass_file)
+        if not ::File.exist?(pass_file)
           print_error("Wordlist File #{pass_file} does not exists!")
           return
         end

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Post
       # gnome-commander connections file
       connections_file = "#{dir}/.gnome-commander/connections"
       if file?(connections_file)
-        #File exists
+        #File.exist
         begin
           str_file=read_file(connections_file)
           print_good("File found: #{connections_file}")

--- a/modules/post/multi/gather/dns_bruteforce.rb
+++ b/modules/post/multi/gather/dns_bruteforce.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Post
     end
 
     name_list = []
-    if ::File.exists?(hostlst)
+    if ::File.exist?(hostlst)
       ::File.open(hostlst).each do |n|
         name_list << n
       end

--- a/modules/post/multi/gather/multi_command.rb
+++ b/modules/post/multi/gather/multi_command.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
   # Run Method for when run command is issued
   def run
     print_status("Running module against #{sysinfo['Computer']}")
-    if not ::File.exists?(datastore['RESOURCE'])
+    if not ::File.exist?(datastore['RESOURCE'])
       raise "Resource File does not exists!"
     else
       ::File.open(datastore['RESOURCE'], "rb").each_line do |cmd|

--- a/modules/post/multi/gather/run_console_rc_file.rb
+++ b/modules/post/multi/gather/run_console_rc_file.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Post
   # Run Method for when run command is issued
   def run
     print_status("Running module against #{sysinfo['Computer']}")
-    if not ::File.exists?(datastore['RESOURCE'])
+    if not ::File.exist?(datastore['RESOURCE'])
       raise "Resource File does not exists!"
     else
       ::File.open(datastore['RESOURCE'], "rb").each_line do |cmd|

--- a/modules/post/multi/manage/multi_post.rb
+++ b/modules/post/multi/manage/multi_post.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Post
     print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
     macro = datastore['MACRO']
     entries = []
-    if not ::File.exists?(macro)
+    if not ::File.exist?(macro)
       print_error "Resource File does not exists!"
       return
     else

--- a/modules/post/windows/gather/wmic_command.rb
+++ b/modules/post/windows/gather/wmic_command.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Post
     tmpout = ""
     print_status("Running module against #{sysinfo['Computer']}")
     if datastore['RESOURCE']
-      if ::File.exists?(datastore['RESOURCE'])
+      if ::File.exist?(datastore['RESOURCE'])
 
         ::File.open(datastore['RESOURCE']).each_line do |cmd|
 

--- a/modules/post/windows/manage/ie_proxypac.rb
+++ b/modules/post/windows/manage/ie_proxypac.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Post
     pac_file = session.sys.config.getenv("APPDATA") << "\\" << Rex::Text.rand_text_alpha((rand(8)+6)) << ".pac"
     conf_pac = ""
 
-    if ::File.exists?(local_pac)
+    if ::File.exist?(local_pac)
       conf_pac << ::File.open(local_pac, "rb").read
     else
       print_error("Local PAC file not found.")

--- a/msfupdate
+++ b/msfupdate
@@ -105,12 +105,12 @@ class Msfupdate
   end
 
   def apt?
-    File.exists?(File.expand_path(File.join(@msfbase_dir, '.apt')))
+    File.exist?(File.expand_path(File.join(@msfbase_dir, '.apt')))
   end
 
   # Are you an installer, or did you get here via a source checkout?
   def binary_install?
-    File.exists?(File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))) && !apt?
+    File.exist?(File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))) && !apt?
   end
 
   def git?
@@ -201,7 +201,7 @@ class Msfupdate
   def update_binary_install!
     update_script = File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))
     product_key =   File.expand_path(File.join(@msfbase_dir, "..", "engine", "license", "product.key"))
-    if File.exists? product_key
+    if File.exist? product_key
       if File.readable? product_key
         if (@offline_file)
           system("ruby", update_script, @offline_file)

--- a/plugins/sounds.rb
+++ b/plugins/sounds.rb
@@ -52,7 +52,7 @@ class Plugin::EventSounds < Msf::Plugin
       while(true)
         while(event = self.queue.shift)
           path = ::File.join(self.base, self.theme, "#{event}.wav")
-          if(::File.exists?(path))
+          if(::File.exist?(path))
             Rex::Compat.play_sound(path)
           else
             print_status("Warning: sound file not found: #{path}")

--- a/scripts/meterpreter/file_collector.rb
+++ b/scripts/meterpreter/file_collector.rb
@@ -67,7 +67,7 @@ if client.platform =~ /win32|win64/
     end
     # Read log file and download those files found
     if input_file and logs
-      if ::File.exists?(input_file)
+      if ::File.exist?(input_file)
         print_status("Reading file #{input_file}")
         print_status("Downloading to #{logs}")
         ::File.open(input_file, "r").each_line do |line|

--- a/scripts/meterpreter/hostsedit.rb
+++ b/scripts/meterpreter/hostsedit.rb
@@ -84,7 +84,7 @@ if client.platform =~ /win32|win64/
       cleardnscach(session)
     when "-l"
       checkuac(session)
-      if not ::File.exists?(val)
+      if not ::File.exist?(val)
         raise "File #{val} does not exists!"
       else
         backuphosts(session,hosts)

--- a/scripts/meterpreter/multi_console_command.rb
+++ b/scripts/meterpreter/multi_console_command.rb
@@ -58,7 +58,7 @@ end
     commands = val.split(",")
   when "-rc"
     script = val
-    if not ::File.exists?(script)
+    if not ::File.exist?(script)
       raise "Command List File does not exists!"
     else
       commands = []

--- a/scripts/meterpreter/multicommand.rb
+++ b/scripts/meterpreter/multicommand.rb
@@ -81,7 +81,7 @@ end
     commands = val.split(",")
   when "-rc"
     script = val
-    if not ::File.exists?(script)
+    if not ::File.exist?(script)
       raise "Command List File does not exists!"
     else
       ::File.open(script, "r").each_line do |line|

--- a/scripts/meterpreter/multiscript.rb
+++ b/scripts/meterpreter/multiscript.rb
@@ -57,7 +57,7 @@ end
     commands = val.gsub(/;/,"\n")
   when "-rc"
     script = val
-    if not ::File.exists?(script)
+    if not ::File.exist?(script)
       raise "Script List File does not exists!"
     else
       ::File.open(script, "rb").each_line do |line|

--- a/scripts/meterpreter/netenum.rb
+++ b/scripts/meterpreter/netenum.rb
@@ -146,7 +146,7 @@ def frwdlp(session, hostlst, domain, dest)
   threads = []
   tmpout = []
   begin
-    if ::File.exists?(hostlst)
+    if ::File.exist?(hostlst)
       ::File.open(hostlst).each {|line|
         threads << ::Thread.new(line) { |h|
           #print_status("checking #{h.chomp}")

--- a/scripts/meterpreter/process_memdump.rb
+++ b/scripts/meterpreter/process_memdump.rb
@@ -52,7 +52,7 @@ end
   when "-r"
     list = val
     resource = ""
-    if not ::File.exists?(list)
+    if not ::File.exist?(list)
       raise "Command List File does not exists!"
     else
       ::File.open(list, "r").each_line do |line|

--- a/scripts/meterpreter/schelevator.rb
+++ b/scripts/meterpreter/schelevator.rb
@@ -89,7 +89,7 @@ upload_fn = nil
 
   when "-u"
     upload_fn = val
-    if not ::File.exists?(upload_fn)
+    if not ::File.exist?(upload_fn)
       raise "Specified file to upload does not exist!"
     end
 

--- a/scripts/meterpreter/schtasksabuse.rb
+++ b/scripts/meterpreter/schtasksabuse.rb
@@ -131,7 +131,7 @@ end
     delay = val.to_i
   when "-s"
     script = val
-    if not ::File.exists?(script)
+    if not ::File.exist?(script)
       raise "Command List File does not exists!"
     else
       ::File.open(script, "r").each_line do |line|
@@ -140,7 +140,7 @@ end
     end
   when "-l"
     list = val
-    if not ::File.exists?(list)
+    if not ::File.exist?(list)
       raise "Command List File does not exists!"
     else
       ::File.open(list, "r").each_line do |line|

--- a/scripts/meterpreter/uploadexec.rb
+++ b/scripts/meterpreter/uploadexec.rb
@@ -25,7 +25,7 @@ def usage()
 end
 
 def upload(session,file,trgloc = "")
-  if not ::File.exists?(file)
+  if not ::File.exist?(file)
     raise "File to Upload does not exists!"
   else
     if trgloc == ""

--- a/scripts/meterpreter/virusscan_bypass.rb
+++ b/scripts/meterpreter/virusscan_bypass.rb
@@ -36,7 +36,7 @@ end
 @location = ""
 
 def upload(session,file,trgloc)
-  if not ::File.exists?(file)
+  if not ::File.exist?(file)
     raise "File to Upload does not exists!"
   else
     @location = session.sys.config.getenv('TEMP')

--- a/scripts/meterpreter/win32-sshclient.rb
+++ b/scripts/meterpreter/win32-sshclient.rb
@@ -90,7 +90,7 @@ EOS
 #
 
 def upload(client,file,trgloc = nil)
-  if not ::File.exists?(file)
+  if not ::File.exist?(file)
     raise "File to Upload does not exists!"
   else
     if trgloc == nil
@@ -164,7 +164,7 @@ downloaded = nil
       usage
     end
     plink = val
-    if not ::File.exists?(plink)
+    if not ::File.exist?(plink)
       print_error("Plink.exe not found/accessible!")
       usage
     end
@@ -258,7 +258,7 @@ downloaded = nil
       usage
     end
     keyfile = val
-    if not ::File.exists?(keyfile)
+    if not ::File.exist?(keyfile)
       print_error("keyfile not found or not accessible!")
       usage
     end
@@ -269,7 +269,7 @@ downloaded = nil
       usage
     end
     cmdfile = val
-    if not ::File.exists?(cmdfile)
+    if not ::File.exist?(cmdfile)
       print_error("cmd-file not found/accessible!")
       usage
     end
@@ -320,7 +320,7 @@ end
 # Ask user before downloading
 #
 if not manual
-  if not ::File.exists?(plink)
+  if not ::File.exist?(plink)
     print_status("plink.exe could not be found. Downloading it now...")
     print_status(license)
     plinkexe = Net::HTTP.get URI.parse(plinkurl)

--- a/scripts/meterpreter/win32-sshserver.rb
+++ b/scripts/meterpreter/win32-sshserver.rb
@@ -108,7 +108,7 @@ type = "auto"
       usage
     end
     extractfilename = val
-    if not ::File.exists?(extractfilename)
+    if not ::File.exist?(extractfilename)
       print_error("OpenSSH-SFX not found/accessible!")
       usage
     end
@@ -244,7 +244,7 @@ end
 #
 
 if manual == false
-  if not ::File.exists?(extractfilename)
+  if not ::File.exist?(extractfilename)
     print_status("openssh-extract.sfx could not be found. Downloading it now...")
     print_status(license)
     extractexe = Net::HTTP.get URI.parse(downloadurl)
@@ -262,7 +262,7 @@ if dirname == nil
   print_status("Creating directory #{dirname}.....")
   client.fs.dir.mkdir(dirname)
 else
-  if  !::File.exists?(dirname) && !::File.directory?(dirname)
+  if  !::File.exist?(dirname) && !::File.directory?(dirname)
     print_status("Creating directory #{dirname}.....")
     client.fs.dir.mkdir(dirname)
   end

--- a/scripts/meterpreter/winbf.rb
+++ b/scripts/meterpreter/winbf.rb
@@ -77,7 +77,7 @@ def passbf(session,passlist,target,user,opt,logfile)
   a = []
   i = 0
   if opt == 1
-    if not ::File.exists?(user)
+    if not ::File.exist?(user)
       raise "Usernames List File does not exists!"
     else
       user = ::File.open(user, "r")
@@ -170,7 +170,7 @@ unsupported if client.platform !~ /win32|win64/i
   when "-p"
 
     passlist = val
-    if not ::File.exists?(passlist)
+    if not ::File.exist?(passlist)
       raise "Password File does not exists!"
     end
   when "-t"

--- a/scripts/meterpreter/wmic.rb
+++ b/scripts/meterpreter/wmic.rb
@@ -103,7 +103,7 @@ end
   when "-s"
 
     script = val
-    if not ::File.exists?(script)
+    if not ::File.exist?(script)
       raise "Command List File does not exists!"
     else
       ::File.open(script, "r").each_line do |line|

--- a/spec/tools/md5_lookup_spec.rb
+++ b/spec/tools/md5_lookup_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Md5LookupUtility do
         let(:opts) { subject.parse(valid_argv) }
 
         before(:example) do
-          allow(File).to receive(:exists?).and_return(true)
+          allow(File).to receive(:exist?).and_return(true)
         end
 
         it 'returns the input file path' do
@@ -330,7 +330,7 @@ RSpec.describe Md5LookupUtility do
 
       context 'when the required input file is not set' do
         before(:example) do
-          allow(File).to receive(:exists?).and_return(false)
+          allow(File).to receive(:exist?).and_return(false)
         end
 
         it 'raises an OptionParser::MissingArgument error' do

--- a/tools/exploit/jsobfu.rb
+++ b/tools/exploit/jsobfu.rb
@@ -48,7 +48,7 @@ module Jsobfu
         raise OptionParser::MissingArgument, 'No options set, try -h for usage'
       elsif options[:iteration] && options[:iteration] !~ /^\d+$/
         raise OptionParser::InvalidOption, "#{options[:format]} is not a number"
-      elsif !::File.exists?(options[:input].to_s)
+      elsif !::File.exist?(options[:input].to_s)
         raise OptionParser::InvalidOption, "Cannot find: #{options[:input]}"
       end
 

--- a/tools/exploit/virustotal.rb
+++ b/tools/exploit/virustotal.rb
@@ -316,7 +316,7 @@ class OptsConsole
         files = v.split.delete_if { |e| e.nil? }
         bad_files = []
         files.each do |f|
-          unless ::File.exists?(f)
+          unless ::File.exist?(f)
             bad_files << f
           end
         end

--- a/tools/password/md5_lookup.rb
+++ b/tools/password/md5_lookup.rb
@@ -292,7 +292,7 @@ module Md5LookupUtility
 
         opt.on('-i', '--input <file>',
           'The file that contains all the MD5 hashes (one line per hash)') do |v|
-          if v && !::File.exists?(v)
+          if v && !::File.exist?(v)
             raise OptionParser::InvalidOption, "Invalid input file: #{v}"
           end
 

--- a/tools/recon/makeiplist.rb
+++ b/tools/recon/makeiplist.rb
@@ -58,7 +58,7 @@ Usage: #{__FILE__} [options]|
         puts opts
         raise OptionParser::MissingArgument, "-i is a required option"
       end
-      unless ::File.exists?(options['input'])
+      unless ::File.exist?(options['input'])
         raise OptionParser::InvalidArgument, "Not found: #{options['input']}"
       end
     rescue OptionParser::InvalidOption
@@ -99,7 +99,7 @@ def load_files(in_f, out_f)
   handle_in = ::File.open(in_f, 'r')
 
   # Output file not found, assuming we should create one automatically
-  ::File.open(out_f, 'w') {} unless ::File.exists?(out_f)
+  ::File.open(out_f, 'w') {} unless ::File.exist?(out_f)
 
   handle_out = ::File.open(out_f, 'a')
 


### PR DESCRIPTION
This removes the deprecated calls to File.exists? in favor of File.exist?, the lowest of low-hanging fruit from running 'ruby -w'
## Verification
- [x] Start `msfconsole` with 'ruby -w ./msfconsole'
- [x] **Verify** the warnings about File.exists? do not appear
