### PR TITLE
Fix the issue 7593 where I get a stacktrace when running module auxil…

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -108,21 +108,21 @@ class ClientRequest
           qstr << set_encode_uri(Rex::Text.rand_text_alphanumeric(rand(32)+1))
         end
       end
+      if opts.key?("vars_get") && opts['vars_get']
+        opts['vars_get'].each_pair do |var,val|
+          var = var.to_s
 
-      opts['vars_get'].each_pair do |var,val|
-        var = var.to_s
-
-        qstr << '&' if qstr.length > 0
-        qstr << (opts['encode_params'] ? set_encode_uri(var) : var)
-        # support get parameter without value
-        # Example: uri?parameter
-        if val
-          val = val.to_s
-          qstr << '='
-          qstr << (opts['encode_params'] ? set_encode_uri(val) : val)
+          qstr << '&' if qstr.length > 0
+          qstr << (opts['encode_params'] ? set_encode_uri(var) : var)
+          # support get parameter without value
+          # Example: uri?parameter
+          if val
+            val = val.to_s
+            qstr << '='
+            qstr << (opts['encode_params'] ? set_encode_uri(val) : val)
+          end
         end
       end
-
       if (opts['pad_post_params'])
         1.upto(opts['pad_post_params_count'].to_i) do |i|
           rand_var = Rex::Text.rand_text_alphanumeric(rand(32)+1)


### PR DESCRIPTION
Add a guard against opts['vars_get'] being nil

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/blind_sql_query`
- [x] `set RHOSTS 127.0.0.1`
- [x] `run`
- [x] **Verify** there is no exception
- [x] **Verify** the thing does not do what it should not

```
[*] [Normal response body: 10  code: 200]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```


Add a guard against the case when opts['vars_get'] is nil