### PR TITLE
Added JCL header data to mainframe payload module

### DIFF
--- a/lib/msf/core/payload/mainframe.rb
+++ b/lib/msf/core/payload/mainframe.rb
@@ -2,32 +2,56 @@
 require 'msf/core'
 
 ###
-#
 # This class is here to implement advanced features for mainframe based
 # payloads. Mainframe payloads are expected to include this module if
 # they want to support these features.
-#
 ###
 module Msf::Payload::Mainframe
-
-  #
-  # Z notes
-  # Z notes
-  #
   def initialize(info = {})
-    ret = super(info)
+    super(info)
   end
 
-  #
+  ##
   # Returns a list of compatible encoders based on mainframe architecture
   # most will not work because of the different architecture
   # an XOR-based encoder will be defined soon
-  #
+  ##
   def compatible_encoders
-    encoders = super()
-    encoders2 = ['/generic\/none/','none']
-
-    return encoders2
+    encoders2 = ['/generic\/none/', 'none']
+    encoders2
   end
 
+  ###
+  # This method is here to implement advanced features for cmd:jcl based
+  # payloads.  Common to all are the JCL Job Card, and its options which
+  # are defined here. It is optional for other mainframe payloads.
+  ###
+  def jcl_jobcard
+    # format paramaters with basic constraints
+    # see http://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/
+    #     com.ibm.zos.v2r1.ieab600/iea3b6_Parameter_field8.htm
+    #
+    jobname = format('%1.8s', datastore['JOBNAME']).strip.upcase
+    actnum  = format('%1.60s', datastore['ACTNUM']).strip.upcase
+    pgmname = format('%1.20s', datastore['PGMNAME']).strip
+    jclass  = format('%1.1s', datastore['JCLASS']).strip.upcase
+    notify  = format('%1.8s', datastore['NOTIFY']).strip.upcase
+    notify  = if !notify.empty? && datastore['NTFYUSR']
+                "//   NOTIFY=#{notify}, \n"
+              else
+                ""
+              end
+    msgclass = format('%1.1s', datastore['MSGCLASS']).strip.upcase
+    msglevel = format('%5.5s', datastore['MSGLEVEL']).strip
+
+    # build payload
+    "//#{jobname} JOB "            \
+    "(#{actnum}),\n"               \
+    "//   '#{pgmname}',\n"         \
+    "//   CLASS=#{jclass},\n"      \
+    "#{notify}"                    \
+    "//   MSGCLASS=#{msgclass},\n" \
+    "//   MSGLEVEL=#{msglevel},\n" \
+    "//   REGION=0M \n"
+  end
 end


### PR DESCRIPTION
#### Summary

Existing and future JCL payloads have to have a JOB statement -
basically data that defines the job to z/OS.  See:
http://www.ibm.com/support/knowledgecenter/zosbasics/com.ibm.zos.zjcl/zjclc_jclJOBstmtfreqused.htm

It has information about the job's owner, place it will run, output creation, etc.  All JCL
shares the same job card format.  As such, creating a shared payload
module of JCL allows this text to be imported into any JCL payload.
Additionally, that job card is now parameterized, allowing the
exploit/payload user to edit these job card values-as this may be needed
in order to run the job successfully on any given system.

This information is currently hard coded into the existing payloads.  However, it will be more manageable if it is centralized - and parameterized.
#### Examples

For example - existing payloads have headers like this (From generic_jcl.rb):

```
 51   ##
 52   # Build the command string for JCL submission
 53   ##
 54   def command_string
 55     "//DUMMY  JOB (MFUSER),'dummy job',\n" \
 56     "//   NOTIFY=&SYSUID,\n" \
 57     "//   MSGCLASS=H,\n" \
 58     "//   MSGLEVEL=(1,1),\n" \
 59     "//   REGION=0M\n" \
 60     "//   EXEC PGM=IEFBR14\n"
```

After this PR (and the next one, which will be for the payloads themselves)
that payload would look like this:

```
 70   def command_string
 71     jcl_jobcard +
 72     "//   EXEC PGM=IEFBR14\n"
 73   end
```

And then will yield the exact same output.     More details on how to implement the method, and the options provided will be in the PRs with the Payload updates.
#### Files included in this PR

Cleanup of the mainframe module + additional method for the JCL text mentioned above
#### Parameter

Payloads using this must implement the options mentioned in the datastore lines using defaults.  Only the case and length are checked.
- JOBNAME
- ACTNUM
- PGMNAME
- JCLASS
- NOTIFY
- NTFYUSR <- this is not a JCL parm, rather boolean to include NOTIFY or not
- MSGCLASS
- MSGLEVEL

See the following URL for descriptions of each:
http://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.ieab600/iea3b6_Parameter_field8.htm
