### PR TITLE
Make sure GATEWAY_PROBE_PORT is 0

### DIFF
--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -302,7 +302,7 @@ module Msf
 
       def probe_gateway(addr)
         dst_host = datastore['GATEWAY_PROBE_HOST']
-        dst_port = datastore['GATEWAY_PROBE_PORT'] == 0 ? rand(30000) + 1024 : datastore['GATEWAY_PROBE_PORT']
+        dst_port = datastore['GATEWAY_PROBE_PORT'].to_i == 0 ? rand(30000) + 1024 : datastore['GATEWAY_PROBE_PORT']
         preamble = [datastore['SECRET']].pack("N")
         secret   = "#{preamble}#{Rex::Text.rand_text(rand(0xff)+1)}"
 


### PR DESCRIPTION
This ensures that `dst_port` is set for `UDPSocket#send`.

Probably related to https://github.com/rapid7/metasploit-framework/pull/6946/commits/53b989f283cf74eb65a600b6811fa52a42731553 in #6946.
- [x] `rvmsudo ./msfconsole -L`
- [x] `use auxiliary/spoof/nbns/nbns_response`
- [x] `set verbose true`
- [x] `run`
- [x] It works
