### PR TITLE
Remove unwanted <ruby> tag while generating module doc code

### DIFF
--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -6,6 +6,8 @@ module Redcarpet
     class MsfMdHTML < Redcarpet::Render::HTML
 
       def block_code(code, language)
+        code = $1 if code =~ /^<ruby>(.+)<\/ruby>/m
+
         "<pre>" \
           "<code>#{code}</code>" \
         "</pre>"


### PR DESCRIPTION
## What This Patch Does

This fixes a problem with the code parser generating the ruby tag, which causes the format to look weird like this:

<img width="779" alt="screen shot 2016-07-25 at 3 40 38 pm" src="https://cloud.githubusercontent.com/assets/1170914/17116602/31a56c18-527e-11e6-82da-02858d24a555.png">

(It also might not look exactly like that with other browsers. I'm using Google Chrome)

With this patch, it should look like this:

<img width="768" alt="screen shot 2016-07-25 at 3 41 18 pm" src="https://cloud.githubusercontent.com/assets/1170914/17116619/41b73cc6-527e-11e6-84c2-1e3557ba5670.png">
## Verification
- [x] Start msfconsole
- [x] Do: `use post/windows/gather/enum_ie`
- [x] Do: `info -d`
- [x] The section that tells you how to create a resource script should look like this:

<img width="768" alt="screen shot 2016-07-25 at 3 41 18 pm" src="https://cloud.githubusercontent.com/assets/1170914/17116619/41b73cc6-527e-11e6-84c2-1e3557ba5670.png">
