### PR TITLE
Fixed issue #7689, count of found users not accurate

### DIFF
--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -126,9 +126,9 @@ class MetasploitModule < Msf::Auxiliary
         return
       end
     end
-
+    results = results.flatten.uniq
     print_status("Done. #{results.length} usernames found...")
-    results.flatten.uniq.each do |user|
+    results.each do |user|
       print_good("Found User: #{user}")
 
       report_cred(


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/drupal_views_user_enum`
- [x] `set RHOSTS 127.0.0.1`
- [x]  `run`
```
msf auxiliary(drupal_views_user_enum) > rerun
[*] Reloading module...

[*] Begin enumerating users at 127.0.0.1
[*] Done. 4 usernames found...
[+] Found User: bob
[+] Found User: barry
[+] Found User: john
[+] Found User: joe
[*] Usernames stored in: /home/jqian/.msf4/loot/20161209151734_default_127.0.0.1_drupal_user_028200.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(drupal_views_user_enum) >
```


In module drupal_views_user_enum, the count of found users is not accurate.
Fixed it by doing flatten before doing counting.