### PR TITLE
print_{good,error} more specifically in open_x11

### DIFF
--- a/modules/auxiliary/scanner/x11/open_x11.rb
+++ b/modules/auxiliary/scanner/x11/open_x11.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
       if(success == 1)
         vendor_len = response[24,2].unpack('v')[0]
         vendor = response[40,vendor_len].unpack('A*')[0]
-        print_status("#{ip} Open X Server (#{vendor})")
+        print_good("#{ip} Open X Server (#{vendor})")
         # Add Report
         report_note(
           :host	=> ip,
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
           :data	=> "Open X Server (#{vendor})"
       )
       elsif (success == 0)
-        print_status("#{ip} Access Denied")
+        print_error("#{ip} Access Denied")
       else
         # X can return a reason for auth failure but we don't really care for this
       end


### PR DESCRIPTION
This was an internal request from PSO two years ago. I'm sorry I didn't see your e-mail, Leon!

All this does is print red or green depending on error or success.

- [x] Code looks good
- [x] Prints red on error
- [x] Prints green on success