### PR TITLE
Add a print_bad alias for print_error

### DIFF
--- a/lib/metasploit/framework/login_scanner/telnet.rb
+++ b/lib/metasploit/framework/login_scanner/telnet.rb
@@ -133,6 +133,8 @@ module Metasploit
           @parent.print_error(message)
         end
 
+        alias_method :print_bad, :print_error
+
       end
     end
   end

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -667,6 +667,8 @@ module Auxiliary::AuthBrute
     print_brute :level => :verror, :legacy_msg => msg
   end
 
+  alias_method :vprint_bad, :vprint_error
+
   # Legacy vprint
   def vprint_good(msg='')
     print_brute :level => :vgood, :legacy_msg => msg

--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -326,5 +326,7 @@ class Auxiliary::Web::HTTP
     @parent.print_error message
   end
 
+  alias_method :print_bad, :print_error
+
 end
 end

--- a/lib/msf/core/module/ui/message.rb
+++ b/lib/msf/core/module/ui/message.rb
@@ -8,6 +8,8 @@ module Msf::Module::UI::Message
     super(print_prefix + msg)
   end
 
+  alias_method :print_bad, :print_error
+
   def print_good(msg='')
     super(print_prefix + msg)
   end

--- a/lib/msf/core/module/ui/message/verbose.rb
+++ b/lib/msf/core/module/ui/message/verbose.rb
@@ -4,6 +4,8 @@ module Msf::Module::UI::Message::Verbose
     print_error(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])
   end
 
+  alias_method :vprint_bad, :vprint_error
+
   # Verbose version of #print_good
   def vprint_good(msg='')
     print_good(msg) if datastore['VERBOSE'] || (!framework.nil? && framework.datastore['VERBOSE'])

--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -19,6 +19,8 @@ class Msf::Payload::Apk
     $stderr.puts "[-] #{msg}"
   end
 
+  alias_method :print_bad, :print_error
+
   def usage
     print_error "Usage: #{$0} -x [target.apk] [msfvenom options]\n"
     print_error "e.g. #{$0} -x messenger.apk -p android/meterpreter/reverse_https LHOST=192.168.1.1 LPORT=8443\n"

--- a/lib/msf/core/plugin.rb
+++ b/lib/msf/core/plugin.rb
@@ -112,6 +112,8 @@ class Plugin
     output.print_error(msg) if (output)
   end
 
+  alias_method :print_bad, :print_error
+
   #
   # Prints a 'good' message.
   #

--- a/lib/rex/script/base.rb
+++ b/lib/rex/script/base.rb
@@ -9,6 +9,7 @@ class Base
     def print_status(msg); end
     def print_good(msg); end
     def print_error(msg); end
+    alias_method :print_bad, :print_error
     def print_warning(msg); end
   end
 

--- a/lib/rex/ui/output.rb
+++ b/lib/rex/ui/output.rb
@@ -24,6 +24,8 @@ class Output
   def print_error(msg='')
   end
 
+  alias_method :print_bad, :print_error
+
   #
   # Prints a 'good' message.
   #

--- a/lib/rex/ui/subscriber.rb
+++ b/lib/rex/ui/subscriber.rb
@@ -46,6 +46,8 @@ module Subscriber
       end
     end
 
+    alias_method :print_bad, :print_error
+
     #
     # Wraps user_output.print_good
     #

--- a/lib/rex/ui/text/bidirectional_pipe.rb
+++ b/lib/rex/ui/text/bidirectional_pipe.rb
@@ -80,6 +80,8 @@ class BidirectionalPipe < Rex::Ui::Text::Input
     print_line('[-] ' + msg)
   end
 
+  alias_method :print_bad, :print_error
+
   def print_line(msg='')
     print(msg + "\n")
   end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -61,6 +61,8 @@ module DispatcherShell
       shell.print_error(msg)
     end
 
+    alias_method :print_bad, :print_error
+
     #
     # Wraps shell.print_status
     #

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -51,6 +51,8 @@ class Output < Rex::Ui::Output
     print_line("%bld%red[-]%clr #{msg}")
   end
 
+  alias_method :print_bad, :print_error
+
   def print_good(msg = '')
     print_line("%bld%grn[+]%clr #{msg}")
   end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -276,6 +276,8 @@ module Shell
     log_output(output.print_error(msg))
   end
 
