### PR TITLE
Fix busted alpha encoding on this old-ass exploit

### DIFF
--- a/modules/exploits/windows/iis/ms02_018_htr.rb
+++ b/modules/exploits/windows/iis/ms02_018_htr.rb
@@ -49,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Windows NT 4.0 SP4', {'Platform' => 'win', 'Rets' => [ 593, 0x77f7635d ] }],
           ['Windows NT 4.0 SP5', {'Platform' => 'win', 'Rets' => [ 589, 0x77f76385 ] }],
         ],
+      'DefaultOptions' => { 'AllowWin32SEH' => true }, # needed for pure alpha GetEIP stub
       'DisclosureDate' => 'Apr 10 2002',
       'DefaultTarget' => 0))
 


### PR DESCRIPTION
As reported in comments on #5961, ms02_018_htr was no longer compatible with any encoders. This makes alpha encoders work for it again.
## Verification
- [x] Start `msfconsole`
- [x] `use exploit/windows/iis/ms02_018_htr`
- [x] set RHOST to anything with http server
- [x] **Verify** it doesn't bomb out with a message about no working encoders

Note that this is a **super** old exploit and I don't actually care that much if you test it on a real vulnerable system.
