### PR TITLE
Fix the prompt again

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -139,7 +139,7 @@ begin
       # for rb-readline to support setting input and output.  Output needs to be set so that colorization works for the
       # prompt on Windows.
       self.prompt = prompt
-      reset_sequence = "\001\r\033[K\002"
+      reset_sequence = "\n\001\r\033[K\002"
       if (/mingw/ =~ RUBY_PLATFORM)
         reset_sequence = ""
       end


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/7661
This fixes an issue where the updated cursor behavior in https://github.com/rapid7/metasploit-framework/pull/7570/files and https://github.com/rapid7/metasploit-framework/pull/7643/files eats some bytes.

In the case where a line was printed without a newline at the end, the carriage return returned over part of the data.  This PR simply inserts a newline before executing the carriage return.

 ## Verification

List the steps needed to make sure this thing works

- [x] Create a psh command payload:
```
./msfvenom -p windows/meterpreter/reverse_tcp_rc4 -f psh-cmd LHOST=127.0.0.1 LPORT=4567 RC4PASSWORD=secret > msfvenom_cmd.txt
```

- [x] Start `msfconsole`
- [ ] `cat msfvenom_cmd.txt`
- [ ] verify that all the characters in the command showed up on the screen

