### PR TITLE
netbsd mail.local bash removal

### DIFF
--- a/modules/exploits/unix/local/netbsd_mail_local.rb
+++ b/modules/exploits/unix/local/netbsd_mail_local.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged'      => true,
         'Payload'         => {
           'Compat'        => {
-            'PayloadType' => 'cmd cmd_bash',
+            'PayloadType' => 'cmd',
             'RequiredCmd' => 'generic openssl'
           }
         },


### PR DESCRIPTION
Removal of cmd_bash payload from netbsd mail.local priv escalation per @wvu-r7 's [comment](https://github.com/rapid7/metasploit-framework/pull/7245#issuecomment-247911433) in #7425

Thanks for finding that, sorry it took so long to clean it up!
