### PR TITLE
Search with an intersect instead of a union

### DIFF
--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -243,12 +243,6 @@ module Msf::DBManager::ModuleCache
             @types << formatted_values
         end
       end
-
-      # unioned_conditions = union_conditions.inject { |union, condition|
-      #   union.or(condition)
-      # }
-      #
-      # @query = @query.where(unioned_conditions).to_a.uniq { |m| m.fullname }
     end
         
     @query = @query.module_arch(            @archs.to_a.flatten   ) if @archs.any?
@@ -259,7 +253,7 @@ module Msf::DBManager::ModuleCache
     @query = @query.module_type(            @types.to_a.flatten   ) if @types.any?
     @query = @query.module_stance(          @stances.to_a.flatten ) if @stances.any?
     @query = @query.module_ref(             @refs.to_a.flatten    ) if @refs.any?
-
+    
     @query.uniq
   end
 

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -25,11 +25,7 @@ module Msf::DBManager::ModuleCache
   # @param values [Set<String>, #each] a list of strings.
   # @return [Arrray<String>] strings wrapped like %<string>%
   def match_values(values)
-    wrapped_values = values.collect { |value|
-      "%#{value}%"
-    }
-
-    wrapped_values
+    values.collect { |value| "%#{value}%" }
   end
 
   def module_to_details_hash(m)
@@ -200,102 +196,66 @@ module Msf::DBManager::ModuleCache
       end
     end
 
-    query = Mdm::Module::Detail.all
-
     ActiveRecord::Base.connection_pool.with_connection do
-      # Although AREL supports taking the union or two queries, the ActiveRecord where syntax only supports
-      # intersection, so creating the where clause has to be delayed until all conditions can be or'd together and
-      # passed to one call ot where.
-      union_conditions = []
-
+      @query = Mdm::Module::Detail.all
+      
+      @authors = Set.new
+      @names = Set.new
+      @os = Set.new
+      @text = Set.new
+      @types = Set.new
+      @stances = Set.new
+      @refs = Set.new
+            
       value_set_by_keyword.each do |keyword, value_set|
+        formatted_values = match_values(value_set)
+        
         case keyword
           when 'author'
-            formatted_values = match_values(value_set)
-
-            query = query.includes(:authors).references(:authors)
-            module_authors = Mdm::Module::Author.arel_table
-            union_conditions << module_authors[:email].matches_any(formatted_values)
-            union_conditions << module_authors[:name].matches_any(formatted_values)
+            @authors << formatted_values
           when 'name'
-            formatted_values = match_values(value_set)
-
-            module_details = Mdm::Module::Detail.arel_table
-            union_conditions << module_details[:fullname].matches_any(formatted_values)
-            union_conditions << module_details[:name].matches_any(formatted_values)
+            @names << formatted_values
           when 'os', 'platform'
-            formatted_values = match_values(value_set)
-
-            query = query.includes(:platforms).references(:platforms)
-            union_conditions << Mdm::Module::Platform.arel_table[:name].matches_any(formatted_values)
-
-            query = query.includes(:targets).references(:targets)
-            union_conditions << Mdm::Module::Target.arel_table[:name].matches_any(formatted_values)
+            @os << formatted_values
           when 'text'
-            formatted_values = match_values(value_set)
-
-            module_details = Mdm::Module::Detail.arel_table
-            union_conditions << module_details[:description].matches_any(formatted_values)
-            union_conditions << module_details[:fullname].matches_any(formatted_values)
-            union_conditions << module_details[:name].matches_any(formatted_values)
-
-            query = query.includes(:actions).references(:actions)
-            union_conditions << Mdm::Module::Action.arel_table[:name].matches_any(formatted_values)
-
-            query = query.includes(:archs).references(:archs)
-            union_conditions << Mdm::Module::Arch.arel_table[:name].matches_any(formatted_values)
-
-            query = query.includes(:authors).references(:authors)
-            union_conditions << Mdm::Module::Author.arel_table[:name].matches_any(formatted_values)
-
-            query = query.includes(:platforms).references(:platforms)
-            union_conditions << Mdm::Module::Platform.arel_table[:name].matches_any(formatted_values)
-
-            query = query.includes(:refs).references(:refs)
-            union_conditions << Mdm::Module::Ref.arel_table[:name].matches_any(formatted_values)
-
-            query = query.includes(:targets).references(:targets)
-            union_conditions << Mdm::Module::Target.arel_table[:name].matches_any(formatted_values)
+            @text << formatted_values
           when 'type'
