### PR TITLE
fix exploit Passive / Aggressive overrides to do the right thing

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -649,14 +649,14 @@ class Exploit < Msf::Module
   # Returns true if the exploit has an aggressive stance.
   #
   def aggressive?
-    (stance == Stance::Aggressive || stance.include?(Stance::Aggressive))
+    (stance == Stance::Aggressive)
   end
 
   #
   # Returns if the exploit has a passive stance.
   #
   def passive?
-    (stance == Stance::Passive || stance.include?(Stance::Passive))
+    (stance == Stance::Passive)
   end
 
   #

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -73,7 +73,7 @@ module Exploit::Remote::HttpServer
   end
 
   def print_prefix
-    if cli && (respond_to?(:aggressive) && !aggressive?)
+    if cli && !(stance == Stance::Aggressive || stance.include?(Stance::Aggressive))
       super + "#{cli.peerhost.ljust(16)} #{self.shortname} - "
     else
       super


### PR DESCRIPTION
If a module sets 'Aggressive', the module should not background. We added some extra checks in 0f7e3e954e6f16b810c590ced1277aedead36756 that break things a bit.
## Verification
- [x] Run `./msfconsole -qx 'use exploit/multi/misc/java_rmi_server; set rhost 127.0.0.1; run'
  rhost => 127.0.0.1`
- [x] Verify that the exploit runs in the foreground rather than the background
