### PR TITLE
Fix data_disconnect to shutdown only if datasocket

### DIFF
--- a/lib/msf/core/exploit/ftp.rb
+++ b/lib/msf/core/exploit/ftp.rb
@@ -96,7 +96,7 @@ module Exploit::Remote::Ftp
   # This method handles disconnecting our data channel
   #
   def data_disconnect
-    self.datasocket.shutdown
+    self.datasocket.shutdown if self.datasocket
     self.datasocket = nil
   end
 


### PR DESCRIPTION
Seeing people use this with `ensure` when their data channel was never set up. This breaks things. :)
- [x] Test `auxiliary/scanner/ftp/pcman_ftp_traversal`
- [x] Test `auxiliary/scanner/ftp/bison_ftp_traversal`
- [x] Test `auxiliary/scanner/ftp/konica_ftp_traversal`
- [x] See no stack trace for any of the modules

Fixes #7277.
