### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -96,6 +96,8 @@ FireFart <FireFart@github>             <FireFart@users.noreply.github.com>
 FireFart <FireFart@github>             Christian Mehlmauer <firefart@gmail.com>
 g0tmi1k <g0tmi1k@github>               <g0tmi1k@users.noreply.github.com>
 g0tmi1k <g0tmi1k@github>               <have.you.g0tmi1k@gmail.com>
+h00die <h00die@github>                 <h00die@users.noreply.github.com>
+h00die <h00die@github>                 <mike@shorebreaksecurity.com>
 h0ng10 <h0ng10@github>                 h0ng10 <hansmartin.muench@googlemail.com>
 h0ng10 <h0ng10@github>                 Hans-Martin Münch <hansmartin.muench@googlemail.com>
 hdm <hdm@github>                       HD Moore <hd_moore@rapid7.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
+acammack-r7 <acammack-r7@github>     <acammack@aus-mbp-1099.aus.rapid7.com>
 acammack-r7 <acammack-r7@github>     <adam_cammack@rapid7.com>
 acammack-r7 <acammack-r7@github>     <Adam_Cammack@rapid7.com>
 bcook-r7 <bcook-r7@github>           <bcook@rapid7.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,58 +1,59 @@
-acammack-r7 <acammack-r7@github>     Adam Cammack <Adam_Cammack@rapid7.com>
+acammack-r7 <acammack-r7@github>     <adam_cammack@rapid7.com>
+acammack-r7 <acammack-r7@github>     <Adam_Cammack@rapid7.com>
+bcook-r7 <bcook-r7@github>           <bcook@rapid7.com>
 bcook-r7 <bcook-r7@github>           <busterb@gmail.com>
