### PR TITLE
Fix grammar in browser_exploit_server

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -586,7 +586,7 @@ module Msf
         vprint_status("Serving exploit to user #{cli.peerhost} with tag #{tag}")
         profile = browser_profile[tag]
         if profile.nil?
-          print_status("Browsing visiting directly to the exploit URL is forbidden.")
+          print_status("Browser visiting directly to the exploit URL is forbidden.")
           send_not_found(cli)
         elsif profile[:tried] && !datastore['Retries']
           print_status("Target #{cli.peerhost} with tag \"#{tag}\" wants to retry the module, not allowed.")


### PR DESCRIPTION
This changes one word in lib/msf/core/exploit/remote/browser_exploit_server.rb. It's very easy, so I don't think verification steps are needed.
