### PR TITLE
Having the payload generator check the payload size

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -9,7 +9,7 @@ module Msf
   class EncoderSpaceViolation < PayloadGeneratorError
   end
 
-  class SpaceViolation < PayloadGeneratorError
+  class PayloadSpaceViolation < PayloadGeneratorError
   end
 
   class IncompatibleArch < PayloadGeneratorError
@@ -333,7 +333,7 @@ module Msf
         gen_payload = format_payload(encoded_payload)
       end
       if gen_payload.length > @space and not @smallest
-        raise SpaceViolation, 'The payload exceeds the allocated space'
+        raise PayloadSpaceViolation, 'The payload exceeds the specified space'
       else
         gen_payload
       end

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -4,48 +4,50 @@ require 'msf/core/payload_generator'
 RSpec.describe Msf::PayloadGenerator do
   include_context 'Msf::Simple::Framework#modules loading'
 
-  let(:lhost) { "192.168.172.1"}
-  let(:lport) { "8443" }
-  let(:datastore) { { "LHOST" => lhost, "LPORT" => lport } }
-  let(:add_code) { false }
-  let(:arch) { "x86" }
-  let(:badchars) { "\x20\x0D\x0A" }
-  let(:encoder_reference_name)  {
-    # use encoder_module to ensure it is loaded prior to passing to generator
-    encoder_module.refname
-  }
-  let(:format) { "raw" }
-  let(:iterations) { 1 }
-  let(:keep) { false }
-  let(:nops) { 0 }
-  let(:payload_reference_name) {
-    # use payload_module to ensure it is loaded prior to passing to generator
-    payload_module.refname
-  }
-  let(:platform) { "Windows" }
-  let(:space) { 1073741824 }
-  let(:stdin) { nil }
-  let(:template) { File.join(Msf::Config.data_directory, "templates", "template_x86_windows.exe") }
+  # let(:lhost) { "192.168.172.1"}
+  # let(:lport) { "8443" }
+  # let(:datastore) { { "LHOST" => lhost, "LPORT" => lport } }
+  # let(:add_code) { false }
+  # let(:arch) { "x86" }
+  # let(:badchars) { "\x20\x0D\x0A" }
+  # let(:encoder_reference_name)  {
+  #   # use encoder_module to ensure it is loaded prior to passing to generator
+  #   encoder_module.refname
+  # }
+  # let(:format) { "raw" }
+  # let(:iterations) { 1 }
+  # let(:keep) { false }
+  # let(:nops) { 0 }
+  # let(:payload_reference_name) {
+  #   # use payload_module to ensure it is loaded prior to passing to generator
+  #   payload_module.refname
+  # }
+  # let(:platform) { "Windows" }
+  # let(:space) { 1073741824 }
+  # let(:stdin) { nil }
+  # let(:template) { File.join(Msf::Config.data_directory, "templates", "template_x86_windows.exe") }
+
   let(:generator_opts) {
     {
-        add_code: add_code,
-        arch: arch,
-        badchars: badchars,
-        encoder: encoder_reference_name,
-        datastore: datastore,
-        format: format,
+        add_code: false,
+        arch: 'x86',
+        badchars: "\x20\x0D\x0A",
+        encoder:  'x86/shikata_ga_nai',
+        datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+        format: 'raw',
         framework: framework,
-        iterations: iterations,
-        keep: keep,
-        nops: nops,
-        payload: payload_reference_name,
-        platform: platform,
-        space: space,
-        stdin: stdin,
-        template: template
+        iterations: 1,
+        keep: false,
+        nops: 0,
+        payload: 'windows/meterpreter/reverse_tcp',
+        platform: 'Windows',
+        space: 1073741824,
+        stdin: nil,
+        template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
     }
   }
