### PR TITLE
Module to enumerate writable directories from MySQL

### DIFF
--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Checking #{dir}...")
       res = mysql_query_no_handle("SELECT _utf8'test' INTO DUMPFILE '#{dir}/" + datastore['FILE_NAME'] + "'")
     rescue ::RbMysql::ServerError => e
-      print_warning("#{e.to_s}")
+      print_warning(e.to_s)
     rescue Rex::ConnectionTimeout => e
       print_error("Timeout: #{e.message}")
     else

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -64,10 +64,8 @@ class MetasploitModule < Msf::Auxiliary
       res = mysql_query_no_handle("SELECT _utf8'test' INTO DUMPFILE '#{dir}/" + datastore['FILE_NAME'] + "'")
     rescue ::RbMysql::ServerError => e
       vprint_warning("#{e.to_s}")
-      return
     rescue Rex::ConnectionTimeout => e
       vprint_error("Timeout: #{e.message}")
-      return
     else
       print_good("#{dir} is writeable")
       report_note(
@@ -79,8 +77,6 @@ class MetasploitModule < Msf::Auxiliary
         :update => :unique_data
       )
     end
-
-    return
   end
 
 end

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -51,10 +51,8 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    File.open(datastore['DIR_LIST'], "r") do |f|
-      f.each_line do |line|
-        check_dir(line.chomp)
-      end
+    File.read(datastore['DIR_LIST']).each_line do |dir|
+      check_dir(dir.chomp)
     end
 
   end

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -51,11 +51,11 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    file = File.new(datastore['DIR_LIST'], "r")
-    file.each_line do |line|
-      check_dir(line.chomp)
+    File.open(datastore['DIR_LIST'], "r") do |f|
+      f.each_line do |line|
+        check_dir(line.chomp)
+      end
     end
-    file.close
 
   end
 

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     print_warning("For every writable directory found, a file called #{datastore['FILE_NAME']} with the text test will be written to the directory.")
-    vprint_status("Login...")
+    print_status("Login...")
 
     unless mysql_login_datastore
       print_error('Unable to login to the server.')
@@ -58,12 +58,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def check_dir(dir)
     begin
-      vprint_status("Checking #{dir}...")
+      print_status("Checking #{dir}...")
       res = mysql_query_no_handle("SELECT _utf8'test' INTO DUMPFILE '#{dir}/" + datastore['FILE_NAME'] + "'")
     rescue ::RbMysql::ServerError => e
-      vprint_warning("#{e.to_s}")
+      print_warning("#{e.to_s}")
     rescue Rex::ConnectionTimeout => e
