### PR TITLE
Bug/ms 1789/specing and converting the cisco mixin

### DIFF
--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -391,34 +391,36 @@ module Auxiliary::Cisco
 
         when /^\s*ppp chap (secret|password) (\d+) ([^\s]+)/i
           stype = $2.to_i
-          shash = $3
+          spass = $3
 
           if stype == 5
-            print_good("#{thost}:#{tport} PPP CHAP MD5 Encrypted Password: #{shash}")
-            store_loot("cisco.ios.ppp_password_hash", "text/plain", thost, shash, "ppp_password_hash.txt", "Cisco IOS PPP Password Hash (MD5)")
+            print_good("#{thost}:#{tport} PPP CHAP MD5 Encrypted Password: #{spass}")
+            store_loot("cisco.ios.ppp_password_hash", "text/plain", thost, spass, "ppp_password_hash.txt", "Cisco IOS PPP Password Hash (MD5)")
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 0
-            print_good("#{thost}:#{tport} Password: #{shash}")
-            store_loot("cisco.ios.ppp_password", "text/plain", thost, shash, "ppp_password.txt", "Cisco IOS PPP Password")
+            print_good("#{thost}:#{tport} Password: #{spass}")
+            store_loot("cisco.ios.ppp_password", "text/plain", thost, spass, "ppp_password.txt", "Cisco IOS PPP Password")
 
-            cred = cred_info.dup
-            cred[:pass] = shash
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 7
-            shash = cisco_ios_decrypt7(shash) rescue shash
-            print_good("#{thost}:#{tport} PPP Decrypted Password: #{shash}")
-            store_loot("cisco.ios.ppp_password", "text/plain", thost, shash, "ppp_password.txt", "Cisco IOS PPP Password")
+            spass = cisco_ios_decrypt7(spass) rescue spass
+            print_good("#{thost}:#{tport} PPP Decrypted Password: #{spass}")
+            store_loot("cisco.ios.ppp_password", "text/plain", thost, spass, "ppp_password.txt", "Cisco IOS PPP Password")
 
-            cred = cred_info.dup
-            cred[:pass] = shash
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :password
+            create_credential_and_login(cred)
           end
       end
     end

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -356,36 +356,37 @@ module Auxiliary::Cisco
 
           suser = $1
           stype = $3.to_i
-          shash = $4
+          spass = $4
 
           if stype == 5
-            print_good("#{thost}:#{tport} PPP Username #{suser} MD5 Encrypted Password: #{shash}")
-            store_loot("cisco.ios.ppp_username_password_hash", "text/plain", thost, "#{suser}:#{shash}", "ppp_username_password_hash.txt", "Cisco IOS PPP Username and Password Hash (MD5)")
+            print_good("#{thost}:#{tport} PPP Username #{suser} MD5 Encrypted Password: #{spass}")
+            store_loot("cisco.ios.ppp_username_password_hash", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password_hash.txt", "Cisco IOS PPP Username and Password Hash (MD5)")
+            
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 0
-            print_good("#{thost}:#{tport} PPP Username: #{suser} Password: #{shash}")
-            store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{shash}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
-
-            cred = cred_info.dup
-            cred[:pass] = shash
-            cred[:user] = suser
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            print_good("#{thost}:#{tport} PPP Username: #{suser} Password: #{spass}")
+            store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
+            
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 7
-            shash = cisco_ios_decrypt7(shash) rescue shash
-            print_good("#{thost}:#{tport} PPP Username: #{suser} Decrypted Password: #{shash}")
-            store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{shash}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
+            spass = cisco_ios_decrypt7(spass) rescue spass
+            print_good("#{thost}:#{tport} PPP Username: #{suser} Decrypted Password: #{spass}")
+            store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
 
-            cred = cred_info.dup
-            cred[:pass] = shash
-            cred[:user] = suser
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :password
+            create_credential_and_login(cred)
           end
 
         when /^\s*ppp chap (secret|password) (\d+) ([^\s]+)/i

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -285,71 +285,71 @@ module Auxiliary::Cisco
           user  = $1
           priv  = $2
           stype = $4.to_i
-          shash = $5
+          spass = $5
 
           if stype == 5
-            print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{shash}")
-            store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}_level#{priv}:#{shash}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
+            print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
+            store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 0
-            print_good("#{thost}:#{tport} Username '#{user}' with Password: #{shash}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{shash}", "username_password.txt", "Cisco IOS Username and Password")
+            print_good("#{thost}:#{tport} Username '#{user}' with Password: #{spass}")
+            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
-            cred = cred_info.dup
-            cred[:user] = user
-            cred[:pass] = shash
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 7
-            shash = cisco_ios_decrypt7(shash) rescue shash
-            print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{shash}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{shash}", "username_password.txt", "Cisco IOS Username and Password")
+            spass = cisco_ios_decrypt7(spass) rescue spass
+            print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{spass}")
+            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
-            cred = cred_info.dup
-            cred[:user] = user
-            cred[:pass] = shash
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :password
+            create_credential_and_login(cred)
           end
 
         when /^\s*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i
           user  = $1
           stype = $3.to_i
