### PR TITLE
Fix #7022 - Failing to find wponce in fetch_ninja_form_nonce

### DIFF
--- a/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
@@ -106,12 +106,18 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res && res.code == 200
-      fail_with Failure::UnexpectedReply, "Unable to access FORM_PATH: #{datastore['FORM_PATH']}"
+      fail_with(Failure::UnexpectedReply, "Unable to access FORM_PATH: #{datastore['FORM_PATH']}")
     end
 
     form_wpnonce = res.get_hidden_inputs.first['_wpnonce']
 
-    res.body[/var nfFrontEnd = \{"ajaxNonce":"([a-zA-Z0-9]+)"/i, 1] || form_wpnonce
+    nonce = res.body[/var nfFrontEnd = \{"ajaxNonce":"([a-zA-Z0-9]+)"/i, 1] || form_wpnonce
+
+    unless nonce
+      fail_with(Failure::Unknown, 'Cannot find wpnonce or ajaxNonce from FORM_PATH')
+    end
+
+    nonce
   end
 
   def upload_payload(data)

--- a/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
@@ -105,8 +105,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri'    => uri
     )
 
-    fail_with Failure::UnexpectedReply, 'Failed to acquire a nonce' unless res && res.code == 200
-    res.body[/var nfFrontEnd = \{"ajaxNonce":"([a-zA-Z0-9]+)"/i, 1]
+    unless res && res.code == 200
+      fail_with Failure::UnexpectedReply, "Unable to access FORM_PATH: #{datastore['FORM_PATH']}"
+    end
+
+    form_wpnonce = res.get_hidden_inputs.first['_wpnonce']
+
+    res.body[/var nfFrontEnd = \{"ajaxNonce":"([a-zA-Z0-9]+)"/i, 1] || form_wpnonce
   end
 
   def upload_payload(data)


### PR DESCRIPTION
## What This Patch Does

This patch fixes a problem for the wp_ninja_forms_unauthenticated_file_upload module when it is used against an older version of WP Ninja Forms, such as 2.9.27. An undefined method 'gsub' error occurs due to the nonce value is found in the hidden input instead of the JavaScript code

2.9.27 is not vulnerable, so the exploit will not pop a shell. But the expected result is the module should complete gracefully without seeing any errors.

Fixes #7022
## Verification Steps
- [x] Get a Ubuntu box with Apache2, MySQL, and PHP5.
- [x] Install Wordpress https://wordpress.org/latest.zip
- [x] Install Ninja Forms 2.9.27 (not vulnerable): https://downloads.wordpress.org/plugin/ninja-forms.2.9.27.zip
- [x] After installing Wordpress and Ninja Forms, log into Wordpress, and create a page with a form. Like this:

![ninja_forms](https://cloud.githubusercontent.com/assets/1170914/16496101/f61d941c-3eb5-11e6-91c6-be36716ce5de.png)
- [x] Once you have the page. Start msfconsole
- [x] Do: `use exploit/unix/webapp/wp_ninja_forms_unauthenticated_file_upload`
- [x] Do: `set FORM_PATH [where the page is]`
- [x] Do: `set TARGETURI [where Wordpress is]`
- [x] Do: `set RHOST [target IP]`
- [x] Do: `run`
- [x] You should see that the exploit is trying to exploit the server, but fails, and says: "Failed to upload the payload". You should not see a backtrace.
