### PR TITLE
Fix #7170, Add HttpTrace option for HttpClient

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -347,7 +347,7 @@ module Exploit::Remote::HttpClient
       print_line(e.message) if datastore['HttpTrace']
       nil
     rescue ::Exception => e
-      print_line(e) if datastore['HttpTrace']
+      print_line(e.message) if datastore['HttpTrace']
       raise e
     end
   end
@@ -392,7 +392,7 @@ module Exploit::Remote::HttpClient
       print_line(e.message) if datastore['HttpTrace']
       nil
     rescue ::Exception => e
-      print_line(e) if datastore['HttpTrace']
+      print_line(e.message) if datastore['HttpTrace']
       raise e
     end
   end

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -329,8 +329,12 @@ module Exploit::Remote::HttpClient
       res = c.send_recv(r, actual_timeout)
       print_line(res.to_s) if datastore['HttpTrace']
       res
-    rescue ::Errno::EPIPE, ::Timeout::Error
+    rescue ::Errno::EPIPE, ::Timeout::Error => e
+      print_line(e.message) if datastore['HttpTrace']
       nil
+    rescue ::Exception => e
+      print_line(e) if datastore['HttpTrace']
+      raise e
     end
   end
 
@@ -354,8 +358,12 @@ module Exploit::Remote::HttpClient
       res = c.send_recv(r, actual_timeout)
       print_line(res.to_s) if datastore['HttpTrace']
       res
-    rescue ::Errno::EPIPE, ::Timeout::Error
+    rescue ::Errno::EPIPE, ::Timeout::Error => e
+      print_line(e.message) if datastore['HttpTrace']
       nil
+    rescue ::Exception => e
+      print_line(e) if datastore['HttpTrace']
+      raise e
     end
   end
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -325,9 +325,23 @@ module Exploit::Remote::HttpClient
     begin
       c = connect(opts)
       r = c.request_raw(opts)
-      print_line(r.to_s) if datastore['HttpTrace']
+
+      if datastore['HttpTrace']
+        print_line('#' * 20)
+        print_line('# Request:')
+        print_line('#' * 20)
+        print_line(r.to_s)
+      end
+
       res = c.send_recv(r, actual_timeout)
-      print_line(res.to_s) if datastore['HttpTrace']
+
+      if datastore['HttpTrace']
+        print_line('#' * 20)
+        print_line('# Response:')
+        print_line('#' * 20)
+        print_line(res.to_s)
+      end
+
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']
@@ -351,12 +365,28 @@ module Exploit::Remote::HttpClient
       actual_timeout =  opts[:timeout] || timeout
     end
 
+    print_line("*" * 20) if datastore['HttpTrace']
+
     begin
       c = connect(opts)
       r = c.request_cgi(opts)
-      print_line(r.to_s) if datastore['HttpTrace']
+
+      if datastore['HttpTrace']
+        print_line('#' * 20)
+        print_line('# Request:')
+        print_line('#' * 20)
+        print_line(r.to_s)
+      end
+
       res = c.send_recv(r, actual_timeout)
-      print_line(res.to_s) if datastore['HttpTrace']
+
+      if datastore['HttpTrace']
+        print_line('#' * 20)
+        print_line('# Response:')
+        print_line('#' * 20)
+        print_line(res.to_s)
+      end
+
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -54,7 +54,8 @@ module Exploit::Remote::HttpClient
         Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
-        OptInt.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout'])
+        OptInt.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
+        OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false])
       ], self.class
     )
 
@@ -324,7 +325,10 @@ module Exploit::Remote::HttpClient
     begin
       c = connect(opts)
       r = c.request_raw(opts)
-      c.send_recv(r, actual_timeout)
+      print_line(r.to_s) if datastore['HttpTrace']
+      res = c.send_recv(r, actual_timeout)
+      print_line(res.to_s) if datastore['HttpTrace']
+      res
     rescue ::Errno::EPIPE, ::Timeout::Error
       nil
     end
@@ -346,7 +350,10 @@ module Exploit::Remote::HttpClient
     begin
       c = connect(opts)
       r = c.request_cgi(opts)
-      c.send_recv(r, actual_timeout)
+      print_line(r.to_s) if datastore['HttpTrace']
+      res = c.send_recv(r, actual_timeout)
+      print_line(res.to_s) if datastore['HttpTrace']
+      res
     rescue ::Errno::EPIPE, ::Timeout::Error
       nil
     end


### PR DESCRIPTION
## What this patch does

This adds a new datastore option named `HttpTrace` to the HttpClient mixin. The option allows the user to see the HTTP requests and while using a module that uses the mixin. This is more debugging purposes.
## Verificaiton
- [x] Copy and save the following script for testing:

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Auxiliary

  include Msf::Exploit::Remote::HttpClient

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'Test',
      'Description'    => %q{
        Test
      },
      'Author'         => [ 'sinn3r' ],
      'License'        => MSF_LICENSE
    ))
  end

  def run
    res = send_request_raw({
      'method' => 'GET',
      'uri' => '/'
      })

    if res && res.code == 200
      print_good('good')
    end
  end

end
```
- [x] Start a server for testing, such as: `ruby -run -e httpd . -p 8181`
- [x] Start msfconsole
- [x] Load the test module
- [x] Do: `set HttpTrace true`
- [x] Enter: `run`
- [x] You should there's an HTTP request and the response

@FireFart Is this what you have in mind?