-          shash = $4
+          spass = $4
 
           if stype == 5
-            print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{shash}")
-            store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}:#{shash}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
+            print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
+            store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 0
-            print_good("#{thost}:#{tport} Username '#{user}' with Password: #{shash}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{shash}", "username_password.txt", "Cisco IOS Username and Password")
+            print_good("#{thost}:#{tport} Username '#{user}' with Password: #{spass}")
+            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
-            cred = cred_info.dup
-            cred[:user] = user
-            cred[:pass] = shash
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
           end
 
           if stype == 7
-            shash = cisco_ios_decrypt7(shash) rescue shash
-            print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{shash}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{shash}", "username_password.txt", "Cisco IOS Username and Password")
+            spass = cisco_ios_decrypt7(spass) rescue spass
+            print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{spass}")
+            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
 
-            cred = cred_info.dup
-            cred[:user] = user
-            cred[:pass] = shash
-            cred[:type] = "password"
-            cred[:collect_type] = "password"
-            store_cred(cred)
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :password
+            create_credential_and_login(cred)
           end
 
         when /^\s*ppp.*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -33,11 +33,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
   subject(:aux_cisco) { DummyClass.new }
   
   let!(:workspace) { FactoryGirl.create(:mdm_workspace) }
-  
-  before(:example) do
-    expect(aux_cisco).to receive(:myworkspace).and_return(workspace)
-  end
-  
+    
   context '#create_credential_and_login' do
     
     let(:session) { FactoryGirl.create(:mdm_session) }
@@ -52,6 +48,24 @@ RSpec.describe Msf::Auxiliary::Cisco do
     let(:service) { FactoryGirl.create(:mdm_service, host: FactoryGirl.create(:mdm_host, workspace: workspace)) }
     let(:task) { FactoryGirl.create(:mdm_task, workspace: workspace) }
     
+    let(:login_data) {
+      {
+        address: service.host.address,
+        port: service.port,
+        service_name: service.name,
+        protocol: service.proto,
+        workspace_id: workspace.id,
+        origin_type: :service,
+        module_fullname: 'auxiliary/scanner/smb/smb_login',
+        realm_key: 'Active Directory Domain',
+        realm_value: 'contosso',
+        username: 'Username',
+        private_data: 'password',
+        private_type: :password,
+        status: Metasploit::Model::Login::Status::UNTRIED
+      }
+    }
+    
     it 'creates a Metasploit::Credential::Login' do
       expect{test_object.create_credential_and_login(login_data)}.to change{Metasploit::Credential::Login.count}.by(1)
     end
@@ -62,6 +76,9 @@ RSpec.describe Msf::Auxiliary::Cisco do
   end
   
   context '#cisco_ios_config_eater' do
+    before(:example) do
+      expect(aux_cisco).to receive(:myworkspace).and_return(workspace)
+    end
     
     it 'deals with udp ports' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:161 Unencrypted Enable Password: 1511021F0725')
@@ -239,7 +256,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
           origin_type: :service,
           service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
-          private_data: "1511021F0725",
+          private_data: "cisco",
           private_type: :password,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
@@ -248,12 +265,26 @@ RSpec.describe Msf::Auxiliary::Cisco do
     end
     
     it 'password|secret 5' do
