### PR TITLE
fix check method in seagate expolit

### DIFF
--- a/modules/exploits/linux/http/seagate_nas_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/seagate_nas_php_exec_noauth.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
         headers = res.to_s
 
         # validate headers
-        if headers.incude?('X-Powered-By: PHP/5.2.13') && headers.include?('Server: lighttpd/1.4.28')
+        if headers.include?('X-Powered-By: PHP/5.2.13') && headers.include?('Server: lighttpd/1.4.28')
           # and make sure that the body contains the title we'd expect
           if res.body.include?('Login to BlackArmor')
             return Exploit::CheckCode::Appears


### PR DESCRIPTION
`check` method had incorrectly spelled method name causing `nomethod` error when attempting to check if the RHOST was vulnerable to CVE-2014-8687
## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/linux/http/seagate_nas_php_exec_noauth`
- [x] `check`
