### PR TITLE
Fix #6948, avoid printing rhost:rport twice when using Msf::Exploit::Remote::SMB::Client

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -593,8 +593,7 @@ module Auxiliary::AuthBrute
       old_msg = msg.to_s.strip
       msg_regex = /(#{ip})(:#{port})?(\s*-?\s*)(#{proto.to_s})?(\s*-?\s*)(.*)/ni
       if old_msg.match(msg_regex) and !old_msg.match(msg_regex)[6].to_s.strip.empty?
-        complete_message = [ip,port].join(":")
-        (complete_message << " ") if ip
+        complete_message = ''
         complete_message << (old_msg.match(msg_regex)[4] || proto).to_s
         complete_message << " - "
         progress = tried_over_total(ip,port)
@@ -604,8 +603,7 @@ module Auxiliary::AuthBrute
         complete_message = msg.to_s.strip
       end
     else
-      complete_message = [ip,port].join(":")
-      (complete_message << " ") if ip
+      complete_message = ''
       complete_message << "#{proto.to_s.strip} - " if proto
       progress = tried_over_total(ip,port)
       complete_message << progress if progress

--- a/modules/auxiliary/admin/smb/check_dir_file.rb
+++ b/modules/auxiliary/admin/smb/check_dir_file.rb
@@ -64,11 +64,11 @@ class MetasploitModule < Msf::Auxiliary
       when "STATUS_OBJECT_PATH_NOT_FOUND"
         vprint_error("Object PATH \\\\#{rhost}\\#{datastore['SMBSHARE']}\\#{path} NOT found!")
       when "STATUS_ACCESS_DENIED"
-        vprint_error("Host #{rhost} reports access denied.")
+        vprint_error("Host reports access denied.")
       when "STATUS_BAD_NETWORK_NAME"
-        vprint_error("Host #{rhost} is NOT connected to #{datastore['SMBDomain']}!")
+        vprint_error("Host is NOT connected to #{datastore['SMBDomain']}!")
       when "STATUS_INSUFF_SERVER_RESOURCES"
-        vprint_error("Host #{rhost} rejected with insufficient resources!")
+        vprint_error("Host rejected with insufficient resources!")
       when "STATUS_OBJECT_NAME_INVALID"
         vprint_error("opeining \\#{path} bad filename")
       else
@@ -92,13 +92,13 @@ class MetasploitModule < Msf::Auxiliary
         check_path(path.chomp)
       end #end do
     rescue ::Rex::HostUnreachable
-      vprint_error("Host #{rhost} offline.")
+      vprint_error("Host offline.")
     rescue ::Rex::Proto::SMB::Exceptions::LoginError
-      print_error("Host #{rhost} login error.")
+      print_error("Host login error.")
     rescue ::Rex::ConnectionRefused
-      print_error "Host #{rhost} unable to connect - connection refused"
+      print_error "Unable to connect - connection refused"
     rescue ::Rex::Proto::SMB::Exceptions::ErrorCode
-      print_error "Host #{rhost} unable to connect to share #{datastore['SMBSHARE']}"
+      print_error "Unable to connect to share #{datastore['SMBSHARE']}"
     end # end begin
   end # end def
 end

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -41,11 +41,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def smb_delete_files
-    vprint_status("#{peer}: Connecting to the server...")
+    vprint_status("Connecting to the server...")
     connect()
     smb_login()
 
-    vprint_status("#{peer}: Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
+    vprint_status("Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
     self.simple.connect("\\\\#{rhost}\\#{datastore['SMBSHARE']}")
 
     remote_paths.each do |remote_path|
@@ -53,10 +53,10 @@ class MetasploitModule < Msf::Auxiliary
         simple.delete("\\#{remote_path}")
 
         # If there's no exception raised at this point, we assume the file has been removed.
-        print_good("#{peer}: Deleted: #{remote_path}")
+        print_good("Deleted: #{remote_path}")
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
         elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-        print_error("#{peer}: Cannot delete #{remote_path}: #{e.message}")
+        print_error("Cannot delete #{remote_path}: #{e.message}")
       end
     end
   end
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
       smb_delete_files
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
       elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-      print_error("#{peer}: Unable to login: #{e.message}")
+      print_error("Unable to login: #{e.message}")
     end
   end
 

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def smb_download
-    vprint_status("#{peer}: Connecting...")
+    vprint_status("Connecting...")
     connect()
     smb_login()
 
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
 
     remote_paths.each do |remote_path|
       begin
-        vprint_status("#{peer}: Trying to download #{remote_path}...")
+        vprint_status("Trying to download #{remote_path}...")
 
         data = ''
         fd = simple.open("\\#{remote_path}", 'ro')
@@ -62,10 +62,10 @@ class MetasploitModule < Msf::Auxiliary
 
         fname = remote_path.split("\\")[-1]
         path = store_loot("smb.shares.file", "application/octet-stream", rhost, data, fname)
-        print_good("#{peer}: #{remote_path} saved as: #{path}")
+        print_good("#{remote_path} saved as: #{path}")
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
         elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-        print_error("#{peer} Unable to download #{remote_path}: #{e.message}")
+        print_error("Unable to download #{remote_path}: #{e.message}")
       end
     end
   end
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
       smb_download
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
       elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-      print_error("#{peer} Unable to login: #{e.message}")
+      print_error("Unable to login: #{e.message}")
     end
   end
 

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -49,32 +49,32 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(_ip)
     begin
-      vprint_status("#{peer}: Connecting to the server...")
+      vprint_status("Connecting to the server...")
       connect()
       smb_login()
 
-      vprint_status("#{peer}: Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
+      vprint_status("Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
       self.simple.connect("\\\\#{rhost}\\#{datastore['SMBSHARE']}")
 
       remote_path = remote_paths.first
       local_paths.each do |local_path|
         begin
-          vprint_status("#{peer}: Trying to upload #{local_path} to #{remote_path}...")
+          vprint_status("Trying to upload #{local_path} to #{remote_path}...")
 
           fd = simple.open("\\#{remote_path}", 'rwct')
           data = ::File.read(datastore['LPATH'], ::File.size(datastore['LPATH']))
           fd.write(data)
           fd.close
 
-          print_good("#{peer}: #{local_path} uploaded to #{remote_path}")
+          print_good("#{local_path} uploaded to #{remote_path}")
         rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
           elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-          print_error("#{peer} Unable to upload #{local_path} to #{remote_path} : #{e.message}")
+          print_error("Unable to upload #{local_path} to #{remote_path} : #{e.message}")
         end
       end
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
       elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
-      print_error("#{peer} Unable to login: #{e.message}")
+      print_error("Unable to login: #{e.message}")
     end
   end
 end

--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       dcerpc_bind(handle)
     rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-      print_error("#{rhost} : #{e.message}")
+      print_error(e.message)
       return
     end
 
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Auxiliary
         share_type = share[1]
 
         if share_type == "DISK" && (share_name == "REMINST" || share_comm == "MDT Deployment Share")
-          vprint_good("#{ip}:#{rport} Identified deployment share #{share_name} #{share_comm}")
+          vprint_good("Identified deployment share #{share_name} #{share_comm}")
           deploy_shares << share_name
         end
       end
@@ -164,12 +164,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def query_share(share)
     share_path = "\\\\#{rhost}\\#{share}"
-    vprint_status("#{rhost}:#{rport} Enumerating #{share}...")
+    vprint_status("Enumerating #{share}...")
 
     begin
       simple.connect(share_path)
     rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-      print_error("#{rhost}:#{rport} Could not access share: #{share} - #{e}")
+      print_error("Could not access share: #{share} - #{e}")
       return
     end
 
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Auxiliary
         next unless cred['password'].to_s.length > 0
 
         report_creds(cred['domain'].to_s, cred['username'], cred['password'])
-        print_good("#{rhost}:#{rport} Credentials: " +
+        print_good("Credentials: " +
           "Path=#{share_path}#{file_path} " +
           "Username=#{cred['domain'].to_s}\\#{cred['username'].to_s} " +
           "Password=#{cred['password'].to_s}"
@@ -238,7 +238,7 @@ class MetasploitModule < Msf::Auxiliary
   def loot_unattend(data)
     return if data.empty?
     path = store_loot('windows.unattend.raw', 'text/plain', rhost, data, "Windows Deployment Services")
-    print_status("#{rhost}:#{rport} Stored unattend.xml in #{path}")
+    print_status("Stored unattend.xml in #{path}")
   end
 
   def report_creds(domain, user, pass)

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if(pass.length > 0)
-      print_status("#{ip} - Pipes: #{pass.map{|c| "\\#{c}"}.join(", ")}")
+      print_status("Pipes: #{pass.map{|c| "\\#{c}"}.join(", ")}")
       # Add Report
       report_note(
         :host	=> ip,

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -274,7 +274,7 @@ class MetasploitModule < Msf::Auxiliary
 
         begin
           dcerpc_bind(handle)
-          print_line("#{ip} - UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['SMBPIPE']}")
+          print_line("UUID #{uuid[0]} #{uuid[1]} OPEN VIA #{datastore['SMBPIPE']}")
           # Add Report
           report_note(
             :host	=> ip,

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -62,11 +62,11 @@ class MetasploitModule < Msf::Auxiliary
       when 'STATUS_OBJECT_PATH_NOT_FOUND'
         vprint_error("Object PATH \\\\#{ip}\\#{datastore['SMBSHARE']}\\#{path} NOT found!")
       when 'STATUS_ACCESS_DENIED'
-       vprint_error("Host #{ip} reports access denied.")
+       vprint_error("Host reports access denied.")
       when 'STATUS_BAD_NETWORK_NAME'
-        vprint_error("Host #{ip} is NOT connected to #{datastore['SMBDomain']}!")
+        vprint_error("Host is NOT connected to #{datastore['SMBDomain']}!")
       when 'STATUS_INSUFF_SERVER_RESOURCES'
-        vprint_error("Host #{ip} rejected with insufficient resources!")
+        vprint_error("Host rejected with insufficient resources!")
       when 'STATUS_OBJECT_NAME_INVALID'
         vprint_error("opening \\#{path} bad filename")
       else

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Auxiliary
         ))
     rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
       if e.error_code == 0xC00000BB
-        vprint_error("#{ip}:#{rport} - Got 0xC00000BB while enumerating shares, switching to srvsvc...")
+        vprint_error("Got 0xC00000BB while enumerating shares, switching to srvsvc...")
         @srvsvc = true # Make sure the module is aware of this state
         return srvsvc_netshareenum(ip)
       end
@@ -224,7 +224,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       dcerpc_bind(handle)
     rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-      vprint_error("#{ip} : #{e.message}")
+      vprint_error(e.message)
       return []
     end
 
@@ -336,7 +336,7 @@ class MetasploitModule < Msf::Auxiliary
         next
       end
       if not datastore['ShowFiles']
-        print_status("#{ip}:#{rport} - Spidering #{x}.")
+        print_status("Spidering #{x}.")
       end
       subdirs = [""]
       if x.strip() == "C$" and datastore['SpiderProfiles']
@@ -413,13 +413,13 @@ class MetasploitModule < Msf::Auxiliary
     unless detailed_tbl.rows.empty?
       if datastore['LogSpider'] == '1'
         p = store_loot('smb.enumshares', 'text/csv', ip, detailed_tbl.to_csv)
-        print_good("#{ip} - info saved in: #{p.to_s}")
+        print_good("info saved in: #{p.to_s}")
       elsif datastore['LogSpider'] == '2'
         p = store_loot('smb.enumshares', 'text/plain', ip, detailed_tbl)
-        print_good("#{ip} - info saved in: #{p.to_s}")
+        print_good("info saved in: #{p.to_s}")
       elsif datastore['LogSpider'] == '3'
         p = store_loot('smb.enumshares', 'text/plain', ip, logdata)
-        print_good("#{ip} - info saved in: #{p.to_s}")
+        print_good("info saved in: #{p.to_s}")
       end
     end
   end
@@ -453,10 +453,10 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         os_info     = get_os_info(ip, rport)
-        print_status("#{ip}:#{rport} - #{os_info}") if os_info
+        print_status(os_info) if os_info
 
         if shares.empty?
-          print_status("#{ip}:#{rport} - No shares collected")
+          print_status("No shares collected")
         else
           shares_info = shares.map{|x| "#{ip}:#{rport} - #{x[0]} - (#{x[1]}) #{x[2]}" }.join(", ")
           shares_info.split(", ").each { |share|
@@ -482,7 +482,7 @@ class MetasploitModule < Msf::Auxiliary
         raise $!
       rescue ::Rex::Proto::SMB::Exceptions::LoginError,
         ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-        print_error("#{ip}:#{rport} - #{e.message}")
+        print_error(e.message)
         return if e.message =~ /STATUS_ACCESS_DENIED/
       rescue Errno::ECONNRESET,
         ::Rex::Proto::SMB::Exceptions::InvalidType,
@@ -490,7 +490,7 @@ class MetasploitModule < Msf::Auxiliary
         ::Rex::Proto::SMB::Exceptions::InvalidCommand,
         ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
         ::Rex::Proto::SMB::Exceptions::NoReply => e
-        vprint_error("#{ip}:#{rport} - #{e.message}")
+        vprint_error(e.message)
         next if not shares.empty? and rport == 139 # no results, try again
       rescue Errno::ENOPROTOOPT
         print_status("Wait 5 seconds before retrying...")
@@ -499,7 +499,7 @@ class MetasploitModule < Msf::Auxiliary
       rescue ::Exception => e
         next if e.to_s =~ /execution expired/
         next if not shares.empty? and rport == 139
-        vprint_error("#{ip}:#{rport} - Error: '#{ip}' '#{e.class}' '#{e.to_s}'")
+        vprint_error("Error: '#{ip}' '#{e.class}' '#{e.to_s}'")
       ensure
         disconnect
       end

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -160,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
       resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
 
       if ! (resp and resp.length == 24)
-        print_error("#{ip} Invalid response from the Connect5 request")
+        print_error("Invalid response from the Connect5 request")
         disconnect
         return
       end
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if(perror != 0)
-        print_error("#{ip} Received error #{"0x%.8x" % perror} from the OpenPolicy2 request")
+        print_error("Received error #{"0x%.8x" % perror} from the OpenPolicy2 request")
         disconnect
         return
       end
@@ -312,7 +312,7 @@ class MetasploitModule < Msf::Auxiliary
           extra << "PasswordMin=#{domains[domain][:pass_min]} "
           extra << ")"
         end
-        print_status("#{ip} #{domain.upcase} [ #{users.keys.map{|k| users[k]}.join(", ")} ] #{extra}")
+        print_status("#{domain.upcase} [ #{users.keys.map{|k| users[k]}.join(", ")} ] #{extra}")
       end
 
       # cleanup

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -186,11 +186,11 @@ class MetasploitModule < Msf::Auxiliary
         end
 
       rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-        print_line("UUID #{uuid[0]} #{uuid[1]} ERROR 0x%.8x" % e.error_code)
+        print_error("UUID #{uuid[0]} #{uuid[1]} ERROR 0x%.8x" % e.error_code)
         #puts e
         #return
       rescue ::Exception => e
-        print_line("UUID #{uuid[0]} #{uuid[1]} ERROR #{$!}")
+        print_error("UUID #{uuid[0]} #{uuid[1]} ERROR #{$!}")
         #puts e
         #return
       end

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -163,11 +163,11 @@ class MetasploitModule < Msf::Auxiliary
 
         if datastore['VERBOSE']
           accounts.each do |x|
-            print_status ip + " : " + x[:logon_domain] + "\\" + x[:account_name] +
+            print_status x[:logon_domain] + "\\" + x[:account_name] +
               "\t(logon_server: #{x[:logon_server]}, other_domains: #{x[:other_domains]})"
           end
         else
-          print_status "#{ip} : #{accounts.collect{|x| x[:logon_domain] + "\\" + x[:account_name]}.join(", ")}"
+          print_status "#{accounts.collect{|x| x[:logon_domain] + "\\" + x[:account_name]}.join(", ")}"
         end
 
         found_accounts = []
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Auxiliary
             next
           end
 
-          print_good("#{ip} - Found user: #{comp_user}")
+          print_good("Found user: #{comp_user}")
           store_username(comp_user, resp, ip, rport)
         end
 

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -90,9 +90,9 @@ class MetasploitModule < Msf::Auxiliary
     bogus_result = @scanner.attempt_bogus_login(domain)
     if bogus_result.success?
       if bogus_result.access_level == Metasploit::Framework::LoginScanner::SMB::AccessLevels::GUEST
-        print_status("#{ip} - This system allows guest sessions with any credentials")
+        print_status("This system allows guest sessions with any credentials")
       else
-        print_error("#{ip} - This system accepts authentication with any credentials, brute force is ineffective.")
+        print_error("This system accepts authentication with any credentials, brute force is ineffective.")
         return
       end
     end

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
       resp = dcerpc.last_response ? dcerpc.last_response.stub_data : nil
 
       if ! (resp and resp.length == 24)
-        print_error("#{ip} Invalid response from the OpenPolicy request")
+        print_error("Invalid response from the OpenPolicy request")
         disconnect
         return
       end
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if(perror != 0)
-        print_error("#{ip} Received error #{"0x%.8x" % perror} from the OpenPolicy2 request")
+        print_error("Received error #{"0x%.8x" % perror} from the OpenPolicy2 request")
         disconnect
         return
       end
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Auxiliary
       domain_sid, domain_name = smb_parse_sid(resp)
 
       # Store SID, local domain name, joined domain name
-      print_status("#{ip} PIPE(#{lsa_pipe}) LOCAL(#{host_name} - #{host_sid}) DOMAIN(#{domain_name} - #{domain_sid})")
+      print_status("PIPE(#{lsa_pipe}) LOCAL(#{host_name} - #{host_sid}) DOMAIN(#{domain_name} - #{domain_sid})")
 
       domain = {
         :name    => host_name,
@@ -226,7 +226,7 @@ class MetasploitModule < Msf::Auxiliary
       when 'DOMAIN'
         # Fallthrough to the host SID if no domain SID was returned
         unless domain_sid
-          print_error("#{ip} No domain SID identified, falling back to the local SID...")
+          print_error("No domain SID identified, falling back to the local SID...")
         end
         domain_sid || host_sid
       end
@@ -265,13 +265,13 @@ class MetasploitModule < Msf::Auxiliary
         utype,uname = smb_parse_sid_lookup(resp)
         case utype
         when 1
-          print_status("#{ip} USER=#{uname} RID=#{rid}")
+          print_status("USER=#{uname} RID=#{rid}")
           domain[:users][rid] = uname
         when 2
           domain[:groups][rid] = uname
-          print_status("#{ip} GROUP=#{uname} RID=#{rid}")
+          print_status("GROUP=#{uname} RID=#{rid}")
         else
-          print_status("#{ip} TYPE=#{utype} NAME=#{uname} rid=#{rid}")
+          print_status("TYPE=#{utype} NAME=#{uname} rid=#{rid}")
         end
       end
 
@@ -284,7 +284,7 @@ class MetasploitModule < Msf::Auxiliary
         :data => domain
       )
 
-      print_status("#{ip} #{domain[:name].upcase} [#{domain[:users].keys.map{|k| domain[:users][k]}.join(", ")} ]")
+      print_status("#{domain[:name].upcase} [#{domain[:users].keys.map{|k| domain[:users][k]}.join(", ")} ]")
       disconnect
       return
 
@@ -295,7 +295,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Rex::Proto::SMB::Exceptions::LoginError
       next
     rescue ::Exception => e
-      print_line("Error: #{ip} #{e.class} #{e}")
+      print_line("Error: #{e.class} #{e}")
     end
     end
   end

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Auxiliary
           match_conf['host.domain'] = conf[:SMBDomain]
         end
 
-        print_status("#{rhost}:#{rport} is running #{desc}")
+        print_status("Host is running #{desc}")
 
         # Report the service with a friendly banner
         report_service(
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
       else
         desc = "#{res['native_os']} (#{res['native_lm']})"
         report_service(:host => ip, :port => rport, :name => 'smb', :info => desc)
-        print_status("#{rhost}:#{rport} could not be identified: #{desc}")
+        print_status("Host could not be identified: #{desc}")
       end
 
       # Report a smb.fingerprint hash of attributes for OS fingerprinting

--- a/modules/exploits/windows/oracle/extjob.rb
+++ b/modules/exploits/windows/oracle/extjob.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
       execute_cmdstager({:linemax => 1500})
       handler
     else
-      print_error "#{rhost} does not appear to be vulnerable!"
+      print_error "Host does not appear to be vulnerable!"
     end
   end
 


### PR DESCRIPTION
## What This Patch Does

This removes the extra rhost:rport prefix from modules when using print_*. These modules specifically use Msf::Exploit::Remote::SMB::Client, and that mixin already prints the rhost:rport prefix for us.

I actually had to remove the rhost:rport prefix from the print_brute API in Msf::Auxiliary::AuthBrute, reason being it is possible to see Msf::Exploit::Remote::SMB::Client and Msf::Auxiliary::AuthBrute at the same time. After some discussion we feel it's not a good idea to have the prefix implemented in the AuthBrute mixin, instead it should be on the protocol level (like TCP, UDP, HTTP, etc, etc). Some drawbacks: if a module is not using a mixin that comes from TCP (such as HttpClient), and that it is using print_brute from AuthBrute, then it's no longer printing the prefix. This might be more of a case for login modules, or SSH modules (because we don't have an SSH mixin, we use the Ruby).

After you land this PR, I can go ahead and address those problems.
## Verification
- [x] Manually review the code changes, and make sure that all these changed modules are using the Msf::Exploit::Remote::SMB::Client mixin.
- [x] Set up an SMB server for testing. If you have a server class Windows (such as 2003), you are already good to go.
- [x] Start msfconsole
- [x] Run at least these modules against the SMB server, you should see that they are not printing rhost:rport twice anymore (should be just once):
  - [x] auxiliary/admin/smb/check_dir_file
  - [x] auxiliary/admin/smb/delete_file
  - [x] auxiliary/admin/smb/download_file
  - [x] auxiliary/admin/smb/upload_file
  - [x] auxiliary/scanner/smb/smb_enumshares
  - [x] auxiliary/scanner/smb/smb_enumusers
  - [x] auxiliary/scanner/smb/smb_enumusers_domain
  - [x] auxiliary/scanner/smb/smb_login
  - [x] auxiliary/scanner/smb/smb_version
