### PR TITLE
Improve error handling in tcp channels

### DIFF
--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -57,14 +57,14 @@ class Channel
       cid = packet.get_tlv_value(TLV_TYPE_CHANNEL_ID)
 
       # No channel identifier, then drop it
-      if (cid == nil)
+      if cid.nil?
         return false
       end
 
       channel = client.find_channel(cid)
 
       # No valid channel context? The channel may not be registered yet
-      if (channel == nil)
+      if channel.nil?
         return false
       end
 
@@ -72,7 +72,7 @@ class Channel
       dio = channel.dio_map(packet.method)
 
       # Supported DIO request? Dump it.
-      if (dio == nil)
+      if dio.nil?
         return true
       end
 
@@ -98,12 +98,12 @@ class Channel
     request = Packet.create_request('core_channel_open')
 
     # Set the type of channel that we're allocating
-    if (type != nil)
+    if !type.nil?
       request.add_tlv(TLV_TYPE_CHANNEL_TYPE, type)
     end
 
     # If no factory class was provided, use the default native class
-    if (klass == nil)
+    if klass.nil?
       klass = self
     end
 
@@ -112,15 +112,20 @@ class Channel
     request.add_tlvs(addends);
 
     # Transmit the request and wait for the response
-    response = client.send_request(request)
-    cid      = response.get_tlv_value(TLV_TYPE_CHANNEL_ID)
+    cid = nil
+    begin
+      response = client.send_request(request)
+      cid = response.get_tlv_value(TLV_TYPE_CHANNEL_ID)
+    rescue RequestError
+      # Handle channel open failure exceptions
+    end
 
-    return nil unless cid
-
-    # Create the channel instance
-    channel  = klass.new(client, cid, type, flags)
-
-    return channel
+    if cid
+      # Create the channel instance
+      klass.new(client, cid, type, flags)
+    else
+      raise Rex::ConnectionRefused
+    end
   end
 
   ##
@@ -169,13 +174,13 @@ class Channel
   # Reads data from the remote half of the channel.
   #
   def _read(length = nil, addends = nil)
-    if (self.cid == nil)
+    if self.cid.nil?
       raise IOError, "Channel has been closed.", caller
     end
 
     request = Packet.create_request('core_channel_read')
 
-    if (length == nil)
+    if length.nil?
       # Default block size to a higher amount for passive dispatcher
       length = self.client.passive_service ? (1024*1024) : 65536
     end
@@ -217,7 +222,7 @@ class Channel
   #
   def _write(buf, length = nil, addends = nil)
 
-    if (self.cid == nil)
+    if self.cid.nil?
       raise IOError, "Channel has been closed.", caller
     end
 
@@ -245,7 +250,7 @@ class Channel
     response = self.client.send_request(request)
     written  = response.get_tlv(TLV_TYPE_LENGTH)
 
-    return (written == nil) ? 0 : written.value
+    written.nil? ? 0 : written.value
   end
 
   #
@@ -273,7 +278,7 @@ class Channel
   # Closes the channel.
   #
   def self._close(client, cid, addends=nil)
-    if (cid == nil)
+    if cid.nil?
       raise IOError, "Channel has been closed.", caller
     end
 
@@ -302,7 +307,7 @@ class Channel
   # Enables or disables interactive mode.
   #
   def interactive(tf = true, addends = nil)
-    if (self.cid == nil)
+    if self.cid.nil?
       raise IOError, "Channel has been closed.", caller
     end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -56,7 +56,9 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
           'value' => params.retries
         }
       ])
-    c.params = params
+    if c
+      c.params = params
+    end
     c
   end
 

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -80,8 +80,10 @@ class MetasploitModule < Msf::Auxiliary
                 'ConnectTimeout' => (timeout / 1000.0)
               }
             )
-            print_status("#{ip}:#{port} - TCP OPEN")
-            r << [ip,port,"open"]
+            if s
+              print_status("#{ip}:#{port} - TCP OPEN")
+              r << [ip,port,"open"]
+            end
           rescue ::Rex::ConnectionRefused
             vprint_status("#{ip}:#{port} - TCP closed")
             r << [ip,port,"closed"]
@@ -92,7 +94,9 @@ class MetasploitModule < Msf::Auxiliary
           rescue ::Exception => e
             print_error("#{ip}:#{port} exception #{e.class} #{e} #{e.backtrace}")
           ensure
-            disconnect(s) rescue nil
+            if s
+              disconnect(s) rescue nil
+            end
           end
         end
       end


### PR DESCRIPTION
This makes some minor idiomatic changes to channel handling code, but also fixes some areas where Meterpreter payloads actually send failure responses to opening sockets, but Metasploit does not handle these as expected. Rather than raising an exception or returning a nil socket, often a nil object is instead dereferenced, throwing an entirely different exception, and as a result, a lot of things sort of work only by luck.

## Verification

Run various exploits and modules that use TCP sockets through a pivot. For example, I have been running this RC script for testing mettle's network channel support:

```
use exploit/multi/handler
set payload linux/x86/mettle_reverse_tcp
set lhost 127.0.0.1
run -j
sleep 4
route add 192.168.1.0 255.255.255.0 1
use auxiliary/scanner/portscan/tcp
set RHOSTS 192.168.1.0/24
set SESSION -1
run
```

Your mileage may vary. This is certainly up for discussion, and I suspect I may have gotten intent vs what the code was actually doing mixed up. It does seem to help a bit with handling sudden unexpected socket closes.
