### PR TITLE
remove duplicate key

### DIFF
--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Auxiliary
         This does not need administrative privileges on the source machine, which
         may be useful if pivoting.
       },
-      'Description' => 'Enumerate open TCP services',
       'Author'      => [ 'hdm', 'kris katterjohn' ],
       'License'     => MSF_LICENSE
     )


### PR DESCRIPTION
This removes a duplicate key. Since ruby 2.3.1 a warning is printed on msfconsole start
