### PR TITLE
disable async output until we have a better handle on new quirks

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -133,16 +133,23 @@ begin
     private
 
     def readline_with_output(prompt, add_history=false)
-      # rb-readlines's Readline.readline hardcodes the input and output to $stdin and $stdout, which means setting
-      # `Readline.input` or `Readline.ouput` has no effect when running `Readline.readline` with rb-readline, so need
-      # to reimplement []`Readline.readline`](https://github.com/luislavena/rb-readline/blob/ce4908dae45dbcae90a6e42e3710b8c3a1f2cd64/lib/readline.rb#L36-L58)
-      # for rb-readline to support setting input and output.  Output needs to be set so that colorization works for the
-      # prompt on Windows.
+      # rb-readlines's Readline.readline hardcodes the input and output to
+      # $stdin and $stdout, which means setting `Readline.input` or
+      # `Readline.ouput` has no effect when running `Readline.readline` with
+      # rb-readline, so need to reimplement
+      # []`Readline.readline`](https://github.com/luislavena/rb-readline/blob/ce4908dae45dbcae90a6e42e3710b8c3a1f2cd64/lib/readline.rb#L36-L58)
+      # for rb-readline to support setting input and output.  Output needs to
+      # be set so that colorization works for the prompt on Windows.
+      #
       self.prompt = prompt
-      reset_sequence = "\n\001\r\033[K\002"
-      if (/mingw/ =~ RUBY_PLATFORM)
-        reset_sequence = ""
-      end
+
+      # TODO: there are unhandled quirks in async output buffering that
+      # we have not solved yet, for instance when loading meterpreter
+      # extensions, supporting Windows, printing output from commands, etc.
+      # Remove this guard when issues are resolved.
+      # reset_sequence = "\n\001\r\033[K\002"
+      reset_sequence = ""
+
       if defined? RbReadline
         RbReadline.rl_instream = fd
         RbReadline.rl_outstream = output

--- a/lib/rex/ui/text/output/stdio.rb
+++ b/lib/rex/ui/text/output/stdio.rb
@@ -58,18 +58,22 @@ class Output::Stdio < Rex::Ui::Text::Output
   # Use ANSI Control chars to reset prompt position for async output
   # SEE https://github.com/rapid7/metasploit-framework/pull/7570
   def print_line(msg = '')
-    if (/mingw/ =~ RUBY_PLATFORM)
-      print(msg + "\n")
-      return
-    end
-    print("\033[s") # Save cursor position
-    print("\r\033[K" + msg + "\n")
-    if input and input.prompt
-      print("\r\033[K")
-      print(input.prompt.tr("\001\002", ''))
-      print(input.line_buffer.tr("\001\002", ''))
-      print("\033[u\033[B") # Restore cursor, move down one line
-    end
+
+    # TODO: there are unhandled quirks in async output buffering that
+    # we have not solved yet, for instance when loading meterpreter
+    # extensions, supporting Windows, printing output from commands, etc.
+    # Remove this guard when issues are resolved.
+    #
+    # print("\033[s") # Save cursor position
+    # print("\r\033[K" + msg + "\n")
+    # if input and input.prompt
+    #   print("\r\033[K")
+    #   print(input.prompt.tr("\001\002", ''))
+    #   print(input.line_buffer.tr("\001\002", ''))
+    #   print("\033[u\033[B") # Restore cursor, move down one line
+    # end
+
+    print(msg + "\n")
   end
 
   #


### PR DESCRIPTION
This disables the async output changes until we have a better handle on more of the quirks or someone has time to address them. Issues we've had reported include:

 - output from meterpreter commands getting truncated by a line occasionally
 - output from loading meterpreter extensions disappearing
 - advanced readline keystrokes not working as expected
 - double newlines in prompt output
 - problems working quickly on the console, vs. working slowly

A deeper rework of the output subsystem might be needed to fully address the issues that folks have run into in a truly robust way.

## Verification

- [x] Start `msfconsole`
- [x] Do normal things at normal speeds, ensure output is not corrupted.
