### PR TITLE
Add module to scan for Octopus Deploy server

### DIFF
--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -1,0 +1,64 @@
+require 'metasploit/framework/login_scanner/http'
+require 'json'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # Octopus Deploy login scanner
+      class OctopusDeploy < HTTP
+
+        # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
+        CAN_GET_SESSION = true
+        DEFAULT_PORT    = 80
+        PRIVATE_TYPES   = [ :password ]
+
+        # (see Base#set_sane_defaults)
+        def set_sane_defaults
+          uri = '/api/users/login' if uri.nil?
+          method = 'POST' if method.nil?
+
+          super
+        end
+
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
+          if ssl
+            result_opts[:service_name] = 'https'
+          else
+            result_opts[:service_name] = 'http'
+          end
+          begin
+            json_post_data = JSON.pretty_generate({ Username: credential.public, Password: credential.private })
+            cli = Rex::Proto::Http::Client.new(host, port, { 'Msf' => framework, 'MsfExploit' => framework_module }, ssl, ssl_version, http_username, http_password)
+            configure_http_client(cli)
+            cli.connect
+            req = cli.request_cgi(
+              'method' => 'POST',
+              'uri' => uri,
+              'ctype' => 'application/json',
+              'data' => json_post_data
+            )
+            res = cli.send_recv(req)
+            body = JSON.parse(res.body)
+            if res && res.code == 200 && body.key?('IsActive') && body['IsActive']
+              result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.body)
+            else
+              result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
+            end
+          rescue ::JSON::ParserError
+            result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res.body)
+          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
+            result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+          end
+          Result.new(result_opts)
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/octopusdeploy_login.rb
+++ b/modules/auxiliary/scanner/http/octopusdeploy_login.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'metasploit/framework/credential_collection'
+require 'metasploit/framework/login_scanner/octopusdeploy'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'           => 'Octopus Deploy Login Utility',
+      'Description'    => %q{
+        This module simply attempts to login to a Octopus Deploy server using a specific
+        username and password. It has been confirmed to work on version 3.4.4
+      },
+      'Author'         => [ 'James Otten <jamesotten1[at]gmail.com>' ],
+      'License'        => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'URI for login. Default is /api/users/login', '/api/users/login'])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    cred_collection = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['USERNAME'],
+      user_as_pass: datastore['USER_AS_PASS']
+    )
+
+    scanner = Metasploit::Framework::LoginScanner::OctopusDeploy.new(
+      configure_http_login_scanner(
+        cred_details: cred_collection,
+        stop_on_success: datastore['STOP_ON_SUCCESS'],
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 10,
+        http_username: datastore['HttpUsername'],
+        http_password: datastore['HttpPassword'],
+        uri: datastore['TARGETURI']
+      )
+    )
+
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      )
+
+      if result.success?
+        credential_core = create_credential(credential_data)
+        credential_data[:core] = credential_core
+        create_credential_login(credential_data)
+
+        print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential}"
+      else
+        invalidate_login(credential_data)
+        print_status "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+      end
+    end
+  end
+end

--- a/spec/lib/metasploit/framework/login_scanner/octopusdeploy_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/octopusdeploy_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/octopusdeploy'
+
+RSpec.describe Metasploit::Framework::LoginScanner::OctopusDeploy do
+
+    it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
+    it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
+    it_behaves_like 'Metasploit::Framework::LoginScanner::HTTP'
+
+end


### PR DESCRIPTION
Add login scanner module for Octopus Deploy
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/octopusdeploy_login`
- [x] set `PASSWORD`, `RHOSTS`, `RPORT`, `SSL`, `TARGETURI`, and `USERNAME`
- [x] `run`
- [x] **Verify** that valid login attempts are reported as correct.

Sample output:

```
msf auxiliary(octopusdeploy_login) > info

       Name: Octopus Deploy Login Utility
     Module: auxiliary/scanner/http/octopusdeploy_login
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  James Otten <jamesotten1@gmail.com>

Basic options:
  Name              Current Setting        Required  Description
  ----              ---------------        --------  -----------
  BLANK_PASSWORDS   false                  no        Try blank passwords for all users
  BRUTEFORCE_SPEED  5                      yes       How fast to bruteforce, from 0 to 5
  DB_ALL_CREDS      false                  no        Try each user/password couple stored in the current database
  DB_ALL_PASS       false                  no        Add all passwords in the current database to the list
  DB_ALL_USERS      false                  no        Add all users in the current database to the list
  PASSWORD          password               no        A specific password to authenticate with
  PASS_FILE                                no        File containing passwords, one per line
  Proxies                                  no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS            10.0.0.28              yes       The target address range or CIDR identifier
  RPORT             81                     yes       The target port
  SSL               false                  no        Negotiate SSL/TLS for outgoing connections
  STOP_ON_SUCCESS   false                  yes       Stop guessing when a credential works for a host
  TARGETURI         /octo/api/users/login  yes       URI for login. Default is /api/users/login
  THREADS           1                      yes       The number of concurrent threads
  USERNAME          admin                  no        A specific username to authenticate as
  USERPASS_FILE                            no        File containing users and passwords separated by space, one pair per line
  USER_AS_PASS      false                  no        Try the username as the password for all users
  USER_FILE                                no        File containing usernames, one per line
  VERBOSE           true                   yes       Whether to print output for all attempts
  VHOST                                    no        HTTP server virtual host

Description:
  This module simply attempts to login to a Octopus Deploy server 
  using a specific username and password. It has been confirmed to 
  work on version 3.4.4

msf auxiliary(octopusdeploy_login) > run

[*] 10.0.0.28:81 - LOGIN FAILED: admin:password (Incorrect)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(octopusdeploy_login) > set PASSWORD Today123!
PASSWORD => Today123!
msf auxiliary(octopusdeploy_login) > run

[+] 10.0.0.28:81 - LOGIN SUCCESSFUL: admin:Today123!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(octopusdeploy_login) >
```

This module tries to log into one or more Octopus Deploy servers.

More information about Octopus Deploy:
https://octopus.com # #
