### PR TITLE
Net::SSH Regression Fixes

### DIFF
--- a/lib/msf/core/exploit/ssh.rb
+++ b/lib/msf/core/exploit/ssh.rb
@@ -1,5 +1,6 @@
 module Msf
   module Exploit::Remote::SSH
+    require 'rex/socket/ssh_factory'
     def ssh_socket_factory
       Rex::Socket::SSHFactory.new(framework, self, datastore['Proxies'])
     end

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 require 'net/ssh'
 require 'metasploit/framework/login_scanner/ssh'
 require 'metasploit/framework/credential_collection'
+require 'sshkey'
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Auxiliary
 
@@ -140,7 +142,7 @@ class MetasploitModule < Msf::Auxiliary
     return cleartext_keys
   end
 
-  def session_setup(result, ssh_socket)
+  def session_setup(result, ssh_socket, fingerprint)
     return unless ssh_socket
 
     # Create a new session from the socket
@@ -157,7 +159,7 @@ class MetasploitModule < Msf::Auxiliary
       'KEY_PATH'        => nil
     }
 
-    info = "SSH #{result.credential.public}:#{ssh_socket.auth_info[:pubkey_id]} (#{ip}:#{rport})"
+    info = "SSH #{result.credential.public}:#{fingerprint} (#{ip}:#{rport})"
     s = start_session(self, info, merge_me, false, conn.lsock)
     self.sockets.delete(ssh_socket.transport.socket)
 
@@ -229,7 +231,9 @@ class MetasploitModule < Msf::Auxiliary
           credential_core = create_credential(credential_data)
           credential_data[:core] = credential_core
           create_credential_login(credential_data)
-          session_setup(result, scanner.ssh_socket)
+          tmp_key = result.credential.private
+          ssh_key = SSHKey.new tmp_key
+          session_setup(result, scanner.ssh_socket, ssh_key.fingerprint)
           :next_user
         when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           if datastore['VERBOSE']


### PR DESCRIPTION
This PR addresses the regressions listed in the following issues:

https://github.com/rapid7/metasploit-framework/issues/7229
https://github.com/rapid7/metasploit-framework/issues/7175
https://github.com/rapid7/metasploit-framework/issues/7160

A separate PR will be coming up soon for the pivoting issue described in https://github.com/rapid7/metasploit-framework/issues/7211
## Verification
- [x] Start `msfconsole`
- [x] `use exploit/linux/ssh/ubiquiti_airos_file_upload`
- [x]  VERIFY you do not get `NameError uninitialized constant Rex::Socket::SSHFactory`
- [x]  `use auxiliary/scanner/ssh/ssh_login_pubkey`
- [x]  use a valid username and pubkey
- [x] VERIFY that it opens the session without throwing an exception
- [x] VERIFY that you can interact with the SSH session
- [x] Close #7229 #7175 #7160 
