### PR TITLE
Fix pivoting of UDP sockets in scanners, recv/recvfrom for all pivoted UDP Rex sockets

### DIFF
--- a/lib/rex/post/meterpreter/channels/datagram.rb
+++ b/lib/rex/post/meterpreter/channels/datagram.rb
@@ -33,8 +33,10 @@ class Datagram < Rex::Post::Meterpreter::Channel
       'udp'
     end
 
-    def recvfrom_nonblock(length,flags = nil)
-      return [super(length, flags)[0], super(length, flags)[0]]
+    def recvfrom_nonblock(length, flags = 0)
+      data = super(length, flags)[0]
+      sockaddr = super(length, flags)[0]
+      [data, sockaddr]
     end
 
     def send(buf, flags, saddr)
@@ -53,17 +55,12 @@ class Datagram < Rex::Post::Meterpreter::Channel
     )
 
     if peerhost && peerport
-      # Maxlen here is 65507, to ensure we dont overflow, we need to write twice
-      # If the other side has a full 64k, handle by splitting up the datagram and
-      # writing multiple times along with the sockaddr. Consumers calling recvfrom
-      # repeatedly will buffer up all the pieces.
-      while data.length > 65507
-        rsock.syswrite(data[0..65506])
-        rsock.syswrite(Rex::Socket.to_sockaddr(peerhost,peerport))
-        data = data - data[0..65506]
-      end
-      rsock.syswrite(data)
-      rsock.syswrite(Rex::Socket.to_sockaddr(peerhost,peerport))
+      # A datagram can be maximum 65507 bytes, truncate longer messages
+      rsock.syswrite(data[0..65506])
+
+      # We write the data and sockaddr data to the local socket, the pop it
+      # back in recvfrom_nonblock.
+      rsock.syswrite(Rex::Socket.to_sockaddr(peerhost, peerport))
       return true
     else
       return false

--- a/lib/rex/post/meterpreter/channels/datagram.rb
+++ b/lib/rex/post/meterpreter/channels/datagram.rb
@@ -39,8 +39,15 @@ class Datagram < Rex::Post::Meterpreter::Channel
       [data, sockaddr]
     end
 
-    def send(buf, flags, saddr)
-      channel.send(buf, flags, saddr)
+    #
+    # This should work just like a UDPSocket.send method
+    #
+    # send(mesg, flags, host, port) => numbytes_sent click to toggle source
+    # send(mesg, flags, sockaddr_to) => numbytes_sent
+    # send(mesg, flags) => numbytes_sent
+    #
+    def send(buf, flags, a = nil, b = nil)
+      channel.send(buf, flags, a, b)
     end
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
@@ -77,24 +77,41 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
   end
 
   #
-  # This function is called by Rex::Socket::Udp.sendto and writes data to a specified
-  # remote peer host/port via the remote end of the channel.
+  # This function is called by Rex::Socket::Udp.sendto and writes data to a
+  # specified remote peer host/port via the remote end of the channel.
   #
-  def send(buf, flags, saddr)
-    _af, peerhost, peerport = Rex::Socket.from_sockaddr(saddr)
+  # This should work just like a UDPSocket.send method
+  #
+  # send(mesg, flags, host, port) => numbytes_sent click to toggle source
+  # send(mesg, flags, sockaddr_to) => numbytes_sent
+  # send(mesg, flags) => numbytes_sent
+  #
+  def send(buf, flags, a = nil, b = nil)
+    host = nil
+    port = nil
 
-    addends = [
-      {
-        'type'  => TLV_TYPE_PEER_HOST,
-        'value' => peerhost
-      },
-      {
-        'type'  => TLV_TYPE_PEER_PORT,
-        'value' => peerport
-      }
-    ]
+    if a && b.nil?
+      _, host, port = Rex::Socket.from_sockaddr(a)
+    elsif a && b
+      host = a
+      port = b
+    end
 
-    return _write(buf, buf.length, addends)
+    addends = nil
+    if host && port
+      addends = [
+        {
+          'type'  => TLV_TYPE_PEER_HOST,
+          'value' => host
+        },
+        {
+          'type'  => TLV_TYPE_PEER_PORT,
+          'value' => port
+        }
+      ]
+    end
+
+    _write(buf, buf.length, addends)
   end
 
 end

--- a/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
+++ b/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 
 class MetasploitModule < Msf::Auxiliary
 
-  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
@@ -42,8 +42,6 @@ class MetasploitModule < Msf::Auxiliary
     password = nil
 
     begin
-      # Create an unbound UDP socket if no CHOST is specified, otherwise
-      # create a UDP socket bound to CHOST (in order to avail of pivoting)
       udp_sock = Rex::Socket::Udp.create( {
         'LocalHost' => datastore['CHOST'] || nil,
         'PeerHost'  => ip,


### PR DESCRIPTION
While testing UDP pivoting on https://github.com/rapid7/mettle/pull/50 I found that modules calling recvfrom on a pivoted socket did not ever receive any data. Several overzealous rescues deep, I tracked it down to recvfrom_nonblock being changed in #6692 to call super (which is the ruby socket implementation), which does not accept *nil* for the flags parameter. So, any module that does not specify flags on recvfrom will cause a silent exception on that call, and fail to receive any data at all.

At the same time, I found that because the UDP scanner mixin does not bind the UDP socket on creation, the socket does not pivot. Setting CHOST/CPORT doesn't seem to help, and if it did, it's still strange to require it in order to route properly. This switches it to use bound sockets instead.

This also changs the behavior of the DIO handler to truncate datagrams rather than splitting them into smaller chunks, since it should be impossible to actually receive such a large UDP datagram, even with IP fragmentation (the actual limit here.) In other words, if a caller is sending such large datagrams, it is broken.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole` and setup a windows meterpreter session (the only meterpreter with working UDP pivoting currently, unless https://github.com/rapid7/mettle/pull/50 is merged.
- [x] Run a UDP socket pivot-capable module, such as udp_probe, and enable a route so you can scan an active network with UDP services:

```
msf > route add 192.168.1.0 255.255.255.0 1
msf > setg rhosts 192.168.1.0/24
msf > use auxiliary/scanner/discovery/udp_probe
msf > run
msf > use auxiliary/scanner/discovery/udp_sweep
msf > run
```
- [x] **Verify** that the modules can detect UDP services through the pivot, and that it is actually generating traffic via the pivot.
- [x] Run the same modules without a pivot (don't add a route)
- [x] **Verify** that the modules detect the same services locally as well
