### PR TITLE
Use and() and not or() to match the slow search

### DIFF
--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -289,7 +289,7 @@ module Msf::DBManager::ModuleCache
       end
 
       unioned_conditions = union_conditions.inject { |union, condition|
-        union.or(condition)
+.        union.and(condition)
       }
 
       query = query.where(unioned_conditions).to_a.uniq { |m| m.fullname }

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -289,7 +289,7 @@ module Msf::DBManager::ModuleCache
       end
 
       unioned_conditions = union_conditions.inject { |union, condition|
-.        union.and(condition)
+        union.and(condition)
       }
 
       query = query.where(unioned_conditions).to_a.uniq { |m| m.fullname }


### PR DESCRIPTION
For some frustrating reason, the db-backed search behaves completely differently than the slow search. Slow search does an `and()`, which makes a lot of sense; the db-backed search does an `or()`, which makes no sense. The end result is that trying to run the search query from the sample help text (`search cve:2009 type:exploit app:client`) returns thousands of results when connected to a DB and only one page of results when using the slow search.

This has supposedly been an issue back to 2013: https://community.rapid7.com/thread/3601

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole -nq` to disable the database
- [ ] `search cve:2009 type:exploit app:client`
- [ ] Restart `msfconsole` to and enable the database. Wait for the module cache to finish building.
- [ ] `search cve:2009 type:exploit app:client`