+  alias_method :print_bad, :print_error
+
   #
   # Prints a status message to the output handle.
   #

--- a/spec/lib/msf/core/post/windows/mssql_spec.rb
+++ b/spec/lib/msf/core/post/windows/mssql_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Msf::Post::Windows::MSSQL do
   let(:subject) do
     mod = double(Module.new)
     mod.extend described_class
-    stubs = [ :vprint_status, :print_status, :vprint_good, :print_good, :print_error, :print_warning ]
+    stubs = [ :vprint_status, :print_status, :vprint_good, :print_good,
+      :print_error, :vprint_error, :print_bad, :vprint_bad, :print_warning ]
     stubs.each { |meth| allow(mod).to receive(meth) }
     allow(mod).to receive(:service_info).and_return({})
     mod

--- a/spec/lib/msf/core/post/windows/runas_spec.rb
+++ b/spec/lib/msf/core/post/windows/runas_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Msf::Post::Windows::Runas do
   let(:subject) do
     mod = double(Module.new)
     mod.extend described_class
-    stubs = [ :vprint_status, :print_status, :vprint_good, :print_good, :print_error ]
+    stubs = [ :vprint_status, :print_status, :vprint_good, :print_good,
+      :print_error, :vprint_error, :print_bad, :vprint_bad ]
     stubs.each { |meth| allow(mod).to receive(meth) }
     allow(mod).to receive_message_chain("session.railgun.kernel32").and_return(kernel32)
     allow(mod).to receive_message_chain("session.railgun.advapi32").and_return(advapi32)

--- a/spec/support/shared/contexts/msf/ui_driver.rb
+++ b/spec/support/shared/contexts/msf/ui_driver.rb
@@ -17,6 +17,10 @@ RSpec.shared_context 'Msf::UIDriver' do
         @error ||= []
         @error.concat string.split("\n")
       end
+      allow(driver).to receive(:print_bad).with(kind_of(String)) do |string|
+        @error ||= []
+        @error.concat string.split("\n")
+      end
     }
   end
 end

--- a/spec/support/shared/examples/msf/module/ui/message.rb
+++ b/spec/support/shared/examples/msf/module/ui/message.rb
@@ -2,6 +2,7 @@ RSpec.shared_examples_for 'Msf::Module::UI::Message' do
   it_should_behave_like 'Msf::Module::UI::Message::Verbose'
 
   it { is_expected.to respond_to :print_error }
+  it { is_expected.to respond_to :print_bad }
   it { is_expected.to respond_to :print_good }
   it { is_expected.to respond_to :print_prefix }
   it { is_expected.to respond_to :print_status }

--- a/spec/support/shared/examples/msf/module/ui/message/verbose.rb
+++ b/spec/support/shared/examples/msf/module/ui/message/verbose.rb
@@ -1,5 +1,6 @@
 RSpec.shared_examples_for 'Msf::Module::UI::Message::Verbose' do
   it { is_expected.to respond_to :vprint_error }
+  it { is_expected.to respond_to :vprint_bad }
   it { is_expected.to respond_to :vprint_good }
   it { is_expected.to respond_to :vprint_status }
   it { is_expected.to respond_to :vprint_warning }


### PR DESCRIPTION
Came up on Twitter, where Justin may have been trolling a little:

https://twitter.com/jstnkndy/status/798671298302017536

We have a `print_good` method, but not a `print_bad`, which seems a
little weird for Ruby -- opposite methods should be intuitive as Justin
is implying.

Anyway, I went with alias_method, thanks to the compelling argument at

https://github.com/bbatsov/ruby-style-guide#alias-method

...since Metasploit is all about the singleton, and didn't want to risk
some unexpected scoping thing.

So, TL;dr: This adds `print_bad` as an alias for `print_error` everywhere that `print_error` is defined. It also adds `vprint_bad` as an alias for `vprint_error`.

## Verification

- [ ] `echo "<ruby>" > /tmp/print.rc`
- [ ] `echo "print_good 'This is good';print_bad 'This is bad'" >> /tmp/print.rc`
- [ ] `echo "</ruby>" >> /tmp/print.rc`
- [ ] `./msfconsole -Lqr /tmp/print.rc -x exit`

- [ ] **Verify** that you see the lines printed with correct console coloring.
