### PR TITLE
Fix #6398, Missing Content-Length header in HTTP POST

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -393,7 +393,17 @@ class ClientRequest
   # Return the content length header
   #
   def set_content_len_header(clen)
-    return "" if clen == 0 || opts['chunked_size'] > 0 || (opts['headers'] && opts['headers']['Content-Length'])
+    if opts['method'] == 'GET' && (clen == 0 || opts['chunked_size'] > 0)
+      # This condition only applies to GET because of the specs.
+      # RFC-7230:
+      # A Content-Length header field is normally sent in a POST
+      # request even when the value is 0 (indicating an empty payload body)
+      return ''
+    elsif opts['headers'] && opts['headers']['Content-Length']
+      # If the module has a modified content-length header, respect that by
+      # not setting another one.
+      return ''
+    end
     set_formatted_header("Content-Length", clen)
   end
 

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -170,6 +170,16 @@ RSpec.describe Rex::Proto::Http::ClientRequest do
         :set_content_len_header => { args: 1024, result: "Content-Length: 1024\r\n"}
       }
     ],
+
+    [
+      "with a POST request and no payload body",
+      default_options.merge({
+        'method' => 'POST'
+      }),
+      {
+        :set_content_len_header => { args: 0, result: "Content-Length: 0\r\n"}
+      }
+    ],
   
   ].each do |c, opts, expectations|
     context c do


### PR DESCRIPTION
## What This Patch Does

RFC-7230 states that a Content-Length header is normally sent in a POST request even when the value (length) is 0, indicating an empty payload body. Rex HTTP client failed to follow this spec, and caused some modules to fail (such as winrm_login).

Fix #6398
## Verification

The issue was originally reported while testing a WinRM machine, so let's do that:
- [x] First, make sure Travis is green.
- [x] Start a Windows 7 x64 SP1 box
- [x] Open a command prompt as an Administrator
- [x] Enter: `winrm quickconfig`
- [x] Enter: `winrm set winrm/config/service @{AllowUnencrypted="true"}`
- [x] Do: `netstat -an |find "5985"`, and make sure this port is open.
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/winrm/winrm_login`
- [x] Do: `set RHOSTS [IP]`
- [x] Do: `set USERNAME [valid Windows username]`
- [x] Do: `set PASSWORD [valid Windows password]`
- [x] Do: `run`
- [x] It should say **LOGIN SUCCESSFUL**
## Demo

```
msf auxiliary(winrm_login) > run

[+] 192.168.146.143:5985 - LOGIN SUCCESSFUL: WORKSTATION\sinn3r:goodpassword
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(winrm_login) > 
```
