### PR TITLE
Update redis file_upload to optionally FLUSHALL before writing

### DIFF
--- a/modules/auxiliary/scanner/redis/file_upload.rb
+++ b/modules/auxiliary/scanner/redis/file_upload.rb
@@ -40,7 +40,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         OptPath.new('LocalFile', [false, 'Local file to be uploaded']),
         OptString.new('RemoteFile', [false, 'Remote file path']),
-        OptBool.new('DISABLE_RDBCOMPRESSION', [true, 'Disable compression when saving if found to be enabled', true])
+        OptBool.new('DISABLE_RDBCOMPRESSION', [true, 'Disable compression when saving if found to be enabled', true]),
+        OptBool.new('FLUSHALL', [true, 'Run flushall to remove all redis data before saving', false])
       ]
     )
   end
@@ -80,6 +81,13 @@ class MetasploitModule < Msf::Auxiliary
       else
         print_error("#{peer} -- Unable to disable rdbcompresssion")
         reset_rdbcompression = false
+      end
+    end
+
+    if datastore['FLUSHALL']
+      data = redis_command('FLUSHALL')
+      unless data.include?('+OK')
+        print_warning("#{peer} -- failed to flushall(); continuing")
       end
     end
 


### PR DESCRIPTION
This increases the chances that the uploaded file will be usable as-is rather than being surrounded by the data in redis itself.  Adopted from the techniques disclosed in https://duo.com/blog/over-18-000-redis-instances-targeted-by-fake-ransomware

CC'ing @nixawk given their help on the original module.
## Verification

List the steps needed to make sure this thing works
- [x] Start `redis-server` on some host you control
- [x] Wipe redis by running `redis-cli flushall`
- [x] Insert some identifiable mock test data with `redis-cli set test_key thisissometestdata.therearemanylikeitbutthisoneismine`
- [x] Create a test file for uploading with `echo this is only a test > /tmp/test.txt`
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/redis/file_upload`
- [x] `set RHOST <your_rhost>`
- [x] `set LocalFile /tmp/test.txt`
- [x] `set RemoteFile /tmp/output.txt`
- [x] `run` and confirm that the module completes successfully and that `/tmp/output.txt` contains both the redis structure itself, your test data ('this is only a test') and the mock data ('thisissometestdata.therearemanylikeitbutthisoneismine`)
- [x] `set FLUSHALL true`
- [x]  `run` and confirm that the module completes successfully and that `/tmp/output.txt` contains both the redis structure itself, your test data ('this is only a test') but NOT the mock data ('thisissometestdata.therearemanylikeitbutthisoneismine`)
