### PR TITLE
Remove unused validation

### DIFF
--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -32,10 +32,6 @@ class MetasploitModule < Msf::Post
 
 
   def run
-    if session.type != "meterpreter"
-      print_error "Only meterpreter sessions are supported by this post module"
-      return
-    end
 
     progfiles_env = session.sys.config.getenvs('ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432')
     locations = []


### PR DESCRIPTION
There is no need to validate the session is meterpreter, since:
'SessionTypes'   => ['meterpreter' ] 
will validate at runtime the session type.
