### PR TITLE
Add Support for Unicode Domains

### DIFF
--- a/lib/rex/proto/ntlm/utils.rb
+++ b/lib/rex/proto/ntlm/utils.rb
@@ -402,16 +402,20 @@ class Utils
         data[:default_name] =  temp_name.encode("UTF-8")
       when 2
         #netbios domain
-        data[:default_domain] = addr
-        data[:default_domain].force_encoding("UTF-16LE")
+        temp_domain = addr
+        temp_domain.force_encoding("UTF-16LE")
+        data[:default_domain] =  temp_domain.encode("UTF-8")
       when 3
         #dns name
-        data[:dns_host_name] =  addr
-        data[:dns_host_name].force_encoding("UTF-16LE")
+        temp_dns = addr
+        temp_dns.force_encoding("UTF-16LE")
+        data[:dns_host_name] =  temp_dns.encode("UTF-8")
+
       when 4
         #dns domain
-        data[:dns_domain_name] =  addr
-        data[:dns_domain_name].force_encoding("UTF-16LE")
+        temp_dns_domain = addr
+        temp_dns_domain.force_encoding("UTF-16LE")
+        data[:dns_domain_name] =  temp_dns_domain.encode("UTF-8")
       when 5
         #The FQDN of the forest.
       when 6

--- a/lib/rex/proto/ntlm/utils.rb
+++ b/lib/rex/proto/ntlm/utils.rb
@@ -410,7 +410,6 @@ class Utils
         temp_dns = addr
         temp_dns.force_encoding("UTF-16LE")
         data[:dns_host_name] =  temp_dns.encode("UTF-8")
-
       when 4
         #dns domain
         temp_dns_domain = addr

--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -760,7 +760,13 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 
     self.peer_native_os = info[0]
     self.peer_native_lm = info[1]
-    self.default_domain = info[2]
+    #
+    # if the PC belongs to a domain, this value is already populated
+    # if it is not populated, we're in a workgroup and need to pupulate it now
+    #
+    if self.default_domain.nil?
+      self.default_domain = info[2]
+    end
 
     return ack
   end
@@ -906,7 +912,13 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
     #dns name
     self.dns_host_name =  blob_data[:dns_host_name] || ''
     #dns domain
-    self.dns_domain_name =  blob_data[:dns_domain_name] || ''
+    if blob_data[:default_name] != blob_data[:default_domain]
+      # We're in a domain; get the domain name now
+      self.default_domain =  blob_data[:default_domain] || ''
+    else
+      # We're in a workgroup; workgroup names come later in the handshake
+      self.default_domain = nil
+    end
 
     type3 = @ntlm_client.init_context([blob].pack('m'))
     type3_blob = type3.serialize


### PR DESCRIPTION
# This PR requires changes to the metasploit_data_models gem: https://github.com/rapid7/metasploit_data_models/pull/162
## What does this do?

Practically speaking, this PR changes Framework to allow the smb_version scan to read and parse international domain names and store them to the database and to discern between workgroups and domains.
It does so by changing the way the ntlm blob is parsed during an ntlm handshake so that the domain name is converted to UTF-8 rather than ANSI, and if a workgroup is detected, it flags that data, preserving international characters and allowing proper tagging of workgroups and domains.  Other changes ensure that smb_version scanning accepts these changes and passes them properly though to the database and purposes are still matched properly.
## Verification

To verify this PR, it is useful to have the following:
A Windows VM with a domain name in some international language (I used Russian)
A Windows VM with a Workgroup in some international language (I used French)
A Windows VM with a domain name in English
A Windows VM with a Workgroup in English
More VMs as you deem necessary
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_version`
- [x] `set rhosts <IPs>`
- [x] `run`
- [x] **Verify** the Hostnames, Workgroups, and Domains are correctly displayed (Workgroups cannot have unicode values, so they are parsed out)
- [x] `hosts`
- [x] **Verify** the Hostnames are correct
- [x] `services`
- [x] **Verify** the domains and workgroups are correct
# Example Run

```
msf auxiliary(smb_version) > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

msf auxiliary(smb_version) > services

Services
========

host  port  proto  name  state  info
----  ----  -----  ----  -----  ----

msf auxiliary(smb_version) > run

[*] Scanned 1 of 6 hosts (16% complete)
[-] xxx.xxx.xxx.xxx:445    - Found incompatible (non-ANSI) character in Workgroup name. Replaced with '?'
[*] xxx.xxx.xxx.xxx:445    - Host is running Windows 10 Pro (build:14393) (name:GÉNÉRÉ) (workgroup:AL?ATOIREMENT )
[*] Scanned 2 of 6 hosts (33% complete)
[*] xxx.xxx.xxx.xxx:445    - Host is running Windows 2012 R2 Standard (build:9600) (name:КОМПЬЮТЕР) (domain:домен)
[*] Scanned 3 of 6 hosts (50% complete)
[*] xxx.xxx.xxx.xxx:445    - Host is running Windows 10 Pro (build:10586) (name:DESKTOP-OQBO9P9) (workgroup:WORKGROUP )
[*] Scanned 4 of 6 hosts (66% complete)
[*] xxx.xxx.xxx.xxx:445    - Host is running Windows 2012 R2 Standard (build:9600) (name:COMPUTER) (domain:TEST)
[*] Scanned 5 of 6 hosts (83% complete)
[*] xxx.xxx.xxx.xxx:445       - Host is running Windows 7 Enterprise (build:7600) (name:SMB-W7-64) (domain:MS)
[*] Scanned 6 of 6 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(smb_version) > hosts

Hosts
=====

address         mac  name                os_name          os_flavor   os_sp  purpose  info  comments
-------         ---  ----                -------          ---------   -----  -------  ----  --------
xxx.xxx.xxx.xxx          SMB-W7-64           Windows 7        Enterprise         client         
xxx.xxx.xxx.xxx       GÉNÉRÉ           Windows 10       Pro                client         
xxx.xxx.xxx.xxx       КОМПЬЮТЕР  Windows 2012 R2  Standard           server         
xxx.xxx.xxx.xxx       DESKTOP-OQBO9P9     Windows 10       Pro                client         
xxx.xxx.xxx.xxx       COMPUTER            Windows 2012 R2  Standard           server         

msf auxiliary(smb_version) > services

Services
========

host            port  proto  name  state  info
----            ----  -----  ----  -----  ----
xxx.xxx.xxx.xxx     445   tcp    smb   open   Windows 7 Enterprise (build:7600) (name:SMB-W7-64) (domain:MS)
xxx.xxx.xxx.xxx  445   tcp    smb   open   Windows 10 Pro (build:14393) (name:GÉNÉRÉ) (workgroup:AL?ATOIREMENT )
xxx.xxx.xxx.xxx  445   tcp    smb   open   Windows 2012 R2 Standard (build:9600) (name:КОМПЬЮТЕР) (domain:домен)
xxx.xxx.xxx.xxx  445   tcp    smb   open   Windows 10 Pro (build:10586) (name:DESKTOP-OQBO9P9) (workgroup:WORKGROUP )
xxx.xxx.xxx.xxx  445   tcp    smb   open   Windows 2012 R2 Standard (build:9600) (name:COMPUTER) (domain:TEST)

msf auxiliary(smb_version) > 
```
