### PR TITLE
fix get_ipv4_addr(@interface) usage

### DIFF
--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
       raise RuntimeError ,'Source MAC is not in correct format' unless is_mac?(@smac)
 
       @sip = datastore['LOCALSIP']
-      @sip ||= get_ipv4_addr(@interface)[0] if @netifaces
+      @sip ||= get_ipv4_addr(@interface) if @netifaces
       raise "LOCALSIP is not defined and can not be guessed" unless @sip
       raise "LOCALSIP is not an ipv4 address" unless Rex::Socket.is_ipv4?(@sip)
 


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification
### Command to reproduce
```
msfconsole
use auxiliary/spoof/arp/arp_poisoning
set AUTO_ADD true
set BIDIRECTIONAL true
set INTERFACE eth0
set SHOSTS 192.168.0.101
set DHOSTS 192.168.0.1
run -j
```

It raises **LOCALSIP is not an ipv4 address**
### Related code:
```
@sip = datastore['LOCALSIP']
@sip ||= get_ipv4_addr(@interface)[0] if @netifaces
```
`raise "LOCALSIP is not an ipv4 address" unless Rex::Socket.is_ipv4?(@sip)`

Debug to find the @sip is 1 , which is 1 in 192.168.0.101 , obviously a mistake of taking the string as an array.
Removing the [0] , working good.


get_ipv4_addr(@interface) returns a string not array, so get_ipv4_addr(@interface)[0] only got the first character of IP , which raises an error.
