### PR TITLE
Fix check command with an IP or IP range

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -30,7 +30,7 @@ class DataStore < Hash
     opt = @options[k]
     unless opt.nil?
       if opt.validate_on_assignment?
-        unless opt.valid?(v)
+        unless opt.valid?(v, check_empty: false)
           raise OptionValidateError.new(["Value '#{v}' is not valid for option '#{k}'"])
         end
         v = opt.normalize(v)

--- a/lib/msf/core/opt_address.rb
+++ b/lib/msf/core/opt_address.rb
@@ -12,8 +12,8 @@ class OptAddress < OptBase
     return 'address'
   end
 
-  def valid?(value)
-    return false if empty_required_value?(value)
+  def valid?(value, check_empty: true)
+    return false if check_empty && empty_required_value?(value)
     return false unless value.kind_of?(String) or value.kind_of?(NilClass)
 
     if (value != nil and value.empty? == false)

--- a/lib/msf/core/opt_address_range.rb
+++ b/lib/msf/core/opt_address_range.rb
@@ -35,8 +35,8 @@ class OptAddressRange < OptBase
     return value
   end
 
-  def valid?(value)
-    return false if empty_required_value?(value)
+  def valid?(value, check_empty: true)
+    return false if check_empty && empty_required_value?(value)
     return false unless value.kind_of?(String) or value.kind_of?(NilClass)
 
     if (value != nil and value.empty? == false)

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -88,14 +88,10 @@ module Msf
     def valid?(value, check_empty: true)
       if check_empty && required?
         # required variable not set
-        return false if (value == nil or value.to_s.empty?)
+        return false if (value.nil? || value.to_s.empty?)
       end
       if regex
-        if value.match(regex)
-          return true
-        else
-          return false
-        end
+        return !!value.match(regex)
       end
       return true
     end

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -85,8 +85,8 @@ module Msf
     #
     # If it's required and the value is nil or empty, then it's not valid.
     #
-    def valid?(value)
-      if required?
+    def valid?(value, check_empty: true)
+      if check_empty && required?
         # required variable not set
         return false if (value == nil or value.to_s.empty?)
       end

--- a/lib/msf/core/opt_bool.rb
+++ b/lib/msf/core/opt_bool.rb
@@ -15,8 +15,8 @@ class OptBool < OptBase
     return 'bool'
   end
 
