### PR TITLE
Fix 6879, REXML::ParseException in moodle_cmd_exec

### DIFF
--- a/modules/exploits/multi/http/moodle_cmd_exec.rb
+++ b/modules/exploits/multi/http/moodle_cmd_exec.rb
@@ -101,17 +101,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'cookie' => sess
       })
 
-      tinymce.body.each_line do |line|
-        next if line !~ /name="sesskey"/
-        sesskey = line[0..line.index('>')]
-      end
-
-      if sesskey == ''
+      sesskey = tinymce.get_hidden_inputs[1]['sesskey']
+      unless sesskey
         fail_with(Failure::UnexpectedReply, "Unable to get proper session key")
       end
-
-      sesskey = REXML::Document.new sesskey
-      sesskey = sesskey.root.attributes["value"]
     else
       sesskey = datastore['SESSKEY']
     end

--- a/modules/exploits/multi/http/moodle_cmd_exec.rb
+++ b/modules/exploits/multi/http/moodle_cmd_exec.rb
@@ -9,7 +9,6 @@ require 'rexml/document'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
 
-  include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info={})


### PR DESCRIPTION
## What This Patch Does

This patch fixes what appears to be an HTML parsing problem. I couldn't actually reproduce the error, but `No close tag for /div` pretty much says the parsing is taking in some HTML data with a missing /div tag. Since the purpose of using REXML in this module is to extract the session key, we can make this parsing safer by using Nokogiri.

Fix #6879
## Verification

Honestly, I couldn't get the exploit to give me a shell even on the vulnerable 2.5.2. I also have a different spellchecker/rpc.php path than what the exploit is requesting. And since there is no verification history, I'm not able to investigate how this exploit was tested/verified.

So I recommend do this:
- [x] Start a Ubuntu box with Apache, PHP, and MySQL. If you don't know how to do this, the quickest way is probably: https://www.apachefriends.org/index.html
- [x] Open a terminal on the Ubuntu box, and do: `sudo apt-get install php5-pspell`
- [x] Also do: `sudo apt-get install libspell-dev`
- [x] Also do: `sudo apt-get install aspell-en`
- [x] Download moodle 2.5.2: https://download.moodle.org/stable25/moodle-2.5.2.zip
- [x] Unzip moodle, move the moodle folder to the www directory.
- [x] Browse to to moodle directory w/ a browser, installation should begin.
- [x] Start msfconsole
- [x] Do: `use exploit/multi/http/moodle_cmd_exec`
- [x] Set rhost
- [x] Set password
- [x] Run the exploit
- [x] You should not see this error: `Exploit failed: REXML::ParseException No close tag for /div`
