### PR TITLE
Update allwinner_backdoor report_vuln hash

### DIFF
--- a/modules/post/multi/escalate/allwinner_backdoor.rb
+++ b/modules/post/multi/escalate/allwinner_backdoor.rb
@@ -50,9 +50,10 @@ class MetasploitModule < Msf::Post
       if is_root?
         print_good "Privilege Escalation Successful"
         report_vuln(
-          host: session,
-          type: "host.escalation",
-          data: "Escalated to root shell via Allwinner backdoor"
+          host: session.session_host,
+          name: self.name,
+          refs: self.references,
+          info: 'Escalated to root shell via Allwinner backdoor'
         )
       else
         print_error "Privilege Escalation FAILED"


### PR DESCRIPTION
Fixes #6890.

```
>> active_module.session
=> #<Session:shell [redacted]:56868 ([redacted]) "">
>> active_module.session.session_host
=> "[redacted]"
>> active_module.report_vuln(host: active_module.session, type: 'host.escalation', data: 'Escalated to root shell via Allwinner backdoor')
ArgumentError: Deprecated data column for vuln, use .info instead
    from /Users/wvu/metasploit-framework/lib/msf/core/db_manager/vuln.rb:92:in `report_vuln'
    from /Users/wvu/metasploit-framework/lib/msf/core/auxiliary/report.rb:277:in `report_vuln'
    from (irb):1:in `cmd_irb'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/irb_shell.rb:53:in `block in run'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `catch'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `run'
    from /Users/wvu/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:900:in `cmd_irb'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
    from /Users/wvu/metasploit-framework/lib/rex/ui/text/shell.rb:203:in `run'
    from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
    from /Users/wvu/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
    from ./msfconsole:48:in `<main>'
>> active_module.report_vuln(host: active_module.session.session_host, name: active_module.name, refs: active_module.references, info: 'Escalated to root shell via Allwinner backdoor')
=> #<Mdm::Vuln id: 136, host_id: 182, service_id: nil, created_at: "2016-05-24 06:09:21", name: "Allwinner 3.4 Legacy Kernel Local Privilege Escala...", updated_at: "2016-05-24 06:09:21", info: "Escalated to root shell via Allwinner backdoor", exploited_at: nil, vuln_detail_count: 0, vuln_attempt_count: 0, origin_id: nil, origin_type: nil>
>> 
```
