### PR TITLE
Fix nonce bug in wp_ninja_forms_unauthenticated_file_upload on Windows

### DIFF
--- a/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
@@ -109,7 +109,8 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "Unable to access FORM_PATH: #{datastore['FORM_PATH']}")
     end
 
-    form_wpnonce = res.get_hidden_inputs.first['_wpnonce']
+    form_wpnonce = res.get_hidden_inputs.first
+    form_wpnonce = form_wpnonce['_wpnonce'] if form_wpnonce
 
     nonce = res.body[/var nfFrontEnd = \{"ajaxNonce":"([a-zA-Z0-9]+)"/i, 1] || form_wpnonce
 


### PR DESCRIPTION
# What This Patch Does

On some specific setups of Wordpress, the nonce value might be in the JavaScript code instead of the hidden form input. The module incorrectly assumes there is always a hidden input, and causes an undefined error method nil.
# Verification
- [x] Get a Windows box such as 2008
- [x] Install [WAMP](http://www.wampserver.com/en/), so you have Apache, PHP, and MySQL
- [x] Start the MySQL console, and create a database called "wordpress"
- [x] Download Wordpress: https://wordpress.org/latest.zip
- [x] Extract the Wordpress folder to C:\wamp\www\,
- [x] By default, the Wordpress folder is read-only. Rich click on that folder, and uncheck read-only.
- [x] Go to http://localhost/wordpress and install Wordpress
- [x] Download the vulnerable plugin: https://downloads.wordpress.org/plugin/ninja-forms.2.9.42.zip
- [x] Extract the plugin, and move the nina form folder to the plugin directory
- [x] Log into Wordpress, and activate the plugin
- [x] Create a page with a form like this:

![ninja_forms](https://cloud.githubusercontent.com/assets/1170914/16496101/f61d941c-3eb5-11e6-91c6-be36716ce5de.png)
- [x] Once you have the page. Start msfconsole
- [x] Do: `use exploit/unix/webapp/wp_ninja_forms_unauthenticated_file_upload`
- [x] Do: `set FORM_PATH [where the page is]`
- [x] Do: `set TARGETURI [where Wordpress is]`
- [x] Do: `set RHOST [target IP]`
- [x] Do: `run`
- [x] You should get a session
