### PR TITLE
Add missing rank check to msftidy

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -422,6 +422,8 @@ class Msftidy
       if not available_ranks.include?($1)
         error("Invalid ranking. You have '#{$1}'")
       end
+    else
+      info('No Rank specified. The default is NormalRanking.')
     end
   end
 

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -423,7 +423,7 @@ class Msftidy
         error("Invalid ranking. You have '#{$1}'")
       end
     else
-      info('No Rank specified. The default is NormalRanking.')
+      info('No Rank specified. The default is NormalRanking. Please add an explicit Rank value.')
     end
   end
 


### PR DESCRIPTION
Quick patch for `msftidy` to check for missing rank in exploit modules.
- [x] Delete the rank from an existing module
- [x] Run `msftidy` against the module
- [x] Verify that an info message pops up
- [x] Make sure you don't commit the changed module
