### PR TITLE
fix  suspending shells from meterpreter

### DIFF
--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -253,11 +253,11 @@ protected
   # Installs a signal handler to monitor suspend signal notifications.
   #
   def handle_suspend
-    if (orig_suspend == nil)
+    if orig_suspend.nil?
       begin
-        self.orig_suspend = Signal.trap("TSTP") {
-          _suspend
-        }
+        self.orig_suspend = Signal.trap("TSTP") do
+          Thread.new { _suspend }.join
+        end
       rescue
       end
     end
@@ -269,7 +269,7 @@ protected
   #
   def restore_suspend
     begin
-      if (orig_suspend)
+      if orig_suspend
         Signal.trap("TSTP", orig_suspend)
       else
         Signal.trap("TSTP", "DEFAULT")


### PR DESCRIPTION
This PR fixes an error that happens when suspending a shell in a Meterpreter session. The problem is that you can only do a limited subset of things from a signal handler (e.g. you can't do anything that is not async-signal safe). So, we spawn a thread to do the things, but still join the thread from the signal context to avoid doing anything more thread-unsafe (as to not surprise the existing set of signal handlers)

This also partially addresses #4555

Prior to this patch, this happens when you background a shell

```
./msfconsole -qx 'use exploit/multi/handler; set payload python/meterpreter/reverse_tcp; set lhost 192.168.56.1; run'
payload => python/meterpreter/reverse_tcp
lhost => 192.168.56.1
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Starting the payload handler...
[*] Sending stage (38526 bytes) to 192.168.56.1
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:50194) at 2016-05-10 03:57:14 -0500

meterpreter > shell 
Process 17558 created.
Channel 1 created.
/bin/sh: 0: can't access tty; job control turned off
\[\033[00;32m\]\u@\h:\w$ \[\033[00m\]^Z
Background channel 1? [y/N]  y
[-] Error running command shell: ThreadError can't be called from trap context
meterpreter >
Background channel 1? [y/N]  [-] Session manipulation failed: can't be called from trap context ["/home/bcook/projects/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:170:in `synchronize'", "/home/bcook/projects/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:170:in `send_packet'", "/home/bcook/projects/metasploit-framew
```
## Verification

List the steps needed to make sure this thing works
- [ ] Start a meterpreter session (any meterpreter will do)

```
./msfconsole -qx 'use exploit/multi/handler; set payload python/meterpreter/reverse_tcp; set lhost 192.168.56.1; run'
```
- [ ] run the `shell` command
- [ ] hit Ctrl-Z to background the shell, hit 'y' to accept at the prompt
- [ ] Verify that the shell backgrounds without an error
- [ ] run `channel -i 1` to interact with the shell command again
- [ ] verify that you can still interact with the channel

```
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Starting the payload handler...
[*] Sending stage (38526 bytes) to 192.168.56.1
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:50356) at 2016-05-10 04:04:48 -0500

meterpreter > shell 
Process 18036 created.
Channel 1 created.
/bin/sh: 0: can't access tty; job control turned off
\[\033[00;32m\]\u@\h:\w$ \[\033[00m\]^Z
Background channel 1? [y/N]  y

meterpreter > channel -i 1
Interacting with channel 1...


\[\033[00;32m\]\u@\h:\w$ \[\033[00m\]ls
and.sh             HACKING               payloads.json
app            lib               plugins
bin            LICENSE               railgun-calls.txt
build_rev.txt.2        local                 Rakefile
callgrind.out.25815    log               README.md
cheatsheet         metasploit-framework.gemspec  script
CODE_OF_CONDUCT.md     modules               scripts
config             msfbinscan            spec
CONTRIBUTING.md        msfconsole            test
COPYING            msfd              test.db
coverage           msfelfscan            test.elf
cp_meterp_dlls         msfinstall            test.exe
data               msfmachscan           test.exectig
db             msfpescan             test.jar
documentation          msfrop                test.php
external           msfrpc                test.py
features           msfrpcd               test.rc
Gemfile            msfupdate             test-scripts
Gemfile.local.example  msfvenom              test.xml
Gemfile.lock           mytest                tmp
gen_payloads           notes.txt             tools
\[\033[00;32m\]\u@\h:\w$ \[\033[00m\]^Z
Background channel 1? [y/N]  y
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.56.1 - Meterpreter session 1 closed.  Reason: User exit
```
