### PR TITLE
add reverse_tcp handler to fix bug in latest update

### DIFF
--- a/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_tcp.rb
@@ -5,6 +5,7 @@
 require 'msf/core'
 require 'msf/core/payload/android'
 require 'msf/core/payload/transport_config'
+require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/meterpreter_android'
 require 'msf/base/sessions/meterpreter_options'
 require 'rex/payloads/meterpreter/config'


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] **Verify** the thing does not do what it should not

The payload was missing require 'msf/core/handler/reverse_tcp', latest update pulled with msfupdate broke the startup of the framework, where you got this kind of an error:

!master ~/4tools/metasploit-framework> msfconsole 
/home/tony/4tools/metasploit-framework/modules/payloads/singles/android/meterpreter_reverse_tcp.rb:28:in `initialize': uninitialized constant Msf::Handler::ReverseTcp (NameError)
    from /home/tony/4tools/metasploit-framework/lib/msf/core/payload_set.rb:198:in`new'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/payload_set.rb:198:in `add_module'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/module_manager/loading.rb:71:in`on_module_load'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/modules/loader/base.rb:182:in `load_module'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/modules/loader/base.rb:237:in`block in load_modules'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/modules/loader/directory.rb:55:in `block (2 levels) in each_module_reference_name'
    from /var/lib/gems/2.3.0/gems/rex-core-0.1.2/lib/rex/file.rb:127:in`block in find'
    from /var/lib/gems/2.3.0/gems/rex-core-0.1.2/lib/rex/file.rb:126:in `catch'
    from /var/lib/gems/2.3.0/gems/rex-core-0.1.2/lib/rex/file.rb:126:in`find'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/modules/loader/directory.rb:46:in `block in each_module_reference_name'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/modules/loader/directory.rb:34:in`foreach'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/modules/loader/directory.rb:34:in `each_module_reference_name'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/modules/loader/base.rb:236:in`load_modules'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `block in load_modules'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/module_manager/loading.rb:115:in`each'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/module_manager/loading.rb:115:in `load_modules'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:41:in`block in add_module_path'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in `each'
    from /home/tony/4tools/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:40:in`add_module_path'
    from /home/tony/4tools/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:50:in `block in init_module_paths'
    from /home/tony/4tools/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in`each'
    from /home/tony/4tools/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:49:in `init_module_paths'
    from /home/tony/4tools/metasploit-framework/lib/msf/ui/console/driver.rb:204:in`initialize'
    from /home/tony/4tools/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `new'
    from /home/tony/4tools/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in`driver'
    from /home/tony/4tools/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
    from /home/tony/4tools/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in`start'
    from /home/tony/4tools/metasploit-framework/msfconsole:48:in `<main>'