-bcook-r7 <bcook-r7@github>           Brent Cook <bcook@rapid7.com>
-bpatterson-r7 <bpatterson-r7@github> Brian Patterson <Brian_Patterson@rapid7.com>
-bpatterson-r7 <bpatterson-r7@github> bpatterson-r7 <Brian_Patterson@rapid7.com>
-bturner-r7 <bturner-r7@github>       Brandon Turner <brandon_turner@rapid7.com>
-bwatters-r7 <bwatters-r7@github>     Brendan <bwatters@rapid7.com>
-bwatters-r7 <bwatters-r7@github>     Brendan Watters <bwatters@rapid7.com>
-cdoughty-r7 <cdoughty-r7@github>     Chris Doughty <chris_doughty@rapid7.com>
-dheiland-r7 <dheiland-r7@github>     Deral Heiland <dh@layereddefense.com>
-dmaloney-r7 <dmaloney-r7@github>     David Maloney <DMaloney@rapid7.com>
-dmaloney-r7 <dmaloney-r7@github>     David Maloney <David_Maloney@rapid7.com>
-dmaloney-r7 <dmaloney-r7@github>     dmaloney-r7 <DMaloney@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>     Dev Mohanty <Dev_Mohanty@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>     Dev Mohanty <Dev_Mohanty@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>     dmohanty-r7 <Dev_Mohanty@rapid7.com>
-dmohanty-r7 <dmohanty-r7@github>     dmohanty-r7 <Dev_Mohanty@rapid7.com>
-ecarey-r7 <ecarey-r7@github>         Erran Carey <e@ipwnstuff.com>
-farias-r7 <farias-r7@github>         Fernando Arias <fernando_arias@rapid7.com>
-gmikeska-r7 <gmikeska-r7@github>     Greg Mikeska <greg_mikeska@rapid7.com>
-gmikeska-r7 <gmikeska-r7@github>     Gregory Mikeska <greg_mikeska@rapid7.com>
-jbarnett-r7 <jbarnett-r7@github>     James Barnett <James_Barnett@rapid7.com>
-jhart-r7 <jhart-r7@github>           Jon Hart <jon_hart@rapid7.com>
-jlee-r7 <jlee-r7@github>             <egypt@metasploit.com> # aka egypt
-jlee-r7 <jlee-r7@github>             <james_lee@rapid7.com>
-kgray-r7 <kgray-r7@github>           Kyle Gray <kyle_gray@rapid7.com>
-khayes-r7 <khayes-r7@github>         l0gan <Kirk_Hayes@rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance.sanchez+github@gmail.com>
-lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance.sanchez@rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance@AUS-MAC-1041.local>
-lsanchez-r7 <lsanchez-r7@github>     Lance Sanchez <lance@aus-mac-1041.aus.rapid7.com>
-lsanchez-r7 <lsanchez-r7@github>     darkbushido <lance.sanchez@gmail.com>
-lsato-r7 <lsato-r7@github>           Louis Sato <lsato@rapid7.com>
-pbarry-r7 <pbarry-r7@github>         Pearce Barry <pearce_barry@rapid7.com>
-pdeardorff-r7 <pdeardorff-r7@github> Paul Deardorff <Paul_Deardorff@rapid7.com>
-pdeardorff-r7 <pdeardorff-r7@github> pdeardorff-r7 <paul_deardorff@rapid7.com>
-sdavis-r7 <sdavis-r7@github>         Scott Davis <Scott_Davis@rapid7.com>
-sdavis-r7 <sdavis-r7@github>         Scott Lee Davis <scott_davis@rapid7.com>
-sdavis-r7 <sdavis-r7@github>         Scott Lee Davis <sdavis@rapid7.com>
-sgonzalez-r7 <sgonzalez-r7@github>   Sonny Gonzalez <sgonzalez@rapid7.com>
-sgonzalez-r7 <sgonzalez-r7@github>   Sonny Gonzalez <sonny_gonzalez@rapid7.com>
-shuckins-r7 <shuckins-r7@github>     Samuel Huckins <samuel_huckins@rapid7.com>
-tdoan-r7 <tdoan-r7@github>           tdoan-r7 <thao_doan@rapid7.com>
-tdoan-r7 <tdoan-r7@github>           thao doan <thao_doan@rapid7.com>
-todb-r7 <todb-r7@github>             Tod Beardsley <tod_beardsley@rapid7.com>
-todb-r7 <todb-r7@github>             Tod Beardsley <todb@metasploit.com>
-todb-r7 <todb-r7@github>             Tod Beardsley <todb@packetfu.com>
+bpatterson-r7 <bpatterson-r7@github> <“bpatterson@rapid7.com”>
+bpatterson-r7 <bpatterson-r7@github> <Brian_Patterson@rapid7.com>
+bturner-r7 <bturner-r7@github>       <brandon_turner@rapid7.com>
+bwatters-r7 <bwatters-r7@github>     <bwatters@rapid7.com>
+cdoughty-r7 <cdoughty-r7@github>     <chris_doughty@rapid7.com>
+dheiland-r7 <dheiland-r7@github>     <dh@layereddefense.com>
+dmaloney-r7 <dmaloney-r7@github>     <David_Maloney@rapid7.com>
+dmaloney-r7 <dmaloney-r7@github>     <DMaloney@rapid7.com>
+dmohanty-r7 <dmohanty-r7@github>     <Dev_Mohanty@rapid7.com>
+ecarey-r7 <ecarey-r7@github>         <e@ipwnstuff.com>
+egypt <egypt@github>                 <egypt@metasploit.com> # aka egypt
+egypt <egypt@github>                 <james_lee@rapid7.com>
+farias-r7 <farias-r7@github>         <fernando_arias@rapid7.com>
+gmikeska-r7 <gmikeska-r7@github>     <greg_mikeska@rapid7.com>
+gmikeska-r7 <gmikeska-r7@github>     greg.mikeska@rapid7.com <=>
+gmikeska-r7 <gmikeska-r7@github>     greg.mikeska@rapid7.com <YOUR_USERNAME_FOR_EMAIL>
+jbarnett-r7 <jbarnett-r7@github>     <James_Barnett@rapid7.com>
+jbarnett-r7 <jbarnett-r7@github>     <jbarnett@rapid7.com>
+jhart-r7 <jhart-r7@github>           <jon_hart@rapid7.com>
+jinq102030 <jinq102030@github>       <Jin_Qian@rapid7.com>
+jinq102030 <jinq102030@github>       <jqian@rapid7.com>
+jmartin-r7 <jmartin-r7@github>       <Jeffrey_Martin@rapid7.com>
+kgray-r7 <kgray-r7@github>           <kyle_gray@rapid7.com>
+khayes-r7 <khayes-r7@github>         <Kirk_Hayes@rapid7.com>
+lsanchez-r7 <lsanchez-r7@github>     <lance@aus-mac-1041.aus.rapid7.com>
+lsanchez-r7 <lsanchez-r7@github>     <lance@AUS-MAC-1041.local>
+lsanchez-r7 <lsanchez-r7@github>     <lance.sanchez+github@gmail.com>
+lsanchez-r7 <lsanchez-r7@github>     <lance.sanchez@gmail.com>
+lsanchez-r7 <lsanchez-r7@github>     <lance.sanchez@rapid7.com>
+lsato-r7 <lsato-r7@github>           <lsato@rapid7.com>
+lvarela-r7 <lvarela-r7@github>       <“leonardo_varela@rapid7.com”>
+pbarry-r7 <pbarry-r7@github>         <pearce_barry@rapid7.com>
+pdeardorff-r7 <pdeardorff-r7@github> <paul_deardorff@rapid7.com>
+pdeardorff-r7 <pdeardorff-r7@github> <Paul_Deardorff@rapid7.com>
+sdavis-r7 <sdavis-r7@github>         <scott_davis@rapid7.com>
+sdavis-r7 <sdavis-r7@github>         <Scott_Davis@rapid7.com>
+sdavis-r7 <sdavis-r7@github>         <sdavis@rapid7.com>
+sgonzalez-r7 <sgonzalez-r7@github>   <sgonzalez@rapid7.com>
+sgonzalez-r7 <sgonzalez-r7@github>   <sonny_gonzalez@rapid7.com>
+shuckins-r7 <shuckins-r7@github>     <samuel_huckins@rapid7.com>
+tatanus <tatanus@github>             <adam_compton@rapid7.com>
+tdoan-r7 <tdoan-r7@github>           <thao_doan@rapid7.com>
+todb-r7 <todb-r7@github>             <tod_beardsley@rapid7.com>
+todb-r7 <todb-r7@github>             <todb@metasploit.com>
+todb-r7 <todb-r7@github>             <todb@packetfu.com>
 wchen-r7 <wchen-r7@github>           <msfsinn3r@gmail.com> # aka sinn3r
 wchen-r7 <wchen-r7@github>           <wei_chen@rapid7.com>
