### PR TITLE
Add database check to WMAP plugin

### DIFF
--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -2244,6 +2244,10 @@ class Plugin::Wmap < Msf::Plugin
   def initialize(framework, opts)
     super
 
+    if framework.db.active == false
+      raise 'Database not connected (try db_connect)'
+    end
+
     color = self.opts["ConsoleDriver"].output.supports_color? rescue false
 
     wmapversion = '1.5.1'


### PR DESCRIPTION
```
msf > db_disconnect 
msf > load wmap 
[-] Failed to load plugin from /Users/wvu/metasploit-framework/plugins/wmap: Database not connected (try db_connect)
msf > db_connect -y
[*] Rebuilding the module cache in the background...
msf > load wmap 

.-.-.-..-.-.-..---..---.
| | | || | | || | || |-'
`-----'`-'-'-'`-^-'`-'
[WMAP 1.5.1] ===  et [  ] metasploit.com 2012
[*] Successfully loaded plugin: wmap
msf > wmap_sites -a 192.168.33.134
[*] Site created.
msf > 
```

Closes #7755.