### PR TITLE
Fix the hanging of module auxiliary/scanner/ftp/titanftp_xcrc_travers…

### DIFF
--- a/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
     progress(file_size, file_size)
 
     fname = datastore['PATH'].gsub(/[\/\\]/, '_')
-    p = store_loot("titanftp.traversal", "text/plain", "rhost", file_data, fname)
+    p = store_loot("titanftp.traversal", "text/plain", ip, file_data, fname)
     print_status("Saved in: #{p}")
     vprint_status(file_data.inspect)
 


### PR DESCRIPTION
Fix the call to store_loop, thanks to Wei who pointed it out.

## Verification

List the steps needed to make sure this thing works

install titan ftp server or emulator:

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ftp/titanftp_xcrc_traversal`
- [x] set RHOSTS 127.0.0.1
- [x] run
- [x] observe that it succeed and you get the retrieved file in loot.



Thanks for Wei who pointed out the error: in store_loop call, it used "rhosts", should have been ip.