### PR TITLE
Improve Meterpreter ps -A experience

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -448,7 +448,7 @@ class Console::CommandDispatcher::Stdapi::Sys
           if val.nil? or val.empty?
             return false
           end
-          searched_procs << proc if proc["arch"] == val
+          searched_procs << proc if proc["arch"] == (val == 'x64' ? 'x86_64' : val)
         end
         processes = searched_procs
       when "-s"


### PR DESCRIPTION
Long-time users of Metasploit know to use `ps -A x86_64`, even though the process table shows `x64` now (see `Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList#to_table`). This patch improves the experience by allowing `ps -A x64` to work.
- [x] `ps -A x86_64`
- [x] Ensure it still works
- [x] `ps -A x64`
- [x] See that it works
