### PR TITLE
Fix post/windows/gather/credentials/steam for an empty env var

### DIFF
--- a/modules/post/windows/gather/credentials/steam.rb
+++ b/modules/post/windows/gather/credentials/steam.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
     # We will just use an x64 only defined env variable to check.
     progfiles_env = session.sys.config.getenvs('ProgramFiles(X86)', 'ProgramFiles')
     progfilesx86 = progfiles_env['ProgramFiles(X86)']
-    if not progfilesx86.empty? and progfilesx86 !~ /%ProgramFiles\(X86\)%/
+    if not progfilesx86.blank? and progfilesx86 !~ /%ProgramFiles\(X86\)%/
       progs = progfilesx86 # x64
     else
       progs = progfiles_env['ProgramFiles'] # x86

--- a/modules/post/windows/gather/credentials/steam.rb
+++ b/modules/post/windows/gather/credentials/steam.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Post
     else
       progs = progfiles_env['ProgramFiles'] # x86
     end
-    path = progs + '\\Steam\\config'
+    path = "#{progs}\\Steam\\config"
 
     print_status("Checking for Steam configs in #{path}")
 


### PR DESCRIPTION
# What This Patch Does

This fixes an undefined method bug in post/windows/gather/credentials/steam. If an environment variable is not available on the target machine, the API returns nil, which would result an undefined method issue while calling `#empty?`

Verification
- [x] Start a Windows box
- [x] Go to Control Panel, System, remove the `ProgramFiles` and `ProgramFiles(X86)` environment variables.
- [x] Get a Meterpreter session for the Windows box
- [x] At the Meterpreter prompt, do: `run post/windows/gather/credentials/steam`
- [x] You should not see an undefined method error/backtrace
