### PR TITLE
Filter login scanner specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
   - RAKE_TASKS="cucumber cucumber:boot" CREATE_BINSTUBS=true
   - RAKE_TASKS=spec SPEC_OPTS="--tag content"
   - RAKE_TASKS=spec SPEC_OPTS="--tag ~content"
-  - SPEC_ALL=true
 
 matrix:
   fast_finish: true
@@ -32,6 +31,7 @@ before_script:
   - bundle exec rake --version
   - bundle exec rake db:create
   - bundle exec rake db:migrate
+  - export SPEC_ALL=true
 script:
   # fail build if db/schema.rb update is not committed
   - git diff --exit-code db/schema.rb && bundle exec rake $RAKE_TASKS

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - RAKE_TASKS="cucumber cucumber:boot" CREATE_BINSTUBS=true
   - RAKE_TASKS=spec SPEC_OPTS="--tag content"
   - RAKE_TASKS=spec SPEC_OPTS="--tag ~content"
+  - SPEC_ALL=true
 
 matrix:
   fast_finish: true

--- a/spec/lib/metasploit/framework/login_scanner/afp_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/afp_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/afp'
 
-RSpec.describe Metasploit::Framework::LoginScanner::AFP do
+RSpec.describe Metasploit::Framework::LoginScanner::AFP, :login_scanner => true do
 
   subject(:scanner) { described_class.new }
 

