### PR TITLE
Fix empty output in nbns_response

### DIFF
--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
 
     return unless nbnsq_decodedname =~ /#{datastore['REGEX'].source}/i
 
-    vprint_good("#{rhost.ljust 16} nbns - #{nbnsq_decodedname} matches regex, responding with #{spoof}")
+    print_good("#{rhost.ljust 16} nbns - #{nbnsq_decodedname} matches regex, responding with #{spoof}")
 
     vprint_status("transid:        #{nbnsq_transid.unpack('H4')}")
     vprint_status("tlags:          #{nbnsq_flags.unpack('B16')}")


### PR DESCRIPTION
Normally, the module prints nothing unless `VERBOSE` is `true`. In practice, we at least want to see responded-to hosts. We leave details to be printed when `VERBOSE` is set.
- [x] Run the module without `VERBOSE`
- [x] See responded-to hosts printed
- [x] Run the module with `VERBOSE`
- [x] See full details printed
