### PR TITLE
Respect SSLCipher in server mixins

### DIFF
--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -130,15 +130,11 @@ module Msf
       xploit.datastore['PAYLOAD']     = p.first[:payload_name]
       xploit.datastore['LPORT']       = p.first[:payload_lport]
       xploit.datastore['SRVHOST']     = datastore['SRVHOST']
-      xploit.datastore['JsObfuscate'] = datastore['JsObfuscate'] if datastore['JsObfuscate']
-      xploit.datastore['CookieName']  = datastore['CookieName'] if datastore['CookieName']
-      xploit.datastore['VERBOSE']     = datastore['VERBOSE'] if datastore['VERBOSE']
-      xploit.datastore['Retries']     = datastore['Retries'] if datastore['Retries']
-      xploit.datastore['SSL']         = datastore['SSL'] if datastore['SSL']
-      xploit.datastore['SSLVersion']  = datastore['SSLVersion'] if datastore['SSLVersion']
-      xploit.datastore['URIHOST']     = datastore['URIHOST'] if datastore['URIHOST']
-      xploit.datastore['URIPORT']     = datastore['URIPORT'] if datastore['URIPORT']
       xploit.datastore['LHOST']       = get_payload_lhost
+
+      %w(JsObfuscate CookieName VERBOSE Retries SSL SSLVersion SSLCipher URIHOST URIPORT).each do |opt|
+        xploit.datastore[opt] = datastore[opt] if datastore[opt]
+      end
 
       # Set options only configurable by BAP.
       xploit.datastore['DisablePayloadHandler'] = true
@@ -325,22 +321,14 @@ module Msf
         multi_handler.datastore['LHOST']                = get_payload_lhost
         multi_handler.datastore['PAYLOAD']              = payload_name
         multi_handler.datastore['LPORT']                = wanted[:payload_lport]
-        multi_handler.datastore['DebugOptions']         = datastore['DebugOptions'] if datastore['DebugOptions']
-        multi_handler.datastore['AutoLoadAndroid']      = datastore['AutoLoadAndroid'] if datastore['AutoLoadAndroid']
-        multi_handler.datastore['PrependMigrate']       = datastore['PrependMigrate'] if datastore['PrependMigrate']
-        multi_handler.datastore['PrependMigrateProc']   = datastore['PrependMigrateProc'] if datastore['PrependMigrateProc']
-        multi_handler.datastore['InitialAutoRunScript'] = datastore['InitialAutoRunScript'] if datastore['InitialAutoRunScript']
-        multi_handler.datastore['AutoRunScript']        = datastore['AutoRunScript'] if datastore['AutoRunScript']
-        multi_handler.datastore['CAMPAIGN_ID']          = datastore['CAMPAIGN_ID'] if datastore['CAMPAIGN_ID']
-        multi_handler.datastore['HandlerSSLCert']       = datastore['HandlerSSLCert'] if datastore['HandlerSSLCert']
-        multi_handler.datastore['StagerVerifySSLCert']  = datastore['StagerVerifySSLCert'] if datastore['StagerVerifySSLCert']
-        multi_handler.datastore['PayloadUUIDTracking']  = datastore['PayloadUUIDTracking'] if datastore['PayloadUUIDTracking']
-        multi_handler.datastore['PayloadUUIDName']      = datastore['PayloadUUIDName'] if datastore['PayloadUUIDName']
-        multi_handler.datastore['IgnoreUnknownPayloads'] = datastore['IgnoreUnknownPayloads'] if datastore['IgnoreUnknownPayloads']
-        multi_handler.datastore['SessionRetryTotal']     = datastore['SessionRetryTotal'] if datastore['SessionRetryTotal']
-        multi_handler.datastore['SessionRetryWait']      = datastore['SessionRetryWait'] if datastore['SessionRetryWait']
-        multi_handler.datastore['SessionExpirationTimeout'] = datastore['SessionExpirationTimeout'] if datastore['SessionExpirationTimeout']
-        multi_handler.datastore['SessionCommunicationTimeout'] = datastore['SessionCommunicationTimeout'] if datastore['SessionCommunicationTimeout']
+
+        %w(DebugOptions AutoLoadAndroid PrependMigrate PrependMigrateProc
+           InitialAutoRunScript AutoRunScript CAMPAIGN_ID HandlerSSLCert
+           StagerVerifySSLCert PayloadUUIDTracking PayloadUUIDName
+           IgnoreUnknownPayloads SessionRetryTotal SessionRetryWait
+           SessionExpirationTimeout SessionCommunicationTimeout).each do |opt|
+          multi_handler.datastore[opt] = datastore[opt] if datastore[opt]
+        end
 
         # Configurable only by BAP
         multi_handler.datastore['ExitOnSession'] = false

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -144,7 +144,8 @@ module Exploit::Remote::HttpServer
       },
       opts['Comm'],
       datastore['SSLCert'],
