### PR TITLE
fix renamed rex text

### DIFF
--- a/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
+++ b/modules/post/windows/gather/credentials/mdaemon_cred_collector.rb
@@ -296,7 +296,7 @@ class MetasploitModule < Msf::Post
   end
 
   def get_mdaemon_creds(userlist)
-    credentials = Rex::Ui::Text::Table.new(
+    credentials = Rex::Text::Table.new(
       'Header'    => 'MDaemon Email Server Credentials',
       'Indent'    => 1,
       'Columns'   =>


### PR DESCRIPTION
This just renames a final reference to Rex::Text::Table that was missed earlier in #7200 