-      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted VTY Password: password')
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted VTY Password: 1511021F0725')
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.vty_password", "text/plain", "127.0.0.1", "password", "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)"
+        "cisco.ios.vty_password", "text/plain", "127.0.0.1", "1511021F0725", "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)"
       )
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:create_credential_and_login).with(
+        {
+          address: "127.0.0.1",
+          port: 1337,
+          protocol: "tcp",
+          workspace_id: workspace.id,
+          origin_type: :service,
+          service_name: '',
+          module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+          private_data: "1511021F0725",
+          private_type: :nonreplayable_hash,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 5 1511021F0725')
     end
@@ -263,15 +294,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
-      expect(aux_cisco).to receive(:store_cred).with(
+      expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
-          host: "127.0.0.1",
+          address: "127.0.0.1",
           port: 1337,
-          user: "",
-          pass: "1511021F0725",
-          type: "password",
-          collect_type: "password",
-          active: true
+          protocol: "tcp",
+          workspace_id: workspace.id,
+          origin_type: :service,
+          service_name: '',
+          module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+          private_data: "1511021F0725",
+          private_type: :nonreplayable_hash,
+          status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 0 1511021F0725')
@@ -282,15 +316,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
-      expect(aux_cisco).to receive(:store_cred).with(
+      expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
-          host: "127.0.0.1",
+          address: "127.0.0.1",
           port: 1337,
-          user: "",
-          pass: "1511021F0725",
-          type: "password",
-          collect_type: "password",
-          active: true
+          protocol: "tcp",
+          workspace_id: workspace.id,
+          origin_type: :service,
+          service_name: '',
+          module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+          private_data: "1511021F0725",
+          private_type: :nonreplayable_hash,
+          status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 1511021F0725')
@@ -316,15 +353,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.wireless_wpapsk", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "",
-            pass: "1511021F0725",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 0 1511021F0725')
@@ -338,6 +378,20 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.wireless_wpapsk_hash", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wpapsk_hash.txt", "Cisco IOS Wireless WPA-PSK Password Hash (MD5)"
         )
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
+          {
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }
+        )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 5 1511021F0725')
       end
       
@@ -349,42 +403,49 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.wireless_wpapsk", "text/plain", "127.0.0.1", "cisco", "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Decrypted Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "",
-            pass: "cisco",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "cisco",
+            private_type: :password,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
+        
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 7 1511021F0725')
       end
             
     end
     
     it 'crypto isakmp key' do
-      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 VPN IPSEC ISAKMP Key 'somestring' Host 'someaddress'")
+      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 VPN IPSEC ISAKMP Key '1511021F0725' Host 'someaddress'")
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.config", "text/plain", "127.0.0.1",  "crypto isakmp key somestring address someaddress", "config.txt", "Cisco IOS Configuration"
+        "cisco.ios.config", "text/plain", "127.0.0.1",  "crypto isakmp key 1511021F0725 address someaddress", "config.txt", "Cisco IOS Configuration"
       )
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.vpn_ipsec_key", "text/plain", "127.0.0.1", "somestring", "vpn_ipsec_key.txt", "Cisco VPN IPSEC Key"
+        "cisco.ios.vpn_ipsec_key", "text/plain", "127.0.0.1", "1511021F0725", "vpn_ipsec_key.txt", "Cisco VPN IPSEC Key"
       )
-      expect(aux_cisco).to receive(:store_cred).with(
+      expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
-          host: "127.0.0.1",
+          address: "127.0.0.1",
           port: 1337,
-          user: "",
-          pass: "somestring",
-          type: "password",
-          collect_type: "password",
-          active: true
+          protocol: "tcp",
+          workspace_id: workspace.id,
+          origin_type: :service,
+          service_name: '',
+          module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+          private_data: "1511021F0725",
+          private_type: :nonreplayable_hash,
+          status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'crypto isakmp key somestring address someaddress')
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'crypto isakmp key 1511021F0725 address someaddress')
     end
     
     it 'interface tunnel' do
@@ -395,25 +456,28 @@ RSpec.describe Msf::Auxiliary::Cisco do
     end
     
     it 'tunnel key' do
