### PR TITLE
Don't complain when Proxies is an empty string

### DIFF
--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -61,7 +61,7 @@ module Msf
       # if it fails to start the listener.
       #
       def setup_handler
-        if datastore['Proxies'] and not datastore['ReverseAllowProxy']
+        if !datastore['Proxies'].blank? && !datastore['ReverseAllowProxy']
           raise RuntimeError, "TCP connect-back payloads cannot be used with Proxies. Use 'set ReverseAllowProxy true' to override this behaviour."
         end
 

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -63,7 +63,7 @@ module ReverseTcpDoubleSSL
   # if it fails to start the listener.
   #
   def setup_handler
-    if datastore['Proxies'] and not datastore['ReverseAllowProxy']
+    if !datastore['Proxies'].blank? && !datastore['ReverseAllowProxy']
       raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies. Can be overriden by setting ReverseAllowProxy to true'
     end
 

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -43,7 +43,7 @@ module ReverseTcpSsl
   # if it fails to start the listener.
   #
   def setup_handler
-    if datastore['Proxies'] and not datastore['ReverseAllowProxy']
+    if !datastore['Proxies'].blank? && !datastore['ReverseAllowProxy']
       raise RuntimeError, "TCP connect-back payloads cannot be used with Proxies. Use 'set ReverseAllowProxy true' to override this behaviour."
     end
 


### PR DESCRIPTION
Sometimes `'Proxies'` ends up being an empty string instead of the `nil` this code expects, which is still fine.

## Verification

- [x] Start `msfconsole`
- [x] use an exploit
- [x] `set Proxies ""`
- [x] `run`
- [x] **Verify** exploit works, no error about `ReverseAllowProxy`
- [x] `unset Proxies`
- [x] **Verify** exploit works, no error about `ReverseAllowProxy`

Fixes MS-2250