### PR TITLE
remove logging of expected exceptions in connection_established? method

### DIFF
--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -124,8 +124,6 @@ module Msf::DBManager::Connection
         ActiveRecord::Base.connection.active?
       }
     rescue ActiveRecord::ConnectionNotEstablished, PG::ConnectionBad => error
-      elog("Connection not established: #{error.class} #{error}:\n#{error.backtrace.join("\n")}")
-
       false
     end
   end


### PR DESCRIPTION
For some reason, the database 'connection_established?' method logs any time it returns false with a full back trace. This does not make any sense given that this function is expected to catch that exception to do its job. Logging the exception only makes framework.log fill with noise.

## Verification

- [x] tail -f ~/.msf4/logs/framework.log
- [x] Start `msfconsole` in an environment with a database
- [x] You should not see this, or something like it, logged to framework.log:
```
[01/02/2017 07:46:11] [e(0)] core: Connection not established: ActiveRecord::ConnectionNotEstablished ActiveRecord::ConnectionNotEstablished:
/home/bcook/.rvm/gems/ruby-2.3.3@metasploit-framework/gems/activerecord-4.2.7.1/lib/active_record/connection_handling.rb:109:in `connection_pool'
/home/bcook/projects/metasploit-framework/lib/msf/core/db_manager/connection.rb:123:in `connection_established?'
/home/bcook/projects/metasploit-framework/lib/msf/core/db_manager/connection.rb:54:in `connect'
/home/bcook/projects/metasploit-framework/lib/msf/ui/console/driver.rb:187:in `initialize'
/home/bcook/projects/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `new'
/home/bcook/projects/metasploit-framework/lib/metasploit/framework/command/console.rb:62:in `driver'
/home/bcook/projects/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/bcook/projects/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```