### PR TITLE
Added initialization of RHOST value prior to calling child check() fu…

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -47,6 +47,7 @@ end
 
 def check
   nmod = replicant
+  nmod.datastore['RHOST'] = @original_rhost
   begin
     nmod.check_host(datastore['RHOST'])
   rescue NoMethodError


### PR DESCRIPTION
Fixes #7348 
## Verification

List the steps needed to make sure this thing works
### Window 1
- [x] Start local netcat listener on port 21 `nc -lv 127.0.0.1 -p 21`
### Window 2
- [x] start msfconsole
- [x] `use auxiliary/scanner/ftp/bison_ftp_traversal`
- [x] `set rhosts 127.0.0.1`
- [x] `set verbose true`
- [x] `check`
- [x] **Verify** that the check module prints out the IP address (127.0.0.1) and does not error trying to connect:

```
msf auxiliary(bison_ftp_traversal) > use auxiliary/scanner/ftp/bison_ftp_traversal 
msf auxiliary(bison_ftp_traversal) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf auxiliary(bison_ftp_traversal) > set verbose true
verbose => true
msf auxiliary(bison_ftp_traversal) > check

[*] 127.0.0.1:21          - Connecting to FTP server 127.0.0.1:21...
[*] 127.0.0.1:21          - Connected to target FTP server.
[*] 127.0.0.1:21 The target is not exploitable.
[*] Checked 1 of 1 hosts (100% complete)
msf auxiliary(bison_ftp_traversal) > 
```