-  def valid?(value, check_empty: false)
-    return false if check_empty && empty_required_value?(value)
+  def valid?(value, check_empty: true)
+    return false if empty_required_value?(value)
 
     if ((value != nil and
         (value.to_s.empty? == false) and

--- a/lib/msf/core/opt_bool.rb
+++ b/lib/msf/core/opt_bool.rb
@@ -15,8 +15,8 @@ class OptBool < OptBase
     return 'bool'
   end
 
-  def valid?(value)
-    return false if empty_required_value?(value)
+  def valid?(value, check_empty: false)
+    return false if check_empty && empty_required_value?(value)
 
     if ((value != nil and
         (value.to_s.empty? == false) and

--- a/lib/msf/core/opt_enum.rb
+++ b/lib/msf/core/opt_enum.rb
@@ -13,8 +13,8 @@ class OptEnum < OptBase
     return 'enum'
   end
 
-  def valid?(value=self.value)
-    return false if empty_required_value?(value)
+  def valid?(value=self.value, check_empty: true)
+    return false if check_empty && empty_required_value?(value)
     return true if value.nil? and !required?
 
     (value and self.enums.include?(value.to_s))

--- a/lib/msf/core/opt_int.rb
+++ b/lib/msf/core/opt_int.rb
@@ -13,16 +13,15 @@ class OptInt < OptBase
   end
 
   def normalize(value)
-    if (value.to_s.match(/^0x[a-fA-F\d]+$/))
+    if value.to_s.match(/^0x[a-fA-F\d]+$/)
       value.to_i(16)
     else
       value.to_i
     end
   end
 
-  def valid?(value)
-    return super if !required? and value.to_s.empty?
-    return false if empty_required_value?(value)
+  def valid?(value, check_empty: true)
+    return false if check_empty && empty_required_value?(value)
 
     if value and not value.to_s.match(/^0x[0-9a-fA-F]+$|^-?\d+$/)
       return false

--- a/lib/msf/core/opt_path.rb
+++ b/lib/msf/core/opt_path.rb
@@ -17,8 +17,8 @@ class OptPath < OptBase
   end
 
   # Generally, 'value' should be a file that exists.
-  def valid?(value)
-    return false if empty_required_value?(value)
+  def valid?(value, check_empty: true)
+    return false if check_empty && empty_required_value?(value)
     if value and !value.empty?
       if value =~ /^memory:\s*([0-9]+)/i
         return false unless check_memory_location($1)

--- a/lib/msf/core/opt_port.rb
+++ b/lib/msf/core/opt_port.rb
@@ -12,12 +12,9 @@ class OptPort < OptInt
     return 'port'
   end
 
-  def valid?(value)
-    if !required? and value.to_s.empty?
-      super
-    else
-      super && normalize(value) <= 65535 && normalize(value) >= 0
-    end
+  def valid?(value, check_empty: true)
+    port = normalize(value)
+    super && port <= 65535 && port >= 0
   end
 end
 

--- a/lib/msf/core/opt_regexp.rb
+++ b/lib/msf/core/opt_regexp.rb
@@ -17,7 +17,7 @@ class OptRegexp < OptBase
 
     begin
       Regexp.compile(value)
-      return super
+      return true
     rescue RegexpError, TypeError
       return false
     end

--- a/lib/msf/core/opt_regexp.rb
+++ b/lib/msf/core/opt_regexp.rb
@@ -12,16 +12,12 @@ class OptRegexp < OptBase
     return 'regexp'
   end
 
-  def valid?(value)
-    unless super
-      return false
-    end
-    return true if (not required? and value.nil?)
+  def valid?(value, check_empty: true)
+    return false if check_empty && empty_required_value?(value)
 
     begin
       Regexp.compile(value)
-
-      return true
+      return super
     rescue RegexpError, TypeError
       return false
     end

--- a/lib/msf/core/opt_regexp.rb
+++ b/lib/msf/core/opt_regexp.rb
@@ -13,11 +13,15 @@ class OptRegexp < OptBase
   end
 
   def valid?(value, check_empty: true)
-    return false if check_empty && empty_required_value?(value)
+    if check_empty && empty_required_value?(value)
+      return false
+    elsif value.nil?
+      return true
+    end
 
     begin
       Regexp.compile(value)
-      return true
+      return super
     rescue RegexpError, TypeError
       return false
     end

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -28,9 +28,9 @@ class OptString < OptBase
     value
   end
 
-  def valid?(value=self.value)
+  def valid?(value=self.value, check_empty: true)
     value = normalize(value)
-    return false if empty_required_value?(value)
+    return false if check_empty && empty_required_value?(value)
     return super
   end
 end

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -191,13 +191,13 @@ module ModuleCommandDispatcher
         'LocalOutput' => driver.output)
       if (code and code.kind_of?(Array) and code.length > 1)
         if (code == Msf::Exploit::CheckCode::Vulnerable)
-          print_good("#{code[1]}")
+          print_good("#{peer} #{code[1]}")
           report_vuln(instance)
         else
-          print_status("#{code[1]}")
+          print_status("#{peer} #{code[1]}")
         end
       else
-        msg = "Check failed: The state could not be determined."
+        msg = "#{peer} Check failed: The state could not be determined."
         print_error(msg)
         elog("#{msg}\n#{caller.join("\n")}")
       end
@@ -208,7 +208,7 @@ module ModuleCommandDispatcher
       # Some modules raise RuntimeError but we don't necessarily care about those when we run check()
       elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue Msf::OptionValidateError => e
-      print_error("Check failed: #{e.message}")
+      print_error("{peer} - Check failed: #{e.message}")
       elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue ::Exception => e
       print_error("Check failed: #{e.class} #{e}")

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Rex::Proto::Http::ClientRequest do
         :set_content_len_header => { args: 0, result: "Content-Length: 0\r\n"}
       }
     ],
-  
+
   ].each do |c, opts, expectations|
     context c do
       subject(:client_request) { Rex::Proto::Http::ClientRequest.new(opts) }


### PR DESCRIPTION
This fixes #6899 and #6898 by adding some peer elements that should have not been removed in #6526, and addresses a corner case from the recent datastore that prevented a nil element from being assigned to a required datastore option.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] **Verify** that `check 192.168.56.101` works as expected
- [x] **Verify** that `check 192.168.56.101-192.168.56.104` works as expected.
