### PR TITLE
Adjusted Code to Dereference Client Object as Opposed to SimpleClient Object

### DIFF
--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -123,7 +123,7 @@ require 'rex/proto/smb/exceptions'
       smb.login('*SMBSERVER', self.options['smb_user'], self.options['smb_pass'])
       smb.connect("\\\\#{self.handle.address}\\IPC$")
       self.smb = smb
-      self.smb.read_timeout = self.options['read_timeout']
+      self.smb.client.read_timeout = self.options['read_timeout']
     end
 
     f = self.smb.create_pipe(self.handle.options[0])


### PR DESCRIPTION
Line originally references the read_timeout instance variable associated with the smb variable (line 118 || 120), which is an object of the simpleclient class that doesn't have a read_timeout instance variable. Updated the line to reference the client instance variable of smb, which does have a read_timeout variable. Testing this change appears to result in expected behavior.

I discovered this issue while using Rex distinct from Metasploit so it's a little difficult to illustrate without showing my half-baked code at the moment. Here's a snippet of code that would generate an error:

	peerport = 445

	socket_opts = 	{
						'PeerHost'	=>	peerhost,
						'PeerPort'		=>	peerport
					}

	sock = SOCKET::create_tcp(socket_opts)

	uuid = '4b324fc8-1670-01d3-1278-5a47bf6ee188'

	handle = DCERPC::Handle.new([uuid,'3.0'], 'ncacn_np', peerhost, ["\\srvsvc"])

	dclient_opts =  {
						'smb_user'			=>	creds.username,
						'smb_pass'			=>	creds.password,
						'smb_pipeio'		        =>	'rw',				
						'smb_name'			=>	nil,				
						'read_timeout'		=>	10,					
						'connect_timeout'	=>	5					
					}

        # Error would occur here as client generation would attempt to use
        # 'read_timeout' on a simpleclient object
	dclient = DCERPC::Client.new(handle, sock, dclient_opts)