### PR TITLE
Resolve #6839, Make Knowledge Base as default

### DIFF
--- a/data/markdown_doc/html_template.erb
+++ b/data/markdown_doc/html_template.erb
@@ -23,13 +23,27 @@
     document.getElementById('overview_info').style.display = "none";
     document.getElementById('knowledge_base').style.display = "inline";
   }
+
+  function initDoc() {
+    var kb = document.getElementById('knowledge_base');
+    var oi = document.getElementById('overview_info');
+    oi.style.display = "none";
+    kb.style.display = "inline";
+
+    var kb_button = document.getElementById('knowledge_base_button');
+    var oi_button = document.getElementById('overview_info_button');
+    kb_button.style.borderColor = "#ccc";
+    kb_button.style.color = "#333";
+    oi_button.style.borderColor = "#EEEEEE";
+    oi_button.style.color = "#C4C4C4";
+  }
 </script>
 <% end %>
 <style>
 <%= load_css %>
 </style>
 </head>
-<body>
+<body onload="initDoc()">
 <% unless kb.empty? %>
 <table border="0">
 <tr>

--- a/data/markdown_doc/markdown.css
+++ b/data/markdown_doc/markdown.css
@@ -114,8 +114,8 @@ pre code {
   padding:10px 5px;
   border-style:solid;
   border-width:1px;
-  border-color:#ccc;
-  color:#333;
+  border-color:#EEEEEE;
+  color:#C4C4C4;
 }
 #knowledge_base_button {
   font-family:Arial, sans-serif;
@@ -123,14 +123,11 @@ pre code {
   padding:10px 5px;
   border-style:solid;
   border-width:1px;
-  border-color:#EEEEEE;
-  color:#C4C4C4;
+  border-color:#ccc;
+  color:#333;
 }
 #overview_info_button:hover, #knowledge_base_button:hover {
   cursor: pointer;
-}
-#knowledge_base {
-  display: none;
 }
 #long_list {
   height:280px;


### PR DESCRIPTION
## What This Patch Does

This patch changes the default view of module documentation to knowledge base, as requested by @egypt.
## Verification
- [x] Start msfconsole
- [x] Do: `use exploit/windows/smb/ms08_067_netap`
- [x] Do: `info -d`
- [x] The Knowledge section should be the first thing you see
- [x] Click on Overview
- [x] You should see the module doc overview section
- [x] In msfconsole, do: `use exploit/windows/smb/ms05_039_pnp`
- [x] Do: `info -d`
- [x] You should see the module doc overview content
