### PR TITLE
remove architecture fidling from platform string for now

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -326,9 +326,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
 
-    self.platform =
-      self.sys.config.sysinfo["Architecture"].downcase + '/' +
-      self.platform.split('/')[0] +'/' +
+    self.platform = self.platform.split('/')[0] + '/' +
       case self.sys.config.sysinfo['OS']
       when /windows/i
         Msf::Module::Platform::Windows


### PR DESCRIPTION
This prevents a crash in 'is_system?' on Windows meterpreter sessions. This is just a quick backout for a regression.
## Verification
- [x] Start a session and run smart_hashdump: `./msfconsole -qx 'use exploit/multi/handler; set payload windows/meterpreter/reverse_tcp; set lhost 192.168.56.1; run; use post/windows/gather/smart_hashdump; set session -1; run'
- [x] **Verify** that the session does not crash
