### PR TITLE
Add module documentation for exploit/multi/http/struts_dmi_exec

### DIFF
--- a/documentation/modules/exploit/multi/http/struts_dmi_exec.md
+++ b/documentation/modules/exploit/multi/http/struts_dmi_exec.md
@@ -1,0 +1,56 @@
+struts_dmi_exec is a module that exploits Apache Struts 2's Dynamic Method Invocation,
+and it supports Windows and Linux platforms.
+
+## Vulnerable Application
+
+Apache Struts versions between 2.3.20 and 2.3.28 are vulnerable, except 2.3.20.2 and 2.3.24.2.
+The application's struts.xml also needs set ```struts.enable.DynamicMethodInvocation``` to true,
+and ```struts.devMode``` to false.
+
+For testing purposes, here is how you would set up the vulnerable machine:
+
+1. Download Apache Tomcat
+2. Download Java. [Choose an appropriate version](http://tomcat.apache.org/whichversion.html) based on the Apache Tomcat version you downloaded.
+3. Download the vulnerable [Apache Struts application](https://github.com/rapid7/metasploit-framework/files/241784/struts2-blank.tar.gz).
+4. Install Java first. Make sure you have the JAVA_HOME environment variable.
+5. Extract Apache Tomcat.
+6. In conf directory of Apache Tomcat, open the tomcat-users.xml file with a text editor.
+7. In tomcat-users.xml, add this role: ```<role rolename="manager-gui"/>```
+8. In tomcat-users.xml, add this role to user tomcat: ```<user username="tomcat" password="tomcat" roles="tomcat,manager-gui"/>```
+9. Remove other users.
+10. In a terminal or command prompt, ```cd``` to the bin directory, and run: ```catalina.bat run``` (or catalina.sh). You should have Apache Tomcat running on port 8080.
+11. Extract the vulnerable struts app: ```tar -xf struts2-blank.tar.gz```
+12. Navigate to the Apache Tomcat server with a browser on port 8080.
+13. Click on Manager App
+14. In the WAR file to deploy section, deploy struts2-blank.war
+15. Stop struts2-blank in the manager app.
+16. On the server, ```cd``` to ```apache-tomcat-[version]/webapps/struts2-blank/WEB-INF/classes```, open struts.xml with a text editor.
+17. In the XML file, update ```struts.enable.DynamicMethodInvocation``` to true
+18. In the XML file, update ```struts.devMode``` to false.
+19. Back to Apache Tomcat's manager app. Start the struts2-blank again.
+
+And now you have a vulnerable server.
+
+
+## Options
+
+**TMPPATH**
+
+By default, the struts_dmi_exec exploit should be ready to go without much configuration. However,
+in case you need to change where the payload should be uploaded to, make sure to set the correct
+target, and then change the TMPPATH datastore option.
+
+## Scenarios
+
+struts_dmi_exec supports three platforms: Windows, Linux, and Java. By default, it uses Java, so
+you don't need to worry about configuring this. Running the module can be as simple as the usage
+explained in the Overview section.
+
+However, native payload do have their benefits (for example: Windows Meterpreter has better
+support than Java), so if you decide to switch to a different platform, here is what you do:
+
+1. Do ```show targets```, and see which one you should be using
+2. Do ```set target [id]```
+3. Do ```show payloads```, which shows you a list of compatible payloads for that target.
+4. Do: ```set payload [payload name]```
+5. Do: ```exploit```


### PR DESCRIPTION
## What This Does

This adds module documentation for exploit/multi/http/struts_dmi_exec. I decided to add this, mainly because I don't want to forget how to configure the vulnerable application again.
## Verification
- [x] Start msfconsole
- [x] Do: `use exploit/multi/http/struts_dmi_exec`
- [x] Do: `info -d`
- [x] You should see the Knowledge Base for exploit/multi/http/struts_dmi_exec
