### PR TITLE
Fix #6841, info -d [module path] not spawning module documentation

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -802,7 +802,7 @@ class Core
         print(Serializer::Json.dump_module(mod) + "\n")
       elsif show_doc
         print_status("Please wait, generating documentation for #{mod.shortname}")
-        Msf::Util::DocumentGenerator.get_module_document(mod)
+        Msf::Util::DocumentGenerator.spawn_module_document(mod)
       else
         print(Serializer::ReadableText.dump_module(mod))
       end


### PR DESCRIPTION
## What This Patch Does

This fixes the `info` command where `-d [module path ]` is unable to spawn the module documentation with a browser, because it uses the wrong API method.
## Verification
- [x] Start msfconsole
- [x] Do: `use exploit/windows/smb/ms08_067_netapi`
- [x] Do: `info -d`
- [x] You should see module documentation in a browser
- [x] Do: `info -d exploit/windows/smb/ms08_067_netapi`
- [x] You should again see module documentation in a browser
