### PR TITLE
Added IP address to returned information.

### DIFF
--- a/modules/auxiliary/scanner/http/jenkins_enum.rb
+++ b/modules/auxiliary/scanner/http/jenkins_enum.rb
@@ -97,13 +97,13 @@ class MetasploitModule < Msf::Auxiliary
 
     case res.code
     when 200
-      print_good("#{uri_path} does not require authentication (200)")
+      print_good("#{full_uri} - #{uri_path} does not require authentication (200)")
       report_note({
         :type  => "jenkins_path",
         :host  => rhost,
         :port  => rport,
         :proto => 'tcp',
-        :data  => "#{uri_path} does not require authentication (200)",
+        :data  => "#{full_uri} - #{uri_path} does not require authentication (200)",
         :update => :unique_data
       })
       case app


### PR DESCRIPTION
This scanner module doesn't tell you the location of the found information. So when using the -R option to fill the RHOSTS all you get is a bunch of successful findings, however you won't know to which systems they belong.
