### PR TITLE
check if there is a stance set before checking the value in http exploit server

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -73,7 +73,8 @@ module Exploit::Remote::HttpServer
   end
 
   def print_prefix
-    if cli && !(stance == Msf::Exploit::Stance::Aggressive || stance.include?(Msf::Exploit::Stance::Aggressive))
+    if cli && self.respond_to?(:stance) &&
+        !(stance == Msf::Exploit::Stance::Aggressive || stance.include?(Msf::Exploit::Stance::Aggressive))
       super + "#{cli.peerhost.ljust(16)} #{self.shortname} - "
     else
       super


### PR DESCRIPTION
This fixes #7388 by verifying that we have a stance before comparing.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use auxiliary/server/browser_autopwn2`
- [x] `set SRVHOST 127.0.0.1`
- [x] `set URIPATH test`
- [x] `run`
- [x] browse to https://127.0.0.1:8080/test
- [x] **Verify** that it does something like this:

```
msf auxiliary(browser_autopwn2) > run
[*] Gathering target information for 127.0.0.1
[*] Sending HTML response to 127.0.0.1
[*] No suitable exploits to send for 127.0.0.1
Interrupt: use the 'exit' command to quit
```
