### PR TITLE
Fix exception on msf 'db_export' cmd (see #7008)

### DIFF
--- a/lib/msf/core/db_export.rb
+++ b/lib/msf/core/db_export.rb
@@ -125,7 +125,7 @@ class Export
     @owned_hosts = []
     @hosts = myworkspace.hosts
     @hosts.each do |host|
-      if host.notes.find :first, :conditions => { :ntype => 'pro.system.compromise' }
+      if host.notes.where(:ntype => 'pro.system.compromise').first
         @owned_hosts << host
       end
     end
@@ -133,7 +133,7 @@ class Export
 
   # Extracts all events from a project, storing them in @events
   def extract_event_entries
-    @events = myworkspace.events.find :all, :order => 'created_at ASC'
+    @events = myworkspace.events.order('created_at ASC')
   end
 
   # Extracts all services from a project, storing them in @services


### PR DESCRIPTION
## Description

This PR fixes issue #7008.

The **db_export** command in msfconsole would hit an exception and not complete when attempting to export the database in XML format.  This was due to some changes withinin the recent Rails upgrade, easily remedied with a couple small changes to a few queries the msf code makes during db_export.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `db_export -f xml foo.xml`
- [x] **Verify** that the command output does not contain any error messages and appears to complete successfully
- [x] **Verify** that the exported file exists and (via text editor or **cat\* or **less** or some such) that the contents appear reasonable

Current behavior:

```
msf > db_export -f xml foo.xml
[*] Starting export of workspace default to foo.xml [ xml ]...
[*]     >> Starting export of report
[-] Error while running command db_export: Couldn't find all Mdm::Notes with 'id': (first, {:conditions=>{:ntype=>"pro.system.compromise"}}) [WHERE "notes"."host_id" = ?] (found 0 results, but was looking for 2)

Call stack:
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/relation/finder_methods.rb:324:in `raise_record_not_found_exception!'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/relation/finder_methods.rb:467:in `find_some'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/relation/finder_methods.rb:426:in `find_with_ids'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/relation/finder_methods.rb:71:in `find'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/associations/collection_association.rb:99:in `find'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/associations/collection_proxy.rb:141:in `find'
/home/pbarry/metasploit-framework/lib/msf/core/db_export.rb:128:in `block in extract_host_entries'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/relation/delegation.rb:46:in `each'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/relation/delegation.rb:46:in `each'
/home/pbarry/metasploit-framework/lib/msf/core/db_export.rb:127:in `extract_host_entries'
/home/pbarry/metasploit-framework/lib/msf/core/db_export.rb:115:in `extract_target_entries'
/home/pbarry/metasploit-framework/lib/msf/core/db_export.rb:48:in `to_xml_file'
/home/pbarry/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1804:in `block in cmd_db_export'
/home/pbarry/.rvm/gems/ruby-2.3.1@metasploit-framework/gems/activerecord-4.2.6/lib/active_record/connection_adapters/abstract/connection_pool.rb:292:in `with_connection'
/home/pbarry/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1771:in `cmd_db_export'
/home/pbarry/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
/home/pbarry/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
/home/pbarry/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
/home/pbarry/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
/home/pbarry/metasploit-framework/lib/rex/ui/text/shell.rb:203:in `run'
/home/pbarry/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/pbarry/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```

New behavior:

```
msf > db_export -f xml foo.xml
[*] Starting export of workspace default to foo.xml [ xml ]...
[*]     >> Starting export of report
[*]     >> Starting export of hosts
[*]     >> Starting export of events
[*]     >> Starting export of services
[*]     >> Starting export of web sites
[*]     >> Starting export of web pages
[*]     >> Starting export of web forms
[*]     >> Starting export of web vulns
[*]     >> Starting export of module details
[*]     >> Finished export of report
[*] Finished export of workspace default to foo.xml [ xml ]...
msf > 
```
