### PR TITLE
Fix the exception issue reported in issue #7585

### DIFF
--- a/modules/auxiliary/scanner/http/brute_dirs.rb
+++ b/modules/auxiliary/scanner/http/brute_dirs.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Auxiliary
 
         # Look for a string we can signature on as well
         if(tcode >= 200 and tcode <= 299)
-
+          emesg = nil
           File.open(datastore['HTTP404Sigs'], 'rb').each do |str|
             if(res.body.index(str))
               emesg = str


### PR DESCRIPTION
Fixed the exception when running module auxiliary/scanner/http/brute_dirs

## Verification

List the steps needed to make sure this thing works

msf auxiliary(brute_dirs) > rerun
[*] Reloading module...


msf auxiliary(brute_dirs) >
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/brute_dirs`
- [x] `set RHOST 127.0.0.1`
- [x] `run`
- [x] verify getting output like the following (no exception)

[*] Using first 256 bytes of the response as 404 string
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

Fix the exception by initialize a key variable that caused the exception.