### PR TITLE
Change the PCRE in clansphere_traversal

### DIFF
--- a/modules/auxiliary/scanner/http/clansphere_traversal.rb
+++ b/modules/auxiliary/scanner/http/clansphere_traversal.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
 
     elsif res and res.code == 200
       pattern_end = "     UTC +1 - Load:"
-      data = res.body.scan(/\<div id\=\"bottom\"\>\n(.+)\n\x20{5}UTC.+/m).flatten[0].lstrip
+      data = res.body.scan(/\<div id\=\"bottom\"\>\n(.+)\n\x20{5}UTC/).flatten[0].lstrip
       fname = datastore['FILE']
       p = store_loot(
         'clansphere.cms',


### PR DESCRIPTION
# Tell us what this change does. If you're fixing a bug, please mention the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/clansphere_traversal`
- [x] `set RHOSTS 127.0.0.1`
- [x] `run`

```
msf auxiliary(clansphere_traversal) > run
[*] Reloading module...

[*] Reading '/etc/passwd'
[+] /etc/passwd stored as '/home/jqian/.msf4/loot/20161216154000_default_127.0.0.1_clansphere.cms_465169.bin'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

msf auxiliary(clansphere_traversal) > cat /home/jqian/.msf4/loot/20161216154000_default_127.0.0.1_clansphere.cms_465169.bin
[*] exec: cat /home/jqian/.msf4/loot/20161216154000_default_127.0.0.1_clansphere.cms_465169.bin

all my secret1 here
```

Note that the loot doesn't have any HTML tag in it.

Fixed issue #7719