### PR TITLE
fix "ERROR_CODE: 123" in psexec

### DIFF
--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -115,6 +115,11 @@ module Exploit::Remote::SMB::Client::Psexec
     end
 
     vprint_status("Creating the service...")
+
+    # ensure the service name and display name are not empty
+    service_name ||= Rex::Text.rand_text_alpha(8)
+    display_name ||= Rex::Text.rand_text_alpha(16)
+
     svc_handle, svc_status = svc_client.createservicew(scm_handle, service_name, display_name, command, opts)
 
     case svc_status


### PR DESCRIPTION
This sort of relates to #6222 - seeing "ERROR_CODE: 123" when using `exploit/windows/smb/psexec`, but everything is fine with `exploit/windows/smb/psexec_psh`.

Empty `service_name` and `display_name` variables are being passed to `createservicew()` in `lib/msf/core/exploit/smb/client/psexec.rb`.

edit: The culprit seems to be `save`ing your psexec settings, since it writes empty `SERVICE_DISPLAY_NAME` and `SERVICE_NAME` variables into ~/.msf4/config which get picked up when msfconsole is restarted. The error 123 can be reproduced using psexec_psh by `save`ing.
