### PR TITLE
Set defaults in WordpressMulticall login scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -29,10 +29,10 @@ module Metasploit
 
 
         def set_default
-          self.wordpress_url_xmlrpc = 'xmlrpc.php'
-          self.block_wait = 6
-          self.base_uri = '/'
-          self.chunk_size = 1700
+          @wordpress_url_xmlrpc ||= 'xmlrpc.php'
+          @block_wait ||= 6
+          @base_uri ||= '/'
+          @chunk_size ||= 1700
         end
 
         # Returns the XML data that is used for the login.
@@ -110,6 +110,8 @@ module Metasploit
         # @param credential [Metasploit::Framework::Credential]
         # @return [Metasploit::Framework::LoginScanner::Result]
         def attempt_login(credential)
+          set_default
+          @passwords ||= [credential.private]
           generate_xml(credential.public).each do |xml|
             send_wp_request(xml)
             req_xml = Nokogiri::Slop(xml)


### PR DESCRIPTION
This login scanner would crash it was used like a normal login scanner.

MS-2007
# Verification
- [x] Get an irb shell in msfconsole
- [x] `require 'metasploit/framework/login_scanner/wordpress_multicall'`
- [x] `a = Metasploit::Framework::LoginScanner::WordpressMulticall.new`
- [x] `c = Metasploit::Framework::Credential.new public: 'asdf', private: 'asdf'`
- [x] `a.attempt_login c`
- [x] Verify it does not crash while generating the request (it may hang or crash while connecting since we didn't point it at anything, but this is out of the scope of this bug).
