### PR TITLE
Repair cross architecture migration on Windows

### DIFF
--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -518,6 +518,9 @@ class ClientCore < Extension
 
     # if we change architecture, we need to change UUID as well
     if current_process['arch'] != target_process['arch']
+      if client.payload_uuid.nil?
+        client.payload_uuid = Msf::Payload::UUID.new(arch: client.arch, platform: client.platform)
+      end
       client.payload_uuid.arch = target_process['arch']
       request.add_tlv( TLV_TYPE_UUID, client.payload_uuid.to_raw )
     end


### PR DESCRIPTION
During testing of a long-overdue merge with upstream, discovered
that migrating between architectures is problematic for sessions
lacking a UUID. Tracked down the problem to client_core assigning
the client.payload_uuid.arch variable for the migration stub,
which causes a call to nil.arch= and that doesnt fly. Initially
attempted to bypass the assignment altogether with a check for
the payload_uuid, but this caused failure on the meterpreter side.

Addressed by generating a UUID from the arch and platform in the
same manner as the payload mixin does, but did not address the
tracking aspect (registration).

This issue and solution were validated on BlackArch pacakged MSF
which will be used as upstream baseline for testing, as well as
the SVIT fork which illustrated the issue first.

@OJ: this is your doing! could you please take a look at what ive
done here? For all i know you intended for all payloads to mixin
UUID functionality, or some other logical paradigm i'm not aware
of, so this fix may be an incorrect approach.