### PR TITLE
add a missing postgresql 9.4.1-5 matching case

### DIFF
--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -299,6 +299,7 @@ module Exploit::Remote::Postgres
     when "Fpostinit.c:L718:RInitPostgres"     ; return {:preauth => "9.1.6"} # Good creds, non-existent but allowed database
     when "Fauth.c:L483:RClientAuthentication" ; return {:preauth => "9.1.6"} # Bad user
     when "Fauth.c:L285:Rauth_failed"          ; return {:preauth => "9.4.1-5"} # Bad creds, good database
+    when "Fpostinit.c:L794:RInitPostgres"     ; return {:preauth => "9.4.1-5"} # Good creds, non-existent but allowed database
     when "Fauth.c:L481:RClientAuthentication" ; return {:preauth => "9.4.1-5"} # bad user or host
 
     # Windows

--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -298,6 +298,7 @@ module Exploit::Remote::Postgres
     when "Fauth.c:L302:Rauth_failed"          ; return {:preauth => "9.1.6"} # Bad password, good database
     when "Fpostinit.c:L718:RInitPostgres"     ; return {:preauth => "9.1.6"} # Good creds, non-existent but allowed database
     when "Fauth.c:L483:RClientAuthentication" ; return {:preauth => "9.1.6"} # Bad user
+    when "Fmiscinit.c:L362:RInitializeSessionUserId" ; return {:preauth => "9.4.1-5"} # Bad user
     when "Fauth.c:L285:Rauth_failed"          ; return {:preauth => "9.4.1-5"} # Bad creds, good database
     when "Fpostinit.c:L794:RInitPostgres"     ; return {:preauth => "9.4.1-5"} # Good creds, non-existent but allowed database
     when "Fauth.c:L481:RClientAuthentication" ; return {:preauth => "9.4.1-5"} # bad user or host


### PR DESCRIPTION
This adds more cases for postgresql 9.4.1-5 matching (when you have a user, but don't know the database)

MS-1102
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/postgres/postgres_version`
- [x]  set username and password to something invalid
- [x]  set RHOST to target a postgres 9.4.1 - 9.4.5 server that you can reach (omnibus installer databases work)
- [x] `run`
- [x] VERIFY it identifies the server as 9.4.1-5

Test run from OS X omnibus package:

```
msf > use auxiliary/scanner/postgres/postgres_version
msf auxiliary(postgres_version) > set USERNAME msf
USERNAME => msf
msf auxiliary(postgres_version) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(postgres_version) > set RPORT 5433
RPORT => 5433
msf auxiliary(postgres_version) > set DATABASE msf
DATABASE => msf
msf auxiliary(postgres_version) > run

[*] 127.0.0.1:5433 Postgres - Version PostgreSQL 9.4.5 on x86_64-apple-darwin14.5.0, compiled by Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn), 64-bit (Post-Auth)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

msf auxiliary(postgres_version) > set USERNAME monkey
USERNAME => monkey
msf auxiliary(postgres_version) > run
[*] 127.0.0.1:5433 Postgres - Version 9.4.1-5 (Pre-Auth)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```
