### PR TITLE
Change Burp import to allow blank references

### DIFF
--- a/lib/rex/parser/burp_issue_nokogiri.rb
+++ b/lib/rex/parser/burp_issue_nokogiri.rb
@@ -111,7 +111,6 @@ module Rex
         return unless @state[:service_object]
         return unless @state[:vuln_name]
         return unless @state[:issue_detail]
-        #return unless @state[:refs]
         vuln_info = {workspace: @args[:wspace]}
         vuln_info[:service_id] = @state[:service_object].id
         vuln_info[:host] = @state[:host]

--- a/lib/rex/parser/burp_issue_nokogiri.rb
+++ b/lib/rex/parser/burp_issue_nokogiri.rb
@@ -111,7 +111,7 @@ module Rex
         return unless @state[:service_object]
         return unless @state[:vuln_name]
         return unless @state[:issue_detail]
-        return unless @state[:refs]
+        #return unless @state[:refs]
         vuln_info = {workspace: @args[:wspace]}
         vuln_info[:service_id] = @state[:service_object].id
         vuln_info[:host] = @state[:host]


### PR DESCRIPTION
This fix allows db_import to import Burp issues that d not have a corresponding reference.  Previously, those vulnerabilities without a reference were dropped.
## Steps to reproduce:
- [x] open msfconsole
- [x] `workspace -a <new_workspace>`
- [x] `db_import <xml_file>`
- [x] verify that vulnerabilities without corresponding references are not imported.
## Steps to test:
- [x] open msfconsole
- [x] `workspace -a <new_workspace>`
- [x] `db_import <xml_file>`
- [x] verify that vulnerabilities without corresponding references are imported.
# Example Run:
## Before:

```
msf > workspace -a before_change
[*] Added workspace: before_change
msf > db_import '<issue_file>' 
[*] Importing 'Burp Issue XML' data
[*] Import: Parsing with 'Nokogiri v1.6.8'
[*] Successfully imported <issue_file>
msf > vulns
[*] Time: 2016-07-15 15:40:29 UTC Vuln: host=203.0.113.19 name=Cross-site scripting (reflected) refs=URI-https://support.portswigger.net/customer/portal/articles/1965737-Methodology_XSS.html 
[*] Time: 2016-07-15 15:40:29 UTC Vuln: host=203.0.113.19 name=External service interaction (DNS) refs=URI-http://blog.portswigger.net/2015/04/introducing-burp-collaborator.html 
[*] Time: 2016-07-15 15:40:30 UTC Vuln: host=203.0.113.19 name=Open redirection refs=URI-https://support.portswigger.net/customer/portal/articles/1965733-Methodology_Testing%20for%20Open%20Redirections.html 
[*] Time: 2016-07-15 15:40:31 UTC Vuln: host=203.0.113.19 name=Path-relative style sheet import refs=URI-http://blog.portswigger.net/2015/02/prssi.html 
[*] Time: 2016-07-15 15:40:32 UTC Vuln: host=203.0.113.19 name=Cross-site request forgery refs=URI-https://support.portswigger.net/customer/portal/articles/1965674-using-burp-to-test-for-cross-site-request-forgery-csrf- 
msf > exit
```
## After:

```
msf > workspace -a after_change
[*] Added workspace: after_change
msf > db_import '<issue_file>' 
[*] Importing 'Burp Issue XML' data
[*] Import: Parsing with 'Nokogiri v1.6.8'
[*] Successfully imported <issue_file>
msf > vulns
[*] Time: 2016-07-15 15:42:11 UTC Vuln: host=203.0.113.19 name=Form does not contain an anti-CSRF token refs= 
[*] Time: 2016-07-15 15:42:12 UTC Vuln: host=203.0.113.19 name=Request vulnerable to Cross-site Request Forgery refs= 
[*] Time: 2016-07-15 15:42:12 UTC Vuln: host=203.0.113.19 name=Password field with autocomplete enabled refs= 
[*] Time: 2016-07-15 15:42:13 UTC Vuln: host=203.0.113.19 name=Duplicate cookies set refs= 
[*] Time: 2016-07-15 15:42:10 UTC Vuln: host=203.0.113.19 name=Cross-site scripting (reflected) refs=URI-https://support.portswigger.net/customer/portal/articles/1965737-Methodology_XSS.html 
[*] Time: 2016-07-15 15:42:10 UTC Vuln: host=203.0.113.19 name=Cleartext submission of password refs= 
[*] Time: 2016-07-15 15:42:11 UTC Vuln: host=203.0.113.19 name=External service interaction (DNS) refs=URI-http://blog.portswigger.net/2015/04/introducing-burp-collaborator.html 
[*] Time: 2016-07-15 15:42:13 UTC Vuln: host=203.0.113.19 name=Open redirection refs=URI-https://support.portswigger.net/customer/portal/articles/1965733-Methodology_Testing%20for%20Open%20Redirections.html 
[*] Time: 2016-07-15 15:42:13 UTC Vuln: host=203.0.113.19 name=Cross-domain Referer leakage refs= 
[*] Time: 2016-07-15 15:42:13 UTC Vuln: host=203.0.113.19 name=Cookie without HttpOnly flag set refs= 
[*] Time: 2016-07-15 15:42:13 UTC Vuln: host=203.0.113.19 name=Email addresses disclosed refs= 
[*] Time: 2016-07-15 15:42:13 UTC Vuln: host=203.0.113.19 name=Multiple content types specified refs= 
[*] Time: 2016-07-15 15:42:14 UTC Vuln: host=203.0.113.19 name=Path-relative style sheet import refs=URI-http://blog.portswigger.net/2015/02/prssi.html 
[*] Time: 2016-07-15 15:42:15 UTC Vuln: host=203.0.113.19 name=Content type incorrectly stated refs= 
[*] Time: 2016-07-15 15:42:15 UTC Vuln: host=203.0.113.19 name=Cross-site request forgery refs=URI-https://support.portswigger.net/customer/portal/articles/1965674-using-burp-to-test-for-cross-site-request-forgery-csrf- 
[*] Time: 2016-07-15 15:42:16 UTC Vuln: host=203.0.113.19 name=HTML uses unrecognized charset refs= 
msf > 
```
