### PR TITLE
Fix #7202, Make print_brute print ip:rport if available

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -594,7 +594,12 @@ module Auxiliary::AuthBrute
       msg_regex = /(#{ip})(:#{port})?(\s*-?\s*)(#{proto.to_s})?(\s*-?\s*)(.*)/ni
       if old_msg.match(msg_regex) and !old_msg.match(msg_regex)[6].to_s.strip.empty?
         complete_message = ''
-        complete_message << (old_msg.match(msg_regex)[4] || proto).to_s
+        unless ip.blank? && port.blank?
+          complete_message << "#{ip}:#{rport}"
+        else
+          complete_message << (old_msg.match(msg_regex)[4] || proto).to_s
+        end
+
         complete_message << " - "
         progress = tried_over_total(ip,port)
         complete_message << progress if progress

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -128,7 +128,11 @@ class MetasploitModule < Msf::Auxiliary
         print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential}"
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        if result.proof
+          vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+        else
+          vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+        end
       end
     end
   end


### PR DESCRIPTION
# What This Patch Does

This patch allows the print_brute method in the AuthBrute mixin to print the ip:rport when it's available instead of forcing itself to print the module name. Showing the module name doesn't seem to be very helpful.

Fix #7202
# Verification

First, set up a Tomcat box:
- [x] Start a Windows box (such as Windows 7)
- [x] Make sure Java is installed.
- [x] After installing Java, make sure you have the system environment variable set for JAVA_HOME (it should be your Java directory, like this:

<img width="359" alt="screen shot 2016-08-12 at 3 36 33 pm" src="https://cloud.githubusercontent.com/assets/1170914/17636426/9956bc68-60a2-11e6-8f95-1c4c11b2f670.png">
- [x] Install Apache Tomcat: http://www-us.apache.org/dist/tomcat/tomcat-8/v8.0.35/bin/apache-tomcat-8.0.35.zip
- [x] Extract Tomcat. In there, you will find conf\tomcat-users.xml, make sure you have the following settings:

```
  <role rolename="manager-gui"/>
  <user username="tomcat" password="pass123" roles="tomcat,manager-gui"/>
```
- [ ] Go to the bin directory and run startup.bat to start Apache Tomcat.

Now you're ready to test:
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/http/tomcat_mgr_login`
- [x] Do: `set rhosts [IP]`
- [x] Do: `run`
- [x] For all the failed credentials, you should see the ip:port like this format:

```
[-] 10.6.0.61:8080 - LOGIN FAILED: xampp:xampp (Incorrect)
```
