### PR TITLE
Allow data to be merged into a datastore

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -67,6 +67,19 @@ class DataStore < Hash
     super(k.downcase)
   end
 
+  def merge!(h2)
+    h2.each do |key, val|
+      self[key] = val
+    end
+
+    self
+  end
+
+  def merge(h2)
+    other = self.clone
+    other.merge! h2
+  end
+
   # Override Hash's to_h method so we can include the original case of each key
   # (failing to do this breaks a number of places in framework and pro that use
   # serialized datastores)


### PR DESCRIPTION
This ensures that data merged into the datastore is
case-insensitive-itized and we keep the original case.
# Verification
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/psexec`
- [ ] `irb`
- [ ] `active_module.datastore.merge!({"RHOST" => "192.168.1.1"})`
- [ ] `exit`
- [ ] `show options` should show the `RHOST` option as set.
