### PR TITLE
Improve atg_client to detected unsupported commands

### DIFF
--- a/modules/auxiliary/admin/atg/atg_client.rb
+++ b/modules/auxiliary/admin/atg/atg_client.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Auxiliary
         This module acts as a simplistic administrative client for interfacing
         with Veeder-Root Automatic Tank Gauges (ATGs) or other devices speaking
         the TLS-250 and TLS-350 protocols.  This has been tested against
-        GasPot, a honeypot meant to simulate ATGs; it has not been tested
-        against anything else, so use at your own risk.
+        GasPot and Conpot, both honeypots meant to simulate ATGs; it has not
+        been tested against anything else, so use at your own risk.
       },
       'Author'         =>
         [
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://community.rapid7.com/community/infosec/blog/2015/01/22/the-internet-of-gas-station-tank-gauges'],
           ['URL', 'http://www.trendmicro.com/vinfo/us/security/news/cybercrime-and-digital-threats/the-gaspot-experiment'],
           ['URL', 'https://github.com/sjhilt/GasPot'],
+          ['URL', 'https://github.com/mushorg/conpot'],
           ['URL', 'http://www.veeder.com/us/automatic-tank-gauge-atg-consoles'],
           ['URL', 'http://www.chipkin.com/files/liz/576013-635.pdf'],
           ['URL', 'http://www.veeder.com/gold/download.cfm?doc_id=6227']
@@ -187,6 +188,8 @@ class MetasploitModule < Msf::Auxiliary
   def get_response(request)
     sock.put(request)
     response = sock.get_once(-1, timeout)
+    response.strip!
+    response += " (command not understood)" if response == "9999FF1B"
     response
   end
 
@@ -245,7 +248,8 @@ class MetasploitModule < Msf::Auxiliary
         end
       else
         response = get_response("#{action.opts[protocol_opt_name]}\n")
-        print_good("#{protocol} #{action.opts['Description']}:\n#{response}")
+        print_good("#{protocol} #{action.opts['Description']}:")
+        print_line(response)
       end
     ensure
       disconnect


### PR DESCRIPTION
Previously, if you chose an `ACTION` that the target didn't support, you'd get this output:

```
*] Scanned 1 of 2 hosts (50% complete)
[+] 127.0.0.1:10001       - TLS-350 IS00100 Reset (untested):
9999FF1B
```

99999FF1B is the response returned when the command is not understood, which could mean that the command in general isn't understood or the options were invalid, etc.  This just cleans up the output and makes it more obvious that this is what the output represents.

## Verification

List the steps needed to make sure this thing works

- [x] Install and run either GasPot or Conpot
- [x] Start `msfconsole`
- [x] `use auxiliary/admin/atg/atg_client`
- [x] `set RHOSTS <your target>`
- [x] `run`, confirming that it returns the default `INVENTORY`output, like:
```
[+] 127.0.0.1:10001       - TLS-350 200/I20100 In-tank inventory report:
I20100
11/03/2016 22:15

STATOIL STATION



IN-TANK INVENTORY

TANK PRODUCT             VOLUME TC VOLUME   ULLAGE   HEIGHT    WATER     TEMP
  1  SUPER                 4924      5084     6930    36.08     7.30    51.41
  2  UNLEAD                5995      6104     5618    46.18     8.23    59.81
  3  DIESEL                6618      6642     6572    37.11     0.38    55.96
  4  PREMIUM               5372      5409     6572    68.07     3.47    54.38
```
- [x] `set ACTION <some command the target doesn't support>`.  The `RESET` action seems to trigger this behavior against both GasPot and Conpot.
- [ ] `run`, confirming that the output indicates the command is not supported.

