### PR TITLE
Modify stdapi so it also uses exist? over exists? for ruby parity

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -136,6 +136,8 @@ module Msf::Post::File
     end
   end
 
+  alias :exists? :exist?
+
   #
   # Writes a given string to a given local file
   #

--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -79,7 +79,7 @@ module UserProfiles
     read_profile_list().each do |hive|
       hive['OURS']=false
       if hive['LOADED']== false
-        if session.fs.file.exists?(hive['DAT'])
+        if session.fs.file.exist?(hive['DAT'])
           hive['OURS'] = registry_loadkey(hive['HKU'], hive['DAT'])
           print_error("Error loading USER #{hive['SID']}: Hive could not be loaded, are you Admin?") unless hive['OURS']
         else

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -702,7 +702,7 @@ class Console::CommandDispatcher::Stdapi::Fs
           client.framework.events.on_session_upload(client, src, dest) if msf_loaded?
         }
       elsif (stat.file?)
-        if client.fs.file.exists?(dest) and client.fs.file.stat(dest).directory?
+        if client.fs.file.exist?(dest) and client.fs.file.stat(dest).directory?
           client.fs.file.upload(dest, src) { |step, src, dst|
             print_status("#{step.ljust(11)}: #{src} -> #{dst}")
             client.framework.events.on_session_upload(client, src, dest) if msf_loaded?

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -702,7 +702,7 @@ class Console::CommandDispatcher::Stdapi::Fs
           client.framework.events.on_session_upload(client, src, dest) if msf_loaded?
         }
       elsif (stat.file?)
-        if client.fs.file.exist?(dest) and client.fs.file.stat(dest).directory?
+        if client.fs.file.exist?(dest) && client.fs.file.stat(dest).directory?
           client.fs.file.upload(dest, src) { |step, src, dst|
             print_status("#{step.ljust(11)}: #{src} -> #{dst}")
             client.framework.events.on_session_upload(client, src, dest) if msf_loaded?

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Post
 
     # Check target for the necessary files
     if session.type == "meterpreter"
-      if session.fs.file.exists?(@paths['ff'] + temp_file) && !session.fs.file.exists?(@paths['ff'] + org_file)
+      if session.fs.file.exist?(@paths['ff'] + temp_file) && !session.fs.file.exist?(@paths['ff'] + org_file)
         print_error("Detected #{temp_file} without #{org_file}. This is a good sign of previous DECRYPT attack gone wrong.")
         return
-      elsif session.fs.file.exists?(@paths['ff'] + temp_file)
+      elsif session.fs.file.exist?(@paths['ff'] + temp_file)
         decrypt_file_stats(temp_file, org_file, @paths['ff'])
         if datastore['RECOVER']
           return unless decrypt_recover_omni(temp_file, org_file)
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Post
           print_warning("If you wish to continue by trying to recover, set the advanced option, RECOVER, to TRUE.")
           return
         end
-      elsif !session.fs.file.exists?(@paths['ff'] + org_file)
+      elsif !session.fs.file.exist?(@paths['ff'] + org_file)
         print_error("Could not download #{org_file}. File does not exist.")
         return
       end
@@ -216,9 +216,9 @@ class MetasploitModule < Msf::Post
     rename_file(@paths['ff'] + temp_file, @paths['ff'] + org_file)
 
     if session.type == "meterpreter"
-      print_error("There is still #{temp_file} on the target. Something went wrong.") if session.fs.file.exists?(@paths['ff'] + temp_file)
+      print_error("There is still #{temp_file} on the target. Something went wrong.") if session.fs.file.exist?(@paths['ff'] + temp_file)
 
-      unless session.fs.file.exists?(@paths['ff'] + org_file)
+      unless session.fs.file.exist?(@paths['ff'] + org_file)
         print_error("#{org_file} is no longer at #{@paths['ff'] + org_file}")
         return false
       end
@@ -610,13 +610,13 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
     # Lets just check theres something before going forward
     if session.type == "meterpreter"
       i=20
-      vprint_status("Waiting up to #{i} seconds for loot file (#{@paths['loot']}) to be generated") unless session.fs.file.exists?(@paths['loot'])
-      while (!session.fs.file.exists?(@paths['loot']))
+      vprint_status("Waiting up to #{i} seconds for loot file (#{@paths['loot']}) to be generated") unless session.fs.file.exist?(@paths['loot'])
+      while (!session.fs.file.exist?(@paths['loot']))
         sleep 1
         i -= 1
         break if i == 0
       end
-      print_error("Missing loot file. Something went wrong.") unless session.fs.file.exists?(@paths['loot'])
+      print_error("Missing loot file. Something went wrong.") unless session.fs.file.exist?(@paths['loot'])
     end # session.type == "meterpreter"
 
     print_status("Restoring original .JA: #{temp_file}")
@@ -627,17 +627,17 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
     vprint_status("Cleaning up: #{new_file}")
     file_rm(new_file)
     if session.type == "meterpreter"
-      if session.fs.file.exists?(temp_file)
+      if session.fs.file.exist?(temp_file)
         print_error("Detected backup file (#{temp_file}) still on the target. Something went wrong.")
       end
-      unless session.fs.file.exists?(org_file)
+      unless session.fs.file.exist?(org_file)
         print_error("Unable to find #{org_file} on target. Something went wrong.")
       end
     end # session.type == "meterpreter"
 
     # At this time, there should have a loot file
     if session.type == "meterpreter"
-      unless session.fs.file.exists?(@paths['loot'])
+      unless session.fs.file.exist?(@paths['loot'])
         print_error("DECRYPT failed. Either something went wrong (download/upload? Injecting?), there is a master password or an unsupported Firefox version.")
         # Another issue is encoding. The files may be seen as 'data' rather than 'ascii'
         print_error("Tip: Try swtiching to a meterpreter shell if possible (as its more reliable/stable when downloading/uploading)") if session.type != "meterpreter"

--- a/modules/post/windows/gather/credentials/rdc_manager_creds.rb
+++ b/modules/post/windows/gather/credentials/rdc_manager_creds.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Post
       connection_files = settings.scan(/string&gt;(.*?)&lt;\/string/)
 
       connection_files.each do |con_f|
-        next unless session.fs.file.exists?(con_f[0])
+        next unless session.fs.file.exist?(con_f[0])
         print_status("\tOpening RDC Manager server list: #{con_f[0]}")
         connection_data = read_file(con_f[0])
         if connection_data

--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -271,7 +271,7 @@ class MetasploitModule < Msf::Post
     #Get history and cookies
     print_status("Retrieving history.....")
     h_paths.each do |hpath|
-      if session.fs.file.exists?(hpath)
+      if session.fs.file.exist?(hpath)
         print_line("\tFile: #{hpath}")
         #copy file
         cmd = "cmd.exe /c type \"#{hpath}\" > \"#{base}\\index.dat\""
@@ -291,7 +291,7 @@ class MetasploitModule < Msf::Post
 
     print_status("Retrieving cookies.....")
     c_paths.each do |cpath|
-      if session.fs.file.exists?(cpath)
+      if session.fs.file.exist?(cpath)
         print_line("\tFile: #{cpath}")
         #copy file
         cmd = "cmd.exe /c type \"#{cpath}\" > \"#{base}\\index.dat\""

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -233,7 +233,7 @@ class MetasploitModule < Msf::Post
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)
       vprint_status("done")
