### PR TITLE
Fix issue #7640 where cisco SSL VPN not move despite server responded

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -84,6 +84,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       res = send_request_cgi('uri' => '/', 'method' => 'GET')
       vprint_good("Server is responsive...")
+      return true
     rescue ::Rex::ConnectionRefused,
            ::Rex::HostUnreachable,
            ::Rex::ConnectionTimeout,


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/cisco_ssl_vpn`
- [x] `set RHOSTS 127.0.01`
- [x] `run`

```
msf auxiliary(cisco_ssl_vpn) > run
[*] Reloading module...

[+] Server is responsive...
[+] Application appears to be Cisco SSL VPN. Module will continue.
[*] Attempt to Enumerate VPN Groups...
[!] Unable to enumerate groups
[!] Using the default group: DefaultWEBVPNGroup
[*] Starting login brute force...
[*] Trying username:"cisco" with password:"cisco" and group:"DefaultWEBVPNGroup"
[+] SUCCESSFUL LOGIN - "cisco":"cisco":"DefaultWEBVPNGroup"
[*] Trying username:"cisco" with password:"cisco" and group:""
[+] SUCCESSFUL LOGIN - "cisco":"cisco":""
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```


Add the "return true" statement that was missing.