### PR TITLE
Corrected for console width errors causing incorrect SHA-512 hashes

### DIFF
--- a/modules/post/windows/gather/credentials/mssql_local_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mssql_local_hashdump.rb
@@ -116,7 +116,12 @@ class MetasploitModule < Msf::Post
 
     if get_hash_result.include?('0x')
       # Parse Data
-      hash_array = get_hash_result.split("\r\n").grep(/0x/)
+      if hash_type == "mssql12"
+        crlfRepair = get_hash_result.unpack('H*')[0].gsub("200d0a","PLACEHOLDER").gsub("0d0a","").gsub("PLACEHOLDER","0d0a").gsub(/../) { |pair| pair.hex.chr }
+        hash_array = crlfRepair.split("\r\n").grep(/0x/)
+      else
+        hash_array = get_hash_result.split("\r\n").grep(/0x/)
+      end
 
       store_hashes(hash_array, hash_type)
     else


### PR DESCRIPTION
- The database query used by this module was returning input that contained \x0d\x0a after 200 characters.  When SQL Server moved to SHA-512 hashes this was not enough characters to contain the entire hash and all the whitespace the query inserted, which resulted in \x0d\x0a in the hash value.  When the string was tokenized by \r\n this truncated the hash.  This resulted in hashes that could not be processed by password cracking tools.
  I added a conditional so other versions of MS SQL will not be affected.  The text parsing is a little awkward, but the gsub function call was giving me issues since \r\n was both in the middle of the hash and in between rows.  There are probably some better options to make this part work.
- [x] - start msfconsole
- [x] - open a meterpreter session as system to a MS SQL Server 2012 server running with mixed-mode authentication (AD and local SQL server authentication) and running in the context of a service account.
- [x] - use post/windows/gather/credentials/mssql_local_hashdump
- [x] - Verify MS SQL SHA-512 hashes should be returned for all local accounts. (ie. sa:0x0200F382135109E1CA9D2595368D04EDD4D85520379B503713EF39B94772CD5D65C4768F833F2FCA3600315780A02D985F1F05A18E7A86E0BF3A1164C6FB788B1EC161861E30)
