### PR TITLE
Fix DRDoS mixin to handle empty responses

### DIFF
--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -46,7 +46,11 @@ module Auxiliary::DRDoS
       bandwidth_amplification = total_size - request.size
       if bandwidth_amplification > 0
         vulnerable = true
-        multiplier = total_size / request.size
+        if request.size == 0
+          multiplier = total_size
+        else
+          multiplier = total_size / request.size
+        end
         this_proof += "a #{multiplier}x, #{bandwidth_amplification}-byte bandwidth amplification"
       else
         this_proof += 'no bandwidth amplification'

--- a/spec/lib/msf/core/auxiliary/drdos_spec.rb
+++ b/spec/lib/msf/core/auxiliary/drdos_spec.rb
@@ -34,5 +34,11 @@ RSpec.describe Msf::Auxiliary::DRDoS do
       result, _ = subject.prove_amplification(map)
       expect(result).to be false
     end
+
+    it 'should handle empty responses' do
+      map = { '' => [ 'foo' ] }
+      result, _ = subject.prove_amplification(map)
+      expect(result).to be true
+    end
   end
 end


### PR DESCRIPTION
Prior to this, calling `prove_amplification` with a zero-length key (indicating that no UDP payload was sent), this would fail with a divide by zero error.  To verify this, try the `rspec` diff in isolation without the corresponding fix to `DRDoS`:

```
$  bundle exec rspec ./spec/lib/msf/core/auxiliary/drdos_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 23888
Msf::Auxiliary::DRDoS .F...

  1) Msf::Auxiliary::DRDoS#prove_amplification should handle empty responses
     Failure/Error: multiplier = total_size / request.size

     ZeroDivisionError:
       divided by 0
     # ./lib/msf/core/auxiliary/drdos.rb:52:in `/'
     # ./lib/msf/core/auxiliary/drdos.rb:52:in `block in prove_amplification'
     # ./lib/msf/core/auxiliary/drdos.rb:30:in `each'
     # ./lib/msf/core/auxiliary/drdos.rb:30:in `prove_amplification'
     # ./spec/lib/msf/core/auxiliary/drdos_spec.rb:40:in `block (3 levels) in <top (required)>'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-rails-3.5.2/lib/rspec/rails/adapters.rb:127:in `block (2 levels) in <module:MinitestLifecycleAdapter>'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /Users/jhart/.rbenv/versions/2.1.7/lib/ruby/gems/2.1.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /Users/jhart/.rbenv/versions/2.1.7/bin/rspec:23:in `load'
     # /Users/jhart/.rbenv/versions/2.1.7/bin/rspec:23:in `<main>'

Top 5 slowest examples (0.01995 seconds, 36.5% of total time):
  Msf::Auxiliary::DRDoS#prove_amplification should detect drdos when there is packet and bandwidth amplification
    0.01673 seconds ./spec/lib/msf/core/auxiliary/drdos_spec.rb:26
  Msf::Auxiliary::DRDoS#prove_amplification should detect drdos when there is bandwidth amplification only
    0.00088 seconds ./spec/lib/msf/core/auxiliary/drdos_spec.rb:20
  Msf::Auxiliary::DRDoS#prove_amplification should not detect drdos when there is no packet and no bandwidth amplification
    0.00084 seconds ./spec/lib/msf/core/auxiliary/drdos_spec.rb:32
  Msf::Auxiliary::DRDoS#prove_amplification should handle empty responses
    0.0008 seconds ./spec/lib/msf/core/auxiliary/drdos_spec.rb:38
  Msf::Auxiliary::DRDoS#prove_amplification should detect drdos when there is packet amplification only
    0.0007 seconds ./spec/lib/msf/core/auxiliary/drdos_spec.rb:14

Finished in 0.05468 seconds (files took 3.81 seconds to load)
5 examples, 1 failure

Failed examples:

rspec ./spec/lib/msf/core/auxiliary/drdos_spec.rb:38 # Msf::Auxiliary::DRDoS#prove_amplification should handle empty responses
```