-      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 GRE Tunnel Key somestring for Interface Tunnel ")
+      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 GRE Tunnel Key 1511021F0725 for Interface Tunnel ")
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.gre_tunnel_key", "text/plain", "127.0.0.1", "tunnel_somestring", "gre_tunnel_key.txt", "Cisco GRE Tunnel Key"
+        "cisco.ios.gre_tunnel_key", "text/plain", "127.0.0.1", "tunnel_1511021F0725", "gre_tunnel_key.txt", "Cisco GRE Tunnel Key"
       )
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.config", "text/plain", "127.0.0.1",  "tunnel key somestring", "config.txt", "Cisco IOS Configuration"
+        "cisco.ios.config", "text/plain", "127.0.0.1",  "tunnel key 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
-      expect(aux_cisco).to receive(:store_cred).with(
+      expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
-          host: "127.0.0.1",
+          address: "127.0.0.1",
           port: 1337,
-          user: "",
-          pass: "somestring",
-          type: "password",
-          collect_type: "password",
-          active: true
+          protocol: "tcp",
+          workspace_id: workspace.id,
+          origin_type: :service,
+          service_name: '',
+          module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+          private_data: "1511021F0725",
+          private_type: :nonreplayable_hash,
+          status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'tunnel key somestring')
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'tunnel key 1511021F0725')
     end
     
     it 'ip nhrp authentication' do

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -676,15 +676,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
           "cisco.ios.ppp_username_password", "text/plain", "127.0.0.1", "someusername:1511021F0725", "ppp_username_password.txt",
           "Cisco IOS PPP Username and Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "someusername",
-            pass: "1511021F0725",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 0 1511021F0725')
@@ -699,6 +702,20 @@ RSpec.describe Msf::Auxiliary::Cisco do
           "cisco.ios.ppp_username_password_hash", "text/plain", "127.0.0.1", "someusername:1511021F0725", "ppp_username_password_hash.txt",
           "Cisco IOS PPP Username and Password Hash (MD5)"
         )
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
+          {
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }
+        )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 5 1511021F0725')
       end
 
@@ -712,15 +729,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
           "cisco.ios.ppp_username_password", "text/plain", "127.0.0.1", "someusername:cisco", "ppp_username_password.txt",
           "Cisco IOS PPP Username and Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "someusername",
