### PR TITLE
resolved #7645 where dolibarr_login module crashed

### DIFF
--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     return [nil, nil] if res.nil? || res.get_cookies.empty?
 
     # Get the session ID from the cookie
-    m = get_cookies.match(/(DOLSESSID_.+);/)
+    m = res.get_cookies.match(/(DOLSESSID_.+);/)
     id = (m.nil?) ? nil : m[1]
 
     # Get the token from the decompressed HTTP body response


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/dolibarr_login`
- [x] `set RHOSTS 127.0.0.1`
- [x] `run`
lots of output like:
```
[-] Bad login: "xampp-dav-unsecure:wampp"
[*] Trying "xampp-dav-unsecure:turnkey"
[*] Using sessiond ID: DOLSESSID_G=1234
[*] Using token: 567789
[-] Bad login: "xampp-dav-unsecure:turnkey"
[*] Trying "xampp-dav-unsecure:vagrant"
[*] Using sessiond ID: DOLSESSID_G=1234
[*] Using token: 567789
[-] Bad login: "xampp-dav-unsecure:vagrant"
[*] Trying "vagrant:admin"
[*] Using sessiond ID: DOLSESSID_G=1234
[*] Using token: 567789
[-] Bad login: "vagrant:admin"
[*] Trying "vagrant:password"
[*] Using sessiond ID: DOLSESSID_G=1234
[*] Using token: 567789
[-] Bad login: "vagrant:password"
[*] Trying "vagrant:manager"

```

closed #7645
Add "res" (http response) when trying to retrieve the cookie