### PR TITLE
Fix connect to smb with russians logins

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ PATH
       sqlite3
       tzinfo
       tzinfo-data
+      unicode_utils
 
 GEM
   remote: https://rubygems.org/
@@ -134,7 +135,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-credential (2.0.2)
+    metasploit-credential (2.0.3)
       metasploit-concern
       metasploit-model
       metasploit_data_models
@@ -258,6 +259,7 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2016.5)
       tzinfo (>= 1.0.0)
+    unicode_utils (1.4.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)

--- a/lib/rex/proto/smb/simpleclient.rb
+++ b/lib/rex/proto/smb/simpleclient.rb
@@ -41,8 +41,12 @@ attr_accessor :socket, :client, :direct, :shares, :last_share
       send_lm = true, use_lanman_key = false, send_ntlm = true,
       native_os = 'Windows 2000 2195', native_lm = 'Windows 2000 5.0', spnopt = {})
 
-    begin
+    if RUBY_VERSION < '2.4'
+      require "unicode_utils/upcase"
+      user = UnicodeUtils.upcase(user.force_encoding('UTF-8'))
+    end
 
+    begin
       if (self.direct != true)
         self.client.session_request(name)
       end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -96,6 +96,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'patch_finder'
   # TimeZone info
   spec.add_runtime_dependency 'tzinfo-data'
+  # Needed for fix upcase functionality in unicode strings for ruby < 2.4
+  spec.add_runtime_dependency 'unicode_utils'
 
   #
   # REX Libraries
@@ -110,7 +112,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rex-zip'
   # Library for parsing offline Windows Registry files
   spec.add_runtime_dependency 'rex-registry'
-  
+
   # rb-readline doesn't work with Ruby Installer due to error with Fiddle:
   #   NoMethodError undefined method `dlopen' for Fiddle:Module
   unless Gem.win_platform?


### PR DESCRIPTION
In ruby < 2.4 does not work upcase for unicode strings. String.upcase was used in smb auth. And if SMBLogin is a unicode string (for example Администратор) upcase not work.

``` ruby
2.3.1 :001 > "Администратор".upcase
 => "Администратор"
2.3.1 :002 > require "unicode_utils/upcase"
 => true
2.3.1 :003 > UnicodeUtils.upcase("Администратор")
 => "АДМИНИСТРАТОР"
```
