### PR TITLE
Add functionality to pull .NET versions on Windows hosts

### DIFF
--- a/lib/msf/core/post/windows.rb
+++ b/lib/msf/core/post/windows.rb
@@ -21,4 +21,5 @@ module Msf::Post::Windows
   require 'msf/core/post/windows/ldap'
   require 'msf/core/post/windows/reflective_dll_injection'
   require 'msf/core/post/windows/kiwi'
+  require 'msf/core/post/windows/dotnet'
 end

--- a/lib/msf/core/post/windows/dotnet.rb
+++ b/lib/msf/core/post/windows/dotnet.rb
@@ -1,0 +1,93 @@
+# -*- coding: binary -*-
+require 'msf/core/post/common'
+require 'msf/core/post/windows/registry'
+
+module Msf
+class Post
+module Windows
+
+module Dotnet
+  include ::Msf::Post::Common
+  include ::Msf::Post::Windows::Registry
+  
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        OptInt.new('Dotnet::Post::timeout',   [true, 'Dotnet execution timeout, set < 0 to run async without termination', 15]),
+        OptBool.new('Dotnet::Post::log_output', [true, 'Write output to log file', false]),
+        OptBool.new('Dotnet::Post::dry_run', [true, 'Return encoded output to caller', false]),
+        OptBool.new('Dotnet::Post::force_wow64', [true, 'Force WOW64 execution', false]),
+      ], self.class)
+  end
+  #
+  # Searches the subkey for the value 'Version' which contains the
+  # actual version, rather than the over-arching release
+  # An alternative would be to query for it, and catch the exception.
+  #
+  def search_for_version(dotnet_subkey)
+    dotnet_version = nil
+    begin
+      subkeys = registry_enumvals(dotnet_subkey)
+    rescue::Exception => e
+      print_status("Encountered exception in search_for_version: #{e.class} #{e}")
+    end
+    subkeys.each do |i|
+      if i == 'Version'
+        dotnet_version = registry_getvaldata(dotnet_subkey, i)
+        break
+      end
+    end
+    return dotnet_version
+  end
+  
+  #
+  # Bruteforce search all subkeys in an over-arching release to
+  # locate the actual release version.
+  #
+  def get_versionception(dotnet_vkey)
+    exact_version = nil
+    begin
+      subkeys = registry_enumkeys(dotnet_vkey)
+    rescue::Exception => e
+      print_status("Encountered exception in get_versionception: #{e.class} #{e}")
+    end
+    subkeys.each do |i|
+      exact_version = search_for_version(dotnet_vkey + '\\' +i)
+      unless exact_version.nil?
+        #if we find a version, stop looking
+        break
+      end
+    end
+    return exact_version
+  end
+  
+  #
+  # 'Public' function that returns a list of all .NET versions on
+  # a windows host
+  #
+  def get_dotnet_versions
+    ret_val = Array.new
+    key = 'HKLM\\SOFTWARE\\Microsoft\NET Framework Setup\\NDP'
+    begin
+      dotnet_keys = registry_enumkeys(key)
+    rescue::Exception => e
+      print_status("Encountered exception in get_dotnet_version: #{e.class} #{e}")
+    end
+    unless dotnet_keys.nil?
+      dotnet_keys.each do |i|
+        if i[0,1] == 'v'
+          key = 'HKLM\\SOFTWARE\\Microsoft\NET Framework Setup\\NDP\\'+i
+          dotnet_version = get_versionception(key)
+          unless dotnet_version.nil?
+            ret_val << dotnet_version
+          end
+        end
+      end
+    end
+    return ret_val
+  end
+end
+end
+end
+end

--- a/lib/msf/core/post/windows/dotnet.rb
+++ b/lib/msf/core/post/windows/dotnet.rb
@@ -6,30 +6,36 @@ module Msf
 class Post
 module Windows
 
+#
+# This module serves to hold methods related to .NET framework
+#
 module Dotnet
   include ::Msf::Post::Common
   include ::Msf::Post::Windows::Registry
