### PR TITLE
Create #make_fast_nops for huge NOP chunks

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1002,6 +1002,30 @@ class Exploit < Msf::Module
     }
   end
 
+
+  #
+  # Generates a NOP sled using the #make_nops method.
+  # The difference between this and #make_nops is this method is much faster, good for exploit
+  # developers that actually want huge chunks of NOPs. The downside of using this is the NOP sled
+  # is less randomized.
+  #
+  # @param count [String] Number of NOPs to return.
+  # @return [String] NOPs
+  #
+  def make_fast_nops(count)
+    max_nop_chunk_size = 100
+
+    if count < max_nop_chunk_size
+      return make_nops(count)
+    end
+
+    nops = make_nops(max_nop_chunk_size)
+    nops += nops while nops.length < count
+
+    nops[0, count]
+  end
+
+
   #
   # Generates a nop sled of a supplied length and returns it to the caller.
   #


### PR DESCRIPTION
## What This Patch Does

This patch creates a new method called make_fast_nops in order to create large chunks of NOPs faster than make_nops.

Some backstory about this. So first off, make_nops is an expensive operation. Ever since my first day at Metasploit, I've always been told to avoid generating a huge chunk of NOPs by using make_nops. [I still enforce that practice today](https://github.com/rapid7/metasploit-framework/pull/6940#discussion_r66088575). Basically I just tell people to create a small chunk using make_nops, and then use that to build to whole buffer. Instead of making people do it manually on the module's level, I figured it should be an API method people can use.

Some pros and cons about make_nops vs make_fast_nops:
- make_fast_nops is fast, but less random, therefore less evasive.
- make_nops is slow, but more random, therefore more evasive (but in reality I bet people have found ways to flag this anyway)
## Verification
- [x] Save the following script:

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Exploit::Remote

  Rank = NormalRanking

  def initialize(info={})
    super(update_info(info,
      'Name'            => "Benchmark NOP Generating Methods",
      'Description'     => %q{
        This module tests the performance of make_nops vs make_fast_nops
      },
      'License'         => MSF_LICENSE,
      'Author'          => [ 'sinn3r' ],
      'References'      => [ [ 'URL', 'http://metasploit.com' ] ],
      'Platform'        => 'win',
      'Targets'         => [ [ 'Windows', {} ] ],
      'Payload'         => { 'BadChars' => "\x00" },
      'Privileged'      => false,
      'DisclosureDate'  => "Jun 10 2016",
      'DefaultTarget'   => 0))
  end

  def bench_nops
    max = 50000
    c = 3

    print_line

    print_status("Using make_fast_nops")
    t1 = Time.now
    c.times { make_fast_nops(max) }
    t2 = Time.now
    print_status("Completed. Time spent for make_fast_nops: #{(t2-t1).to_f}")

    print_line "=" * 10

    print_status("Using make_nops")
    t1 = Time.now
    c.times { make_nops(max) }
    t2 = Time.now
    print_status("Completed. Time spent for make_nops: #{(t2-t1).to_f}")
  end

  def exploit
    bench_nops
  end

end
```
- [x] You should see that make_fast_nops is significantly faster than make_nops. The output looks something like this:

```
msf exploit(benchmark_nops) > run

[*] Started reverse TCP handler on xxx.xxx.xxx.xxx:4444 

[*] Using make_fast_nops
[*] Completed. Time spent for make_fast_nops: 0.012195
==========
[*] Using make_nops
[*] Completed. Time spent for make_nops: 7.754217
[*] Exploit completed, but no session was created.
msf exploit(benchmark_nops) > 
```
- [x] Save the following script:

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Exploit::Remote

  Rank = NormalRanking

  include Msf::Exploit::EXE
  include Msf::Exploit::FILEFORMAT

  def initialize(info={})
    super(update_info(info,
      'Name'            => "make_fast_nops Payload",
      'Description'     => %q{
        This module generates a messagebox payload with make_fast_nops
      },
      'License'         => MSF_LICENSE,
      'Author'          => [ 'sinn3r' ],
      'References'      => [ [ 'URL', 'http://metasploit.com' ] ],
      'Platform'        => 'win',
      'Targets'         => [ [ 'Windows', {} ] ],
      'Payload'         => { 'BadChars' => "\x00" },
      'Privileged'      => false,
      'DisclosureDate'  => "Jun 10 2016",
      'DefaultTarget'   => 0))
  end

  def file_format_filename
    'test.exe'
  end

  def exploit
    datastore['PAYLOAD'] = 'windows/messagebox'
    file_create(generate_payload_exe(
      code: make_fast_nops(100000) + payload.encoded
    ))
  end

end
```
- [x] Run the above script. It should generate a Windows executable.
- [x] Copy the executable to a Windows.
- [x] If you check the file's property, the size is about this big (which proves you have the huge chunk of NOPs):

<img width="392" alt="screen shot 2016-06-13 at 3 39 20 pm" src="https://cloud.githubusercontent.com/assets/1170914/16022351/09d39a24-317d-11e6-8977-194b904be1b1.png">
- [x] Double click on the executable, you should see this prompt (which indicates the NOPs and payload are working properly):

<img width="163" alt="screen shot 2016-06-13 at 3 40 20 pm" src="https://cloud.githubusercontent.com/assets/1170914/16022374/27de3ee8-317d-11e6-9534-7330008971d6.png">

Feel free to generate the exe and run it a couple of times.
