### PR TITLE
Add a method to check the Powershell version

### DIFF
--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -37,11 +37,11 @@ module Powershell
     case sysinfo['OS']
     when /Windows 8|10/
       cmd_out = cmd_exec('wmic /namespace:\\\\root\\cimv2 path win32_optionalfeature where "caption like \'.NET Framework%\' and InstallState = 1" get caption')
-      cmd_out.scan(/(\d\.[\d\.]+)/).flatten.first || ''
     else
       cmd_out = cmd_exec('wmic /namespace:\\\\root\\cimv2 path win32_product where "name like \'%%.NET%%\'" get version')
-      cmd_out.scan(/[\d\.]+/).flatten.first || ''
     end
+
+    cmd_out.scan(/(\d\.[\d\.]+)/).flatten.first
   end
 
 

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -31,43 +31,6 @@ module Powershell
   end
 
   #
-  # Returns the .Net version
-  #
-  def get_dotnet_version
-    case sysinfo['OS']
-    when /Windows 8|10/
-      cmd = 'wmic /namespace:\\\\root\\cimv2 path win32_optionalfeature where "caption like \'.NET Framework%\' and InstallState = 1" get caption'
-    else
-      cmd = 'wmic /namespace:\\\\root\\cimv2 path win32_product where "name like \'%%.NET%%\'" get version'
-    end
-
-    if have_powershell?
-      process, pid, c = execute_script(cmd)
-      cmd_out = ''
-      while (d = process.channel.read)
-        if d == ""
-          if (Time.now.to_i - start < time_out) && (cmd_out == '')
-            sleep 0.1
-          else
-            break
-          end
-        else
-          cmd_out << d
-        end
-      end
-    else
-      begin
-        cmd_out = cmd_exec(cmd)
-      rescue Rex::TimeoutError
-        return nil
-      end
-    end
-
-    cmd_out.scan(/(\d\.[\d\.]+)/).flatten.first
-  end
-
-
-  #
   # Returns the Powershell version
   #
   def get_powershell_version

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -31,6 +31,42 @@ module Powershell
   end
 
   #
+  # Returns the .Net version
+  #
+  def get_dotnet_version
+    cmd_out = cmd_exec('wmic /namespace:\\\\root\\cimv2 path win32_product where "name like \'%%.NET%%\'" get version')
+    cmd_out.scan(/[\d\.]+/).flatten.first || ''
+  end
+
+
+  #
+  # Returns the Powershell version
+  #
+  def get_powershell_version
+    return nil unless have_powershell?
+
+    process, pid, c = execute_script('$PSVersionTable.PSVersion')
+
+    o = ''
+
+    while (d = process.channel.read)
+      if d == ""
+        if (Time.now.to_i - start < time_out) && (o == '')
+          sleep 0.1
+        else
+          break
+        end
+      else
+        o << d
+      end
+    end
+
+    o
+
+    o.scan(/[\d \-]+/).last.split[0,2] * '.'
+  end
+
+  #
   # Get/compare list of current PS processes - nested execution can spawn many children
   # doing checks before and after execution allows us to kill more children...
   # This is a hack, better solutions are welcome since this could kill user

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -34,8 +34,14 @@ module Powershell
   # Returns the .Net version
   #
   def get_dotnet_version
-    cmd_out = cmd_exec('wmic /namespace:\\\\root\\cimv2 path win32_product where "name like \'%%.NET%%\'" get version')
-    cmd_out.scan(/[\d\.]+/).flatten.first || ''
+    case sysinfo['OS']
+    when /Windows 8|10/
+      cmd_out = cmd_exec('wmic /namespace:\\\\root\\cimv2 path win32_optionalfeature where "caption like \'.NET Framework%\' and InstallState = 1" get caption')
+      cmd_out.scan(/(\d\.[\d\.]+)/).flatten.first || ''
+    else
+      cmd_out = cmd_exec('wmic /namespace:\\\\root\\cimv2 path win32_product where "name like \'%%.NET%%\'" get version')
+      cmd_out.scan(/[\d\.]+/).flatten.first || ''
+    end
   end
 
 
@@ -60,8 +66,6 @@ module Powershell
         o << d
       end
     end
-
-    o
 
     o.scan(/[\d \-]+/).last.split[0,2] * '.'
   end


### PR DESCRIPTION
## What This Does

When using Powershell, sometimes the script we are using might be sensitive to the Powershell version. These methods allow us to check that.
## Verification
- [x] Prepare a Windows box that has Powershell
- [x] Place the following test script in your Metasploit post module directory (somewhere, as long as you can find it):

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Post

  include Msf::Post::Windows::Powershell

  def initialize(info={})
    super(update_info(info,
        'Name'          => 'post test',
        'Description'   => %q{
          post
        },
        'License'       => MSF_LICENSE,
        'Author'        => [ 'sinn3r' ],
        'Platform'      => [ 'win' ],
        'SessionTypes'  => [ 'meterpreter' ]
    ))
  end

  def run
    powershell = get_powershell_version
    print_status("Powershell version: #{powershell.inspect}")
  end

end
```
- [ ] Get a Windows Meterpreter session from the Windows box
- [ ] Do: `use [module path]`
- [ ]  Do: `run`
- [ ] Your output should be similar to this:

```
meterpreter > run post/windows/manage/test 

[*] Powershell version: "4.0"
```
