### PR TITLE
Deprecate/move wp_ninja_forms_unauthenticated_file_upload

### DIFF
--- a/modules/exploits/multi/http/wp_ninja_forms_unauthenticated_file_upload.rb
+++ b/modules/exploits/multi/http/wp_ninja_forms_unauthenticated_file_upload.rb
@@ -10,9 +10,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HTTP::Wordpress
-  include Msf::Module::Deprecated
-
-  deprecated(Date.new(2016, 12, 10), 'exploit/multi/http/wp_ninja_forms_unauthenticated_file_upload')
 
   def initialize(info = {})
     super(update_info(


### PR DESCRIPTION
wp_ninja_forms_unauthenticated_file_upload actually supports multiple platforms.
    
Instead of using:
exploit/unix/webapp/wp_ninja_forms_unauthenticated_file_upload
    
Please use:
exploit/multi/http/wp_ninja_forms_unauthenticated_file_upload


Verification

- [x] Load exploit/unix/webapp/wp_ninja_forms_unauthenticated_file_upload in msfconsole, you should see the following message:

```
msf > use exploit/unix/webapp/wp_ninja_forms_unauthenticated_file_upload 

[!] ******************************************************************************************
[!] *    The module unix/webapp/wp_ninja_forms_unauthenticated_file_upload is deprecated!    *
[!] *                       It will be removed on or about 2016-12-10                        *
[!] *       Use exploit/multi/http/wp_ninja_forms_unauthenticated_file_upload instead        *
[!] ******************************************************************************************
```

- [x] Make sure you can load exploit/multi/http/wp_ninja_forms_unauthenticated_file_upload