### PR TITLE
only set log_level in the Metasploit Framework context

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
-Metasploit::Framework::Application.configure do
-  config.log_level = :info
+if defined? Metasploit::Framework::Application
+  Metasploit::Framework::Application.configure do
+    config.log_level = :info
+  end
 end


### PR DESCRIPTION
We need to set log level to avoid a rails 5 deprecation warning, but this needs to be set separately in Metasploit pro. So we need to make this a conditional wrapper.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] Verify it starts without warnings
- [x] Apply same change to metasploit gem
- [x] Verify prosvc starts without any issues

MS-1518
