### PR TITLE
Add final filesize to msfvenom output, useful when using different formats.

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -333,15 +333,15 @@ module Msf
         gen_payload = format_payload(encoded_payload)
       end
 
-      if format.to_s != 'raw'
-        cli_print "Final size of #{format} file: #{gen_payload.length} bytes"
-      end
-
       if gen_payload.nil?
         raise PayloadGeneratorError, 'The payload could not be generated, check options'
       elsif gen_payload.length > @space and not @smallest
         raise PayloadSpaceViolation, 'The payload exceeds the specified space'
       else
+        if format.to_s != 'raw'
+          cli_print "Final size of #{format} file: #{gen_payload.length} bytes"
+        end
+
         gen_payload
       end
     end

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -333,8 +333,8 @@ module Msf
         gen_payload = format_payload(encoded_payload)
       end
 
-      if encoded_payload.length != gen_payload.length
-        cli_print "Final size of #{format}: #{gen_payload.length} bytes"
+      if format.to_s != 'raw'
+        cli_print "Final size of #{format} file: #{gen_payload.length} bytes"
       end
 
       if gen_payload.nil?

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -332,6 +332,11 @@ module Msf
         cli_print "Payload size: #{encoded_payload.length} bytes"
         gen_payload = format_payload(encoded_payload)
       end
+
+      if encoded_payload.length != gen_payload.length
+        cli_print "Final size of #{format}: #{gen_payload.length} bytes"
+      end
+
       if gen_payload.nil?
         raise PayloadGeneratorError, 'The payload could not be generated, check options'
       elsif gen_payload.length > @space and not @smallest


### PR DESCRIPTION
This adds the string `Final size of <format>: <n> bytes` to the output from `msfvenom` when generating payloads of non-raw formats.

Before:

```
$ ./msfvenom -p linux/x64/shell_reverse_tcp -f elf LHOST=0.0.0.0 LPORT=5555 > /tmp/elf.bin
No platform was selected, choosing Msf::Module::Platform::Linux from the payload
No Arch selected, selecting Arch: x86_64 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 74 bytes

```

After:

```
$ ./msfvenom -p linux/x64/shell_reverse_tcp -f elf LHOST=0.0.0.0 LPORT=5555 > /tmp/elf.bin
No platform was selected, choosing Msf::Module::Platform::Linux from the payload
No Arch selected, selecting Arch: x86_64 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 74 bytes
Final size of elf: 194 bytes

```
