### PR TITLE
Beholder Plugin Migration Tweek

### DIFF
--- a/plugins/beholder.rb
+++ b/plugins/beholder.rb
@@ -180,8 +180,8 @@ class Plugin::Beholder < Msf::Plugin
       # Attempt to migrate, but flag that we tried either way
       self.state[sid][:migrated] = true
 
-      # Grab the first explorer.exe process we find
-      target_ps = ps.select{|x| x['name'].to_s.downcase == 'explorer.exe' }.first
+      # Grab the first explorer.exe process we find that we have rights to
+      target_ps = ps.select{|x| x['name'].to_s.downcase == 'explorer.exe' && x['user'].to_s != '' }.first
       unless target_ps
         # No explorer.exe process?
         session_log(sid, "no explorer.exe process found for automigrate")


### PR DESCRIPTION
## Overview

This PR fixes an issue with migration in the Beholder plugin that occurs when multiple users are logged into a Windows machine. In this situation, there are multiple 'explorer.exe' processes, but each user only has rights to their 'explorer.exe' process. As Beholder is currently written, it tries to migrate into the first 'explorer.exe' process it finds. If that process does not belong to the user associated with the session, the migration fails. This is the same issue I ran into while working on post/windows/manage/priv_migrate in PR #6557. 

Below is the error from Beholder's log when it tries to migrate into another user's 'explorer.exe' process.

```
Session 1 [] triggered an exception: Rex::RuntimeError Cannot migrate into this process (insufficient privileges) ["/home/jhale/git/metasploit-framework/plugins/beholder.rb:193:in `verify_migration'"
```

The fix is simple, check to make sure that the 'user' attribute for the 'explorer.exe' process is not blank. This ensures that the session has rights to the process it is trying to migrate into.
## Verification
- [x] Fire up a Windows box - 7, 8.1, or 10 - Doesn't matter
- [x] Have two users logged in at the same time.
- [x] Startup `msfconsole` and a listener for the meterpreter payload of your choice.
- [x] `load beholder` and make sure `automigrate: true` in `beholder_conf`
- [x] Fire off a meterpreter session from each user on the Windows box.
- [x] Check Beholder log to make sure it migrated appropriately for both sessions.
