### PR TITLE
adding karaf to unix wordlists

### DIFF
--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1004,3 +1004,4 @@ raspberry
 74k&^*nh#$
 arcsight
 MargaretThatcheris110%SEXY
+karaf

--- a/data/wordlists/unix_users.txt
+++ b/data/wordlists/unix_users.txt
@@ -40,6 +40,7 @@ hplip
 informix
 install
 irc
+karaf
 kernoops
 libuuid
 list


### PR DESCRIPTION
Per @wchen-r7 's last comment on #4358 adding karaf to the unix_*.txt wordlists.  This should finish out that ticket so it can be closed.

**Verification**
- [x] see 'karaf' in both files

When this merges, #4358 should be able to be closed! (Resolves #4358.)
