### PR TITLE
Add wordpress_url_uploads

### DIFF
--- a/lib/msf/core/exploit/http/wordpress/uris.rb
+++ b/lib/msf/core/exploit/http/wordpress/uris.rb
@@ -115,6 +115,13 @@ module Msf::Exploit::Remote::HTTP::Wordpress::URIs
     normalize_uri(wordpress_url_wp_content, 'themes')
   end
 
+  # Returns the Wordpress uploads dir URL
+  #
+  # @return [String] Wordpress uploads dir URL
+  def wordpress_url_uploads
+    normalize_uri(wordpress_url_wp_content, 'uploads')
+  end
+
   # Returns the Wordpress XMLRPC URL
   #
   # @return [String] Wordpress XMLRPC URL


### PR DESCRIPTION
Easy one. Adds `/wp-content/uploads` to the `Wordpress` mixin.
- [x] `use` a module that includes `Msf::Exploit::Remote::HTTP::Wordpress`
- [x] `irb -e 'puts active_module.wordpress_url_uploads'`
- [x] See `/wp-content/uploads`
