### PR TITLE
Make SMTP delivery work with a range of server SSL

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -71,20 +71,32 @@ module Exploit::Remote::SMTPDeliver
   # This method currently only knows about PLAIN authentication.
   #
   def connect_login(global = true)
-    vprint_status("Connecting to SMTP server #{rhost}:#{rport}...")
-    nsock = connect(global)
-
-    if datastore['DOMAIN'] and not datastore['DOMAIN'] == ''
+    if datastore['DOMAIN'] && datastore['DOMAIN'] != ''
       domain = datastore['DOMAIN']
     else
       domain = Rex::Text.rand_text_alpha(rand(32)+1)
     end
 
-    res = raw_send_recv("EHLO #{domain}\r\n", nsock)
+    nsock, res = connect_ehlo(global, domain)
+
     if res =~ /STARTTLS/
       print_status("Starting tls")
       raw_send_recv("STARTTLS\r\n", nsock)
-      swap_sock_plain_to_ssl(nsock)
+
+      [:high, :medium, :default].each do |level|
+        begin
+          swap_sock_plain_to_ssl(nsock, level)
+          break
+        rescue OpenSSL::SSL::SSLError
+          # Perform manual fallback for servers that can't
+          print_status 'Could not negotiate SSL, falling back to older ciphers'
+          nsock.close
+          nsock, res = connect_ehlo(global)
+          raw_send_recv("STARTTLS\r\n", nsock)
+          raise if level == :default
+        end
+      end
+
       res = raw_send_recv("EHLO #{domain}\r\n", nsock)
     end
 
@@ -122,6 +134,12 @@ module Exploit::Remote::SMTPDeliver
     return nsock
   end
 
+  def connect_ehlo(global = true, domain)
+    vprint_status("Connecting to SMTP server #{rhost}:#{rport}...")
+    nsock = connect(global)
+
+    [nsock, raw_send_recv("EHLO #{domain}\r\n", nsock)]
+  end
 
   #
   # Sends an email message, connecting to the server first if a connection is
@@ -216,8 +234,8 @@ protected
   # Create a new SSL session on the existing socket.  Used for STARTTLS
   # support.
   #
-  def swap_sock_plain_to_ssl(nsock=self.sock)
-    ctx = generate_ssl_context()
+  def swap_sock_plain_to_ssl(nsock=self.sock, security=:high)
+    ctx = generate_ssl_context(security)
     ssl = OpenSSL::SSL::SSLSocket.new(nsock, ctx)
 
     ssl.connect
@@ -227,10 +245,17 @@ protected
     nsock.sslctx  = ctx
   end
 
-  def generate_ssl_context
-    ctx = OpenSSL::SSL::SSLContext.new(:SSLv23)
-    ctx.ciphers = "ALL:!ADH:!EXPORT:!SSLv2:!SSLv3:+HIGH:+MEDIUM"
-    ctx
+  def generate_ssl_context(security=:high)
+    case security
+    when :high
+      ctx = OpenSSL::SSL::SSLContext.new(:SSLv23)
+      ctx.ciphers = "ALL:!ADH:!EXPORT:!SSLv2:!SSLv3:+HIGH:+MEDIUM"
+      ctx
+    when :medium
+      OpenSSL::SSL::SSLContext.new(:TLSv1)
+    when :default
+      OpenSSL::SSL::SSLContext.new
+    end
   end
 
 end


### PR DESCRIPTION
Verification
========
- [x] Get access to and SMTP server with an old STARTTLS SSL config (Exchange 2010 on Server 2003 is known to have such a config, or ping @jinq102030 for an emulated service)
- [x] Attempt to send an email (via `auxiliary/client/smtp/emailer` or pro social engineering)
- [x] You don't need to actually send email, but when when you connect, you should see the client attempt and fail to STARTTLS followed by a reconnect and successful STARTTLS negotiation