### PR TITLE
this fixes an issue with nexposeapi errors

### DIFF
--- a/lib/rapid7/nexpose.rb
+++ b/lib/rapid7/nexpose.rb
@@ -182,6 +182,25 @@ class APIRequest
       end
     end
 
+    @res.elements.each('//Failure') do |s|
+
+      # 1.1 returns lower case elements
+      s.elements.each('message') do |m|
+        @error = m.text
+      end
+      s.elements.each('stacktrace') do |m|
+        @trace = m.text
+      end
+
+      # 1.2 returns capitalized elements
+      s.elements.each('Message') do |m|
+        @error = m.text
+      end
+      s.elements.each('Stacktrace') do |m|
+        @trace = m.text
+      end
+    end
+
     # This is a hack to handle corner cases where a heavily loaded Nexpose instance
     # drops our HTTP connection before processing. We try 5 times to establish a
     # connection in these situations. The actual exception occurs in the Ruby

--- a/plugins/nexpose.rb
+++ b/plugins/nexpose.rb
@@ -520,7 +520,14 @@ class Plugin::Nexpose < Msf::Plugin
         print_status(" >> Created temporary report configuration ##{report.config_id}") if opt_verbose
 
         # Run the scan
-        res = site.scanSite()
+        begin
+          res  = site.scanSite()
+        rescue Nexpose::APIError => e
+          nexpose_error_message = e.message
+          nexpose_error_message.gsub!(/NexposeAPI: Action failed: /, '')
+          print_error "#{nexpose_error_message}"
+          return
+        end
         sid = res[:scan_id]
 
         print_status(" >> Scan has been launched with ID ##{sid}") if opt_verbose


### PR DESCRIPTION
on newer versions of the nexpose api the error
XML schema has been changed, this prevents the
exception from being generated correctly

MS-289

## Verification

List the steps needed to make sure this thing works
- [x] Set a blackout period in your nexpose console 
- [x] wait for blackout to start
- [x] Start `msfconsole`
- [x] `load nexpose`
- [x] `nexpose_connect <user>:<pass>@<address of nexpose console>:3780 'ok' `
- [x] `nexpose_scan <target ip>`
- [x] **Verify** You get an error message like this: [-] This scan cannot run because there is an active blackout.
- [x] **Verify** you do not get a stack trace


