### PR TITLE
Fix for MS 2267 (from MSSI 103) SE campaign langing page will hang

### DIFF
--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -70,10 +70,10 @@ module Rex::Socket::SslTcpServer
 
       if not allow_nonblock?(ssl)
         begin
-          Timeout::timeout(2) {
+          Timeout::timeout(3.5) {
             ssl.accept
           }
-          rescue ::Exception => e
+          rescue ::Timeout::Error => e
             sock.close 
             raise ::OpenSSL::SSL::SSLError
           end

--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -3,6 +3,7 @@ require 'rex/socket'
 require 'rex/socket/tcp_server'
 require 'rex/io/stream_server'
 require 'rex/parser/x509_certificate'
+require 'timeout'
 
 ###
 #
@@ -68,7 +69,14 @@ module Rex::Socket::SslTcpServer
       ssl = OpenSSL::SSL::SSLSocket.new(sock, self.sslctx)
 
       if not allow_nonblock?(ssl)
-        ssl.accept
+        begin
+          Timeout::timeout(2) {
+            ssl.accept
+          }
+          rescue ::Exception => e
+            sock.close 
+            raise ::OpenSSL::SSL::SSLError
+          end
       else
         begin
           ssl.accept_nonblock


### PR DESCRIPTION
Social Engineering (SE) campaign with HTTPS landing page may hang. Turned out a single hang connection (say a client to the HTTPS server, not doing SSL handshake) can cause all access to landing page to hang.

The solution is to add a timeout for it.

## Verification
start a SE campaign with landing page with SSL enabled (HTTPS), 

telnet to the HTTPS server at the port

curl -v -k http://<serverIp:port>

Observe "curl" command will run successfully in the sense that it will do SSL handshake and then HTTP transaction (the result may be 404, but that's OK).

Add a timeout for ssl accept.