### PR TITLE
Fix #7455, handle the URIPORT option properly in is_uxss_injection

### DIFF
--- a/modules/auxiliary/gather/ie_uxss_injection.rb
+++ b/modules/auxiliary/gather/ie_uxss_injection.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
       host = "[#{host}]"
     end
 
-    if datastore['URIPORT'] != 0
+    if datastore['URIPORT']
       port = ':' + datastore['URIPORT'].to_s
     elsif (ssl and datastore["SRVPORT"] == 443)
       port = ''


### PR DESCRIPTION
The is_uxss_injection module is always treating the URIPORT as an integer even when it's not set. If not set, the option should be nil.

Verification

- [x] Start msfconsole
- [x] ```use auxiliary/gather/ie_uxss_injection```
- [x] Do ```run```
- [x] Go to the URL with IE
- [x] From the browser, view the HTML source. You should see a Base64 string
- [x] If you decode the Base64 string, you should see that the source URL for the image element has a port number #