### PR TITLE
conditionalize fingerprinting

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -94,12 +94,12 @@ module Msf::DBManager::Import
     yield(:filetype, @import_filedata[:type]) if block
     self.send "import_#{ftype}".to_sym, args, &block
     if preserve_hosts
-      new_host_ids = wspace.hosts.map(&:id)
+      new_host_ids = Mdm::Host.where(workspace: wspace).map(&:id)
       (new_host_ids - existing_host_ids).each do |id|
-        wspace.hosts.where(id: id).first.normalize_os
+        Mdm::Host.where(id: id).first.normalize_os
       end
     else
-      wspace.hosts.each(&:normalize_os)
+      Mdm::Host.where(workspace: wspace).each(&:normalize_os)
     end
     wspace.update_attribute(:import_fingerprint, false)
   end

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -91,7 +91,7 @@ module Msf::DBManager::Import
     ftype = import_filetype_detect(data)
     yield(:filetype, @import_filedata[:type]) if block
     self.send "import_#{ftype}".to_sym, args, &block
-    wspace.hosts.each(&:normalize_os)
+    wspace.hosts.each(&:normalize_os) unless args[:task].options["DS_PRESERVE_HOSTS"]
     wspace.update_attribute(:import_fingerprint, false)
   end
 


### PR DESCRIPTION
Previous commit to fix performance on fingerprinting ignored the preserve hosts option
## Verification

List the steps needed to make sure this thing works
- [x] Start msfconsole
- [x] grab a file to import
- [x] verify db_import /path/to/file/to/import.xml passes
- [x] verify the hosts imported are fingerprinted
- [x] verify import still works in pro and hosts are fingerprinted and preserved by creating a host in the database that is different than what you are importing
- fix bug where host not preserved
