### PR TITLE
fix spec warnings

### DIFF
--- a/spec/lib/msf/base/sessions/meterpreter_spec.rb
+++ b/spec/lib/msf/base/sessions/meterpreter_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Msf::Sessions::Meterpreter do
   describe "#find_internet_connected_address" do
 
     subject(:connected_address) do
+      allow_message_expectations_on_nil
       m = described_class.new(StringIO.new(""), skip_ssl: true)
       allow(m).to receive_message_chain(:private_methods, :net)
       allow(m).to receive_message_chain(:private_methods, :net, :config, :get_interfaces).and_return(interfaces)

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -108,9 +108,6 @@ RSpec.describe Rex::Proto::Http::ClientRequest do
         :set_uri_append        => { :result => "" },
         :set_agent_header      => { :result => "User-Agent: Mozilla/4.0 (compatible; Metasploit RSPEC)\r\n" },
         :set_host_header       => { :result => "Host: www.example.com\r\n" },
-        :set_formatted_header  => { :args => ["Foo", "Bar"], :result => "Foo: Bar\r\n" },
-        :set_formatted_header  => { :args => ["foo", "Bar"], :result => "foo: Bar\r\n" },
-        :set_formatted_header  => { :args => ["Foo", "Bar\twith\ttabs"], :result => "Foo: Bar\twith\ttabs\r\n" },
         :set_formatted_header  => { :args => ["Foo\twith\tabs", "Bar"], :result => "Foo\twith\tabs: Bar\r\n" },
       }
     ],
@@ -127,9 +124,6 @@ RSpec.describe Rex::Proto::Http::ClientRequest do
         :set_agent_header      => { :result => "User-Agent:\r\n\tMozilla/4.0 (compatible; Metasploit RSPEC)\r\n" },
         :set_cookie_header     => { :result => "" },
         :set_connection_header => { :result => "Connection:\r\n\tclose\r\n" },
-        :set_formatted_header  => { :args => ["Foo", "Bar"], :result => "Foo:\r\n\tBar\r\n" },
-        :set_formatted_header  => { :args => ["foo", "Bar"], :result => "foo:\r\n\tBar\r\n" },
-        :set_formatted_header  => { :args => ["Foo", "Bar\twith\ttabs"], :result => "Foo:\r\n\tBar\twith\ttabs\r\n" },
         :set_formatted_header  => { :args => ["Foo\twith\tabs", "Bar"], :result => "Foo\twith\tabs:\r\n\tBar\r\n" },
       }
     ],
@@ -180,7 +174,7 @@ RSpec.describe Rex::Proto::Http::ClientRequest do
         :set_content_len_header => { args: 0, result: "Content-Length: 0\r\n"}
       }
     ],
-  
+
   ].each do |c, opts, expectations|
     context c do
       subject(:client_request) { Rex::Proto::Http::ClientRequest.new(opts) }


### PR DESCRIPTION
This is a very simple PR, intended just to clean up some residual spec warnings from the RSpec / Ruby upgrade.
# Validation steps
- [x] Passes specs without warnings
