### PR TITLE
Fix powershell option for shell_to_meterpreter module

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Post
     case platform
     when 'win'
       if session.type == 'powershell'
-        template_path = File.join(Msf::Config.data_directory, 'templates', 'scripts')
+        template_path = Rex::Powershell::Templates::TEMPLATE_DIR
         psh_payload = case datastore['Powershell::method']
                       when 'net'
                         Rex::Powershell::Payload.to_win32pe_psh_net(template_path, payload_data)


### PR DESCRIPTION
when we cleaned up all the other powershell template refs
we missed the one in this module which seems to e replicating
large ammounts of library code

7533

https://github.com/rapid7/metasploit-framework/issues/7533

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] get a  powershell shell session on a windows box
- [x] use the sessions -u console command on the session 
- [x] **Verify** it runs the session upgrade
- [x] **Verify** you do not get an error about a missing file

