### PR TITLE
Add module to runas using powershell

### DIFF
--- a/documentation/modules/post/windows/manage/run_as_psh.md
+++ b/documentation/modules/post/windows/manage/run_as_psh.md
@@ -39,7 +39,7 @@ my-pc\test
 
 C:\\>
 
-meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword hidden=false channelize=false interactive=false exe=cmd path=C:\\windows args="/c start notepad"
+meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword hidden=false channelize=false interactive=false exe=cmd path=C:\\\\windows args="/c start notepad"
 
 [*] Process 9768 created.
 meterpreter > 

--- a/documentation/modules/post/windows/manage/run_as_psh.md
+++ b/documentation/modules/post/windows/manage/run_as_psh.md
@@ -8,7 +8,7 @@ By default, it will start an interactive cmd as the target user.
 - **DOMAIN** - The domain of the user
 - **EXE** - The program to run (default cmd.exe)
 - **PASS** - The program arguments 
-- **PATH** - The path to run the program in (default C:\)
+- **PATH** - The path to run the program in (default C:\\)
 - **CHANNELIZE** - Channelize the output, required to read output or interact
 - **INTERACT** - Interact with program
 - **HIDDEN** - Hide the console window
@@ -33,11 +33,11 @@ meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword
 Microsoft Windows [Version 10.0.14393]
 (c) 2016 Microsoft Corporation. All rights reserved.
 
-C:\>whoami
+C:\\>whoami
 whoami
 my-pc\test
 
-C:\>
+C:\\>
 
 meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword hidden=false channelize=false interactive=false exe=cmd path=C:\\windows args="/c start notepad"
 

--- a/documentation/modules/post/windows/manage/run_as_psh.md
+++ b/documentation/modules/post/windows/manage/run_as_psh.md
@@ -1,0 +1,47 @@
+## Overview
+This module will start a process as another user using powershell.
+By default, it will start an interactive cmd as the target user.
+
+## Module Options
+- **USER** - The use to run the program as. 
+- **PASS** - The user's password  
+- **DOMAIN** - The domain of the user
+- **EXE** - The program to run (default cmd.exe)
+- **PASS** - The program arguments 
+- **PATH** - The path to run the program in (default C:\)
+- **CHANNELIZE** - Channelize the output, required to read output or interact
+- **INTERACT** - Interact with program
+- **HIDDEN** - Hide the console window
+
+## Module Process
+The process will use the Start-Process command of powershell to run a process as another user.
+## Limitations
+- Requires Powershell
+- Hidden Mode does not work with older powershell versions
+- Interactive mode needs to be ran from a meterpreter console
+
+## Examples
+
+`
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword
+
+[*] Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false
+[*] Process 1672 created.
+[*] Channel 30 created.
+Microsoft Windows [Version 10.0.14393]
+(c) 2016 Microsoft Corporation. All rights reserved.
+
+C:\>whoami
+whoami
+my-pc\test
+
+C:\>
+
+meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword hidden=false channelize=false interactive=false exe=cmd path=C:\\windows args="/c start notepad"
+
+[*] Process 9768 created.
+meterpreter > 
+
+`

--- a/documentation/modules/post/windows/manage/run_as_psh.md
+++ b/documentation/modules/post/windows/manage/run_as_psh.md
@@ -7,7 +7,7 @@ By default, it will start an interactive cmd as the target user.
 - **PASS** - The user's password  
 - **DOMAIN** - The domain of the user
 - **EXE** - The program to run (default cmd.exe)
-- **PASS** - The program arguments 
+- **ARGS** - The program arguments 
 - **PATH** - The path to run the program in (default C:\\)
 - **CHANNELIZE** - Channelize the output, required to read output or interact
 - **INTERACT** - Interact with program
@@ -15,10 +15,11 @@ By default, it will start an interactive cmd as the target user.
 
 ## Module Process
 The process will use the Start-Process command of powershell to run a process as another user.
+
 ## Limitations
 - Requires Powershell
 - Hidden Mode does not work with older powershell versions
-- Interactive mode needs to be ran from a meterpreter console
+- Interactive mode needs to be run from a meterpreter console
 
 ## Examples
 

