### PR TITLE
Fix Acunetix import with a blacklist

### DIFF
--- a/lib/rex/parser/acunetix_nokogiri.rb
+++ b/lib/rex/parser/acunetix_nokogiri.rb
@@ -333,9 +333,9 @@ module Rex
       return unless (host && port && scheme)
       address = resolve_address(host)
       return unless address
-      service_info = [ @args[:wspace], address, "tcp", port ]
-      service_object = db.get_service(*service_info)
-      service_object = db_report(:service,service_info) unless service_object
+      # If we didn't create the service, we don't care about the site
+      service_object = db.get_service @args[:wspace], address, "tcp", port
+      return unless service_object
       web_site_info = {
         :workspace => @args[:wspace],
         :service => service_object,


### PR DESCRIPTION
If a host is blacklisted, we won't create the service for it. If we
don't create the service, we don't want to create entries for the web
pages.

MS-1517
# Verification
- [x] Point pro to this branch
- [x] Import the file as specified in the ticket
- [x] See no hosts imported and a successfully completed task
- [x] Without a blacklist, the file should import as before
