### PR TITLE
Change class name Metasploit4 to MetasploitModule

### DIFF
--- a/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
-module Metasploit4
+module MetasploitModule
 
   CachedSize = 118
 


### PR DESCRIPTION
## What This Patch Does

This changes the module class name from `Metasploit4` to `MetasploitModule` for payloads/singles/linux/armbe/shell_bind_tcp. It looks like it was overlooked in https://github.com/rapid7/metasploit-framework/commit/cfc368ab650e1e34fa97d20d9769acbb95e4fe51
## Verification
- [x] Start msfconsole
- [x] You should not get a warning about Metasploit4 class name
