### PR TITLE
Prevent auxiliary/admin/smb/psexec_command from dying when one host errors

### DIFF
--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       simple.connect("\\\\#{@ip}\\#{@smbshare}")
     rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
-      print_error("Unable to connect for cleanup: #{accesserror}. Maybe you'll need to manually remove #{left.join(", ")} from the target.")
+      print_error("Unable to connect for cleanup: #{accesserror}. Maybe you'll need to manually remove #{files.join(", ")} from the target.")
       return
     end
     print_status("Executing cleanup...")

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -136,7 +136,11 @@ class MetasploitModule < Msf::Auxiliary
 
   # check if our process is done using these files
   def exclusive_access(*files)
+    begin
       simple.connect("\\\\#{@ip}\\#{@smbshare}")
+    rescue
+      return false
+    end
       files.each do |file|
       begin
         print_status("checking if the file is unlocked")
@@ -154,7 +158,12 @@ class MetasploitModule < Msf::Auxiliary
 
   # Removes files created during execution.
   def cleanup_after(*files)
-    simple.connect("\\\\#{@ip}\\#{@smbshare}")
+    begin
+      simple.connect("\\\\#{@ip}\\#{@smbshare}")
+    rescue
+      print_error("Unable to connect for cleanup. Maybe you'll need to manually remove #{left.join(", ")} from the target.")
+      return
+    end
     print_status("Executing cleanup...")
     files.each do |file|
       begin

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -155,8 +155,8 @@ class MetasploitModule < Msf::Auxiliary
     end
     return true
   end
-  
-  
+
+
   # Removes files created during execution.
   def cleanup_after(*files)
     begin

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -138,10 +138,11 @@ class MetasploitModule < Msf::Auxiliary
   def exclusive_access(*files)
     begin
       simple.connect("\\\\#{@ip}\\#{@smbshare}")
-    rescue
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
+      print_status("Unable to get handle: #{accesserror}")
       return false
     end
-      files.each do |file|
+    files.each do |file|
       begin
         print_status("checking if the file is unlocked")
         fd = smb_open(file, 'rwo')
@@ -154,14 +155,14 @@ class MetasploitModule < Msf::Auxiliary
     end
     return true
   end
-
-
+  
+  
   # Removes files created during execution.
   def cleanup_after(*files)
     begin
       simple.connect("\\\\#{@ip}\\#{@smbshare}")
-    rescue
-      print_error("Unable to connect for cleanup. Maybe you'll need to manually remove #{left.join(", ")} from the target.")
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
+      print_error("Unable to connect for cleanup: #{accesserror}. Maybe you'll need to manually remove #{left.join(", ")} from the target.")
       return
     end
     print_status("Executing cleanup...")


### PR DESCRIPTION
This fixes an issue where certain hosts can cause auxiliary/admin/smb/psexec_command to completely stop execution by returning STATUS_BAD_NETWORK_NAME during cleanup. This is a problem when RHOSTS contains many hosts. Execution should continue for other hosts and gracefully fail for the failed host.

A traceback of the issue in the wild is:
```
[*] 192.168.0.1:445      - Closing service handle...
[-] Auxiliary failed: Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_BAD_NETWORK_NAME (Command=117 WordCount=0)
[-] Call stack:
[-]   /opt/metasploit-framework/lib/rex/proto/smb/client.rb:259:in `smb_recv_parse'
[-]   /opt/metasploit-framework/lib/rex/proto/smb/client.rb:1114:in `tree_connect'
[-]   /opt/metasploit-framework/lib/rex/proto/smb/simpleclient.rb:135:in `connect'
[-]   /opt/metasploit-framework/modules/auxiliary/admin/smb/psexec_command.rb:139:in `exclusive_access'
[-]   /opt/metasploit-framework/modules/auxiliary/admin/smb/psexec_command.rb:81:in `block in run_host'
[-]   /usr/local/rvm/gems/ruby-2.3.1@metasploit-framework/gems/activesupport-4.2.7/lib/active_support/core_ext/range/each.rb:7:in `each'
[-]   /usr/local/rvm/gems/ruby-2.3.1@metasploit-framework/gems/activesupport-4.2.7/lib/active_support/core_ext/range/each.rb:7:in `each_with_time_with_zone'
[-]   /opt/metasploit-framework/modules/auxiliary/admin/smb/psexec_command.rb:78:in `run_host'
[-]   /opt/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:133:in `block (2 levels) in run'
[-]   /opt/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
[*] Auxiliary module execution completed
```


## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/smb/psexec_command`
- [x] set RHOSTS to a value with many hosts, including one host that returns STATUS_BAD_NETWORK_NAME
- [x] `exploit`
- [x] Observe that execution only fails on the host that fails, not all unfinished hosts.

