### PR TITLE
use platform for session_compatible? to support shell sessions

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -169,7 +169,7 @@ module Msf::PostMixin
     mod_arch = self.module_info['Arch']
     unless mod_arch.nil?
     mod_arch = [mod_arch] unless mod_arch.kind_of?(Array)
-      return false unless mod_arch.include? s.base_arch
+      return false unless mod_arch.include? s.arch
     end
 
     # If we got here, we haven't found anything that definitely

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -162,7 +162,7 @@ module Msf::PostMixin
 
     # Types are okay, now check the platform.
     if self.platform and self.platform.kind_of?(Msf::Module::PlatformList)
-      return false unless self.platform.supports?(Msf::Module::PlatformList.transform(s.base_platform))
+      return false unless self.platform.supports?(Msf::Module::PlatformList.transform(s.platform))
     end
 
     # Check to make sure architectures match


### PR DESCRIPTION
Address issue https://github.com/rapid7/metasploit-framework/issues/7656

restore support for basic shell sessions in session_compatible?

## Verification

- [x] Start `msfconsole`
- [x] get a session from a system
- [x] apply following diff to modules/post/multi/gather/env.rb
```
diff --git a/modules/post/multi/gather/env.rb b/modules/post/multi/gather/env.rb
index 9a970b7..117ab47 100644
--- a/modules/post/multi/gather/env.rb
+++ b/modules/post/multi/gather/env.rb
@@ -22,7 +22,32 @@ class MetasploitModule < Msf::Post
     @ltype = 'generic.environment'
   end
 
+  def _find_module(mname)
+    mod = self.framework.modules.create(mname)
+    if(not mod)
+      error(500, "Invalid Module")
+    end
+
+    mod
+  end
+
+  def test_all_modules
+    ret = []
+
+    mtype = "post"
+    names = framework.post.keys.map{ |x| "post/#{x}" }
+    names.each do |mname|
+      m = _find_module(mname)
+      next if not m.session_compatible?(1)
+      print_line m.fullname
+      ret << m.fullname
+    end
+    ret
+  end
+
+
   def run
+    test_all_modules
     case session.type
     when "shell"
       get_env_shell
```
- [x] `use post/multi/gather/env` && set SESSION {id}` && `run` module
- [x] **Verify** the module valid for the session are listed.
- [x] execute same for basic shell session type `linux/x64/shell/reverse_tcp`
