### PR TITLE
Fix the issue in MS2132 where OWA_LOGIN doesn't continue on connectio…

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -366,7 +366,7 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         print_line(res.to_s)
       end
-
+      disconnect(c)
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if not res
       print_error("#{msg} HTTP Connection Error, Aborting")
-      return :abort
+      return
     end
 
     if action.name != "OWA_2013" and res.get_cookies.empty?


### PR DESCRIPTION
When there is connection related error during the process of trying different user/pass pairs, it should continue.

## Verification

List the steps needed to make sure this thing works

- [x] Locate a OWA server you can control network connectivity to *or* use Jin's cool perf tool
- [x] Create a text file of username+passwords (userpass.lst) with the following contents:
```
admin admin
root password
jdole abc123
```
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/owa_login`
- [x] `set RHOST <IP of OWA server>`
- [x] `set USERPASS_FILE userpass.lst`
- [x] `run`

```
[*] 127.0.0.1:443 OWA - Testing version OWA_2013
[+] Found target domain: DOMA
[*] 127.0.0.1:443 - [1/3] - Trying admin : admin
[-] 127.0.0.1:443 OWA - HTTP Connection Error, Aborting
[*] 127.0.0.1:443 - [2/3] - Trying root : password
[+] 127.0.0.1:443 OWA - SUCCESSFUL LOGIN. 0.015487037 'DOMA\root' : 'password': NOTE password change required
[!] No active DB -- Credential data will not be saved!
[*] 127.0.0.1:443 - [3/3] - Trying jdole : abc123
[+] 127.0.0.1:443 OWA - SUCCESSFUL LOGIN. 0.015839386 'DOMA\jdole' : 'abc123': NOTE password change required
[*] Auxiliary module execution completed
```


The possibility of temporary connection disruption means this module should keep trying other user/pass pairs upon error.