### PR TITLE
Add DETECT_ANY_AUTH to smb_login

### DIFF
--- a/documentation/modules/auxiliary/scanner/smb/smb_login.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_login.md
@@ -115,3 +115,12 @@ set SMBPass [password]
 
 Note: If an account has been successfully brute-forced, that account will not be tried again.
 
+Additionally, if you wish to disable automatic detection of all-access systems, you can change the following option:
+
+**The DETECT_ANY_AUTH option**
+
+This option enables detection of systems accepting any authentication. A bogus login will be attempted.
+
+```
+set DETECT_ANY_AUTH false
+```


### PR DESCRIPTION
This resolves #7237 by providing an option to turn off the bogus login check. It is still enabled by default.
- [x] Test the module normally
- [x] Test with `DETECT_ANY_AUTH` disabled
- [x] Test with `VERBOSE` disabled
- [x] `info -d` and make sure the docs look right
