### PR TITLE
Fix #4885, Support basic and form auth at the same time

### DIFF
--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -17,7 +17,7 @@ module Metasploit
         # (see Base#attempt_login)
         def attempt_login(credential)
           http_client = Rex::Proto::Http::Client.new(
-            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
+            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password
           )
 
           configure_http_client(http_client)

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -34,7 +34,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, http_username, http_password)
             configure_http_client(cli)
             cli.connect
             req = cli.request_cgi({

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -69,7 +69,7 @@ module Metasploit
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies)
+          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies, http_username, http_password)
           configure_http_client(cli)
           cli.connect
           req = cli.request_raw(opts)

--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -35,7 +35,9 @@ module Metasploit
                                                },
                                                ssl,
                                                ssl_version,
-                                               proxies)
+                                               proxies,
+                                               http_username,
+                                               http_password)
             configure_http_client(cli)
             cli.connect
 

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -20,6 +20,13 @@ module Metasploit
         #   @return [String] Cookie session
         attr_accessor :jsession
 
+        # @!attribute http_username
+        attr_accessor :http_username
+        #   @return [String] HTTP username
+
+        # @!attribute http_password
+        attr_accessor :http_password
+
         # (see Base#check_setup)
         def check_setup
           begin
@@ -61,7 +68,7 @@ module Metasploit
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
+          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
           configure_http_client(cli)
           cli.connect
           req = cli.request_raw(opts)

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -161,6 +161,14 @@ module Metasploit
         #   @return [Boolean] Whether to conform to IIS digest authentication mode.
         attr_accessor :digest_auth_iis
 
+        # @!attribute http_username
+        # @return [String]
+        attr_accessor :http_username
+
+        # @!attribute http_password
+        # @return [String]
+        attr_accessor :http_password
+
 
         validates :uri, presence: true, length: { minimum: 1 }
 
@@ -171,7 +179,7 @@ module Metasploit
         # (see Base#check_setup)
         def check_setup
           http_client = Rex::Proto::Http::Client.new(
-            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
+            host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password
           )
           request = http_client.request_cgi(
             'uri' => uri,
@@ -213,8 +221,8 @@ module Metasploit
           cli_ssl         = opts['ssl'] || ssl
           cli_ssl_version = opts['ssl_version'] || ssl_version
           cli_proxies     = opts['proxies'] || proxies
-          username        = opts['credential'] ? opts['credential'].public : ''
-          password        = opts['credential'] ? opts['credential'].private : ''
+          username        = opts['credential'] ? opts['credential'].public : http_username
+          password        = opts['credential'] ? opts['credential'].private : http_password
           realm           = opts['credential'] ? opts['credential'].realm : nil
           context         = opts['context'] || { 'Msf' => framework, 'MsfExploit' => framework_module}
 

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -7,10 +7,18 @@ module Metasploit
       # IP Board login scanner
       class IPBoard < HTTP
 
+        # @!attribute http_username
+        # @return [String]
+        attr_accessor :http_username
+
+        # @!attribute http_password
+        # @return [String]
+        attr_accessor :http_password
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           http_client = Rex::Proto::Http::Client.new(
-              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
+              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, self.http_username, self.http_password
           )
           configure_http_client(http_client)
 

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -37,7 +37,7 @@ module Metasploit
             result_opts[:service_name] = 'http'
           end
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
             configure_http_client(cli)
             cli.connect
             req = cli.request_cgi({

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -35,7 +35,7 @@ module Metasploit
           begin
             cred = Rex::Text.uri_encode(credential.private)
             body = "data%5BLogin%5D%5Bowner_name%5D=admin&data%5BLogin%5D%5Bowner_passwd%5D=#{cred}"
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, http_username, http_password)
             configure_http_client(cli)
             cli.connect
             req = cli.request_cgi(

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -33,7 +33,7 @@ module Metasploit
           res = nil
 
           begin
-            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies)
+            cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password)
             configure_http_client(cli)
             cli.connect
             req = cli.request_cgi(req_opts)

--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -92,7 +92,7 @@ module Metasploit
               'ctype'   =>'text/xml'
             }
 
-          client = Rex::Proto::Http::Client.new(rhost)
+          client = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version, proxies, http_username, http_password)
           client.connect
           req  = client.request_cgi(opts)
           res  = client.send_recv(req)

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -10,7 +10,7 @@ module Metasploit
         # (see Base#attempt_login)
         def attempt_login(credential)
           http_client = Rex::Proto::Http::Client.new(
-              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies
+              host, port, {'Msf' => framework, 'MsfExploit' => framework_module}, ssl, ssl_version, proxies, http_username, http_password
           )
           configure_http_client(http_client)
 
@@ -32,7 +32,7 @@ module Metasploit
             request = http_client.request_cgi(
                 'uri' => uri,
                 'method' => method,
-                'data' => generate_xml_request(credential.public,credential.private),
+                'data' => generate_xml_request(credential.public,credential.private)
             )
             response = http_client.send_recv(request)
 

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -66,7 +66,7 @@ module Metasploit
         # @param (see Rex::Proto::Http::Resquest#request_raw)
         # @return [Rex::Proto::Http::Response] The HTTP response
         def send_request(opts)
-          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies)
+          cli = Rex::Proto::Http::Client.new(host, port, {'Msf' => framework, 'MsfExploit' => self}, ssl, ssl_version, proxies, http_username, http_password)
           configure_http_client(cli)
           cli.connect
           req = cli.request_raw(opts)

--- a/lib/msf/core/auxiliary/crawler.rb
+++ b/lib/msf/core/auxiliary/crawler.rb
@@ -23,8 +23,8 @@ module Auxiliary::HttpCrawler
         OptInt.new('MAX_PAGES', [ true, 'The maximum number of pages to crawl per URL', 500]),
         OptInt.new('MAX_MINUTES', [ true, 'The maximum number of minutes to spend on each URL', 5]),
         OptInt.new('MAX_THREADS', [ true, 'The maximum number of concurrent requests', 4]),
-        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication']),
+        OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication']),
+        OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication']),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentication', 'WORKSTATION']),
         OptBool.new('SSL', [ false, 'Negotiate SSL/TLS for outgoing connections', false])
 
@@ -123,9 +123,9 @@ module Auxiliary::HttpCrawler
       :info     => ""
     })
 
-    if datastore['USERNAME'] and datastore['USERNAME'] != ''
-      t[:username] = datastore['USERNAME'].to_s
-      t[:password] = datastore['PASSWORD'].to_s
+    if datastore['HttpUsername'] and datastore['HttpUsername'] != ''
+      t[:username] = datastore['HttpUsername'].to_s
+      t[:password] = datastore['HttpPassword'].to_s
       t[:domain]   = datastore['DOMAIN'].to_s
     end
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -48,8 +48,8 @@ module Exploit::Remote::HttpClient
         OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests',
           Rex::Proto::Http::Client::DefaultUserAgent
           ]),
-        OptString.new('HTTPUSERNAME', [false, 'The HTTP username to specify for authentication', '']),
-        OptString.new('HTTPPASSWORD', [false, 'The HTTP password to specify for authentication', '']),
+        OptString.new('HttpUsername', [false, 'The HTTP username to specify for authentication', '']),
+        OptString.new('HttpPassword', [false, 'The HTTP password to specify for authentication', '']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
@@ -149,8 +149,8 @@ module Exploit::Remote::HttpClient
       dossl = ssl
     end
 
-    client_username = opts['username'] || datastore['HTTPUSERNAME'] || ''
-    client_password = opts['password'] || datastore['HTTPPASSWORD'] || ''
+    client_username = opts['username'] || datastore['HttpUsername'] || ''
+    client_password = opts['password'] || datastore['HttpPassword'] || ''
 
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -48,8 +48,8 @@ module Exploit::Remote::HttpClient
         OptString.new('UserAgent', [false, 'The User-Agent header to use for all requests',
           Rex::Proto::Http::Client::DefaultUserAgent
           ]),
-        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', '']),
+        OptString.new('HTTPUSERNAME', [false, 'The HTTP username to specify for authentication', '']),
+        OptString.new('HTTPPASSWORD', [false, 'The HTTP password to specify for authentication', '']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
@@ -149,8 +149,8 @@ module Exploit::Remote::HttpClient
       dossl = ssl
     end
 
-    client_username = opts['username'] || datastore['USERNAME'] || ''
-    client_password = opts['password'] || datastore['PASSWORD'] || ''
+    client_username = opts['username'] || datastore['HTTPUSERNAME'] || ''
+    client_password = opts['password'] || datastore['HTTPPASSWORD'] || ''
 
     nclient = Rex::Proto::Http::Client.new(
       opts['rhost'] || rhost,

--- a/modules/auxiliary/admin/appletv/appletv_display_image.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_image.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['URL', 'http://nto.github.io/AirPlay.html']
         ],
-      'DefaultOptions' => { 'HTTPUSERNAME' => 'AirPlay' },
+      'DefaultOptions' => { 'HttpUsername' => 'AirPlay' },
       'License'        => MSF_LICENSE
     ))
 

--- a/modules/auxiliary/admin/appletv/appletv_display_image.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_image.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['URL', 'http://nto.github.io/AirPlay.html']
         ],
-      'DefaultOptions' => { 'USERNAME' => 'AirPlay' },
+      'DefaultOptions' => { 'HTTPUSERNAME' => 'AirPlay' },
       'License'        => MSF_LICENSE
     ))
 
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(7000),
       OptInt.new('TIME', [true, 'Time in seconds to show the image', 10]),
       OptPath.new('FILE', [true, 'Image to upload and show']),
-      OptString.new('PASSWORD', [false, 'The password for AppleTV AirPlay'])
+      OptString.new('HTTPPASSWORD', [false, 'The password for AppleTV AirPlay'])
     ], self.class)
 
     # We're not actually using any of these against AppleTV in our Rex HTTP client init,
@@ -72,8 +72,8 @@ class MetasploitModule < Msf::Auxiliary
       ssl,
       ssl_version,
       proxies,
-      datastore['USERNAME'],
-      datastore['PASSWORD']
+      datastore['HTTPUSERNAME'],
+      datastore['HTTPPASSWORD']
     )
     add_socket(http)
 

--- a/modules/auxiliary/admin/appletv/appletv_display_image.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_image.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(7000),
       OptInt.new('TIME', [true, 'Time in seconds to show the image', 10]),
       OptPath.new('FILE', [true, 'Image to upload and show']),
-      OptString.new('HTTPPASSWORD', [false, 'The password for AppleTV AirPlay'])
+      OptString.new('HttpPassword', [false, 'The password for AppleTV AirPlay'])
     ], self.class)
 
     # We're not actually using any of these against AppleTV in our Rex HTTP client init,
@@ -72,8 +72,8 @@ class MetasploitModule < Msf::Auxiliary
       ssl,
       ssl_version,
       proxies,
-      datastore['HTTPUSERNAME'],
-      datastore['HTTPPASSWORD']
+      datastore['HttpUsername'],
+      datastore['HttpPassword']
     )
     add_socket(http)
 

--- a/modules/auxiliary/admin/appletv/appletv_display_video.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_video.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['URL', 'http://nto.github.io/AirPlay.html']
         ],
-      'DefaultOptions' => { 'HTTPUSERNAME' => 'AirPlay' },
+      'DefaultOptions' => { 'HttpUsername' => 'AirPlay' },
       'License'        => MSF_LICENSE
     ))
 
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(7000),
       OptInt.new('TIME', [true, 'Time in seconds to show the video', 60]),
       OptString.new('URL', [true, 'URL of video to show. Must use an IP address']),
-      OptString.new('HTTPPASSWORD', [false, 'The password for AppleTV AirPlay'])
+      OptString.new('HttpPassword', [false, 'The password for AppleTV AirPlay'])
     ], self.class)
 
     # We're not actually using any of these against AppleTV in our Rex HTTP client init,
@@ -77,8 +77,8 @@ class MetasploitModule < Msf::Auxiliary
       ssl,
       ssl_version,
       proxies,
-      datastore['HTTPUSERNAME'],
-      datastore['HTTPPASSWORD']
+      datastore['HttpUsername'],
+      datastore['HttpPassword']
     )
     add_socket(http)
 

--- a/modules/auxiliary/admin/appletv/appletv_display_video.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_video.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['URL', 'http://nto.github.io/AirPlay.html']
         ],
-      'DefaultOptions' => { 'USERNAME' => 'AirPlay' },
+      'DefaultOptions' => { 'HTTPUSERNAME' => 'AirPlay' },
       'License'        => MSF_LICENSE
     ))
 
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(7000),
       OptInt.new('TIME', [true, 'Time in seconds to show the video', 60]),
       OptString.new('URL', [true, 'URL of video to show. Must use an IP address']),
-      OptString.new('PASSWORD', [false, 'The password for AppleTV AirPlay'])
+      OptString.new('HTTPPASSWORD', [false, 'The password for AppleTV AirPlay'])
     ], self.class)
 
     # We're not actually using any of these against AppleTV in our Rex HTTP client init,
@@ -77,8 +77,8 @@ class MetasploitModule < Msf::Auxiliary
       ssl,
       ssl_version,
       proxies,
-      datastore['USERNAME'],
-      datastore['PASSWORD']
+      datastore['HTTPUSERNAME'],
+      datastore['HTTPPASSWORD']
     )
     add_socket(http)
 

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -32,16 +32,16 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'admin']),
-        OptString.new('HTTPPASSWORD',[ true, 'Password to login with', 'password']),
+        OptString.new('HttpUsername',[ true, 'User to login with', 'admin']),
+        OptString.new('HttpPassword',[ true, 'Password to login with', 'password']),
         OptString.new('CMD', [ true, 'The command to execute', 'telnetd -p 1337'])
       ], self.class)
   end
 
   def run
     uri = '/apply.cgi'
