### PR TITLE
Resolve #6813, remove the border padding for info -d output

### DIFF
--- a/data/markdown_doc/markdown.css
+++ b/data/markdown_doc/markdown.css
@@ -89,7 +89,6 @@ code {
 }
 pre {
     display: block;
-    padding: 16px;
     margin: 0 0 18px;
     line-height: 16px;
     font-size: 13px;
@@ -139,7 +138,6 @@ pre code {
   border-style: solid;
   border-width: 1px;
   border-color: #ccc;
-  padding: 5px;
 }
 
 


### PR DESCRIPTION
## What this patch does

It changes how the code boxes and list boxes look.
## Verification
- [x] Start msfconsole
- [x] Do: `use exploit/windows/smb/ms08_067_netapi`
- [x] Do: `info -d`
- [x] The code boxes should look like this:

![screen shot 2016-04-27 at 12 09 51 pm](https://cloud.githubusercontent.com/assets/1170914/14861016/fc32bd7c-0c70-11e6-96b4-5dad72bd0b7f.png)

And not like this:

![screen shot 2016-04-27 at 12 10 41 pm](https://cloud.githubusercontent.com/assets/1170914/14861044/18aa8818-0c71-11e6-8dc1-3fe52597eed7.png)
