### PR TITLE
Account for the newer R7 committers in mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,11 @@
 acammack-r7 <acammack-r7@github>     Adam Cammack <Adam_Cammack@rapid7.com>
 bcook-r7 <bcook-r7@github>           <busterb@gmail.com>
 bcook-r7 <bcook-r7@github>           Brent Cook <bcook@rapid7.com>
-bturner-r7 <bturner-r7@github>       Brandon Turner <brandon_turner@rapid7.com>
 bpatterson-r7 <bpatterson-r7@github> Brian Patterson <Brian_Patterson@rapid7.com>
+bpatterson-r7 <bpatterson-r7@github> bpatterson-r7 <Brian_Patterson@rapid7.com>
+bturner-r7 <bturner-r7@github>       Brandon Turner <brandon_turner@rapid7.com>
+bwatters-r7 <bwatters-r7@github>     Brendan <bwatters@rapid7.com>
+bwatters-r7 <bwatters-r7@github>     Brendan Watters <bwatters@rapid7.com>
 cdoughty-r7 <cdoughty-r7@github>     Chris Doughty <chris_doughty@rapid7.com>
 dheiland-r7 <dheiland-r7@github>     Deral Heiland <dh@layereddefense.com>
 dmaloney-r7 <dmaloney-r7@github>     David Maloney <DMaloney@rapid7.com>
@@ -16,30 +19,39 @@ ecarey-r7 <ecarey-r7@github>         Erran Carey <e@ipwnstuff.com>
 farias-r7 <farias-r7@github>         Fernando Arias <fernando_arias@rapid7.com>
 gmikeska-r7 <gmikeska-r7@github>     Greg Mikeska <greg_mikeska@rapid7.com>
 gmikeska-r7 <gmikeska-r7@github>     Gregory Mikeska <greg_mikeska@rapid7.com>
+jbarnett-r7 <jbarnett-r7@github>     James Barnett <James_Barnett@rapid7.com>
 jhart-r7 <jhart-r7@github>           Jon Hart <jon_hart@rapid7.com>
 jlee-r7 <jlee-r7@github>             <egypt@metasploit.com> # aka egypt
 jlee-r7 <jlee-r7@github>             <james_lee@rapid7.com>
 kgray-r7 <kgray-r7@github>           Kyle Gray <kyle_gray@rapid7.com>
+khayes-r7 <khayes-r7@github>         l0gan <Kirk_Hayes@rapid7.com>
 lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance.sanchez+github@gmail.com>
 lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance.sanchez@rapid7.com>
 lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance@AUS-MAC-1041.local>
 lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance@aus-mac-1041.aus.rapid7.com>
 lsanchez-r7 <lsanchez-r7@github>     darkbushido <lance.sanchez@gmail.com>
 lsato-r7 <lsato-r7@github>           Louis Sato <lsato@rapid7.com>
+pbarry-r7 <pbarry-r7@github>         Pearce Barry <pearce_barry@rapid7.com>
 pdeardorff-r7 <pdeardorff-r7@github> Paul Deardorff <Paul_Deardorff@rapid7.com>
 pdeardorff-r7 <pdeardorff-r7@github> pdeardorff-r7 <paul_deardorff@rapid7.com>
+sdavis-r7 <sdavis-r7@github>         Scott Davis <Scott_Davis@rapid7.com>
+sdavis-r7 <sdavis-r7@github>         Scott Lee Davis <scott_davis@rapid7.com>
+sdavis-r7 <sdavis-r7@github>         Scott Lee Davis <sdavis@rapid7.com>
+sgonzalez-r7 <sgonzalez-r7@github>   Sonny Gonzalez <sgonzalez@rapid7.com>
 sgonzalez-r7 <sgonzalez-r7@github>   Sonny Gonzalez <sonny_gonzalez@rapid7.com>
 shuckins-r7 <shuckins-r7@github>     Samuel Huckins <samuel_huckins@rapid7.com>
