### PR TITLE
Added some error checking to CredEnumerateA() railgun call

### DIFF
--- a/modules/post/windows/gather/credentials/enum_cred_store.rb
+++ b/modules/post/windows/gather/credentials/enum_cred_store.rb
@@ -178,14 +178,25 @@ class MetasploitModule < Msf::Post
     credentials = []
     #call credenumerate to get the ptr needed
     adv32 = session.railgun.advapi32
-    ret = adv32.CredEnumerateA(nil,0,4,4)
-    p_to_arr = ret["Credentials"].unpack("V")
-    if is_86
-      count = ret["Count"]
-      arr_len = count * 4
+    begin
+      ret = adv32.CredEnumerateA(nil,0,4,4)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      print_error("This module requires WinXP or higher")
+      print_error("CredEnumerateA() failed: #{e.class} #{e}")
+      ret = nil
+    end
+    if ret.nil?
+      count = 0
+      arr_len = 0
     else
-      count = ret["Count"] & 0x00000000ffffffff
-      arr_len = count * 8
+      p_to_arr = ret["Credentials"].unpack("V")
+      if is_86
+        count = ret["Count"]
+        arr_len = count * 4
+      else
+        count = ret["Count"] & 0x00000000ffffffff
+        arr_len = count * 8
+      end
     end
 
     #tell user what's going on


### PR DESCRIPTION
This fixes an issue where the post module `enum_cred_store` crashes on Windows 2K.

The reason it crashes is because the module relies on the Windows API function `CredEnumerate()`, which is only present on Windows XP and later.  By encapsulating the call to the function in a try/catch, this cleans the error output and gives explicit warning that only XP and later are supported.

Source: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374794(v=vs.85).aspx
## Previously:

```
meterpreter > sysinfo
Computer        : A-9EF3C1E7FEF64
OS              : Windows 2000 (Build 2195).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/win32
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > use post/windows/gather/credentials/enum_cred_store
msf post(enum_cred_store) > set session 1
session => 1
msf post(enum_cred_store) > run

[-] Post failed: Rex::Post::Meterpreter::RequestError stdapi_railgun_api: Operation failed: The specified procedure could not be found.
[-] Call stack:
[-]   /home/bwatters/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/dll.rb:262:in `process_function_call'
[-]   /home/bwatters/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/dll.rb:84:in `call_function'
[-]   /home/bwatters/rapid7/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/dll_wrapper.rb:24:in `method_missing'
[-]   /home/bwatters/rapid7/metasploit-framework/modules/post/windows/gather/credentials/enum_cred_store.rb:181:in `get_creds'
[-]   /home/bwatters/rapid7/metasploit-framework/modules/post/windows/gather/credentials/enum_cred_store.rb:249:in `run'
[*] Post module execution completed
msf post(enum_cred_store) >
```
## After Fix

```
meterpreter > sysinfo
Computer        : A-9EF3C1E7FEF64
OS              : Windows 2000 (Build 2195).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/win32
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > use post/windows/gather/credentials/enum_cred_store
msf post(enum_cred_store) > set session 1
msf post(enum_cred_store) > run

[-] This script requires WinXP or higher
[-] CredEnumerateA() failed: Rex::Post::Meterpreter::RequestError stdapi_railgun_api: Operation failed: The specified procedure could not be found.
[*] 0 credentials found in the Credential Store
[*] Post module execution completed
msf post(enum_cred_store) > 
```
# Testing
- [ ] Start `msfconsole`
- [ ] `background`
- [ ] `use post/windows/gather/credentials/enum_cred_store`
- [ ] `set session x`
- [ ] `run`
- [ ] verify that the post module fails gracefully on Windows 2000
- [ ] verify that the post module works on other Windows versions
