### PR TITLE
add auto-complete info for 'show info'

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -570,7 +570,7 @@ module Msf
 
             res = %w{all encoders nops exploits payloads auxiliary post plugins options}
             if (active_module)
-              res.concat(%w{ missing advanced evasion targets actions })
+              res.concat %w{missing advanced evasion targets actions info}
               if (active_module.respond_to? :compatible_sessions)
                 res << "sessions"
               end


### PR DESCRIPTION
This just adds some auto-complete info for the show command

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/http/nuuo_nvrmini_reset`
- [x] type `show` <tab> <tab>
- [x] screen should look like this:

```
msf > use auxiliary/admin/http/nuuo_nvrmini_reset
msf auxiliary(nuuo_nvrmini_reset) > show
show actions    show all        show encoders   show exploits   show missing    show options    show plugins    show targets
show advanced   show auxiliary  show evasion    show info       show nops       show payloads   show post
```

Fixes #7756
