### PR TITLE
Fix #7155 - Add post module to compress (zip) a file or directory

### DIFF
--- a/data/post/zip/zip.vbs
+++ b/data/post/zip/zip.vbs
@@ -1,3 +1,5 @@
+On Error Resume Next
+
 Function WindowsZip(sFile, sZipFile)
   'This script is provided under the Creative Commons license located
   'at http://creativecommons.org/licenses/by-nc/2.5/ . It may not

--- a/data/post/zip/zip.vbs
+++ b/data/post/zip/zip.vbs
@@ -1,0 +1,60 @@
+Function WindowsZip(sFile, sZipFile)
+  'This script is provided under the Creative Commons license located
+  'at http://creativecommons.org/licenses/by-nc/2.5/ . It may not
+  'be used for commercial purposes with out the expressed written consent
+  'of NateRice.com
+
+  Set oZipShell = CreateObject("WScript.Shell")  
+  Set oZipFSO = CreateObject("Scripting.FileSystemObject")
+  
+  If Not oZipFSO.FileExists(sZipFile) Then
+    NewZip(sZipFile)
+  End If
+
+  Set oZipApp = CreateObject("Shell.Application")
+  
+  sZipFileCount = oZipApp.NameSpace(sZipFile).items.Count
+
+  aFileName = Split(sFile, "\")
+  sFileName = (aFileName(Ubound(aFileName)))
+  
+  'listfiles
+  sDupe = False
+  For Each sFileNameInZip In oZipApp.NameSpace(sZipFile).items
+    If LCase(sFileName) = LCase(sFileNameInZip) Then
+      sDupe = True
+      Exit For
+    End If
+  Next
+  
+  If Not sDupe Then
+    oZipApp.NameSpace(sZipFile).Copyhere sFile
+
+    'Keep script waiting until Compressing is done
+    On Error Resume Next
+    sLoop = 0
+    Do Until sZipFileCount < oZipApp.NameSpace(sZipFile).Items.Count
+      Wscript.Sleep(100)
+      sLoop = sLoop + 1
+    Loop
+    On Error GoTo 0
+  End If
+End Function
+
+Sub NewZip(sNewZip)
+  'This script is provided under the Creative Commons license located
+  'at http://creativecommons.org/licenses/by-nc/2.5/ . It may not
+  'be used for commercial purposes with out the expressed written consent
+  'of NateRice.com
+
+  Set oNewZipFSO = CreateObject("Scripting.FileSystemObject")
+  Set oNewZipFile = oNewZipFSO.CreateTextFile(sNewZip)
+    
+  oNewZipFile.Write Chr(80) & Chr(75) & Chr(5) & Chr(6) & String(18, 0)
+  
+  oNewZipFile.Close
+  Set oNewZipFSO = Nothing
+
+  Wscript.Sleep(500)
+End Sub
+

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Post
   end
 
   def do_zip
-    output = cmd_exec("zip -D -d -q -r #{datastore['DESTINATION']} #{datastore['SOURCE']}")
+    output = cmd_exec("zip -D -q -r #{datastore['DESTINATION']} #{datastore['SOURCE']}")
     vprint_line(output)
   end
 

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('DESTINATION', [false, 'The destination path']),
+        OptString.new('DESTINATION', [true, 'The destination path']),
         OptString.new('SOURCE', [true, 'The directory or file to compress'])
       ], self.class)
   end

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
     super(update_info(info,
         'Name'          => 'Multi Manage File Compressor',
         'Description'   => %q{
-          This module zips a directory or a directory. On Linux, it uses the zip command.
+          This module zips a file or a directory. On Linux, it uses the zip command.
           On Windows, it will try to use remote target's 7Zip if found. If not, it falls
           back to its own VBScript.
         },

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -31,9 +31,7 @@ class MetasploitModule < Msf::Post
   end
 
   def get_program_file_path
-    @program_file_path ||= lambda {
-      session.sys.config.getenvs("ProgramFiles")['ProgramFiles']
-    }.call
+    get_env('ProgramFiles')
   end
 
   def has_7zip?
@@ -48,7 +46,7 @@ class MetasploitModule < Msf::Post
 
   def upload_exec_vbs_zip
     script = vbs(datastore['DESTINATION'], datastore['SOURCE'])
-    tmp_path = "#{session.sys.config.getenvs('TEMP')['TEMP']}\\zip.vbs"
+    tmp_path = "#{get_env('TEMP')}\\zip.vbs"
     print_status("VBS file uploaded to #{tmp_path}")
     write_file(tmp_path, script)
     cmd_exec("wscript.exe #{tmp_path}")

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -1,0 +1,94 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+
+  def initialize(info={})
+    super(update_info(info,
+        'Name'          => 'Multi Manage File Compressor',
+        'Description'   => %q{
+          This module zips a directory or a directory. On Linux, it uses the zip command.
+          On Windows, it will try to use remote target's 7Zip if found. If not, it falls
+          back to its own VBScript.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'sinn3r' ],
+        'Platform'      => [ 'win', 'linux' ],
+        'SessionTypes'  => [ 'meterpreter', 'shell' ]
+    ))
+
+    register_options(
+      [
+        OptString.new('DESTINATION', [false, 'The destination path']),
+        OptString.new('SOURCE', [true, 'The directory or file to compress'])
+      ], self.class)
+  end
+
+  def get_program_file_path
+    @program_file_path ||= lambda {
+      session.sys.config.getenvs("ProgramFiles")['ProgramFiles']
+    }.call
+  end
+
+  def has_7zip?
+    file?("#{get_program_file_path}\\7-Zip\\7z.exe")
+  end
+
+  def vbs(dest, src)
+    vbs_file = File.read(File.join(Msf::Config.data_directory, "post", "zip", "zip.vbs"))
+    vbs_file << "WindowsZip \"#{src}\",\"#{dest}\""
+    vbs_file
+  end
+
+  def upload_exec_vbs_zip
+    script = vbs(datastore['DESTINATION'], datastore['SOURCE'])
+    tmp_path = "#{session.sys.config.getenvs('TEMP')['TEMP']}\\zip.vbs"
+    print_status("VBS file uploaded to #{tmp_path}")
+    write_file(tmp_path, script)
+    cmd_exec("wscript.exe #{tmp_path}")
+  end
+
+  def do_7zip
+    program_file_path = get_program_file_path
+    output = cmd_exec("#{program_file_path}\\7-Zip\\7z.exe a -tzip \"#{datastore['DESTINATION']}\" \"#{datastore['SOURCE']}\"")
+    vprint_line(output)
+  end
+
+  def do_zip
+    output = cmd_exec("zip -D -d -q -r #{datastore['DESTINATION']} #{datastore['SOURCE']}")
+    vprint_line(output)
+  end
+
+  def windows_zip
+    if has_7zip?
+      print_status("Compressing #{datastore['DESTINATION']} via 7zip")
+      do_7zip
+    else
+      print_status("Compressing #{datastore['DESTINATION']} via VBS")
+      upload_exec_vbs_zip
+    end
+  end
+
+  def linux_zip
+    print_status("Compressing #{datastore['DESTINATION']} via zip")
+    do_zip
+  end
+
+  def run
+    os = get_target_os
+    case os
+    when Msf::Module::Platform::Windows.realname.downcase
+      windows_zip
+    else
+      linux_zip
+    end
+  end
+
+end
+


### PR DESCRIPTION
## What This Module Does

This module zips a directory or file on the target machine. Having the file smaller allows it to be moved or downloaded more quickly.
#7155
## Verification

**Windows**
- [x] Prepare a Windows box
- [x] Make sure AV is disabled
- [x] Get a windows/meterpreter/reverse_tcp session from the Windows box
- [x] Do: `use post/multi/manage/zip`
- [x] Do: `set SESSION [ID]`
- [x] Do: `set SOURCE [The directory or file you want to zip]`
- [x] Do: `set DESTINATION [Where the zip should be saved as]`
- [x] Do: `run`
- [x] Go to that directory (destination), the zip file should be there

**Linux**
- [x] Prepare a Linux box such as Ubuntu
- [x] Get a linux/x86/meterpreter/reverse_tcp from the Linux box
- [x] Do: `use post/multi/manage/zip`
- [x] Do: `set SESSION [ID]`
- [x] Do: `set SOURCE [The directory or file you want to zip]`
- [x] Do: `set DESTINATION [Where the zip should be saved as]`
- [x] Do: `run`
- [x] Go to that directory (destination), the zip file should be there
