### PR TITLE
fixes #7707: risk_factor and risk_score in the nexpose plugin

### DIFF
--- a/lib/rapid7/nexpose.rb
+++ b/lib/rapid7/nexpose.rb
@@ -553,8 +553,8 @@ module NexposeAPI
         res << {
           :site_id       => site.attributes['id'].to_i,
           :name          => site.attributes['name'].to_s,
-          :risk_factor   => site.attributes['risk_factor'].to_f,
-          :risk_score    => site.attributes['risk_score'].to_f,
+          :risk_factor   => site.attributes['riskfactor'].to_f,
+          :risk_score    => site.attributes['riskscore'].to_f,
         }
       end
       return res
@@ -595,8 +595,8 @@ module NexposeAPI
         res << {
           :device_id     => device.attributes['id'].to_i,
           :address       => device.attributes['address'].to_s,
-          :risk_factor   => device.attributes['risk_factor'].to_f,
-          :risk_score    => device.attributes['risk_score'].to_f,
+          :risk_factor   => device.attributes['riskfactor'].to_f,
+          :risk_score    => device.attributes['riskscore'].to_f,
         }
       end
       return res


### PR DESCRIPTION
This fixes the bug reported in #7707. The Nexpose API responds with keys like riskfactor instead of risk_factor. This causes some of the nexpose commands to report a risk factor and score of 0.0:

broken:
```
msf > nexpose_sites
[*]     Site #1 'site-A' Risk Factor: 1.0 Risk Score: 0.0
[*]     Site #2 'site-B' Risk Factor: 1.0 Risk Score: 0.0
[*]     Site #5 'Metasploit-1481661040' Risk Factor: 1.0 Risk Score: 0.0
```
working:
```
msf > nexpose_sites
[*]     Site #1 'site-A' Risk Factor: 1.0 Risk Score: 1460485.6
[*]     Site #2 'site-B' Risk Factor: 1.0 Risk Score: 451796.1
[*]     Site #5 'Metasploit-1481661040' Risk Factor: 1.0 Risk Score: 159064.89
```

Thanks!