### PR TITLE
Fix #7628, concrete5_member_list HTML parser

### DIFF
--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -66,9 +66,9 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def extract_members(res, url)
-    members = res.body.scan(/<div class="ccm\-profile\-member\-username">(.*)<\/div>/i)
+    members = res.get_html_document.search('div[@class="ccm-profile-member-username"]')
 
-    if members
+    unless members.empty?
       print_good("#{peer} Extracted #{members.length} entries")
 
       # separate user data into userID, username and Profile URL
@@ -76,13 +76,15 @@ class MetasploitModule < Msf::Auxiliary
       users = []
 
       members.each do | mem |
-        userid = mem[0].scan(/\/view\/(\d+)/i)
-        username = mem[0].scan(/">(.+)<\/a>/i)
-        profile = mem[0].scan(/href="(.+)">/i)
+        userid = mem.text.scan(/\/view\/(\d+)/i).flatten.first
+        anchor = mem.at('a')
+        username = anchor.text
+        profile = anchor.attributes['href'].value
         # add all data to memberlist for table output
-        memberlist.push([userid[0], username[0], profile[0]])
+
+        memberlist.push([userid, username, profile])
         # add usernames to users array for reporting
-        users.push(username[0])
+        users.push(username)
       end
 
       membertbl = Msf::Ui::Console::Table.new(
@@ -99,7 +101,7 @@ class MetasploitModule < Msf::Auxiliary
             ]})
 
       memberlist.each do | mem |
-        membertbl << ["#{mem[0].join}", "#{mem[1].join}", "#{mem[2].join}"]
+        membertbl << [mem[0], mem[1], mem[2]]
       end
 
       # print table


### PR DESCRIPTION
This fixes the HTML parser in concrete5_member_list. While extracting the username, the parser also ends up grabbing some junk HTML using regex. This fix uses Nokogiri to be able to collect strings more accurately.

@jinq102030 Could you grab this PR? Thanks.

Fix #7628

Verification

- [ ] Using vulnerabilityEmu, do: ```set 80 concrete5```
- [ ] Start msfconsole
- [ ] Do: ```use auxiliary/scanner/http/concrete5_member_list```
- [ ] Do: ```set rhosts 127.0.0.1```
- [ ] Do: ```run```
- [ ] You should get an output like the following:

```
msf auxiliary(concrete5_member_list) > rerun
[*] Reloading module...

[+] 127.0.0.1:80          Extracted 2 entries

Concrete5 members
=================

   UserID  Username  Profile
   ------  --------  -------
   123     john      profiles/123
   345     mary      profiles/345


[*] Scanned 1 of 1 hosts (100% complete)
```