### PR TITLE
Hint about incorrect RAILSVERSION

### DIFF
--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -247,7 +247,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if check_secret(match[2],match[3])
         print_good("SECRET matches! Sending exploit payload")
       else
-        fail_with(Failure::BadConfig, "SECRET does not match")
+        fail_with(Failure::BadConfig, "SECRET does not match, wrong RAILSVERSION?")
       end
     else
       print_warning("Caution: Cookie not found, maybe you need to adjust TARGETURI")


### PR DESCRIPTION
If the secret doesn't match, you might have set the wrong `RAILSVERSION`. The difference is `secret_token` (Rails 3) vs. `secret_key_base` (Rails 4).
