### PR TITLE
Update pgsql and base Ubuntu test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 group: stable
 bundler_args: --without coverage development pcap

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ group: stable
 bundler_args: --without coverage development pcap
 cache: bundler
 addons:
-  postgresql: '9.3'
+  postgresql: '9.6'
   apt:
     packages:
       - libpcap-dev


### PR DESCRIPTION
This updates the travis test infrastructure to match the jenkins updates so that the generated SQL is the same between both systems.

## Validation Steps

 - [ ] Travis is green (that's all this should really do)