### PR TITLE
Revert back win32/win64 platform string for Windows meterpreter

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -325,24 +325,37 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   def update_session_info
     username = self.sys.config.getuid
     sysinfo  = self.sys.config.sysinfo
+    tuple = self.platform.split('/')
 
-    self.platform = self.platform.split('/')[0] + '/' +
-      case self.sys.config.sysinfo['OS']
-      when /windows/i
-        Msf::Module::Platform::Windows
-      when /darwin/i
-        Msf::Module::Platform::OSX
-      when /freebsd/i
-        Msf::Module::Platform::FreeBSD
-      when /netbsd/i
-        Msf::Module::Platform::NetBSD
-      when /openbsd/i
-        Msf::Module::Platform::OpenBSD
-      when /sunos/i
-        Msf::Module::Platform::Solaris
-      else
-        Msf::Module::Platform::Linux
+    #
+    # Windows meterpreter currently needs 'win32' or 'win64' to be in the
+    # second half of the platform tuple, in order for various modules and
+    # library code match on that specific string.
+    #
+    if self.platform !~ /win32|win64/
+
+      platform = case self.sys.config.sysinfo['OS']
+        when /windows/i
+          Msf::Module::Platform::Windows
+        when /darwin/i
+          Msf::Module::Platform::OSX
+        when /freebsd/i
+          Msf::Module::Platform::FreeBSD
+        when /netbsd/i
+          Msf::Module::Platform::NetBSD
+        when /openbsd/i
+          Msf::Module::Platform::OpenBSD
+        when /sunos/i
+          Msf::Module::Platform::Solaris
+        else
+          Msf::Module::Platform::Linux
       end.realname.downcase
+
+      #
+      # This normalizes the platform from 'python/python' to 'python/linux'
+      #
+      self.platform = "#{tuple[0]}/#{platform}"
+    end
 
 
     safe_info = "#{username} @ #{sysinfo['Computer']}"

--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Post
 
   def run
 
-    tech = datastore['TECHNIQUE'].to_i
+    technique = datastore['TECHNIQUE'].to_i
 
     unsupported if client.platform !~ /win32|win64/i
 
@@ -48,11 +48,11 @@ class MetasploitModule < Msf::Post
       return
     end
 
-    result = client.priv.getsystem( tech )
-    if result and result[0]
-      print_good( "Obtained SYSTEM via technique #{result[1]}" )
-    else
-      print_error( "Failed to obtain SYSTEM access" )
+    begin
+      result = client.priv.getsystem(technique)
+      print_good("Obtained SYSTEM via technique #{result[1]}")
+    rescue Rex::Post::Meterpreter::RequestError => e
+      print_error("Failed to obtain SYSTEM access")
     end
   end
 


### PR DESCRIPTION
Continuing evolution from #6687, this switches back to un-normalizing Windows-native Meterpreter platform string, since this gets matched specifically along with just /win/ in a lot of places, most frequently as win32|win64. This repairs the functionality at the existing sites first, we can go back and update the other places later.
## Verification
- [x] Start `msfconsole` and get a windows meterpreter session
- [x] Type 'help' and ensure that the 'Priv' extension commands are present
- [x] **Verify** that 'getsystem' works as expected
- [x] background the session and 'use post/windows/escalate/getsystem`
- [x] **Verify** this also handles failure/success without backtracing