-    user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    user = datastore['HttpUsername']
+    pass = datastore['HttpPassword']
 
     print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
 

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -32,16 +32,16 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('USERNAME',[ true, 'User to login with', 'admin']),
-        OptString.new('PASSWORD',[ true, 'Password to login with', 'password']),
+        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'admin']),
+        OptString.new('HTTPPASSWORD',[ true, 'Password to login with', 'password']),
         OptString.new('CMD', [ true, 'The command to execute', 'telnetd -p 1337'])
       ], self.class)
   end
 
   def run
     uri = '/apply.cgi'
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
 
     print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
 

--- a/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
@@ -42,8 +42,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(80),
         OptString.new('TARGETURI',[ true, 'PATH to OS Command Injection', '/apply.cgi']),
-        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'admin']),
-        OptString.new('HTTPPASSWORD',[ false, 'Password to login with', 'password']),
+        OptString.new('HttpUsername',[ true, 'User to login with', 'admin']),
+        OptString.new('HttpPassword',[ false, 'Password to login with', 'password']),
         OptString.new('CMD', [ true, 'The command to execute', 'ping 127.0.0.1']),
         OptString.new('NETMASK', [ false, 'LAN Netmask of the router', '255.255.255.0']),
         OptAddress.new('LANIP', [ false, 'LAN IP address of the router (default is RHOST)']),
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     #setting up some basic variables
     uri = datastore['TARGETURI']
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     rhost = datastore['RHOST']
     netmask = datastore['NETMASK']
     routername = datastore['ROUTER_NAME']
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Auxiliary
 
     ip = lan_ip.split('.')
 
-    if datastore['HTTPPASSWORD'].nil?
+    if datastore['HttpPassword'].nil?
       pass = ""
     else
-      pass = datastore['HTTPPASSWORD']
+      pass = datastore['HttpPassword']
     end
 
     print_status("Trying to login with #{user} / #{pass}")

--- a/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
@@ -42,8 +42,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(80),
         OptString.new('TARGETURI',[ true, 'PATH to OS Command Injection', '/apply.cgi']),
-        OptString.new('USERNAME',[ true, 'User to login with', 'admin']),
-        OptString.new('PASSWORD',[ false, 'Password to login with', 'password']),
+        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'admin']),
+        OptString.new('HTTPPASSWORD',[ false, 'Password to login with', 'password']),
         OptString.new('CMD', [ true, 'The command to execute', 'ping 127.0.0.1']),
         OptString.new('NETMASK', [ false, 'LAN Netmask of the router', '255.255.255.0']),
         OptAddress.new('LANIP', [ false, 'LAN IP address of the router (default is RHOST)']),
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     #setting up some basic variables
     uri = datastore['TARGETURI']
-    user = datastore['USERNAME']
+    user = datastore['HTTPUSERNAME']
     rhost = datastore['RHOST']
     netmask = datastore['NETMASK']
     routername = datastore['ROUTER_NAME']
@@ -75,10 +75,10 @@ class MetasploitModule < Msf::Auxiliary
 
     ip = lan_ip.split('.')
 
-    if datastore['PASSWORD'].nil?
+    if datastore['HTTPPASSWORD'].nil?
       pass = ""
     else
-      pass = datastore['PASSWORD']
+      pass = datastore['HTTPPASSWORD']
     end
 
     print_status("Trying to login with #{user} / #{pass}")

--- a/modules/auxiliary/admin/http/openbravo_xxe.rb
+++ b/modules/auxiliary/admin/http/openbravo_xxe.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     users = send_request_raw({
       'method' => 'GET',
       'uri' => normalize_uri(datastore['TARGETURI'], "/ws/dal/#{datastore["ENDPOINT"]}"),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
     }, 60)
 
     if !users or users.code != 200

--- a/modules/auxiliary/admin/http/openbravo_xxe.rb
+++ b/modules/auxiliary/admin/http/openbravo_xxe.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('TARGETURI', [ true, "Base Openbravo directory path", '/openbravo/']),
-        OptString.new('USERNAME', [true, "The Openbravo user", "Openbravo"]),
-        OptString.new('PASSWORD', [true, "The Openbravo password", "openbravo"]),
+        OptString.new('HTTPUSERNAME', [true, "The Openbravo user", "Openbravo"]),
+        OptString.new('HTTPPASSWORD', [true, "The Openbravo password", "openbravo"]),
         OptString.new('FILEPATH', [true, "The filepath to read on the server", "/etc/passwd"]),
         OptString.new('ENDPOINT', [true, "The XML API REST endpoint to use", "ADUser"])
       ], self.class)
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     users = send_request_raw({
       'method' => 'GET',
       'uri' => normalize_uri(datastore['TARGETURI'], "/ws/dal/#{datastore["ENDPOINT"]}"),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
     }, 60)
 
     if !users or users.code != 200
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'PUT',
         'uri' => normalize_uri(target_uri.path, "/ws/dal/#{datastore["ENDPOINT"]}/#{id}"),
         'data' => xml,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
       })
 
       if !resp or resp.code != 200 or resp.body =~ /Not updating entity/
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
       u = send_request_raw({
         'method' => 'GET',
         'uri' => normalize_uri(datastore['TARGETURI'], "/ws/dal/#{datastore["ENDPOINT"]}/#{id}"),
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
       })
 
       u = REXML::Document.new u.body
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'PUT',
         'uri' => normalize_uri(target_uri.path, "/ws/dal/#{datastore["ENDPOINT"]}/#{id}"),
       'data' => xml,
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
       })
 
       print_good("File saved to: #{path}")

--- a/modules/auxiliary/admin/http/openbravo_xxe.rb
+++ b/modules/auxiliary/admin/http/openbravo_xxe.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('TARGETURI', [ true, "Base Openbravo directory path", '/openbravo/']),
-        OptString.new('HTTPUSERNAME', [true, "The Openbravo user", "Openbravo"]),
-        OptString.new('HTTPPASSWORD', [true, "The Openbravo password", "openbravo"]),
+        OptString.new('HttpUsername', [true, "The Openbravo user", "Openbravo"]),
+        OptString.new('HttpPassword', [true, "The Openbravo password", "openbravo"]),
         OptString.new('FILEPATH', [true, "The filepath to read on the server", "/etc/passwd"]),
         OptString.new('ENDPOINT', [true, "The XML API REST endpoint to use", "ADUser"])
       ], self.class)
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     users = send_request_raw({
       'method' => 'GET',
       'uri' => normalize_uri(datastore['TARGETURI'], "/ws/dal/#{datastore["ENDPOINT"]}"),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
     }, 60)
 
     if !users or users.code != 200
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'PUT',
         'uri' => normalize_uri(target_uri.path, "/ws/dal/#{datastore["ENDPOINT"]}/#{id}"),
         'data' => xml,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
       })
 
       if !resp or resp.code != 200 or resp.body =~ /Not updating entity/
@@ -94,12 +94,12 @@ class MetasploitModule < Msf::Auxiliary
         next
       end
 
-      print_status("Found writeable #{datastore["ENDPOINT"]}: #{other_id}")
+      print_status("Found writable #{datastore["ENDPOINT"]}: #{other_id}")
 
       u = send_request_raw({
         'method' => 'GET',
         'uri' => normalize_uri(datastore['TARGETURI'], "/ws/dal/#{datastore["ENDPOINT"]}/#{id}"),
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
       })
 
       u = REXML::Document.new u.body
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'PUT',
         'uri' => normalize_uri(target_uri.path, "/ws/dal/#{datastore["ENDPOINT"]}/#{id}"),
       'data' => xml,
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
       })
 
       print_good("File saved to: #{path}")

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -32,8 +32,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(50013),
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
-        OptString.new('HTTPUSERNAME', [true, 'Username to use', '']),
-        OptString.new('HTTPPASSWORD', [true, 'Password to use', '']),
+        OptString.new('HttpUsername', [true, 'Username to use', '']),
+        OptString.new('HttpPassword', [true, 'Password to use', '']),
         OptString.new('CMD', [true, 'Command to run', 'set']),
       ], self.class)
     register_autofilter_ports([ 50013 ])
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Auxiliary
     data << '</SOAP-ENV:Body>' + "\r\n"
     data << '</SOAP-ENV:Envelope>' + "\r\n\r\n"
 
-    user_pass = Rex::Text.encode_base64(datastore['HTTPUSERNAME'] + ":" + datastore['HTTPPASSWORD'])
+    user_pass = Rex::Text.encode_base64(datastore['HttpUsername'] + ":" + datastore['HttpPassword'])
 
     begin
       res = send_request_raw({

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -32,8 +32,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(50013),
         OptString.new('URI', [false, 'Path to the SAP Management Console ', '/']),
-        OptString.new('USERNAME', [true, 'Username to use', '']),
-        OptString.new('PASSWORD', [true, 'Password to use', '']),
+        OptString.new('HTTPUSERNAME', [true, 'Username to use', '']),
+        OptString.new('HTTPPASSWORD', [true, 'Password to use', '']),
         OptString.new('CMD', [true, 'Command to run', 'set']),
       ], self.class)
     register_autofilter_ports([ 50013 ])
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Auxiliary
     data << '</SOAP-ENV:Body>' + "\r\n"
     data << '</SOAP-ENV:Envelope>' + "\r\n\r\n"
 
-    user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
+    user_pass = Rex::Text.encode_base64(datastore['HTTPUSERNAME'] + ":" + datastore['HTTPPASSWORD'])
 
     begin
       res = send_request_raw({

--- a/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
+++ b/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('PASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
       OptString.new('DIRNAME', [true, 'Directory Path which contains the file to delete', '/tmp']),
       OptString.new('FILENAME', [true, 'Filename to delete', 'msf.txt'])
     ], self.class)
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
+++ b/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
+      OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('DIRNAME', [true, 'Directory Path which contains the file to delete', '/tmp']),
       OptString.new('FILENAME', [true, 'Filename to delete', 'msf.txt'])
     ], self.class)
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/gather/snare_registry.rb
+++ b/modules/auxiliary/gather/snare_registry.rb
@@ -35,8 +35,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(6161),
-        OptString.new('HTTPUSERNAME', [ false, 'The username for Snare remote access', 'snare' ]),
-        OptString.new('HTTPPASSWORD', [ false, 'The password for Snare remote access', '' ]),
+        OptString.new('HttpUsername', [ false, 'The username for Snare remote access', 'snare' ]),
+        OptString.new('HttpPassword', [ false, 'The password for Snare remote access', '' ]),
         OptString.new('REG_DUMP_KEY', [ false, 'Retrieve this registry key and all sub-keys', 'HKLM\\HARDWARE\\DESCRIPTION\\System' ]),
         OptBool.new('REG_DUMP_ALL', [false, 'Retrieve the entire Windows registry', false]),
         OptInt.new('TIMEOUT', [true, 'Timeout in seconds for downloading each registry key/hive', 300])
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     res = send_request_cgi({
       'uri' => normalize_uri('RegDump'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'vars_get' => vars_get
     }, datastore['TIMEOUT'])
     if !res
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("#{peer} - Retrieving list of registry hives ...")
     res = send_request_cgi(
       'uri' => normalize_uri('RegDump'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
     )
     if !res
       fail_with(Failure::Unreachable, "#{peer} - Connection failed")

--- a/modules/auxiliary/gather/snare_registry.rb
+++ b/modules/auxiliary/gather/snare_registry.rb
@@ -35,8 +35,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(6161),
-        OptString.new('USERNAME', [ false, 'The username for Snare remote access', 'snare' ]),
-        OptString.new('PASSWORD', [ false, 'The password for Snare remote access', '' ]),
+        OptString.new('HTTPUSERNAME', [ false, 'The username for Snare remote access', 'snare' ]),
+        OptString.new('HTTPPASSWORD', [ false, 'The password for Snare remote access', '' ]),
         OptString.new('REG_DUMP_KEY', [ false, 'Retrieve this registry key and all sub-keys', 'HKLM\\HARDWARE\\DESCRIPTION\\System' ]),
         OptBool.new('REG_DUMP_ALL', [false, 'Retrieve the entire Windows registry', false]),
         OptInt.new('TIMEOUT', [true, 'Timeout in seconds for downloading each registry key/hive', 300])
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     res = send_request_cgi({
       'uri' => normalize_uri('RegDump'),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'vars_get' => vars_get
     }, datastore['TIMEOUT'])
     if !res
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("#{peer} - Retrieving list of registry hives ...")
     res = send_request_cgi(
       'uri' => normalize_uri('RegDump'),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
     )
     if !res
       fail_with(Failure::Unreachable, "#{peer} - Connection failed")

--- a/modules/auxiliary/gather/xbmc_traversal.rb
+++ b/modules/auxiliary/gather/xbmc_traversal.rb
@@ -38,8 +38,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8080),
         OptString.new('FILEPATH', [false, 'The name of the file to download', '/private/var/mobile/Library/Preferences/XBMC/userdata/passwords.xml']),
         OptInt.new('DEPTH', [true, 'The max traversal depth', 9]),
-        OptString.new('HTTPUSERNAME', [true, 'The username to use for the HTTP server', 'xbmc']),
-        OptString.new('HTTPPASSWORD', [false, 'The password to use for the HTTP server', 'xbmc']),
+        OptString.new('HttpUsername', [true, 'The username to use for the HTTP server', 'xbmc']),
+        OptString.new('HttpPassword', [false, 'The password to use for the HTTP server', 'xbmc']),
       ], self.class)
   end
 
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'method' => 'GET',
         'uri'    => "/#{traversal}/#{datastore['FILEPATH']}",
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'],datastore['HTTPPASSWORD'])
+        'authorization' => basic_auth(datastore['HttpUsername'],datastore['HttpPassword'])
       }, 25)
     rescue Rex::ConnectionRefused
       print_error("#{rhost}:#{rport} Could not connect.")

