### PR TITLE
Remove extra def report_cred in vbulletin_vote_sqli_exec

### DIFF
--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -385,32 +385,6 @@ class MetasploitModule < Msf::Exploit::Remote
       module_fullname: fullname,
       username: opts[:user],
       private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::UNTRIED,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
-  end
-
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
       private_type: :nonreplayable_hash,
       jtr_format: 'md5,raw-md5'
     }.merge(service_data)


### PR DESCRIPTION
There's actually two ```def report_cred``` in vbulletin_vote_sqli_exec, the one that doesn't report the credentials as hashes should be removed.