### PR TITLE
Fix issue #7434 - nessus_db_scan_workspace: wrong number of arguments

### DIFF
--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -968,13 +968,14 @@ module Msf
         end
         if valid_policy(uuid)
           print_status("Creating scan from policy number #{uuid}, called #{scan_name} - #{description} and scanning #{targets}")
-          et=Hash.new
-          et['enabled']=false
-          et['launch']='ONETIME'
-          et['name']=scan_name
-          et['text_targets']=targets
-          et['description']=description
-          et['launch_now']=false
+          et = {
+            'enabled'      => false,
+            'launch'       => 'ONETIME',
+            'name'         => scan_name,
+            'text_targets' => targets,
+            'description'  => description,
+            'launch_now'   => false
+          }
           scan = @n.scan_create(uuid, et)
           tbl = Rex::Text::Table.new(
             'Columns' => [
@@ -1077,13 +1078,14 @@ module Msf
         end
         targets.chop!
         print_status("Creating scan from policy #{policy_id}, called \"#{name}\" and scanning all hosts in all the workspaces")
-        et=Hash.new
-        et['enabled']=false
-        et['launch']='ONETIME'
-        et['name']=name
-        et['text_targets']=targets
-        et['description']=desc
-        et['launch_now']=true
+        et = {
+          'enabled'      => false,
+          'launch'       => 'ONETIME',
+          'name'         => name,
+          'text_targets' => targets,
+          'description'  => desc,
+          'launch_now'   => true
+        }
         scan = @n.scan_create(policy_id, et)
         if !scan["error"]
           scan = scan["scan"]
@@ -1136,13 +1138,14 @@ module Msf
         end
         targets.chop!
         print_status("Creating scan from policy #{policy_id}, called \"#{name}\" and scanning all hosts in #{framework.db.workspace.name}")
-        et=Hash.new
-        et['enabled']=false
-        et['launch']='ONETIME'
-        et['name']=name
-        et['text_targets']=targets
-        et['description']=desc
-        et['launch_now']=false
+        et = {
+          'enabled'      => false,
+          'launch'       => 'ONETIME',
+          'name'         => name,
+          'text_targets' => targets,
+          'description'  => desc,
+          'launch_now'   => false
+        }
         scan = @n.scan_create(policy_id, et)
         if !scan["error"]
           scan = scan["scan"]

--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -1136,7 +1136,14 @@ module Msf
         end
         targets.chop!
         print_status("Creating scan from policy #{policy_id}, called \"#{name}\" and scanning all hosts in #{framework.db.workspace.name}")
-        scan = @n.scan_create(policy_id, name, desc, targets)
+        et=Hash.new
+        et['enabled']=false
+        et['launch']='ONETIME'
+        et['name']=name
+        et['text_targets']=targets
+        et['description']=desc
+        et['launch_now']=false
+        scan = @n.scan_create(policy_id, et)
         if !scan["error"]
           scan = scan["scan"]
           print_status("Scan ID #{scan['id']} successfully created")


### PR DESCRIPTION
## What this does

This piece of code fix my issue #7434. 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `load nessus`
- [x] `nessus_connect  USER:PASSWORD@IP:8834`
- [x] `nessus_db_scan_workspace <policy ID> <scan name> <scan description> <workspace>`

## Example Output

```
msf > load nessus
[*] Nessus Bridge for Metasploit
[*] Type nessus_help for a command listing
[*] Successfully loaded plugin: Nessus

msf > nessus_connect  msf:pass@10.0.2.15:8834
[*] Connecting to https://10.0.2.15:8834/ as msf
[*] User msf authenticated successfully.

msf > workspace testlab
[*] Workspace: testlab

msf > workspace 
  default
* testlab

msf > services 

Services
========

host       port  proto  name        state  info
----       ----  -----  ----        -----  ----
127.0.0.1  22    tcp    ssh         open   
127.0.0.1  111   tcp    rpcbind     open   
127.0.0.1  5432  tcp    postgresql  open   
127.0.0.5  22    tcp    ssh         open   
127.0.0.5  111   tcp    rpcbind     open   

msf > nessus_policy_list 
Policy ID  Name     Policy UUID
---------  ----     -----------
4          advance  ad629e16-03b6-8c1d-cef6-ef8c9dd3c658d24bd260ef5f9e66


msf > nessus_db_scan_workspace  ad629e16-03b6-8c1d-cef6-ef8c9dd3c658d24bd260ef5f9e66 "Nessus Testscan" "only a test scan" testlab
[*] Switched workspace: testlab
[*] Targets: 127.0.0.1,
[*] Targets: 127.0.0.1,127.0.0.5,
[*] Creating scan from policy ad629e16-03b6-8c1d-cef6-ef8c9dd3c658d24bd260ef5f9e66, called "Nessus Testscan" and scanning all hosts in testlab
[*] Scan ID 56 successfully created
[*] Run nessus_scan_launch 56 to launch the scan

msf > nessus_scan_launch 56
[+] Scan ID 56 successfully launched. The Scan UUID is 2ac6fd7e-2005-3ae4-88fd-eaf857f8f10c8fb6a794084359a6

msf > 

```