--- a/modules/auxiliary/gather/xbmc_traversal.rb
+++ b/modules/auxiliary/gather/xbmc_traversal.rb
@@ -38,8 +38,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8080),
         OptString.new('FILEPATH', [false, 'The name of the file to download', '/private/var/mobile/Library/Preferences/XBMC/userdata/passwords.xml']),
         OptInt.new('DEPTH', [true, 'The max traversal depth', 9]),
-        OptString.new('USERNAME', [true, 'The username to use for the HTTP server', 'xbmc']),
-        OptString.new('PASSWORD', [false, 'The password to use for the HTTP server', 'xbmc']),
+        OptString.new('HTTPUSERNAME', [true, 'The username to use for the HTTP server', 'xbmc']),
+        OptString.new('HTTPPASSWORD', [false, 'The password to use for the HTTP server', 'xbmc']),
       ], self.class)
   end
 
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'method' => 'GET',
         'uri'    => "/#{traversal}/#{datastore['FILEPATH']}",
-        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD'])
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'],datastore['HTTPPASSWORD'])
       }, 25)
     rescue Rex::ConnectionRefused
       print_error("#{rhost}:#{rport} Could not connect.")

--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -29,14 +29,14 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(5984),
         OptString.new('TARGETURI', [true, 'Path to list all the databases', '/_all_dbs']),
-        OptString.new('HTTPUSERNAME', [false, 'The username to login as']),
-        OptString.new('HTTPPASSWORD', [false, 'The password to login with'])
+        OptString.new('HttpUsername', [false, 'The username to login as']),
+        OptString.new('HttpPassword', [false, 'The password to login with'])
       ], self.class)
   end
 
   def run
-    username = datastore['HTTPUSERNAME']
-    password = datastore['HTTPPASSWORD']
+    username = datastore['HttpUsername']
+    password = datastore['HttpPassword']
 
     begin
       res = send_request_cgi(

--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -29,14 +29,14 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(5984),
         OptString.new('TARGETURI', [true, 'Path to list all the databases', '/_all_dbs']),
-        OptString.new('USERNAME', [false, 'The username to login as']),
-        OptString.new('PASSWORD', [false, 'The password to login with'])
+        OptString.new('HTTPUSERNAME', [false, 'The username to login as']),
+        OptString.new('HTTPPASSWORD', [false, 'The password to login with'])
       ], self.class)
   end
 
   def run
-    username = datastore['USERNAME']
-    password = datastore['PASSWORD']
+    username = datastore['HTTPUSERNAME']
+    password = datastore['HTTPPASSWORD']
 
     begin
       res = send_request_cgi(

--- a/modules/auxiliary/scanner/couchdb/couchdb_login.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_login.rb
@@ -38,6 +38,8 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
         OptBool.new('USER_AS_PASS', [ false, "Try the username as the password for all users", false]),
       ], self.class)
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/couchdb/couchdb_login.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_login.rb
@@ -39,13 +39,13 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('USER_AS_PASS', [ false, "Try the username as the password for all users", false]),
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def run_host(ip)
 
-    user = datastore['USERNAME'].to_s
-    pass = datastore['PASSWORD'].to_s
+    user = datastore['HttpUsername'].to_s
+    pass = datastore['HttpPassword'].to_s
 
     if user.nil? || user.strip == ''
       each_user_pass do |user, pass|

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options(
         'USERNAME', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_USERS', 'NTLM::SendLM', 'NTLM::SendNTLM',
         'NTLM::SendSPN', 'NTLM::UseLMKey', 'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2',
-        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HTTPUSERNAME'
+        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HttpUsername'
     )
   end
 

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options(
         'USERNAME', 'USER_AS_PASS', 'DB_ALL_CREDS', 'DB_ALL_USERS', 'NTLM::SendLM', 'NTLM::SendNTLM',
         'NTLM::SendSPN', 'NTLM::UseLMKey', 'NTLM::UseNTLM2_session', 'NTLM::UseNTLMv2',
-        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN'
+        'REMOVE_USERPASS_FILE', 'REMOVE_USER_FILE', 'DOMAIN', 'HTTPUSERNAME'
     )
   end
 

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -84,8 +84,8 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_username: datastore['HttpUsername'],
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -83,7 +83,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5
+        connection_timeout: 5,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -28,8 +28,6 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(80)
       ], self.class)
-
-    deregister_options('RHOST')
   end
 
   def run_host(ip)
@@ -48,7 +46,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 10
+        connection_timeout: 10,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class)
 
     # caidao does not have an username, there's only password
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
+    deregister_options('HTTPUSERNAME', 'HttpPassword', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
   end
 
   def scanner(ip)
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
           bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
           connection_timeout: 5,
           http_username: datastore['HTTPUSERNAME'],
-          http_password: datastore['HTTPPASSWORD']
+          http_password: datastore['HttpPassword']
         ))
     }.call
   end

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class)
 
     # caidao does not have an username, there's only password
-    deregister_options('USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
   end
 
   def scanner(ip)
@@ -61,7 +61,9 @@ class MetasploitModule < Msf::Auxiliary
           cred_details:       cred_collection,
           stop_on_success:    datastore['STOP_ON_SUCCESS'],
           bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
-          connection_timeout: 5
+          connection_timeout: 5,
+          http_username: datastore['HTTPUSERNAME'],
+          http_password: datastore['HTTPPASSWORD']
         ))
     }.call
   end

--- a/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/caidao_bruteforce_login.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class)
 
     # caidao does not have an username, there's only password
-    deregister_options('HTTPUSERNAME', 'HttpPassword', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
+    deregister_options('HttpUsername', 'HttpPassword', 'USERNAME', 'USER_AS_PASS', 'USERPASS_FILE', 'USER_FILE', 'DB_ALL_USERS')
   end
 
   def scanner(ip)
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
           stop_on_success:    datastore['STOP_ON_SUCCESS'],
           bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
           connection_timeout: 5,
-          http_username: datastore['HTTPUSERNAME'],
+          http_username: datastore['HttpUsername'],
           http_password: datastore['HttpPassword']
         ))
     }.call

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/chef_webui_login.rb
+++ b/modules/auxiliary/scanner/http/chef_webui_login.rb
@@ -36,6 +36,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
+        OptString.new('USERNAME', [false, 'The username to specify for authentication', '']),
+        OptString.new('PASSWORD', [false, 'The password to specify for authentication', '']),
         OptString.new('TARGETURI', [ true,  'The path to the Chef Web UI application', '/']),
       ], self.class)
   end
@@ -149,7 +151,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5
+        connection_timeout: 5,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -39,6 +39,8 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
       ], self.class)
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def target_url

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
   def target_url

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def target_url

--- a/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def target_url

--- a/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
   def target_url

--- a/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
@@ -42,6 +42,8 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
       ], self.class)
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def target_url

--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Auxiliary
     'License'        => MSF_LICENSE
     ))
 
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
     'License'        => MSF_LICENSE
     ))
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
     'License'        => MSF_LICENSE
     ))
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(80),
         OptString.new('HTTPUSERNAME', [ true, 'The username to test', 'root' ]),
-        OptString.new('HTTPPASSWORD', [ true, 'The password to test', '5iveL!fe' ]),
+        OptString.new('HttpPassword', [ true, 'The password to test', '5iveL!fe' ]),
         OptString.new('TARGETURI', [true, 'The path to GitLab', '/'])
       ], self.class)
 
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file: datastore['PASS_FILE'],
-      password: datastore['HTTPPASSWORD'],
+      password: datastore['HttpPassword'],
       user_file: datastore['USER_FILE'],
       userpass_file: datastore['USERPASS_FILE'],
       username: datastore['HTTPUSERNAME'],

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('HTTPUSERNAME', [ true, 'The username to test', 'root' ]),
+        OptString.new('HttpUsername', [ true, 'The username to test', 'root' ]),
         OptString.new('HttpPassword', [ true, 'The password to test', '5iveL!fe' ]),
         OptString.new('TARGETURI', [true, 'The path to GitLab', '/'])
       ], self.class)
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['HttpPassword'],
       user_file: datastore['USER_FILE'],
       userpass_file: datastore['USERPASS_FILE'],
-      username: datastore['HTTPUSERNAME'],
+      username: datastore['HttpUsername'],
       user_as_pass: datastore['USER_AS_PASS']
     )
 

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -28,8 +28,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('USERNAME', [ true, 'The username to test', 'root' ]),
-        OptString.new('PASSWORD', [ true, 'The password to test', '5iveL!fe' ]),
+        OptString.new('HTTPUSERNAME', [ true, 'The username to test', 'root' ]),
+        OptString.new('HTTPPASSWORD', [ true, 'The password to test', '5iveL!fe' ]),
         OptString.new('TARGETURI', [true, 'The path to GitLab', '/'])
       ], self.class)
 
@@ -58,10 +58,10 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file: datastore['PASS_FILE'],
-      password: datastore['PASSWORD'],
+      password: datastore['HTTPPASSWORD'],
       user_file: datastore['USER_FILE'],
       userpass_file: datastore['USERPASS_FILE'],
-      username: datastore['USERNAME'],
+      username: datastore['HTTPUSERNAME'],
       user_as_pass: datastore['USER_AS_PASS']
     )
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username:      datastore['HTTPUSERNAME'],
-        http_password:      datastore['HTTPPASSWORD']
+        http_password:      datastore['HttpPassword']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username:      datastore['HTTPUSERNAME'],
+        http_username:      datastore['HttpUsername'],
         http_password:      datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -92,7 +92,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5
+        connection_timeout: 5,
+        http_username:      datastore['HTTPUSERNAME'],
+        http_password:      datastore['HTTPPASSWORD']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -74,10 +74,10 @@ class MetasploitModule < Msf::Auxiliary
     @cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file:       datastore['PASS_FILE'],
-      password:        datastore['PASSWORD'],
+      password:        datastore['HTTPPASSWORD'],
       user_file:       datastore['USER_FILE'],
       userpass_file:   datastore['USERPASS_FILE'],
-      username:        datastore['USERNAME'],
+      username:        datastore['HTTPUSERNAME'],
       user_as_pass:    datastore['USER_AS_PASS']
     )
 
@@ -88,6 +88,8 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5
+        http_username:      datastore['HTTPUSERNAME'],
+        http_password:      datastore['HTTPPASSWORD']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5
+        connection_timeout: 5,
         http_username:      datastore['HTTPUSERNAME'],
         http_password:      datastore['HTTPPASSWORD']
       )

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Auxiliary
     @cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file:       datastore['PASS_FILE'],
-      password:        datastore['HTTPPASSWORD'],
+      password:        datastore['HttpPassword'],
       user_file:       datastore['USER_FILE'],
       userpass_file:   datastore['USERPASS_FILE'],
       username:        datastore['HTTPUSERNAME'],
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username:      datastore['HTTPUSERNAME'],
-        http_password:      datastore['HTTPPASSWORD']
+        http_password:      datastore['HttpPassword']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       password:        datastore['HttpPassword'],
       user_file:       datastore['USER_FILE'],
       userpass_file:   datastore['USERPASS_FILE'],
-      username:        datastore['HTTPUSERNAME'],
+      username:        datastore['HttpUsername'],
       user_as_pass:    datastore['USER_AS_PASS']
     )
 
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username:      datastore['HTTPUSERNAME'],
+        http_username:      datastore['HttpUsername'],
         http_password:      datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['HttpPassword'],
       user_file: datastore['USER_FILE'],
       userpass_file: datastore['USERPASS_FILE'],
-      username: datastore['HTTPUSERNAME'],
+      username: datastore['HttpUsername'],
       user_as_pass: datastore['USER_AS_PASS'],
     )
 

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file: datastore['PASS_FILE'],
-      password: datastore['HTTPPASSWORD'],
+      password: datastore['HttpPassword'],
       user_file: datastore['USER_FILE'],
       userpass_file: datastore['USERPASS_FILE'],
       username: datastore['HTTPUSERNAME'],

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -48,6 +48,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('REQUESTTYPE', [ false, "Use HTTP-GET or HTTP-PUT for Digest-Auth, PROPFIND for WebDAV (default:GET)", "GET" ])
       ], self.class)
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000, 8008, 8443, 8444, 8880, 8888 ])
+
+    deregister_options('USERNAME', 'PASSWORD')
   end
 
   def to_uri(uri)
@@ -146,10 +148,10 @@ class MetasploitModule < Msf::Auxiliary
     cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],
       pass_file: datastore['PASS_FILE'],
-      password: datastore['PASSWORD'],
+      password: datastore['HTTPPASSWORD'],
       user_file: datastore['USER_FILE'],
       userpass_file: datastore['USERPASS_FILE'],
-      username: datastore['USERNAME'],
+      username: datastore['HTTPUSERNAME'],
       user_as_pass: datastore['USER_AS_PASS'],
     )
 

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -166,7 +166,7 @@ class MetasploitModule < Msf::Auxiliary
     req['uri']        = this_path
     req['headers']    = {'Cookie'=>datastore['COOKIE']} if not datastore['COOKIE'].empty?
     req['data']       = data if not data.empty?
