### PR TITLE
Deprecate udp_probe in favor of udp_sweep

### DIFF
--- a/modules/auxiliary/scanner/discovery/udp_probe.rb
+++ b/modules/auxiliary/scanner/discovery/udp_probe.rb
@@ -11,6 +11,9 @@ class MetasploitModule < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
+  include Msf::Module::Deprecated
+
+  deprecated(Date.new(2016, 11, 23), 'auxiliary/scanner/discovery/udp_sweep')
 
   def initialize
     super(


### PR DESCRIPTION
These two modules are almost completely identical except for minor variable name changes, etc.  The primary difference used to be that `UDPScanner` wouldnt' work over pivots, but that hasn't been the case for quite a long time.  I removed the `udp_probe` version because `udp_sweep` uses more modern msf UDP capabilities.
## Verification
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/discover/udp_probe`
- [x] **Verify** that the module says that it is deprecated as of 11/23/2016.
- [x] `use auxiliary/scanner/discover/udp_sweep`
- [x] **Verify** that it does not mention anything about be deprecated.
