### PR TITLE
refresh sysinfo when explicitly requested on a session

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
@@ -104,7 +104,7 @@ class Config
   #
   # Returns a hash of information about the remote computer.
   #
-  def sysinfo(refresh = false)
+  def sysinfo(refresh: false)
     request  = Packet.create_request('stdapi_sys_config_sysinfo')
     if @sysinfo.nil? || refresh
       response = client.send_request(request)

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
@@ -104,9 +104,9 @@ class Config
   #
   # Returns a hash of information about the remote computer.
   #
-  def sysinfo
+  def sysinfo(refresh = false)
     request  = Packet.create_request('stdapi_sys_config_sysinfo')
-    if @sysinfo.nil?
+    if @sysinfo.nil? || refresh
       response = client.send_request(request)
 
       @sysinfo = {

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -808,7 +808,7 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Displays information about the remote system.
   #
   def cmd_sysinfo(*args)
-    info = client.sys.config.sysinfo(:refresh)
+    info = client.sys.config.sysinfo(refresh: true)
     width = "Meterpreter".length
     info.keys.each { |k| width = k.length if k.length > width and info[k] }
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -808,7 +808,7 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Displays information about the remote system.
   #
   def cmd_sysinfo(*args)
-    info = client.sys.config.sysinfo
+    info = client.sys.config.sysinfo(:refresh)
     width = "Meterpreter".length
     info.keys.each { |k| width = k.length if k.length > width and info[k] }
 


### PR DESCRIPTION
`sysinfo` in a Meterpreter session consists of a lot of info that largely doesn't change (e.g. 'OS' shouldn't change no matter how many times we refer to it). On an initial connect, we'll refer to this hash a half-dozen times, so it's nice to be able to cache it and avoid all of the round trips. However, it does contain some mutable data like logged-on users. This PR changes the caching behavior so that you can force it to refresh, and updates the interactive command to always force a refresh. @OJ noted this problem a while back on IRC.
## Verification
- [x] Start `msfconsole` and get a meterpreter session (psexec is a good method to use)
- [x] run `sysinfo` and verify the output seems correct
- [x] log into the target box
- [x] run `sysinfo` and verify the number of logged on users increases
