### PR TITLE
Use old async-print behavior on Windows

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -139,12 +139,16 @@ begin
       # for rb-readline to support setting input and output.  Output needs to be set so that colorization works for the
       # prompt on Windows.
       self.prompt = prompt
+      reset_sequence = "\001\r\033[K\002"
+      if (/mingw/ =~ RUBY_PLATFORM)
+        reset_sequence = ""
+      end
       if defined? RbReadline
         RbReadline.rl_instream = fd
         RbReadline.rl_outstream = output
 
         begin
-          line = RbReadline.readline("\001\r\033[K\002" + prompt)
+          line = RbReadline.readline(reset_sequence + prompt)
         rescue ::Exception => exception
           RbReadline.rl_cleanup_after_signal()
           RbReadline.rl_deprep_terminal()
@@ -158,7 +162,7 @@ begin
 
         line.try(:dup)
       else
-        ::Readline.readline("\001\r\033[K\002" + prompt, true)
+        ::Readline.readline(reset_sequence + prompt, true)
       end
     end
 

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -63,6 +63,10 @@ class Output < Rex::Ui::Output
   end
 
   def print_line(msg = '')
+    if (/mingw/ =~ RUBY_PLATFORM) != nil
+      print(msg + "\n")
+      return
+    end
     print("\033[s") # Save cursor position
     print("\r\033[K" + msg + "\n")
     if input and input.prompt

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -63,7 +63,7 @@ class Output < Rex::Ui::Output
   end
 
   def print_line(msg = '')
-    if (/mingw/ =~ RUBY_PLATFORM) != nil
+    if (/mingw/ =~ RUBY_PLATFORM)
       print(msg + "\n")
       return
     end


### PR DESCRIPTION
This patch reverts the new async output behavior to the old behavior for Metasploit on Windows because Windows prompts do not understand ANSI terminal sequences. This addresses the windows-only regression mentioned by bcook-r7 at https://github.com/rapid7/metasploit-framework/pull/7570#issuecomment-261820423

## Verification

- [x] Install Metasploit for Windows from https://windows.metasploit.com/
- [x] Use the patched versions of readline.rb and output.rb
- [x] Notice that the old async print behavior is used, and there are no stray un-interpreted ANSI terminal sequences being printed.
