### PR TITLE
fixing typo for reference for golden ticket

### DIFF
--- a/modules/post/windows/escalate/golden_ticket.rb
+++ b/modules/post/windows/escalate/golden_ticket.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Post
       'SessionTypes' => [ 'meterpreter' ],
       'References'   =>
             [
-              ['URL', 'https:/github.com/gentilkiwi/mimikatz/wiki/module-~-kerberos']
+              ['URL', 'https://github.com/gentilkiwi/mimikatz/wiki/module-~-kerberos']
             ]
     ))
 


### PR DESCRIPTION
This typo was causing the post exploitation module to cause errors within Pro.
## Verification
- [x] make sure this one character addition looks beautiful and elegant
- [x] look over code to make sure there aren't any typos
- [x] tell me how good of a job I did