-            pass: "cisco",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "cisco",
+            private_type: :password,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 7 1511021F0725')

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -1,0 +1,612 @@
+# -*- coding: binary -*-
+require 'spec_helper'
+
+require 'msf/core/auxiliary/cisco'
+
+RSpec.describe Msf::Auxiliary::Cisco do
+  class DummyClass
+    include Msf::Auxiliary::Cisco
+    def framework
+      Msf::Simple::Framework.create(
+          'ConfigDirectory' => Rails.root.join('spec', 'dummy', 'framework', 'config').to_s,
+          # don't load any module paths so we can just load the module under test and save time
+          'DeferModuleLoads' => true
+      )
+    end
+    def print_good(str=nil)
+      raise StandardError("This method needs to be stubbed.")
+    end
+    def store_cred(hsh=nil)
+      raise StandardError("This method needs to be stubbed.")
+    end
+  end
+  
+  subject(:aux_cisco) { DummyClass.new }
+  
+  context '#cisco_ios_config_eater' do
+    
+    it 'deals with udp ports' do
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:161 Unencrypted Enable Password: 1511021F0725')
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 161,
+          user: "",
+          pass: "1511021F0725",
+          type: "password",
+          collect_type: "password",
+          active: true,
+          proto: 'udp'
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',161,'enable password 1511021F0725')
+    end
+    
+    context 'Enable Password|Secret' do
+      
+      it 'with password type 0' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Enable Password: password0')
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.enable_pass", "text/plain", "127.0.0.1", "password0", "enable_password.txt", "Cisco IOS Enable Password"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 0 password0", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            :host=>"127.0.0.1",
+            :port=>1337,
+            :user=>"",
+            :pass=>"password0",
+            :type=>"password",
+            :collect_type=>"password",
+            :active=>true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 0 password0')
+      end
+      
+      it 'with password type 5' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted Enable Password: somehashlikestring')
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 5 somehashlikestring')
+      end
+      
+      it 'with password type 7' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted Enable Password: cisco')
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.enable_pass", "text/plain", "127.0.0.1", "cisco", "enable_password.txt", "Cisco IOS Enable Password"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            :host=>"127.0.0.1",
+            :port=>1337,
+            :user=>"",
+            :pass=>"cisco",
+            :type=>"password",
+            :collect_type=>"password",
+            :active=>true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 7 1511021F0725')
+      end
+      
+    end
+    
+    it 'enable password' do
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted Enable Password: 1511021F0725')
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 1337,
+          user: "",
+          pass: "1511021F0725",
+          type: "password",
+          collect_type: "password",
+          active: true
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 1511021F0725')
+    end
+    
+    context 'snmp-server community' do
+      
+      it 'with RO' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 SNMP Community (RO): 1511021F0725')
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            :host=>"127.0.0.1",
+            :port=>161,
+            :user=>"",
+            :pass=>"1511021F0725",
+            :type=>"password_ro",
+            :collect_type=>"password_ro",
+            :sname=>"snmp",
+            :proto=>"udp",
+            :active=>true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'snmp-server community 1511021F0725 RO')
+      end
+      
+      it 'with RW' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 SNMP Community (RW): 1511021F0725')
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            :host=>"127.0.0.1",
+            :port=>161,
+            :user=>"",
+            :pass=>"1511021F0725",
+            :type=>"password",
+            :collect_type=>"password",
+            :sname=>"snmp",
+            :proto=>"udp",
+            :active=>true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'snmp-server community 1511021F0725 RW')
+      end
+      
+    end
+    
+    it 'password 7' do
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted VTY Password: cisco')
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "password 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 1337,
+          user: "",
+          pass: "cisco",
+          type: "password",
+          collect_type: "password",
+          active: true
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 7 1511021F0725')
+    end
+    
+    it 'password|secret 5' do
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted VTY Password: password')
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.vty_password", "text/plain", "127.0.0.1", "password", "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)"
+      )
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "password 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 5 1511021F0725')
+    end
+    
+    it 'password 0' do
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted VTY Password: 1511021F0725')
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "password 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 1337,
+          user: "",
+          pass: "1511021F0725",
+          type: "password",
+          collect_type: "password",
+          active: true
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 0 1511021F0725')
+    end
+    
+    it 'password' do
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Unencrypted VTY Password: 1511021F0725')
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "password 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 1337,
+          user: "",
+          pass: "1511021F0725",
+          type: "password",
+          collect_type: "password",
+          active: true
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'password 1511021F0725')
+    end
+    
+    it 'encryption key' do
+      expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WEP Key: 1511021F0725')
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "encryption key 777 size 8bit 8 1511021F0725", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.wireless_wep", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wep.txt", "Cisco IOS Wireless WEP Key"
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'encryption key 777 size 8bit 8 1511021F0725')
+    end
+    
+    context 'wpa-psk' do
+      it 'with password type 0' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK Password: 1511021F0725')
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.wireless_wpapsk", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "",
+            pass: "1511021F0725",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 0 1511021F0725')
+      end
+      
+      it 'with password type 5' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK MD5 Password Hash: 1511021F0725')
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.wireless_wpapsk_hash", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wpapsk_hash.txt", "Cisco IOS Wireless WPA-PSK Password Hash (MD5)"
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 5 1511021F0725')
+      end
+      
+      it 'with password type 7' do
+        expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Wireless WPA-PSK Decrypted Password: cisco')
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.wireless_wpapsk", "text/plain", "127.0.0.1", "cisco", "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Decrypted Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "",
+            pass: "cisco",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'wpa-psk ascii 7 1511021F0725')
+      end
+            
+    end
+    
+    it 'crypto isakmp key' do
+      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 VPN IPSEC ISAKMP Key 'somestring' Host 'someaddress'")
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1",  "crypto isakmp key somestring address someaddress", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.vpn_ipsec_key", "text/plain", "127.0.0.1", "somestring", "vpn_ipsec_key.txt", "Cisco VPN IPSEC Key"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 1337,
+          user: "",
+          pass: "somestring",
+          type: "password",
+          collect_type: "password",
+          active: true
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'crypto isakmp key somestring address someaddress')
+    end
+    
+    it 'interface tunnel' do
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1",  "interface tunnel7", "config.txt", "Cisco IOS Configuration"
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'interface tunnel7')
+    end
+    
+    it 'tunnel key' do
+      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 GRE Tunnel Key somestring for Interface Tunnel ")
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.gre_tunnel_key", "text/plain", "127.0.0.1", "tunnel_somestring", "gre_tunnel_key.txt", "Cisco GRE Tunnel Key"
+      )
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1",  "tunnel key somestring", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 1337,
+          user: "",
+          pass: "somestring",
+          type: "password",
+          collect_type: "password",
+          active: true
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'tunnel key somestring')
+    end
+    
+    it 'ip nhrp authentication' do
+      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 NHRP Authentication Key somestring for Interface Tunnel ")
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.config", "text/plain", "127.0.0.1", "ip nhrp authentication somestring", "config.txt", "Cisco IOS Configuration"
+      )
+      expect(aux_cisco).to receive(:store_loot).with(
+        "cisco.ios.nhrp_tunnel_key", "text/plain", "127.0.0.1", "tunnel_somestring", "nhrp_tunnel_key.txt", "Cisco NHRP Authentication Key"
+      )
+      expect(aux_cisco).to receive(:store_cred).with(
+        {
+          host: "127.0.0.1",
+          port: 1337,
+          user: "",
+          pass: "somestring",
+          type: "password",
+          collect_type: "password",
+          active: true
+        }
+      )
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ip nhrp authentication somestring')
+    end
+    
+    context 'username privilege secret' do
+      it 'with password type 0' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername_level0:1511021F0725", "username_password.txt", "Cisco IOS Username and Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "someusername",
+            pass: "1511021F0725",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 0 1511021F0725')
+      end
+      
+      it 'with password type 5' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.username_password_hash", "text/plain", "127.0.0.1", "someusername_level0:1511021F0725",
+          "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)"
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 5 1511021F0725')
+      end
+
+    
+      it 'with password type 7' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername_level0:cisco", "username_password.txt", "Cisco IOS Username and Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "someusername",
+            pass: "cisco",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 7 1511021F0725')
+      end
+    end
+    
+    context 'username secret' do
+      it 'with password type 0' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername:1511021F0725", "username_password.txt",
+          "Cisco IOS Username and Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "someusername",
+            pass: "1511021F0725",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 0 1511021F0725')
+      end
+      
+      it 'with password type 5' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.username_password_hash", "text/plain", "127.0.0.1", "someusername:1511021F0725", "username_password_hash.txt",
+          "Cisco IOS Username and Password Hash (MD5)"
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 5 1511021F0725')
+      end
+
+    
+      it 'with password type 7' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Username 'someusername' with Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername:cisco", "username_password.txt",
+          "Cisco IOS Username and Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "someusername",
+            pass: "cisco",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 7 1511021F0725')
+      end
+    end
+    
+    context 'ppp.*username secret' do
+      it 'with password type 0' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username: someusername Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.ppp_username_password", "text/plain", "127.0.0.1", "someusername:1511021F0725", "ppp_username_password.txt",
+          "Cisco IOS PPP Username and Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "someusername",
+            pass: "1511021F0725",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 0 1511021F0725')
+      end
+      
+      it 'with password type 5' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username someusername MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.ppp_username_password_hash", "text/plain", "127.0.0.1", "someusername:1511021F0725", "ppp_username_password_hash.txt",
+          "Cisco IOS PPP Username and Password Hash (MD5)"
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 5 1511021F0725')
+      end
+
+    
+      it 'with password type 7' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Username: someusername Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.ppp_username_password", "text/plain", "127.0.0.1", "someusername:cisco", "ppp_username_password.txt",
+          "Cisco IOS PPP Username and Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "someusername",
+            pass: "cisco",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp123username someusername secret 7 1511021F0725')
+      end
+    end
+    
+    context 'ppp chap secret' do
+      it 'with password type 0' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.ppp_password", "text/plain", "127.0.0.1", "1511021F0725", "ppp_password.txt", "Cisco IOS PPP Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "",
+            pass: "1511021F0725",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 0 1511021F0725')
+      end
+      
+      it 'with password type 5' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP CHAP MD5 Encrypted Password: 1511021F0725")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.ppp_password_hash", "text/plain", "127.0.0.1", "1511021F0725", "ppp_password_hash.txt",
+          "Cisco IOS PPP Password Hash (MD5)"
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 5 1511021F0725')
+      end
+
+    
+      it 'with password type 7' do
+        expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 PPP Decrypted Password: cisco")
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
+        )
+        expect(aux_cisco).to receive(:store_loot).with(
+          "cisco.ios.ppp_password", "text/plain", "127.0.0.1", "cisco", "ppp_password.txt", "Cisco IOS PPP Password"
+        )
+        expect(aux_cisco).to receive(:store_cred).with(
+          {
+            host: "127.0.0.1",
+            port: 1337,
+            user: "",
+            pass: "cisco",
+            type: "password",
+            collect_type: "password",
+            active: true
+          }
+        )
+        aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 7 1511021F0725')
+      end
+    end
+    
+  end
+  
+end

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -481,25 +481,28 @@ RSpec.describe Msf::Auxiliary::Cisco do
     end
     
     it 'ip nhrp authentication' do
