### PR TITLE
Update ActiveRecord syntax for framework db credential iteration

### DIFF
--- a/lib/msf/core/db_manager/cred.rb
+++ b/lib/msf/core/db_manager/cred.rb
@@ -2,7 +2,7 @@ module Msf::DBManager::Cred
   # This methods returns a list of all credentials in the database
   def creds(wspace=workspace)
   ::ActiveRecord::Base.connection_pool.with_connection {
-    Mdm::Cred.includes({:service => :host}).where("hosts.workspace_id = ?", wspace.id)
+    Mdm::Cred.where("hosts.workspace_id = ?", wspace.id).joins(:service => :host)
   }
   end
 


### PR DESCRIPTION
This fixes #7085 by using the new join syntax with the Metasploit database.
## Verification
- [x] Start `msfconsole`
- [x] run `irb`
- [x] run `framework.db.creds.each`
- [x] **Verify** that an iterator is returned, without a stack trace
- [x] type `quit`
- [x] **Verify** that the `creds` command works as expected
