### PR TITLE
restore NTLM constant class shortcuts

### DIFF
--- a/lib/msf/core/exploit/ntlm.rb
+++ b/lib/msf/core/exploit/ntlm.rb
@@ -5,11 +5,11 @@ require 'rex/proto/ntlm/base'
 require 'rex/proto/ntlm/message'
 require 'rex/proto/ntlm/utils'
 
-NTLM_CONST   = ::Rex::Proto::NTLM::Constants
-NTLM_CRYPT   = ::Rex::Proto::NTLM::Crypt
-NTLM_UTILS   = ::Rex::Proto::NTLM::Utils
-NTLM_BASE    = ::Rex::Proto::NTLM::Base
-NTLM_MESSAGE = ::Rex::Proto::NTLM::Message
+NTLM_CONST   ||= ::Rex::Proto::NTLM::Constants
+NTLM_CRYPT   ||= ::Rex::Proto::NTLM::Crypt
+NTLM_UTILS   ||= ::Rex::Proto::NTLM::Utils
+NTLM_BASE    ||= ::Rex::Proto::NTLM::Base
+NTLM_MESSAGE ||= ::Rex::Proto::NTLM::Message
 
 module Msf
 

--- a/lib/msf/core/exploit/ntlm.rb
+++ b/lib/msf/core/exploit/ntlm.rb
@@ -5,6 +5,12 @@ require 'rex/proto/ntlm/base'
 require 'rex/proto/ntlm/message'
 require 'rex/proto/ntlm/utils'
 
+NTLM_CONST   = ::Rex::Proto::NTLM::Constants
+NTLM_CRYPT   = ::Rex::Proto::NTLM::Crypt
+NTLM_UTILS   = ::Rex::Proto::NTLM::Utils
+NTLM_BASE    = ::Rex::Proto::NTLM::Base
+NTLM_MESSAGE = ::Rex::Proto::NTLM::Message
+
 module Msf
 
 ###


### PR DESCRIPTION
The PR to use rubyntlm's upstream gem (#7279) removed some shortcut aliases in the ntlm exploit library mixin, but didn't verify that these weren't still in use. This broke modules dealing with NTLM hash stealing.

This is probably the wrong fix. The right fix probably carefully audits the uses of NTLM_CONST, NTLM_MESSAGE, etc. to either expand them out to not need these constant aliases. And we get rid of all of the duplicate aliases, not just 1 out of 3.

fix #7319 
## Verification
- [x] Start `msfconsole`
- [x] ensure that `auxiliary/server/capture/mssql` works
- [x] ensure that `auxiliary/server/capture/smb` works
- [x] ensure that `exploits/windows/smb/smb_relay` works

Note, I added some artificial calls to the various functions just to exercise them when verifying locally as well. You will probably need a couple of VMs setup with Windows sharing to test these.
