### PR TITLE
only use ANSI ctrl chars in stdio output

### DIFF
--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -63,18 +63,7 @@ class Output < Rex::Ui::Output
   end
 
   def print_line(msg = '')
-    if (/mingw/ =~ RUBY_PLATFORM)
-      print(msg + "\n")
-      return
-    end
-    print("\033[s") # Save cursor position
-    print("\r\033[K" + msg + "\n")
-    if input and input.prompt
-      print("\r\033[K")
-      print(input.prompt.tr("\001\002", ''))
-      print(input.line_buffer.tr("\001\002", ''))
-      print("\033[u\033[B") # Restore cursor, move down one line
-    end
+   print(msg + "\n")
   end
 
   def print_warning(msg = '')

--- a/lib/rex/ui/text/output/stdio.rb
+++ b/lib/rex/ui/text/output/stdio.rb
@@ -55,6 +55,23 @@ class Output::Stdio < Rex::Ui::Text::Output
     @io ||= $stdout
   end
 
+  # Use ANSI Control chars to reset prompt position for async output
+  # SEE https://github.com/rapid7/metasploit-framework/pull/7570
+  def print_line(msg = '')
+    if (/mingw/ =~ RUBY_PLATFORM)
+      print(msg + "\n")
+      return
+    end
+    print("\033[s") # Save cursor position
+    print("\r\033[K" + msg + "\n")
+    if input and input.prompt
+      print("\r\033[K")
+      print(input.prompt.tr("\001\002", ''))
+      print(input.line_buffer.tr("\001\002", ''))
+      print("\033[u\033[B") # Restore cursor, move down one line
+    end
+  end
+
   #
   # Prints the supplied message to standard output.
   #


### PR DESCRIPTION
MS-2298

When the ASYNC output cleanup went in for https://github.com/rapid7/metasploit-framework/pull/7570 the change was made to lib/rex/ui/text/output.rb which is the base class all UI output classes inherit from. This means that if output were directed to say a file, instead of a terminal, we'd still get those ANSI sequences which would be meaningless. By moving the changes over to the the stdio output class,a and reverting the base output class, we can mantain the new terminal behaviour while preserving the other outputs.

## Verification

- [x] Start `msfconsole`
- [x] use exploit/multi/handler
- [x] set ExitOnSession false
- [x] exploit -j -z
- [x] Pop many shells
- [x] Keep using msfconsole while the shells pop and notice that your prompt stays intact

## Pro Verification
- [x] Point your pro Gemfile to this copy of framework
- [x] launch a task inside Metasploit Pro
- [x] VERIFY you do not see things like `K[*]` in the Task Log

