### PR TITLE
Fix an error when exiting a interactive shell

### DIFF
--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -185,7 +185,7 @@ protected
   # writing it to the other.  Both are expected to implement Rex::IO::Stream.
   #
   def interact_stream(stream)
-    while self.interacting
+    while self.interacting && _remote_fd(stream)
 
       # Select input and rstream
       sd = Rex::ThreadSafe.select([ _local_fd, _remote_fd(stream) ], nil, nil, 0.25)


### PR DESCRIPTION
This PR fixes an error that occasionally happens when exiting a interactive shell in a meterpreter session. It seems that the error easily occurs when using windows/meterpreter/reverse_http payload.

Current behavior:

```

msf > use exploit/multi/handler
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_http
PAYLOAD => windows/meterpreter/reverse_http
msf exploit(handler) > set LHOST 192.168.56.82
LHOST => 192.168.56.82
msf exploit(handler) > set LPORT 8080
LPORT => 8080
msf exploit(handler) > set ExitOnSession false
ExitOnSession => false
msf exploit(handler) > exploit -j
[*] Exploit running as background job.

[*] Started HTTP reverse handler on http://192.168.56.82:8080
[*] Starting the payload handler...
msf exploit(handler) > [*] http://192.168.56.82:8080 handling request from 192.168.56.124; (UUID: gijjf2xt) Staging Native payload...
[*] Meterpreter session 1 opened (192.168.56.82:8080 -> 192.168.56.124:49334) at 2016-06-28 16:26:48 +0900

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : PC-T8X1S63GH
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > execute -f cmd -i -H
Process 1576 created.
Channel 1 created.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\user\Desktop>exit
exit

::
::

meterpreter > execute -f cmd -i -H
Process 2352 created.
Channel 4 created.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\user\Desktop>exit
exit
[-] Error running command execute: NoMethodError undefined method `closed?' for nil:NilClass

meterpreter > 
```

Call stack:

```
[06/28/2016 16:46:09] [e(0)] meterpreter: Error running command execute: NoMethodError undefined method `closed?' for nil:NilClass
[06/28/2016 16:46:09] [d(0)] meterpreter: Call stack:
/opt/metasploit-framework/embedded/framework/lib/rex/sync/thread_safe.rb:29:in `block in select'
/opt/metasploit-framework/embedded/framework/lib/rex/sync/thread_safe.rb:29:in `each'
/opt/metasploit-framework/embedded/framework/lib/rex/sync/thread_safe.rb:29:in `select'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/interactive.rb:191:in `interact_stream'
/opt/metasploit-framework/embedded/framework/lib/rex/post/meterpreter/ui/console/interactive_channel.rb:25:in `_interact'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/interactive.rb:49:in `interact'
/opt/metasploit-framework/embedded/framework/lib/rex/post/meterpreter/ui/console.rb:88:in `interact_with_channel'
/opt/metasploit-framework/embedded/framework/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb:230:in `cmd_execute'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
/opt/metasploit-framework/embedded/framework/lib/rex/post/meterpreter/ui/console.rb:105:in `run_command'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
/opt/metasploit-framework/embedded/framework/lib/rex/post/meterpreter/ui/console.rb:68:in `block in interact'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/shell.rb:193:in `call'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/shell.rb:193:in `run'
/opt/metasploit-framework/embedded/framework/lib/rex/post/meterpreter/ui/console.rb:66:in `interact'
/opt/metasploit-framework/embedded/framework/lib/msf/base/sessions/meterpreter.rb:436:in `_interact'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/interactive.rb:49:in `interact'
/opt/metasploit-framework/embedded/framework/lib/msf/ui/console/command_dispatcher/core.rb:1968:in `cmd_sessions'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
/opt/metasploit-framework/embedded/framework/lib/rex/ui/text/shell.rb:203:in `run'
/opt/metasploit-framework/embedded/framework/lib/metasploit/framework/command/console.rb:48:in `start'
/opt/metasploit-framework/embedded/framework/lib/metasploit/framework/command/base.rb:82:in `start'
/opt/metasploit-framework/bin/../embedded/framework/msfconsole:48:in `<main>'
[06/28/2016 16:46:09] [w(0)] core: monitor_rsock: the remote socket is nil, exiting loop
```
## Verification
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set PAYLOAD windows/meterpreter/reverse_http`
- [x] `set LHOST <msf host>`
- [x] `set LPORT <msf port>`
- [x] `exploit`
- [x] Start Meterpreter session
- [x] Repeat `execute -f cmd -i -H`, `exit`
- [x] **Verify** that the output does not contain any error messages
