### PR TITLE
Add Msf::Util::EXE.to_zip to create ZIP files more easily

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -74,6 +74,29 @@ require 'msf/core/exe/segment_appender'
     template % hash_sub
   end
 
+
+  # Generates a ZIP file.
+  #
+  # @param files [Array<Hash>] Items to compress. Each item is a hash that supports these options:
+  #  * :data - The content of the file.
+  #  * :fname - The file path in the ZIP file
+  #  * :comment - A comment
+  # @example Compressing two files, one in a folder called 'test'
+  #   Msf::Util::EXE.to_zip([{data: 'AAAA', fname: "file1.txt"}, {data: 'data', fname: 'test/file2.txt'}])
+  # @return [String]
+  def self.to_zip(files)
+    zip = Rex::Zip::Archive.new
+
+    files.each do |f|
+      data    = f[:data]
+      fname   = f[:fname]
+      comment = f[:comment] || ''
+      zip.add_file(fname, data, comment)
+    end
+
+    zip.pack
+  end
+
   # Executable generators
   #
   # @param arch       [Array<String>] The architecture of the system (i.e :x86, :x64)


### PR DESCRIPTION
## What This Does

Msf::Util::EXE.to_zip allows you to create a ZIP file more easily without the need to figure out how the Rex part works. Every once in a while, something like this is needed for exploitation.
## Verification
- [x] Start msfconsole
- [x] In the msf prompt, enter: `irb`, and you're in irb mode.
- [x] Do the following in irb: `File.open('/tmp/files.zip', 'wb') { |f| f.write(Msf::Util::EXE.to_zip([{data: "AAAA", fname: "file1.txt"}, {data: "BBBB", fname: "new_folder/file2.txt"}])) }`
- [x] Inspect /tmp/files.zip. Unzip it, and you should see there is a text file named "file1.txt". And there is another "file2.txt" in the "new_folder" directory.
