### PR TITLE
Fix missing form inputs in skybluecanvas_exec

### DIFF
--- a/modules/exploits/unix/webapp/skybluecanvas_exec.rb
+++ b/modules/exploits/unix/webapp/skybluecanvas_exec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_raw('uri' => uri)
 
-    if res and res.body =~ /[1.1 r248]/
+    if res && res.body.include?('SkyBlueCanvas [1.1 r248]')
       vprint_good("SkyBlueCanvas CMS 1.1 r248-xx found")
       return Exploit::CheckCode::Appears
     end
@@ -89,7 +89,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'email' => rand_text_alphanumeric(10),
           'subject' => rand_text_alphanumeric(10),
           'message' => rand_text_alphanumeric(10),
-          'action' => 'Send'
+          'action' => 'Send',
+          'mailinglist' => '0',
+          'cc' => '0'
         }
     })
   end


### PR DESCRIPTION
Not sure how these were missed in 1.1 r248-03, but they're there. Maybe they were backported changes.

You can download SkyBlueCanvas here: https://sourceforge.net/projects/skybluecanvas/files/skybluecanvas.v1.1-r248-03.zip/download.
- [x] Test `check`
- [x] Shell it

P.S. If you have payload failures, let me fix the badchars.
