### PR TITLE
Add a `sess` command to MSF and Meterpreter shells

### DIFF
--- a/features/commands/help.feature
+++ b/features/commands/help.feature
@@ -42,6 +42,7 @@ Feature: Help command
           route         Route traffic through a session
           save          Saves the active datastores
           search        Searches module names and descriptions
+          sess          Interact with a given session
           sessions      Dump session listings and display information about sessions
           set           Sets a context-specific variable to a value
           setg          Sets a global variable to a value

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -136,6 +136,7 @@ class Core
       "route"      => "Route traffic through a session",
       "save"       => "Saves the active datastores",
       "search"     => "Searches module names and descriptions",
+      "sess"       => "Interact with a given session",
       "sessions"   => "Dump session listings and display information about sessions",
       "set"        => "Sets a context-specific variable to a value",
       "setg"       => "Sets a global variable to a value",
@@ -1754,6 +1755,25 @@ class Core
     return
   end
 
+  def cmd_sess_help
+    print_line('Usage: sess <session id>')
+    print_line
+    print_line('Interact with the given session ID.')
+    print_line('This works the same as: sessions -i <session id>')
+    print_line
+  end
+
+  #
+  # Helper function to quickly select a session
+  #
+  def cmd_sess(*args)
+    if args.length == 0 || args[0].to_i == 0
+      cmd_sess_help
+    else
+      cmd_sessions('-i', args[0])
+    end
+  end
+
   def cmd_sessions_help
     print_line "Usage: sessions [options]"
     print_line
@@ -1955,22 +1975,26 @@ class Core
         end
       end
     when 'interact'
-      session = verify_session(sid)
-      if session
-        if session.respond_to?(:response_timeout)
-          last_known_timeout = session.response_timeout
-          session.response_timeout = response_timeout
-        end
-        print_status("Starting interaction with #{session.name}...\n") unless quiet
-        begin
-          self.active_session = session
-          session.interact(driver.input.dup, driver.output)
-          self.active_session = nil
-          driver.input.reset_tab_completion if driver.input.supports_readline
-        ensure
-          if session.respond_to?(:response_timeout) && last_known_timeout
-            session.response_timeout = last_known_timeout
+      while sid
+        session = verify_session(sid)
+        if session
+          if session.respond_to?(:response_timeout)
+            last_known_timeout = session.response_timeout
+            session.response_timeout = response_timeout
           end
+          print_status("Starting interaction with #{session.name}...\n") unless quiet
+          begin
+            self.active_session = session
+            sid = session.interact(driver.input.dup, driver.output)
+            self.active_session = nil
+            driver.input.reset_tab_completion if driver.input.supports_readline
+          ensure
+            if session.respond_to?(:response_timeout) && last_known_timeout
+              session.response_timeout = last_known_timeout
+            end
+          end
+        else
+          sid = nil
         end
       end
     when 'scriptall'

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -65,6 +65,7 @@ class Console::CommandDispatcher::Core
       "bgkill"     => "Kills a background meterpreter script",
       "get_timeouts" => "Get the current session timeout values",
       "set_timeouts" => "Set the current session timeout values",
+      "sess"       => "Quickly switch to another session",
       "bglist"     => "Lists running background scripts",
       "write"      => "Writes data to a channel",
       "enable_unicode_encoding"  => "Enables encoding of unicode strings",
@@ -109,6 +110,28 @@ class Console::CommandDispatcher::Core
   #
   def name
     "Core"
+  end
+
+  def cmd_sess_help
+    print_line('Usage: sess <session id>')
+    print_line
+    print_line('Interact with a different session Id.')
+    print_line('This works the same as calling this from the MSF shell: sessions -i <session id>')
+    print_line
+  end
+
+  def cmd_sess(*args)
+    if args.length == 0 || args[0].to_i == 0
+      cmd_sess_help
+    elsif args[0].to_s == client.name.to_s
+      print_status("Session #{client.name} is already interactive.")
+    else
+      print_status("Backgrounding session #{client.name}...")
+      # store the next session id so that it can be referenced as soon
+      # as this session is no longer interacting
+      client.next_session = args[0]
+      client.interacting = false
+    end
   end
 
   def cmd_background_help