--- a/modules/post/windows/manage/run_as_psh.rb
+++ b/modules/post/windows/manage/run_as_psh.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Post
     include Msf::Post::Windows::Powershell
     def initialize(info={})
         super( update_info( info,
-            'Name'          => 'Windows Shell As Another User',
+            'Name'          => 'Windows \'Run As\' Using Powershell',
             'Description'   => %q{ This module will start a process as another user using powershell. },
             'License'       => MSF_LICENSE,
             'Author'        => [ 'p3nt4' ],
@@ -42,7 +42,6 @@ class MetasploitModule < Msf::Post
         inter = datastore['interactive']
         args = datastore['args']
         path = datastore['path'].gsub("\\","\\\\\\\\")
-        sessNo = datastore['session']
         channelized = datastore['channelize']
         hidden = datastore['hidden']
         #Check if session is interactive

--- a/modules/post/windows/manage/run_as_psh.rb
+++ b/modules/post/windows/manage/run_as_psh.rb
@@ -1,0 +1,90 @@
+##
+    # This module requires Metasploit: http://metasploit.com/download
+    # Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/windows/powershell'
+
+class MetasploitModule < Msf::Post
+    include Msf::Post::Windows::Powershell
+    def initialize(info={})
+        super( update_info( info,
+            'Name'          => 'Windows Shell As Another User',
+            'Description'   => %q{ This module will start a process as another user using powershell. },
+            'License'       => MSF_LICENSE,
+            'Author'        => [ 'p3nt4' ],
+            'Platform'      => [ 'win' ],
+            'SessionTypes'  => [ 'meterpreter' ]
+        ))
+        register_options(
+            [
+                OptString.new('USER', [true, 'User to run executable as', nil]),
+                OptString.new('PASS', [true, 'Password of user', nil]),
+                OptString.new('DOMAIN', [false, 'Domain of user', '']),
+                OptString.new('EXE', [true, 'Executable to run', 'cmd.exe']),
+                OptString.new('ARGS', [false, 'Arguments', nil]),
+                OptString.new('PATH', [true, 'Working Directory', 'C:\\']),
+                OptBool.new('CHANNELIZE', [true, 'Chanelize output, required for reading output or interracting', true]),
+                OptBool.new('INTERACTIVE', [true, 'Run interactively', true]),
+                OptBool.new('HIDDEN', [true, 'Hide the window', true]),
+                #OptString.new('DUMMY', [false, 'Run in a dummy host process', '']),
+            ], self.class)
+    end
+
+    def run
+        begin
+            raise "Powershell is required" if !have_powershell?
+            #Variable Setup
+            user=datastore['user']
+            pass=datastore['pass']
+            domain = datastore['domain']
+            exe=datastore['exe'].gsub("\\","\\\\\\\\")
+            inter=datastore['interactive']
+            args=datastore['args']
+            path=datastore['path'].gsub("\\","\\\\\\\\")
+            #dummy=datastore['dummy']
+            sessNo=datastore['session']
+            channelized = datastore['channelize']
+            hidden = datastore['hidden']
+            #Check if dession si interactive
+            if (!session.interacting and inter)
+                print_error("Interactive mode can only be used in a meterpreter console")
+                print_error("Use 'run post/windows/manage/run_as_psh USER=x PASS=X EXE=X' or SET INTERACTIVE false")
+                raise 'Invalide console'
+            end
+            scr="$pw = convertto-securestring '#{pass}' -asplaintext -force; "
+            scr+="$pp = new-object -typename System.Management.Automation.PSCredential -argumentlist '#{domain}\\\\#{user}',$pw; "
+            scr+="Start-process '#{exe}' -WorkingDirectory '#{path}' -Credential $pp"
+            if args and args!=''
+                scr+=" -argumentlist '#{args}' "
+            end
+            if hidden
+                print_status("Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false")
+                scr+= " -WindowStyle hidden"
+            end
+            scr=" -c \"#{scr}\""
+            p = client.sys.process.execute("powershell.exe", scr,
+              'Channelized' => channelized,
+              'Desktop'     => false,
+              'Session'     => false,
+              'Hidden'      => true,
+              'Interactive' => inter,
+              'InMemory'    => nil,
+            'UseThreadToken' => false)
+            print_status("Process #{p.pid} created.")
+            print_status("Channel #{p.channel.cid} created.") if (p.channel)
+            if (inter and p.channel)
+                client.console.interact_with_channel(p.channel)
+            elsif p.channel
+                data = p.channel.read()
+                print_line(data) if data
+            end
+            rescue ::Interrupt
+                raise $!
+            rescue ::Exception => e
+                raise e
+        end
+    end
+end

--- a/modules/post/windows/manage/run_as_psh.rb
+++ b/modules/post/windows/manage/run_as_psh.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Post
         sessNo = datastore['session']
         channelized = datastore['channelize']
         hidden = datastore['hidden']
-        #Check if session si interactive
+        #Check if session is interactive
         if (!session.interacting and inter)
             print_error("Interactive mode can only be used in a meterpreter console")
             print_error("Use 'run post/windows/manage/run_as_psh USER=x PASS=X EXE=X' or 'SET INTERACTIVE false'")

--- a/modules/post/windows/manage/run_as_psh.rb
+++ b/modules/post/windows/manage/run_as_psh.rb
@@ -1,6 +1,6 @@
 ##
-    # This module requires Metasploit: http://metasploit.com/download
-    # Current source: https://github.com/rapid7/metasploit-framework
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
@@ -8,77 +8,80 @@ require 'rex'
 require 'msf/core/post/windows/powershell'
 
 class MetasploitModule < Msf::Post
-    include Msf::Post::Windows::Powershell
-    def initialize(info={})
-        super( update_info( info,
-            'Name'          => 'Windows \'Run As\' Using Powershell',
-            'Description'   => %q{ This module will start a process as another user using powershell. },
-            'License'       => MSF_LICENSE,
-            'Author'        => [ 'p3nt4' ],
-            'Platform'      => [ 'win' ],
-            'SessionTypes'  => [ 'meterpreter' ]
-        ))
-        register_options(
-            [
-                OptString.new('USER', [true, 'User to run executable as', nil]),
-                OptString.new('PASS', [true, 'Password of user', nil]),
-                OptString.new('DOMAIN', [false, 'Domain of user', '']),
-                OptString.new('EXE', [true, 'Executable to run', 'cmd.exe']),
-                OptString.new('ARGS', [false, 'Arguments', nil]),
-                OptString.new('PATH', [true, 'Working Directory', 'C:\\']),
-                OptBool.new('CHANNELIZE', [true, 'Chanelize output, required for reading output or interracting', true]),
-                OptBool.new('INTERACTIVE', [true, 'Run interactively', true]),
-                OptBool.new('HIDDEN', [true, 'Hide the window', true]),
-            ], self.class)
-    end
+  include Msf::Post::Windows::Powershell
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'         => 'Windows \'Run As\' Using Powershell',
+        'Description'  => %q( This module will start a process as another user using powershell. ),
+        'License'      => MSF_LICENSE,
+        'Author'       => [ 'p3nt4' ],
+        'Platform'     => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
+    register_options(
+      [
+        OptString.new('USER', [true, 'User to run executable as', nil]),
+        OptString.new('PASS', [true, 'Password of user', nil]),
+        OptString.new('DOMAIN', [false, 'Domain of user', '']),
+        OptString.new('EXE', [true, 'Executable to run', 'cmd.exe']),
+        OptString.new('ARGS', [false, 'Arguments', nil]),
+        OptString.new('PATH', [true, 'Working Directory', 'C:\\']),
+        OptBool.new('CHANNELIZE', [true, 'Chanelize output, required for reading output or interracting', true]),
+        OptBool.new('INTERACTIVE', [true, 'Run interactively', true]),
+        OptBool.new('HIDDEN', [true, 'Hide the window', true])
+      ], self.class)
+  end
 
-    def run
-        raise "Powershell is required" if !have_powershell?
-        #Variable Setup
-        user = datastore['user']
-        pass = datastore['pass']
-        domain = datastore['domain']
-        exe = datastore['exe'].gsub("\\","\\\\\\\\")
-        inter = datastore['interactive']
-        args = datastore['args']
-        path = datastore['path'].gsub("\\","\\\\\\\\")
-        channelized = datastore['channelize']
-        hidden = datastore['hidden']
-        #Check if session is interactive
-        if (!session.interacting and inter)
-            print_error("Interactive mode can only be used in a meterpreter console")
-            print_error("Use 'run post/windows/manage/run_as_psh USER=x PASS=X EXE=X' or 'SET INTERACTIVE false'")
-            raise 'Invalide console'
-        end
-        #Prepare powershell script
-        scr = "$pw = convertto-securestring '#{pass}' -asplaintext -force; "
-        scr << "$pp = new-object -typename System.Management.Automation.PSCredential -argumentlist '#{domain}\\\\#{user}',$pw; "
-        scr << "Start-process '#{exe}' -WorkingDirectory '#{path}' -Credential $pp"
-        if args and args!=''
-            scr << " -argumentlist '#{args}' "
-        end
-        if hidden
-            print_status("Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false")
-            scr <<  " -WindowStyle hidden"
-        end
-        scr = " -c \"#{scr}\""
-        #Execute script
-        p = client.sys.process.execute("powershell.exe", scr,
-          'Channelized' => channelized,
-          'Desktop'     => false,
-          'Session'     => false,
-          'Hidden'      => true,
-          'Interactive' => inter,
-          'InMemory'    => false,
-        'UseThreadToken' => false)
-        print_status("Process #{p.pid} created.")
-        print_status("Channel #{p.channel.cid} created.") if (p.channel)
-        #Process output
-        if (inter and p.channel)
-            client.console.interact_with_channel(p.channel)
-        elsif p.channel
-            data = p.channel.read()
-            print_line(data) if data
-        end
+  def run
+    raise "Powershell is required" if !have_powershell?
+    # Variable Setup
+    user = datastore['user']
+    pass = datastore['pass']
+    domain = datastore['domain']
+    exe = datastore['exe'].gsub("\\", "\\\\\\\\")
+    inter = datastore['interactive']
+    args = datastore['args']
+    path = datastore['path'].gsub("\\", "\\\\\\\\")
+    channelized = datastore['channelize']
+    hidden = datastore['hidden']
+    # Check if session is interactive
+    if (!session.interacting and inter)
+      print_error("Interactive mode can only be used in a meterpreter console")
+      print_error("Use 'run post/windows/manage/run_as_psh USER=x PASS=X EXE=X' or 'SET INTERACTIVE false'")
+      raise 'Invalide console'
     end
+    # Prepare powershell script
+    scr = "$pw = convertto-securestring '#{pass}' -asplaintext -force; "
+    scr << "$pp = new-object -typename System.Management.Automation.PSCredential -argumentlist '#{domain}\\\\#{user}',$pw; "
+    scr << "Start-process '#{exe}' -WorkingDirectory '#{path}' -Credential $pp"
+    if (args and args != '')
+      scr << " -argumentlist '#{args}' "
+    end
+    if hidden
+      print_status("Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false")
+      scr << " -WindowStyle hidden"
+    end
+    scr = " -c \"#{scr}\""
+    # Execute script
+    p = client.sys.process.execute("powershell.exe", scr,
+      'Channelized' => channelized,
+      'Desktop'     => false,
+      'Session'     => false,
+      'Hidden'      => true,
+      'Interactive' => inter,
+      'InMemory'    => false,
+      'UseThreadToken' => false)
+    print_status("Process #{p.pid} created.")
+    print_status("Channel #{p.channel.cid} created.") if (p.channel)
+    # Process output
+    if (inter and p.channel)
+      client.console.interact_with_channel(p.channel)
+    elsif p.channel
+      data = p.channel.read()
+      print_line(data) if data
+    end
+  end
 end


### PR DESCRIPTION
## Overview
This module will start a process as another user using powershell.
By default, it will start an interactive cmd as the target user.

## Module Options
- **USER** - The use to run the program as. 
- **PASS** - The user's password  
- **DOMAIN** - The domain of the user
- **EXE** - The program to run (default cmd.exe)
- **ARGS** - The program arguments 
- **PATH** - The path to run the program in (default C:\\)
- **CHANNELIZE** - Channelize the output, required to read output or interact
- **INTERACT** - Interact with program
- **HIDDEN** - Hide the console window

## Module Process
The process will use the Start-Process command of powershell to run a process as another user.

## Limitations
- Requires Powershell
- Hidden Mode does not work with older powershell versions
- Interactive mode needs to be run from a meterpreter console

## Examples

`
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword

[*] Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false
[*] Process 1672 created.
[*] Channel 30 created.
Microsoft Windows [Version 10.0.14393]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\\>whoami
whoami
my-pc\test

C:\\>

meterpreter > run post/windows/manage/run_as_psh user=test pass=mypassword hidden=false channelize=false interactive=false exe=cmd path=C:\\\\windows args="/c start notepad"

[*] Process 9768 created.
meterpreter > 

`