### PR TITLE
Make errors more meaningful for wp_ninja_forms_unauthenticated_file_upload

### DIFF
--- a/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ninja_forms_unauthenticated_file_upload.rb
@@ -69,7 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res && res.code == 200
-      fail_with(Failure::Unreachable, 'Failed to enable the vulnerable V3 functionality')
+      if res
+        fail_with(Failure::Unreachable, "Failed to enable the vulnerable V3 functionality. Server returned: #{res.code}, should be 200.")
+      else
+        fail_with(Failure::Unreachable, 'Connection timed out.')
+      end
     end
 
     vprint_good 'Enabled V3 functionality'
@@ -85,6 +89,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200
       vprint_good 'Disabled V3 functionality'
+    elsif !res
+      print_error('Connection timed out while disabling V3 functionality')
     else
       print_error 'Failed to disable the vulnerable V3 functionality'
     end


### PR DESCRIPTION
# What This Fixes

While testing the module, we felt the errors were too confusing to understand. We couldn't tell either our vuln box was incorrectly configured, or the module was broken, or whatever. Having the errors more meaningful would allow us to troubleshoot better.
# Verification
- [x] Code review should be enough. It's just updating the output.
