### PR TITLE
Fix #7600 where connections to server are not closed after r…

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -366,7 +366,7 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         print_line(res.to_s)
       end
-
+      disconnect(c)
       res
     rescue ::Errno::EPIPE, ::Timeout::Error => e
       print_line(e.message) if datastore['HttpTrace']


### PR DESCRIPTION
Fix issue #7600 where MSF leaks socket after running CGI transaction against web server.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/owa_login`
- [ ] `set RHOST 127.0.0.1`
- [ ] `set USERPASS_FILE userpass.lst`  (it's a simple user/pass file with 3 entries)
- [ ] `run`
```
[*] 127.0.0.1:443 OWA - Testing version OWA_2013
[+] Found target domain: DOMA
[*] 127.0.0.1:443 - [1/3] - Trying admin : admin
[+] 127.0.0.1:443 OWA - SUCCESSFUL LOGIN. 0.005554442 'DOMA\admin' : 'admin': NOTE password change required
[!] No active DB -- Credential data will not be saved!
[*] 127.0.0.1:443 - [2/3] - Trying root : password
[+] 127.0.0.1:443 OWA - SUCCESSFUL LOGIN. 0.010243977 'DOMA\root' : 'password': NOTE password change required
[*] 127.0.0.1:443 - [3/3] - Trying jdole : abc123
[+] 127.0.0.1:443 OWA - SUCCESSFUL LOGIN. 0.005333255 'DOMA\jdole' : 'abc123': NOTE password change required
[*] Auxiliary module execution completed
```

on command line, run 
- [ ] `netstat -antp | grep 443`
- [ ]  verify there are no connections from 127.0.0.1 that are at ESTABLISHED state.


…unning CGI request to web server

Just add a call to disconnect.