### PR TITLE
delay fingerprinting of host

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -85,10 +85,14 @@ module Msf::DBManager::Import
   # import_file_detect will raise an error if the filetype
   # is unknown.
   def import(args={}, &block)
+    wspace = args[:wspace] || args['wspace'] || workspace
+    wspace.update_attribute(:import_fingerprint, true)
     data = args[:data] || args['data']
     ftype = import_filetype_detect(data)
     yield(:filetype, @import_filedata[:type]) if block
     self.send "import_#{ftype}".to_sym, args, &block
+    wspace.hosts.each(&:normalize_os)
+    wspace.update_attribute(:import_fingerprint, false)
   end
 
   #


### PR DESCRIPTION
MS-2073
- imports are slow mainly caused by fingerprinting after every service creation
- now only fingerprints after all the services are created for imports

OS Fingerprinting was making imports take a while if there were hosts with thousands of hosts. We were fingerprinting as a callback of service.rb and note.rb after every service and note creation. With the metasploit data model changes and these changes, for imports, we mark the workspace 'import_fingerprint' attribute as true not kicking off the callback to normalize the host. Imports that used to take 5 hours + now takes <10 minutes. Yay!
## Verification
- [x] make sure https://github.com/rapid7/metasploit_data_models/pull/163 is merged in metasploit_data_models before continuing
- [x] Start `msfconsole`
- [x] grab a file to import
- [x] verify `db_import /path/to/file/to/import.xml` passes
- [x] verify the hosts imported are fingerprinted
- [x] verify import still works in pro and hosts are fingerprinted
