### PR TITLE
fixing import of zip workspace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (2.0.1)
+    metasploit-credential (2.0.2)
       metasploit-concern
       metasploit-model
       metasploit_data_models

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -49,7 +49,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
 
   # Parses host Nokogiri::XML::Element
   def parse_zip_host(host, wspace, bl, allow_yaml, btag, args, basedir, host_info, &block)
-    host_info[host.at("id").text.to_s.strip] = nils_for_nulls(host.at("address").text.to_s.strip)
+    host_info[host.at("id").text.to_s.strip] = nils_for_nulls(host.at("address").text.to_s.strip) unless host.at('address').nil?
   end
 
   # Parses loot Nokogiri::XML::Element

--- a/lib/msf/core/db_manager/import/report.rb
+++ b/lib/msf/core/db_manager/import/report.rb
@@ -28,7 +28,7 @@ module Msf::DBManager::Import::Report
     report_id = report_report(report_info)
 
     # Handle artifacts
-    report.elements['artifacts'].elements.each do |artifact|
+    report.elements.at('artifacts').elements.each do |artifact|
       artifact_opts = {}
       artifact.elements.each do |attr|
         skip_nodes = %w|id accessed-at|


### PR DESCRIPTION
Workspace zip wasn't working. With the new parser, parsing the hosts was failing. Along with that, we for importing reports, we weren't using the correct syntax to grab elements.

MS-1528
## Verification
- [x] look through code 
- [x] verify specs pass
- [x] import an xml to test for regression
- [x] merge and build metasploit framework gem
- [x] **On Pro:** use built gem locally + bundle install
- [x] **On Pro:** start foreman
- [x] grab export from MS-1528
- [x] **On Pro:** import zip
- [x] **On Pro:** should pass and be imported
- [x] **On Pro:** check data consistency
