### PR TITLE
Bump to lastest metasploit_data_models gem.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
     metasploit-payloads (1.1.13)
-    metasploit_data_models (2.0.0)
+    metasploit_data_models (2.0.1)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers


### PR DESCRIPTION
Bump the Gemfile.lock version number for the metasploit_data_models gem to pick up the patch for MS-1598 (MAC address validation)
## Verification

The steps below use an nmap scan to bring in an invalid MAC address, but feel free to substitute those for any other steps that allow you to specify an invalid MAC address.
- [x] `nmap -sS <IP of another system you can reach and is OK to scan> -oX myscan.out`
- [x] edit the myscan.out file, search for the **address** tag that has 'addrtype="mac"'
- [x] make the value for 'addr' on that same line an INVAID MAC address and save myscan.out
- [x] `bundle install`
- [x] `rake spec`, verify no errors
- [x] Start `msfconsole`
- [x] `hosts -a 1.2.3.4`
- [x] **Verify** you don't get an error (validates that an empty MAC address is allowed)
- [x] `db_import <path to your myscan.out file>`
- [x] **Verify** you get an error that the MAC address is not valid

Fixes MS-1598.
