### PR TITLE
Fix #7610, cisco_ironport_enum falsely claimed connection failed.

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -61,6 +61,7 @@ class MetasploitModule < Msf::Auxiliary
         'method'    => 'GET'
       })
       print_good("#{rhost}:#{rport} - Server is responsive...")
+      return 1
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
       return
     end


### PR DESCRIPTION
Ensure cisco_ironport_enum module doesn't incorrectly report a failed connection when everything is fine.

Fixes #7610.

## Verification

List the steps needed to make sure this thing works

- [x] Locate a Cisco IronPort web portal you can use or use Jin's cool perf tool
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/cisco_ironport_enum`
- [x] `set RHOSTS <IP of Cisco IronPort portal>`
- [x] ` run`
- [x] verify we get
```
[+] 127.0.0.1:443 - Server is responsive...
[+] 127.0.0.1:443 - Running Cisco IronPort Security Management Appliances (SMA) - AsyncOS v10.2 
[*] 127.0.0.1:443 - Starting login brute force...
[*] 127.0.0.1:443 - [1/1] - Trying username:"admin" with password:"ironport"
[+] 127.0.0.1:443 - SUCCESSFUL LOGIN - "admin":"ironport"
[!] No active DB -- Credential data will not be saved!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```


Make sure we return 1 in check_conn method.