### PR TITLE
Raise if an unsupported arch is used with elf-so

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -2171,6 +2171,8 @@ require 'msf/core/exe/segment_appender'
         case arch
         when ARCH_X64
           to_linux_x64_elf_dll(framework, code, exeopts)
+        else
+          raise "#{arch} is not supported with elf-so"
         end
       end
     when 'macho', 'osx-app'


### PR DESCRIPTION
Only x64 is supported...

- [ ] Run through the repro in the PR linked below
- [ ] Decide if this is the right "fix" or not

Resolves #7723.