### PR TITLE
CVE-2013-5093 Graphite Pickle Handling - Add Version Check

### DIFF
--- a/modules/exploits/unix/webapp/graphite_pickle_exec.rb
+++ b/modules/exploits/unix/webapp/graphite_pickle_exec.rb
@@ -20,7 +20,8 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author' 		=>
         [
-          'Charlie Eriksen' # Initial discovery and exploit
+          'Charlie Eriksen', # Initial discovery and exploit
+          'funkypickle' # Version check to prove vulnerable
         ],
       'License' 		=> MSF_LICENSE,
       'References'    =>
@@ -53,13 +54,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    response = send_request_cgi({
+    res1 = send_request_cgi({
+      # trailing slash required
+      'uri'      => normalize_uri(target_uri.path, 'version/'),
+      'method' => 'GET'
+    })
+
+    res2 = send_request_cgi({
       'uri' 	 => normalize_uri(target_uri.path, 'render', 'local'),
       'method' => 'POST'
     })
 
-    if response and response.code == 500
-      return Exploit::CheckCode::Detected
+    if (res1 and %w(0.9.5 0.9.10).include?(res1.body.strip)) and (res2 and res2.code == 500)
+      return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe
   end


### PR DESCRIPTION
This PR adds a version check to better determine exploitability for CVE-2013-5093 Graphite Web Unsafe Pickle Handling

Prior to this check, the module returned Exploit::CheckCode::Detected, e.g. "The target service is running, but could not be validated.". This can be interpreted as a false positive by Rapid7 and is commonly looked past by pentesters.

With this new check, we specifically check if the graphite instance is running a vulnerable version and return Exploit::CheckCode::Vulnerable, e.g. "The target is vulnerable". 
## Verification
- Started up msfconsole
- Set RHOST against vulnerable graphite instance
- Ran `check`, it returned "The target is vulnerable"
- Ran `check` against a non-vulnerable instance, verified it didn't say it was vulnerable
