### PR TITLE
Fix issue #7608 where the SSL option was not turned on by default

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
+        OptBool.new('SSL', [ false, 'Negotiate SSL/TLS for outgoing connections', true]),
         OptString.new('FILE', [ true, 'The file to traverse for', '/etc/passwd']),
         OptInt.new('MAXDIRS', [ true, 'The maximum directory depth to search', 7]),
       ], self.class)


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/cisco_nac_manager_traversal`
- [x] ` show options`
- [x]  verify that SSL option is true by default
```
Module options (auxiliary/scanner/http/cisco_nac_manager_traversal):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   FILE     /etc/passwd      yes       The file to traverse for
   MAXDIRS  7                yes       The maximum directory depth to search
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   127.0.0.1        yes       The target address range or CIDR identifier
   RPORT    443              yes       The target port
   SSL      true             no        Negotiate SSL/TLS for outgoing connections
   THREADS  1                yes       The number of concurrent threads
   VHOST                     no        HTTP server virtual host
```

Set the SSL option to be on by default.