-    req['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+    req['authorization'] = basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
 
     return req
   end

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -166,7 +166,7 @@ class MetasploitModule < Msf::Auxiliary
     req['uri']        = this_path
     req['headers']    = {'Cookie'=>datastore['COOKIE']} if not datastore['COOKIE'].empty?
     req['data']       = data if not data.empty?
-    req['authorization'] = basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
+    req['authorization'] = basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
 
     return req
   end

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -166,7 +166,7 @@ class MetasploitModule < Msf::Auxiliary
     req['uri']        = this_path
     req['headers']    = {'Cookie'=>datastore['COOKIE']} if not datastore['COOKIE'].empty?
     req['data']       = data if not data.empty?
-    req['authorization'] = basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+    req['authorization'] = basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
 
     return req
   end

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -43,7 +43,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5
+        connection_timeout: 5,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -51,7 +51,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 10
+        connection_timeout: 10,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
+++ b/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptPath.new('SENSITIVE_FILES',  [ true, "File containing senstive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
-        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'admin']),
+        OptString.new('HttpUsername',[ true, 'User to login with', 'admin']),
         OptString.new('HttpPassword',[ true, 'Password to login with', 'password']),
 
       ], self.class)
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
 
     vprint_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")

--- a/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
+++ b/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('SENSITIVE_FILES',  [ true, "File containing senstive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
         OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'admin']),
-        OptString.new('HTTPPASSWORD',[ true, 'Password to login with', 'password']),
+        OptString.new('HttpPassword',[ true, 'Password to login with', 'password']),
 
       ], self.class)
   end
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    pass = datastore['HttpPassword']
 
     vprint_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
 

--- a/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
+++ b/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
@@ -33,8 +33,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptPath.new('SENSITIVE_FILES',  [ true, "File containing senstive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
-        OptString.new('USERNAME',[ true, 'User to login with', 'admin']),
-        OptString.new('PASSWORD',[ true, 'Password to login with', 'password']),
+        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'admin']),
+        OptString.new('HTTPPASSWORD',[ true, 'Password to login with', 'password']),
 
       ], self.class)
   end
@@ -91,8 +91,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
 
     vprint_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
 

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -46,7 +46,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details:       @cred_collection,
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 5
+        connection_timeout: 5,
+        http_username:      datastore['HTTPUSERNAME'],
+        http_password:      datastore['HTTPPASSWORD']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username:      datastore['HTTPUSERNAME'],
-        http_password:      datastore['HTTPPASSWORD']
+        http_password:      datastore['HttpPassword']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
+++ b/modules/auxiliary/scanner/http/manageengine_desktop_central_login.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username:      datastore['HTTPUSERNAME'],
+        http_username:      datastore['HttpUsername'],
         http_password:      datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -60,6 +60,8 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
+++ b/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('FILELIST',  [ true, "File containing sensitive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
         OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'service']),
-        OptString.new('HTTPPASSWORD',[ true, 'Password to login with', 'service'])
+        OptString.new('HttpPassword',[ true, 'Password to login with', 'service'])
       ], self.class)
   end
 
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    pass = datastore['HttpPassword']
 
     vprint_status("Trying to login with #{user} / #{pass}")
 

--- a/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
+++ b/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptPath.new('FILELIST',  [ true, "File containing sensitive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
-        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'service']),
+        OptString.new('HttpUsername',[ true, 'User to login with', 'service']),
         OptString.new('HttpPassword',[ true, 'Password to login with', 'service'])
       ], self.class)
   end
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
 
     vprint_status("Trying to login with #{user} / #{pass}")

--- a/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
+++ b/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
@@ -31,8 +31,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptPath.new('FILELIST',  [ true, "File containing sensitive files, one per line",
           File.join(Msf::Config.data_directory, "wordlists", "sensitive_files.txt") ]),
-        OptString.new('USERNAME',[ true, 'User to login with', 'service']),
-        OptString.new('PASSWORD',[ true, 'Password to login with', 'service'])
+        OptString.new('HTTPUSERNAME',[ true, 'User to login with', 'service']),
+        OptString.new('HTTPPASSWORD',[ true, 'Password to login with', 'service'])
       ], self.class)
   end
 
@@ -82,8 +82,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
 
     vprint_status("Trying to login with #{user} / #{pass}")
 

--- a/modules/auxiliary/scanner/http/pocketpad_login.rb
+++ b/modules/auxiliary/scanner/http/pocketpad_login.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
     'License'        => MSF_LICENSE
     ))
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/pocketpad_login.rb
+++ b/modules/auxiliary/scanner/http/pocketpad_login.rb
@@ -25,6 +25,8 @@ class MetasploitModule < Msf::Auxiliary
       ],
     'License'        => MSF_LICENSE
     ))
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/pocketpad_login.rb
+++ b/modules/auxiliary/scanner/http/pocketpad_login.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
     'License'        => MSF_LICENSE
     ))
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
+++ b/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [true, "A specific password to authenticate with, deault 'radware'", "radware"])
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
+++ b/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSWORD', [true, "A specific password to authenticate with, deault 'radware'", "radware"])
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
+++ b/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
@@ -38,6 +38,8 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [true, "A specific username to authenticate as, default 'radware'", "radware"]),
         OptString.new('PASSWORD', [true, "A specific password to authenticate with, deault 'radware'", "radware"])
       ], self.class)
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -28,6 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           'SSL'        => true,
         }
     ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
+        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', ''])
+      ], self.class)
   end
 
 
@@ -50,7 +56,9 @@ class MetasploitModule < Msf::Auxiliary
           cred_details:       cred_collection,
           stop_on_success:    datastore['STOP_ON_SUCCESS'],
           bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
-          connection_timeout: 5
+          connection_timeout: 5,
+          http_username:      datastore['HTTPUSERNAME'],
+          http_password:      datastore['HTTPPASSWORD']
         ))
     }.call
   end

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
           bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
           connection_timeout: 5,
           http_username:      datastore['HTTPUSERNAME'],
-          http_password:      datastore['HTTPPASSWORD']
+          http_password:      datastore['HttpPassword']
         ))
     }.call
   end

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -31,8 +31,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
-        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', ''])
+        OptString.new('USERNAME', [false, 'The username to specify for authentication', '']),
+        OptString.new('PASSWORD', [false, 'The password to specify for authentication', ''])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
+++ b/modules/auxiliary/scanner/http/symantec_web_gateway_login.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
           stop_on_success:    datastore['STOP_ON_SUCCESS'],
           bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
           connection_timeout: 5,
-          http_username:      datastore['HTTPUSERNAME'],
+          http_username:      datastore['HttpUsername'],
           http_password:      datastore['HttpPassword']
         ))
     }.call

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -58,6 +58,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(8080),
+        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
+        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', '']),
         OptString.new('TARGETURI', [true, "URI for Manager login. Default is /manager/html", "/manager/html"]),
         OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
           File.join(Msf::Config.data_directory, "wordlists", "tomcat_mgr_default_userpass.txt") ]),
@@ -110,7 +112,9 @@ class MetasploitModule < Msf::Auxiliary
         cred_details: cred_collection,
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
-        connection_timeout: 10
+        connection_timeout: 10,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 10,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
+++ b/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
+++ b/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
@@ -116,6 +116,8 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
+++ b/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -70,6 +70,8 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success: datastore['STOP_ON_SUCCESS'],
         bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Auxiliary
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
         http_username:      datastore['HTTPUSERNAME'],
-        http_password:      datastore['HTTPPASSWORD']
+        http_password:      datastore['HttpPassword']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -153,6 +153,8 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
+        http_username:      datastore['HTTPUSERNAME'],
+        http_password:      datastore['HTTPPASSWORD']
       )
     )
   end

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Auxiliary
         stop_on_success:    datastore['STOP_ON_SUCCESS'],
         bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
         connection_timeout: 5,
-        http_username:      datastore['HTTPUSERNAME'],
+        http_username:      datastore['HttpUsername'],
         http_password:      datastore['HttpPassword']
       )
     )

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [ true,  'The path to the Nessus server login API', '/session']),
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
 

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [ true,  'The path to the Nessus server login API', '/session']),
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
 

