### PR TITLE
Fix "username" key to add login in creds database

### DIFF
--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Post
       origin_type: :session,
       private_data: opts[:password],
       private_type: :password,
-      username: opts[:user]
+      username: opts[:username]
     }.merge(service_data)
 
     login_data = {


### PR DESCRIPTION
Fix a bad key name in opts variable, causing Filezilla login to no appear in the creds database.

Step to check :
- [x] msfconsole
- [x] use post/multi/gather/filezilla_client_cred
- [x] run
- [x] creds

Filezilla login must appear in "public" column.
