### PR TITLE
more verbose info -d #6964

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -778,8 +778,13 @@ class Core
         if dump_json
           print(Serializer::Json.dump_module(active_module) + "\n")
         elsif show_doc
-          print_status("Please wait, generating documentation for #{active_module.shortname}")
-          Msf::Util::DocumentGenerator.spawn_module_document(active_module)
+          f = Rex::Quickfile.new(["#{active_module.shortname}_doc", '.html'])
+          begin
+            print_status("Generating documentation for #{active_module.shortname}, then opening #{f.path} in a browser...")
+            Msf::Util::DocumentGenerator.spawn_module_document(active_module, f)
+          ensure
+            f.close if f
+          end
         else
           print(Serializer::ReadableText.dump_module(active_module))
         end
@@ -801,8 +806,13 @@ class Core
       elsif dump_json
         print(Serializer::Json.dump_module(mod) + "\n")
       elsif show_doc
-        print_status("Please wait, generating documentation for #{mod.shortname}")
-        Msf::Util::DocumentGenerator.spawn_module_document(mod)
+        f = Rex::Quickfile.new(["#{active_module.shortname}_doc", '.html'])
+        begin
+          print_status("Generating documentation for #{active_module.shortname}, then opening #{f.path} in a browser...")
+          Msf::Util::DocumentGenerator.spawn_module_document(active_module, f)
+        ensure
+          f.close if f
+        end
       else
         print(Serializer::ReadableText.dump_module(mod))
       end

--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -15,15 +15,12 @@ module Msf
       # Spawns a module document with a browser locally.
       #
       # @param mod [Msf::Module] Module to create document for.
+      # @param out_file [Rex::Quickfile] File handle to write the document to.
       # @return [void]
-      def self.spawn_module_document(mod)
+      def self.spawn_module_document(mod, out_file)
         md = get_module_document(mod)
-        f = Rex::Quickfile.new(["#{mod.shortname}_doc", '.html'])
-        f.write(md)
-        f.close
-        kb_path = f.path
-        print_status("Opening web browser for file://#{kb_path}")
-        Rex::Compat.open_webrtc_browser("file://#{kb_path}")
+        out_file.write(md)
+        Rex::Compat.open_webrtc_browser("file://#{out_file.path}")
       end
 
 

--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -22,7 +22,7 @@ module Msf
         f.write(md)
         f.close
         kb_path = f.path
-
+        print_status("Opening web browser for file://#{kb_path}")
         Rex::Compat.open_webrtc_browser("file://#{kb_path}")
       end
 


### PR DESCRIPTION
Solves #6964 by notifying the user that a web browser is opening the html file.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/psexec` (module doesn't matter
- [x] `info -d`
- [x] **Verify**  You should see something similar to
  `[*] Generating documentation for psexec, then opening /tmp/psexec_doc20160615-3582-1ay1yw8.html in a browser...`
- [x] `info -d exploit/windows/smb/psexec`
- [x] **Verify** the thing does what it should

You should see something similar to
`[*] Generating documentation for psexec, then opening /tmp/psexec_doc20160615-3582-1c5tfa3.html in a browser...`
- [x] **Verify** You should **NOT** see the old way of not mentioning a browser doesn't show
  `[*] Please wait, generating documentation for psexec`
