### PR TITLE
Fix nil bug in generic/custom and change opt order

### DIFF
--- a/modules/payloads/singles/generic/custom.rb
+++ b/modules/payloads/singles/generic/custom.rb
@@ -42,10 +42,12 @@ module MetasploitModule
       self.arch = actual_arch
     end
 
-    if datastore['PAYLOADFILE']
-      IO.read(datastore['PAYLOADFILE'])
-    elsif datastore['PAYLOADSTR']
+    if datastore['PAYLOADSTR']
       datastore['PAYLOADSTR']
+    elsif datastore['PAYLOADFILE']
+      IO.read(datastore['PAYLOADFILE'])
+    else
+      ''
     end
   end
 


### PR DESCRIPTION
- [x] ```set PAYLOAD generic/custom```
- [x] See no ```nil``` bug when it does the thing
- [x] ```set PAYLOADFILE``` *or* ```PAYLOADSTR```
- [x] See it do the thing from your chosen option
- [x] ```set PAYLOADFILE``` *and* ```PAYLOADSTR```
- [x] See it do the thing from ```PAYLOADSTR```