### PR TITLE
Fix tools that need Rex::Text

### DIFF
--- a/tools/exploit/find_badchars.rb
+++ b/tools/exploit/find_badchars.rb
@@ -13,6 +13,8 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+gem 'rex-text'
+
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
 require 'msfenv'
 
@@ -112,7 +114,7 @@ case fmt
       translated << ln.chomp[10,47].gsub!(/(-| )/, '')
     end
     from_dbg = Rex::Text.hex_to_raw(translated)
-    
+
   when "gdb"
     translated = ''
     from_dbg.each_line do |ln|

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -20,6 +20,8 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+gem 'rex-text'
+
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
 require 'msfenv'
 
@@ -40,7 +42,7 @@ def usage
   $stderr.puts("\nUsage: #{$0} <options>\n" + $args.usage)
   exit
 end
-    
+
 $args = Rex::Parser::Arguments.new(
   "-a" => [ true, "The architecture to encode as (#{@Arch.sort.collect{|a| a + ', ' }.join.gsub(/\, $/,'')})"],
   "-e" => [ true, "The endianess to encode as (#{@Endian.sort.collect{|a| a + ', ' }.join.gsub(/\, $/,'')})" ],

--- a/tools/exploit/pattern_create.rb
+++ b/tools/exploit/pattern_create.rb
@@ -8,6 +8,8 @@ end
 $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
 $LOAD_PATH.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
+gem 'rex-text'
+
 require 'optparse'
 
 module PatternCreate
@@ -72,7 +74,6 @@ if __FILE__ == $PROGRAM_NAME
   begin
     driver.run
   rescue ::StandardError => e
-    elog("#{e.class}: #{e.message}\n#{e.backtrace * "\n"}")
     $stderr.puts "[x] #{e.class}: #{e.message}"
     $stderr.puts "[*] If necessary, please refer to framework.log for more details."
   end

--- a/tools/exploit/pattern_offset.rb
+++ b/tools/exploit/pattern_offset.rb
@@ -8,6 +8,8 @@ end
 $LOAD_PATH.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
 $LOAD_PATH.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
+gem 'rex-text'
+
 require 'optparse'
 
 module PatternOffset
@@ -140,7 +142,6 @@ if __FILE__ == $PROGRAM_NAME
   begin
     driver.run
   rescue ::StandardError => e
-    elog("#{e.class}: #{e.message}\n#{e.backtrace * "\n"}")
     $stderr.puts "[x] #{e.class}: #{e.message}"
     $stderr.puts "[*] If necessary, please refer to framework.log for more details."
 

--- a/tools/exploit/psexec.rb
+++ b/tools/exploit/psexec.rb
@@ -9,6 +9,8 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+gem 'rex-text'
+
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
 require 'msfenv'
 
@@ -67,7 +69,7 @@ def dcerpc_bind(handle, csocket, csimple, cuser, cpass)
     opts['smb_pass'] = cpass
     opts['frag_size'] = 512
     opts['smb_client'] = csimple
-    
+
     Rex::Proto::DCERPC::Client.new(handle, csocket, opts)
   end
 
@@ -131,7 +133,7 @@ if (not simple.client.auth_user)
   exit(1)
 end
 
-    
+
 
 fname = Rex::Text.rand_text_alpha(8) + ".exe"
 sname = Rex::Text.rand_text_alpha(8)

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -13,6 +13,8 @@ require 'msfenv'
 
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
+gem 'rex-text'
+
 require 'rex'
 require 'msf/ui'
 require 'msf/base'

--- a/tools/password/cpassword_decrypt.rb
+++ b/tools/password/cpassword_decrypt.rb
@@ -38,9 +38,11 @@ while File.symlink?(msfbase)
 end
 
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
+
+gem 'rex-text'
+
 require 'msfenv'
 require 'rex'
-
 
 class CPassword
 


### PR DESCRIPTION
When Rex::Text got factored out into the rex-text gem, tools using Rex::Text got left behind.
## Verification

Run each of these tools and verify that the function:
- [x] tools/exploit/find_badchars.rb
- [x] tools/exploit/metasm_shell.rb
- [x] tools/exploit/pattern_create.rb
- [x] tools/exploit/pattern_offset.rb
- [x] tools/exploit/psexec.rb
- [x] tools/modules/update_payload_cached_sizes.rb
- [x] tools/password/cpassword_decrypt.rb
