### PR TITLE
Adds command that allows nessus to scan a given workspace

### DIFF
--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -1097,7 +1097,7 @@ module Msf
           new_workspace = framework.db.find_workspace(args[3])
         else
           print_status("Usage: ")
-          print_status("nessus_db_scan <policy ID> <scan name> <scan description> <workspace>")
+          print_status("nessus_db_scan_workspace <policy ID> <scan name> <scan description> <workspace>")
           print_status("Use nessus_policy_list to list all available policies with their corresponding policy IDs")
           return
         end

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -72,10 +72,10 @@ module Msf
           "nessus_index" => "Manually generates a search index for exploits",
           "nessus_template_list" => "List all the templates on the server",
           "nessus_db_scan" => "Create a scan of all IP addresses in db_hosts",
+          "nessus_db_scan_workspace" => "Create a scan of all IP addresses in db_hosts for a given workspace",
           "nessus_db_import" => "Import Nessus scan to the Metasploit connected database",
           "nessus_save" => "Save credentials of the logged in user to nessus.yml",
           "nessus_folder_list" => "List folders configured on the Nessus server",
-          "nessus_scanner_list" => "List the configured scanners on the Nessus server",
           "nessus_family_list" => "List all the plugin families along with their corresponding family IDs and plugin count"
         }
       end
@@ -253,6 +253,7 @@ module Msf
         tbl << [ "Nessus Database Commands", "" ]
         tbl << [ "-----------------", "-----------------" ]
         tbl << [ "nessus_db_scan", "Create a scan of all IP addresses in db_hosts" ]
+        tbl << [ "nessus_db_scan_workspace", "Create a scan of all IP addresses in db_hosts for a given workspace" ]
         tbl << [ "nessus_db_import", "Import Nessus scan to the Metasploit connected database" ]
         tbl << [ "", ""]
         tbl << [ "Reports Commands", "" ]
@@ -1065,6 +1066,59 @@ module Msf
         end
         targets.chop!
         print_status("Creating scan from policy #{policy_id}, called \"#{name}\" and scanning all hosts in all the workspaces")
+        scan = @n.scan_create(policy_id, name, desc, targets)
+        if !scan["error"]
+          scan = scan["scan"]
+          print_status("Scan ID #{scan['id']} successfully created")
+          print_status("Run nessus_scan_launch #{scan['id']} to launch the scan")
+        else
+          print_error(JSON.pretty_generate(scan))
+        end
+      end
+
+      def cmd_nessus_db_scan_workspace(*args)
+        if args[0] == "-h"
+          print_status("nessus_db_scan_workspace <policy ID> <scan name> <scan description> <workspace>")
+          print_status("Creates a scan based on all the hosts listed in db_hosts for a given workspace.")
+          print_status("Use nessus_policy_list to list all available policies with their corresponding policy IDs")
+          return
+        end
+        if !nessus_verify_db
+          return
+        end
+        if !nessus_verify_token
+          return
+        end
+        case args.length
+        when 4
+          policy_id = args[0]
+          name = args[1]
+          desc = args[2]
+          new_workspace = framework.db.find_workspace(args[3])
+        else
+          print_status("Usage: ")
+          print_status("nessus_db_scan <policy ID> <scan name> <scan description> <workspace>")
+          print_status("Use nessus_policy_list to list all available policies with their corresponding policy IDs")
+          return
+        end
+        if !valid_policy(policy_id)
+          print_error("That policy does not exist.")
+          return
+        end
+        if new_workspace.nil?
+          print_error("That workspace does not exist.")
+          return
+        end
+        framework.db.workspace = new_workspace
+        print_status("Switched workspace: #{framework.db.workspace.name}")
+        targets = ""
+        framework.db.hosts.each do |host|
+          targets << host.address
+          targets << ","
+        print_status("Targets: #{targets}")
+        end
+        targets.chop!
+        print_status("Creating scan from policy #{policy_id}, called \"#{name}\" and scanning all hosts in #{framework.db.workspace.name}")
         scan = @n.scan_create(policy_id, name, desc, targets)
         if !scan["error"]
           scan = scan["scan"]

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -76,6 +76,7 @@ module Msf
           "nessus_db_import" => "Import Nessus scan to the Metasploit connected database",
           "nessus_save" => "Save credentials of the logged in user to nessus.yml",
           "nessus_folder_list" => "List folders configured on the Nessus server",
+          "nessus_scanner_list" => "List the configured scanners on the Nessus server",
           "nessus_family_list" => "List all the plugin families along with their corresponding family IDs and plugin count"
         }
       end


### PR DESCRIPTION
Adds command 'nessus_db_scan_workspace', an extension of 'nessus_db_scan'. The standard nessus_db_scan puts all hosts in all workspaces into one scan, which seems to violate the spirit of workplaces being logical groupings of hosts. This new command adds a workspace argument, throwing an error if the workspace doesn't exist and switching to the workspace if it does. I considered not taking an argument and just making the targets those in the current workspace, it seemed to provide more flexibility if it had the power to switch workspaces and enabled a user not to have to run workspace to know if they were in the right place. 
## Example Output

```
> load nessus
> nessus_connect <user>:<pass>@<ip of host>:<port>
> workspace -a newexistingworkspace
[*] Added workspace: newexistingworkspace- nessus_workspace_db scan
> nessus_db_scan_workspace
[*] Usage:
[*] nessus_db_scan_workspace <policy ID> <scan name> <scan description> <workspace>
[*] Use nessus_policy_list to list all available policies with their corresponding policy IDs
nessus_db_scan_workspace
> nessus_db_scan_workspace <validPolicy #>  aName "a desc" notrealworkspace
[-] That workspace does not exist.
> nessus_db_scan_workspace <validPolicy #> "a desc" newexistingworkspace
[*] Switched workspace: newexistingworkspace
[*] Targets: 127.0.0.1,
[*] Creating scan from policy <validPolicy #>, called "aName" and scanning all hosts in newexistingworkspace
[*] Scan ID <#> successfully created
```
