### PR TITLE
Update nbns_response.rb description

### DIFF
--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Auxiliary
       'Description'    => %q{
           This module forges NetBIOS Name Service (NBNS) responses. It will listen for NBNS requests
           sent to the local subnet's broadcast address and spoof a response, redirecting the querying
-          machine to an IP of the attacker's choosing. Combined with auxiliary/capture/server/smb or
-          capture/server/http_ntlm it is a highly effective means of collecting crackable hashes on
+          machine to an IP of the attacker's choosing. Combined with auxiliary/server/capture/smb or
+          auxiliary/server/capture/http_ntlm it is a highly effective means of collecting crackable hashes on
           common networks.
 
           This module must be run as root and will bind to udp/137 on all interfaces.


### PR DESCRIPTION
This patch updates the module description for auxiliary/spoof/nbns/nbns_response.rb.
- [x] To verify, please make sure the module paths in the description make sense.
