### PR TITLE
Revert #6581, it causes regressions

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -433,7 +433,9 @@ protected
         unless [:unknown_uuid, :unknown_uuid_url].include?(info[:mode])
           print_status("Unknown request to #{request_summary}")
         end
-        resp = nil
+        resp.code    = 200
+        resp.message = 'OK'
+        resp.body    = datastore['HttpUnknownRequestResponse'].to_s
         self.pending_connections -= 1
     end
 


### PR DESCRIPTION
Reverting my own PR #6581 from earlier, since it breaks HttpUnknownRequestResponse support (as @mubix noted in the original PR). Sorry for the noise, will look at a way of attacking this from the stager PoV instead.
## Verification
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload windows/meterpreter/reverse_http`
- [x] `set HttpUnknownRequestResponse "Nobody here but us chickens"`
- [x] `run`
- [x] **Verify** that hitting a random URL on the handler returns that response