-            formatted_values = match_values(value_set)
-            union_conditions << Mdm::Module::Detail.arel_table[:mtype].matches_any(formatted_values)
+            @types << formatted_values
           when 'app'
             formatted_values = value_set.collect { |value|
               formatted_value = 'aggressive'
-
               if value == 'client'
                 formatted_value = 'passive'
               end
-
               formatted_value
             }
-
-            union_conditions << Mdm::Module::Detail.arel_table[:stance].eq_any(formatted_values)
+            @stances << formatted_values
           when 'ref'
-            formatted_values = match_values(value_set)
-
-            query = query.includes(:refs).references(:refs)
-            union_conditions << Mdm::Module::Ref.arel_table[:name].matches_any(formatted_values)
+            @refs << formatted_values
           when 'cve', 'bid', 'edb'
             formatted_values = value_set.collect { |value|
               prefix = keyword.upcase
-
               "#{prefix}-%#{value}%"
             }
-
-            query = query.includes(:refs).references(:refs)
-            union_conditions << Mdm::Module::Ref.arel_table[:name].matches_any(formatted_values)
         end
       end
 
-      unioned_conditions = union_conditions.inject { |union, condition|
-        union.or(condition)
-      }
-
-      query = query.where(unioned_conditions).to_a.uniq { |m| m.fullname }
+      # unioned_conditions = union_conditions.inject { |union, condition|
+      #   union.or(condition)
+      # }
+      #
+      # @query = @query.where(unioned_conditions).to_a.uniq { |m| m.fullname }
     end
+     
+    @query = @query.module_author(          @authors.to_a.flatten ) if @authors.any?
+    @query = @query.module_name(            @names.to_a.flatten   ) if @names.any?
+    @query = @query.module_os_or_platform(  @os.to_a.flatten      ) if @os.any?
+    @query = @query.module_text(            @text.to_a.flatten    ) if @text.any?
+    @query = @query.module_type(            @types.to_a.flatten   ) if @types.any?
+    @query = @query.module_app(             @stances.to_a.flatten ) if @stances.any?
+    @query = @query.module_ref(             @refs.to_a.flatten    ) if @refs.any?
 
-    query
+    @query.uniq
   end
 
   # Destroys the old Mdm::Module::Detail and creates a new Mdm::Module::Detail for


### PR DESCRIPTION
Making search work as expected.
Now when you search for multiple terms you will get a shorter list of modules instead of all of them.
Before this change when you run `search author:hdm arch:x64 app:aggressive` you will get 2287ish modules because its returning any module that matches each term individually. With this change you will get 2 results.

https://github.com/rapid7/metasploit_data_models/pull/166

