### PR TITLE
A POST module to enumerate binary paths that EMET protects

### DIFF
--- a/modules/post/windows/gather/enum_emet.rb
+++ b/modules/post/windows/gather/enum_emet.rb
@@ -8,39 +8,28 @@ require 'rex'
 require 'msf/core/post/common'
 
 class MetasploitModule < Msf::Post
-
   include Msf::Post::Windows::Registry
   include Msf::Post::Common
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Windows Gather EMET Protected Paths',
-        'Description'   => %q{ This module will enumerate the EMET protected paths on the target host.},
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'vysec <vincent.yiu[at]mwrinfosecurity.com>'],
-        'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
-
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'Windows Gather EMET Protected Paths',
+      'Description'   => %q( This module will enumerate the EMET protected paths on the target host.),
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'vysec <vincent.yiu[at]mwrinfosecurity.com>' ],
+      'Platform'      => [ 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
   end
 
- def run
-    if sysinfo['Architecture'] =~ /x64/
-        reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings',REGISTRY_VIEW_64_BIT)
+  def run
+    reg_view = sysinfo['Architecture'] =~ /x64/ ? REGISTRY_VIEW_64_BIT : REGISTRY_VIEW_32_BIT
+    reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings', reg_view)
+    if reg_vals.nil?
+      print_status('Failed to enumerate EMET Protected.')
     else
-      reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings',REGISTRY_VIEW_32_BIT)
-    end 
-    
-    t = ""
-
-    reg_vals.each do |x|
-        t << "#{x}\r\n"
+      path = store_loot('host.emet_paths', 'text/plain', session, reg_vals.join("\r\n"), 'emet_paths.txt', 'EMET Paths')
+      print_good("Results stored in: #{path}")
     end
-
-    puts t
-
-    p = store_loot("host.emet_paths", "text/plain", session, t, "emet_paths.txt", "EMET Paths")
-    print_status("Results stored in: #{p}")
   end
-
 end

--- a/modules/post/windows/gather/enum_emet.rb
+++ b/modules/post/windows/gather/enum_emet.rb
@@ -1,0 +1,56 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Common
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Windows Gather EMET Protected Paths',
+        'Description'   => %q{ This module will enumerate the EMET protected paths on the target host.},
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'vysec <vincent.yiu[at]mwrinfosecurity.com>'],
+        'Platform'      => [ 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ]
+      ))
+
+  end
+
+  # Run Method for when run command is issued
+  def run
+    print_status("Running module against #{sysinfo['Computer']}")
+    
+    if sysinfo['Architecture'] =~ /x64/
+        print_status("The underlying OS is 64 bit")
+        if client.platform =~ /x86/
+          print_error("You are in a 32 bit process, migrate to 64 bit and try again.")
+        end
+    end
+    
+    isadmin = is_admin?
+
+    #a = registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System','SystemBiosVersion')
+    reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings')
+    
+    t = ""
+
+    reg_vals.each do |x|
+        t << "#{x}\r\n"
+    end
+
+    puts t
+
+    p = store_loot("host.emet_paths", "text/plain", session, t, "emet_paths.txt", "EMET Paths")
+    print_status("Results stored in: #{p}")
+  end
+
+end

--- a/modules/post/windows/gather/enum_emet.rb
+++ b/modules/post/windows/gather/enum_emet.rb
@@ -30,16 +30,15 @@ class MetasploitModule < Msf::Post
     print_status("Running module against #{sysinfo['Computer']}")
     
     if sysinfo['Architecture'] =~ /x64/
-        print_status("The underlying OS is 64 bit")
-        if client.platform =~ /x86/
-          print_error("You are in a 32 bit process, migrate to 64 bit and try again.")
-        end
+        reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings',REGISTRY_VIEW_64_BIT)
+    else
+      reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings',REGISTRY_VIEW_32_BIT)
     end
     
     isadmin = is_admin?
 
     #a = registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System','SystemBiosVersion')
-    reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings')
+    
     
     t = ""
 

--- a/modules/post/windows/gather/enum_emet.rb
+++ b/modules/post/windows/gather/enum_emet.rb
@@ -9,7 +9,6 @@ require 'msf/core/post/common'
 
 class MetasploitModule < Msf::Post
 
-  include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Registry
   include Msf::Post::Common
 
@@ -25,20 +24,12 @@ class MetasploitModule < Msf::Post
 
   end
 
-  # Run Method for when run command is issued
-  def run
-    print_status("Running module against #{sysinfo['Computer']}")
-    
+ def run
     if sysinfo['Architecture'] =~ /x64/
         reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings',REGISTRY_VIEW_64_BIT)
     else
       reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings',REGISTRY_VIEW_32_BIT)
-    end
-    
-    isadmin = is_admin?
-
-    #a = registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System','SystemBiosVersion')
-    
+    end 
     
     t = ""
 


### PR DESCRIPTION
# Description

A module to enumerate all the EMET wildcard paths where EMET is applying its protection.

_My first module to begin contributing, I thought this one would be useful and easy to write._
# Output

![image](https://cloud.githubusercontent.com/assets/3596242/14727120/0af7861c-0820-11e6-9033-04736c5a9ea5.png)
# Verification Steps

_use post/windows/gather/enum_emet_
1) Install EMET: https://www.microsoft.com/en-us/download/details.aspx?id=50766
2) Run the module on different systems
3) If you are on 64 bit Windows, migrate to a 64 bit process.
4) Run module
5) Check results match EMET's configuration.