-wvu-r7 <wvu-r7@github>               William Vu <William_Vu@rapid7.com>
-wvu-r7 <wvu-r7@github>               William Vu <wvu@cs.nmt.edu>
-wvu-r7 <wvu-r7@github>               William Vu <wvu@metasploit.com>
-wvu-r7 <wvu-r7@github>               wvu-r7 <William_Vu@rapid7.com>
-wwebb-r7 <wwebb-r7@github>           William Webb <William_Webb@rapid7.com>
-wwebb-r7 <wwebb-r7@github>           wwebb-r7 <William_Webb@rapid7.com>
+wvu-r7 <wvu-r7@github>               <William_Vu@rapid7.com>
+wvu-r7 <wvu-r7@github>               <wvu@cs.nmt.edu>
+wvu-r7 <wvu-r7@github>               <wvu@metasploit.com>
+wwalker-r7 <wwalker-r7@github>       <wyatt_walker@rapid7.com>
+wwebb-r7 <wwebb-r7@github>           <William_Webb@rapid7.com>
 
 # Above this line are current Rapid7 employees. Below this paragraph are
 # volunteers, former employees, and potential Rapid7 employees who, at
@@ -157,7 +158,7 @@ TomSellers <TomSellers@github>         Tom Sellers <tom@fadedcode.net>
 trevrosen <trevrosen@github>           Trevor Rosen <trevor@catapult-creative.com>
 trevrosen <trevrosen@github>           Trevor Rosen <Trevor_Rosen@rapid7.com>
 TrustedSec <davek@trustedsec.com>      trustedsec <davek@trustedsec.com>
-void-in <void-in@github>               root <void-in@users.noreply.github.com>
+void-in <void-in@github>               <void-in@users.noreply.github.com>
 void-in <void-in@github>               void-in <root@localhost.localdomain>
 void-in <void-in@github>               void-in <waqas.bsquare@gmail.com>
 void-in <void-in@github>               void_in <root@localhost.localdomain>

--- a/.mailmap
+++ b/.mailmap
@@ -75,8 +75,7 @@ bwall <bwall@github>                   Brian Wallace <bwall@openbwall.com>
 bwall <bwall@github>                   (B)rian (Wall)ace <nightstrike9809@gmail.com>
 ceballosm <ceballosm@github>           Mario Ceballos <mc@metasploit.com>
 Chao-mu <Chao-Mu@github>               chao-mu <chao@confusion.(none)>
