### PR TITLE
Rename the `sess` command to `terminal`

### DIFF
--- a/features/commands/help.feature
+++ b/features/commands/help.feature
@@ -26,7 +26,6 @@ Feature: Help command
           quit          Exit the console
           route         Route traffic through a session
           save          Saves the active datastores
-          sess          Interact with a given session
           sessions      Dump session listings and display information about sessions
           set           Sets a context-specific variable to a value
           setg          Sets a global variable to a value

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -110,11 +110,11 @@ class Core
       "quit"       => "Exit the console",
       "route"      => "Route traffic through a session",
       "save"       => "Saves the active datastores",
-      "sess"       => "Interact with a given session",
       "sessions"   => "Dump session listings and display information about sessions",
       "set"        => "Sets a context-specific variable to a value",
       "setg"       => "Sets a global variable to a value",
       "sleep"      => "Do nothing for the specified number of seconds",
+      "terminal"   => "Interact with a given session",
       "threads"    => "View and manipulate background threads",
       "unload"     => "Unload a framework plugin",
       "unset"      => "Unsets one or more context-specific variables",
@@ -988,8 +988,8 @@ class Core
     return
   end
 
-  def cmd_sess_help
-    print_line('Usage: sess <session id>')
+  def cmd_terminal_help
+    print_line('Usage: terminal <session id>')
     print_line
     print_line('Interact with the given session ID.')
     print_line('This works the same as: sessions -i <session id>')
@@ -999,9 +999,9 @@ class Core
   #
   # Helper function to quickly select a session
   #
-  def cmd_sess(*args)
+  def cmd_terminal(*args)
     if args.length == 0 || args[0].to_i == 0
-      cmd_sess_help
+      cmd_terminal_help
     else
       cmd_sessions('-i', args[0])
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -65,7 +65,7 @@ class Console::CommandDispatcher::Core
       "bgkill"     => "Kills a background meterpreter script",
       "get_timeouts" => "Get the current session timeout values",
       "set_timeouts" => "Set the current session timeout values",
-      "sess"       => "Quickly switch to another session",
+      "terminal"   => "Quickly switch to another session",
       "bglist"     => "Lists running background scripts",
       "write"      => "Writes data to a channel",
       "enable_unicode_encoding"  => "Enables encoding of unicode strings",
@@ -118,17 +118,17 @@ class Console::CommandDispatcher::Core
     "Core"
   end
 
-  def cmd_sess_help
-    print_line('Usage: sess <session id>')
+  def cmd_terminal_help
+    print_line('Usage: terminal <session id>')
     print_line
     print_line('Interact with a different session Id.')
     print_line('This works the same as calling this from the MSF shell: sessions -i <session id>')
     print_line
   end
 
-  def cmd_sess(*args)
+  def cmd_terminal(*args)
     if args.length == 0 || args[0].to_i == 0
-      cmd_sess_help
+      cmd_terminal_help
     elsif args[0].to_s == client.name.to_s
       print_status("Session #{client.name} is already interactive.")
     else

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -65,7 +65,7 @@ class Console::CommandDispatcher::Core
       "bgkill"     => "Kills a background meterpreter script",
       "get_timeouts" => "Get the current session timeout values",
       "set_timeouts" => "Set the current session timeout values",
-      "terminal"   => "Quickly switch to another session",
+      "sessions"   => "Quickly switch to another session",
       "bglist"     => "Lists running background scripts",
       "write"      => "Writes data to a channel",
       "enable_unicode_encoding"  => "Enables encoding of unicode strings",
@@ -118,17 +118,17 @@ class Console::CommandDispatcher::Core
     "Core"
   end
 
-  def cmd_terminal_help
-    print_line('Usage: terminal <session id>')
+  def cmd_sessions_help
+    print_line('Usage: sessions <id>')
     print_line
     print_line('Interact with a different session Id.')
     print_line('This works the same as calling this from the MSF shell: sessions -i <session id>')
     print_line
   end
 
-  def cmd_terminal(*args)
+  def cmd_sessions(*args)
     if args.length == 0 || args[0].to_i == 0
-      cmd_terminal_help
+      cmd_sessions_help
     elsif args[0].to_s == client.name.to_s
       print_status("Session #{client.name} is already interactive.")
     else


### PR DESCRIPTION
Lots of people have been frustrated by the `sess` command as it mucks with the autocomplete for `sessions`. This is a fair concern, especially given that `sess` was intended to be a non-annoying shortcut.

This commit changes the `sess` command so that it is instead called `terminal`. I couldn't think of a better option that didn't already clash with another name or meaning. At least `terminal` is something that doesn't clash, doesn't muck with any existin autocomplete rules, and is in some way another name for the existing sessions.

Feedback appreciated!

## Verification

- [ ] Get a couple of sessions going (meterp, shells, whatever)
- [ ] Check that `ses<tab>` autocompletes to `session `.
- [ ] Check that `term<tab>` autocompletes to `terminal`.
- [ ] Check that `terminal` behaves like `sess` used to in the MSF console.
- [ ] Check that `terminal` behaves like `sess` used to in the Meterpreter console.

/cc @0x42424242 @mubix