### PR TITLE
Add reference name enforcement to cmd_use

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -598,11 +598,11 @@ module Msf
             mod_name = args[0]
 
             # Ensure we have a reference name and not a path
-            if mod_name.start_with?('modules/')
-              mod_name.sub!(/^modules\//, '')
+            if mod_name.start_with?('modules/', '/')
+              mod_name.sub!(/^(?:modules)?\//, '')
             end
-            if mod_name.end_with?('.', '.rb')
-              mod_name.sub!(/\.(?:rb)?$/, '')
+            if mod_name.end_with?('.', '.r', '.rb')
+              mod_name.sub!(/\.(?:rb?)?$/, '')
             end
 
             begin

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -597,6 +597,14 @@ module Msf
             # Try to create an instance of the supplied module name
             mod_name = args[0]
 
+            # Ensure we have a reference name and not a path
+            if mod_name.start_with?('modules/')
+              mod_name.sub!(/^modules\//, '')
+            end
+            if mod_name.end_with?('.', '.rb')
+              mod_name.sub!(/\.(?:rb)?$/, '')
+            end
+
             begin
               mod = framework.modules.create(mod_name)
               unless mod


### PR DESCRIPTION
**Feature description:**

This PR updates the ```use``` command in ```msfconsole``` to accept partial and complete module paths instead of only reference names. This patch also bypasses the ***three***-second delay from #4615 for the scenarios listed below.

**Verification steps:**

- [x] Test with ```exploits/windows/smb/ms08_067_netapi.```
- [x] Test with ```exploits/windows/smb/ms08_067_netapi.r```
- [x] Test with ```exploits/windows/smb/ms08_067_netapi.rb```
- [x] Test with ```/exploits/windows/smb/ms08_067_netapi.rb```
- [x] Test with ```modules/exploits/windows/smb/ms08_067_netapi.rb```

*Additional tests for that warm, cozy feeling:*

- [x] Test the above with ```exploit``` in place of ```exploits```
- [x] Test the above without any module type specified

**Sample run:**

```
msf > use exploits/windows/smb/ms08_067_netapi.
msf exploit(ms08_067_netapi) > back
msf > use exploits/windows/smb/ms08_067_netapi.r
msf exploit(ms08_067_netapi) > back
msf > use exploits/windows/smb/ms08_067_netapi.rb
msf exploit(ms08_067_netapi) > back
msf > use /exploits/windows/smb/ms08_067_netapi.rb
msf exploit(ms08_067_netapi) > back
msf > use modules/exploits/windows/smb/ms08_067_netapi.rb
msf exploit(ms08_067_netapi) > 
```

FYI, I have a benchmarking script if you desire performance testing.

Resolves #7693.