### PR TITLE
Add password "vagrant" to wordlists

### DIFF
--- a/data/wordlists/common_roots.txt
+++ b/data/wordlists/common_roots.txt
@@ -4722,3 +4722,4 @@ zxcvbn
 zxcvbnm
 zzzz
 zzzzzz
+vagrant

--- a/data/wordlists/default_pass_for_services_unhash.txt
+++ b/data/wordlists/default_pass_for_services_unhash.txt
@@ -1212,3 +1212,4 @@ SQL
 CMOSPWD
 dadmin
 wlcsystem
+vagrant

--- a/data/wordlists/http_default_pass.txt
+++ b/data/wordlists/http_default_pass.txt
@@ -16,3 +16,4 @@ xampp
 wampp
 ppmax2011
 turnkey
+vagrant

--- a/data/wordlists/http_default_userpass.txt
+++ b/data/wordlists/http_default_userpass.txt
@@ -8,3 +8,4 @@ wampp xampp
 newuser wampp
 xampp-dav-unsecure ppmax2011 
 admin turnkey
+vagrant vagrant

--- a/data/wordlists/http_default_users.txt
+++ b/data/wordlists/http_default_users.txt
@@ -11,3 +11,4 @@ sys
 wampp
 newuser
 xampp-dav-unsecure
+vagrant

--- a/data/wordlists/password.lst
+++ b/data/wordlists/password.lst
@@ -88393,3 +88393,4 @@ zürich
 émigrés
 épée
 étude
+vagrant

--- a/data/wordlists/root_userpass.txt
+++ b/data/wordlists/root_userpass.txt
@@ -49,3 +49,4 @@ root dbps
 root ibm
 root monitor
 root turnkey
+

--- a/data/wordlists/tomcat_mgr_default_pass.txt
+++ b/data/wordlists/tomcat_mgr_default_pass.txt
@@ -4,3 +4,4 @@ role1
 root
 tomcat
 s3cret
+vagrant

--- a/data/wordlists/tomcat_mgr_default_userpass.txt
+++ b/data/wordlists/tomcat_mgr_default_userpass.txt
@@ -6,3 +6,4 @@ ADMIN ADMIN
 xampp xampp
 tomcat s3cret
 QCC QLogic66
+admin vagrant

--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1005,3 +1005,4 @@ raspberry
 arcsight
 MargaretThatcheris110%SEXY
 karaf
+vagrant

--- a/data/wordlists/unix_users.txt
+++ b/data/wordlists/unix_users.txt
@@ -109,3 +109,4 @@ www-data
 xpdb
 xpopr
 zabbix
+vagrant


### PR DESCRIPTION
This PR adds the password "vagrant" to the default wordlists. "vagrant" is a common password used by Metasploitable3.

Verification:

None required.
