### PR TITLE
Fix incorrect disclosure date for OpenNMS exploit

### DIFF
--- a/modules/exploits/linux/misc/opennms_java_serialize.rb
+++ b/modules/exploits/linux/misc/opennms_java_serialize.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'OpenNMS / Linux x86_64', { 'Arch' => ARCH_X64, 'Platform' => 'linux' } ]
           ],
         'DefaultTarget'  => 0,
-        'DisclosureDate' => 'Nov 19 2014'
+        'DisclosureDate' => 'Nov 06 2015'
       )
     )
 


### PR DESCRIPTION
The disclosure date for modules/exploits/linux/misc/opennms_java_serialize.rb is incorrect. It is listed as Nov 19 2014 and should be post Nov 06 2015 based on the original source

(I was searching for exploits by date when I noticed this)

Fixes #7587 