### PR TITLE
fix: issues/6803 - info command references bug

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -471,7 +471,7 @@ class ReadableText
   def self.dump_references(mod, indent = '')
     output = ''
 
-    if (mod.respond_to? :references && mod.references && mod.references.length > 0)
+    if (mod.respond_to?(:references) && mod.references && mod.references.length > 0)
       output << "References:\n"
       mod.references.each { |ref|
         output << indent + ref.to_s + "\n"


### PR DESCRIPTION
Please read https://github.com/rapid7/metasploit-framework/issues/6803. When we use **`info`** to show module references. an issue is as follow:

```
msf > info exploit/windows/scada/advantech_webaccess_dashboard_file_upload 
[-] Error while running command info: true is not a symbol

Call stack:
/Users/Open-Security/Code/metasploit-framework/lib/msf/base/serializer/readable_text.rb:474:in `respond_to?'
/Users/Open-Security/Code/metasploit-framework/lib/msf/base/serializer/readable_text.rb:474:in `dump_references'
/Users/Open-Security/Code/metasploit-framework/lib/msf/base/serializer/readable_text.rb:210:in `dump_exploit_module'
/Users/Open-Security/Code/metasploit-framework/lib/msf/base/serializer/readable_text.rb:30:in `dump_module'
/Users/Open-Security/Code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:807:in `block in cmd_info'
/Users/Open-Security/Code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:796:in `each'
/Users/Open-Security/Code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:796:in `cmd_info'
/Users/Open-Security/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
/Users/Open-Security/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
/Users/Open-Security/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
/Users/Open-Security/Code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
/Users/Open-Security/Code/metasploit-framework/lib/rex/ui/text/shell.rb:203:in `run'
/Users/Open-Security/Code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/Open-Security/Code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `info exploit/windows/scada/advantech_webaccess_dashboard_file_upload`
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not

```
msf > info exploit/windows/scada/advantech_webaccess_dashboard_file_upload 

       Name: Advantech WebAccess Dashboard Viewer Arbitrary File Upload
     Module: exploit/windows/scada/advantech_webaccess_dashboard_file_upload
   Platform: Windows
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2016-02-05

Provided by:
...
...
```
