### PR TITLE
Fix preamble in bind_php to include php tag+escape

### DIFF
--- a/lib/msf/core/payload/php.rb
+++ b/lib/msf/core/payload/php.rb
@@ -25,7 +25,7 @@ module Msf::Payload::Php
 
     # Canonicalize the list of disabled functions to facilitate choosing a
     # system-like function later.
-    preamble = "
+    preamble = "/*<?php /**/
       @set_time_limit(0); @ignore_user_abort(1); @ini_set('max_execution_time',0);
       #{dis}=@ini_get('disable_functions');
       if(!empty(#{dis})){


### PR DESCRIPTION
OJ's fix for the bind_php payload tag bug https://github.com/rapid7/metasploit-framework/issues/7001

Not sure how this got dropped for so long