--- a/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_rest_login.rb
@@ -32,6 +32,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8834),
         OptString.new('TARGETURI', [ true,  'The path to the Nessus server login API', '/session']),
       ], self.class)
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class)
     register_autofilter_ports([ 50013 ])
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
       ], self.class)
     register_autofilter_ports([ 50013 ])
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -39,6 +39,8 @@ class MetasploitModule < Msf::Auxiliary
                                    File.join(Msf::Config.data_directory, "wordlists", "sap_common.txt") ])
       ], self.class)
     register_autofilter_ports([ 50013 ])
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT',   [true,  'SAP client', '001']),
-      OptString.new('HTTPUSERNAME', [false, 'Username (Ex SAP*)']),
+      OptString.new('HttpUsername', [false, 'Username (Ex SAP*)']),
       OptString.new('HttpPassword', [false, 'Password (Ex 06071992)']),
       OptAddress.new('LHOST',   [true,  'Server IP or hostname of the SMB Capture system']),
       OptEnum.new('ABUSE',      [true,  'SMB Relay abuse to use', "MMR",
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def valid_credentials?
-    if datastore['HTTPUSERNAME'].blank?
+    if datastore['HttpUsername'].blank?
       return false
     end
 
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'uri' => '/sap/bw/xml/soap/xmla?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
         'method' => 'POST',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'data' => data,
         'ctype' => 'text/xml; charset=UTF-8',
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT']
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       smb_uri = "\\\\#{datastore['LHOST']}\\#{Rex::Text.rand_text_alpha_lower(7)}.#{Rex::Text.rand_text_alpha_lower(3)}"
 
-      if datastore['HTTPUSERNAME'].empty?
+      if datastore['HttpUsername'].empty?
         vprint_status("#{rhost}:#{rport} - Sending unauthenticated request for #{smb_uri}")
         res = send_request_cgi({
           'uri' => '/mmr/MMR',
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
         res = send_request_cgi({
           'uri' => '/mmr/MMR',
           'method' => 'GET',
-          'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+          'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
           'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
           'ctype' => 'text/xml; charset=UTF-8',
           'vars_get' => {
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -53,8 +53,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT',   [true,  'SAP client', '001']),
-      OptString.new('USERNAME', [false, 'Username (Ex SAP*)']),
-      OptString.new('PASSWORD', [false, 'Password (Ex 06071992)']),
+      OptString.new('HTTPUSERNAME', [false, 'Username (Ex SAP*)']),
+      OptString.new('HTTPPASSWORD', [false, 'Password (Ex 06071992)']),
       OptAddress.new('LHOST',   [true,  'Server IP or hostname of the SMB Capture system']),
       OptEnum.new('ABUSE',      [true,  'SMB Relay abuse to use', "MMR",
         [
@@ -69,11 +69,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def valid_credentials?
-    if datastore['USERNAME'].nil? or datastore['USERNAME'].empty?
+    if datastore['HTTPUSERNAME'].blank?
       return false
     end
 
-    if datastore['PASSWORD'].nil? or datastore['PASSWORD'].empty?
+    if datastore['HTTPPASSWORD'].blank?
       return false
     end
     return true
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'uri' => '/sap/bw/xml/soap/xmla?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
         'method' => 'POST',
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'data' => data,
         'ctype' => 'text/xml; charset=UTF-8',
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT']
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       smb_uri = "\\\\#{datastore['LHOST']}\\#{Rex::Text.rand_text_alpha_lower(7)}.#{Rex::Text.rand_text_alpha_lower(3)}"
 
-      if datastore['USERNAME'].empty?
+      if datastore['HTTPUSERNAME'].empty?
         vprint_status("#{rhost}:#{rport} - Sending unauthenticated request for #{smb_uri}")
         res = send_request_cgi({
           'uri' => '/mmr/MMR',
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
         res = send_request_cgi({
           'uri' => '/mmr/MMR',
           'method' => 'GET',
-          'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+          'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
           'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
           'ctype' => 'text/xml; charset=UTF-8',
           'vars_get' => {
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(8000),
       OptString.new('CLIENT',   [true,  'SAP client', '001']),
       OptString.new('HTTPUSERNAME', [false, 'Username (Ex SAP*)']),
-      OptString.new('HTTPPASSWORD', [false, 'Password (Ex 06071992)']),
+      OptString.new('HttpPassword', [false, 'Password (Ex 06071992)']),
       OptAddress.new('LHOST',   [true,  'Server IP or hostname of the SMB Capture system']),
       OptEnum.new('ABUSE',      [true,  'SMB Relay abuse to use', "MMR",
         [
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
       return false
     end
 
-    if datastore['HTTPPASSWORD'].blank?
+    if datastore['HttpPassword'].blank?
       return false
     end
     return true
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'uri' => '/sap/bw/xml/soap/xmla?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
         'method' => 'POST',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'data' => data,
         'ctype' => 'text/xml; charset=UTF-8',
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT']
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
         res = send_request_cgi({
           'uri' => '/mmr/MMR',
           'method' => 'GET',
-          'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+          'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
           'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
           'ctype' => 'text/xml; charset=UTF-8',
           'vars_get' => {
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP client', '001']),
-      OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('PASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
       OptString.new('BAPI_FIRST',[true,'First name','John']),
       OptString.new('BAPI_LAST',[true,'Last name','Doe']),
       OptString.new('BAPI_PASSWORD',[true,'Password for the account (Default is msf1234)','msf1234']),
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP client', '001']),
       OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('BAPI_FIRST',[true,'First name','John']),
       OptString.new('BAPI_LAST',[true,'Last name','Doe']),
       OptString.new('BAPI_PASSWORD',[true,'Password for the account (Default is msf1234)','msf1234']),
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP client', '001']),
-      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
       OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('BAPI_FIRST',[true,'First name','John']),
       OptString.new('BAPI_LAST',[true,'Last name','Doe']),
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "sap_default.txt") ])
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HttpPassword')
+    deregister_options('HttpUsername', 'HttpPassword')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
           File.join(Msf::Config.data_directory, "wordlists", "sap_default.txt") ])
       ], self.class)
 
-    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
+    deregister_options('HTTPUSERNAME', 'HttpPassword')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -49,6 +49,8 @@ class MetasploitModule < Msf::Auxiliary
         OptPath.new('USERPASS_FILE', [ false, "File containing users and passwords separated by space, one pair per line",
           File.join(Msf::Config.data_directory, "wordlists", "sap_default.txt") ])
       ], self.class)
+
+    deregister_options('HTTPUSERNAME', 'HTTPPASSWORD')
   end
 
   def run_host(rhost)

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
         OptEnum.new('OS', [true, 'Target OS', "linux", ['linux','windows']]),
         OptString.new('CMD', [true, 'Command to run', "id"])
       ], self.class)
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptEnum.new('OS', [true, 'Target OS', "linux", ['linux','windows']]),
         OptString.new('CMD', [true, 'Command to run', "id"])
       ], self.class)
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptEnum.new('OS', [true, 'Target OS', "linux", ['linux','windows']]),
         OptString.new('CMD', [true, 'Command to run', "id"])
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptEnum.new('OS', [true, 'Target OS', "linux", ['linux','windows']]),
         OptString.new('CMD', [true, 'Command to run', "id"])
       ], self.class)
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -44,8 +44,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
         OptEnum.new('OS', [true, 'Target OS', "linux", ['linux','windows']]),
         OptString.new('CMD', [true, 'Command to run', "id"])
       ], self.class)
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptEnum.new('OS', [true, 'Target OS', "linux", ['linux','windows']]),
         OptString.new('CMD', [true, 'Command to run', "id"])
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
@@ -50,8 +50,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('PASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
       OptString.new('DIR',[true,'Directory path (e.g. /etc)','/etc'])
     ], self.class)
   end
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
       OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('DIR',[true,'Directory path (e.g. /etc)','/etc'])
     ], self.class)
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(8000),
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
       OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('DIR',[true,'Directory path (e.g. /etc)','/etc'])
     ], self.class)
   end
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
@@ -52,8 +52,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('PASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
       OptString.new('FILEPATH',[true,'File Path to check for  (e.g. /etc)','/etc/passwd'])
     ], self.class)
   end
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
       OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('FILEPATH',[true,'File Path to check for  (e.g. /etc)','/etc/passwd'])
     ], self.class)
   end
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
       OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('FILEPATH',[true,'File Path to check for  (e.g. /etc)','/etc/passwd'])
     ], self.class)
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username ', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username ', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password ', '06071992'])
       ], self.class)
   end
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'POST',
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{client}",
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'ctype'  => 'text/xml; charset=UTF-8',
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username ', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password ', '06071992'])
+        OptString.new('HttpPassword', [true, 'Password ', '06071992'])
       ], self.class)
   end
 
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'POST',
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{client}",
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'ctype'  => 'text/xml; charset=UTF-8',
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'Client', '001']),
-        OptString.new('USERNAME', [true, 'Username ', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password ', '06071992'])
+        OptString.new('HTTPUSERNAME', [true, 'Username ', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password ', '06071992'])
       ], self.class)
   end
 
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'POST',
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{client}",
         'data' => data,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'ctype'  => 'text/xml; charset=UTF-8',
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('TABLE', [true, 'Table to read', 'USR02']),
         OptString.new('FIELDS', [true, 'Fields to read', 'BNAME,BCODE'])
       ], self.class)
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'POST',
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('TABLE', [true, 'Table to read', 'USR02']),
         OptString.new('FIELDS', [true, 'Fields to read', 'BNAME,BCODE'])
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'POST',
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
         OptString.new('TABLE', [true, 'Table to read', 'USR02']),
         OptString.new('FIELDS', [true, 'Fields to read', 'BNAME,BCODE'])
       ], self.class)
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'POST',
         'data' => data,
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
       OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('DIR',[true,'Directory path (e.g. /etc)','/etc'])
     ], self.class)
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
       OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HttpPassword', [true, 'Password', '06071992']),
       OptString.new('DIR',[true,'Directory path (e.g. /etc)','/etc'])
     ], self.class)
   end
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
@@ -51,8 +51,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('CLIENT', [true, 'SAP Client', '001']),
-      OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-      OptString.new('PASSWORD', [true, 'Password', '06071992']),
+      OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+      OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
       OptString.new('DIR',[true,'Directory path (e.g. /etc)','/etc'])
     ], self.class)
   end
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
         'uri' => '/sap/bc/soap/rfc',
         'method' => 'POST',
         'data' => data,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
         'ctype' => 'text/xml; charset=UTF-8',
         'headers' => {

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('ABAP_PASSWORD',[false,'Password for the account (Default is msf1234)','msf1234']),
         OptString.new('ABAP_USER',[false,'Username for the account (Username in upper case only. Default is MSF)', 'MSF'])
       ], self.class)
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers'  => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
         OptString.new('ABAP_PASSWORD',[false,'Password for the account (Default is msf1234)','msf1234']),
         OptString.new('ABAP_USER',[false,'Username for the account (Username in upper case only. Default is MSF)', 'MSF'])
       ], self.class)
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers'  => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('ABAP_PASSWORD',[false,'Password for the account (Default is msf1234)','msf1234']),
         OptString.new('ABAP_USER',[false,'Username for the account (Username in upper case only. Default is MSF)', 'MSF'])
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers'  => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
         OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
         OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
         OptEnum.new('OS', [true, 'SM69 Target OS','ANYOS',['ANYOS', 'UNIX', 'Windows NT', 'AS/400', 'OS/400']])
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
         OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
         OptEnum.new('OS', [true, 'SM69 Target OS','ANYOS',['ANYOS', 'UNIX', 'Windows NT', 'AS/400', 'OS/400']])
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
         OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
         OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
         OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
         OptEnum.new('OS', [true, 'SM69 Target OS','ANYOS',['ANYOS', 'UNIX', 'Windows NT', 'AS/400', 'OS/400']])
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
         OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HttpPassword', [true, 'Password', '06071992']),
         OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
         OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
         OptEnum.new('OS', [true, 'SM69 Target OS','ANYOS',['ANYOS', 'UNIX', 'Windows NT', 'AS/400', 'OS/400']])
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client ', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HttpPassword', [true, 'Password', '06071992']),
       ], self.class)
   end
 
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client ', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992']),
       ], self.class)
   end
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -47,8 +47,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client ', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992']),
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992']),
       ], self.class)
   end
 
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers' =>{
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992'])
+        OptString.new('HttpPassword', [true, 'Password', '06071992'])
       ], self.class)
   end
 
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992'])
       ], self.class)
   end
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+        'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992'])
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992'])
       ], self.class)
   end
 
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'ctype' => 'text/xml; charset=UTF-8',
         'encode_params' => false,
-        'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+        'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
         'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Auxiliary
         ],
       'License'        => MSF_LICENSE
     )
-
   end
 
 

--- a/modules/exploits/linux/http/dlink_dcs931l_upload.rb
+++ b/modules/exploits/linux/http/dlink_dcs931l_upload.rb
@@ -61,14 +61,14 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME',  [true, 'Camera username', 'admin']),
-        OptString.new('HTTPPASSWORD',  [false, 'Camera password (default: blank)', ''])
+        OptString.new('HttpPassword',  [false, 'Camera password (default: blank)', ''])
       ], self.class)
   end
 
   def check
     res = send_request_cgi(
       'uri' => normalize_uri('uploadfile.htm'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
     )
 
     unless res
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri('setSystemAdmin'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
       'vars_post' => Hash[{
         'ReplySuccessPage' => 'advanced.htm',
         'ReplyErrorPage' => 'errradv.htm',
@@ -203,7 +203,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri('setFileUpload'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
       'ctype' => "multipart/form-data; boundary=#{boundary}",
       'data' => post_data)
   end

--- a/modules/exploits/linux/http/dlink_dcs931l_upload.rb
+++ b/modules/exploits/linux/http/dlink_dcs931l_upload.rb
@@ -60,16 +60,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME',  [true, 'Camera username', 'admin']),
-        OptString.new('PASSWORD',  [false, 'Camera password (default: blank)', ''])
+        OptString.new('HTTPUSERNAME',  [true, 'Camera username', 'admin']),
+        OptString.new('HTTPPASSWORD',  [false, 'Camera password (default: blank)', ''])
       ], self.class)
   end
 
   def check
     res = send_request_cgi(
       'uri' => normalize_uri('uploadfile.htm'),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']
-    ))
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+    )
 
     unless res
       vprint_status("The connection timed out.")
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri('setSystemAdmin'),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'vars_post' => Hash[{
         'ReplySuccessPage' => 'advanced.htm',
         'ReplyErrorPage' => 'errradv.htm',
@@ -203,7 +203,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri('setFileUpload'),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'ctype' => "multipart/form-data; boundary=#{boundary}",
       'data' => post_data)
   end

--- a/modules/exploits/linux/http/dlink_dcs931l_upload.rb
+++ b/modules/exploits/linux/http/dlink_dcs931l_upload.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME',  [true, 'Camera username', 'admin']),
+        OptString.new('HttpUsername',  [true, 'Camera username', 'admin']),
         OptString.new('HttpPassword',  [false, 'Camera password (default: blank)', ''])
       ], self.class)
   end
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi(
       'uri' => normalize_uri('uploadfile.htm'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
     )
 
     unless res
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri('setSystemAdmin'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'vars_post' => Hash[{
         'ReplySuccessPage' => 'advanced.htm',
         'ReplyErrorPage' => 'errradv.htm',
@@ -203,7 +203,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri('setFileUpload'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'ctype' => "multipart/form-data; boundary=#{boundary}",
       'data' => post_data)
   end

--- a/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
+++ b/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
@@ -46,8 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
-        OptString.new('PASSWORD', [ false, 'Password to login with', ''])
+        OptString.new('HTTPUSERNAME', [ true, 'User to login with', 'admin']),
+        OptString.new('HTTPPASSWORD', [ false, 'Password to login with', ''])
       ], self.class)
 
     register_advanced_options(
@@ -66,8 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD'] || ''
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD'] || ''
 
     test_login(user, pass)
     exploit_telnet

--- a/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
+++ b/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [ true, 'User to login with', 'admin']),
-        OptString.new('HTTPPASSWORD', [ false, 'Password to login with', ''])
+        OptString.new('HttpPassword', [ false, 'Password to login with', ''])
       ], self.class)
 
     register_advanced_options(
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD'] || ''
+    pass = datastore['HttpPassword'] || ''
 
     test_login(user, pass)
     exploit_telnet

--- a/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
+++ b/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [ true, 'User to login with', 'admin']),
+        OptString.new('HttpUsername', [ true, 'User to login with', 'admin']),
         OptString.new('HttpPassword', [ false, 'Password to login with', ''])
       ], self.class)
 
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword'] || ''
 
     test_login(user, pass)

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -55,8 +55,8 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(443),
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/iControl/iControlPortal.cgi']),
-        OptString.new('USERNAME', [true, 'The username to authenticate with', 'admin']),
-        OptString.new('PASSWORD', [true, 'The password to authenticate with', 'admin'])
+        OptString.new('HTTPUSERNAME', [true, 'The username to authenticate with', 'admin']),
+        OptString.new('HTTPPASSWORD', [true, 'The password to authenticate with', 'admin'])
       ])
     register_advanced_options(
       [
@@ -103,8 +103,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
       'data' => pay,
-      'username' => datastore['USERNAME'],
-      'password' => datastore['PASSWORD']
+      'username' => datastore['HTTPUSERNAME'],
+      'password' => datastore['HTTPPASSWORD']
     )
     if res
       return res

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(443),
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/iControl/iControlPortal.cgi']),
-        OptString.new('HTTPUSERNAME', [true, 'The username to authenticate with', 'admin']),
+        OptString.new('HttpUsername', [true, 'The username to authenticate with', 'admin']),
         OptString.new('HttpPassword', [true, 'The password to authenticate with', 'admin'])
       ])
     register_advanced_options(
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path),
       'method' => 'POST',
       'data' => pay,
-      'username' => datastore['HTTPUSERNAME'],
+      'username' => datastore['HttpUsername'],
       'password' => datastore['HttpPassword']
     )
     if res

--- a/modules/exploits/linux/http/f5_icall_cmd.rb
+++ b/modules/exploits/linux/http/f5_icall_cmd.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/iControl/iControlPortal.cgi']),
         OptString.new('HTTPUSERNAME', [true, 'The username to authenticate with', 'admin']),
-        OptString.new('HTTPPASSWORD', [true, 'The password to authenticate with', 'admin'])
+        OptString.new('HttpPassword', [true, 'The password to authenticate with', 'admin'])
       ])
     register_advanced_options(
       [
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'data' => pay,
       'username' => datastore['HTTPUSERNAME'],
-      'password' => datastore['HTTPPASSWORD']
+      'password' => datastore['HttpPassword']
     )
     if res
       return res

--- a/modules/exploits/linux/http/f5_icontrol_exec.rb
+++ b/modules/exploits/linux/http/f5_icontrol_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
           OptBool.new('SSL', [true, 'Use SSL', true]),
           OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
           OptString.new('HTTPUSERNAME', [true, 'The username to authenticate with', 'admin']),
-          OptString.new('HTTPPASSWORD', [true, 'The password to authenticate with', 'admin'])
+          OptString.new('HttpPassword', [true, 'The password to authenticate with', 'admin'])
         ], self.class)
   end
 
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'data' => get_hostname,
       'username' => datastore['HTTPUSERNAME'],
