### PR TITLE
Remove the `cat $FILE | grep $PATTERN` anti-pattern

### DIFF
--- a/modules/exploits/linux/local/kloxo_lxsuexec.rb
+++ b/modules/exploits/linux/local/kloxo_lxsuexec.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Profit
     print_status("Exploiting...")
     cmd_exec("chmod +x #{payload_path}")
-    cmd_exec("LXLABS=`cat /etc/passwd | grep lxlabs | cut -d: -f3`")
+    cmd_exec("LXLABS=`grep lxlabs /etc/passwd | cut -d: -f3`")
     cmd_exec("export MUID=$LXLABS")
     cmd_exec("export GID=$LXLABS")
     cmd_exec("export TARGET=/bin/sh")

--- a/modules/exploits/linux/local/netfilter_priv_esc.rb
+++ b/modules/exploits/linux/local/netfilter_priv_esc.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Local
       # x_tables 36864 2 iptable_filter,ip_tables, Live 0x0000000000000000
       vprint_status('Checking if ip_tables is loaded in kernel')
       if target.name == "Ubuntu"
-        iptables = cmd_exec('cat /proc/modules')
+        iptables = read_file('/proc/modules')
         if iptables.include?('ip_tables')
           vprint_good('ip_tables.ko is loaded')
         else
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
         end
         return iptables.include?('ip_tables')
       elsif target.name == "Fedora"
-        iptables = cmd_exec('cat /proc/modules')
+        iptables = read_file('/proc/modules')
         if iptables.include?('iptable_raw')
           vprint_good('iptable_raw is loaded')
         else

--- a/modules/exploits/linux/local/netfilter_priv_esc.rb
+++ b/modules/exploits/linux/local/netfilter_priv_esc.rb
@@ -62,12 +62,12 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     def iptables_loaded?()
-      # user@ubuntu:~$ cat /proc/modules | grep ip_tables
+      # user@ubuntu:~$ grep ip_tables /proc/modules
       # ip_tables 28672 1 iptable_filter, Live 0x0000000000000000
       # x_tables 36864 2 iptable_filter,ip_tables, Live 0x0000000000000000
       vprint_status('Checking if ip_tables is loaded in kernel')
       if target.name == "Ubuntu"
-        iptables = cmd_exec('cat /proc/modules | grep ip_tables')
+        iptables = cmd_exec('cat /proc/modules')
         if iptables.include?('ip_tables')
           vprint_good('ip_tables.ko is loaded')
         else
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
         end
         return iptables.include?('ip_tables')
       elsif target.name == "Fedora"
-        iptables = cmd_exec('cat /proc/modules | grep iptable_raw')
+        iptables = cmd_exec('cat /proc/modules')
         if iptables.include?('iptable_raw')
           vprint_good('iptable_raw is loaded')
         else


### PR DESCRIPTION
The `kloxo_lxsuexec.rb` and `netfilter_pvi_esc.rb` exploits
were using the infamous `cat+grep` anti-pattern, this commit
replaces it with `cat` and Ruby's `.include?` method.
