### PR TITLE
Fix issue 7632 where MSF keeps trying after success.

### DIFF
--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -77,6 +77,7 @@ class MetasploitModule < Msf::Auxiliary
         password: pass,
         proof: auth.body.to_s
       )
+      return :next_user
     else
       print_error("#{target_url} - Dell iDRAC - Failed to login as '#{user}' with password '#{pass}'")
     end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

- [x] Start `msfconsole`
- [x] `use scanner/http/dell_idrac`
- [x] `set RHOSTS 127.0.0.1`
- [x] `run`
```
msf auxiliary(dell_idrac) > run
[*] Reloading module...

[*] Verifying that login page exists at 127.0.0.1
[*] Attempting authentication
[+] https://127.0.0.1:443/ - SUCCESSFUL login for user 'root' with password 'calvin'
[!] No active DB -- Credential data will not be saved!
[+] https://127.0.0.1:443/ - SUCCESSFUL login for user 'user1' with password 'calvin'
[+] https://127.0.0.1:443/ - SUCCESSFUL login for user 'admin' with password 'calvin'
[*] Scanned 1 of 1 hosts (100% complete)
```


Thanks to Wei who suggested adding "return :next_user" after success.