### PR TITLE
Fix ssh over pivots

### DIFF
--- a/documentation/modules/post/multi/manage/shell_to_meterpreter.md
+++ b/documentation/modules/post/multi/manage/shell_to_meterpreter.md
@@ -1,5 +1,5 @@
-shell_to_meterpreter allows you to upgrade a shell session to Meterpreter. It can be launched as
-a post module, or from the sessions command. By default, this module will use a reverse
+`shell_to_meterpreter` allows you to upgrade a shell session to Meterpreter. It can be launched as
+a post module, or from the `sessions` command. By default, this module will use a reverse
 Meterpreter.
 
 ## Important Options
@@ -29,7 +29,7 @@ use this.
 
 **Using sessions -u**
 
-```sessions -u``` is the same as running the post module against a specific session. However, this
+`sessions -u` is the same as running the post module against a specific session. However, this
 is limited to using the default reverse Meterpreter payload, so you will not be able to use it
 via a pivot.
 
@@ -46,7 +46,7 @@ Active sessions
   --  ----           -----------  ----------
   1   shell windows               192.168.146.1:4444 -> 192.168.146.128:1204 (192.168.146.128)
 
-msf > 
+msf >
 ```
 
 In this demonstration, session 1 is a shell, so we upgrade that:

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -360,8 +360,9 @@ module Exploit::Remote::HttpClient
   # Connects to the server, creates a request, sends the request,
   # reads the response
   #
-  # Passes +opts+ through directly to Rex::Proto::Http::Client#request_cgi.
+  # Passes `opts` through directly to {Rex::Proto::Http::Client#request_cgi}.
   #
+  # @return (see Rex::Proto::Http::Client#send_recv))
   def send_request_cgi(opts={}, timeout = 20)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']
@@ -401,14 +402,14 @@ module Exploit::Remote::HttpClient
     end
   end
 
+  # Connects to the server, creates a request, sends the request, reads the
+  # response if a redirect (HTTP 30x response) is received it will attempt to
+  # follow the direct and retrieve that URI.
   #
-  # Connects to the server, creates a request, sends the request, reads the response
-  # if a redirect (HTTP 30x response) is received it will attempt to follow the
-  # direct and retrieve that URI.
+  # @note `opts` will be updated to the updated location and
+  #   `opts['redirect_uri']` will contain the full URI.
   #
-  # @note The +opts+ will be updated to the updated location and +opts['redirect_uri']+
-  #   will contain the full URI.
-  #
+  # @return (see #send_request_cgi)
   def send_request_cgi!(opts={}, timeout = 20, redirect_depth = 1)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']

--- a/lib/rex/post/meterpreter/channels/socket_abstraction.rb
+++ b/lib/rex/post/meterpreter/channels/socket_abstraction.rb
@@ -18,16 +18,8 @@ module Meterpreter
 ###
 module SocketAbstraction
 
-  class << self
-    def cls
-      raise NotImplementedError
-    end
-  end
-
   module SocketInterface
-    def type?
-      raise NotImplementedError
-    end
+    include Rex::Socket
 
     def getsockname
       return super if not channel
@@ -46,9 +38,8 @@ module SocketAbstraction
 
     def getpeername
       return super if not channel
-      address_family,_caddr,_cport = channel.client.sock.getpeername_as_array
       maddr,mport = [ channel.params.peerhost, channel.params.peerport ]
-      [ address_family, "#{maddr}", "#{mport}" ]
+      ::Socket.sockaddr_in(mport, maddr)
     end
 
     %i{localhost localport peerhost peerport}.map do |meth|

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -358,7 +358,7 @@ class Rex::Socket::Comm::Local
       talk_mode = 1 # ref: http://help.sap.com/saphelp_dimp50/helpdata/En/f8/bb960899d743378ccb8372215bb767/content.htm
       num_rest_nodes = 1
 
-      shost, sport = sock.peerinfo.split(":")
+      _af, shost, sport = sock.getpeername_as_array
       first_route_item = [shost, 0, sport, 0, 0].pack("A*CA*cc")
       route_data = [first_route_item.length, first_route_item].pack("NA*")
       route_data << [host, 0, port.to_s, 0, 0].pack("A*CA*cc")


### PR DESCRIPTION
Fixes #7211 by making `Rex::IO::SocketAbstraction` also include `Rex::Socket`. This allows re-using the new `getpeername_as_array` method.
## Verification
- [x] Get a meterpreter session
- [x] Add a route for the victim network
- [x] `use auxiliary/scanner/ssh/ssh_login`
- [x] set appropriate values for your ssh victim, then `run` it
- [x] **Verify** You get a session with a connection like this:
  
  ```
  1   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ SMB-W2012-64     10.0.0.104:45866 -> 10.1.1.84:1234 (10.1.1.84)
  2   shell linux            SSH root:redacted (10.1.1.54:22)       10.0.0.104-10.1.1.84:0 -> 10.1.1.54:22 (10.1.1.54)
  ```

In the above example, 10.0.0.104 is my attacker and 10.1.1.\* is my victim network