-Chao-mu <Chao-Mu@github>               chao-mu <chao.mu@minorcrash.com>
-Chao-mu <Chao-Mu@github>               Chao Mu <chao.mu@minorcrash.com>
+Chao-mu <Chao-Mu@github>               <chao.mu@minorcrash.com>
 ChrisJohnRiley <ChrisJohnRiley@github> Chris John Riley <chris.riley@c22.cc>
 ChrisJohnRiley <ChrisJohnRiley@github> Chris John Riley <reg@c22.cc>
 claudijd <claudijd@github>             Jonathan Claudius <claudijd@yahoo.com>
@@ -87,12 +86,9 @@ crcatala <crcatala@github>             Christian Catalan <ccatalan@rapid7.com>
 darkoperator <darkoperator@github>     Carlos Perez <carlos_perez@darkoperator.com>
 efraintorres <efraintorres@github>     efraintorres <etlownoise@gmail.com>
 efraintorres <efraintorres@github>     et <>
-espreto <espreto@github>               Roberto Soares Espreto <robertoespreto@gmail.com>
-espreto <espreto@github>               Roberto Soares Espreto <robertoespreto@gmail.com>
-espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
-espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
+espreto <espreto@github>               <robertoespreto@gmail.com>
 fab <fab@???>                          fab <> # fab at revhosts.net (Fabrice MOURRON)
-FireFart <FireFart@github>             Christian Mehlmauer <firefart@gmail.com>
+FireFart <FireFart@github>             <firefart@gmail.com>
 FireFart <FireFart@github>             <FireFart@users.noreply.github.com>
 g0tmi1k <g0tmi1k@github>               <g0tmi1k@users.noreply.github.com>
 g0tmi1k <g0tmi1k@github>               <have.you.g0tmi1k@gmail.com>
@@ -103,8 +99,7 @@ h0ng10 <h0ng10@github>                 Hans-Martin Münch <hansmartin.muench@goo
 hdm <hdm@github>                       HD Moore <hdm@digitaloffense.net>
 hdm <hdm@github>                       HD Moore <hd_moore@rapid7.com>
 hdm <hdm@github>                       HD Moore <x@hdm.io>
-jabra <jabra@github>                   Josh Abraham <jabra@spl0it.org>
-jabra <jabra@github>                   Joshua Abraham <jabra@spl0it.org>
+jabra <jabra@github>                   <jabra@spl0it.org>
 jcran <jcran@github>                   <jcran@0x0e.org>
 jcran <jcran@github>                   <jcran@pentestify.com>
 jcran <jcran@github>                   <jcran@pwnieexpress.com>

--- a/.mailmap
+++ b/.mailmap
@@ -68,15 +68,15 @@ bcoles <bcoles@github>                 bcoles <bcoles@gmail.com>
 bcoles <bcoles@github>                 Brendan Coles <bcoles@gmail.com>
 bokojan <bokojan@github>               parzamendi-r7 <peter_arzamendi@rapid7.com>
 brandonprry <brandonprry@github>       <bperry@brandons-mbp.attlocal.net>
-brandonprry <brandonprry@github>       Brandon Perry <bperry.volatile@gmail.com>
 brandonprry <brandonprry@github>       Brandon Perry <bperry@bperry-rapid7.(none)>
+brandonprry <brandonprry@github>       Brandon Perry <bperry.volatile@gmail.com>
 brandonprry <brandonprry@github>       Brandon Perry <brandon.perry@zenimaxonline.com>
-bwall <bwall@github>                   (B)rian (Wall)ace <nightstrike9809@gmail.com>
 bwall <bwall@github>                   Brian Wallace <bwall@openbwall.com>
+bwall <bwall@github>                   (B)rian (Wall)ace <nightstrike9809@gmail.com>
 ceballosm <ceballosm@github>           Mario Ceballos <mc@metasploit.com>
-Chao-mu <Chao-Mu@github>               Chao Mu <chao.mu@minorcrash.com>
-Chao-mu <Chao-Mu@github>               chao-mu <chao.mu@minorcrash.com>
 Chao-mu <Chao-Mu@github>               chao-mu <chao@confusion.(none)>
+Chao-mu <Chao-Mu@github>               chao-mu <chao.mu@minorcrash.com>
+Chao-mu <Chao-Mu@github>               Chao Mu <chao.mu@minorcrash.com>
 ChrisJohnRiley <ChrisJohnRiley@github> Chris John Riley <chris.riley@c22.cc>
 ChrisJohnRiley <ChrisJohnRiley@github> Chris John Riley <reg@c22.cc>
 claudijd <claudijd@github>             Jonathan Claudius <claudijd@yahoo.com>
