### PR TITLE
Fix #7687, fix crashing from bad error message argument

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -272,6 +272,7 @@ module Shell
   #
   def print_error(msg='')
     return if (output.nil?)
+    return if (msg.nil?)
 
     self.on_print_proc.call(msg) if self.on_print_proc
     # Errors are not subject to disabled output


### PR DESCRIPTION
# What this does

This prevents an exception being thrown if 'msg' from print_error is nil by checking if msg is nil before attempting to work with 'msg'.

Fix [#7687](https://github.com/rapid7/metasploit-framework/issues/7687) 

# Verification

- [ ] Start with a Windows XP SP3 box or VM for the victim.
- [ ] In attacking machine, start `msfconsole`
- [ ] DO: `use  use exploit/multi/handler`
- [ ] DO: `set payload windows/meterpreter/reverse_tcp`
- [ ] DO: `set LHOST [IP]`
- [ ] DO: `set LHOST [PORT]`
- [ ] DO: `setg SessionLogging true`
- [ ] DO: `run`
- [ ] DO: `sysinfo` in meterpreter session.
- [ ] You should see no error logs if there is no session information. If there are session logs they will be displayed.
- [ ] The application will not crash if a bad 'msg' is passed to `print_error`.


