### PR TITLE
Add `resolve` to the meterpreter command line

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -36,6 +36,14 @@ class Console::CommandDispatcher::Stdapi::Net
   end
 
   #
+  # Options for the resolve command
+  #
+  @@resolve_opts = Rex::Parser::Arguments.new(
+    '-h' => [false, 'Help banner.' ],
+    '-f' => [true,  'Address family - IPv4 or IPv6 (default IPv4)'])
+
+
+  #
   # Options for the route command.
   #
   @@route_opts = Rex::Parser::Arguments.new(
@@ -77,6 +85,7 @@ class Console::CommandDispatcher::Stdapi::Net
       "arp"      => "Display the host ARP cache",
       "netstat"  => "Display the network connections",
       "getproxy" => "Display the current proxy configuration",
+      'resolve'  => 'Resolve a set of host names on the target',
     }
     reqs = {
       "ipconfig" => [ "stdapi_net_config_get_interfaces" ],
@@ -94,6 +103,7 @@ class Console::CommandDispatcher::Stdapi::Net
       "arp"      => [ "stdapi_net_config_get_arp_table" ],
       "netstat"  => [ "stdapi_net_config_get_netstat" ],
       "getproxy" => [ "stdapi_net_config_get_proxy" ],
+      'resolve'  => ['stdapi_net_resolve_host'],
     }
 
     all.delete_if do |cmd, desc|
@@ -472,6 +482,56 @@ class Console::CommandDispatcher::Stdapi::Net
     print_line( "Auto config URL : #{p[:autoconfigurl]}" )
     print_line( "Proxy URL       : #{p[:proxy]}" )
     print_line( "Proxy Bypass    : #{p[:proxybypass]}" )
+  end
+
+  #
+  # Resolve 1 or more hostnames on the target session
+  #
+  def cmd_resolve(*args)
+    args.unshift('-h') if args.length == 0
+
+    hostnames = []
+    family = AF_INET
+
+    @@resolve_opts.parse(args) { |opt, idx, val|
+      case opt
+      when '-h'
+        print_line('Usage: resolve host1 host2 .. hostN [-h] [-f IPv4|IPv6]')
+        print_line
+        print_line(@@resolve_opts.usage)
+        return false
+      when '-f'
+        if val.downcase == 'ipv6'
+          family = AF_INET6
+        elsif val.downcase != 'ipv4'
+          print_error("Invalid family: #{val}")
+          return false
+        end
+      else
+        hostnames << val
+      end
+    }
+
+    response = client.net.resolve.resolve_hosts(hostnames, family)
+
+    table = Rex::Ui::Text::Table.new(
+      'Header'    => 'Host resolutions',
+      'Indent'    => 4,
+      'SortIndex' => 0,
+      'Columns'   => ['Hostname', 'IP Address']
+    )
+
+    response.each do |result|
+      if result[:ip].nil?
+        table << [result[:hostname], '[Failed To Resolve]']
+      else
+        table << [result[:hostname], result[:ip]]
+      end
+    end
+
+    print_line
+    print_line(table.to_s)
+    
   end
 
 protected


### PR DESCRIPTION
I'm aware that this already exists as a post module, but there's nothing more annoying than having to bail out of Meterpreter, use the right module, set up the host list, etc all to just fire off a one-liner.

So this commit adds the command directly to Meterpreter's command line so that you don't have to do all that. This doesn't support specifying a file with the hosts in it (the post module does that). This is intended for quick resolution of particular hosts quickly.
## Sample run

```
meterpreter > resolve
Usage: resolve host1 host2 .. hostN [-h] [-f IPv4|IPv6]


OPTIONS:

    -f <opt>  Address family - IPv4 or IPv6 (default IPv4)
    -h        Help banner.


meterpreter > resolve google.com

Host resolutions
================

    Hostname    IP Address
    --------    ----------
    google.com  103.2.118.117

meterpreter > resolve live.com rapid7.com hotmail.com

Host resolutions
================

    Hostname     IP Address
    --------     ----------
    hotmail.com  157.55.152.112
    live.com     65.55.206.154
    rapid7.com   54.192.134.63
```
## Verification
- [x] Create a meterpreter session
- [x] Make sure the `resolve` command appears in the `net` help menu.
- [x] Make sure that the command outputs usage if `-h` is specified or if the command line is blank.
- [x] Validate that host resolution works for internal IP addresses.
- [x] Validate that host resolution works for external IP addresses.
- [ ] Validate that host resolution works for IPv6 as well as IPv4.
## Note

I was going to tidy this module up at the same time, however there is another PR open with the code tidies in it already (it's the reverse port forward PR #6753).