@@ -87,21 +87,21 @@ crcatala <crcatala@github>             Christian Catalan <ccatalan@rapid7.com>
 darkoperator <darkoperator@github>     Carlos Perez <carlos_perez@darkoperator.com>
 efraintorres <efraintorres@github>     efraintorres <etlownoise@gmail.com>
 efraintorres <efraintorres@github>     et <>
-espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
-espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
 espreto <espreto@github>               Roberto Soares Espreto <robertoespreto@gmail.com>
 espreto <espreto@github>               Roberto Soares Espreto <robertoespreto@gmail.com>
+espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
+espreto <espreto@github>               Roberto Soares <robertoespreto@gmail.com>
 fab <fab@???>                          fab <> # fab at revhosts.net (Fabrice MOURRON)
-FireFart <FireFart@github>             <FireFart@users.noreply.github.com>
 FireFart <FireFart@github>             Christian Mehlmauer <firefart@gmail.com>
+FireFart <FireFart@github>             <FireFart@users.noreply.github.com>
 g0tmi1k <g0tmi1k@github>               <g0tmi1k@users.noreply.github.com>
 g0tmi1k <g0tmi1k@github>               <have.you.g0tmi1k@gmail.com>
 h00die <h00die@github>                 <h00die@users.noreply.github.com>
 h00die <h00die@github>                 <mike@shorebreaksecurity.com>
 h0ng10 <h0ng10@github>                 h0ng10 <hansmartin.muench@googlemail.com>
 h0ng10 <h0ng10@github>                 Hans-Martin Münch <hansmartin.muench@googlemail.com>
-hdm <hdm@github>                       HD Moore <hd_moore@rapid7.com>
 hdm <hdm@github>                       HD Moore <hdm@digitaloffense.net>
+hdm <hdm@github>                       HD Moore <hd_moore@rapid7.com>
 hdm <hdm@github>                       HD Moore <x@hdm.io>
 jabra <jabra@github>                   Josh Abraham <jabra@spl0it.org>
 jabra <jabra@github>                   Joshua Abraham <jabra@spl0it.org>
@@ -112,9 +112,9 @@ jcran <jcran@github>                   <jcran@rapid7.com>
 jduck <jduck@github>                   <github.jdrake@qoop.org>
 jduck <jduck@github>                   <jdrake@qoop.org>
 jgor <jgor@github>                     jgor <jgor@indiecom.org>
+joevennix <joevennix@github>           Joe Vennix <joevennix@gmail.com>
 joevennix <joevennix@github>           <Joe_Vennix@rapid7.com>
 joevennix <joevennix@github>           <joev@metasploit.com>
-joevennix <joevennix@github>           Joe Vennix <joevennix@gmail.com>
 joevennix <joevennix@github>           jvennix-r7 <Joe_Vennix@rapid7.com>
 juanvazquez <juanvazquez@github>       jvazquez-r7 <juan.vazquez@metasploit.com>
 juanvazquez <juanvazquez@github>       jvazquez-r7 <juan_vazquez@rapid7.com>
@@ -150,8 +150,8 @@ scriptjunkie <scriptjunkie@github>     Matt Weeks <scriptjunkie@scriptjunkie.us>
 scriptjunkie <scriptjunkie@github>     scriptjunkie <scriptjunkie@scriptjunkie.us>
 skape <skape@???>                      Matt Miller <mmiller@hick.org>
 spoonm <spoonm@github>                 Spoon M <spoonm@gmail.com>
-stufus <stufus@github>                 Stuart <stufus@users.noreply.github.com>
 stufus <stufus@github>                 Stuart Morgan <stuart.morgan@mwrinfosecurity.com>
+stufus <stufus@github>                 Stuart <stufus@users.noreply.github.com>
 swtornio <swtornio@github>             Steve Tornio <swtornio@gmail.com>
 Tasos Laskos <Tasos_Laskos@rapid7.com> Tasos Laskos <Tasos_Laskos@rapid7.com>
 techpeace <techpeace@github>           Matt Buck <Matthew_Buck@rapid7.com>
