### PR TITLE
Fix #7603, Race condition when loading auto_win32_multihandler.rc

### DIFF
--- a/scripts/resource/auto_win32_multihandler.rc
+++ b/scripts/resource/auto_win32_multihandler.rc
@@ -13,6 +13,10 @@ def out_path
   "#{Msf::Config::local_directory}/meterpreter_reverse_tcp.exe"
 end
 
+# Please see:
+# https://github.com/rapid7/metasploit-framework/issues/7603
+sleep(1)
+
 run_single("use payload/#{PAYLOAD}")
 run_single("set lhost #{payload_lhost}")
 run_single("set lport #{payload_lport}")


### PR DESCRIPTION
This fixes a ```undefined method `length' for nil:NilClass``` bug when msfconsole tries to load the auto_win32_multihandler RC script.

Verification

- [x] In a terminal, do: ```./msfconsole -r scripts/resource/auto_win32_multihandler.rc ```
- [x] You should see that a meterpreter is generated
- [x] In msfconsole, do ```jobs```, you should see that there is a listener/handler running.