### PR TITLE
Remove the bug where downcase() is invoked on password which is optio…

### DIFF
--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -312,7 +312,7 @@ class MetasploitModule < Msf::Exploit::Remote
         origin_type: :service,
         module_fullname: self.fullname,
         private_type: :password,
-        private_data: datastore['PASSWORD'].downcase,
+        private_data: datastore['PASSWORD'],
         username: datastore['USERNAME']
     }
 


### PR DESCRIPTION
The simple fix the bug where the module exploits/multi/http/tomcat_mgr_deploy will call downcast() on the password user parameter, but this parameter is optional and can be empty, causing an error.

## Verification

List the steps needed to make sure this thing works

Assume you have tomcat mgr installed on localhost:

- [x] Start `msfconsole`
- [x] `use exploits/multi/http/tomcat_mgr_deploy`
- [x]  `set RHOST 127.0.0.1`
- [x]  Note that it doesn't show "Exploit failed: NoMethodError undefined method `downcase' for nil:NilClass" as before the fix.