-  
+
   def initialize(info = {})
     super
     register_advanced_options(
       [
-        OptInt.new('Dotnet::Post::timeout',   [true, 'Dotnet execution timeout, set < 0 to run async without termination', 15]),
+        OptInt.new('Dotnet::Post::timeout', [true, 'Dotnet execution timeout, set < 0 to run async without termination', 15]),
         OptBool.new('Dotnet::Post::log_output', [true, 'Write output to log file', false]),
         OptBool.new('Dotnet::Post::dry_run', [true, 'Return encoded output to caller', false]),
-        OptBool.new('Dotnet::Post::force_wow64', [true, 'Force WOW64 execution', false]),
-      ], self.class)
+        OptBool.new('Dotnet::Post::force_wow64', [true, 'Force WOW64 execution', false])
+      ], 
+      self.class
+    )
   end
   #
   # Searches the subkey for the value 'Version' which contains the
   # actual version, rather than the over-arching release
   # An alternative would be to query for it, and catch the exception.
   #
+  
   def search_for_version(dotnet_subkey)
     dotnet_version = nil
     begin
       subkeys = registry_enumvals(dotnet_subkey)
-    rescue::Exception => e
+    rescue ::Exception => e
       print_status("Encountered exception in search_for_version: #{e.class} #{e}")
     end
     subkeys.each do |i|
@@ -40,7 +46,7 @@ module Dotnet
     end
     return dotnet_version
   end
-  
+
   #
   # Bruteforce search all subkeys in an over-arching release to
   # locate the actual release version.
@@ -49,13 +55,13 @@ module Dotnet
     exact_version = nil
     begin
       subkeys = registry_enumkeys(dotnet_vkey)
-    rescue::Exception => e
+    rescue ::Exception => e
       print_status("Encountered exception in get_versionception: #{e.class} #{e}")
     end
     subkeys.each do |i|
-      exact_version = search_for_version(dotnet_vkey + '\\' +i)
+      exact_version = search_for_version(dotnet_vkey + '\\' + i)
       unless exact_version.nil?
-        #if we find a version, stop looking
+        # if we find a version, stop looking
         break
       end
     end
@@ -67,19 +73,19 @@ module Dotnet
   # a windows host
   #
   def get_dotnet_versions
-    ret_val = Array.new
+    ret_val = []
     key = 'HKLM\\SOFTWARE\\Microsoft\NET Framework Setup\\NDP'
     begin
       dotnet_keys = registry_enumkeys(key)
-    rescue::Exception => e
+    rescue ::Exception => e
       print_status("Encountered exception in get_dotnet_version: #{e.class} #{e}")
     end
     unless dotnet_keys.nil?
       dotnet_keys.each do |i|
         if i[0,1] == 'v'
-          key = 'HKLM\\SOFTWARE\\Microsoft\NET Framework Setup\\NDP\\'+i
+          key = 'HKLM\\SOFTWARE\\Microsoft\NET Framework Setup\\NDP\\' + i
           dotnet_version = get_versionception(key)
-          unless dotnet_version.nil?
+          unless dotnet_version.nil? 
             ret_val << dotnet_version
           end
         end


### PR DESCRIPTION
This adds a .NET library that has a function to pull the installed versions of .NET from a windows host using a pretty ugly bruteforce attempt to locate the information in the registry, as different versions store the version data in different subkeys.
Because multiple versions of .NET can be installed, this pulls all versions and returns them in an array.  If there are no versions installed, it returns an empty array.
Requested by Issue https://github.com/rapid7/metasploit-framework/issues/7201
# Testing Instructions
- [ ] create a post module like this one I stole from @sinn3r :

```
require 'msf/core'

class MetasploitModule < Msf::Post

  include Msf::Post::Windows::Powershell
  include Msf::Post::Windows::Dotnet

  def initialize(info={})
    super(update_info(info,
        'Name'          => 'post test',
        'Description'   => %q{
          post
        },
        'License'       => MSF_LICENSE,
        'Author'        => [ 'sinn3r' ],
        'Platform'      => [ 'win' ],
        'SessionTypes'  => [ 'meterpreter' ]
    ))
  end

  def run
    powershell = get_powershell_version
    print_status("Powershell version: #{powershell.inspect}")
    print_status(".NET versions: #{get_dotnet_versions}")
  end
end
```
- [ ] Save the post module in a known location (in the below testing scenario I picked `modules/post/windows/manage/testdotnet.rb`)
- [ ] Establish a meterpreter session on a windows host
- [ ] `run <testmodule>`
- [ ] verify that it produces the correct versions (It may take a few minutes to run)
- [ ] profit
# My Testing Runs:
## Windows XPx86 with x86 meterpreter:

