### PR TITLE
NTLM Util change to support Unicode hostnames

### DIFF
--- a/lib/rex/proto/ntlm/utils.rb
+++ b/lib/rex/proto/ntlm/utils.rb
@@ -374,6 +374,7 @@ class Utils
 
   # Parse an ntlm type 2 challenge blob and return usefull data
   def self.parse_ntlm_type_2_blob(blob)
+    puts("NTLM BLOB:\n#{blob.each_byte.map { |b| b.to_s(16)+" " }.join}")
     data = {}
     # Extract the NTLM challenge key the lazy way
     cidx = blob.index("NTLMSSP\x00\x02\x00\x00\x00")
@@ -392,21 +393,38 @@ class Utils
 
     while(alist_buf.length > 0)
       atype, alen = alist_buf.slice!(0,4).unpack('vv')
+#      puts("alen=#{alen}\natype=#{atype}")
       break if atype == 0x00
       addr = alist_buf.slice!(0, alen)
       case atype
       when 1
         #netbios name
-        data[:default_name] =  addr.gsub("\x00", '')
+        puts("\nNETBIOS NAME")
+        data[:default_name] =  addr
+        puts("#{data[:default_name].each_byte.map { |b| b.to_s(16)+" " }.join}")
+        data[:default_name].force_encoding("UTF-16LE")
+        puts(data[:default_name].encode("UTF-8"))
       when 2
         #netbios domain
-        data[:default_domain] = addr.gsub("\x00", '')
+        puts("\nNETBIOS DOMAIN")
+        data[:default_domain] = addr
+        puts("#{data[:default_domain].each_byte.map { |b| b.to_s(16)+" " }.join}")
+        data[:default_domain].force_encoding("UTF-16LE")
+        puts(data[:default_domain].encode("UTF-8"))
       when 3
         #dns name
-        data[:dns_host_name] =  addr.gsub("\x00", '')
+        puts("\nDNS NAME")
+        data[:dns_host_name] =  addr
+        puts("#{data[:dns_host_name].each_byte.map { |b| b.to_s(16)+" " }.join}")
+        data[:dns_host_name].force_encoding("UTF-16LE")
+        puts(data[:dns_host_name].encode("UTF-8"))
       when 4
         #dns domain
-        data[:dns_domain_name] =  addr.gsub("\x00", '')
+        puts("\nDNS DOMAIN")
+        data[:dns_domain_name] =  addr
+        puts("#{data[:dns_domain_name].each_byte.map { |b| b.to_s(16)+" " }.join}")
+        data[:dns_domain_name].force_encoding("UTF-16LE")
+        puts(data[:dns_domain_name].encode("UTF-8"))
       when 5
         #The FQDN of the forest.
       when 6

--- a/lib/rex/proto/ntlm/utils.rb
+++ b/lib/rex/proto/ntlm/utils.rb
@@ -374,7 +374,6 @@ class Utils
 
   # Parse an ntlm type 2 challenge blob and return usefull data
   def self.parse_ntlm_type_2_blob(blob)
-    puts("NTLM BLOB:\n#{blob.each_byte.map { |b| b.to_s(16)+" " }.join}")
     data = {}
     # Extract the NTLM challenge key the lazy way
     cidx = blob.index("NTLMSSP\x00\x02\x00\x00\x00")
@@ -393,38 +392,26 @@ class Utils
 
     while(alist_buf.length > 0)
       atype, alen = alist_buf.slice!(0,4).unpack('vv')
-#      puts("alen=#{alen}\natype=#{atype}")
       break if atype == 0x00
       addr = alist_buf.slice!(0, alen)
       case atype
       when 1
         #netbios name
-        puts("\nNETBIOS NAME")
-        data[:default_name] =  addr
-        puts("#{data[:default_name].each_byte.map { |b| b.to_s(16)+" " }.join}")
-        data[:default_name].force_encoding("UTF-16LE")
-        puts(data[:default_name].encode("UTF-8"))
+        temp_name = addr
+        temp_name.force_encoding("UTF-16LE")
+        data[:default_name] =  temp_name.encode("UTF-8")
       when 2
         #netbios domain
-        puts("\nNETBIOS DOMAIN")
         data[:default_domain] = addr
-        puts("#{data[:default_domain].each_byte.map { |b| b.to_s(16)+" " }.join}")
         data[:default_domain].force_encoding("UTF-16LE")
-        puts(data[:default_domain].encode("UTF-8"))
       when 3
         #dns name
-        puts("\nDNS NAME")
         data[:dns_host_name] =  addr
-        puts("#{data[:dns_host_name].each_byte.map { |b| b.to_s(16)+" " }.join}")
         data[:dns_host_name].force_encoding("UTF-16LE")
-        puts(data[:dns_host_name].encode("UTF-8"))
       when 4
         #dns domain
-        puts("\nDNS DOMAIN")
         data[:dns_domain_name] =  addr
-        puts("#{data[:dns_domain_name].each_byte.map { |b| b.to_s(16)+" " }.join}")
         data[:dns_domain_name].force_encoding("UTF-16LE")
-        puts(data[:dns_domain_name].encode("UTF-8"))
       when 5
         #The FQDN of the forest.
       when 6


### PR DESCRIPTION
# This PR relies on a change to rex-text: https://github.com/rapid7/rex-text/pull/3
# What does this do?

This is a change to the ntlm utilities library to properly convert and store unicode hostnames.  Previously, the NTLM blob was parsed and the data was put into ANSI using an in-house conversion before it was passed back to the calling module.  That destroyed any hostname that could not be rendered by ANSI characters.  This PR adds code to convert the UTF-16LE native hostnames contained in the blob to UTF-8 strings using ruby built-ins so that they can be displayed and stored to the database.  This probably fixes international domain names, too.  Without the rex-text change, the UTF-8 encoded data will display in the scanner, but the sanitization functions called before the db write will choke on the UTF-8 characters.
# What does this break?

I know that there seems to be an issue in displaying the data, as when you run `hosts`, the whitespace padding appears incorrect.  Otherwise, I do not know.  This does have the possibility of breaking other things, though I tried to minimize it.
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_version`
- [x] `set rhosts <host with international hostname>`
- [x] `run`
- [x] **Verify** hostname is given correctly in the output
- [x] `hosts`
- [x] **Verify** hostname is stored in the database correctly
## Example Run:

```
msf > use auxiliary/scanner/smb/smb_version 
msf auxiliary(smb_version) > set rhosts <russian_host_ip>
rhosts => <russian_host_ip>
msf auxiliary(smb_version) > run

[*] <russian_host_ip>:445    - Host is running Windows 2012 R2 Standard (build:9600) (name:КОМПЬЮТЕР)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(smb_version) > hosts

Hosts
=====

address         mac  name                os_name          os_flavor  os_sp  purpose  info  comments
-------         ---  ----                -------          ---------  -----  -------  ----  --------
<russian_host_ip>       КОМПЬЮТЕР  Windows 2012 R2  Standard          server         

msf auxiliary(smb_version) >
```
