### PR TITLE
Add history deduplication

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -529,7 +529,6 @@ class Core
     print_line
     print_line "Shows the command history."
     print_line "If -n is not set, only the last #{@history_limit} commands will be shown."
-    print_line
     print @@history_opts.usage
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -89,8 +89,7 @@ class Core
     "-h" => [ false, "Help banner."                                   ],
     "-a" => [ false, "Show all commands in history."                  ],
     "-n" => [ true,  "Show the last n commands."                      ],
-    "-u" => [ false, "Show only unique commands."                     ],
-    "-c" => [ false, "Clear command history."                         ])
+    "-u" => [ false, "Show only unique commands."                     ])
 
   @@irb_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -503,9 +502,6 @@ class Core
         end
       when "-u"
         uniq = true
-      when "-c"
-        Readline::HISTORY.clear
-        return
       when "-h"
         cmd_history_help
         return false

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -88,7 +88,9 @@ class Core
   @@history_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
     "-a" => [ false, "Show all commands in history."                  ],
-    "-n" => [ true,  "Show the last n commands."                      ])
+    "-n" => [ true,  "Show the last n commands."                      ],
+    "-u" => [ false, "Show only unique commands."                     ],
+    "-c" => [ false, "Clear command history."                         ])
 
   @@irb_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -480,6 +482,7 @@ class Core
 
   def cmd_history(*args)
     length = Readline::HISTORY.length
+    uniq   = false
 
     if length < @history_limit
       limit = length
@@ -498,6 +501,11 @@ class Core
         else
           limit = val.to_i
         end
+      when "-u"
+        uniq = true
+      when "-c"
+        Readline::HISTORY.clear
+        return
       when "-h"
         cmd_history_help
         return false
@@ -508,6 +516,9 @@ class Core
     pad_len = length.to_s.length
 
     (start..length-1).each do |pos|
+      if uniq && Readline::HISTORY[pos] == Readline::HISTORY[pos-1]
+        next unless pos == 0
+      end
       cmd_num = (pos + 1).to_s
       print_line "#{cmd_num.ljust(pad_len)}  #{Readline::HISTORY[pos]}"
     end


### PR DESCRIPTION
WIP branching off #7765.

```
msf > history 
1  history 
msf > history 
1  history 
2  history 
msf > history -u
1  history 
3  history -u
msf > history -c
msf > history 
1  history 
msf > 
```

**Notes:**

* Only consecutive dupes are collapsed
* Clearing is not working right now if you actually keep a history file (unlike me)
   * ```Rex::Ui::Text::Shell```'s history file saving isn't looking very promising for clearing
   * On second thought, ```history -c``` in ```bash``` actually clears the file, too
   * I may be able to rework ```Rex::Ui::Text::Shell``` to clear only the current session
   * I am removing history clearing until I fix ```Rex::Ui::Text::Shell```