### PR TITLE
Fix erroneous cred reporting in SonicWALL exploit

### DIFF
--- a/modules/exploits/multi/http/sonicwall_scrutinizer_methoddetail_sqli.rb
+++ b/modules/exploits/multi/http/sonicwall_scrutinizer_methoddetail_sqli.rb
@@ -180,9 +180,9 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "Username '#{datastore['USERNAME']}' is incorrect.")
     elsif res['loginfailed']
       fail_with(Failure::NoAccess, "Password '#{datastore['PASSWORD']}' is incorrect.")
+    elsif res['sessionid']
+      report_cred(datastore['USERNAME'], datastore['PASSWORD'])
     end
-
-    report_cred(datastore['USERNAME'], datastore['PASSWORD'])
 
     res
   end


### PR DESCRIPTION
A session ID will be returned in the parsed JSON if the login succeeded.

Bad user:

```
{"noldapnouser"=>1, "loginfailed"=>1}
```

Bad password:

```
{"loginfailed"=>1}
```

Good user/password:

```
{"userid"=>"1", "sessionid"=>"4WJ9cNg1TkBrwjzX"}
```

The check can be improved if required. Right now, it's simply doing a key match for `sessionid`, much like the checks above it.
- [x] `wget http://software.sonicwall.com/ScrutinizerSW/184-003184-00_Rev_A_sonicwall-oem-Scrutinizer-windows-installer.exe`
- [x] Install it
- [x] Verify creds
- [x] `python -m SimpleHTTPServer 8080`
- [x] Verify no creds
