### PR TITLE
Check environment variables before using for winscp module

### DIFF
--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -115,11 +115,11 @@ class MetasploitModule < Msf::Post
     env = get_envs('APPDATA', prog_files_env, 'USERNAME')
 
     if env['APPDATA'].nil?
-      fail_with(Failure::Unknown, 'Target does not hav environment variable APPDATA')
+      fail_with(Failure::Unknown, 'Target does not have environment variable APPDATA')
     elsif env[prog_files_env].nil?
-      fail_with(Failure::Unknown, "Target does not hav environment variable #{prog_files_env}")
+      fail_with(Failure::Unknown, "Target does not have environment variable #{prog_files_env}")
     elsif env['USERNAME'].nil?
-      fail_with(Failure::Unknown, 'Target does not hav environment variable USERNAME')
+      fail_with(Failure::Unknown, 'Target does not have environment variable USERNAME')
     end
 
     user_dir = "#{env['APPDATA']}\\..\\.."

--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -114,6 +114,14 @@ class MetasploitModule < Msf::Post
     end
     env = get_envs('APPDATA', prog_files_env, 'USERNAME')
 
+    if env['APPDATA'].nil?
+      fail_with(Failure::Unknown, 'Target does not hav environment variable APPDATA')
+    elsif env[prog_files_env].nil?
+      fail_with(Failure::Unknown, "Target does not hav environment variable #{prog_files_env}")
+    elsif env['USERNAME'].nil?
+      fail_with(Failure::Unknown, 'Target does not hav environment variable USERNAME')
+    end
+
     user_dir = "#{env['APPDATA']}\\..\\.."
     user_dir << "\\.." if user_dir.include?('Users')
 


### PR DESCRIPTION
This is a patch for post/windows/gather/credentials/winscp for checking environment variables before using them.

Backtrace:

```
[*] Looking for WinSCP.ini file storage...
[-] Post failed: NoMethodError undefined method `gsub' for nil:NilClass
[-] Call stack:
[-] /Users/[user]/rapid7/metasploit-framework/modules/post/windows/gather/credentials/winscp.rb:123:in `block in run'
[-] /Users/[user]/rapid7/metasploit-framework/modules/post/windows/gather/credentials/winscp.rb:121:in `each'
[-] /Users/[user]/rapid7/metasploit-framework/modules/post/windows/gather/credentials/winscp.rb:121:in `run'
```

Verification
- [x] Make sure you have a Windows box
- [x] On the Windows box, make sure you remove one of these environment variables: `USERNAME`, `ProgramFiles`, or `APPDATA`
- [x] Get a meterpreter session on the Windows box
- [x] In the meterpreter prompt, do `run post/windows/gather/credentials/winscp`
- [x] You should get an error saying you don't have the environment variable
