### PR TITLE
Added IP addresses to the output

### DIFF
--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -131,12 +131,12 @@ class MetasploitModule < Msf::Auxiliary
       # Append filename if there isn't one
       if path !~ /(.+\.\w+)$/
         path << "#{Rex::Text.rand_text_alpha(5)}.txt"
-        vprint_status("#{ip}: No filename specified. Using: #{path}")
+        vprint_status("No filename specified. Using: #{path}")
       end
 
       # Upload file
       res = do_put(path, data)
-      vprint_status("Reply: #{res.code.to_s}") if not res.nil?
+      vprint_status("#{ip}: Reply: #{res.code.to_s}") if not res.nil?
 
       # Check file
       if not res.nil? and file_exists(path, data)

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
         }, 20
       ).to_s
     rescue ::Exception => e
-      print_error("Error: #{e.to_s}")
+      print_error("#{ip}: Error: #{e.to_s}")
       return nil
     end
 
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
         }, 20
       )
     rescue ::Exception => e
-      print_error("Error: #{e.to_s}")
+      print_error("#{ip}: Error: #{e.to_s}")
       return nil
     end
 
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
         }, 20
       )
     rescue ::Exception => e
-      print_error("Error: #{e.to_s}")
+      print_error("#{ip}: Error: #{e.to_s}")
       return nil
     end
 
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
       # Append filename if there isn't one
       if path !~ /(.+\.\w+)$/
         path << "#{Rex::Text.rand_text_alpha(5)}.txt"
-        vprint_status("No filename specified. Using: #{path}")
+        vprint_status("#{ip}: No filename specified. Using: #{path}")
       end
 
       # Upload file
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
           :exploited_at => Time.now.utc
         )
       else
-        print_error("File doesn't seem to exist. The upload probably failed.")
+        print_error("#{ip}: File doesn't seem to exist. The upload probably failed.")
       end
 
     when 'DELETE'
@@ -167,11 +167,11 @@ class MetasploitModule < Msf::Auxiliary
 
       # Delete our file
       res = do_delete(path)
-      vprint_status("Reply: #{res.code.to_s}") if not res.nil?
+      vprint_status("#{ip}: Reply: #{res.code.to_s}") if not res.nil?
 
       # Check if DELETE was successful
       if res.nil? or file_exists(path, data)
-        print_error("DELETE failed. File is still there.")
+        print_error("#{ip}: DELETE failed. File is still there.")
       else
         turl = "#{(ssl ? 'https' : 'http')}://#{ip}:#{rport}#{path}"
         print_good("File deleted: #{turl}")

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
   # Send a normal HTTP request and see if we successfully uploaded or deleted a file.
   # If successful, return true, otherwise false.
   #
-  def file_exists(path, data)
+  def file_exists(path, data, ip)
     begin
       res = send_request_cgi(
         {
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
   #
   # Do a PUT request to the server.  Function returns the HTTP response.
   #
-  def do_put(path, data)
+  def do_put(path, data, ip)
     begin
       res = send_request_cgi(
         {
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Auxiliary
   #
   # Do a DELETE request. Function returns the HTTP response.
   #
-  def do_delete(path)
+  def do_delete(path, ip)
     begin
       res = send_request_cgi(
         {
@@ -135,11 +135,11 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       # Upload file
-      res = do_put(path, data)
+      res = do_put(path, data, ip)
       vprint_status("#{ip}: Reply: #{res.code.to_s}") if not res.nil?
 
       # Check file
-      if not res.nil? and file_exists(path, data)
+      if not res.nil? and file_exists(path, data, ip)
         turl = "#{(ssl ? 'https' : 'http')}://#{ip}:#{rport}#{path}"
         print_good("File uploaded: #{turl}")
         report_vuln(
@@ -160,17 +160,17 @@ class MetasploitModule < Msf::Auxiliary
       if path !~ /(.+\.\w+)$/
         print_error("You must supply a filename")
         return
-      elsif not file_exists(path, data)
+      elsif not file_exists(path, data, ip)
         print_error("File is already gone. Will not continue DELETE")
         return
       end
 
       # Delete our file
-      res = do_delete(path)
+      res = do_delete(path, ip)
       vprint_status("#{ip}: Reply: #{res.code.to_s}") if not res.nil?
 
       # Check if DELETE was successful
-      if res.nil? or file_exists(path, data)
+      if res.nil? or file_exists(path, data, ip)
         print_error("#{ip}: DELETE failed. File is still there.")
       else
         turl = "#{(ssl ? 'https' : 'http')}://#{ip}:#{rport}#{path}"


### PR DESCRIPTION
The output of this script was a little too generic with output stating "File doesn't seem to exist. The upload probably failed." That's not really helpful when going back to a log file and trying to ensure certain systems did not support this method. So I've simply modified the output so that the respective IP address is shown.