-      'password' => datastore['HTTPPASSWORD']
+      'password' => datastore['HttpPassword']
     })
 
     res.body =~ /y:string">(.*)<\/return/
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'data' => get_hostname,
       'username' => datastore['HTTPUSERNAME'],
-      'password' => datastore['HTTPPASSWORD']
+      'password' => datastore['HttpPassword']
     })
 
     res.body =~ /y:string">(.*)<\/return/
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'POST',
         'data' => pay,
         'username' => datastore['HTTPUSERNAME'],
-        'password' => datastore['HTTPPASSWORD']
+        'password' => datastore['HttpPassword']
       })
 
       return Exploit::CheckCode::Vulnerable
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'data' => pay,
       'username' => datastore['HTTPUSERNAME'],
-      'password' => datastore['HTTPPASSWORD']
+      'password' => datastore['HttpPassword']
     })
   end
 

--- a/modules/exploits/linux/http/f5_icontrol_exec.rb
+++ b/modules/exploits/linux/http/f5_icontrol_exec.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
           Opt::RPORT(443),
           OptBool.new('SSL', [true, 'Use SSL', true]),
           OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
-          OptString.new('USERNAME', [true, 'The username to authenticate with', 'admin']),
-          OptString.new('PASSWORD', [true, 'The password to authenticate with', 'admin'])
+          OptString.new('HTTPUSERNAME', [true, 'The username to authenticate with', 'admin']),
+          OptString.new('HTTPPASSWORD', [true, 'The password to authenticate with', 'admin'])
         ], self.class)
   end
 
@@ -61,8 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
       'data' => get_hostname,
-      'username' => datastore['USERNAME'],
-      'password' => datastore['PASSWORD']
+      'username' => datastore['HTTPUSERNAME'],
+      'password' => datastore['HTTPPASSWORD']
     })
 
     res.body =~ /y:string">(.*)<\/return/
@@ -73,8 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
       'data' => get_hostname,
-      'username' => datastore['USERNAME'],
-      'password' => datastore['PASSWORD']
+      'username' => datastore['HTTPUSERNAME'],
+      'password' => datastore['HTTPPASSWORD']
     })
 
     res.body =~ /y:string">(.*)<\/return/
@@ -95,8 +95,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
         'method' => 'POST',
         'data' => pay,
-        'username' => datastore['USERNAME'],
-        'password' => datastore['PASSWORD']
+        'username' => datastore['HTTPUSERNAME'],
+        'password' => datastore['HTTPPASSWORD']
       })
 
       return Exploit::CheckCode::Vulnerable
@@ -120,8 +120,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
       'data' => pay,
-      'username' => datastore['USERNAME'],
-      'password' => datastore['PASSWORD']
+      'username' => datastore['HTTPUSERNAME'],
+      'password' => datastore['HTTPPASSWORD']
     })
   end
 

--- a/modules/exploits/linux/http/f5_icontrol_exec.rb
+++ b/modules/exploits/linux/http/f5_icontrol_exec.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Opt::RPORT(443),
           OptBool.new('SSL', [true, 'Use SSL', true]),
           OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
-          OptString.new('HTTPUSERNAME', [true, 'The username to authenticate with', 'admin']),
+          OptString.new('HttpUsername', [true, 'The username to authenticate with', 'admin']),
           OptString.new('HttpPassword', [true, 'The password to authenticate with', 'admin'])
         ], self.class)
   end
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
       'data' => get_hostname,
-      'username' => datastore['HTTPUSERNAME'],
+      'username' => datastore['HttpUsername'],
       'password' => datastore['HttpPassword']
     })
 
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
       'data' => get_hostname,
-      'username' => datastore['HTTPUSERNAME'],
+      'username' => datastore['HttpUsername'],
       'password' => datastore['HttpPassword']
     })
 
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
         'method' => 'POST',
         'data' => pay,
-        'username' => datastore['HTTPUSERNAME'],
+        'username' => datastore['HttpUsername'],
         'password' => datastore['HttpPassword']
       })
 
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
       'data' => pay,
-      'username' => datastore['HTTPUSERNAME'],
+      'username' => datastore['HttpUsername'],
       'password' => datastore['HttpPassword']
     })
   end

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'admin' ]),
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60])
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/apply.cgi'
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
 

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -63,8 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'admin' ]),
+        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60])
@@ -100,8 +100,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/apply.cgi'
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
 

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/apply.cgi'
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ))
 
     register_options([
-      OptString.new('USERNAME', [ false, 'Valid router administrator username', 'admin']),
-      OptString.new('PASSWORD', [ false, 'Password to login with', 'admin']),
+      OptString.new('HTTPUSERNAME', [ false, 'Valid router administrator username', 'admin']),
+      OptString.new('HTTPPASSWORD', [ false, 'Password to login with', 'admin']),
       OptAddress.new('RHOST', [true, 'The address of the router', '192.168.1.1']),
       OptInt.new('TIMEOUT', [false, 'The timeout to use in every request', 20])
     ], self.class)
@@ -106,11 +106,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Helper methods
   def user
-    datastore['USERNAME']
+    datastore['HTTPUSERNAME']
   end
 
   def pass
-    datastore['PASSWORD'] || ''
+    datastore['HTTPPASSWORD'] || ''
   end
 
   def send_auth_request_cgi(opts={}, timeout=nil)

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ))
 
     register_options([
-      OptString.new('HTTPUSERNAME', [ false, 'Valid router administrator username', 'admin']),
+      OptString.new('HttpUsername', [ false, 'Valid router administrator username', 'admin']),
       OptString.new('HttpPassword', [ false, 'Password to login with', 'admin']),
       OptAddress.new('RHOST', [true, 'The address of the router', '192.168.1.1']),
       OptInt.new('TIMEOUT', [false, 'The timeout to use in every request', 20])
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Helper methods
   def user
-    datastore['HTTPUSERNAME']
+    datastore['HttpUsername']
   end
 
   def pass

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('HTTPUSERNAME', [ false, 'Valid router administrator username', 'admin']),
-      OptString.new('HTTPPASSWORD', [ false, 'Password to login with', 'admin']),
+      OptString.new('HttpPassword', [ false, 'Password to login with', 'admin']),
       OptAddress.new('RHOST', [true, 'The address of the router', '192.168.1.1']),
       OptInt.new('TIMEOUT', [false, 'The timeout to use in every request', 20])
     ], self.class)
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def pass
-    datastore['HTTPPASSWORD'] || ''
+    datastore['HttpPassword'] || ''
   end
 
   def send_auth_request_cgi(opts={}, timeout=nil)

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('LHOST', [ true, 'The listen IP address from where the victim downloads the MIPS payload' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(4))
     uri = '/apply.cgi'
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
     lhost = datastore['LHOST']
 

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -65,8 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'admin' ]),
+        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('LHOST', [ true, 'The listen IP address from where the victim downloads the MIPS payload' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 10])
@@ -102,8 +102,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(4))
     uri = '/apply.cgi'
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
     lhost = datastore['LHOST']
 
     #

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'admin' ]),
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('LHOST', [ true, 'The listen IP address from where the victim downloads the MIPS payload' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 10])
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(4))
     uri = '/apply.cgi'
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    pass = datastore['HttpPassword']
     lhost = datastore['LHOST']
 
     #

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -65,8 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'admin' ]),
+        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
@@ -243,8 +243,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/apply.cgi'
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
     restore = datastore['RESTORE_CONF']

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'admin' ]),
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
@@ -244,7 +244,7 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/apply.cgi'
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
     restore = datastore['RESTORE_CONF']

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/apply.cgi'
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'password' ]),
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'password' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60])
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/setup.cgi'
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
 

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -65,8 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'password' ]),
+        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'password' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60])
@@ -104,8 +104,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/setup.cgi'
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']
 

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'password' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/setup.cgi'
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
     rhost = datastore['RHOST']
     rport = datastore['RPORT']

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -65,8 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'password' ]),
+        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'password' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
@@ -217,8 +217,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/pppoe.cgi'
-    user = datastore['USERNAME']
-    pass = datastore['PASSWORD']
+    user = datastore['HTTPUSERNAME']
+    pass = datastore['HTTPPASSWORD']
     @timeout = datastore['RELOAD_CONF_DELAY']
 
     #

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
-        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'password' ]),
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'password' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
@@ -218,7 +218,7 @@ class MetasploitModule < Msf::Exploit::Remote
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/pppoe.cgi'
     user = datastore['HTTPUSERNAME']
-    pass = datastore['HTTPPASSWORD']
+    pass = datastore['HttpPassword']
     @timeout = datastore['RELOAD_CONF_DELAY']
 
     #

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [ true, 'The username to authenticate as', 'admin' ]),
+        OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'password' ]),
         OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     uri = '/pppoe.cgi'
-    user = datastore['HTTPUSERNAME']
+    user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
     @timeout = datastore['RELOAD_CONF_DELAY']
 

--- a/modules/exploits/linux/http/piranha_passwd_exec.rb
+++ b/modules/exploits/linux/http/piranha_passwd_exec.rb
@@ -70,8 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [true, 'The HTTP username to specify for basic authentication', 'piranha']),
-        OptString.new('PASSWORD', [true, 'The HTTP password to specify for basic authentication', 'q'])
+        OptString.new('HTTPUSERNAME', [true, 'The HTTP username to specify for basic authentication', 'piranha']),
+        OptString.new('HTTPPASSWORD', [true, 'The HTTP password to specify for basic authentication', 'q'])
       ], self.class)
   end
 

--- a/modules/exploits/linux/http/piranha_passwd_exec.rb
+++ b/modules/exploits/linux/http/piranha_passwd_exec.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [true, 'The HTTP username to specify for basic authentication', 'piranha']),
+        OptString.new('HttpUsername', [true, 'The HTTP username to specify for basic authentication', 'piranha']),
         OptString.new('HttpPassword', [true, 'The HTTP password to specify for basic authentication', 'q'])
       ], self.class)
   end

--- a/modules/exploits/linux/http/piranha_passwd_exec.rb
+++ b/modules/exploits/linux/http/piranha_passwd_exec.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [true, 'The HTTP username to specify for basic authentication', 'piranha']),
-        OptString.new('HTTPPASSWORD', [true, 'The HTTP password to specify for basic authentication', 'q'])
+        OptString.new('HttpPassword', [true, 'The HTTP password to specify for basic authentication', 'q'])
       ], self.class)
   end
 

--- a/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
+++ b/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
         register_options(
           [
-            OptString.new('HTTPUSERNAME', [ true, 'User to login with', 'admin']),
+            OptString.new('HttpUsername', [ true, 'User to login with', 'admin']),
             OptString.new('HttpPassword', [ true, 'Password to login with', 'admin'])
           ], self.class)
 
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     def exploit
       print_status('Exploiting')
-      user = datastore['HTTPUSERNAME']
+      user = datastore['HttpUsername']
       pass = datastore['HttpPassword']
       test_login(user, pass)
       exploit_telnet

--- a/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
+++ b/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
         register_options(
           [
             OptString.new('HTTPUSERNAME', [ true, 'User to login with', 'admin']),
-            OptString.new('HTTPPASSWORD', [ true, 'Password to login with', 'admin'])
+            OptString.new('HttpPassword', [ true, 'Password to login with', 'admin'])
           ], self.class)
 
         register_advanced_options(
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     def exploit
       print_status('Exploiting')
       user = datastore['HTTPUSERNAME']
-      pass = datastore['HTTPPASSWORD']
+      pass = datastore['HttpPassword']
       test_login(user, pass)
       exploit_telnet
     end

--- a/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
+++ b/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
         register_options(
           [
-            OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
-            OptString.new('PASSWORD', [ true, 'Password to login with', 'admin'])
+            OptString.new('HTTPUSERNAME', [ true, 'User to login with', 'admin']),
+            OptString.new('HTTPPASSWORD', [ true, 'Password to login with', 'admin'])
           ], self.class)
 
         register_advanced_options(
@@ -66,8 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     def exploit
       print_status('Exploiting')
-      user = datastore['USERNAME']
-      pass = datastore['PASSWORD']
+      user = datastore['HTTPUSERNAME']
+      pass = datastore['HTTPPASSWORD']
       test_login(user, pass)
       exploit_telnet
     end

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(444),
         OptBool.new('SSL', [true, 'Use SSL', true]),
         OptString.new('HTTPUSERNAME', [true, 'The username for the application', 'admin']),
-        OptString.new('HTTPPASSWORD', [true, 'The password for the application', 'admin'])
+        OptString.new('HttpPassword', [true, 'The password for the application', 'admin'])
       ], self.class)
   end
 
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     user  = datastore['HTTPUSERNAME']
-    pass  = datastore['HTTPPASSWORD']
+    pass  = datastore['HttpPassword']
     cmd   = Rex::Text.uri_encode(";#{payload.encoded}&")
     lines = rand(100) + 1
 

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -59,8 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(444),
         OptBool.new('SSL', [true, 'Use SSL', true]),
-        OptString.new('USERNAME', [true, 'The username for the application', 'admin']),
-        OptString.new('PASSWORD', [true, 'The password for the application', 'admin'])
+        OptString.new('HTTPUSERNAME', [true, 'The username for the application', 'admin']),
+        OptString.new('HTTPPASSWORD', [true, 'The password for the application', 'admin'])
       ], self.class)
   end
 
@@ -86,8 +86,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    user  = datastore['USERNAME']
-    pass  = datastore['PASSWORD']
+    user  = datastore['HTTPUSERNAME']
+    pass  = datastore['HTTPPASSWORD']
     cmd   = Rex::Text.uri_encode(";#{payload.encoded}&")
     lines = rand(100) + 1
 

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(444),
         OptBool.new('SSL', [true, 'Use SSL', true]),
