### PR TITLE
Metasploit payloads 1.2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.3)
+      metasploit-payloads (= 1.2.4)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.1.3)
       msgpack
@@ -169,7 +169,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.3)
+    metasploit-payloads (1.2.4)
     metasploit_data_models (2.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.3'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.4'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.3'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1189423
+  CachedSize = 1189935
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1190467
+  CachedSize = 1190979
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1190467
+  CachedSize = 1190979
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1189423
+  CachedSize = 1189935
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -13,7 +13,7 @@ require 'rex/payloads/meterpreter/config'
 
 module MetasploitModule
 
-  CachedSize = 1189423
+  CachedSize = 1189935
 
   include Msf::Payload::TransportConfig
   include Msf::Payload::Windows


### PR DESCRIPTION
Bump `metasploit-payloads` to version `1.2.4`. This brings in the updated binaries that fixes the UUID related issues that are causing failures for migration/etc.

/cc @wvu-r7 @bwatters-r7 

Thanks!