### PR TITLE
Fix minor route command issues

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1334,14 +1334,13 @@ class Core
 
     when "add", "remove", "del"
       subnet = args.shift
-      subnet,cidr_mask = subnet.split("/")
-
-      if cidr_mask
-        netmask = Rex::Socket.addr_ctoa(cidr_mask.to_i)
-      else
-        netmask = args.shift
+      netmask = nil
+      if subnet
+        subnet, cidr_mask = subnet.split("/")
+        netmask = Rex::Socket.addr_ctoa(cidr_mask.to_i) if cidr_mask
       end
 
+      netmask = args.shift if netmask.nil?
       gateway_name = args.shift
 
       if (subnet.nil? || netmask.nil? || gateway_name.nil?)
@@ -1354,7 +1353,7 @@ class Core
       case gateway_name
       when /local/i
         gateway = Rex::Socket::Comm::Local
-      when /^[0-9]+$/
+      when /^(-1|[0-9]+)$/
         session = framework.sessions.get(gateway_name)
         if session.kind_of?(Msf::Session::Comm)
           gateway = session
@@ -1362,7 +1361,7 @@ class Core
           print_error("Not a session: #{gateway_name}")
           return false
         else
-          print_error("Cannout route through specified session (not a Comm)")
+          print_error("Cannot route through the specified session (not a Comm)")
           return false
         end
       else

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1416,7 +1416,7 @@ class Core
             'Netmask' => { 'MaxWidth' => 17 },
           })
 
-      Rex::Socket::SwitchBoard.each.with_index { |route, idx|
+      Rex::Socket::SwitchBoard.each { |route|
         if (route.comm.kind_of?(Msf::Session))
           gw = "Session #{route.comm.sid}"
         else

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1327,10 +1327,7 @@ class Core
   # which session a given subnet should route through.
   #
   def cmd_route(*args)
-    if (args.length == 0)
-      cmd_route_help
-      return false
-    end
+    args << 'print' if args.length == 0
 
     action = args.shift
     case action
@@ -1420,8 +1417,7 @@ class Core
             'Netmask' => { 'MaxWidth' => 17 },
           })
 
-      Rex::Socket::SwitchBoard.each { |route|
-
+      Rex::Socket::SwitchBoard.each.with_index { |route, idx|
         if (route.comm.kind_of?(Msf::Session))
           gw = "Session #{route.comm.sid}"
         else
@@ -1431,7 +1427,11 @@ class Core
         tbl << [ route.subnet, route.netmask, gw ]
       }
 
-      print(tbl.to_s)
+      if tbl.rows.length == 0
+        print_status('There are currently no routes defined.')
+      else
+        print(tbl.to_s)
+      end
     else
       cmd_route_help
     end


### PR DESCRIPTION
This PR makes the following minor tweaks to the Metasploit `route` command (as opposed to the Meterpreter `route` command).
1. Fix the stack trace seen when using the `route (add/del/remove)` while missing arguments
2. Add support for specifying the last open session as `-1` like other parts of the framework support
3. Change the default behavior to print the route table when no arguments are specified
4. Add a default message saying no routes are present instead of simply returning when the route table is empty
## Verification
- [x] Start `msfconsole`
- [x] Verify that using the add / del /remove arguments do not throw a stack trace when arguments are missing
- [x] Verify that using the `route` command with no arguments states that no routes are defined
- [x] Open a meterpreter session and add a route for it using session ID `-1`
- [x] Simply use the `route` command with no arguments to see your newly added route
## Example output

```
metasploit-framework (S:1 J:0) exploit(handler) > route add
[-] Missing arguments to route add.
metasploit-framework (S:1 J:0) exploit(handler) > route
[*] There are currently no routes defined.
metasploit-framework (S:1 J:0) exploit(handler) > route add 1.2.3.4/32 -1
[*] Route added
metasploit-framework (S:1 J:0) exploit(handler) > route

Active Routing Table
====================

   Subnet             Netmask            Gateway
   ------             -------            -------
   1.2.3.4            255.255.255.255    Session 1

```
