### PR TITLE
fixes bad file refs for cmdstagers

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -26,10 +26,10 @@ module Exploit::CmdStager
 
   # Constant for decoders - used when checking the default flavor decoder.
   DECODERS = {
-    :debug_asm => File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "debug_asm"),
-    :debug_write => File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "debug_write"),
-    :vbs => File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64"),
-    :vbs_adodb => File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64_adodb")
+    :debug_asm => File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "debug_asm"),
+    :debug_write => File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "debug_write"),
+    :vbs => File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64"),
+    :vbs_adodb => File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64_adodb")
   }
 
   attr_accessor :stager_instance

--- a/modules/exploits/multi/http/rocket_servergraph_file_requestor_rce.rb
+++ b/modules/exploits/multi/http/rocket_servergraph_file_requestor_rce.rb
@@ -201,7 +201,7 @@ SH
   end
 
   def generate_decoder_vbs(opts = {})
-    decoder_path = File.join(Msf::Config.data_directory, "exploits", "cmdstager", "vbs_b64")
+    decoder_path = File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64")
 
     f = File.new(decoder_path, "rb")
     decoder = f.read(f.stat.size)

--- a/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
+++ b/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DefaultOptions'  =>
         {
-          'CMDSTAGER::DECODER' => File.join(Msf::Config.data_directory, "exploits", "cmdstager", "vbs_b64_noquot")
+          'CMDSTAGER::DECODER' => File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64_noquot")
         },
       'DisclosureDate' => 'Jul 29 2013'))
 

--- a/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'CMDSTAGER::DECODER' => File.join(Msf::Config.data_directory, "exploits", "cmdstager", "vbs_b64_noquot")
+          'CMDSTAGER::DECODER' => File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64_noquot")
         },
       'Platform'        => 'win',
       'Targets'         =>

--- a/modules/exploits/windows/winrm/winrm_script_exec.rb
+++ b/modules/exploits/windows/winrm/winrm_script_exec.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'WfsDelay'     => 30,
           'EXITFUNC' => 'thread',
           'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
-          'CMDSTAGER::DECODER' => File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64_sleep")
+          'CMDSTAGER::DECODER' => File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64_sleep")
         },
       'Platform'       => 'win',
       'Arch'          => [ ARCH_X86, ARCH_X86_64 ],

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -201,7 +201,7 @@ class MetasploitModule < Msf::Post
       #:nodelete => true # keep temp files (for debugging)
     }
     if session.platform =~ /win/i
-      opts[:decoder] = File.join(Msf::Config.data_directory, 'exploits', 'cmdstager', 'vbs_b64')
+      opts[:decoder] = File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", 'vbs_b64')
       cmdstager = Rex::Exploitation::CmdStagerVBS.new(exe)
     else
       opts[:background] = true

--- a/spec/lib/msf/core/exploit/cmdstager_spec.rb
+++ b/spec/lib/msf/core/exploit/cmdstager_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe Msf::Exploit::CmdStager do
     context "when decoder set in the datastore" do
 
       let(:decoder) do
-        File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64")
+        File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64")
       end
 
       subject do
@@ -619,7 +619,7 @@ RSpec.describe Msf::Exploit::CmdStager do
       context "and decoder set in the opts" do
 
         let(:decoder_opts) do
-          File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64_adodb")
+          File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64_adodb")
         end
 
         it "returns the decoder_opts" do
@@ -637,7 +637,7 @@ RSpec.describe Msf::Exploit::CmdStager do
     context "with :decoder option" do
 
       let(:decoder) do
-        File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64")
+        File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64")
       end
 
       it "returns the :decoder option" do


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/7466
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] get a windows shell session( NOT meterpreter, but shell)
- [x] run sessions -u <session id>
- [x] **Verify** you do not get an error stating the cmd stager file can't be found

when moving to the rex-exploitation gem some of the
file references were missed, partially due to silly differences
between how each file was referenced

Fixes #7466