-      res &&= session.fs.file.exists?(remote)
+      res &&= session.fs.file.exist?(remote)
       vprint_status("remote file exists? #{res.inspect}")
 
       if res
@@ -285,7 +285,7 @@ class MetasploitModule < Msf::Post
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)
       vprint_status("done")
-      res &&= session.fs.file.exists?(remote)
+      res &&= session.fs.file.exist?(remote)
       vprint_status("remote file exists? #{res.inspect}")
 
       if res


### PR DESCRIPTION
AlienTrooper noticed that #6795 was incomplete and that I modified the stdapi file object to have an exist? method by did not leave in an exists? alias, as Ruby does. To avoid confusion and to make stdapi more Ruby-like, this PR adds the missing alias and fixes stdapi references to exists? that were broken in #6795

fix #6815
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] get a windows meterpreter shell
- [x] verify that file upload and download both work as expected
- [x] verify that the meterpreter test module passes with any errors:

```
msf exploit(handler) > loadpath test/modules
Loaded 34 modules:
    13 auxiliarys
    13 exploits
    8 posts
msf exploit(handler) > use post/test/meterpreter
msf post(meterpreter) > set session -1
session => -1
msf post(meterpreter) > run

[*] Running against session -1
[*] Session type is meterpreter and platform is x86/win32
[+] should return its own process id
[+] should return a list of processes
[+] should return a user id
[+] should return a sysinfo Hash
[+] should return network interfaces
[+] should have an interface that matches session_host
[+] should return network routes
[+] should return the proper directory separator
[+] should return the current working directory
[+] should list files in the current directory
[+] should stat a directory
[+] should create and remove a dir
[+] should change directories
[+] should create and remove files
[+] should upload a file
[+] should move files
[+] should do md5 and sha1 of files
[*] Passed: 17; Failed: 0
[*] Post module execution completed
```
