### PR TITLE
Deprecate nbname_probe, which duplicates nbname

### DIFF
--- a/modules/auxiliary/scanner/netbios/nbname_probe.rb
+++ b/modules/auxiliary/scanner/netbios/nbname_probe.rb
@@ -11,6 +11,9 @@ class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
+  include Msf::Module::Deprecated
+
+  deprecated(Date.new(2016, 9, 1), 'auxiliary/scanner/netbios/nbname')
 
   def initialize
     super(


### PR DESCRIPTION
The differences highlighted in https://gist.github.com/jhart-r7/79b5c4cd82795bcfede2532c8de9bf74 show that these two modules are nearly identical as-is, the only difference is that `nbname_probe` had `CHOST` support to work over a pivot.  That functionality now exists in `UDPScanner` as of https://github.com/rapid7/metasploit-framework/commit/77cd6dbc8be4adc1e93c9538c160e8e14fe9df5a, which `nbname` uses, therefore `nbname_probe` can be deprecated.
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/netbios/nbname`
- [x] **Verify** that once loaded this module prints no deprecation warning.
- [x] `use use auxiliary/scanner/netbios/nbname_probe`
- [x] **Verify** that once loaded this module prints the deprecation warning.

```
msf > use auxiliary/scanner/netbios/nbname_probe 

[!] ******************************************************************************************
[!] *                 The module scanner/netbios/nbname_probe is deprecated!                 *
[!] *                       It will be removed on or about 2016-09-01                        *
[!] *                      Use auxiliary/scanner/netbios/nbname instead                      *
[!] ******************************************************************************************
msf auxiliary(nbname_probe) > use auxiliary/scanner/netbios/nbname
msf auxiliary(nbname) > 
```
