### PR TITLE
Update chromecast wifi gather module to use Scanner for scanning in bulk

### DIFF
--- a/modules/auxiliary/gather/chromecast_wifi.rb
+++ b/modules/auxiliary/gather/chromecast_wifi.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
     return unless res && res.code == 200
 
     waps_table = Rex::Text::Table.new(
-      'Header' => "Wireless Access Points from #{rhost}",
+      'Header' => "Wireless Access Points from #{ip}",
       'Columns' => [
         'BSSID',
         'PWR',

--- a/modules/auxiliary/scanner/http/chromecast_wifi.rb
+++ b/modules/auxiliary/scanner/http/chromecast_wifi.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
     unless waps_table.rows.empty?
       print_line(waps_table.to_s)
       report_note(
-        :host => rhost,
+        :host => ip,
         :port => rport,
         :proto => 'tcp',
         :type => 'chromecast.wifi',
@@ -70,23 +70,16 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scan
-    begin
-      send_request_raw(
-        'method' => 'POST',
-        'uri' => '/setup/scan_wifi',
-        'agent' => Rex::Text.rand_text_english(rand(42) + 1)
-      )
-      send_request_raw(
-        'method' => 'GET',
-        'uri' => '/setup/scan_results',
-        'agent' => Rex::Text.rand_text_english(rand(42) + 1)
-      )
-    rescue Rex::ConnectionRefused, Rex::ConnectionTimeout,
-           Rex::HostUnreachable => e
-      fail_with(Failure::Unreachable, e)
-    ensure
-      disconnect
-    end
+    send_request_raw(
+      'method' => 'POST',
+      'uri' => '/setup/scan_wifi',
+      'agent' => Rex::Text.rand_text_english(rand(42) + 1)
+    )
+    send_request_raw(
+      'method' => 'GET',
+      'uri' => '/setup/scan_results',
+      'agent' => Rex::Text.rand_text_english(rand(42) + 1)
+    )
   end
 
   def enc(wap)


### PR DESCRIPTION
This simply updates this module to use `Scanner` so that one can run this across larger networks more easily.

## Verification


- [x] Start `msfconsole`
- [x] `use auxiliary/gather/chromecast_wifi`
- [x] Set `RHOSTS` to some network with 1 or more chromecasts
- [x] **Verify** that each chromecast has a unique table printed out with the wireless networks it sees

```
msf auxiliary(chromecast_wifi) > run

Wireless Access Points from 192.168.1.57
========================================

BSSID              PWR  ENC   CIPHER  AUTH  ESSID
-----              ---  ---   ------  ----  -----
00:2a:a8:f7:ff:93  -45  WPA2  CCMP    PSK   blah (*)

Wireless Access Points from 192.168.1.50
========================================

BSSID              PWR  ENC   CIPHER  AUTH  ESSID
-----              ---  ---   ------  ----  -----
00:2a:a8:f7:ff:93  -45  WPA2  CCMP    PSK   blah (*)
01:17:1d:b7:e0:78  -86  WPA2  CCMP    PSK   blah2


[*] Scanned 2 of 2 hosts (100% complete)
```