### PR TITLE
fixes #7519 psh payload generation

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1346,17 +1346,11 @@ require 'msf/core/exe/segment_appender'
   end
 
   def self.to_win32pe_psh_net(framework, code, opts={})
-    template_path = File.join(Msf::Config.data_directory,
-                                  "templates",
-                                  "scripts")
-    Rex::Powershell::Payload.to_win32pe_psh_net(template_path, code)
+    Rex::Powershell::Payload.to_win32pe_psh_net(Rex::Powershell::Templates::TEMPLATE_DIR, code)
   end
 
   def self.to_win32pe_psh(framework, code, opts = {})
-    template_path = File.join(Msf::Config.data_directory,
-                              "templates",
-                              "scripts")
-    Rex::Powershell::Payload.to_win32pe_psh(template_path, code)
+    Rex::Powershell::Payload.to_win32pe_psh(Rex::Powershell::Templates::TEMPLATE_DIR, code)
   end
 
   #
@@ -1365,10 +1359,7 @@ require 'msf/core/exe/segment_appender'
   # Originally from PowerSploit
   #
   def self.to_win32pe_psh_reflection(framework, code, opts = {})
-    template_path = File.join(Msf::Config.data_directory,
-                              "templates",
-                              "scripts")
-    Rex::Powershell::Payload.to_win32pe_psh_reflection(template_path, code)
+    Rex::Powershell::Payload.to_win32pe_psh_reflection(Rex::Powershell::Templates::TEMPLATE_DIR, code)
   end
 
   def self.to_powershell_command(framework, arch, code)


### PR DESCRIPTION

a few files references to the templates for pwoershell were
missed when transfering the templates over to the rex-powershell gem

https://github.com/rapid7/metasploit-framework/issues/7519

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use payload/windows/meterpreter/reverse_tcp`
- [x] `set LHOST 192.168.172.1`
- [x] `generate -t psh`
- [x] **Verify** it generates a psh payload
- [x] **Verify**  you do not get a missing file error
