### PR TITLE
Modernize TLS protocol configuration for SMTP / SQL Server

### DIFF
--- a/lib/metasploit/framework/mssql/tdssslproxy.rb
+++ b/lib/metasploit/framework/mssql/tdssslproxy.rb
@@ -51,8 +51,9 @@ class TDSSSLProxy
   def setup_ssl
     @running = true
     @t1 = Thread.start { ssl_setup_thread }
-    ssl_context = OpenSSL::SSL::SSLContext.new(:TLSv1)
-    @ssl_socket = OpenSSL::SSL::SSLSocket.new(@s1, ssl_context)
+    ctx = OpenSSL::SSL::SSLContext.new(:SSLv23)
+    ctx.ciphers = "ALL:!ADH:!EXPORT:!SSLv2:!SSLv3:+HIGH:+MEDIUM"
+    @ssl_socket = OpenSSL::SSL::SSLSocket.new(@s1, ctx)
     @ssl_socket.connect
   end
 

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -228,12 +228,9 @@ protected
   end
 
   def generate_ssl_context
-    ctx = OpenSSL::SSL::SSLContext.new
-    ctx.key = OpenSSL::PKey::RSA.new(1024){ }
-
-    ctx.session_id_context = Rex::Text.rand_text(16)
-
-    return ctx
+    ctx = OpenSSL::SSL::SSLContext.new(:SSLv23)
+    ctx.ciphers = "ALL:!ADH:!EXPORT:!SSLv2:!SSLv3:+HIGH:+MEDIUM"
+    ctx
   end
 
 end

--- a/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
+++ b/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   end
 
-  # NRPE uses unauthenticated Annonymous-Diffie-Hellman
+  # NRPE uses unauthenticated Anonymous-Diffie-Hellman
 
   # setting the global SSL => true will break as we would be overlaying
   # an SSLSocket on another SSLSocket which hasnt completed its handshake
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
     self.sock = super(global, opts)
 
     if datastore['NRPESSL'] or @force_ssl
-      ctx = OpenSSL::SSL::SSLContext.new("TLSv1")
+      ctx = OpenSSL::SSL::SSLContext.new(:TLSv1)
       ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
       ctx.ciphers = "ADH"
 


### PR DESCRIPTION
Metasploit's ability to interact with modern SMTP / SQL server implementations is being restricted by upstream implementations switching off SSLv3 / RC4 and denying connectivity to clients. This change enables auto-configuration via the misleadingly-named SSLv23 option, but disables weak algorithms and SSLv2/v3.

Note, there are not many easy-to-verify SMTP-using modules in Metasploit Framework, since you need to get an account on an SMTP server. I used a personal Postfix server and smtp.office365.com to verify that STARTTLS works as expected.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/apple_ios/email/mobilemail_libtiff`
- [x] configure the module to send via SMTP and run it against a Postfix server and an Exchange server.
- [x] Look at the traffic on the wire - verify that we can execute STARTTLS without being disconnected during negoation
- [x] Verify that auxiliary/scanner/mssql/mssql_login works against an MSSQL server with TLS enabled.