-      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 NHRP Authentication Key somestring for Interface Tunnel ")
+      expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 NHRP Authentication Key 1511021F0725 for Interface Tunnel ")
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.config", "text/plain", "127.0.0.1", "ip nhrp authentication somestring", "config.txt", "Cisco IOS Configuration"
+        "cisco.ios.config", "text/plain", "127.0.0.1", "ip nhrp authentication 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.nhrp_tunnel_key", "text/plain", "127.0.0.1", "tunnel_somestring", "nhrp_tunnel_key.txt", "Cisco NHRP Authentication Key"
+        "cisco.ios.nhrp_tunnel_key", "text/plain", "127.0.0.1", "tunnel_1511021F0725", "nhrp_tunnel_key.txt", "Cisco NHRP Authentication Key"
       )
-      expect(aux_cisco).to receive(:store_cred).with(
+      expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
-          host: "127.0.0.1",
+          address: "127.0.0.1",
           port: 1337,
-          user: "",
-          pass: "somestring",
-          type: "password",
-          collect_type: "password",
-          active: true
+          protocol: "tcp",
+          workspace_id: workspace.id,
+          origin_type: :service,
+          service_name: '',
+          module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+          private_data: "1511021F0725",
+          private_type: :nonreplayable_hash,
+          status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
-      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ip nhrp authentication somestring')
+      aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ip nhrp authentication 1511021F0725')
     end
     
     context 'username privilege secret' do
@@ -511,17 +514,21 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername_level0:1511021F0725", "username_password.txt", "Cisco IOS Username and Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "someusername",
-            pass: "1511021F0725",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
+
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 0 1511021F0725')
       end
       
@@ -533,6 +540,20 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.username_password_hash", "text/plain", "127.0.0.1", "someusername_level0:1511021F0725",
           "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)"
+        )
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
+          {
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 5 1511021F0725')
       end
@@ -546,15 +567,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername_level0:cisco", "username_password.txt", "Cisco IOS Username and Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "someusername",
-            pass: "cisco",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "cisco",
+            private_type: :password,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername privilege 0 secret 7 1511021F0725')
@@ -571,15 +595,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
           "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername:1511021F0725", "username_password.txt",
           "Cisco IOS Username and Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "someusername",
-            pass: "1511021F0725",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 0 1511021F0725')
@@ -594,6 +621,20 @@ RSpec.describe Msf::Auxiliary::Cisco do
           "cisco.ios.username_password_hash", "text/plain", "127.0.0.1", "someusername:1511021F0725", "username_password_hash.txt",
           "Cisco IOS Username and Password Hash (MD5)"
         )
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
+          {
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }
+        )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 5 1511021F0725')
       end
 