-        OptString.new('HTTPUSERNAME', [true, 'The username for the application', 'admin']),
+        OptString.new('HttpUsername', [true, 'The username for the application', 'admin']),
         OptString.new('HttpPassword', [true, 'The password for the application', 'admin'])
       ], self.class)
   end
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    user  = datastore['HTTPUSERNAME']
+    user  = datastore['HttpUsername']
     pass  = datastore['HttpPassword']
     cmd   = Rex::Text.uri_encode(";#{payload.encoded}&")
     lines = rand(100) + 1

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       Opt::RPORT(631),
       OptBool.new('SSL', [ true, 'Use SSL', true ]),
-      OptString.new('HTTPUSERNAME', [ true, 'CUPS username', 'root']),
+      OptString.new('HttpUsername', [ true, 'CUPS username', 'root']),
       OptString.new('HttpPassword', [ true, 'CUPS user password', '']),
       OptEnum.new('CVE', [ true, 'CVE to exploit', 'CVE-2014-6271', ['CVE-2014-6271', 'CVE-2014-6278'] ]),
       OptString.new('RPATH', [ true, 'Target PATH for binaries', '/bin' ])
@@ -233,7 +233,7 @@ EOF
       'ctype' => "multipart/form-data; boundary=#{pd.bound}",
       'data' => data,
       'cookie' => "org.cups.sid=#{@cookie};",
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword'])
     )
   end
 
@@ -245,7 +245,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'printers', printer_name),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'cookie' => "org.cups.sid=#{@cookie}",
       'vars_post' => {
         'org.cups.sid' => @cookie,
@@ -262,7 +262,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'admin'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'cookie' => "org.cups.sid=#{@cookie}",
       'vars_post' => {
         'org.cups.sid' => @cookie,

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(631),
       OptBool.new('SSL', [ true, 'Use SSL', true ]),
       OptString.new('HTTPUSERNAME', [ true, 'CUPS username', 'root']),
-      OptString.new('HTTPPASSWORD', [ true, 'CUPS user password', '']),
+      OptString.new('HttpPassword', [ true, 'CUPS user password', '']),
       OptEnum.new('CVE', [ true, 'CVE to exploit', 'CVE-2014-6271', ['CVE-2014-6271', 'CVE-2014-6278'] ]),
       OptString.new('RPATH', [ true, 'Target PATH for binaries', '/bin' ])
     ], self.class)
@@ -233,7 +233,7 @@ EOF
       'ctype' => "multipart/form-data; boundary=#{pd.bound}",
       'data' => data,
       'cookie' => "org.cups.sid=#{@cookie};",
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword'])
     )
   end
 
@@ -245,7 +245,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'printers', printer_name),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
       'cookie' => "org.cups.sid=#{@cookie}",
       'vars_post' => {
         'org.cups.sid' => @cookie,
@@ -262,7 +262,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'admin'),
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
       'cookie' => "org.cups.sid=#{@cookie}",
       'vars_post' => {
         'org.cups.sid' => @cookie,

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -59,8 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       Opt::RPORT(631),
       OptBool.new('SSL', [ true, 'Use SSL', true ]),
-      OptString.new('USERNAME', [ true, 'CUPS username', 'root']),
-      OptString.new('PASSWORD', [ true, 'CUPS user password', '']),
+      OptString.new('HTTPUSERNAME', [ true, 'CUPS username', 'root']),
+      OptString.new('HTTPPASSWORD', [ true, 'CUPS user password', '']),
       OptEnum.new('CVE', [ true, 'CVE to exploit', 'CVE-2014-6271', ['CVE-2014-6271', 'CVE-2014-6278'] ]),
       OptString.new('RPATH', [ true, 'Target PATH for binaries', '/bin' ])
     ], self.class)
@@ -233,7 +233,7 @@ EOF
       'ctype' => "multipart/form-data; boundary=#{pd.bound}",
       'data' => data,
       'cookie' => "org.cups.sid=#{@cookie};",
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD'])
     )
   end
 
@@ -245,7 +245,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'printers', printer_name),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'cookie' => "org.cups.sid=#{@cookie}",
       'vars_post' => {
         'org.cups.sid' => @cookie,
@@ -262,7 +262,7 @@ EOF
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'admin'),
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'cookie' => "org.cups.sid=#{@cookie}",
       'vars_post' => {
         'org.cups.sid' => @cookie,

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -46,17 +46,17 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
     [
       OptString.new('TARGETURI', [true, 'URI', '/gestioip/']),
-      OptString.new('USERNAME', [false, 'The username to auth as', 'gipadmin']),
-      OptString.new('PASSWORD', [false, 'The password to auth with', nil])
+      OptString.new('HTTPUSERNAME', [false, 'The username to auth as', 'gipadmin']),
+      OptString.new('HTTPPASSWORD', [false, 'The password to auth with', nil])
     ], self.class)
   end
 
   def user
-    datastore['USERNAME']
+    datastore['HTTPUSERNAME']
   end
 
   def pass
-    datastore['PASSWORD']
+    datastore['HTTPPASSWORD']
   end
 
   def use_auth

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
     [
       OptString.new('TARGETURI', [true, 'URI', '/gestioip/']),
       OptString.new('HTTPUSERNAME', [false, 'The username to auth as', 'gipadmin']),
-      OptString.new('HTTPPASSWORD', [false, 'The password to auth with', nil])
+      OptString.new('HttpPassword', [false, 'The password to auth with', nil])
     ], self.class)
   end
 
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def pass
-    datastore['HTTPPASSWORD']
+    datastore['HttpPassword']
   end
 
   def use_auth

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -46,13 +46,13 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
     [
       OptString.new('TARGETURI', [true, 'URI', '/gestioip/']),
-      OptString.new('HTTPUSERNAME', [false, 'The username to auth as', 'gipadmin']),
+      OptString.new('HttpUsername', [false, 'The username to auth as', 'gipadmin']),
       OptString.new('HttpPassword', [false, 'The password to auth with', nil])
     ], self.class)
   end
 
   def user
-    datastore['HTTPUSERNAME']
+    datastore['HttpUsername']
   end
 
   def pass

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -640,7 +640,7 @@ class MetasploitModule < Msf::Exploit::Remote
       configure_http_login_scanner(
         cred_details: @cred_collection,
         connection_timeout: 5,
-        http_username: datastore['HTTPUSERNAME'],
+        http_username: datastore['HttpUsername'],
         http_password: datastore['HttpPassword']
       )
     )

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -641,7 +641,7 @@ class MetasploitModule < Msf::Exploit::Remote
         cred_details: @cred_collection,
         connection_timeout: 5,
         http_username: datastore['HTTPUSERNAME'],
-        http_password: datastore['HTTPPASSWORD']
+        http_password: datastore['HttpPassword']
       )
     )
   end

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -639,7 +639,9 @@ class MetasploitModule < Msf::Exploit::Remote
     @scanner = Metasploit::Framework::LoginScanner::Glassfish.new(
       configure_http_login_scanner(
         cred_details: @cred_collection,
-        connection_timeout: 5
+        connection_timeout: 5,
+        http_username: datastore['HTTPUSERNAME'],
+        http_password: datastore['HTTPPASSWORD']
       )
     )
   end

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('HTTPUSERNAME', [ false, 'The username to authenticate as' ]),
+        OptString.new('HttpUsername', [ false, 'The username to authenticate as' ]),
         OptString.new('HttpPassword', [ false, 'The password for the specified username' ]),
         OptString.new('JSP',      [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
         OptString.new('APPBASE',  [ false, 'Application base name, (default: random)', nil ]),

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -82,8 +82,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('USERNAME', [ false, 'The username to authenticate as' ]),
-        OptString.new('PASSWORD', [ false, 'The password for the specified username' ]),
+        OptString.new('HTTPUSERNAME', [ false, 'The username to authenticate as' ]),
+        OptString.new('HTTPPASSWORD', [ false, 'The password for the specified username' ]),
         OptString.new('JSP',      [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
         OptString.new('APPBASE',  [ false, 'Application base name, (default: random)', nil ]),
         OptString.new('PATH',     [ true,  'The URI path of the console', '/jmx-console' ]),

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('HTTPUSERNAME', [ false, 'The username to authenticate as' ]),
-        OptString.new('HTTPPASSWORD', [ false, 'The password for the specified username' ]),
+        OptString.new('HttpPassword', [ false, 'The password for the specified username' ]),
         OptString.new('JSP',      [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
         OptString.new('APPBASE',  [ false, 'Application base name, (default: random)', nil ]),
         OptString.new('PATH',     [ true,  'The URI path of the console', '/jmx-console' ]),

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(7021),
         OptString.new('HTTPUSERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
-        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'password' ])
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'password' ])
       ], self.class)
   end
 
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
     {
       'uri'     => '/cgi/surgeftpmgr.cgi',
       'method'  => 'POST',
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
       'vars_post' =>
         {
           'global_smtp' => "",

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(7021),
-        OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The password for the specified username', 'password' ])
+        OptString.new('HTTPUSERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
+        OptString.new('HTTPPASSWORD', [ true, 'The password for the specified username', 'password' ])
       ], self.class)
   end
 
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
     {
       'uri'     => '/cgi/surgeftpmgr.cgi',
       'method'  => 'POST',
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'vars_post' =>
         {
           'global_smtp' => "",

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(7021),
-        OptString.new('HTTPUSERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
+        OptString.new('HttpUsername', [ true, 'The username with admin role to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'password' ])
       ], self.class)
   end
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
     {
       'uri'     => '/cgi/surgeftpmgr.cgi',
       'method'  => 'POST',
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'vars_post' =>
         {
           'global_smtp' => "",

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -102,8 +102,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ false, 'The username to authenticate as' ]),
-        OptString.new('PASSWORD', [ false, 'The password for the specified username' ]),
+        OptString.new('HTTPUSERNAME', [ false, 'The username to authenticate as' ]),
+        OptString.new('HTTPPASSWORD', [ false, 'The password for the specified username' ]),
         # /cognos_express/manager/ for Cognos Express (19300)
         OptString.new('PATH', [ true,  "The URI path of the manager app (/deploy and /undeploy will be used)", '/manager'])
       ], self.class)
@@ -312,8 +312,8 @@ class MetasploitModule < Msf::Exploit::Remote
         origin_type: :service,
         module_fullname: self.fullname,
         private_type: :password,
-        private_data: datastore['PASSWORD'].downcase,
-        username: datastore['USERNAME']
+        private_data: datastore['HTTPPASSWORD'].downcase,
+        username: datastore['HTTPUSERNAME']
     }
 
     credential_data.merge!(service_data)

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [ false, 'The username to authenticate as' ]),
+        OptString.new('HttpUsername', [ false, 'The username to authenticate as' ]),
         OptString.new('HttpPassword', [ false, 'The password for the specified username' ]),
         # /cognos_express/manager/ for Cognos Express (19300)
         OptString.new('PATH', [ true,  "The URI path of the manager app (/deploy and /undeploy will be used)", '/manager'])
@@ -313,7 +313,7 @@ class MetasploitModule < Msf::Exploit::Remote
         module_fullname: self.fullname,
         private_type: :password,
         private_data: datastore['HttpPassword'].downcase,
-        username: datastore['HTTPUSERNAME']
+        username: datastore['HttpUsername']
     }
 
     credential_data.merge!(service_data)

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [ false, 'The username to authenticate as' ]),
-        OptString.new('HTTPPASSWORD', [ false, 'The password for the specified username' ]),
+        OptString.new('HttpPassword', [ false, 'The password for the specified username' ]),
         # /cognos_express/manager/ for Cognos Express (19300)
         OptString.new('PATH', [ true,  "The URI path of the manager app (/deploy and /undeploy will be used)", '/manager'])
       ], self.class)
@@ -312,7 +312,7 @@ class MetasploitModule < Msf::Exploit::Remote
         origin_type: :service,
         module_fullname: self.fullname,
         private_type: :password,
-        private_data: datastore['HTTPPASSWORD'].downcase,
+        private_data: datastore['HttpPassword'].downcase,
         username: datastore['HTTPUSERNAME']
     }
 

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('HTTPUSERNAME', [false, 'The username to authenticate as']),
-        OptString.new('HTTPPASSWORD', [false, 'The password for the specified username']),
+        OptString.new('HttpPassword', [false, 'The password for the specified username']),
         # /cognos_express/manager/ for Cognos Express (19300)
         OptString.new('TARGETURI', [true, "The URI path of the manager app (/html/upload and /undeploy will be used)", '/manager'])
       ], self.class)
@@ -310,7 +310,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'       => 'POST',
       'ctype'        => 'multipart/form-data; boundary=---------------------------' + boundary_identifier,
       'user'         => datastore['HTTPUSERNAME'],
-      'password'     => datastore['HTTPPASSWORD'],
+      'password'     => datastore['HttpPassword'],
       'cookie'       => @session_id,
       'vars_get'     => vars_get,
       'data'         => generate_multipart_msg(boundary_identifier, war),
@@ -325,7 +325,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get'     => vars_get,
       'method'       => 'POST',
       'user'         => datastore['HTTPUSERNAME'],
-      'password'     => datastore['HTTPPASSWORD'],
+      'password'     => datastore['HttpPassword'],
       'cookie'       => @session_id
     })
 
@@ -417,7 +417,7 @@ class MetasploitModule < Msf::Exploit::Remote
         origin_type: :service,
         module_fullname: self.fullname,
         private_type: :password,
