### PR TITLE
remove osvdb links

### DIFF
--- a/lib/msf/core/db_manager/import/nmap.rb
+++ b/lib/msf/core/db_manager/import/nmap.rb
@@ -182,7 +182,6 @@ module Msf::DBManager::Import::Nmap
                 :info => 'Microsoft Windows Server Service Crafted RPC Request Handling Unspecified Remote Code Execution',
                 :refs =>['CVE-2008-4250',
                   'BID-31874',
-                  'OSVDB-49243',
                   'CWE-94',
                   'MSFT-MS08-067',
                   'MSF-Microsoft Server Service Relative Path Stack Corruption',
@@ -204,8 +203,6 @@ module Msf::DBManager::Import::Nmap
                   'BID-18325',
                   'BID-18358',
                   'BID-18424',
-                  'OSVDB-26436',
-                  'OSVDB-26437',
                   'MSFT-MS06-025',
                   'MSF-Microsoft RRAS Service RASMAN Registry Overflow',
                   'NSS-21689']
@@ -224,7 +221,6 @@ module Msf::DBManager::Import::Nmap
                 :info => 'Vulnerability in Windows DNS RPC Interface Could Allow Remote Code Execution',
                 # Add more refs based on nessus/nexpose .. results
                 :refs =>['CVE-2007-1748',
-                  'OSVDB-34100',
                   'MSF-Microsoft DNS RPC Service extractQuotedChar()',
                   'NSS-25168']
               }

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -158,7 +158,6 @@ module Msf::DBManager::ModuleCache
   # +edb+:: Matches modules with the given Exploit-DB ID.
   # +name+:: Matches modules with the given full name or name.
   # +os+, +platform+:: Matches modules with the given platform or target name.
-  # +osvdb+:: Matches modules with the given OSVDB ID.
   # +ref+:: Matches modules with the given reference ID.
   # +type+:: Matches modules with the given type.
   #
@@ -277,7 +276,7 @@ module Msf::DBManager::ModuleCache
 
             query = query.includes(:refs).references(:refs)
             union_conditions << Mdm::Module::Ref.arel_table[:name].matches_any(formatted_values)
-          when 'cve', 'bid', 'osvdb', 'edb'
+          when 'cve', 'bid', 'edb'
             formatted_values = value_set.collect { |value|
               prefix = keyword.upcase
 

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -77,7 +77,7 @@ class Msf::Module::SiteReference < Msf::Module::Reference
 
   #
   # Initializes a site reference from an array.  ary[0] is the site and
-  # ary[1] is the site context identifier, such as OSVDB.
+  # ary[1] is the site context identifier, such as CVE.
   #
   def self.from_a(ary)
     return nil if (ary.length < 2)
@@ -95,9 +95,7 @@ class Msf::Module::SiteReference < Msf::Module::Reference
     self.ctx_id  = in_ctx_id
     self.ctx_val = in_ctx_val
 
-    if (in_ctx_id == 'OSVDB')
-      self.site = "http://www.osvdb.org/#{in_ctx_val}"
-    elsif (in_ctx_id == 'CVE')
+    if (in_ctx_id == 'CVE')
       self.site = "http://cvedetails.com/cve/#{in_ctx_val}/"
     elsif (in_ctx_id == 'CWE')
       self.site = "https://cwe.mitre.org/data/definitions/#{in_ctx_val}.html"
@@ -150,7 +148,7 @@ class Msf::Module::SiteReference < Msf::Module::Reference
   #
   attr_reader :site
   #
-  # The context identifier of the site, such as OSVDB.
+  # The context identifier of the site, such as CVE.
   #
   attr_reader :ctx_id
   #

--- a/lib/msf/core/module/search.rb
+++ b/lib/msf/core/module/search.rb
@@ -86,8 +86,6 @@ module Msf::Module::Search
               match = [t,w] if refs.any? { |ref| ref =~ /^cve\-/i and ref =~ r }
             when 'bid'
               match = [t,w] if refs.any? { |ref| ref =~ /^bid\-/i and ref =~ r }
-            when 'osvdb'
-              match = [t,w] if refs.any? { |ref| ref =~ /^osvdb\-/i and ref =~ r }
             when 'edb'
               match = [t,w] if refs.any? { |ref| ref =~ /^edb\-/i and ref =~ r }
           end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1615,7 +1615,6 @@ class Core
       'cve'      => 'Modules with a matching CVE ID',
       'edb'      => 'Modules with a matching Exploit-DB ID',
       'name'     => 'Modules with a matching descriptive name',
-      'osvdb'    => 'Modules with a matching OSVDB ID',
       'platform' => 'Modules affecting this platform',
       'ref'      => 'Modules with a matching ref',
       'type'     => 'Modules of a specific type (exploit, auxiliary, or post)',

--- a/spec/support/shared/examples/msf/db_manager/module_cache.rb
+++ b/spec/support/shared/examples/msf/db_manager/module_cache.rb
@@ -301,8 +301,6 @@ RSpec.shared_examples_for 'Msf::DBManager::ModuleCache' do
 
     it_should_behave_like 'Msf::DBManager#search_modules Mdm::Module::Platform#name or Mdm::Module::Target#name keyword', :os
 
-    it_should_behave_like 'Msf::DBManager#search_modules Mdm::Module::Ref#name keyword', :osvdb
-
     it_should_behave_like 'Msf::DBManager#search_modules Mdm::Module::Platform#name or Mdm::Module::Target#name keyword', :platform
 
     context 'with ref keyword' do

--- a/spec/support/shared/examples/msf/module/search.rb
+++ b/spec/support/shared/examples/msf/module/search.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples_for 'Msf::Module::Search' do
   describe '#search_filter' do
-    REF_TYPES = %w(CVE BID OSVDB EDB)
+    REF_TYPES = %w(CVE BID EDB)
 
     shared_examples "search_filter" do |opts|
       accept = opts[:accept] || []

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -178,8 +178,6 @@ class Msftidy
         case identifier
         when 'CVE'
           warn("Invalid CVE format: '#{value}'") if value !~ /^\d{4}\-\d{4,}$/
-        when 'OSVDB'
-          warn("Invalid OSVDB format: '#{value}'") if value !~ /^\d+$/
         when 'BID'
           warn("Invalid BID format: '#{value}'") if value !~ /^\d+$/
         when 'MSB'
@@ -197,9 +195,7 @@ class Msftidy
         when 'PACKETSTORM'
           warn("Invalid PACKETSTORM reference") if value !~ /^\d+$/
         when 'URL'
-          if value =~ /^http:\/\/www\.osvdb\.org/
-            warn("Please use 'OSVDB' for '#{value}'")
-          elsif value =~ /^http:\/\/cvedetails\.com\/cve/
+          if value =~ /^http:\/\/cvedetails\.com\/cve/
             warn("Please use 'CVE' for '#{value}'")
           elsif value =~ /^http:\/\/www\.securityfocus\.com\/bid\//
             warn("Please use 'BID' for '#{value}'")

--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -24,7 +24,6 @@ require 'uri'
 def types
   {
     'ALL'         => '',
-    'OSVDB'       => 'http://www.osvdb.org/#{in_ctx_val}',
     'CVE'         => 'http://cvedetails.com/cve/#{in_ctx_val}/',
     'CWE'         => 'http://cwe.mitre.org/data/definitions/#{in_ctx_val}.html',
     'BID'         => 'http://www.securityfocus.com/bid/#{in_ctx_val}',


### PR DESCRIPTION
This selectively reapplies PR #6812, but just the library/spec/tool bits, leaving the actual references in place.
