### PR TITLE
Check presence in local admin group

### DIFF
--- a/modules/post/windows/gather/win_privs.rb
+++ b/modules/post/windows/gather/win_privs.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Post
     usr_tbl = Rex::Ui::Text::Table.new(
       'Header'  => 'Current User',
       'Indent'  => 1,
-      'Columns' => ['Is Admin', 'Is System', 'UAC Enabled', 'Foreground ID', 'UID']
+      'Columns' => ['Is Admin', 'Is System', 'Is In Local Admin Group', 'UAC Enabled', 'Foreground ID', 'UID']
     )
 
     privs_tbl = Rex::Ui::Text::Table.new(
@@ -39,10 +39,11 @@ class MetasploitModule < Msf::Post
     )
 
     # Gather data
-    uac   = is_uac_enabled? ? 'True' : 'False'
-    admin = is_admin? ? 'True' : 'False'
-    sys   = is_system? ? 'True' : 'False'
-    uid   = client.sys.config.getuid.inspect
+    uac         = is_uac_enabled? ? 'True' : 'False'
+    admin       = is_admin? ? 'True' : 'False'
+    admin_group = is_in_admin_group? ? 'True' : 'False'
+    sys         = is_system? ? 'True' : 'False'
+    uid         = client.sys.config.getuid.inspect
     begin
       # Older OS might not have this (min support is XP)
       fid = client.railgun.kernel32.WTSGetActiveConsoleSessionId["return"]
@@ -52,7 +53,7 @@ class MetasploitModule < Msf::Post
     privs = client.sys.config.getprivs
 
     # Store in tables
-    usr_tbl << [admin, sys, uac, fid, uid]
+    usr_tbl << [admin, sys, admin_group, uac, fid, uid]
     privs.each do |priv|
       privs_tbl << [priv]
     end


### PR DESCRIPTION
## Verification

As the "is_admin?" function only checks if the current session effectively has admin rights, I offer to add a check to know if the current user is in the local admin group using the "is_in_admin_group?" function. This information is better suited to check if admin rights are obtainable using the "bypassuac" module.

Before change

```
msf post(win_privs) > run

Current User
============

 Is Admin  Is System  UAC Enabled  Foreground ID  UID
 --------  ---------  -----------  -------------  ---
 False     False      True         1              "PC1\\User"

Windows Privileges
==================

 Name
 ----
 SeChangeNotifyPrivilege
 SeShutdownPrivilege
 SeUndockPrivilege
```

After change

```
msf post(win_privs) > run

Current User
============

 Is Admin  Is System  Is In Local Admin Group  UAC Enabled  Foreground ID  UID
 --------  ---------  -----------------------  -----------  -------------  ---
 False     False      True                     True         1              "PC1\\User"

Windows Privileges
==================

 Name
 ----
 SeChangeNotifyPrivilege
 SeShutdownPrivilege
 SeUndockPrivilege

[*] Post module execution completed
```
