### PR TITLE
Import, sign, and publish signed dev keys

### DIFF
--- a/tools/dev/sign-dev-keys.sh
+++ b/tools/dev/sign-dev-keys.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Imports and signs dev keys fetched from Keybase, as asserted by the
+# Metasploit-Framework development wiki. Requires bash version 3 or so for
+# regular expression pattern match
+
+COMMITTER_KEYS_URL='https://raw.githubusercontent.com/wiki/rapid7/metasploit-framework/Committer-Keys.md'
+KEYBASE_KEY_URLS=$(
+ \curl -sSL $COMMITTER_KEYS_URL |
+ \awk '$4 ~/https:\/\/keybase.io\//' |
+ \sed 's#.*\(https://keybase.io/[^)]*\).*#\1/key.asc#'
+)
+
+for key in $KEYBASE_KEY_URLS; do
+  echo [*] Importing $key
+  THIS_KEY=$(
+    \curl -sSL $key |
+    \gpg --no-auto-check-trustdb --import - 2>&1 |
+    \head -1 | \cut -f 3 -d " " | \sed 's/://'
+  )
+  echo [*] Signing $THIS_KEY
+  \gpg --sign-key $THIS_KEY
+  echo [*] Sending $THIS_KEY
+  \gpg --keyserver sks-keyservers.net --send-key $THIS_KEY
+done
+


### PR DESCRIPTION
This largely automates the process of importing developer keys, much like
`import-dev-keys.sh`, but also takes the additional, sadly manual step of
signing the key with your default key, and uploading those keys to
https://sks-keyservers.net.

In effect, you are stating that you trust keys published on keybase.io and
are listed as such on the official Metasploit-Framework development wiki.

If your own default key either has no passphrase, or has a passphrase
cached in a keymanager, the process merely requires you hit `y` for every key,
and `y` again for keys with multiple IDs. Otherwise, you will need to provide
your passphrase for each signing. Temporarily removing the passphrase
alleviates this pain.

Of course, this assumes you actually trust the development wiki and keybase
to do the right thing. The tradition is to individually verify each key through
some personally invented means, such as in person with a government ID check.

Note that `import-dev-keys.sh` currently lists a number of keys not on
Keybase, and that functionality has not been carried over to this script.
## Verification

Performing these actions will cause you to start signing all keys.
- [x] `tools\dev\sign-dev-keys.sh`
- [x] Currently, the first key on the list is @acammack-r7's, so see something like this:

```
$ tools/dev/sign-dev-keys.sh 
[*] Importing https://keybase.io/acammackr7/key.asc
[*] Signing 88092D66

gpg: checking the trustdb
gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
gpg: depth: 0  valid:  33  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 33u
gpg: next trustdb check due at 2016-08-07
pub  4096R/88092D66  created: 2016-01-20  expires: 2017-07-13  usage: SC  
                     trust: unknown       validity: unknown
sub  4096R/04A2A63C  created: 2016-01-20  expires: 2017-07-13  usage: E   
[ unknown] (1). Adam Cammack <adam_cammack@rapid7.com>


pub  4096R/88092D66  created: 2016-01-20  expires: 2017-07-13  usage: SC  
                     trust: unknown       validity: unknown
 Primary key fingerprint: C63C D69F 09D4 49DE C2AF  CC89 C937 8BA0 8809 2D66

     Adam Cammack <adam_cammack@rapid7.com>

This key is due to expire on 2017-07-13.
Are you sure that you want to sign this key with your
key "Tod Beardsley <todb@metasploit.com>" (C85943FE)

Really sign? (y/N) 
```
- [x] Hit `y`
- [x] See that the key is reported as signed and sent:

```
Really sign? (y/N) y

You need a passphrase to unlock the secret key for
user: "Tod Beardsley <todb@metasploit.com>"
4096-bit RSA key, ID C85943FE, created 2016-06-30


[*] Sending 88092D66
gpg: sending key 88092D66 to hkp server sks-keyservers.net
[*] Importing https://keybase.io/busterb/key.asc
[*] Signing D5E4D8D5
```
- [ ] See that the key is actually signed, [here](https://sks-keyservers.net/pks/lookup?op=vindex&search=0x88092D66).
- [ ] If @acammack-r7's key was unsigned before, see that his recent signed commits are actually verified with a `[G]` on the results of `git log --pretty=format:'%Cred%h%Creset -%Creset %s %Cgreen(%cr) %C(bold blue)<%aE>%Creset [%G?]' --author Cammack -5` , like so:

```
todb@ubuntu:~/git/metasploit-framework$ git log --pretty=format:'%Cred%h%Creset -%Creset %s %Cgreen(%cr) %C(bold blue)<%aE>%Creset [%G?]' --author Adam -5
ac5d270 - Land #7031, Revert #6729 (8 days ago) <acammack-r7@github> [G]
158176a - replaced "if !" on line 41 with "unless" replaced "$1" on line 51 with "Regexp.last_match(1) restructed the print statement on line 56 to more closely match suggestion removed "self." from line 71 changed line 78 to loop for 2 seconds insetead of 1 second (4 weeks ago) <adam_compton@rapid7.com> [N]
75a34c4 - added a new aux module to quickly scan for Jenkins servers on the local broadcast network by sending out a udp packet to port 33848 on the broadcast address.  Any Jenkins server should respond with XML data containing the Jenkins server version. (4 weeks ago) <adam_compton@rapid7.com> [N]
08f1e68 - Fix Acunetix import with a blacklist (5 weeks ago) <acammack-r7@github> [G]
fda4c62 - Respect SSLCipher in server mixins (7 weeks ago) <acammack-r7@github> [G]
```
