### PR TITLE
Add sort by column to services and hosts commands

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -586,6 +586,11 @@ class Db
           return
         end
         output_file = ::File.expand_path(output_file)
+      when '-O'
+        if (order_by = args.shift.to_i - 1) == -1
+          print_error('Please specify a column number starting from 1')
+          return
+        end
       when '-R', '--rhosts'
         set_rhosts = true
       when '-S', '--search'
@@ -604,6 +609,7 @@ class Db
         print_line "  -r <protocol>     Only show [tcp|udp] services"
         print_line "  -u,--up           Only show services which are up"
         print_line "  -o <file>         Send output to a file in csv format"
+        print_line "  -O <column>       Order rows by specified column number"
         print_line "  -R,--rhosts       Set RHOSTS from the results of the search"
         print_line "  -S,--search       Search string to filter by"
         print_line
@@ -651,8 +657,9 @@ class Db
       col_names = col_search
     end
     tbl = Rex::Text::Table.new({
-        'Header'  => "Services",
-        'Columns' => ['host'] + col_names,
+        'Header'    => "Services",
+        'Columns'   => ['host'] + col_names,
+        'SortIndex' => order_by
       })
 
     # Sentinal value meaning all

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -360,6 +360,11 @@ class Db
         onlyup = true
       when '-o'
         output = args.shift
+      when '-O'
+        if (order_by = args.shift.to_i - 1) < 0
+          print_error('Please specify a column number starting from 1')
+          return
+        end
       when '-R', '--rhosts'
         set_rhosts = true
       when '-S', '--search'
@@ -386,6 +391,7 @@ class Db
         print_line "  -h,--help         Show this help information"
         print_line "  -u,--up           Only show hosts which are up"
         print_line "  -o <file>         Send output to a file in csv format"
+        print_line "  -O <column>       Order rows by specified column number"
         print_line "  -R,--rhosts       Set RHOSTS from the results of the search"
         print_line "  -S,--search       Search string to filter by"
         print_line "  -i,--info         Change the info of a host"
@@ -425,8 +431,9 @@ class Db
     # If we got here, we're searching.  Delete implies search
     tbl = Rex::Text::Table.new(
       {
-        'Header'  => "Hosts",
-        'Columns' => col_names,
+        'Header'    => "Hosts",
+        'Columns'   => col_names,
+        'SortIndex' => order_by
       })
 
     # Sentinal value meaning all

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -587,7 +587,7 @@ class Db
         end
         output_file = ::File.expand_path(output_file)
       when '-O'
-        if (order_by = args.shift.to_i - 1) == -1
+        if (order_by = args.shift.to_i - 1) < 0
           print_error('Please specify a column number starting from 1')
           return
         end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -387,6 +387,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -h,--help         Show this help information",
           "  -u,--up           Only show hosts which are up",
           "  -o <file>         Send output to a file in csv format",
+          "  -O <column>       Order rows by specified column number",
           "  -R,--rhosts       Set RHOSTS from the results of the search",
           "  -S,--search       Search string to filter by",
           "  -i,--info         Change the info of a host",

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -462,6 +462,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -r <protocol>     Only show [tcp|udp] services",
           "  -u,--up           Only show services which are up",
           "  -o <file>         Send output to a file in csv format",
+          "  -O <column>       Order rows by specified column number",
           "  -R,--rhosts       Set RHOSTS from the results of the search",
           "  -S,--search       Search string to filter by",
           "Available columns: created_at, info, name, port, proto, state, updated_at"


### PR DESCRIPTION
This adds the ```-O``` option to the ```services``` and ```hosts``` commands to allow sorting by a specific column.

FYI, there's some weirdness with sorting a column with identical rows. I'm simply passing the sort on to ```Rex::Text::Table```. There's no magic here.

- [x] Test ```-O``` without an argument
- [x] See the helpful error message
- [x] Test ```-O``` with an erroneous argument
- [x] See the same helpful error message
- [x] Test ```-O``` for ```services```
- [x] Test ```-O``` for ```hosts```
- [x] Ship it?

Resolves #7642.