### PR TITLE
Better async print

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -40,6 +40,20 @@ begin
       ::Readline.completion_proc = tab_complete_proc || @rl_saved_proc
     end
 
+
+    #
+    # Retrieve the line buffer
+    #
+    def line_buffer
+      if defined? RbReadline
+        RbReadline.rl_line_buffer
+      else
+        ::Readline.line_buffer
+      end
+    end
+
+    attr_accessor :prompt
+
     #
     # Whether or not the input medium supports readline.
     #
@@ -124,12 +138,13 @@ begin
       # to reimplement []`Readline.readline`](https://github.com/luislavena/rb-readline/blob/ce4908dae45dbcae90a6e42e3710b8c3a1f2cd64/lib/readline.rb#L36-L58)
       # for rb-readline to support setting input and output.  Output needs to be set so that colorization works for the
       # prompt on Windows.
+      self.prompt = prompt
       if defined? RbReadline
         RbReadline.rl_instream = fd
         RbReadline.rl_outstream = output
 
         begin
-          line = RbReadline.readline(prompt)
+          line = RbReadline.readline("\001\r\033[K\002" + prompt)
         rescue ::Exception => exception
           RbReadline.rl_cleanup_after_signal()
           RbReadline.rl_deprep_terminal()
@@ -143,7 +158,7 @@ begin
 
         line.try(:dup)
       else
-        ::Readline.readline(prompt, true)
+        ::Readline.readline("\001\r\033[K\002" + prompt, true)
       end
     end
 

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -61,11 +61,13 @@ class Output < Rex::Ui::Output
   end
 
   def print_line(msg = '')
+    print("\033[s") # Save cursor position
     print("\r\033[K" + msg + "\n")
     if input and input.prompt
       print("\r\033[K")
       print(input.prompt)
       print(input.line_buffer)
+      print("\033[u\033[B") # Restore cursor, move down one line
     end
   end
 

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -29,6 +29,7 @@ class Output < Rex::Ui::Output
     super
   end
   attr_reader :config
+  attr_accessor :input
 
   def disable_color
     @config[:color] = false
@@ -60,7 +61,12 @@ class Output < Rex::Ui::Output
   end
 
   def print_line(msg = '')
-    print(msg + "\n")
+    print("\r\033[K" + msg + "\n")
+    if input and input.prompt
+      print("\r\033[K")
+      print(input.prompt)
+      print(input.line_buffer)
+    end
   end
 
   def print_warning(msg = '')

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -184,7 +184,9 @@ module Shell
           self.init_prompt = input.prompt
         end
 
+        output.input = input
         line = input.pgets()
+        output.input = nil
         log_output(input.prompt)
 
         # If a block was passed in, pass the line to it.  If it returns true,


### PR DESCRIPTION
This patch prevents information printed by background jobs from interfering with the interactive command prompt. It does this by cleanly reprinting the interactive prompt when it would otherwise be mangled by output. These animations help illustrate the change:

Old and Busted: https://gfycat.com/GoldenThoroughHummingbird
The New Hotness: https://gfycat.com/LivelyDefiniteArrowana

## Verification

- [x] Start `msfconsole`
- [x] use exploit/multi/handler
- [x] set ExitOnSession false
- [x] exploit -j -z
- [x] Pop many shells
- [x] Keep using msfconsole while the shells pop and notice that your prompt stays intact


