### PR TITLE
New module enumerate subdomains

### DIFF
--- a/modules/auxiliary/scanner/discovery/enum_subdomains.rb
+++ b/modules/auxiliary/scanner/discovery/enum_subdomains.rb
@@ -1,0 +1,46 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'socket'
+
+class MetasploitModule < Msf::Auxiliary
+	include Msf::Auxiliary::Report
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'			=> 'Enumerate subdomains',
+			'Description'	=> %q{
+				Enumerate subdomains of domain using a specific list.
+			},
+			'Author'		=> [
+				'Kevin Gonzalvo'
+			],
+			'License'		=> MSF_LICENSE,
+			'References'	=>[
+				['CVE', '1999-0532']
+			]))
+		register_options(
+			[
+				OptString.new('DOMAIN', [true, 'The target domain']),
+				OptPath.new('WORDLIST', [true, 'Wordlist of subdomains', ::File.join(Msf::Config.data_directory, 'wordlists', 'namelist.txt')])
+
+			], self.class)
+
+	end
+
+	def run
+		domain = datastore['DOMAIN']
+		subdomains = datastore['WORDLIST']
+		print_status("Checking subdomains...")
+		File.foreach(subdomains) do |subdomain|
+			begin
+				info = TCPSocket.gethostbyname("#{subdomain.chomp}.#{domain}")
+				print_good("#{subdomain.chomp}" + ', ' + info[0] + ', ' + info[3])
+			rescue
+			end
+		end
+	end
+end


### PR DESCRIPTION
New module to enumerate subdomains using a specific list.
## Verification
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/discovery/enum_subdomains`
- [ ] `set DOMAIN [target]`
- [ ] `run`
- [ ] **Verify** [+] subdomains existing
- [ ] **Verify** [+] [subdomain], [resolution], [ip]
## Output

> msf auxiliary(enum_subdomains) > info
> 
> ```
>    Name: Enumerate subdomains
>  Module: auxiliary/scanner/discovery/enum_subdomains
> License: Metasploit Framework License (BSD)
>    Rank: Normal
> ```
> 
> Provided by:
>   Kevin Gonzalvo
> 
> Basic options:
>   Name      Current Setting                                                           Required  Description
> ---
> 
>   DOMAIN    xxxxxxx.com                                                           yes       The target domain
>   WORDLIST  /opt/metasploit-framework/embedded/framework/data/wordlists/namelist.txt  yes       Wordlist of subdomains
> 
> Description:
>   Enumerate subdomains of domain using a specific list.
> 
> References:
>   http://cvedetails.com/cve/1999-0532/
> 
> msf auxiliary(enum_subdomains) > run
> 
> [*] Checking subdomains...
> [+] autodiscover, autodiscover.xxxxxx.com, xxx.xxx.245.79
> [+] ftp, xxxxx.com, xxx.xxx.245.79
> ^C