@@ -161,10 +161,10 @@ TomSellers <TomSellers@github>         Tom Sellers <tom@fadedcode.net>
 trevrosen <trevrosen@github>           Trevor Rosen <trevor@catapult-creative.com>
 trevrosen <trevrosen@github>           Trevor Rosen <Trevor_Rosen@rapid7.com>
 TrustedSec <davek@trustedsec.com>      trustedsec <davek@trustedsec.com>
-void-in <void-in@github>               <void-in@users.noreply.github.com>
-void-in <void-in@github>               void-in <root@localhost.localdomain>
-void-in <void-in@github>               void-in <waqas.bsquare@gmail.com>
 void-in <void-in@github>               void_in <root@localhost.localdomain>
+void-in <void-in@github>               void-in <root@localhost.localdomain>
+void-in <void-in@github>               <void-in@users.noreply.github.com>
+void-in <void-in@github>               void-in <waqas.bsquare@gmail.com>
 void-in <void-in@github>               Waqas Ali <waqas.bsquare@gmail.com>
 zeroSteiner <zeroSteiner@github>       Spencer McIntyre <zeroSteiner@gmail.com>
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -378,25 +378,38 @@ class Console::CommandDispatcher::Stdapi::Net
     index = nil
 
     # Parse the options
-    @@portfwd_opts.parse(args) { |opt, idx, val|
+    @@portfwd_opts.parse(args) do |opt, idx, val|
+      p opt, idx, val
       case opt
-        when '-h'
-          cmd_portfwd_help
-          return true
-        when '-l'
-          lport = val.to_i
-        when '-L'
+      when '-h'
+        cmd_portfwd_help
+        return true
+      when '-l'
+        lport = val.to_i
+      when '-L'
+        parts = val.split(":")
+        case parts.count
+        when 4
+          lhost, lport, rhost, rport = parts
+        when 3
+          lport, rhost, rport = parts
+        when 1
+          # Assume this is just a host.
           lhost = val
-        when '-p'
-          rport = val.to_i
-        when '-r'
-          rhost = val
-        when '-R'
-          reverse = true
-        when '-i'
-          index = val.to_i
+        else
+          print_error("-L expects [bind_address:]local_port:remote_host:remote_port")
+          return true
+        end
+      when '-p'
+        rport = val.to_i
+      when '-r'
+        rhost = val
+      when '-R'
+        reverse = true
+      when '-i'
+        index = val.to_i
       end
-    }
+    end
 
     # If we haven't extended the session, then do it now since we'll
     # need to track port forwards
@@ -574,6 +587,8 @@ class Console::CommandDispatcher::Stdapi::Net
 
   def cmd_portfwd_help
     print_line 'Usage: portfwd [-h] [add | delete | list | flush] [args]'
+    print_line
+    print_line ''
     print_line
     print @@portfwd_opts.usage
   end

--- a/tools/modules/module_targets.rb
+++ b/tools/modules/module_targets.rb
@@ -48,19 +48,19 @@ opts.parse(ARGV) { |opt, idx, val|
   when "-x"
     puts "Filter: #{val}"
     filter = val
-    fil=1		
+    fil=1
   end
 }
 
 Indent = '    '
 
 # Initialize the simplified framework instance.
-$framework = Msf::Simple::Framework.create('DisableDatabase' => true)
+$framework = Msf::Simple::Framework.create('DisableDatabase' => true, module_types: [ 'exploit' ])
 
 tbl = Rex::Text::Table.new(
   'Header'  => 'Module Targets',
   'Indent'  => Indent.length,
-  'Columns' => [ 'Module name','Target' ]
+  'Columns' => [ 'Module name','Space' ]
 )
 
 all_modules = $framework.exploits
@@ -69,7 +69,8 @@ all_modules.each_module { |name, mod|
   x = mod.new
   x.targets.each do |targ|
     if fil==0 or targ.name=~/#{filter}/
-      tbl << [ x.fullname, targ.name ]
+      next unless x.payload_space(targ).to_i > 0
+      tbl << [ x.fullname, x.payload_space(targ) ]
     end
   end
 }


### PR DESCRIPTION
Add Jeffrey Martin, Adam Compton, and Jin Qian.

Drop names for most so only email addresses matter.

## Verification

- [x] with mailmap: `git log --author rapid7.com --format=%aE --since 2016-01-01 | sort -u`
  - [x] **VERIFY** Displays github usernames for all the `-r7` folks.
  - [x] **VERIFY** contains only *one* name for each user, e.g. `jinq102030@github` and not both `Jin_Qian@rapid7.com` and `jqian@rapid7.com`