+tdoan-r7 <tdoan-r7@github>           thao doan <thao_doan@rapid7.com>
 todb-r7 <todb-r7@github>             Tod Beardsley <tod_beardsley@rapid7.com>
 todb-r7 <todb-r7@github>             Tod Beardsley <todb@metasploit.com>
 todb-r7 <todb-r7@github>             Tod Beardsley <todb@packetfu.com>
 wchen-r7 <wchen-r7@github>           <msfsinn3r@gmail.com> # aka sinn3r
 wchen-r7 <wchen-r7@github>           <wei_chen@rapid7.com>
 wvu-r7 <wvu-r7@github>               William Vu <William_Vu@rapid7.com>
-wvu-r7 <wvu-r7@github>               William Vu <wvu@metasploit.com>
 wvu-r7 <wvu-r7@github>               William Vu <wvu@cs.nmt.edu>
+wvu-r7 <wvu-r7@github>               William Vu <wvu@metasploit.com>
 wvu-r7 <wvu-r7@github>               wvu-r7 <William_Vu@rapid7.com>
 wwebb-r7 <wwebb-r7@github>           William Webb <William_Webb@rapid7.com>
+wwebb-r7 <wwebb-r7@github>           wwebb-r7 <William_Webb@rapid7.com>
 
 # Above this line are current Rapid7 employees. Below this paragraph are
 # volunteers, former employees, and potential Rapid7 employees who, at
@@ -151,10 +163,11 @@ void-in <void-in@github>               void_in <root@localhost.localdomain>
 void-in <void-in@github>               Waqas Ali <waqas.bsquare@gmail.com>
 zeroSteiner <zeroSteiner@github>       Spencer McIntyre <zeroSteiner@gmail.com>
 
-
 # Aliases for utility author names. Since they're fake, typos abound
 
-Tab Assassin <tabassassin@metasploit.com> Tabassassin <tabassassin@metasploit.com>
+Metasploit Bot <metasploit@rapid7.com>    Metasploit <metasploit@rapid7.com>
+Jenkins Bot <jenkins@rapid7.com>          Jenkins <jenkins@rapid7.com>
 Tab Assassin <tabassassin@metasploit.com> TabAssassin <tabasssassin@metasploit.com>
+Tab Assassin <tabassassin@metasploit.com> Tabassassin <tabassassin@metasploit.com>
 Tab Assassin <tabassassin@metasploit.com> Tabasssassin <tabassassin@metasploit.com>
 Tab Assassin <tabassassin@metasploit.com> URI Assassin <tabassassin@metasploit.com>

--- a/.mailmap
+++ b/.mailmap
@@ -40,6 +40,7 @@ sdavis-r7 <sdavis-r7@github>         Scott Lee Davis <sdavis@rapid7.com>
 sgonzalez-r7 <sgonzalez-r7@github>   Sonny Gonzalez <sgonzalez@rapid7.com>
 sgonzalez-r7 <sgonzalez-r7@github>   Sonny Gonzalez <sonny_gonzalez@rapid7.com>
 shuckins-r7 <shuckins-r7@github>     Samuel Huckins <samuel_huckins@rapid7.com>
+tdoan-r7 <tdoan-r7@github>           tdoan-r7 <thao_doan@rapid7.com>
 tdoan-r7 <tdoan-r7@github>           thao doan <thao_doan@rapid7.com>
 todb-r7 <todb-r7@github>             Tod Beardsley <tod_beardsley@rapid7.com>
 todb-r7 <todb-r7@github>             Tod Beardsley <todb@metasploit.com>


### PR DESCRIPTION
This updates the .mailmap username mapping to display folks in the Rapid7 organization with the usual `flast-r7` format.
## Verification

List the steps needed to make sure this thing works
- [x] `git log -1000 --format="%aE" | grep rapid7.com`
- [x] **Verify** that no humans show up in the list
  - [x] Except `adam_compton@rapid7.com` because I don't know which account he likes associated.

Easy peasy.
