### PR TITLE
Fix typo in exploit/unix/local/chkrootkit

### DIFF
--- a/modules/exploits/unix/local/chkrootkit.rb
+++ b/modules/exploits/unix/local/chkrootkit.rb
@@ -16,11 +16,11 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'           => 'Chkrootkit Local Privilege Escalation',
       'Description'    => %q{
-        Chkrootkit before 0.50 will run any executable file named
-        /tmp/update as root, allowing a trivial privsec.
+        Chkrootkit before 0.50 will run any executable file named /tmp/update
+        as root, allowing a trivial privilege escalation.
 
-        WfsDelay is set to 24h, since this is how often a chkrootkit
-        scan is scheduled by default.
+        WfsDelay is set to 24h, since this is how often a chkrootkit scan is
+        scheduled by default.
       },
       'Author'         => [
         'Thomas Stangner',        # Original exploit


### PR DESCRIPTION
## Verification
- [x] "privsec" is spelled "privilege escalation". :smile:
