### PR TITLE
Fix #6989, scanner modules printing RHOST in progress messages

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -31,6 +31,18 @@ def initialize(info = {})
 
 end
 
+# If a module is using the scanner mixin, technically the RHOST datastore option should be
+# disabled. Only the mixin should be setting this. See #6989
+
+def setup
+  @original_rhost = datastore['RHOST']
+  datastore['RHOST'] = nil
+end
+
+def cleanup
+  datastore['RHOST'] = @original_rhost
+end
+
 
 def check
   nmod = replicant

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if(banner)
       banner_sanitized = Rex::Text.to_hex_ascii(self.banner.to_s)
-      print_status("#{rhost}:#{rport} FTP Banner: '#{banner_sanitized}'")
+      print_status("FTP Banner: '#{banner_sanitized}'")
       report_service(:host => rhost, :port => rport, :name => "ftp", :info => banner_sanitized)
     end
 


### PR DESCRIPTION
## What This Patch Does

If the RHOST datastore option is set, some scanner modules will print that in the progress messages, which makes no sense. The RHOST option in Msf::Auxiliary::Scanner should never be configurable by the user anyway, it is set in the mixin.

Fix #6989
## Verification
- [ ] First let's set up an FTP server for testing. In a terminal, do: `gem install ftpd`
- [ ] Do `irb`
- [ ] In IRB, paste the following code:

``` ruby
require 'ftpd'
require 'tmpdir'

class Driver

  def initialize(temp_dir)
    @temp_dir = temp_dir
  end

  def authenticate(user, password)
    true
  end

  def file_system(user)
    Ftpd::DiskFileSystem.new(@temp_dir)
  end

end

Dir.mktmpdir do |temp_dir|
  driver = Driver.new(temp_dir)
  server = Ftpd::FtpServer.new(driver)
  server.start
  puts "Server listening on port #{server.bound_port}"
  gets
end
```
- [ ] When the FTP server is running, it should tell you which port it's running, like this (it is listening on 127.0.0.1):

```
Server listening on port 62866
```
- [x] Start msfconsole
- [x] Do: `auxiliary/scanner/ftp/ftp_version`
- [x] Do: `set RHOSTS 127.0.0.1`
- [x] Do: `set RHOST 1.1.1.1`
- [x] Do: `run`
- [x] The output should look like the following. Notice the progress message ("Scanned x of x hosts") does not print the rhost:rport:

```
msf auxiliary(ftp_version) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(ftp_version) > set RPORT 62866
RPORT => 62866
msf auxiliary(ftp_version) > set RHOST 1.1.1.1
RHOST => 1.1.1.1
msf auxiliary(ftp_version) > run

[*] 127.0.0.1:62866       - FTP Banner: '220 wconrad/ftpd 2.0.0\x0d\x0a'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ftp_version) > 
```
