### PR TITLE
fix VAR=VAL loading from config

### DIFF
--- a/lib/rex/parser/ini.rb
+++ b/lib/rex/parser/ini.rb
@@ -165,7 +165,12 @@ protected
       # Is it a VAR=VAL?
       elsif (md = line.match(/^(.+?)=(.*)$/))
         if (active_group)
-          self[active_group][md[1]] = md[2]
+          var, val = md[1], md[2]
+
+          # don't clobber datastore nils with ""
+          unless val.empty?
+            self[active_group][var] = val
+          end
         end
       end
     }


### PR DESCRIPTION
This fixes #6222 in a weird way, also see #7120.

When ~/.msf4/config is read, the values in the [module] sections will clobber the datastore nils with "" when the `VAR=VAL` lines are parsed and `VAL` is empty, like `VAR=`. This results from using `save`.
