### PR TITLE
Netcore/netis backdoor scanner (issue #6876, pr #6880)

### DIFF
--- a/modules/auxiliary/scanner/misc/netis_backdoor_scanner.rb
+++ b/modules/auxiliary/scanner/misc/netis_backdoor_scanner.rb
@@ -54,12 +54,15 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     begin
       connect_udp
-      udp_sock.put("\r\n\r\n")
+      udp_sock.put("\x00" * 8)
       res = udp_sock.get(datastore['TIMEOUT'])
       if res.end_with?("\xD0\xA5Login:")
         #we need to try to login, but need the password first.
         #do_report(ip)
         print_good("#{ip}:#{rport} - Netis/Netcore backdoor detected.")
+        do_report(ip)
+      elsif res.end_with?("\x00\x00\x00\x05\x00\x01\x00\x00\x00\x00\x01\x00\x00")
+        print_good("#{ip}:#{rport} - Netis/Netcore authenticated backdoor detected.")
         do_report(ip)
       else
         vprint_status("#{ip}:#{rport} - Backdoor not detected.")

--- a/modules/auxiliary/scanner/misc/netis_backdoor_scanner.rb
+++ b/modules/auxiliary/scanner/misc/netis_backdoor_scanner.rb
@@ -1,0 +1,64 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'Netis/Netcore Network Device Backdoor Detection',
+      'Description' => %q{
+        This module can identify Netcore (Chinese) and Netis manufactured
+        network devices which contain a backdoor, allowing command
+        injection or account disclosure.
+      },
+      'Author'        =>
+        [
+          'Tim Yeh, Trend Micro',              # Discovery
+          'h00die <mike[at]stcyrsecurity.com>' # Module
+        ],
+        'License'     => MSF_LICENSE,
+        'References'  =>
+        [
+          [ 'URL', 'http://blog.trendmicro.com/trendlabs-security-intelligence/netis-routers-leave-wide-open-backdoor/' ]
+        ],
+        'DisclosureDate' => "Aug 25 2014" ))
+
+    register_options([
+        Opt::RPORT(53413)
+      ])
+  end
+
+  def do_report(ip)
+    report_vuln({
+      :host => ip,
+      :port => rport,
+      :name => "Netis Network Device Backdoor",
+      :refs => self.references,
+      :info => "Netis Network Device Backdoor found on device"
+    })
+  end
+
+  def run_host(ip)
+    begin
+      connect
+      sock.put(Rex::Text.rand_text(5))
+      res = sock.get_once
+      if res.start_with?("login")
+        #we need to try to login, but need the password first.
+        #do_report(ip)
+        vprint_status("#{ip}:#{rport} - Backdoor not detected.")
+      end
+    rescue Rex::ConnectionError => e
+      vprint_status("#{ip}:#{rport} - Connection failed: #{e.class}: #{e}")
+    end
+  end
+
+end


### PR DESCRIPTION
This is a fast scanner module to help detect the Netcore/netis udp backdoor.
Per comments in #6880 these module should be released together, I think that makes sense.

This module identifies the response given by the UDP backoor on the device, to then be exploited by #6880 
## Verification

Per #6876 I purchased and verified that 192.168.1.1 is a vulnerable device.  192.168.2.1 is a non-vulnerable device.
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/misc/netis_backdoor_scanner`
- [ ] `set rhosts 192.168.2.1 192.168.1.1`
- [ ] `set verbose true`
- [ ] `run`
- [ ] **Verify** the thing does what it should
  `[+] 192.168.1.1:53413 - Netis/Netcore backdoor detected.`
- [ ] **Verify** the thing does not do what it should not
  `[*] 192.168.2.1:53413 - Backdoor not detected.`

For the full flow, just to help see it all in action:

```
msf > use auxiliary/scanner/misc/netis_backdoor_scanner 
msf auxiliary(netis_backdoor_scanner) > set rhosts 192.168.2.1 192.168.1.1
rhosts => 192.168.2.1 192.168.1.1
msf auxiliary(netis_backdoor_scanner) > set verbose true
verbose => true
msf auxiliary(netis_backdoor_scanner) > run

[*] 192.168.2.1:53413 - Backdoor not detected.
[*] Scanned 1 of 2 hosts (50% complete)
[+] 192.168.1.1:53413 - Netis/Netcore backdoor detected.
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
