### PR TITLE
Fixed issues #7691, silent exit.

### DIFF
--- a/modules/auxiliary/scanner/http/error_sql_injection.rb
+++ b/modules/auxiliary/scanner/http/error_sql_injection.rb
@@ -78,12 +78,14 @@ class MetasploitModule < Msf::Auxiliary
       if not datastore['QUERY'].empty?
         qvars = queryparse(datastore['QUERY']) #Now its a Hash
       else
+        print_error("You need to set QUERY param for GET")
         return
       end
     else
       if not datastore['DATA'].empty?
         qvars = queryparse(datastore['DATA']) #Now its a Hash
       else
+        print_error("You need to set DATA parameter for POST")
         return
       end
     end


### PR DESCRIPTION
Add a print statement to alert user what is missing, user could be confused that "show missing" is empty yet something is missing.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/error_sql_injection`
- [x] `set RHOSTS 127.0.0.1`
- [x] `run`
```
msf auxiliary(error_sql_injection) > run

[-] You need to set QUERY param for GET
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
