### PR TITLE
Warn user when session not compat instead of failing

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -30,7 +30,7 @@ module Msf::PostMixin
   # @raise [OptionValidateError] if {#session} returns nil
   def setup
     unless session_compatible?(session)
-      raise Msf::OptionValidateError.new(["SESSION (type not valid for this module)"])
+      print_warning('SESSION may not be compatible with this module.')
     end
 
     super
@@ -168,8 +168,8 @@ module Msf::PostMixin
     # Check to make sure architectures match
     mod_arch = self.module_info['Arch']
     unless mod_arch.nil?
-    mod_arch = [mod_arch] unless mod_arch.kind_of?(Array)
-      return false unless mod_arch.include? s.arch
+      mod_arch = [mod_arch] unless mod_arch.kind_of?(Array)
+      return false unless mod_arch.include?(s.arch)
     end
 
     # If we got here, we haven't found anything that definitely


### PR DESCRIPTION
This commit changes the post mixin so that the session compat check only shows a warning rather than throwing an exception and stopping the module from working completely.

This is off the back of the discussion involved with #7736

With this in place, the running of http://pastebin.com/j5FHCUz6 changes to this instead:
```
msf exploit(chkrootkit) > run
[*] Exploit completed, but no session was created.


[!] [2016.12.21-11:14:11] SESSION may not be compatible with this module.
[*] [2016.12.21-11:14:11] Started reverse TCP double handler on xx.xx.xx.xx:4444 
[!] [2016.12.21-11:14:11] Rooting depends on the crontab (this could take a while)
[*] [2016.12.21-11:14:11] Payload written to /tmp/update
[*] [2016.12.21-11:14:11] Waiting for chkrootkit to run via cron...
```

I think this is a good short term measure to stop things from breaking while we figure out the best way to move ahead.