### PR TITLE
Add timestamping to downloaded files

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -195,7 +195,7 @@ class Dir < Rex::Post::Dir
   # Downloads the contents of a remote directory a
   # local directory, optionally in a recursive fashion.
   #
-  def Dir.download(dst, src, recursive = false, force = true, glob = nil, &stat)
+  def Dir.download(dst, src, recursive = false, force = true, glob = nil, timestamp = nil, &stat)
 
     self.entries(src, glob).each { |src_sub|
       dst_item = dst + ::File::SEPARATOR + client.unicode_filter_encode(src_sub)
@@ -208,7 +208,12 @@ class Dir < Rex::Post::Dir
       src_stat = client.fs.filestat.new(src_item)
 
       if (src_stat.file?)
+        if timestamp
+          dst_item << timestamp
+        end
+
         stat.call('downloading', src_item, dst_item) if (stat)
+
         begin
           result = client.fs.file.download_file(dst_item, src_item)
           stat.call(result, src_item, dst_item) if (stat)
@@ -231,7 +236,7 @@ class Dir < Rex::Post::Dir
         end
 
         stat.call('mirroring', src_item, dst_item) if (stat)
-        download(dst_item, src_item, recursive, force, glob, &stat)
+        download(dst_item, src_item, recursive, force, glob, timestamp, &stat)
         stat.call('mirrored', src_item, dst_item) if (stat)
       end
     }

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -280,12 +280,17 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   # If a block is given, it will be called before each file is downloaded and
   # again when each download is complete.
   #
-  def File.download(dest, *src_files, &stat)
-    src_files.each { |src|
+  def File.download(dest, src_files, timestamp = nil, &stat)
+    [*src_files].each { |src|
       if (::File.basename(dest) != File.basename(src))
         # The destination when downloading is a local file so use this
         # system's separator
         dest += ::File::SEPARATOR + File.basename(src)
+      end
+
+      # XXX: dest can be the same object as src, so we use += instead of <<
+      if timestamp
+        dest += timestamp
       end
 
       stat.call('downloading', src, dest) if (stat)


### PR DESCRIPTION
This adds an option to the `download` command in Meterpreter that allows us to timestamp saved files.
- [x] Try `download` without `-t`
- [x] Try `download` with `-t` and a single file
- [x] Try `download` with `-r` and `-t` and a directory
- [x] Try `download` with `-r` and `-t` and a glob
