### PR TITLE
Ensure 'show options' reflects correct values.

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -401,7 +401,7 @@ class ReadableText
         ])
 
     mod.options.sorted.each do |name, opt|
-      val = mod.datastore[name] || opt.default
+      val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
 
       next if (opt.advanced?)
       next if (opt.evasion?)
@@ -431,7 +431,7 @@ class ReadableText
 
     mod.options.sorted.each do |name, opt|
       next unless opt.advanced?
-      val = mod.datastore[name] || opt.default
+      val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
       tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
     end
 
@@ -456,7 +456,7 @@ class ReadableText
 
     mod.options.sorted.each do |name, opt|
       next unless opt.evasion?
-      val = mod.datastore[name] || opt.default
+      val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
       tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
     end
 


### PR DESCRIPTION
## Description

This is a minor bug+fix.  The msfconsole's **show options** command can sometime reflect the incorrect 'Current Setting' value for an option variable.  Specifically, this occurs when a boolean option variable has a default value of 'true', in that **show options** will always say the 'Current Setting' is 'true' even when the user has changed the value of the option variable to 'false'.  It should be noted that this is only a cosmetic issue, as the usual set/get operations against option variables work as expected.

This PR will ensure that, even when boolean 'option' variables have a default value of 'true', that their current value is correctly reflected via the 'show options' command.  This change should play fine with all other option variable types, I believe.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use auxiliary/gather/darkcomet_filedownloader`
- [x] `show options`
- [x] **Verify** the value of STORE_LOOT shows as **true** (its default value) under the 'Current Setting' column
- [x] `set STORE_LOOT false`
- [x] `show options`
- [x] **Verify** the value of STORE_LOOT shows as **false** (its new setting) under the 'Current Setting' column

---

Current behavior:

```
msf > use auxiliary/gather/darkcomet_filedownloader
msf auxiliary(darkcomet_filedownloader) > show options

Module options (auxiliary/gather/darkcomet_filedownloader):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   BRUTETIMEOUT  1                no        Timeout (in seconds) for bruteforce attempts
   KEY                            no        DarkComet RC4 key (include DC prefix with key eg. #KCMDDC51#-890password)
   LHOST         0.0.0.0          yes       This is our IP (as it appears to the DarkComet C2 server)
   NEWVERSION    true             no        Set to true if DarkComet version >= 5.1, set to false if version < 5.1
   RHOST         0.0.0.0          yes       The target address
   RPORT         1604             yes       The target port
   STORE_LOOT    true             no        Store file in loot (will simply output file to console if set to false).
   TARGETFILE                     no        Target file to download (assumes password is set)

msf auxiliary(darkcomet_filedownloader) > set STORE_LOOT false
STORE_LOOT => false
msf auxiliary(darkcomet_filedownloader) > get STORE_LOOT
STORE_LOOT => false
msf auxiliary(darkcomet_filedownloader) > set NEW_VERSION false
NEW_VERSION => false
msf auxiliary(darkcomet_filedownloader) > get NEW_VERSION
NEW_VERSION => false
msf auxiliary(darkcomet_filedownloader) > show options

Module options (auxiliary/gather/darkcomet_filedownloader):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   BRUTETIMEOUT  1                no        Timeout (in seconds) for bruteforce attempts
   KEY                            no        DarkComet RC4 key (include DC prefix with key eg. #KCMDDC51#-890password)
   LHOST         0.0.0.0          yes       This is our IP (as it appears to the DarkComet C2 server)
   NEWVERSION    true             no        Set to true if DarkComet version >= 5.1, set to false if version < 5.1
   RHOST         0.0.0.0          yes       The target address
   RPORT         1604             yes       The target port
   STORE_LOOT    true             no        Store file in loot (will simply output file to console if set to false).
   TARGETFILE                     no        Target file to download (assumes password is set)
```

New behavior with this change:

```
msf > use auxiliary/gather/darkcomet_filedownloader
msf auxiliary(darkcomet_filedownloader) > show options

Module options (auxiliary/gather/darkcomet_filedownloader):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   BRUTETIMEOUT  1                no        Timeout (in seconds) for bruteforce attempts
   KEY                            no        DarkComet RC4 key (include DC prefix with key eg. #KCMDDC51#-890password)
   LHOST         0.0.0.0          yes       This is our IP (as it appears to the DarkComet C2 server)
   NEWVERSION    true             no        Set to true if DarkComet version >= 5.1, set to false if version < 5.1
   RHOST         0.0.0.0          yes       The target address
   RPORT         1604             yes       The target port
   STORE_LOOT    true             no        Store file in loot (will simply output file to console if set to false).
   TARGETFILE                     no        Target file to download (assumes password is set)

msf auxiliary(darkcomet_filedownloader) > set STORE_LOOT false
STORE_LOOT => false
msf auxiliary(darkcomet_filedownloader) > get STORE_LOOT
STORE_LOOT => false
msf auxiliary(darkcomet_filedownloader) > set NEWVERSION false
NEWVERSION => false
msf auxiliary(darkcomet_filedownloader) > get NEWVERSION
NEWVERSION => false
msf auxiliary(darkcomet_filedownloader) > show options

Module options (auxiliary/gather/darkcomet_filedownloader):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   BRUTETIMEOUT  1                no        Timeout (in seconds) for bruteforce attempts
   KEY                            no        DarkComet RC4 key (include DC prefix with key eg. #KCMDDC51#-890password)
   LHOST         0.0.0.0          yes       This is our IP (as it appears to the DarkComet C2 server)
   NEWVERSION    false            no        Set to true if DarkComet version >= 5.1, set to false if version < 5.1
   RHOST         0.0.0.0          yes       The target address
   RPORT         1604             yes       The target port
   STORE_LOOT    false            no        Store file in loot (will simply output file to console if set to false).
   TARGETFILE                     no        Target file to download (assumes password is set)
```
