### PR TITLE
Fix #3860, tearing down TCP connection for send_request_cgi

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -41,6 +41,7 @@ end
 
 def cleanup
   datastore['RHOST'] = @original_rhost
+  super
 end
 
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -210,9 +210,9 @@ module Exploit::Remote::HttpClient
       if (self.client)
         disconnect
       end
-
-      self.client = nclient
     end
+
+    self.client = nclient
 
     return nclient
   end
@@ -297,6 +297,10 @@ module Exploit::Remote::HttpClient
     end
 
     if (nclient == self.client)
+      if self.client.respond_to?(:close)
+        self.client.close
+      end
+
       self.client = nil
     end
   end


### PR DESCRIPTION
# What This Patch Does

This patch fixes an issue explained in #3860.

When `send_request_cgi` is used without the global socket, it does not close the TCP connection even when the `disconnect` method is called explicitly. It also does not close when the module is completed. This patch addresses those problems.

The patch also ensures `super` is called in the scanner mixin's `cleanup` method, that way auxiliary modules that use the scanner and HttpClient mixin will be able to close the TCP connection properly.

Fix #3860 
MS-440
# Verification
- [x] `cd` to a directory where you prefer to host a fake web server.
- [x] `echo "Hello world" > test.html`. The test script will be requesting this.
- [x] Under the same directory, do: `ruby -run -e httpd . -p 8181` to start a web server
- [x] Save the following script so you can use in msfconsole:

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Auxiliary

  include Msf::Exploit::Remote::HttpClient
  include Msf::Auxiliary::Scanner

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'Test',
      'Description'    => %q{
        Test
      },
      'Author'         => [ 'sinn3r' ],
      'License'        => MSF_LICENSE,
      'References'     => 
        [
          ['URL', 'http://metasploit.com']
        ]
    ))
  end

  def print_status(msg='')
    super("#{peer} - #{msg}")
  end

  def test_case_1
    print_status("Sending HTTP request...")
    res = send_request_cgi({
      'uri' => '/test.html',
      'method' => 'GET'
    })

    if res
      print_status(res.body.strip)
    end

    print_status('Sleeping for 10 seconds.')
    print_status('Do netstat, and you should see port 8181 is connected')
    sleep(10)

    print_status('Manually disconnecting TCP connection now...')
    disconnect
    print_status('Do netstat, you should see that port 8181 is no longer connected')
    sleep(10)
  end

  def test_case_2
    print_status("Sending HTTP request...")
    res = send_request_cgi({
      'uri'    => '/test.html',
      'method' => 'GET',
      'global' => true
    })

    if res
      print_status(res.body.strip)
    end

    print_status('Sleeping for 10 seconds.')
    print_status('Do netstat, and you should see port 8181 is connected')
    sleep(10)

    disconnect
    print_status('Do netstat, you should see that port 8181 is no longer connected')
    sleep(10)
  end

  def test_case_3
    print_status("Sending HTTP request...")
    send_request_cgi({
      'uri'    => '/test.html',
      'method' => 'GET'
    })

    print_status('The module is about to end. After it finishes, you should not see any port 8181 connected.')
  end

  def run_host(ip)
    test_case_1
    print_line
    test_case_2
    print_line
    test_case_3
  end

end
```
- [x] Start msfconsole
- [x] Do: `use [path to the test module]`
- [x] Do: `set RHOST [IP]`
- [x] Do: `set RPORT8181`
- [x] Follow the instructions the module gives you. Basically it just tells you when to netstat to check if you're connected to port 8181 or not.

Since this change could potential break a lot of modules, please feel free to explore other edge cases to test.
