### PR TITLE
Set correct default options; fix usage on OS X

### DIFF
--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -53,10 +53,10 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         OptString.new('VERSIONS', [false, 'Specific versions to fuzz (csv)', '2,3,4']),
-        OptString.new('MODES', [false, 'Modes to fuzz (csv)', nil]),
-        OptString.new('MODE_6_OPERATIONS', [false, 'Mode 6 operations to fuzz (csv)', nil]),
-        OptString.new('MODE_7_IMPLEMENTATIONS', [false, 'Mode 7 implementations to fuzz (csv)', nil]),
-        OptString.new('MODE_7_REQUEST_CODES', [false, 'Mode 7 request codes to fuzz (csv)', nil])
+        OptString.new('MODES', [false, 'Modes to fuzz (csv)']),
+        OptString.new('MODE_6_OPERATIONS', [false, 'Mode 6 operations to fuzz (csv)']),
+        OptString.new('MODE_7_IMPLEMENTATIONS', [false, 'Mode 7 implementations to fuzz (csv)']),
+        OptString.new('MODE_7_REQUEST_CODES', [false, 'Mode 7 request codes to fuzz (csv)'])
       ], self.class)
   end
 
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     thing = setting.upcase
     const_name = thing.to_sym
     var_name = thing.downcase
-    if datastore.key?(thing)
+    if datastore[thing]
       instance_variable_set("@#{var_name}", datastore[thing].split(/[^\d]/).select { |v| !v.empty? }.map { |v| v.to_i })
       unsupported_things = instance_variable_get("@#{var_name}") - Rex::Proto::NTP.const_get(const_name)
       fail "Unsupported #{thing}: #{unsupported_things}" unless unsupported_things.empty?
@@ -178,7 +178,11 @@ class MetasploitModule < Msf::Auxiliary
   # Sends +message+ to +host+ on UDP port +port+, returning all replies
   def probe(host, port, message)
     replies = []
-    udp_sock.sendto(message, host, port, 0)
+    begin
+      udp_sock.sendto(message, host, port, 0)
+    rescue ::Errno::EISCONN
+      udp_sock.write(message)
+    end
     reply = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0)
     while reply && reply[1]
       replies << reply


### PR DESCRIPTION
This fixes usage of the `ntp_protocol_fuzzer` when run in its default mode.  The bug was that the default NTP options were set to `nil` but the option parsing code would see that the option was set but didn't handle the `nil` value.  
## Verification
- [x] Start `msfconsole`
- [x] `use auxilliary/fuzzers/ntp/ntp_protocol_fuzzer`
- [x] `set RHOSTS <some host you own>`
- [x] `run`
- [x] **Verify** that no error occurs

Fixes #7404
