### PR TITLE
prevent further lockouts in smb_login

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -203,6 +203,8 @@ module Metasploit
             status = case e.get_error(e.error_code)
                      when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
                        Metasploit::Model::Login::Status::DENIED_ACCESS
+                     when 'STATUS_ACCOUNT_LOCKED_OUT'
+                       Metasploit::Model::Login::Status::LOCKED_OUT
                      when 'STATUS_LOGON_FAILURE', 'STATUS_ACCESS_DENIED'
                        Metasploit::Model::Login::Status::INCORRECT
                      else


### PR DESCRIPTION
@wchen-r7 I made a new PR because I'm a git moron and messed up the push to the other branch.

This change adds the ability to abort the entire run when an account lockout is detected, resulting in only one account being locked out instead of every user listed in USER_FILE or USERPASS_FILE. (This assumes each account has had the same number of failed login attempts, which is usually the case when using userlists.)

Verification:

* `set abort_on_lockout false`
* Put some users in a file and set USER_FILE
* Lock them out
* `set abort_on_lockout true`
* `run`, and it should stop after the first locked account