-  let(:payload_module) {
+
+  let!(:payload_module) {
     load_and_create_module(
         ancestor_reference_names: %w{
           stagers/windows/reverse_tcp
@@ -55,17 +57,13 @@ RSpec.describe Msf::PayloadGenerator do
         reference_name: 'windows/meterpreter/reverse_tcp'
     )
   }
-  let(:shellcode) { "\x50\x51\x58\x59" }
-  let(:encoder_module) {
-    load_and_create_module(
-        module_type: 'encoder',
-        reference_name: 'x86/shikata_ga_nai'
-    )
-  }
-  let(:var_name) { 'buf' }
+  
+  # let(:shellcode) { "\x50\x51\x58\x59" }
+  
+  # let(:var_name) { 'buf' }
 
   subject(:payload_generator) {
-    described_class.new(generator_opts)
+    Msf::PayloadGenerator.new(generator_opts)
   }
 
   it { is_expected.to respond_to :add_code }
@@ -85,71 +83,199 @@ RSpec.describe Msf::PayloadGenerator do
   it { is_expected.to respond_to :stdin }
   it { is_expected.to respond_to :template }
 
+
   context 'when creating a new generator' do
     subject(:new_payload_generator) { -> { described_class.new(generator_opts) } }
 
     context 'when not given a framework instance' do
       let(:generator_opts) {
         {
-            add_code: add_code,
-            arch: arch,
-            badchars: badchars,
-            encoder: encoder_reference_name,
-            datastore: datastore,
-            format: format,
-            iterations: iterations,
-            keep: keep,
-            nops: nops,
-            payload: payload_reference_name,
-            platform: platform,
-            space: space,
-            stdin: stdin,
-            template: template
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
         }
       }
 
-      it { is_expected.to raise_error(KeyError, "key not found: :framework") }
+      it { is_expected.to raise_error(KeyError, 'key not found: :framework') }
     end
 
     context 'when not given a payload' do
-      let(:payload_reference_name) { nil }
-
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: nil,
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
+      
       it { is_expected.to raise_error(ArgumentError, "Invalid Payload Selected") }
     end
 
     context 'when given an invalid payload' do
-      let(:payload_reference_name) { "beos/meterpreter/reverse_gopher" }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'beos/meterpreter/reverse_gopher',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       it { is_expected.to raise_error(ArgumentError, "Invalid Payload Selected") }
     end
 
     context 'when given a payload through stdin' do
-      let(:payload_reference_name) { "stdin" }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'stdin',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       it { is_expected.not_to raise_error }
     end
 
     context 'when given an invalid format' do
-      let(:format) { "foobar" }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'foobar',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       it { is_expected.to raise_error(ArgumentError, "Invalid Format Selected") }
     end
 
     context 'when given any valid transform format' do
-      let(:format) { ::Msf::Simple::Buffer.transform_formats.sample }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: ::Msf::Simple::Buffer.transform_formats.sample,
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       it { is_expected.not_to raise_error }
     end
 
     context 'when given any valid executable format' do
       let(:format) { ::Msf::Util::EXE.to_executable_fmt_formats.sample }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: ::Msf::Util::EXE.to_executable_fmt_formats.sample,
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       it { is_expected.not_to raise_error }
     end
   end
 
   context 'when not given a platform' do
-    let(:platform) { '' }
+    let(:generator_opts) {
+      {
+          add_code: false,
+          arch: 'x86',
+          badchars: "\x20\x0D\x0A",
+          encoder:  'x86/shikata_ga_nai',
+          datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+          format: 'raw',
+          framework: framework,
+          iterations: 1,
+          keep: false,
+          nops: 0,
+          payload: 'windows/meterpreter/reverse_tcp',
+          platform: '',
+          space: 1073741824,
+          stdin: nil,
+          template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+      }
+    }
 
     context '#platform_list' do
       it 'returns an empty PlatformList' do
@@ -172,7 +298,25 @@ RSpec.describe Msf::PayloadGenerator do
   end
 
   context 'when given an invalid platform' do
-    let(:platform) { 'foobar' }
+    let(:generator_opts) {
+      {
+          add_code: false,
+          arch: 'x86',
+          badchars: "\x20\x0D\x0A",
+          encoder:  'x86/shikata_ga_nai',
+          datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+          format: 'raw',
+          framework: framework,
+          iterations: 1,
+          keep: false,
+          nops: 0,
+          payload: 'windows/meterpreter/reverse_tcp',
+          platform: 'foobar',
+          space: 1073741824,
+          stdin: nil,
+          template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+      }
+    }
 
     context '#platform_list' do
       it 'returns an empty PlatformList' do
@@ -204,7 +348,25 @@ RSpec.describe Msf::PayloadGenerator do
       end
 
       context 'when the chosen platform and module do not match' do
-        let(:platform) { "linux" }
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'x86',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'windows/meterpreter/reverse_tcp',
+              platform: 'linux',
+              space: 1073741824,
+              stdin: nil,
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
         it 'returns an empty PlatformList' do
           expect(payload_generator.choose_platform(payload_module).platforms).to be_empty
         end
@@ -215,7 +377,25 @@ RSpec.describe Msf::PayloadGenerator do
 
   context '#choose_arch' do
     context 'when no arch is selected' do
-      let(:arch) { '' }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: '',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       it 'returns the first arch of the module' do
         expect(payload_generator.choose_arch(payload_module)).to eq "x86"
@@ -230,12 +410,31 @@ RSpec.describe Msf::PayloadGenerator do
 
     context 'when the arch matches the module' do
       it 'returns the selected arch' do
-        expect(payload_generator.choose_arch(payload_module)).to eq arch
+        expect(payload_generator.choose_arch(payload_module)).to eq 'x86'
       end
     end
 
     context 'when the arch does not match the module' do
       let(:arch) { "mipsle" }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'mipsle',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       it "returns nil" do
         expect(payload_generator.choose_arch(payload_module)).to be_nil
@@ -246,11 +445,26 @@ RSpec.describe Msf::PayloadGenerator do
   context '#generate_raw_payload' do
 
     context 'when passing a payload through stdin' do
-      let(:stdin) { "\x90\x90\x90"}
-      let(:payload_reference_name) { "stdin" }
-
       context 'when no arch has been selected' do
-        let(:arch) { '' }
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: '',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'stdin',
+              platform: 'Windows',
+              space: 1073741824,
+              stdin: "\x90\x90\x90",
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
 
         it 'raises an IncompatibleArch error' do
           expect{payload_generator.generate_raw_payload}.to raise_error(Msf::IncompatibleArch, "You must select an arch for a custom payload")
@@ -258,21 +472,75 @@ RSpec.describe Msf::PayloadGenerator do
       end
 
       context 'when no platform has been selected' do
-        let(:platform) { '' }
-
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'x86',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'stdin',
+              platform: '',
+              space: 1073741824,
+              stdin: "\x90\x90\x90",
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
         it 'raises an IncompatiblePlatform error' do
           expect{payload_generator.generate_raw_payload}.to raise_error(Msf::IncompatiblePlatform, "You must select a platform for a custom payload")
         end
       end
-
+      
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'stdin',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: "\x90\x90\x90",
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       it 'returns the payload from stdin' do
-        expect(payload_generator.generate_raw_payload).to eq stdin
+        expect(payload_generator.generate_raw_payload).to eq "\x90\x90\x90"
       end
     end
 
     context 'when selecting a metasploit payload' do
       context 'when the platform is incompatible with the payload' do
-        let(:platform) { "linux" }
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'x86',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'windows/meterpreter/reverse_tcp',
+              platform: 'linux',
+              space: 1073741824,
+              stdin: "\x90\x90\x90",
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
 
         it 'raises an IncompatiblePlatform error' do
           expect{payload_generator.generate_raw_payload}.to raise_error(Msf::IncompatiblePlatform, "The selected platform is incompatible with the payload")
@@ -280,16 +548,50 @@ RSpec.describe Msf::PayloadGenerator do
       end
 
       context 'when the arch is incompatible with the payload' do
-        let(:arch) { "mipsle" }
-
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'mipsle',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'windows/meterpreter/reverse_tcp',
+              platform: 'Windows',
+              space: 1073741824,
+              stdin: "\x90\x90\x90",
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
         it 'raises an IncompatibleArch error' do
           expect{payload_generator.generate_raw_payload}.to raise_error(Msf::IncompatibleArch, "The selected arch is incompatible with the payload")
         end
       end
 
       context 'when one or more datastore options are missing' do
-        let(:datastore) { {} }
-
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'x86',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: {} ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'windows/meterpreter/reverse_tcp',
+              platform: 'Windows',
+              space: 1073741824,
+              stdin: "\x90\x90\x90",
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
         it 'should raise an error' do
           expect{payload_generator.generate_raw_payload}.to raise_error(Msf::OptionValidateError)
         end
@@ -302,7 +604,7 @@ RSpec.describe Msf::PayloadGenerator do
   end
 
   context '#add_shellcode' do
-
+    let(:shellcode) { "\x50\x51\x58\x59" }
     context 'when add_code is empty' do
       it 'returns the original shellcode' do
         expect(payload_generator.add_shellcode(shellcode)).to eq shellcode
@@ -310,18 +612,53 @@ RSpec.describe Msf::PayloadGenerator do
     end
 
     context 'when add_code points to a valid file' do
-      let(:add_code) { File.join(FILE_FIXTURES_PATH, "nop_shellcode.bin")}
-
       context 'but platform is not Windows' do
-        let(:platform) { "Linux" }
-
+        let(:generator_opts) {
+          {
+              add_code: File.join(FILE_FIXTURES_PATH, "nop_shellcode.bin"),
+              arch: 'x86',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'windows/meterpreter/reverse_tcp',
+              platform: 'Linux',
+              space: 1073741824,
+              stdin: nil,
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
+        
         it 'returns the original shellcode' do
           expect(payload_generator.add_shellcode(shellcode)).to eq shellcode
         end
       end
 
       context 'but arch is not x86' do
-        let(:arch) { "x86_64" }
+        let(:generator_opts) {
+          {
+              add_code: File.join(FILE_FIXTURES_PATH, "nop_shellcode.bin"),
+              arch: 'x86_64',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'windows/meterpreter/reverse_tcp',
+              platform: 'Windows',
+              space: 1073741824,
+              stdin: nil,
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
+        
 
         it 'returns the original shellcode' do
           expect(payload_generator.add_shellcode(shellcode)).to eq shellcode
@@ -339,7 +676,25 @@ RSpec.describe Msf::PayloadGenerator do
     end
 
     context 'when add_code points to an invalid file' do
-      let(:add_code) { "gurfjhfdjhfdsjhfsdvfverf444" }
+      let(:generator_opts) {
+        {
+            add_code: "gurfjhfdjhfdsjhfsdvfverf444",
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       it 'raises an error' do
         expect{payload_generator.add_shellcode(shellcode)}.to raise_error(Errno::ENOENT)
       end
@@ -347,9 +702,8 @@ RSpec.describe Msf::PayloadGenerator do
   end
 
   context '#prepend_nops' do
+    let(:shellcode) { "\x50\x51\x58\x59" }
     context 'when nops are set to 0' do
-      let(:nops) { 0 }
-
       before(:example) do
         load_and_create_module(
             module_type: 'nop',
@@ -363,16 +717,32 @@ RSpec.describe Msf::PayloadGenerator do
     end
 
     context 'when nops are set to more than 0' do
-      let(:badchars) { '' }
-      let(:nops) { 20 }
-
-      context 'when payload is x86' do
-        before(:example) do
-          load_and_create_module(
+      before(:example) do
+        load_and_create_module(
             module_type: 'nop',
             reference_name: 'x86/opty2'
-          )
-        end
+        )
+      end
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: '',
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 20,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
+      context 'when payload is x86' do
 
         it 'returns shellcode of the correct size' do
           final = payload_generator.prepend_nops(shellcode)
@@ -386,8 +756,31 @@ RSpec.describe Msf::PayloadGenerator do
       end
 
       context 'when payload is Windows x64' do
-        let(:arch) { 'x86_64' }
-        let(:payload_module) {
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'x86_64',
+              badchars: '',
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 20,
+              payload: 'windows/x64/meterpreter/reverse_tcp',
+              platform: 'Windows',
+              space: 1073741824,
+              stdin: nil,
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
+        
+        before(:example) do
+          load_and_create_module(
+              module_type: 'nop',
+              reference_name: 'x64/simple'
+          )
           load_and_create_module(
             ancestor_reference_names: %w{
                 stagers/windows/x64/reverse_tcp
@@ -396,23 +789,16 @@ RSpec.describe Msf::PayloadGenerator do
             module_type: 'payload',
             reference_name: 'windows/x64/meterpreter/reverse_tcp'
           )
-        }
-
-        before(:example) do
-          load_and_create_module(
-              module_type: 'nop',
-              reference_name: 'x64/simple'
-          )
         end
 
         it 'returns shellcode of the correct size' do
           final = payload_generator.prepend_nops(shellcode)
-          expect(final.length).to eq(nops + shellcode.length)
+          expect(final.length).to eq(20 + shellcode.length)
         end
 
         it 'puts the nops in front of the original shellcode' do
           final = payload_generator.prepend_nops(shellcode)
-          expect(final[nops, nops + shellcode.length]).to eq shellcode
+          expect(final[20, 20 + shellcode.length]).to eq shellcode
         end
 
       end
@@ -420,8 +806,32 @@ RSpec.describe Msf::PayloadGenerator do
   end
 
   context '#get_encoders' do
+    let!(:encoder_module) {
+      load_and_create_module(
+          module_type: 'encoder',
+          reference_name: 'x86/shikata_ga_nai'
+      )
+    }
     let(:encoder_names) { ["Polymorphic XOR Additive Feedback Encoder", "Alpha2 Alphanumeric Mixedcase Encoder" ] }
-
+    let(:generator_opts) {
+      {
+          add_code: false,
+          arch: 'x86',
+          badchars: "\x20\x0D\x0A",
+          encoder:  'x86/shikata_ga_nai',
+          datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+          format: 'raw',
+          framework: framework,
+          iterations: 1,
+          keep: false,
+          nops: 0,
+          payload: 'windows/meterpreter/reverse_tcp',
+          platform: 'Windows',
+          space: 1073741824,
+          stdin: nil,
+          template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+      }
+    }
     context 'when an encoder is selected' do
       it 'returns an array' do
         expect(payload_generator.get_encoders).to be_kind_of Array
@@ -441,28 +851,42 @@ RSpec.describe Msf::PayloadGenerator do
       # lets
       #
 
-      let(:encoder_reference_name) {
-        encoder_reference_names.join(',')
-      }
-
-      let(:encoder_reference_names) {
-        %w{
-          x86/shikata_ga_nai
-          x86/alpha_mixed
+      # let(:encoder_reference_name) {
+      #   encoder_reference_names.join(',')
+      # }
+      #
+      # let(:encoder_reference_names) {
+      #   %w{
+      #     x86/shikata_ga_nai
+      #     x86/alpha_mixed
+      #   }
+      # }
+      
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai,x86/alpha_mixed',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
         }
       }
 
-      #
-      # Callbacks
-      #
-
       before(:example) do
-        encoder_reference_names.each do |reference_name|
-          load_and_create_module(
-              module_type: 'encoder',
-              reference_name: reference_name
-          )
-        end
+        load_and_create_module(
+            module_type: 'encoder',
+            reference_name: 'x86/alpha_mixed'
+        )
       end
 
       it 'returns an array of the right size' do
@@ -481,19 +905,61 @@ RSpec.describe Msf::PayloadGenerator do
     end
 
     context 'when no encoder is selected but badchars are present' do
-      let(:encoder_reference_name) { '' }
-
+      # let(:encoder_reference_name) { '' }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  '',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
+      
       it 'returns an array of all encoders with a compatible arch' do
         payload_generator.get_encoders.each do |my_encoder|
-          expect(encoder_module.arch).to include arch
+          expect(my_encoder.arch).to include 'x86'
         end
       end
     end
 
     context 'when no encoder or badchars are selected' do
-      let(:encoder_reference_name) { '' }
-      let(:badchars) { '' }
-
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: '',
+            encoder:  '',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
+      let(:encoder_module) {
+          load_and_create_module(
+              module_type: 'encoder',
+              reference_name: 'x86/shikata_ga_nai'
+          )
+        }
+      
       it 'returns an empty array' do
         expect(payload_generator.get_encoders).to be_empty
       end
@@ -501,14 +967,39 @@ RSpec.describe Msf::PayloadGenerator do
   end
 
   context '#run_encoder' do
-
+    let(:shellcode) { "\x50\x51\x58\x59" }
+    let(:encoder_module) {
+        load_and_create_module(
+            module_type: 'encoder',
+            reference_name: 'x86/shikata_ga_nai'
+        )
+      }
     it 'should call the encoder a number of times equal to the iterations' do
-      expect(encoder_module).to receive(:encode).exactly(iterations).times.and_return(shellcode)
+      expect(encoder_module).to receive(:encode).exactly(1).times.and_return(shellcode)
       payload_generator.run_encoder(encoder_module, shellcode)
     end
 
     context 'when the encoder makes a buffer too large' do
-      let(:space) { 4 }
+      # let(:space) { 4 }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 4,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       it 'should raise an error' do
         expect{payload_generator.run_encoder(encoder_module, shellcode)}.to raise_error(Msf::EncoderSpaceViolation, "encoder has made a buffer that is too big")
       end
@@ -516,8 +1007,27 @@ RSpec.describe Msf::PayloadGenerator do
   end
 
   context '#format_payload' do
+    let(:shellcode) { "\x50\x51\x58\x59" }
     context 'when format is js_be' do
-      let(:format) { "js_be"}
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'js_be',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       context 'and arch is x86' do
         it 'should raise an IncompatibleEndianess error' do
           expect{payload_generator.format_payload(shellcode)}.to raise_error(Msf::IncompatibleEndianess, "Big endian format selected for a non big endian payload")
@@ -526,19 +1036,53 @@ RSpec.describe Msf::PayloadGenerator do
     end
 
     context 'when format is a transform format' do
-      let(:format) { 'c' }
-
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'c',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       it 'applies the appropriate transform format' do
-        expect(::Msf::Simple::Buffer).to receive(:transform).with(shellcode, format, var_name)
+        expect(::Msf::Simple::Buffer).to receive(:transform).with(shellcode, 'c', 'buf')
         payload_generator.format_payload(shellcode)
       end
     end
 
     context 'when format is an executable format' do
-      let(:format) { 'exe' }
-
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'exe',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       it 'applies the appropriate executable format' do
-        expect(::Msf::Util::EXE).to receive(:to_executable_fmt).with(framework, arch, kind_of(payload_generator.platform_list.class), shellcode, format, payload_generator.exe_options)
+        expect(::Msf::Util::EXE).to receive(:to_executable_fmt).with(framework, 'x86', kind_of(payload_generator.platform_list.class), shellcode, 'exe', payload_generator.exe_options)
         payload_generator.format_payload(shellcode)
       end
     end
@@ -546,9 +1090,26 @@ RSpec.describe Msf::PayloadGenerator do
 
   context '#generate_java_payload' do
     context 'when format is war' do
-      let(:format) { 'war' }
-
       context 'if the payload is a valid java payload' do
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'x86',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'war',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'java/meterpreter/reverse_tcp',
+              platform: 'Windows',
+              space: 1073741824,
+              stdin: nil,
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
         let(:payload_module) {
           load_and_create_module(
               ancestor_reference_names: %w{
@@ -561,23 +1122,61 @@ RSpec.describe Msf::PayloadGenerator do
         }
 
         it 'calls the generate_war on the payload' do
-          allow(framework).to receive_message_chain(:payloads, :keys).and_return [payload_reference_name]
+          allow(framework).to receive_message_chain(:payloads, :keys).and_return ['java/meterpreter/reverse_tcp']
           allow(framework).to receive_message_chain(:payloads, :create).and_return(payload_module)
           expect(payload_module).to receive(:generate_war).and_call_original
           payload_generator.generate_java_payload
         end
       end
-
+      
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'war',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
+      
       it 'raises an InvalidFormat exception' do
-        expect{payload_generator.generate_java_payload}.to raise_error(Msf::InvalidFormat)
+        expect{ payload_generator.generate_java_payload }.to raise_error(Msf::InvalidFormat)
       end
     end
 
     context 'when format is raw' do
-      let(:format) { 'raw' }
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'java/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
 
       context 'if the payload responds to generate_jar' do
-        let(:payload_module) {
+        let!(:payload_module) {
           load_and_create_module(
               ancestor_reference_names: %w{
                 stagers/java/reverse_tcp
@@ -589,7 +1188,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
 
         it 'calls the generate_jar on the payload' do
-          allow(framework).to receive_message_chain(:payloads, :keys).and_return [payload_reference_name]
+          allow(framework).to receive_message_chain(:payloads, :keys).and_return ['java/meterpreter/reverse_tcp']
           allow(framework).to receive_message_chain(:payloads, :create).and_return(payload_module)
           expect(payload_module).to receive(:generate_jar).and_call_original
           payload_generator.generate_java_payload
@@ -597,7 +1196,7 @@ RSpec.describe Msf::PayloadGenerator do
       end
 
       context 'if the payload does not respond to generate_jar' do
-        let(:payload_module) {
+        let!(:payload_module) {
           load_and_create_module(
               ancestor_reference_names: %w{
                 singles/java/jsp_shell_reverse_tcp
@@ -606,9 +1205,28 @@ RSpec.describe Msf::PayloadGenerator do
               reference_name: 'java/jsp_shell_reverse_tcp'
           )
         }
+        let(:generator_opts) {
+          {
+              add_code: false,
+              arch: 'x86',
+              badchars: "\x20\x0D\x0A",
+              encoder:  'x86/shikata_ga_nai',
+              datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+              format: 'raw',
+              framework: framework,
+              iterations: 1,
+              keep: false,
+              nops: 0,
+              payload: 'java/jsp_shell_reverse_tcp',
+              platform: 'Windows',
+              space: 1073741824,
+              stdin: nil,
+              template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+          }
+        }
 
         it 'calls #generate' do
-          allow(framework).to receive_message_chain(:payloads, :keys).and_return [payload_reference_name]
+          allow(framework).to receive_message_chain(:payloads, :keys).and_return ['java/jsp_shell_reverse_tcp']
           allow(framework).to receive_message_chain(:payloads, :create).and_return(payload_module)
           expect(payload_module).to receive(:generate).and_call_original
           payload_generator.generate_java_payload
@@ -620,8 +1238,25 @@ RSpec.describe Msf::PayloadGenerator do
     end
 
     context 'when format is a non-java format' do
-      let(:format) { "exe" }
-
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'exe',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'windows/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       it 'raises an InvalidFormat exception' do
         expect{payload_generator.generate_java_payload}.to raise_error(Msf::InvalidFormat)
       end
@@ -629,7 +1264,31 @@ RSpec.describe Msf::PayloadGenerator do
   end
 
   context '#generate_payload' do
-
+    let!(:encoder_module) {
+      load_and_create_module(
+          module_type: 'encoder',
+          reference_name: 'x86/shikata_ga_nai'
+      )
+    }
+    let(:generator_opts) {
+      {
+          add_code: false,
+          arch: 'x86',
+          badchars: "\x20\x0D\x0A",
+          encoder:  'x86/shikata_ga_nai',
+          datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+          format: 'raw',
+          framework: framework,
+          iterations: 1,
+          keep: false,
+          nops: 0,
+          payload: 'windows/meterpreter/reverse_tcp',
+          platform: 'Windows',
+          space: 1073741824,
+          stdin: nil,
+          template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+      }
+    }
     it 'calls each step of the process' do
       expect(payload_generator).to receive(:generate_raw_payload).and_call_original
       expect(payload_generator).to receive(:add_shellcode).and_call_original
@@ -640,7 +1299,7 @@ RSpec.describe Msf::PayloadGenerator do
     end
 
     context 'when the payload is java' do
-      let(:payload_module) {
+      let!(:payload_module) {
         load_and_create_module(
             ancestor_reference_names: %w{
                 stagers/java/reverse_tcp
@@ -650,11 +1309,53 @@ RSpec.describe Msf::PayloadGenerator do
             reference_name: 'java/meterpreter/reverse_tcp'
         )
       }
-
+      let(:generator_opts) {
+        {
+            add_code: false,
+            arch: 'x86',
+            badchars: "\x20\x0D\x0A",
+            encoder:  'x86/shikata_ga_nai',
+            datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+            format: 'raw',
+            framework: framework,
+            iterations: 1,
+            keep: false,
+            nops: 0,
+            payload: 'java/meterpreter/reverse_tcp',
+            platform: 'Windows',
+            space: 1073741824,
+            stdin: nil,
+            template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+        }
+      }
       it 'calls generate_java_payload' do
         expect(payload_generator).to receive(:generate_java_payload).and_call_original
         payload_generator.generate_payload
       end
+    end
+  end
+  context 'when the payload exceeds the specified space' do
+    let(:generator_opts) {
+      {
+          add_code: false,
+          arch: 'x86',
+          badchars: "\x20\x0D\x0A",
+          encoder:  nil,
+          datastore: { 'LHOST' => '192.168.172.1', 'LPORT' => '8443' } ,
+          format: 'raw',
+          framework: framework,
+          iterations: 1,
+          keep: false,
+          nops: 0,
+          payload: 'windows/meterpreter/reverse_tcp',
+          platform: 'Windows',
+          space: 100,
+          stdin: nil,
+          template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
+      }
+    }
+    it 'should raise an error' do
+      expect{payload_generator.generate_payload}.to raise_error(Msf::PayloadSpaceViolation, "The payload exceeds the specified space")
     end
   end
 


### PR DESCRIPTION
Checking the size of the payload and raising an error if its to larger then the size option. This should fix #6558
## Verification

List the steps needed to make sure this thing works
- [x] `msfvenom -a x86 --platform Windows -p windows/meterpreter/reverse_http LHOST=IP LPORT=80 -s 100 -f raw -o rev_http_IP_80` should not generate a payload
