### PR TITLE
Fix #7158, tiki_calendar_exec incorrectly reports successful login

### DIFF
--- a/modules/exploits/linux/http/tiki_calendar_exec.rb
+++ b/modules/exploits/linux/http/tiki_calendar_exec.rb
@@ -53,8 +53,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(80),
         OptString.new('TARGETURI', [ true, 'The URI of Tiki-Wiki', '/']),
-        OptString.new('USERNAME',  [ false, 'Username of a user with calendar access', 'admin']),
-        OptString.new('PASSWORD',  [ false, 'Password of a user with calendar access', 'admin'])
+        OptString.new('USERNAME',  [ true, 'Username of a user with calendar access', 'admin']),
+        OptString.new('PASSWORD',  [ true, 'Password of a user with calendar access', 'admin'])
       ], self.class
     )
   end
@@ -67,6 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri'       => normalize_uri(target_uri.path, 'tiki-login_scr.php'),
         'method'    => 'GET'
       )
+
+      if res && res.code == 404
+        fail_with(Failure::Unknown, 'Target does not have tiki-login_scr.php')
+      end
+
       cookie = res ? res.get_cookies : ''
       # if we have creds, login with them
       vprint_status('Attempting Login')
@@ -88,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # double check auth worked and we got a Log out on the page.
       # at times I got it to auth, but then it would give permission errors
       # so we want to try to double check everything is good
-      if res && !res.body =~ /Log out/
+      if res && res.body !~ /Log out/
         fail_with(Failure::UnexpectedReply, "#{peer} Login Failed with #{datastore['USERNAME']}:#{datastore['PASSWORD']}")
       end
       vprint_good("Login Successful!")


### PR DESCRIPTION
## What This Patch Does

When tiki_calendar_exec is used against a host that does not even have the vulnerable application installed, it incorrectly reports a successful login.

It also should not even attempt to login when the application isn't there.

This patch addresses those problems.

https://github.com/rapid7/metasploit-framework/issues/7158
## Verification Steps
- [x] Do: `ruby -run -e httpd. -p 8181` (This is your fake server)
- [x] Start msfconsole
- [x] Do: `use exploit/linux/http/tiki_calendar_exec`
- [x] Do: `set rhost [IP of the web server]`
- [x] Do: `set rport 8181`
- [x] Do: `run`
- [x] The module should say "Target does not have tiki-login_scr.php"
