### PR TITLE
Fix #6806 and #6820 - Fix send_request_cgi! redirection

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+
 require 'uri'
 require 'digest'
 require 'rex/proto/ntlm/crypt'
@@ -370,22 +371,45 @@ module Exploit::Remote::HttpClient
     return res unless res && res.redirect? && redirect_depth > 0
 
     redirect_depth -= 1
-    location = res.redirection
-    return res if location.nil?
+    return res if res.redirection.nil?
 
-    opts['redirect_uri'] = location
-    opts['uri'] = location.path
-    opts['rhost'] = location.host
-    opts['vhost'] = location.host
-    opts['rport'] = location.port
-
-    if location.scheme == 'https'
-      opts['ssl'] = true
-    else
-      opts['ssl'] = false
-    end
-
+    reconfig_redirect_opts!(res, opts)
     send_request_cgi!(opts, actual_timeout, redirect_depth)
+  end
+
+
+  # Modifies the HTTP request options for a redirection.
+  #
+  # @param res [Rex::Proto::HTTP::Response] HTTP Response.
+  # @param opts [Hash] The HTTP request options to modify.
+  # @return [void]
+  def reconfig_redirect_opts!(res, opts)
+    location = res.redirection
+
+    if location.relative?
+      parent_path = File.dirname(opts['uri'].to_s)
+      parent_path = '/' if parent_path == '.'
+      new_redirect_uri = normalize_uri(parent_path, location.path.gsub(/^\./, ''))
+      opts['redirect_uri'] = new_redirect_uri
+      opts['uri'] = new_redirect_uri
+      opts['rhost'] = datastore['RHOST']
+      opts['vhost'] = opts['vhost'] || opts['rhost'] || self.vhost()
+      opts['rport'] = datastore['RPORT']
+
+      opts['ssl'] = ssl
+    else
+      opts['redirect_uri'] = location
+      opts['uri'] = location.path
+      opts['rhost'] = location.host
+      opts['vhost'] = location.host
+      opts['rport'] = location.port
+
+      if location.scheme == 'https'
+        opts['ssl'] = true
+      else
+        opts['ssl'] = false
+      end
+    end
   end
 
   #

--- a/spec/lib/msf/core/exploit/http/client_spec.rb
+++ b/spec/lib/msf/core/exploit/http/client_spec.rb
@@ -12,6 +12,38 @@ RSpec.describe Msf::Exploit::Remote::HttpClient do
     mod
   end
 
+  describe '#reconfig_redirect_opts!' do
+    context 'when URI is http://127.0.0.1/test/redirect.php' do
+      it 'should return /test/redirect.php as the URI path' do
+        res = Rex::Proto::Http::Response.new
+        allow(res).to receive(:headers).and_return({'Location'=>'http://127.0.0.1/test/redirect.php'})
+        opts = {}
+        subject.reconfig_redirect_opts!(res, opts)
+        expect(opts['uri']).to eq('/test/redirect.php')
+      end
+    end
+
+    context 'when URI is /test/redirect.php' do
+      it 'should return /test/redirect.php' do
+        res = Rex::Proto::Http::Response.new
+        allow(res).to receive(:headers).and_return({'Location'=>'/test/redirect.php'})
+        opts = {}
+        subject.reconfig_redirect_opts!(res, opts)
+        expect(opts['uri']).to eq('/test/redirect.php')
+      end
+    end
+
+    context 'when URI is ./redirect.php' do
+      it 'should return /redirect.php' do
+        res = Rex::Proto::Http::Response.new
+        allow(res).to receive(:headers).and_return({'Location'=>'./redirect.php'})
+        opts = {}
+        subject.reconfig_redirect_opts!(res, opts)
+        expect(opts['uri']).to eq('/redirect.php')
+      end
+    end
+  end
+
   describe '#vhost' do
 
     let(:rhost) do


### PR DESCRIPTION
## What this patch does

This patch fixes two problems:
1. 6820 - If the HTTP server returns a relative path (example: /test), there is no host to extract, therefore the HOST header in the HTTP request ends up being empty. When the web server sees this, it might return an HTTP 400 Bad Request, and the redirection fails.
2. 6806 - If the HTTP server returns a relative path that begins with a dot, send_request_cgi! will literally send that in the GET request. Since that isn't a valid GET request path format, the redirection fails.

Fix #6806
Fix #6820
## Verification
- [x] Make sure Travis is green
- [x] Save the following script in ~/.msf4/modules/auxiliary/http_server.rb (if you don't have the folders, create them)

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Auxiliary

  include Msf::Exploit::Remote::HttpServer

  def initialize(info={})
    super(update_info(info,
      'Name'           => "HttpServer test",
      'Description'    => %q{ HttpServer test },
      'License'        => MSF_LICENSE,
      'Author'         => [ 'sinn3r' ],
      'Platform'       => 'win',
      'Targets'        => [ [ 'Generic', {} ] ],
      'DisclosureDate' => "Apr 1 2016",
      'DefaultOptions' => { 'URIPATH' => '/' },
      'DefaultTarget'  => 0))
  end

  def run
    exploit
  end

  def on_request_uri(cli, request)
    case request.uri
    when '/'
      send_redirect(cli, './redirect1')
    when '/redirect1'
      print_good('The client has found the right path')
      send_response(cli, 'OK')
    else
      print_error("Incorrect path.")
      send_not_found(cli)
    end
  end

end
```
- [x] Save the following script in ~/.msf4/modules/auxiliary/http_test.rb

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Auxiliary

  include Msf::Exploit::Remote::HttpClient

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'HttpClient Test',
      'Description'    => %q{
        HttpClient
      },
      'Author'         => [ 'sinn3r' ],
      'License'        => MSF_LICENSE
    ))
  end

  def run
    res = send_request_cgi!({
      'rhost' => datastore['RHOST'],
      'uri' => '/'
    })

    if res
      puts res.body
    else
      print_error("Timed out")
    end
  end

end
```
- [x] Start msfconsole
- [x] Do: `use auxiliary/http_server`
- [x] Do: `run`. At this point, the HTTP server should be listening.
- [x] Start another msfconsole
- [x] Do: `use auxiliary/http_test`
- [x] Do: `set RHOST [IP]` (The IP should be the web server's IP)
- [x] Do: `set RPORT 8080` (8080 is the default port of http_server)
- [x] Run auxiliary_test
- [x] In the msfconsole where auxiliary/http_test is, you should see the message: `OK`
- [x] In the msfconsole where auxiliary/http_server is, you should see the message: `The client has found the right path` (in green)
