### PR TITLE
 Fix the default num to be 0 when not specified.

### DIFF
--- a/modules/auxiliary/dos/tcp/synflood.rb
+++ b/modules/auxiliary/dos/tcp/synflood.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
     open_pcap
 
     sent = 0
-    num = datastore['NUM']
+    num = datastore['NUM'] || 0
 
     print_status("SYN flooding #{rhost}:#{rport}...")
 


### PR DESCRIPTION
Default to `0` when `NUM` is not specified.
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/dos/tcp/synflood`
- [x] `set rhost <host>`
- [x] `set NUM <0/1/2/-empty->` only one at a time
- [x] `run` 
- [x] **Verify** the module executes with no `NoMethodError`

Fixes #7406.
