### PR TITLE
get_uri missing port fix

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -425,7 +425,7 @@ module Exploit::Remote::HttpServer
       host = "[#{host}]"
     end
 
-    if datastore['URIPORT'] != 0
+    if datastore['URIPORT'] &&  datastore['URIPORT'] != 0
       port = ':' + datastore['URIPORT'].to_s
     elsif (ssl and datastore["SRVPORT"] == 443)
       port = ''


### PR DESCRIPTION
This change checks for the presence of datastore['URIPORT'] before checking if it is not equal to zero. When datastore['URIPORT'] is set to nil, the != 0 statement evaluates to true, causing get_uri to use an empty port number.
## Verification
- [x] Start `msfconsole`
- [x] Use a module that relies on get_uri. E.g., `use exploit/multi/script/web_delivery`
- [x] Set LHOST, e.g., `set LHOST 192.168.133.7`
- [x] **Verify** provided output includes the correct port number

**Ref:** See missing port issues noted in PR #6961
