### PR TITLE
Fix unused SessionType in two modules

### DIFF
--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
           'Donny Maasland <donny.maasland[at]fox-it.com>',
         ],
       'Platform'       => [ 'win' ],
-      'SessionTypes'   => [ 'meterpreter', 'cmd' ],
+      'SessionTypes'   => [ 'meterpreter', 'shell' ],
       'Targets'        =>
         [
           [ 'Automatic', { } ]

--- a/modules/post/windows/manage/sticky_keys.rb
+++ b/modules/post/windows/manage/sticky_keys.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Post
       },
       'Author'        => ['OJ Reeves'],
       'Platform'      => ['win'],
-      'SessionTypes'  => ['meterpreter', 'cmd'],
+      'SessionTypes'  => ['meterpreter', 'shell'],
       'Actions'       => [
         ['ADD',    {'Description' => 'Add the backdoor to the target.'}],
         ['REMOVE', {'Description' => 'Remove the backdoor from the target.'}]


### PR DESCRIPTION
I missed this while reviewing #5760.
- [x] Look for the `cmd` as a session type in `lib/msf/base/sessions`
- [x] Find nothing
- [x] Assume `shell` was intended
- [x] Merge this, yo
