### PR TITLE
Add default config value for log levels

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,0 +1,3 @@
+Metasploit::Framework::Application.configure do
+  config.log_level = :info
+end


### PR DESCRIPTION
This silences a default Rails 5.0 warning when starting msfconsole
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] It starts without complaining about a default loglevel not being specified