@@ -607,15 +648,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
           "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername:cisco", "username_password.txt",
           "Cisco IOS Username and Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "someusername",
-            pass: "cisco",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "cisco",
+            private_type: :password,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'username someusername secret 7 1511021F0725')

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -14,10 +14,13 @@ RSpec.describe Msf::Auxiliary::Cisco do
       )
     end
     def print_good(str=nil)
-      raise StandardError("This method needs to be stubbed.")
+      raise StandardError.new("This method needs to be stubbed.")
     end
     def store_cred(hsh=nil)
-      raise StandardError("This method needs to be stubbed.")
+      raise StandardError.new("This method needs to be stubbed.")
+    end
+    def fullname
+      "Dummy Class / Dummy Ref"
     end
   end
   
@@ -55,15 +58,16 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 0 password0", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential).with(
           {
-            :host=>"127.0.0.1",
-            :port=>1337,
-            :user=>"",
-            :pass=>"password0",
-            :type=>"password",
-            :collect_type=>"password",
-            :active=>true
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: nil,
+            origin_type: :service,
+            module_fullname: "Dummy Class / Dummy Ref",
+            private_data: "password0",
+            private_type: :password
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 0 password0')
@@ -82,15 +86,16 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential).with(
           {
-            :host=>"127.0.0.1",
-            :port=>1337,
-            :user=>"",
-            :pass=>"cisco",
-            :type=>"password",
-            :collect_type=>"password",
-            :active=>true
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: nil,
+            origin_type: :service,
+            module_fullname: "Dummy Class / Dummy Ref",
+            private_data: "cisco",
+            private_type: :password
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 7 1511021F0725')
@@ -103,15 +108,16 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
-      expect(aux_cisco).to receive(:store_cred).with(
+      expect(aux_cisco).to receive(:create_credential).with(
         {
-          host: "127.0.0.1",
+          address: "127.0.0.1",
           port: 1337,
-          user: "",
-          pass: "1511021F0725",
-          type: "password",
-          collect_type: "password",
-          active: true
+          protocol: "tcp",
+          workspace_id: nil,
+          origin_type: :service,
+          module_fullname: "Dummy Class / Dummy Ref",
+          private_data: "1511021F0725",
+          private_type: :password
         }
       )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 1511021F0725')

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -756,15 +756,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.ppp_password", "text/plain", "127.0.0.1", "1511021F0725", "ppp_password.txt", "Cisco IOS PPP Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "",
-            pass: "1511021F0725",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 0 1511021F0725')
@@ -779,6 +782,20 @@ RSpec.describe Msf::Auxiliary::Cisco do
           "cisco.ios.ppp_password_hash", "text/plain", "127.0.0.1", "1511021F0725", "ppp_password_hash.txt",
           "Cisco IOS PPP Password Hash (MD5)"
         )
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
+          {
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }
+        )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 5 1511021F0725')
       end
 
@@ -791,15 +808,18 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.ppp_password", "text/plain", "127.0.0.1", "cisco", "ppp_password.txt", "Cisco IOS PPP Password"
         )
