### PR TITLE
Fix #7021, Pass exploit SRVPORT in BrowserAutopwn2

### DIFF
--- a/lib/msf/core/exploit/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/browser_autopwn2.rb
@@ -130,6 +130,7 @@ module Msf
       xploit.datastore['PAYLOAD']     = p.first[:payload_name]
       xploit.datastore['LPORT']       = p.first[:payload_lport]
       xploit.datastore['SRVHOST']     = datastore['SRVHOST']
+      xploit.datastore['SRVPORT']     = datastore['SRVPORT']
       xploit.datastore['LHOST']       = get_payload_lhost
 
       %w(JsObfuscate CookieName VERBOSE Retries SSL SSLVersion SSLCipher URIHOST URIPORT).each do |opt|


### PR DESCRIPTION
## What This Patch Does

In BrowserAutoPwn2, the mixin forgets to pass the SRVPORT datastore option to the exploits, so they always use the default 8080. As a result, if a different SRVPORT is set, BAP2 would be serving the target machine with bad exploit links.

Fix #7021
## Verification

To test this, you must have a vulnerable box that BAP2 can exploit to trigger the condition.
- [x] Get a Windows 7 box
- [x] Install a vulnerable version of Adobe Flash: https://fpdownload.macromedia.com/pub/flashplayer/installers/archive/fp_18.0.0.194_archive.zip
- [x] Start msfconsole
- [x] Do: `use auxiliary/server/browser_autopwn2`
- [x] Do: `set SRVPORT 8181`
- [x] Do: `set VERBOSE true`
- [x] Do: `run`, and BAP2 should give you a "BrowserAutoPwn URL"
- [x] On the victim machine, open IE (with Flash already installed at this point), and go to the BrowserAutoPwn URL.
- [x] You should see the victim machine is visiting some of the Flash exploit URLs (you can figure this out by looking comparing whatever resource is visited to the exploit list. You will probably get a session, too.
