### PR TITLE
Update the Gemfile to pull in the new rex-text Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.0)
-    rex-text (0.2.4)
+    rex-text (0.2.5)
     rex-zip (0.1.0)
       rex-text
     rkelly-remix (0.0.6)


### PR DESCRIPTION
This PR just updated the Gemfile.lock to pull the latest version of rex-text (0.2.5) now that https://github.com/rapid7/rex-text/pull/5 has been landed.

This fixes #7500

# Testing
- [x] _Before starting metasploit_ `bundle show rex-text`
- [x] Verify that the version shown is 0.2.5
- [x] `msfconsole -q`
- [x] `use exploit/windows/smb/psexec`
- [x] `set SMBDomain домен`
- [x]  `set SMBUser администратор`
- [x] `show options`
- [x] Verify that the table has the correct padding for both Unicode and ANSI values