## Verification
- [x] Start `msfconsole`
- [x] `search author:egypt arch:x64`
- [x] **Verify** it returns the following
```
Matching Modules
================

   Name                                       Disclosure Date  Rank       Description
   ----                                       ---------------  ----       -----------
   exploit/linux/local/udev_netlink           2009-04-16       great      Linux udev Netlink Local Privilege Escalation
   exploit/linux/postgres/postgres_payload    2007-06-05       excellent  PostgreSQL for Linux Payload Execution
   exploit/windows/local/current_user_psexec  1999-01-01       excellent  PsExec via Current User Token
```
- [x] `search author:brent arch:x64`
- [x] **Verify** it returns the following
```
Matching Modules
================

   Name                                  Disclosure Date  Rank    Description
   ----                                  ---------------  ----    -----------
   payload/linux/x64/mettle/bind_tcp                      normal  Linux Mettle x64, Bind TCP Stager
   payload/linux/x64/mettle/reverse_tcp                   normal  Linux Mettle x64, Reverse TCP Stager
```
- [x] `search author:brent author:egypt arch:x64`
- [x] **Verify** it returns the following
```
Matching Modules
================

   Name                                       Disclosure Date  Rank       Description
   ----                                       ---------------  ----       -----------
   exploit/linux/local/udev_netlink           2009-04-16       great      Linux udev Netlink Local Privilege Escalation
   exploit/linux/postgres/postgres_payload    2007-06-05       excellent  PostgreSQL for Linux Payload Execution
   exploit/windows/local/current_user_psexec  1999-01-01       excellent  PsExec via Current User Token
   payload/linux/x64/mettle/bind_tcp                           normal     Linux Mettle x64, Bind TCP Stager
   payload/linux/x64/mettle/reverse_tcp                        normal     Linux Mettle x64, Reverse TCP Stager
```
- [x] `search author:egypt author:brent arch:x64 arch:java`
- [x] **Verify** it returns the following
```
Matching Modules
================

   Name                                             Disclosure Date  Rank       Description
   ----                                             ---------------  ----       -----------
   exploit/linux/local/udev_netlink                 2009-04-16       great      Linux udev Netlink Local Privilege Escalation
   exploit/linux/postgres/postgres_payload          2007-06-05       excellent  PostgreSQL for Linux Payload Execution
   exploit/multi/browser/java_atomicreferencearray  2012-02-14       excellent  Java AtomicReferenceArray Type Violation Vulnerability
   exploit/multi/browser/java_jre17_jmxbean         2013-01-10       excellent  Java Applet JMX Remote Code Execution
   exploit/multi/browser/java_rmi_connection_impl   2010-03-31       excellent  Java RMIConnectionImpl Deserialization Privilege Escalation
   exploit/multi/browser/java_trusted_chain         2010-03-31       excellent  Java Statement.invoke() Trusted Method Chain Privilege Escalation
   exploit/windows/browser/java_basicservice_impl   2010-10-12       excellent  Sun Java Web Start BasicServiceImpl Code Execution
   exploit/windows/local/current_user_psexec        1999-01-01       excellent  PsExec via Current User Token
   payload/java/meterpreter/bind_tcp                                 normal     Java Meterpreter, Java Bind TCP Stager
   payload/java/meterpreter/reverse_http                             normal     Java Meterpreter, Java Reverse HTTP Stager
   payload/java/meterpreter/reverse_https                            normal     Java Meterpreter, Java Reverse HTTPS Stager
   payload/java/meterpreter/reverse_tcp                              normal     Java Meterpreter, Java Reverse TCP Stager
   payload/java/shell/bind_tcp                                       normal     Command Shell, Java Bind TCP Stager
   payload/java/shell/reverse_tcp                                    normal     Command Shell, Java Reverse TCP Stager
   payload/java/shell_reverse_tcp                                    normal     Java Command Shell, Reverse TCP Inline
   payload/linux/x64/mettle/bind_tcp                                 normal     Linux Mettle x64, Bind TCP Stager
   payload/linux/x64/mettle/reverse_tcp                              normal     Linux Mettle x64, Reverse TCP Stager
```
- [x] `search platform:ruby name:bind`
- [x] **Verify** it returns the following
```
Matching Modules
================

   Name                              Disclosure Date  Rank    Description
   ----                              ---------------  ----    -----------
   payload/ruby/shell_bind_tcp                        normal  Ruby Command Shell, Bind TCP
   payload/ruby/shell_bind_tcp_ipv6                   normal  Ruby Command Shell, Bind TCP IPv6
```
Fixes #7580, #6770