### PR TITLE
jira_collector_traversal: Collector looks like hex, store it as a string

### DIFF
--- a/modules/exploits/windows/http/jira_collector_traversal.rb
+++ b/modules/exploits/windows/http/jira_collector_traversal.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to JIRA', '/']),
-        OptInt.new('COLLECTOR', [true, 'Collector ID'])
+        OptString.new('COLLECTOR', [true, 'Collector ID'])
       ], self.class)
 
     register_advanced_options(


### PR DESCRIPTION
## Verification
- [x] Start `msfconsole`
- [x] `use exploit/windows/http/jira_collector_traversal`
- [x] `set COLLECTOR 504c9b56`
- [x] **Verify** it allows that as a value
