### PR TITLE
Ensure http_login scanner module saves passwds.

### DIFF
--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -181,6 +181,7 @@ class MetasploitModule < Msf::Auxiliary
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
         print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}'"
+        credential_data[:private_type] = :password
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
         create_credential_login(credential_data)


### PR DESCRIPTION
## Description

This PR fixes issue #6983.

When using the auxiliary/scanner/http/http_login module to find successful user+password combinations against an HTTP service, the passwords of any successful user+password combinations would fail to be stored.  This led to the **creds** command leaving the _private_ column entry blank for entries populated via http_login.
## Verification

@sinn3r originally saw this when scanning a system running IIS, I did my work with an NGINX instance, so the prereq is to just have a webserver with basic auth enabled (and with a user _admin_ with password _1234_) to verify the fix.
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/http_login`
- [x] `set RHOSTS <IP of your webserver>`
- [x] `run`
- [x] check that you see a `[+] HTTP - Success: 'admin:1234'` message in the output, indicating the scanner successfully identified admin:1234 is a valid username:password combination
- [x] `creds`
- [x] **Verify** you see the password `1234` in the private column

Current behavior:

```
msf auxiliary(http_login) > creds
Credentials
===========

host       origin     service        public  private  realm  private_type
----       ------     -------        ------  -------  -----  ------------
10.6.0.89  10.6.0.89  80/tcp (http)  admin

msf auxiliary(http_login) >
```

New behavior:

```
msf auxiliary(http_login) > creds
Credentials
===========

host       origin     service        public  private  realm  private_type
----       ------     -------        ------  -------  -----  ------------
10.6.0.89  10.6.0.89  80/tcp (http)  admin   1234            Password

msf auxiliary(http_login) >
```