-        private_data: datastore['HTTPPASSWORD'].downcase,
+        private_data: datastore['HttpPassword'].downcase,
         username: datastore['HTTPUSERNAME']
     }
 

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('HTTPUSERNAME', [false, 'The username to authenticate as']),
+        OptString.new('HttpUsername', [false, 'The username to authenticate as']),
         OptString.new('HttpPassword', [false, 'The password for the specified username']),
         # /cognos_express/manager/ for Cognos Express (19300)
         OptString.new('TARGETURI', [true, "The URI path of the manager app (/html/upload and /undeploy will be used)", '/manager'])
@@ -309,7 +309,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'          => url,
       'method'       => 'POST',
       'ctype'        => 'multipart/form-data; boundary=---------------------------' + boundary_identifier,
-      'user'         => datastore['HTTPUSERNAME'],
+      'user'         => datastore['HttpUsername'],
       'password'     => datastore['HttpPassword'],
       'cookie'       => @session_id,
       'vars_get'     => vars_get,
@@ -324,7 +324,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'          => url,
       'vars_get'     => vars_get,
       'method'       => 'POST',
-      'user'         => datastore['HTTPUSERNAME'],
+      'user'         => datastore['HttpUsername'],
       'password'     => datastore['HttpPassword'],
       'cookie'       => @session_id
     })
@@ -418,7 +418,7 @@ class MetasploitModule < Msf::Exploit::Remote
         module_fullname: self.fullname,
         private_type: :password,
         private_data: datastore['HttpPassword'].downcase,
-        username: datastore['HTTPUSERNAME']
+        username: datastore['HttpUsername']
     }
 
     credential_data.merge!(service_data)

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -95,8 +95,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [false, 'The username to authenticate as']),
-        OptString.new('PASSWORD', [false, 'The password for the specified username']),
+        OptString.new('HTTPUSERNAME', [false, 'The username to authenticate as']),
+        OptString.new('HTTPPASSWORD', [false, 'The password for the specified username']),
         # /cognos_express/manager/ for Cognos Express (19300)
         OptString.new('TARGETURI', [true, "The URI path of the manager app (/html/upload and /undeploy will be used)", '/manager'])
       ], self.class)
@@ -309,8 +309,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'          => url,
       'method'       => 'POST',
       'ctype'        => 'multipart/form-data; boundary=---------------------------' + boundary_identifier,
-      'user'         => datastore['USERNAME'],
-      'password'     => datastore['PASSWORD'],
+      'user'         => datastore['HTTPUSERNAME'],
+      'password'     => datastore['HTTPPASSWORD'],
       'cookie'       => @session_id,
       'vars_get'     => vars_get,
       'data'         => generate_multipart_msg(boundary_identifier, war),
@@ -324,8 +324,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'          => url,
       'vars_get'     => vars_get,
       'method'       => 'POST',
-      'user'         => datastore['USERNAME'],
-      'password'     => datastore['PASSWORD'],
+      'user'         => datastore['HTTPUSERNAME'],
+      'password'     => datastore['HTTPPASSWORD'],
       'cookie'       => @session_id
     })
 
@@ -417,8 +417,8 @@ class MetasploitModule < Msf::Exploit::Remote
         origin_type: :service,
         module_fullname: self.fullname,
         private_type: :password,
-        private_data: datastore['PASSWORD'].downcase,
-        username: datastore['USERNAME']
+        private_data: datastore['HTTPPASSWORD'].downcase,
+        username: datastore['HTTPUSERNAME']
     }
 
     credential_data.merge!(service_data)

--- a/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
+++ b/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8001),
         OptString.new('HTTPUSERNAME', [false, "The username to authenticate with"]),
-        OptString.new('HTTPPASSWORD', [false, "The password to authenticate with"])
+        OptString.new('HttpPassword', [false, "The password to authenticate with"])
       ], self.class)
   end
 
@@ -127,6 +127,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def password
-    datastore['HTTPPASSWORD'].blank? ? DEFAULT_PASSWORD : datastore['HTTPPASSWORD']
+    datastore['HttpPassword'].blank? ? DEFAULT_PASSWORD : datastore['HttpPassword']
   end
 end

--- a/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
+++ b/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8001),
-        OptString.new('HTTPUSERNAME', [false, "The username to authenticate with"]),
+        OptString.new('HttpUsername', [false, "The username to authenticate with"]),
         OptString.new('HttpPassword', [false, "The password to authenticate with"])
       ], self.class)
   end
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def username
-    datastore['HTTPUSERNAME'].blank? ? DEFAULT_USERNAME : datastore['HTTPUSERNAME']
+    datastore['HttpUsername'].blank? ? DEFAULT_USERNAME : datastore['HttpUsername']
   end
 
   def password

--- a/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
+++ b/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
@@ -53,8 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8001),
-        OptString.new('USERNAME', [false, "The username to authenticate with"]),
-        OptString.new('PASSWORD', [false, "The password to authenticate with"])
+        OptString.new('HTTPUSERNAME', [false, "The username to authenticate with"]),
+        OptString.new('HTTPPASSWORD', [false, "The password to authenticate with"])
       ], self.class)
   end
 
@@ -123,10 +123,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def username
-    datastore['USERNAME'].blank? ? DEFAULT_USERNAME : datastore['USERNAME']
+    datastore['HTTPUSERNAME'].blank? ? DEFAULT_USERNAME : datastore['HTTPUSERNAME']
   end
 
   def password
-    datastore['PASSWORD'].blank? ? DEFAULT_PASSWORD : datastore['PASSWORD']
+    datastore['HTTPPASSWORD'].blank? ? DEFAULT_PASSWORD : datastore['HTTPPASSWORD']
   end
 end

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992'])
+        OptString.new('HttpPassword', [true, 'Password', '06071992'])
       ], self.class)
     register_advanced_options(
       [
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/sap/bc/soap/rfc',
       'method' => 'POST',
       'data' => data,
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
       'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
       'ctype' => 'text/xml; charset=UTF-8',
       'headers' => {

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992'])
       ], self.class)
     register_advanced_options(
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/sap/bc/soap/rfc',
       'method' => 'POST',
       'data' => data,
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
       'ctype' => 'text/xml; charset=UTF-8',
       'headers' => {

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -83,8 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992'])
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992'])
       ], self.class)
     register_advanced_options(
       [
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/sap/bc/soap/rfc',
       'method' => 'POST',
       'data' => data,
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
       'ctype' => 'text/xml; charset=UTF-8',
       'headers' => {

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HttpUsername', [true, 'Username', 'SAP*']),
         OptString.new('HttpPassword', [true, 'Password', '06071992'])
       ], self.class)
     register_advanced_options(
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/sap/bc/soap/rfc',
       'method' => 'POST',
       'data' => data,
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
+      'authorization' => basic_auth(datastore['HttpUsername'], datastore['HttpPassword']),
       'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
       'ctype' => 'text/xml; charset=UTF-8',
       'headers' => {

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
         OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992'])
+        OptString.new('HttpPassword', [true, 'Password', '06071992'])
       ], self.class)
     register_advanced_options(
       [
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/sap/bc/soap/rfc',
       'method' => 'POST',
       'data' => data,
-      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HttpPassword']),
       'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
       'ctype' => 'text/xml; charset=UTF-8',
       'headers' => {

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -84,8 +84,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8000),
         OptString.new('CLIENT', [true, 'SAP Client', '001']),
-        OptString.new('USERNAME', [true, 'Username', 'SAP*']),
-        OptString.new('PASSWORD', [true, 'Password', '06071992'])
+        OptString.new('HTTPUSERNAME', [true, 'Username', 'SAP*']),
+        OptString.new('HTTPPASSWORD', [true, 'Password', '06071992'])
       ], self.class)
     register_advanced_options(
       [
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/sap/bc/soap/rfc',
       'method' => 'POST',
       'data' => data,
-      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+      'authorization' => basic_auth(datastore['HTTPUSERNAME'], datastore['HTTPPASSWORD']),
       'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
       'ctype' => 'text/xml; charset=UTF-8',
       'headers' => {

--- a/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
+++ b/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(8899),
         OptBool.new('SSL', [ true, 'Use SSL', true ]),
         OptString.new('CMD', [ false,  "A single command to execute instead of the payload" ]),
-        OptString.new('HTTPUSERNAME', [ true,  "The user to authenticate as", 'oracle']),
+        OptString.new('HttpUsername', [ true,  "The user to authenticate as", 'oracle']),
         OptString.new('HttpPassword', [ true,  "The password to authenticate with" ])
       ], self.class)
 

--- a/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
+++ b/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptBool.new('SSL', [ true, 'Use SSL', true ]),
         OptString.new('CMD', [ false,  "A single command to execute instead of the payload" ]),
         OptString.new('HTTPUSERNAME', [ true,  "The user to authenticate as", 'oracle']),
-        OptString.new('HTTPPASSWORD', [ true,  "The password to authenticate with" ])
+        OptString.new('HttpPassword', [ true,  "The password to authenticate with" ])
       ], self.class)
 
     deregister_options(

--- a/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
+++ b/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
@@ -54,8 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(8899),
         OptBool.new('SSL', [ true, 'Use SSL', true ]),
         OptString.new('CMD', [ false,  "A single command to execute instead of the payload" ]),
-        OptString.new('USERNAME', [ true,  "The user to authenticate as", 'oracle']),
-        OptString.new('PASSWORD', [ true,  "The password to authenticate with" ])
+        OptString.new('HTTPUSERNAME', [ true,  "The user to authenticate as", 'oracle']),
+        OptString.new('HTTPPASSWORD', [ true,  "The password to authenticate with" ])
       ], self.class)
 
     deregister_options(

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('HTTPUSERNAME', [true, 'The HTTP username to specify for basic authentication', 'anonymous']),
+        OptString.new('HttpUsername', [true, 'The HTTP username to specify for basic authentication', 'anonymous']),
         OptString.new('HttpPassword', [true, 'The HTTP password to specify for basic authentication', 'mozilla@example.com'])
       ], self.class)
   end

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -70,8 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('USERNAME', [true, 'The HTTP username to specify for basic authentication', 'anonymous']),
-        OptString.new('PASSWORD', [true, 'The HTTP password to specify for basic authentication', 'mozilla@example.com'])
+        OptString.new('HTTPUSERNAME', [true, 'The HTTP username to specify for basic authentication', 'anonymous']),
+        OptString.new('HTTPPASSWORD', [true, 'The HTTP password to specify for basic authentication', 'mozilla@example.com'])
       ], self.class)
   end
 

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('HTTPUSERNAME', [true, 'The HTTP username to specify for basic authentication', 'anonymous']),
-        OptString.new('HTTPPASSWORD', [true, 'The HTTP password to specify for basic authentication', 'mozilla@example.com'])
+        OptString.new('HttpPassword', [true, 'The HTTP password to specify for basic authentication', 'mozilla@example.com'])
       ], self.class)
   end
 

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
       # The USERNAME and PASSWORD are registered again to make them more obvious they're
       # configurable.
-      OptString.new('HTTPUSERNAME',
+      OptString.new('HttpUsername',
         [false, 'The HTTP username to specify for authentication', '']),
       OptString.new('HttpPassword',
         [false, 'The HTTP password to specify for authentication', '']),

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # configurable.
       OptString.new('HTTPUSERNAME',
         [false, 'The HTTP username to specify for authentication', '']),
-      OptString.new('HTTPPASSWORD',
+      OptString.new('HttpPassword',
         [false, 'The HTTP password to specify for authentication', '']),
       OptString.new('PATH',
         [ true, 'The path to attempt to upload', '/metasploit%RAND%.asp']),

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -42,9 +42,9 @@ class MetasploitModule < Msf::Exploit::Remote
       [
       # The USERNAME and PASSWORD are registered again to make them more obvious they're
       # configurable.
-      OptString.new('USERNAME',
+      OptString.new('HTTPUSERNAME',
         [false, 'The HTTP username to specify for authentication', '']),
-      OptString.new('PASSWORD',
+      OptString.new('HTTPPASSWORD',
         [false, 'The HTTP password to specify for authentication', '']),
       OptString.new('PATH',
         [ true, 'The path to attempt to upload', '/metasploit%RAND%.asp']),


### PR DESCRIPTION
## What This Patch Does

When a module uses the HttpClient mixin but registers the USERNAME and PASSWORD datastore options in order to perform a form auth, it loses the ability to also perform a basic auth (sometimes it's
possible to see both). To avoid option name conflicts, basic auth options are now HttpUsername and HttpPassword.

Further more, this PR takes care of the following rules:
- In general, if a module performs a basic auth, it should be using HttpUsername and HttpPassword datastore options.
- If the module performs a form auth (sending the credential in a GET or POST request), then all (HttpUsername, HttpPassword, USERNAME, PASSWORD) can coexist. HttpUsername and HttpPassword are used in case the login form access is locked by basic auth, and USERNAME/PASSWORD are for the login form.
- If the module includes AuthBrute and HttpClient (which is common), but uses the AuthBrute mixin for basic auth, then we use the USERNAME and PASSWORD datastore options. This is necessary, because the AuthBrute uses these two options to import to its own credential list, and not HttpUsername and HttpPassword.
- If the module includes AuthBrute and HttpClient, but does not use the AuthBrute mixin for basic auth, then we can use HttpUsername and HttpPassword. Also, it should deregister USERNAME and PASSWORD if it's not really using the AuthBrute API at all (mostly the case w/ LoginScanner modules)
- If the LoginScanner uses HTTP, then make sure to pass HttpUsername and HttpPassword options from the module.

Fix #4885
## Verification

Verification is kind of tricky, because it's difficult to manually test them all. So I suggest:
- [x] Travis remains green
- [x] Make sure all the changes are following the rules.
- [x] Try to actually run as many modules as possible.
