### PR TITLE
Fix issue 7628, username extracted became garbled

### DIFF
--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def extract_members(res, url)
-    members = res.body.scan(/<div class="ccm\-profile\-member\-username">(.*)<\/div>/i)
+    members = res.body.scan(/<div class="ccm\-profile\-member\-username">(.*?)<\/div>/i)
 
     if members
       print_good("#{peer} Extracted #{members.length} entries")


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/concrete5_member_list`
- [x] `set RHOSTS 127.0.0.1`
- [x] `run`
```
msf auxiliary(concrete5_member_list) > rerun
[*] Reloading module...

[+] 127.0.0.1:80          Extracted 2 entries

Concrete5 members
=================

   UserID  Username  Profile
   ------  --------  -------
   123     john      profiles/123
   345     mary      profiles/345
```

Make the regular expression less aggressive.