### PR TITLE
Fix #7671, support LOCKED_OUT and DISABLED login status

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -123,8 +123,13 @@ class MetasploitModule < Msf::Auxiliary
     @scanner.scan! do |result|
       case result.status
       when Metasploit::Model::Login::Status::LOCKED_OUT
-        print_error("Account lockout detected on '#{result.credential}'")
-        return if datastore['ABORT_ON_LOCKOUT']
+        if datastore['ABORT_ON_LOCKOUT']
+          print_error("Account lockout detected on '#{result.credential.public}', aborting.")
+          return
+        else
+          print_error("Account lockout detected on '#{result.credential.public}', skipping this user.")
+        end
+
       when Metasploit::Model::Login::Status::DENIED_ACCESS
         print_brute :level => :status, :ip => ip, :msg => "Correct credentials, but unable to login: '#{result.credential}', #{result.proof}"
         report_creds(ip, rport, result)

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::Proxies,
-        OptBool.new('ABORT_ON_LOCKOUT', [ true, "Abort the run when an account lockout is detected", true ]),
+        OptBool.new('ABORT_ON_LOCKOUT', [ true, "Abort the run when an account lockout is detected", false ]),
         OptBool.new('PRESERVE_DOMAINS', [ false, "Respect a username that contains a domain name.", true ]),
         OptBool.new('RECORD_GUEST', [ false, "Record guest-privileged random logins to the database", false ]),
         OptBool.new('DETECT_ANY_AUTH', [false, 'Enable detection of systems accepting any authentication', true])


### PR DESCRIPTION
This allows login scanner modules to skip a user if it is locked out, or disabled.

Fix #7671. Also related to #7665

Verification

- [x] Start a Windows server box that supports SMB login
- [x] Create two users
- [x] Enable Account lockout in Local Security Settings -> Account Lockout Policy 
- [x] Create a user/pass list with both usernames on it, but have no valid passwords
- [x] Start msfconsole
- [x] Do: ```use auxiliary/scanner/smb/smb_login```
- [x] Do: ```set ABORT_ON_LOCKOUT false```
- [x] Do: ```set RHOSTS [IP]```
- [x] Do: ```set USERPASS_FILE [path to the list]```
- [x] Do: ```run```
- [x] You should see that if the module detects the account is locked, it tries the next user
- [x] Do: ```set ABORT_ON_LOCKOUT true```
- [x] Do: ```run```
- [ ] You should see that if the module detects the account is locked, it aborts the module