### PR TITLE
Fixed issue #7650 where etherpad_duo_login module may crash

### DIFF
--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       return false
     end
 
-    if (res and res.code == 200 and res.headers['Server'] and res.headers['Server'].include?("EtherPAD") and res.body.include?("EtherPAD Duo"))
+    if (res and res.code == 200 and res.headers['Server'] =~ /EtherPAD/ and res.body.include?("EtherPAD Duo"))
       vprint_good("Running EtherPAD Duo application ...")
       return true
     else

--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       return false
     end
 
-    if (res and res.code == 200 and res.headers['Server'].include?("EtherPAD") and res.body.include?("EtherPAD Duo"))
+    if (res and res.code == 200 and res.headers['Server'] and res.headers['Server'].include?("EtherPAD") and res.body.include?("EtherPAD Duo"))
       vprint_good("Running EtherPAD Duo application ...")
       return true
     else


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/etherpad_duo_login`
- [x] `set RHOSTS 127.0.0.1`
- [x] `set USERPASS_FILE userpass.lst`
- [x] `run`
```
msf auxiliary(etherpad_duo_login) > run
[*] Reloading module...

[+] Running EtherPAD Duo application ...
[*] Starting login bruteforce...
[*] Trying username:"admin" with password:"admin"
[-] FAILED LOGIN - "admin":"admin"
[*] Trying username:"root" with password:"password"
[+] SUCCESSFUL LOGIN - "root":"password"
[!] No active DB -- Credential data will not be saved!
[*] Trying username:"jdole" with password:"abc123"
[-] FAILED LOGIN - "jdole":"abc123"
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```


Add check for presence of Server header.  Fixed issue #7650 