### PR TITLE
Fix the issue 7589, both RHOST and RHOSTS options are quired

### DIFF
--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -8,8 +8,8 @@ require 'metasploit/framework/credential_collection'
 require 'metasploit/framework/login_scanner/buffalo'
 
 class MetasploitModule < Msf::Auxiliary
-  include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
 


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/buffalo_login`
- [x] `show missing`
- [x] verify that only "RHOSTS" shows up.


Thanks to Will who found it's due to the order of mixin. 