### PR TITLE
Add server_port to HTTP fingerprint

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -753,7 +753,7 @@ module Exploit::Remote::HttpClient
 
     # Create a new fingerprint structure to track this response
     fprint = {
-      :uri => uri, :method => method,
+      :uri => uri, :method => method, :server_port => rport,
       :code => res.code.to_s, :message => res.message.to_s,
       :signature => info
     }


### PR DESCRIPTION
- [x] `./msfconsole -qx 'use auxiliary/scanner/http/http_version; set rhosts google.com; run; notes -S google.com'`
- [x] See `:server_port=>80`
- [x] Test it in Pro

MS-1982
