### PR TITLE
Added the history command

### DIFF
--- a/features/commands/help.feature
+++ b/features/commands/help.feature
@@ -21,6 +21,7 @@ Feature: Help command
           getg          Gets the value of a global variable
           grep          Grep the output of another command
           help          Help menu
+          history       Show commands history
           irb           Drop into irb scripting mode
           load          Load a framework plugin
           quit          Exit the console

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -85,7 +85,10 @@ class Core
     "-k" => [ true,  "Keep (include) arg lines at start of output."   ],
     "-c" => [ false, "Only print a count of matching lines."          ])
 
-
+  @@history_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner."                                   ],
+    "-a" => [ false, "Show all commands in history"                ],
+    "-n" => [ true, "Show the last n commands"                       ])
 
   @@irb_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -105,6 +108,7 @@ class Core
       "getg"       => "Gets the value of a global variable",
       "grep"       => "Grep the output of another command",
       "help"       => "Help menu",
+      "history"    => "Show commands history",
       "irb"        => "Drop into irb scripting mode",
       "load"       => "Load a framework plugin",
       "quit"       => "Exit the console",
@@ -472,6 +476,43 @@ class Core
   end
 
   alias cmd_quit cmd_exit
+
+
+  def cmd_history(*args)
+    
+    limit = 100
+    length = Readline::HISTORY.length 
+
+    @@history_opts.parse(args) do |opt, _idx, val|
+      case opt
+      when "-a"
+        limit = length
+      when "-n"
+        return cmd_history_help unless val.match /\A[-+]?\d+\z/
+        limit = val.to_i
+        limit = length if limit >= length
+      when "-h"
+        cmd_history_help
+        return false
+      end
+    end
+
+    start = length - limit 
+    (start..length-1).each do |pos|
+      print "#{pos}  #{Readline::HISTORY[pos]}\n"
+    end
+  end
+
+  def cmd_history_help
+    print_line "Usage: history [options]"
+    print_line
+    print_line "Shows the command history."
+    print_line "If -n is not set, it will only be shown the last 100 commands"
+    print_line
+    print @@history_opts.usage
+  end
+
+
 
   def cmd_sleep_help
     print_line "Usage: sleep <seconds>"

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -87,8 +87,8 @@ class Core
 
   @@history_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
-    "-a" => [ false, "Show all commands in history"                ],
-    "-n" => [ true, "Show the last n commands"                       ])
+    "-a" => [ false, "Show all commands in history."                  ],
+    "-n" => [ true, "Show the last n commands."                       ])
 
   @@irb_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -489,7 +489,7 @@ class Core
       when "-a"
         limit = length
       when "-n"
-        return cmd_history_help unless val.match /\A[-+]?\d+\z/
+        return cmd_history_help unless !val.nil? && val.match(/\A[-+]?\d+\z/)
         limit = val.to_i
         limit = length if limit >= length
       when "-h"
@@ -508,7 +508,7 @@ class Core
     print_line "Usage: history [options]"
     print_line
     print_line "Shows the command history."
-    print_line "If -n is not set, it will only be shown the last #{@history_limit} commands"
+    print_line "If -n is not set, it will only be shown the last #{@history_limit} commands."
     print_line
     print @@history_opts.usage
   end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -137,6 +137,7 @@ class Core
     @cache_payloads = nil
     @previous_module = nil
     @module_name_stack = []
+    @history_limit = 100
   end
 
   #
@@ -480,7 +481,7 @@ class Core
 
   def cmd_history(*args)
     
-    limit = 100
+    limit = @history_limit
     length = Readline::HISTORY.length 
 
     @@history_opts.parse(args) do |opt, _idx, val|
@@ -507,7 +508,7 @@ class Core
     print_line "Usage: history [options]"
     print_line
     print_line "Shows the command history."
-    print_line "If -n is not set, it will only be shown the last 100 commands"
+    print_line "If -n is not set, it will only be shown the last #{@history_limit} commands"
     print_line
     print @@history_opts.usage
   end


### PR DESCRIPTION
Added the "history" command to see a list of commands used before.

```
msf exploit(handler) > history -n 4
2344  set PAYLOAD windows/meterpreter/reverse_tcp
2345  set LHOST 10.0.1.109
2346  exploit
2347  history -n 4
msf exploit(handler) > history -h
Usage: history [options]

Show the command history
If -n is not set, it will only be shown the last 100 commands

OPTIONS:

    -a        Show length commands in history
    -h        Help banner.
    -n <opt>  Show the last n commands

msf exploit(handler) > 
```
