### PR TITLE
fixes the exception handling in #exploit_simple

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -56,11 +56,11 @@ module Exploit
   # 	job.
   #
   def self.exploit_simple(oexploit, opts, &block)
+    exploit = oexploit.replicant
     # Trap and print errors here (makes them UI-independent)
     begin
-
       # Clone the module to prevent changes to the original instance
-      exploit = oexploit.replicant
+
       Msf::Simple::Framework.simplify_module( exploit, false )
       yield(exploit) if block_given?
 


### PR DESCRIPTION
The exception handling in the #exploit_simple method tries to set
error on exploit but exploit is defined within the begin block
causing a noMethodError on nilClass

MS-1608
