### PR TITLE
Fixed interactive password prompt issue

### DIFF
--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -107,7 +107,8 @@ class MetasploitModule < Msf::Exploit::Remote
       :port     => datastore['RPORT'],
       :timeout  => 1,
       :proxies  => datastore['Proxies'],
-      :key_data => OpenSSL::PKey::RSA.new(2048).to_pem
+      :key_data => OpenSSL::PKey::RSA.new(2048).to_pem,
+      :auth_methods => ['publickey']
     }
     return options
   end


### PR DESCRIPTION
Fixed an issue where the exploit would drop to interactive password prompt by default on newer ruby version which rendered the exploit unusable. It now properly forces pubkey authentication instead and proceeds with the bypass as expected.
