### PR TITLE
make assigning payload fast again

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -698,6 +698,12 @@ class Exploit < Msf::Module
     (target and target.arch) ? target.arch : (arch == []) ? nil : arch
   end
 
+  def normalize_platform_arch
+    c_platform = (target and target.platform) ? target.platform : platform
+    c_arch     = (target and target.arch)     ? target.arch     : (arch == []) ? nil : arch
+    c_arch   ||= [ ARCH_X86 ]
+    return c_platform, c_arch
+  end
 
   #
   # Returns whether the requested payload is compatible with the module.
@@ -706,10 +712,23 @@ class Exploit < Msf::Module
   # @return [TrueClass] Payload is compatible.
   # @return [FalseClass] Payload is not compatible.
   #
-  def is_payload_compatible?(payload_name)
-    payload_names = compatible_payloads.collect { |entry| entry[0] }
+  def is_payload_compatible?(name)
+    p = framework.payloads[name]
 
-    payload_names.include?(payload_name)
+    # Skip over payloads that are too big
+    return false if payload_space && p.cached_size && p.cached_size > payload_space
+
+    pi = p.new
+
+    # Are we compatible in terms of conventions and connections and
+    # what not?
+    return false if !compatible?(pi)
+
+    # If the payload is privileged but the exploit does not give
+    # privileged access, then fail it.
+    return false if !self.privileged && pi.privileged
+
+    return true
   end
 
   #
@@ -719,34 +738,11 @@ class Exploit < Msf::Module
   def compatible_payloads
     payloads = []
 
-
-    c_platform = (target and target.platform) ? target.platform : platform
-    c_arch     = (target and target.arch)     ? target.arch     : (arch == []) ? nil : arch
-    c_arch   ||= [ ARCH_X86 ]
+    c_platform, c_arch = normalize_platform_arch
 
     framework.payloads.each_module(
-      'Platform' => c_platform,
-      'Arch'     => c_arch ) { |name, mod|
-
-      # Skip over payloads that are too big
-      if ((payload_space) and
-          (framework.payloads.sizes[name]) and
-          (framework.payloads.sizes[name] > payload_space))
-        dlog("#{refname}: Skipping payload #{name} for being too large", 'core',
-          LEV_1)
-        next
-      end
-
-      # Are we compatible in terms of conventions and connections and
-      # what not?
-      next if (compatible?(framework.payloads.instance(name)) == false)
-
-      # If the payload is privileged but the exploit does not give
-      # privileged access, then fail it.
-      next if (self.privileged == false and framework.payloads.instance(name).privileged == true)
-
-      # This one be compatible!
-      payloads << [ name, mod ]
+      'Arch' => c_arch, 'Platform' => c_platform) { |name, mod|
+      payloads << [ name, mod ] if is_payload_compatible?(name)
     }
 
     return payloads;
@@ -758,12 +754,10 @@ class Exploit < Msf::Module
   def compatible_encoders
     encoders = []
 
-    c_platform = (target and target.platform) ? target.platform : platform
-    c_arch     = (target and target.arch)     ? target.arch     : (arch == []) ? nil : arch
+    c_platform, c_arch = normalize_platform_arch
 
     framework.encoders.each_module_ranked(
       'Arch' => c_arch, 'Platform' => c_platform) { |name, mod|
-
       encoders << [ name, mod ]
     }
 


### PR DESCRIPTION
This streamlines the check for whether the currently-selected payload is compatible on assignment. Rather than building the entire list of compatible payloads, and seeing if what the user typed is in it (and making multiple giant lists on the way), we simply check the module the user typed directly.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload windows/meterpreter/reverse_tcp`
- [x] **Verify** that the assignment happens instantly
- [x] `set payload windows <tab>`
- [x] **Verify** that the tab completion works
- [x] `back` to stop using the module
- [x] `set payload windows <tab`
- [x] **Verify** that nothing blows up
- [x] use a module with more restricted size or payload requirements
- [x] verify that payload gets checked on assignment (see #5404 when this first started being discussed)

