### PR TITLE
Attempts to address issue #6963 x64/xor encoder not working

### DIFF
--- a/modules/encoders/x64/xor.rb
+++ b/modules/encoders/x64/xor.rb
@@ -24,6 +24,14 @@ class MetasploitModule < Msf::Encoder::Xor
         }
       )
   end
+  
+  # Indicate that this module can preserve some registers
+  # ...which is currently not true. This is a temp fix
+  # until the full preserve_registers functionality is
+  # implemented. 
+  def can_preserve_registers?
+    true
+  end
 
   def decoder_stub( state )
 


### PR DESCRIPTION
Attempts to address issue #6963 x64/xor encoder not working. The encoder does not work because it doesn't implement the preserve_registers functionality; which is required by the calling function. I've added a temporary fix that will allow this encoder to work until the preserve_registers functionality is fully implemented. The fix is simply adding in the can_preserve_registers function definition to the x64/xor encoder module and having it return true.
## Verification
- [x] Start `msfconsole`
- [x] `use multi/handler`
- [x] `set payload windows/x64/meterpreter/reverse_tcp`
- [ ] `set ExitOnSession false`
- [ ] `set LHOST 0.0.0.0`
- [ ] `set LPORT 443`
- [ ] `set EnableStageEncoding true`
- [ ] `set StageEncoder x64/xor`
- [ ] `run -j`

Attempt to execute a windows/x64/meterpreter/reverse_tcp payload and note that the encoder now works.
