### PR TITLE
spelling fix for module

### DIFF
--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -15,8 +15,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Chinese Caidao Backdoor Bruteorce',
-      'Description'    => 'This module attempts to brute chinese caidao asp/php/aspx backdoor.',
+      'Name'           => 'Chinese Caidao Backdoor Bruteforce',
+      'Description'    => 'This module attempts to bruteforce chinese caidao asp/php/aspx backdoor.',
       'Author'         => [ 'Nixawk' ],
       'References'     => [
         ['URL', 'https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-i.html'],


### PR DESCRIPTION
bruteforce was missing an F, and later just called "brute".  Simple fixes.