```
bwatters@ubuntu:~/rapid7/metasploit-framework$ ./msfconsole -q
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lport 4545
lport => 4545
msf exploit(handler) > set lhost <msfconsole_IP>
lhost => <msfconsole_IP>
msf exploit(handler) > run

[*] Started reverse TCP handler on <msfconsole_IP>:4545 
[*] Starting the payload handler...
[*] Sending stage (957999 bytes) to <winxp_IP>
[*] Meterpreter session 1 opened (<msfconsole_IP>:4545 -> <winxp_IP>:1045) at 2016-08-15 11:10:19 -0700

meterpreter > sysinfo
Computer        : TEST-8343845B47
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > run post/windows/manage/testdotnet

[*] Powershell version: nil
[*] .NET versions: []
meterpreter > 

```
## Windows 7x64Pro With x64 meterpreter:

```
bwatters@ubuntu:~/rapid7/metasploit-framework$ ./msfconsole -q
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf exploit(handler) > set lport 4545
lport => 4545
msf exploit(handler) > set lhost <msfconsole_IP>
lhost => <msfconsole_IP>
msf exploit(handler) > run

[*] Started reverse TCP handler on <msfconsole_IP>:4545 
[*] Starting the payload handler...
[*] Sending stage (1189423 bytes) to <win7x64_IP>
[*] Meterpreter session 1 opened (<msfconsole_IP>:4545 -> <win7x64_IP>:49416) at 2016-08-15 11:12:47 -0700

meterpreter > sysinfo
Computer        : WIN-CMLEMCUFOB2
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > run post/windows/manage/testdotnet

[*] Powershell version: "2.0"
[*] .NET versions: ["2.0.50727.5420", "3.0.30729.5420", "3.5.30729.5420", "4.6.01055", "4.0.0.0"]
meterpreter > 
```
## Windows 7x64 with x86 meterpreter

```
bwatters@ubuntu:~/rapid7/metasploit-framework$ ./msfconsole -q
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lport 4545
lport => 4545
msf exploit(handler) > set lhost <msfconsole_IP>
lhost => <msfconsole_IP>
msf exploit(handler) > run

[*] Started reverse TCP handler on <msfconsole_IP>:4545 
[*] Starting the payload handler...
[*] Sending stage (957999 bytes) to <win7x64_IP>
[*] Meterpreter session 1 opened (<msfconsole_IP>:4545 -> <win7x64_IP>:49420) at 2016-08-15 11:15:40 -0700

meterpreter > sysinfo
Computer        : WIN-CMLEMCUFOB2
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > run post/windows/manage/testdotnet

[*] Powershell version: "2.0"
[*] .NET versions: ["2.0.50727.5420", "3.0.30729.5420", "3.5.30729.5420", "4.6.01055", "4.0.0.0"]
meterpreter > 
```
## Windows 8x64 Pro with x64 meterpreter

```
msf exploit(handler) > exit
bwatters@ubuntu:~/rapid7/metasploit-framework$ ./msfconsole -q
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf exploit(handler) > set lport 4545
lport => 4545
msf exploit(handler) > set lhost <msfconsole_IP>
lhost => <msfconsole_IP>
msf exploit(handler) > run

[*] Started reverse TCP handler on <msfconsole_IP>:4545 
[*] Starting the payload handler...
[*] Sending stage (1189423 bytes) to <win8x64_IP>
[*] Meterpreter session 1 opened (<msfconsole_IP>:4545 -> <win8x64_IP>:49371) at 2016-08-15 11:21:50 -0700

meterpreter > sysinfo
Computer        : WIN-PPKHT36JTUK
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > run post/windows/manage/testdotnet

[*] Powershell version: "4.0"
[*] .NET versions: ["4.5.51650", "4.0.0.0"]
meterpreter >
```
## Windows 8x64 Pro with x86 meterpreter

```
bwatters@ubuntu:~/rapid7/metasploit-framework$ ./msfconsole -q
msf > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lport 4545
lport => 4545
msf exploit(handler) > set lhost <msfconsole_IP>
lhost => <msfconsole_IP>
msf exploit(handler) > run

[*] Started reverse TCP handler on <msfconsole_IP>:4545 
[*] Starting the payload handler...
[*] Sending stage (957999 bytes) to <win8x64_IP>
[*] Meterpreter session 1 opened (<msfconsole_IP>:4545 -> <win8x64_IP>:49378) at 2016-08-15 11:24:31 -0700

meterpreter > sysinfo
Computer        : WIN-PPKHT36JTUK
OS              : Windows 8.1 (Build 9600).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > run post/windows/manage/testdotnet

[*] Powershell version: "4.0"
[*] .NET versions: ["4.5.51650", "4.0.0.0"]
meterpreter > 
```
