### PR TITLE
Add a check for the linux pkexec module

### DIFF
--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     version = cmd_exec('pkexec --version')
     if version.nil?
-	    print_error "Policykit is not installed"
+      print_error "Policykit is not installed"
       return CheckCode::Safe
     end
 

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -66,19 +66,19 @@ class MetasploitModule < Msf::Exploit::Local
     @executable_path
   end
 
-	def check
-		version = cmd_exec('pkexec --version')
-		if version.nil?
-			print_error "Policykit is not installed"
-			return CheckCode::Safe
-		end
+  def check
+    version = cmd_exec('pkexec --version')
+    if version.nil?
+	    print_error "Policykit is not installed"
+      return CheckCode::Safe
+    end
 
-		if version.split('.')[1].to_f <= 0.101
-			return CheckCode::Vulnerable
-		end
+    if Gem::Version.new(version.split('.')[1]) <= 0.101
+      return CheckCode::Appears
+    end
 
-		CheckCode::Unknown
-	end
+    CheckCode::Unknown
+  end
 
   def exploit
     main = %q^

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -66,6 +66,20 @@ class MetasploitModule < Msf::Exploit::Local
     @executable_path
   end
 
+	def check
+		version = cmd_exec('pkexec --version')
+		if version.nil?
+			print_error "Policykit is not installed"
+			return CheckCode::Safe
+		end
+
+		if version.split('.')[1].to_f <= 0.101
+			return CheckCode::Vulnerable
+		end
+
+		CheckCode::Unknown
+	end
+
   def exploit
     main = %q^
 /*

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Appears
     end
 
-    CheckCode::Safe
+    CheckCode::Detected
   end
 
   def exploit

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -67,17 +67,21 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = cmd_exec('pkexec --version')
-    if version.nil?
-      print_error "Policykit is not installed"
-      return CheckCode::Safe
+    # version can be nil
+    version = cmd_exec('pkexec --version').split.last
+
+    # version can be a string, so we check it
+    if version.nil? || !Gem::Version.correct?(version)
+      vprint_error('pkexec not found or version incorrect')
+      return CheckCode::Unknown
     end
 
-    if Gem::Version.new(version.split('.')[1]) <= 0.101
+    if Gem::Version.new(version) <= Gem::Version.new('0.101')
+      vprint_good("pkexec #{version} found")
       return CheckCode::Appears
     end
 
-    CheckCode::Unknown
+    CheckCode::Safe
   end
 
   def exploit


### PR DESCRIPTION
The PR adds a `check` for the `exploit/linux/local/pkexec` module.
Please squash the PR before merging it.

## Verification
- [x] Start `msfconsole`
- [x] Get a meterpreter session
- [x] Put it in background
- [x] `use` the `exploit/linux/local/pkexec` module
- [x] run `check`, it should output say that the machine is vulnerable if `pkexec` is present and has a version inferior or equal to `0.101`
## Example on a vulnerable instance

```
msf exploit(handler) > run

[*] Started reverse TCP handler on 127.0.0.1:8000 
[*] Starting the payload handler...
[*] Sending stage (2427448 bytes) to 127.0.0.1
[*] Meterpreter session 2 opened (127.0.0.1:8000 -> 127.0.0.1:52304) at 2016-10-27 10:26:15 +0200

meterpreter > 
Background session 2? [y/N]  
msf exploit(handler) > use exploit/linux/local/pkexec
msf exploit(pkexec) > set session 1
session => 1
msf exploit(pkexec) > check
[+]  The target is vulnerable.
msf exploit(pkexec) >  
```