--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -83,8 +83,13 @@ module Interactive
       self.completed = true
     end
 
-    # Return whether or not EOF was reached
-    return eof
+    # if another session was requested, store it
+    next_session = self.next_session
+    # clear the value from the object
+    self.next_session = nil
+
+    # return this session id
+    return next_session
   end
 
   #
@@ -103,6 +108,11 @@ module Interactive
   # Whether or not the session is currently being interacted with
   #
   attr_accessor   :interacting
+
+  #
+  # If another session needs interaction, this is where it goes
+  #
+  attr_accessor   :next_session
 
   #
   # Whether or not the session has completed interaction


### PR DESCRIPTION
## Overview

This PR adds a new command to both the MSF and Metepreter shells is a simpler shortcut that allows for moving around sessions much faster from within the console.
- From inside MSF, `sess <id>` is shorthand for `sessions -i <id>`
- From inside Meterp, `sess <id>` is shorthand for `background; sessions -i <id>`

In the latter case, if the session being switched to is the same id, then no switching happens.
## Sample Run

Typical sessions

```
msf exploit(handler) > sessions

Active sessions
===============

  Id  Type                   Information                           Connection
  --  ----                   -----------                           ----------
  1   meterpreter x86/win32  DESKTOP-5A73R51\oj @ DESKTOP-5A73R51  10.1.10.35:4444 -> 10.1.10.35:64613 (172.16.255.131)
  2   meterpreter x86/win32  WIN-7CH5RT177BA\oj @ WIN-7CH5RT177BA  10.1.10.35:4444 -> 10.1.10.44:49184 (10.1.10.44)

msf exploit(handler) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > machine_id
[+] Machine ID: 3fc9cec59007ffcd84234dfb9aefc1e6
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > machine_id
[+] Machine ID: b8cbd32fa758033e81eb1143d24948da
meterpreter > background
[*] Backgrounding session 2...
```

There is now a new command in the MSF shell:

```
msf exploit(handler) > sess
Usage: sess <session id>

Interact with the given session ID.
This works the same as: sessions -i <session id>
```

We can now skip the painful `sessions -i` syntax (my personal most common use):

```
msf exploit(handler) > sess 2
[*] Starting interaction with 2...

meterpreter > machine_id
[+] Machine ID: b8cbd32fa758033e81eb1143d24948da
```

This exists in Meterp as well:

```
meterpreter > sess
Usage: sess <session id>

Interact with a different session Id.
This works the same as calling this from the MSF shell: sessions -i <session id>
```

And we can skip from one Meterp session to another!

```
meterpreter > sess 1
[*] Backgrounding session 2...
[*] Starting interaction with 1...

meterpreter > machine_id
[+] Machine ID: 3fc9cec59007ffcd84234dfb9aefc1e6
meterpreter > sess 2
[*] Backgrounding session 1...
[*] Starting interaction with 2...

meterpreter > machine_id
[+] Machine ID: b8cbd32fa758033e81eb1143d24948da
```

And if you try to switch to your current session...

```
meterpreter > sess 2
[*] Session 2 is already interactive.
meterpreter > sess 1000
[*] Backgrounding session 1...
[-] Invalid session identifier: 1000
```

It even works with `-1` as the shortcut:

```
msf exploit(handler) > sess -1
[*] Starting interaction with 2...

meterpreter > sess 1
[*] Backgrounding session 2...
[*] Starting interaction with 1...

meterpreter > sess -1
[*] Backgrounding session 1...
[*] Starting interaction with 2...

meterpreter >
```

My life just got a whole lot better.
## Verification
- [x] Fire up MSF console, and create a handler that can receive Meterpreter sessions.
- [x] Create a matching payload that can hit the handler.
- [x] Launch the payload twice to get two sessions.
- [x] Make sure that `sess` shows help inside the MSF console.
- [x] Make sure that `sess` shows help inside the Meterpreter shell.
- [x] Make sure that `sess <id>` functions the same as `sessions -i <id>` (including with `-1`).
- [x] Make sure that `sess <id>` functions the same as `background; sessions -i <id>` (including with `-1`).
- [x] Interact with session `1`, and in the Meterpreter shell type `sess 1`. No switching should occur.

That should be about it!