--- a/spec/lib/metasploit/framework/login_scanner/axis2_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/axis2_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/axis2'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Axis2 do
+RSpec.describe Metasploit::Framework::LoginScanner::Axis2, :login_scanner => true do
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/base_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/base_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/base'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Base do
+RSpec.describe Metasploit::Framework::LoginScanner::Base, :login_scanner => true do
 
   let(:base_class) {
     Class.new do

--- a/spec/lib/metasploit/framework/login_scanner/buffalo_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/buffalo_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/buffalo'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Buffalo do
+RSpec.describe Metasploit::Framework::LoginScanner::Buffalo, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/caidao_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/caidao_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/caidao'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Caidao do
+RSpec.describe Metasploit::Framework::LoginScanner::Caidao, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/chef_webui_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/chef_webui'
 
-RSpec.describe Metasploit::Framework::LoginScanner::ChefWebUI do
+RSpec.describe Metasploit::Framework::LoginScanner::ChefWebUI, :login_scanner => true do
 
   subject(:http_scanner) { described_class.new }
 

--- a/spec/lib/metasploit/framework/login_scanner/db2_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/db2_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/db2'
 
-RSpec.describe Metasploit::Framework::LoginScanner::DB2 do
+RSpec.describe Metasploit::Framework::LoginScanner::DB2, :login_scanner => true do
   let(:public) { 'root' }
   let(:private) { 'toor' }
   let(:test_cred) {

--- a/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/ftp'
 
-RSpec.describe Metasploit::Framework::LoginScanner::FTP do
+RSpec.describe Metasploit::Framework::LoginScanner::FTP, :login_scanner => true do
   let(:public) { 'root' }
   let(:private) { 'toor' }
 

--- a/spec/lib/metasploit/framework/login_scanner/gitlab_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/gitlab_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/gitlab'
 
-RSpec.describe Metasploit::Framework::LoginScanner::GitLab do
+RSpec.describe Metasploit::Framework::LoginScanner::GitLab, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/glassfish'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Glassfish do
+RSpec.describe Metasploit::Framework::LoginScanner::Glassfish, :login_scanner => true do
 
   subject(:http_scanner) { described_class.new }
 

--- a/spec/lib/metasploit/framework/login_scanner/http_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/http_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/http'
 
-RSpec.describe Metasploit::Framework::LoginScanner::HTTP do
+RSpec.describe Metasploit::Framework::LoginScanner::HTTP, :login_scanner => true do
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/invalid_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/invalid_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/invalid'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Invalid do
+RSpec.describe Metasploit::Framework::LoginScanner::Invalid, :login_scanner => true do
 
   subject(:invalid) do
     described_class.new(model)

--- a/spec/lib/metasploit/framework/login_scanner/ipboard_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ipboard_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/ipboard'
 
-RSpec.describe Metasploit::Framework::LoginScanner::IPBoard do
+RSpec.describe Metasploit::Framework::LoginScanner::IPBoard, :login_scanner => true do
 
   subject { described_class.new }
 

--- a/spec/lib/metasploit/framework/login_scanner/jenkins_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/jenkins_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/jenkins'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Jenkins do
+RSpec.describe Metasploit::Framework::LoginScanner::Jenkins, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/manageengine_desktop_central'
 
-RSpec.describe Metasploit::Framework::LoginScanner::ManageEngineDesktopCentral do
+RSpec.describe Metasploit::Framework::LoginScanner::ManageEngineDesktopCentral, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/mssql_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/mssql_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/mssql'
 
-RSpec.describe Metasploit::Framework::LoginScanner::MSSQL do
+RSpec.describe Metasploit::Framework::LoginScanner::MSSQL, :login_scanner => true do
   let(:public) { 'root' }
   let(:private) { 'toor' }
 

--- a/spec/lib/metasploit/framework/login_scanner/mybook_live_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/mybook_live_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/mybook_live'
 
-RSpec.describe Metasploit::Framework::LoginScanner::MyBookLive do
+RSpec.describe Metasploit::Framework::LoginScanner::MyBookLive, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/mysql_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/mysql_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/mysql'
 
-RSpec.describe Metasploit::Framework::LoginScanner::MySQL do
+RSpec.describe Metasploit::Framework::LoginScanner::MySQL, :login_scanner => true do
   let(:public) { 'root' }
   let(:private) { 'toor' }
   let(:pub_blank) {

--- a/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/nessus'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Nessus do
+RSpec.describe Metasploit::Framework::LoginScanner::Nessus, :login_scanner => true do
 
     subject(:http_scanner) { described_class.new }
 

--- a/spec/lib/metasploit/framework/login_scanner/octopusdeploy_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/octopusdeploy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/octopusdeploy'
 
-RSpec.describe Metasploit::Framework::LoginScanner::OctopusDeploy do
+RSpec.describe Metasploit::Framework::LoginScanner::OctopusDeploy, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/pop3_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/pop3_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/pop3'
 
-RSpec.describe Metasploit::Framework::LoginScanner::POP3 do
+RSpec.describe Metasploit::Framework::LoginScanner::POP3, :login_scanner => true do
   subject(:scanner) { described_class.new }
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: false, has_default_realm: false

--- a/spec/lib/metasploit/framework/login_scanner/postgres_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/postgres_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/postgres'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Postgres do
+RSpec.describe Metasploit::Framework::LoginScanner::Postgres, :login_scanner => true do
   let(:public) { 'root' }
   let(:private) { 'toor' }
   let(:realm) { 'template1' }

--- a/spec/lib/metasploit/framework/login_scanner/redis_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/redis_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/redis'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Redis do
+RSpec.describe Metasploit::Framework::LoginScanner::Redis, :login_scanner => true do
 
   def update_socket_res(res)
     socket = double('Socket')

--- a/spec/lib/metasploit/framework/login_scanner/result_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/result_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Result do
+RSpec.describe Metasploit::Framework::LoginScanner::Result, :login_scanner => true do
 
   let(:private) { 'toor' }
   let(:proof) { 'foobar' }

--- a/spec/lib/metasploit/framework/login_scanner/smb_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smb_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/smb'
 
-RSpec.describe Metasploit::Framework::LoginScanner::SMB do
+RSpec.describe Metasploit::Framework::LoginScanner::SMB, :login_scanner => true do
   let(:public) { 'root' }
   let(:private) { 'toor' }
 

--- a/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/smh'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Smh do
+RSpec.describe Metasploit::Framework::LoginScanner::Smh, :login_scanner => true do
 
   subject(:smh_cli) { described_class.new }
 

--- a/spec/lib/metasploit/framework/login_scanner/snmp_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/snmp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/snmp'
 
-RSpec.describe Metasploit::Framework::LoginScanner::SNMP do
+RSpec.describe Metasploit::Framework::LoginScanner::SNMP, :login_scanner => true do
   let(:public) { 'public' }
   let(:private) { nil }
 

--- a/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/ssh'
 
-RSpec.describe Metasploit::Framework::LoginScanner::SSH do
+RSpec.describe Metasploit::Framework::LoginScanner::SSH, :login_scanner => true do
   let(:public) { 'root' }
   let(:private) { 'toor' }
   let(:key) { OpenSSL::PKey::RSA.generate(2048).to_s }

--- a/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/symantec_web_gateway'
 
-RSpec.describe Metasploit::Framework::LoginScanner::SymantecWebGateway do
+RSpec.describe Metasploit::Framework::LoginScanner::SymantecWebGateway, :login_scanner => true do
 
     it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
     it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/telnet_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/telnet_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/telnet'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Telnet do
+RSpec.describe Metasploit::Framework::LoginScanner::Telnet, :login_scanner => true do
 
   subject(:login_scanner) { described_class.new }
 

--- a/spec/lib/metasploit/framework/login_scanner/tomcat_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/tomcat_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/tomcat'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Tomcat do
+RSpec.describe Metasploit::Framework::LoginScanner::Tomcat, :login_scanner => true do
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/vmauthd_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/vmauthd_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/vmauthd'
 
-RSpec.describe Metasploit::Framework::LoginScanner::VMAUTHD do
+RSpec.describe Metasploit::Framework::LoginScanner::VMAUTHD, :login_scanner => true do
   subject(:scanner) { described_class.new }
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: false, has_default_realm: false

--- a/spec/lib/metasploit/framework/login_scanner/vnc_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/vnc_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/vnc'
 
-RSpec.describe Metasploit::Framework::LoginScanner::VNC do
+RSpec.describe Metasploit::Framework::LoginScanner::VNC, :login_scanner => true do
   let(:private) { 'password' }
   let(:blank) { '' }
   let(:test_cred) {

--- a/spec/lib/metasploit/framework/login_scanner/winrm_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/winrm_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/winrm'
 
-RSpec.describe Metasploit::Framework::LoginScanner::WinRM do
+RSpec.describe Metasploit::Framework::LoginScanner::WinRM, :login_scanner => true do
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: true
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/wordpress_multicall_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/wordpress_multicall_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/wordpress_multicall'
 
-RSpec.describe Metasploit::Framework::LoginScanner::WordpressMulticall do
+RSpec.describe Metasploit::Framework::LoginScanner::WordpressMulticall, :login_scanner => true do
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/wordpress_rpc_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/wordpress_rpc_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/wordpress_rpc'
 
-RSpec.describe Metasploit::Framework::LoginScanner::WordpressRPC do
+RSpec.describe Metasploit::Framework::LoginScanner::WordpressRPC, :login_scanner => true do
 
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'

--- a/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'metasploit/framework/login_scanner/zabbix'
 
-RSpec.describe Metasploit::Framework::LoginScanner::Zabbix do
+RSpec.describe Metasploit::Framework::LoginScanner::Zabbix, :login_scanner => true do
 
   subject(:http_scanner) { described_class.new }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,8 @@ RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 
+  config.filter_run_excluding :login_scanner => true unless ENV['SPEC_ALL'] == 'true'
+
   # allow more verbose output when running an individual spec file.
   if config.files_to_run.one?
     # RSpec filters the backtrace by default so as not to be so noisy.


### PR DESCRIPTION
Created a tag for login scaner specs so:
- rspec by default skips those specs
- travis still runs them
## Verification
- [ ] ensure Travis CI is still running all spec
- [ ] running `rspec` in development should skip login scanner specs
- [ ] we'll have to change jenkins config and set SPEC_ALL env to true 

Fixes #6476 