-      datastore['SSLCompression']
+      datastore['SSLCompression'],
+      datastore['SSLCipher']
     )
 
     self.service.server_name = datastore['HTTP::server_name']

--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -28,7 +28,8 @@ module Exploit::Remote::TcpServer
     register_advanced_options(
       [
         OptString.new('ListenerComm', [ false, 'The specific communication channel to use for this service']),
-        OptBool.new('SSLCompression', [ false, 'Enable SSL/TLS-level compression', false ])
+        OptBool.new('SSLCompression', [ false, 'Enable SSL/TLS-level compression', false ]),
+        OptString.new('SSLCipher',    [ false, 'String for SSL cipher spec - "DHE-RSA-AES256-SHA" or "ADH"'])
       ], Msf::Exploit::Remote::TcpServer)
 
     register_evasion_options(
@@ -108,6 +109,7 @@ module Exploit::Remote::TcpServer
         'LocalPort' => srvport,
         'SSL'       => ssl,
         'SSLCert'   => ssl_cert,
+        'SSLCipher'   => ssl_cipher,
         'SSLCompression' => ssl_compression,
         'Comm'      => comm,
         'Context'   =>
@@ -193,6 +195,13 @@ module Exploit::Remote::TcpServer
   #
   def ssl_cert
     datastore['SSLCert']
+  end
+
+  #
+  # Returns the SSLCipher option
+  #
+  def ssl_cipher
+    datastore['SSLCipher']
   end
 
   # @return [Bool] enable SSL/TLS-level compression

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -99,7 +99,9 @@ class Server
   # Initializes an HTTP server as listening on the provided port and
   # hostname.
   #
-  def initialize(port = 80, listen_host = '0.0.0.0', ssl = false, context = {}, comm = nil, ssl_cert = nil, ssl_compression = false)
+  def initialize(port = 80, listen_host = '0.0.0.0', ssl = false, context = {},
+                 comm = nil, ssl_cert = nil, ssl_compression = false,
+                 ssl_cipher = nil)
     self.listen_host     = listen_host
     self.listen_port     = port
     self.ssl             = ssl
@@ -107,6 +109,7 @@ class Server
     self.comm            = comm
     self.ssl_cert        = ssl_cert
     self.ssl_compression = ssl_compression
+    self.ssl_cipher      = ssl_cipher
     self.listener        = nil
     self.resources       = {}
     self.server_name     = DefaultServer
@@ -143,9 +146,10 @@ class Server
       'LocalHost' => self.listen_host,
       'LocalPort' => self.listen_port,
       'Context'   => self.context,
-      'SSL'		=> self.ssl,
-      'SSLCert'	=> self.ssl_cert,
+      'SSL'       => self.ssl,
+      'SSLCert'   => self.ssl_cert,
       'SSLCompression' => self.ssl_compression,
+      'SSLCipher' => self.ssl_cipher,
       'Comm'      => self.comm
     )
 
@@ -269,7 +273,7 @@ class Server
   end
 
   attr_accessor :listen_port, :listen_host, :server_name, :context, :comm
-  attr_accessor :ssl, :ssl_cert, :ssl_compression
+  attr_accessor :ssl, :ssl_cert, :ssl_compression, :ssl_cipher
   attr_accessor :listener, :resources
 
 protected

--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -183,6 +183,10 @@ module Rex::Socket::SslTcpServer
     ctx.extra_chain_cert = chain
     ctx.options = 0
 
+    if params.ssl_cipher
+      ctx.ciphers = params.ssl_cipher
+    end
+
     # Older versions of OpenSSL do not export the OP_NO_COMPRESSION symbol
     if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
       # enable/disable the SSL/TLS-level compression


### PR DESCRIPTION
This allows us to set a sane cipher spec for SSL-enabled server modules.
# Verification

see #6902 for steps
