### PR TITLE
update session_compatible? for changes from PR#7507

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -160,34 +160,18 @@ module Msf::PostMixin
       return false unless self.module_info["SessionTypes"].include?(s.type)
     end
 
-    # Types are okay, now check the platform.  This is kind of a ghetto
-    # workaround for session platforms being ad-hoc and Platform being
-    # inflexible.
+    # Types are okay, now check the platform.
     if self.platform and self.platform.kind_of?(Msf::Module::PlatformList)
-      [
-        # Add as necessary
-        'win', 'linux', 'osx'
-      ].each do |name|
-        if self.platform =~ /#{name}/
-          p = Msf::Module::PlatformList.transform(name)
-          return false unless self.platform.supports? p
-        end
-      end
-    elsif self.platform and self.platform.kind_of?(Msf::Module::Platform)
-      p_klass = Msf::Module::Platform
-      case self.platform
-      when 'win'
-        return false unless self.platform.kind_of?(p_klass::Windows)
-      when 'osx'
-        return false unless self.platform.kind_of?(p_klass::OSX)
-      when 'linux'
-        return false unless self.platform.kind_of?(p_klass::Linux)
-      end
+      return false unless self.platform.supports?(Msf::Module::PlatformList.transform(s.base_platform))
     end
 
     # Check to make sure architectures match
     mod_arch = self.module_info['Arch']
+    unless mod_arch.nil?
     mod_arch = [mod_arch] unless mod_arch.kind_of?(Array)
+      # this looks incomplete like there should have been more testing done here
+      return false unless mod_arch.include? s.base_arch
+    end
 
     # If we got here, we haven't found anything that definitely
     # disqualifies this session.  Assume that means we can use it.

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -169,7 +169,6 @@ module Msf::PostMixin
     mod_arch = self.module_info['Arch']
     unless mod_arch.nil?
     mod_arch = [mod_arch] unless mod_arch.kind_of?(Array)
-      # this looks incomplete like there should have been more testing done here
       return false unless mod_arch.include? s.base_arch
     end
 


### PR DESCRIPTION
Brings session_compatible? method in line with the new session platform and arch layout from https://github.com/rapid7/metasploit-framework/pull/7507

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] get a session from a system
- [x] apply following diff to modules/post/multi/gather/env.rb
```
diff --git a/modules/post/multi/gather/env.rb b/modules/post/multi/gather/env.rb
index 9a970b7..117ab47 100644
--- a/modules/post/multi/gather/env.rb
+++ b/modules/post/multi/gather/env.rb
@@ -22,7 +22,32 @@ class MetasploitModule < Msf::Post
     @ltype = 'generic.environment'
   end
 
+  def _find_module(mname)
+    mod = self.framework.modules.create(mname)
+    if(not mod)
+      error(500, "Invalid Module")
+    end
+
+    mod
+  end
+
+  def test_all_modules
+    ret = []
+
+    mtype = "post"
+    names = framework.post.keys.map{ |x| "post/#{x}" }
+    names.each do |mname|
+      m = _find_module(mname)
+      next if not m.session_compatible?(1)
+      print_line m.fullname
+      ret << m.fullname
+    end
+    ret
+  end
+
+
   def run
+    test_all_modules
     case session.type
     when "shell"
       get_env_shell
```
- [x] `use post/multi/gather/env` && set SESSION {id}` && `run` module
- [x] **Verify** the module valid for the session are listed.


