### PR TITLE
Fix spec failures in ruby-2.3

### DIFF
--- a/spec/support/shared/examples/msf/db_manager/module_cache.rb
+++ b/spec/support/shared/examples/msf/db_manager/module_cache.rb
@@ -702,7 +702,7 @@ RSpec.shared_examples_for 'Msf::DBManager::ModuleCache' do
                   let(:modification_time) do
                     # +1 as rand can return 0 and the time must be different for
                     # this context.
-                    super() - (rand(1.day) + 1)
+                    1.days.ago
                   end
 
                   it_should_behave_like 'Msf::DBManager#update_all_module_details refresh'


### PR DESCRIPTION
Dave Kennedy made a thing that made me look at ruby 2.3, which has spec a failure due to `super` not working quite the same in rspec context.
## Verification

This only changes specs, so no verification other than:
- [x] travis is green