-        expect(aux_cisco).to receive(:store_cred).with(
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
-            host: "127.0.0.1",
+            address: "127.0.0.1",
             port: 1337,
-            user: "",
-            pass: "cisco",
-            type: "password",
-            collect_type: "password",
-            active: true
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "cisco",
+            private_type: :password,
+            status: Metasploit::Model::Login::Status::UNTRIED
           }
         )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'ppp chap secret 7 1511021F0725')

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -115,6 +115,20 @@ RSpec.describe Msf::Auxiliary::Cisco do
       
       it 'with password type 5' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted Enable Password: 1511021F0725')
+        expect(aux_cisco).to receive(:create_credential_and_login).with(
+          {
+            address: "127.0.0.1",
+            port: 1337,
+            protocol: "tcp",
+            workspace_id: workspace.id,
+            origin_type: :service,
+            service_name: '',
+            module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
+            private_data: "1511021F0725",
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED
+          }
+        )
         aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'enable password 5 1511021F0725')
       end
       
@@ -157,9 +171,10 @@ RSpec.describe Msf::Auxiliary::Cisco do
           protocol: "tcp",
           workspace_id: workspace.id,
           origin_type: :service,
+          service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
           private_data: "1511021F0725",
-          private_type: :password,
+          private_type: :nonreplayable_hash,
           status: Metasploit::Model::Login::Status::UNTRIED
         }
       )
@@ -177,6 +192,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             protocol: "udp",
             workspace_id: workspace.id,
             origin_type: :service,
+            service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
             private_type: :password,
@@ -196,6 +212,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
             protocol: "udp",
             workspace_id: workspace.id,
             origin_type: :service,
+            service_name: '',
             module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
             private_data: "1511021F0725",
             private_type: :password,
@@ -213,17 +230,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
-      # expect(aux_cisco).to receive(:store_cred).with(
-      #   {
-      #     host: "127.0.0.1",
-      #     port: 1337,
-      #     user: "",
-      #     pass: "cisco",
-      #     type: "password",
-      #     collect_type: "password",
-      #     active: true
-      #   }
-      # )
       expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
           address: "127.0.0.1",
@@ -231,6 +237,7 @@ RSpec.describe Msf::Auxiliary::Cisco do
           protocol: "tcp",
           workspace_id: workspace.id,
           origin_type: :service,
+          service_name: '',
           module_fullname: "auxiliary/scanner/snmp/cisco_dummy",
           private_data: "1511021F0725",
           private_type: :password,


### PR DESCRIPTION
Adding specs to the cisco mixing and updating it to use Metasploit Credentials
## Verification
- [x] specs should pass
- [x] make sure a module that uses the cisco mixin still works.
