### PR TITLE
Get ready for stageless mettle

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ PATH
       rb-readline-r7
       recog
       redcarpet
-      rex-arch (= 0.1.2)
+      rex-arch (= 0.1.4)
       rex-bin_tools
       rex-core
       rex-encoder
@@ -237,7 +237,7 @@ GEM
     recog (2.1.2)
       nokogiri
     redcarpet (3.3.4)
-    rex-arch (0.1.2)
+    rex-arch (0.1.4)
       rex-text
     rex-bin_tools (0.1.1)
       metasm
@@ -250,7 +250,7 @@ GEM
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.3)
+    rex-exploitation (0.1.4)
       jsobfu
       metasm
       rex-arch

--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -1,0 +1,22 @@
+# -*- coding: binary -*-
+
+require 'msf/core/payload/transport_config'
+require 'base64'
+
+module Msf
+module Sessions
+module MettleConfig
+
+  include Msf::Payload::TransportConfig
+
+  def generate_config(opts={})
+    transport = transport_config_reverse_tcp(opts)
+    opts[:uuid] ||= generate_payload_uuid
+    opts[:uuid] = Base64.encode64(opts[:uuid].to_raw).strip
+    opts[:uri] ||= "#{transport[:scheme]}://#{transport[:lhost]}:#{transport[:lport]}"
+    opts.slice(:uuid, :uri, :debug, :log_file)
+  end
+
+end
+end
+end

--- a/lib/msf/core/payload/uuid.rb
+++ b/lib/msf/core/payload/uuid.rb
@@ -38,7 +38,11 @@ class Msf::Payload::UUID
     19 => ARCH_DALVIK,
     20 => ARCH_PYTHON,
     21 => ARCH_NODEJS,
-    22 => ARCH_FIREFOX
+    22 => ARCH_FIREFOX,
+    23 => ARCH_ZARCH,
+    24 => ARCH_AARCH64,
+    25 => ARCH_MIPS64,
+    26 => ARCH_PPC64LE
   }
 
   Platforms = {

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -107,6 +107,10 @@ require 'msf/core/exe/segment_appender'
   # @return           [String]
   # @return           [NilClass]
   def self.to_executable(framework, arch, plat, code = '', opts = {})
+    if elf? code
+      return code
+    end
+
     if arch.index(ARCH_X86)
 
       if plat.index(Msf::Module::Platform::Windows)
@@ -959,6 +963,9 @@ require 'msf/core/exe/segment_appender'
   # @param big_endian [Boolean]  Set to "false" by default
   # @return           [String]
   def self.to_exe_elf(framework, opts, template, code, big_endian=false)
+    if elf? code
+      return code
+    end
 
     # Allow the user to specify their own template
     set_template_default(opts, template)
@@ -2127,6 +2134,9 @@ require 'msf/core/exe/segment_appender'
       exeopts[:uac] = true
       Msf::Util::EXE.to_exe_msi(framework, exe, exeopts)
     when 'elf'
+      if elf? code
+        return code
+      end
       if !plat || plat.index(Msf::Module::Platform::Linux)
         case arch
         when ARCH_X86,nil
@@ -2154,6 +2164,9 @@ require 'msf/core/exe/segment_appender'
         end
       end
     when 'elf-so'
+      if elf? code
+        return code
+      end
       if !plat || plat.index(Msf::Module::Platform::Linux)
         case arch
         when ARCH_X64
@@ -2291,6 +2304,10 @@ require 'msf/core/exe/segment_appender'
       raise RuntimeError, err_msg
     end
     bo
+  end
+
+  def self.elf?(code)
+    code[0..3] == "\x7FELF"
   end
 
 end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -128,7 +128,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rex-struct2'
   # Library which contains architecture specific information such as registers, opcodes,
   # and stack manipulation routines.
-  spec.add_runtime_dependency 'rex-arch', '0.1.2'
+  spec.add_runtime_dependency 'rex-arch', '0.1.4'
   # Library for working with OLE.
   spec.add_runtime_dependency 'rex-ole'
   # Library for creating and/or parsing MIME messages.

--- a/modules/payloads/stages/linux/armle/mettle.rb
+++ b/modules/payloads/stages/linux/armle/mettle.rb
@@ -6,10 +6,12 @@
 require 'msf/core'
 require 'msf/base/sessions/meterpreter_armle_linux'
 require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
 require 'rex/elfparsey'
 
 module MetasploitModule
   include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
 
   def initialize(info = {})
     super(
@@ -80,8 +82,6 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts[:uuid] ||= generate_payload_uuid
-    MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', opts.slice(:uuid, :url, :debug, :log_file)).
-      to_binary :process_image
+    MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsbe/mettle.rb
+++ b/modules/payloads/stages/linux/mipsbe/mettle.rb
@@ -6,10 +6,12 @@
 require 'msf/core'
 require 'msf/base/sessions/meterpreter_mipsbe_linux'
 require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
 require 'rex/elfparsey'
 
 module MetasploitModule
   include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
 
   def initialize(info = {})
     super(
@@ -91,8 +93,6 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts[:uuid] ||= generate_payload_uuid
-    MetasploitPayloads::Mettle.new('mips-linux-muslsf', opts.slice(:uuid, :url, :debug, :log_file)).
-      to_binary :process_image
+    MetasploitPayloads::Mettle.new('mips-linux-muslsf', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsle/mettle.rb
+++ b/modules/payloads/stages/linux/mipsle/mettle.rb
@@ -6,10 +6,12 @@
 require 'msf/core'
 require 'msf/base/sessions/meterpreter_mipsle_linux'
 require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
 require 'rex/elfparsey'
 
 module MetasploitModule
   include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
 
   def initialize(info = {})
     super(
@@ -91,8 +93,6 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts[:uuid] ||= generate_payload_uuid
-    MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', opts.slice(:uuid, :url, :debug, :log_file)).
-      to_binary :process_image
+    MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x64/mettle.rb
+++ b/modules/payloads/stages/linux/x64/mettle.rb
@@ -6,10 +6,12 @@
 require 'msf/core'
 require 'msf/base/sessions/meterpreter_x64_mettle_linux'
 require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
 require 'rex/elfparsey'
 
 module MetasploitModule
   include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
 
   def initialize(info = {})
     super(
@@ -88,8 +90,6 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts[:uuid] ||= generate_payload_uuid
-    MetasploitPayloads::Mettle.new('x86_64-linux-musl', opts.slice(:uuid, :url, :debug, :log_file)).
-      to_binary :process_image
+    MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x86/mettle.rb
+++ b/modules/payloads/stages/linux/x86/mettle.rb
@@ -6,10 +6,12 @@
 require 'msf/core'
 require 'msf/base/sessions/meterpreter_x86_mettle_linux'
 require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
 require 'rex/elfparsey'
 
 module MetasploitModule
   include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
 
   def initialize(info = {})
     super(
@@ -91,8 +93,6 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts[:uuid] ||= generate_payload_uuid
-    MetasploitPayloads::Mettle.new('i486-linux-musl', opts.slice(:uuid, :url, :debug, :log_file)).
-      to_binary :process_image
+    MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :process_image
   end
 end


### PR DESCRIPTION
Does a couple of things to prepare for stageless mettle payloads:

* Adds new arches to rex-arch UUIDs
* Factors out some common mettle config generation
* Don't touch payloads that are already ELF files in `Msf::Util::Exe`

This needs the changes in rapid7/mettle#42 to be pulled in. These PRs move base64 encoding of UUIDs to MSF in order to avoid dependency inversion.

Verification
========

**DELAYED**
- [x] Tests should still pass
- [x] Mettle payloads should still stage and work