### PR TITLE
Fix unpack causing puid breakage in some cases

### DIFF
--- a/lib/msf/core/payload/uuid.rb
+++ b/lib/msf/core/payload/uuid.rb
@@ -138,7 +138,7 @@ class Msf::Payload::UUID
       raise ArgumentError, "Raw UUID must be at least 16 bytes"
     end
 
-    puid, plat_xor, arch_xor, plat_id, arch_id, tstamp = raw.unpack('A8C4N')
+    puid, plat_xor, arch_xor, plat_id, arch_id, tstamp = raw.unpack('a8C4N')
     plat     = find_platform_name(plat_xor ^ plat_id)
     arch     = find_architecture_name(arch_xor ^ arch_id)
     time_xor = [plat_xor, arch_xor, plat_xor, arch_xor].pack('C4').unpack('N').first


### PR DESCRIPTION
Have you ever seen this?
```
[-] [2016.11.30-14:29:42] https://xx.x.xx.xx:7777 handling request from yy.y.yy.yy; (UUID: xyic9izm) Exception handling request: The :puid parameter must be exactly 8 bytes
```
No? Well that's because it doesn't happen very often at all. It's been nagging away here and there like a mosquito that keeps coming back for another bite, and you can't quite kill the bugger.

This issue was caused by an incorrect `unpack` format in the UUID functionality. Subtle, but important. The unpacking documentation suggests:

* `a` == Arbitrary String
* `A` == Arbitrary String while cleaning whitespace and NULL bytes

We were using the latter, we should have been using the former. Recently we made changes to the way the `puid` in the UUID is generated, so that it makes full use of the entire 255 byte range for each of the 8 bytes, and that it generates the bytes using `SecureRandom`. I'm sure this change has had a result on UUIDs being generated with more characters that make this unpack format fail.

## Sample run

This is actually hard to verify during general, however the functionality can be simulated directly in IRB using a URI that has a UUID known to have bytes that cause the break:
```
>> Msf::Payload::UUID.parse_uri("88T_SwjZmgA91TzXZeto7QhnkkGucG7jYLYOvgjPBmbe6GgNQ49jg92nR5OfOuGHcSH-iF4PhnYr8a9M5REqzIJGxD6uPkeacy4lUx1ZgPd1DvULxhyuDECjwyE_NoHk72tVO8sQpHHyewYFpnOqqUux27A6zvE0dLYmuB7EqacsGsURDIBSUAzB8xVD3EIuGx4EkVLovxpceLiPQiGSjY99hk1bNEZcqAIiBQz1fUc")
88T_SwjZmgA91TzXZeto7QhnkkGucG7jYLYOvgjPBmbe6GgNQ49jg92nR5OfOuGHcSH-iF4PhnYr8a9M5REqzIJGxD6uPkeacy4lUx1ZgPd1DvULxhyuDECjwyE_NoHk72tVO8sQpHHyewYFpnOqqUux27A6zvE0dLYmuB7EqacsGsURDIBSUAzB8xVD3EIuGx4EkVLovxpceLiPQiGSjY99hk1bNEZcqAIiBQz1fUc
=> {:puid=>"\xF3\xC4\xFFK\b\xD9\x9A", :platform=>"windows", :arch=>"x64", :timestamp=>1480480056, :xor1=>61, :xor2=>213}
```

With this change in place, it looks like this instead:
```
>> Msf::Payload::UUID.parse_uri("88T_SwjZmgA91TzXZeto7QhnkkGucG7jYLYOvgjPBmbe6GgNQ49jg92nR5OfOuGHcSH-iF4PhnYr8a9M5REqzIJGxD6uPkeacy4lUx1ZgPd1DvULxhyuDECjwyE_NoHk72tVO8sQpHHyewYFpnOqqUux27A6zvE0dLYmuB7EqacsGsURDIBSUAzB8xVD3EIuGx4EkVLovxpceLiPQiGSjY99hk1bNEZcqAIiBQz1fUc")
88T_SwjZmgA91TzXZeto7QhnkkGucG7jYLYOvgjPBmbe6GgNQ49jg92nR5OfOuGHcSH-iF4PhnYr8a9M5REqzIJGxD6uPkeacy4lUx1ZgPd1DvULxhyuDECjwyE_NoHk72tVO8sQpHHyewYFpnOqqUux27A6zvE0dLYmuB7EqacsGsURDIBSUAzB8xVD3EIuGx4EkVLovxpceLiPQiGSjY99hk1bNEZcqAIiBQz1fUc
=> {:puid=>"\xF3\xC4\xFFK\b\xD9\x9A\x00", :platform=>"windows", :arch=>"x64", :timestamp=>1480480056, :xor1=>61, :xor2=>213}
```
Note that in the second output, the `\x00` (NULL byte) is present!

## Verification

- [x] Do the two above steps to show that things behave differently.

Thanks! /cc @hdm 

## Further Discussion
In the MSF source:
```
$ grep -r 'pack([^)]*A' lib | wc -l
30
```
Is it worth going through the other cases to make sure that the use of `A` is correct?