### PR TITLE
Add zeroSteiner to author.rb

### DIFF
--- a/lib/msf/core/author.rb
+++ b/lib/msf/core/author.rb
@@ -51,7 +51,8 @@ class Msf::Author
     'theLightCosine'      => 'theLightCosine' + 0x40.chr + 'metasploit.com',
     'todb'                => 'todb' + 0x40.chr + 'metasploit.com',
     'vlad902'             => 'vlad902' + 0x40.chr + 'gmail.com',
-    'wvu'                 => 'wvu' + 0x40.chr + 'metasploit.com'
+    'wvu'                 => 'wvu' + 0x40.chr + 'metasploit.com',
+    'zeroSteiner'         => 'zeroSteiner' + 0x40.chr + 'gmail.com'
   }
 
   #


### PR DESCRIPTION
This allows said author to specify their handle in `Author` with automatic e-mail address resolution.
- [x] `info post/windows/gather/enum_patches`
- [x] See no e-mail address associated with `zeroSteiner`
- [x] Apply patch
- [x] `info post/windows/gather/enum_patches`
- [x] See the associated e-mail address
