### PR TITLE
Overwatch Plugin - Active Routing and Session Management

### DIFF
--- a/plugins/overwatch.rb
+++ b/plugins/overwatch.rb
@@ -198,8 +198,6 @@ class Plugin::Overwatch < Msf::Plugin
       return unless route_compatible?(sid)
       return unless framework.sessions[sid].alive?
 
-      switch_board = Rex::Socket::SwitchBoard.instance
-
       framework.sessions[sid].net.config.each_route do | route |
         next unless route.subnet =~ /\./ # Pick out the IPv4 addresses
         subnet = get_subnet(route.subnet, route.netmask) # Make sure that the subnet is actually a subnet and not an IP address. Android phones like to send over their IP.
@@ -208,7 +206,7 @@ class Plugin::Overwatch < Msf::Plugin
         if subnet
           remove_if_stale(subnet, route.netmask, sid, stale_sids) if self.config[:reroute_stale]
 
-          if !switch_board.route_exists?(subnet, route.netmask)
+          if !Rex::Socket::SwitchBoard.route_exists?(subnet, route.netmask)
             begin
               if Rex::Socket::SwitchBoard.add_route(subnet, route.netmask, framework.sessions[sid])
                 session_log(sid, "Route added to subnet #{subnet}/#{route.netmask} from host's routing table.")
@@ -237,8 +235,6 @@ class Plugin::Overwatch < Msf::Plugin
       return unless interface_compatible?(sid)
       return unless framework.sessions[sid].alive?
 
-      switch_board = Rex::Socket::SwitchBoard.instance
-
       framework.sessions[sid].net.config.each_interface do | interface | # Step through each of the network interfaces
 
         (0..(interface.addrs.size - 1)).each do | index | # Step through the addresses for the interface
@@ -253,7 +249,7 @@ class Plugin::Overwatch < Msf::Plugin
           if subnet
             remove_if_stale(subnet, netmask, sid, stale_sids) if self.config[:reroute_stale]
 
-            if !switch_board.route_exists?(subnet, netmask)
+            if !Rex::Socket::SwitchBoard.route_exists?(subnet, netmask)
               begin
                 if Rex::Socket::SwitchBoard.add_route(subnet, netmask, framework.sessions[sid])
                   session_log(sid, "Route added to subnet #{subnet}/#{netmask} from #{interface.mac_name}.")


### PR DESCRIPTION
# Overview and Background

The primary goal of the Overwatch plugin is to better automate the task of Meterpreter session subnet routing to make it as seamless as possible to the user. Overwatch routing adds functionality similar to what was requested in issue #3803. The current `auto _add_route` plugin has very limited functionality and fails for http/https payloads.

The secondary goal is to help manage http/https sessions as they become stale over long engagements. This is accomplished by killing long stale sessions that either do and/or do not have a twin based on the user's preferences. (This behavior is off by default, more information below.)

**The session stepping and logging functionality is borrowed from HDM's Beholder plugin.**

# Features

## Routing
- Automatically adds routes to new subnets as Meterpreter sessions are opened.
- Adds routes based on both the target machine's routing table and interface list. This will add routes for things like full traffic VPN's that may not show up on the target's routing table.
- If a session with a subnet route dies and there is another session on that same subnet, it will re-route to the subnet using the live session within a short period of time.
- Will re-route around stale http/https sessions if there is another "active" session with access to the same subnet. The time to consider a session as stale for routing is configurable. Default is 30 seconds.
- Works with any Meterpeter session that returns target routing information. Confirmed on Windows, Linux, and Android Meterpreter payloads. PHP and Python Meterpreter payloads may not return this information.
- Is as close to "fail-over" routing as I can get it in a plugin. 

## Session management
- If `kill_stale_dup` is active (default is off), stale http/https sessions will be killed if there is an active session with the exact same user, machine, and privilege rights. The time to considder a session stale for duplicate removal is configurable. Default is 14400 seconds. This can come in handy to keep your session list clean on long engagements with http/https payloads.
- if `kill_stale` is active (default is off), a session that hits the configurable stale time is killed. Default time for this is 86400 seconds. This is the default timeout period for an http/https Meterpreter payload. Currently when this time is hit, the http/https payload dies on the target machine, but the framework still lists it. This option removes it from the list of sessions automatically after that time.

**Note: I don't take killing sessions lightly which is why the session management functions are off by default. These functions have a time and a place, but I think it needs to be a conscious effort to turn them on.**

## Logging
- Has the option to provide logs showing routing and session management information. Default is off.

## Other Features
- Can easily be started from a resource file with:
```
load overwatch
overwatch_start
```
- Can specify settings on start line:

`overwatch_start kill_stale_dup=true`

# Testing
I developed this plugin and finished initial testing just prior to starting the OffSec PTWK class. I used this plugin throughout the lab to see how it performed. It worked great! I did not have to worry about routing when Meterpreter payloads were used. (Too bad I can't use it on the exam.) It really came in handy in situations where shells were unstable and had to be restarted numerous times. Routing was automatic; I didn't have to set it up again for each new session after the old one died.

## Conformation
Steps to confirm functionality: (It helps to have serval machines/VM's on multiple subnets.)

- [ ] Check that routing occurs within a short period of time after a new Meterpreter session is created. Make sure all routable subnets and VPN subnets are added.

- [ ] Have two Meterpreter sessions going on the same subnet, kill the one with the route. Ensure that it re-routes to the other session. Can take up to 30 seconds. The time can depend on where the plugin's cycle was when the first session was killed. I worked that delay down as short as I could.

- [ ] Have two http/https sessions going on difference computers on the same subnet. Make one session go stale and ensure that the plugin re-routes to the active session after about 30 seconds.

- [ ] Test it on different Meterpeter payloads: Windows, Linux (and mettle), and Android.

- [ ] Turn on the session management functions and test that they behave as described above.

- [ ] Turn on logging and ensure that it properly logs events.

---

## Limitations
- Cannot distinguish between two networks that have the same subnet definitions. Example: Two targets on difference wireless networks that both use the 192.168.1.X subnet. The plugin will pick the first session that was opened or the session that is not stale.
- May not work with PHP or Python payloads that do not return routing information from their target machine.
- Not true fail-over, TCP connections routed over a session that dies will still be broken. But with the auto re-routing they can be re-established fairly quickly if there is another session with access to the subnet.
- Does not currently support IPv6 routing.

## Future Work / Possibilities
- Add support for IPv6 routing.
- Look at adding an ignore list and the ability to add or remove sessions from that list. Would help with the first limitation above.
- The session stepping functionality is already in place. Other active management functions could easily be added in the future.

## Final Note
I did not see a place for plugin documentation. I am happy to add a markdown document for this plugin if there is a place it needs to go.
