### PR TITLE
Fix #7019, Pad host field in notes -d command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1360,6 +1360,8 @@ class Db
           addr = (host.scope ? host.address + '%' + host.scope : host.address )
           rhosts << addr
         end
+      else
+        csv_note << ''
       end
       if (note.service)
         msg << " service=#{note.service.name}" if note.service.name


### PR DESCRIPTION
## What This Patch Does

The notes -d command is always expecting a host address, but fileformat exploits don't have this type of information when the exploit file is generated, therefore there isn't enough fields provided for Rex table.

Fix #7019
## Verification
- [x] Start msfconsole
- [x] Do: `workspace -a clean_wp` to make sure you have a clean workspace to begin with.
- [x] Do: `use exploit/windows/fileformat/ms12_005`
- [x] Do: `run`
- [x] It should generate an exploit file (docm)
- [x] Do: `notes`
- [x] You should see that there is a note for type: `exploit.fileformat.ms12_005.localpath`
- [x] Do: `notes -o /tmp/test.csv`
- [x] msfconsole should say: "Notes saved as /tmp/test.csv"
