### PR TITLE
Don't duplicate headers when sending emails

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -163,8 +163,8 @@ module Exploit::Remote::SMTPDeliver
       print_error("Server refused our mail")
     else
       full_msg = ''
-      full_msg << date
-      full_msg << subject unless subject.nil?
+      full_msg << date unless data =~ /date: /i
+      full_msg << subject unless subject.nil? || data =~ /subject: /i
       full_msg << data
       send_status = raw_send_recv("#{full_msg}\r\n.\r\n", nsock)
     end

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -119,7 +119,6 @@ class MetasploitModule < Msf::Auxiliary
     datastore['MAILFROM'] = from
 
     msg       = load_file(msg_file)
-    email_sig = load_file(sig_file)
 
     if (type !~ /text/i and type !~ /text\/html/i)
       print_error("YAML config: #{type}")


### PR DESCRIPTION
If Date: and Subject: are present, we should not try to add them again.
This made Amazon SES puke, and that made us sad :(.

MS-1476
# Verification
- [x] Edit `data/emailer_config.yaml` and set `make_payload: false`, `attachment: false`, and `sig: false`
- [x] Create `/tmp/targets.csv` with `John Doe,blargh@example.com`
- [x] Create `/tmp/email_body.txt` with: `You got mail!`
- [x] Run: `socat TCP-LISTEN:2525,bind=127.0.0.1 STDIO`
- [x] Paste in:

```
220 localhost.localdomain SMTP blarg
250 Hello localhost.localdomain
```
- [x] In a separate terminal, start up msfconsole
- [x] `use auxiliary/client/smtp/emailer`
- [x] `set RPORT 2525`
- [x] `set SUBJECT foobar`
- [x] `run`
- [x] In the socat terminal, wait for the `MAIL FROM` command
- [x] Type `250 OK` and press enter
- [x] Ditto to the `RCPT TO` command
- [x] Respond to the `DATA` command with `354`
- [x] The `Date` and `Subject` headers should only appear once.
