### PR TITLE
Update reverse_tcp to show TCP listener information

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -674,6 +674,7 @@ class ReadableText
       row[1] = framework.jobs[job_id].name
 
       pinst = exploit_mod.respond_to?(:payload_instance) ? exploit_mod.payload_instance : nil
+      payload_uri = ''
 
       if pinst.nil?
         row[2] = ""
@@ -682,7 +683,8 @@ class ReadableText
         row[2] = pinst.refname
         row[3] = ""
         if pinst.respond_to?(:payload_uri)
-          row[3] << pinst.payload_uri
+          payload_uri = pinst.payload_uri.strip
+          row[3] << payload_uri
         end
         if pinst.respond_to?(:luri)
           row[3] << pinst.luri
@@ -694,7 +696,12 @@ class ReadableText
         uripath ||= exploit_mod.datastore['URIPATH']
         row[4] = uripath
         row[5] = framework.jobs[job_id].start_time
-        row[6] = pinst.respond_to?(:listener_uri) ? pinst.listener_uri : ""
+        row[6] = ''
+
+        if pinst.respond_to?(:listener_uri)
+          listener_uri = pinst.listener_uri.strip
+          row[6] = listener_uri unless listener_uri == payload_uri
+        end
       end
       tbl << row
     end

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -77,9 +77,23 @@ module ReverseTcp
     "reverse TCP"
   end
 
+  # A URI describing what the payload is configured to use for transport
   def payload_uri
-    "tcp://#{datastore['LHOST']}:#{datastore['LPORT']}"
+    addr = datastore['LHOST']
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "tcp://#{uri_host}:#{datastore['LPORT']}"
   end
+
+  # A URI describing where we are listening
+  #
+  # @param addr [String] the address that
+  # @return [String] A URI of the form +scheme://host:port/+
+  def listener_uri(addr=datastore['ReverseListenerBindAddress'])
+    addr = datastore['LHOST'] if addr.nil? || addr.empty?
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "tcp://#{uri_host}:#{bind_port}"
+  end
+
 
   #
   # Starts monitoring for an inbound connection.


### PR DESCRIPTION
When using `jobs -v`, the output shows extra fields including information about the listener configuration. This is important in cases where the listener is configured to be different to the payload via, say, `ReverseListenerBindAddress/Port`.

Until now, this had the following issues:

* It only worked with `reverse_http/s` listeners.
* The listener field was populated even when the configuration was exactly the same as the payload configuration.

This PR makes the following changes:

* Adds listener information to `reverse_tcp` payloads.
* Prevents output of the listener information unless it is different to the payload information (reducing the noise in the output).

## Verification

- [x] Create a TCP listener that does not utilise `ReverseListenerBindPort` or `ReverseListenerBindHost`.
- [x] Run `jobs -v`, and validate that the `Handler Opts` field is blank for this listener.
- [x] Create a TCP listener that *does* utilise `ReverseListenerBindPort` and/or `ReverseListenerBindHost`.
- [x] Run `jobs -v`, and validate that the `Handler Opts` field is _not_ blank for this listener, and contains details of the listener configuration.
- [x] Create a HTTP listener that does not utilise `ReverseListenerBindPort` or `ReverseListenerBindHost`.
- [x] Run `jobs -v`, and validate that the `Handler Opts` field is blank for this listener.
- [x] Create a HTTP listener that *does* utilise `ReverseListenerBindPort` and/or `ReverseListenerBindHost`.
- [x] Run `jobs -v`, and validate that the `Handler Opts` field is _not_ blank for this listener, and contains details of the listener configuration.
