### PR TITLE
[Fix] sugarcrm_unserialize_exec - Exploit failed: NoMethodError undefined method `include?' for nil:NilClass

### DIFF
--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -94,8 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'data'   => data
     })
-
-    if res.nil? || res.headers['Location'] && res.headers['Location'].include?('action=Login') || res.get_cookies.empty?
+    if res.nil? || (res.headers['Location'] && res.headers['Location'].include?('action=Login')) || res.get_cookies.empty?
       fail_with(Failure::NoAccess, "#{peer} - Login failed with \"#{username}:#{password}\"")
     end
 

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data'   => data
     })
 
-    if res.nil? || res.headers['Location'].include?('action=Login') || res.get_cookies.empty?
+    if res.nil? || res.headers['Location'] && res.headers['Location'].include?('action=Login') || res.get_cookies.empty?
       fail_with(Failure::NoAccess, "#{peer} - Login failed with \"#{username}:#{password}\"")
     end
 


### PR DESCRIPTION
issue: https://github.com/rapid7/metasploit-framework/issues/7302
## Verification

```
msf exploit(sugarcrm_unserialize_exec) > show options

Module options (exploit/unix/webapp/sugarcrm_unserialize_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD                    yes       The password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /sugarcrm/       yes       The base path to the web application
   USERNAME                    yes       The username to authenticate with
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(sugarcrm_unserialize_exec) > set RHOST 172.16.176.162
RHOST => 172.16.176.162
msf exploit(sugarcrm_unserialize_exec) > set USERNAME admin
USERNAME => admin
msf exploit(sugarcrm_unserialize_exec) > set PASSWORD password
PASSWORD => password
msf exploit(sugarcrm_unserialize_exec) > run

[*] Started reverse TCP handler on 172.16.176.1:4444
[-] Exploit aborted due to failure: no-access: 172.16.176.162:80 - Login failed with "admin:password"
[*] Exploit completed, but no session was created.
```