-      vprint_error("Timeout: #{e.message}")
+      print_error("Timeout: #{e.message}")
     else
       print_good("#{dir} is writeable")
       report_note(

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    print_warning("For every writable directory found, a file called test with the text test will be written to the directory."
+    print_warning("For every writable directory found, a file called test with the text test will be written to the directory.")
     vprint_status("Login...")
 
     unless mysql_login_datastore

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -46,6 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status("Login...")
 
     if (not mysql_login_datastore)
+      print_error('Unable to login to the server.')
       return
     end
 

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     vprint_status("Login...")
 
-    if (not mysql_login_datastore)
+    unless mysql_login_datastore
       print_error('Unable to login to the server.')
       return
     end

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'msf/core'
-require 'yaml'
 
 class MetasploitModule < Msf::Auxiliary
 

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description'    => %Q{
           Enumerate writeable directories using the MySQL SELECT INTO DUMPFILE feature, for more
         information see the URL in the references. ***Note: For every writable directory found,
-        a file called test with the text test will be written to the directory.***
+        a file with the specified FILE_NAME containing the text test will be written to the directory.***
       },
       'Author'         => [ 'AverageSecurityGuy <stephen[at]averagesecurityguy.info>' ],
       'References'  => [
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    print_warning("For every writable directory found, a file called test with the text test will be written to the directory.")
+    print_warning("For every writable directory found, a file called #{datastore['FILE_NAME']} with the text test will be written to the directory.")
     vprint_status("Login...")
 
     unless mysql_login_datastore

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -29,7 +29,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptPath.new('DIR_LIST', [ true, "List of directories to test", '' ]),
       OptString.new('FILE_NAME', [ true, "Name of file to write", Rex::Text.rand_text_alpha(8) ]),
-      OptString.new('TABLE_NAME', [ true, "Name of table to use - Warning, if the table already exists its contents will be corrupted", Rex::Text.rand_text_alpha(8) ]),
       OptString.new('USERNAME', [ true, 'The username to authenticate as', "root" ])
     ])
 

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -43,6 +43,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    print_warning("For every writable directory found, a file called test with the text test will be written to the directory."
     vprint_status("Login...")
 
     unless mysql_login_datastore

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'yaml'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::MYSQL
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'           => 'MYSQL Directory Write Test',
+      'Description'    => %Q{
+          Enumerate writeable directories using the MySQL SELECT INTO DUMPFILE feature, for more
+        information see the URL in the references.
+      },
+      'Author'         => [ 'AverageSecurityGuy <stephen[at]averagesecurityguy.info>' ],
+      'References'  => [
+        [ 'URL', 'https://dev.mysql.com/doc/refman/5.7/en/select-into.html' ]
+      ],
+      'License'        => MSF_LICENSE
+    )
+
+    register_options([
+      OptPath.new('DIR_LIST', [ true, "List of directories to test", '' ]),
+      OptString.new('FILE_NAME', [ true, "Name of file to write", Rex::Text.rand_text_alpha(8) ]),
+      OptString.new('TABLE_NAME', [ true, "Name of table to use - Warning, if the table already exists its contents will be corrupted", Rex::Text.rand_text_alpha(8) ]),
+      OptString.new('USERNAME', [ true, 'The username to authenticate as', "root" ])
+    ])
+
+  end
+
+  # This function does not handle any errors, if you use this
+  # make sure you handle the errors yourself
+  def mysql_query_no_handle(sql)
+    res = @mysql_handle.query(sql)
+    res
+  end
+
+  def run_host(ip)
+    vprint_status("Login...")
+
+    if (not mysql_login_datastore)
+      return
+    end
+
+    file = File.new(datastore['DIR_LIST'], "r")
+    file.each_line do |line|
+      check_dir(line.chomp)
+    end
+    file.close
+
+  end
+
+  def check_dir(dir)
+    begin
+      vprint_status("Checking #{dir}...")
+      res = mysql_query_no_handle("SELECT _utf8'test' INTO DUMPFILE '#{dir}/" + datastore['FILE_NAME'] + "'")
+    rescue ::RbMysql::ServerError => e
+      vprint_warning("#{e.to_s}")
+      return
+    rescue Rex::ConnectionTimeout => e
+      vprint_error("Timeout: #{e.message}")
+      return
+    else
+      print_good("#{dir} is writeable")
+      report_note(
+        :host  => rhost,
+        :type  => "filesystem.file",
+        :data  => "#{dir} is writeable",
+        :port  => rport,
+        :proto => 'tcp',
+        :update => :unique_data
+      )
+    end
+
+    return
+  end
+
+end

--- a/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_writable_dirs.rb
@@ -16,7 +16,8 @@ class MetasploitModule < Msf::Auxiliary
       'Name'           => 'MYSQL Directory Write Test',
       'Description'    => %Q{
           Enumerate writeable directories using the MySQL SELECT INTO DUMPFILE feature, for more
-        information see the URL in the references.
+        information see the URL in the references. ***Note: For every writable directory found,
+        a file called test with the text test will be written to the directory.***
       },
       'Author'         => [ 'AverageSecurityGuy <stephen[at]averagesecurityguy.info>' ],
       'References'  => [


### PR DESCRIPTION
This module will test a list of directories to see if they are writable
using MySQL's SELECT INTO DUMPFILE. In some cases, the 
plugin directory is not writable so you cannot create a UDF but
other useful directories may be writable.
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/mysql/mysql_writable_dirs`
- [ ] Set RHOSTS to a valid list of MySQL servers
- [ ] Set USERNAME and PASSWORD to valid credentials for the server
- [ ] Set a DIR_LIST to a valid filename containing a newline separated list of directories.
- [ ] The rescue ::RbMysql::ServerError => e block will trigger if the directory is
      not writable or if the file already exists in the directory.
- [ ] Otherwise the writable directory will be saved using report_note
