### PR TITLE
Fix #7743, nil @cnonce in rex/proto/http/client.rb

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -80,10 +80,6 @@ module Exploit::Remote::HttpClient
     )
     register_autofilter_ports([ 80, 8080, 443, 8000, 8888, 8880, 8008, 3000, 8443 ])
     register_autofilter_services(%W{ http https })
-
-    # Used by digest auth
-    @cnonce = make_cnonce
-    @nonce_count = -1
   end
 
 
@@ -767,10 +763,6 @@ module Exploit::Remote::HttpClient
 
     # Otherwise just return the signature string for compatibility
     fprint[:signature]
-  end
-
-  def make_cnonce
-    Digest::MD5.hexdigest "%x" % (Time.now.to_i + rand(65535))
   end
 
 protected

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -310,12 +310,18 @@ class Client
     auth_str = "Basic " + Rex::Text.encode_base64(auth_str)
   end
 
+
+  def make_cnonce
+    Digest::MD5.hexdigest "%x" % (Time.now.to_i + rand(65535))
+  end
+
   # Send a series of requests to complete Digest Authentication
   #
   # @param opts [Hash] the options used to build an HTTP request
   # @return [Response] the last valid HTTP response we received
   def digest_auth(opts={})
-    @nonce_count = 0
+    cnonce = make_cnonce
+    nonce_count = 0
 
     to = opts['timeout'] || 20
 
@@ -330,7 +336,7 @@ class Client
     end
 
     begin
-    @nonce_count += 1
+    nonce_count += 1
 
     resp = opts['response']
 
@@ -387,7 +393,7 @@ class Client
       [
         algorithm.hexdigest("#{digest_user}:#{parameters['realm']}:#{digest_password}"),
         parameters['nonce'],
-        @cnonce
+        cnonce
       ].join ':'
     else
       "#{digest_user}:#{parameters['realm']}:#{digest_password}"
@@ -397,7 +403,7 @@ class Client
     ha2 = algorithm.hexdigest("#{method}:#{path}")
 
     request_digest = [ha1, parameters['nonce']]
-    request_digest.push(('%08x' % @nonce_count), @cnonce, qop) if qop
+    request_digest.push(('%08x' % nonce_count), cnonce, qop) if qop
     request_digest << ha2
     request_digest = request_digest.join ':'
 
@@ -407,8 +413,8 @@ class Client
       "realm=\"#{parameters['realm']}\"",
       "nonce=\"#{parameters['nonce']}\"",
       "uri=\"#{path}\"",
-      "cnonce=\"#{@cnonce}\"",
-      "nc=#{'%08x' % @nonce_count}",
+      "cnonce=\"#{cnonce}\"",
+      "nc=#{'%08x' % nonce_count}",
       "algorithm=#{algstr}",
       "response=\"#{algorithm.hexdigest(request_digest)[0, 32]}\"",
       # The spec says the qop value shouldn't be enclosed in quotes, but


### PR DESCRIPTION
Fix #7743

This fixes a bug in rex/proto/http/client.rb. When the digest auth code was refactored, we forgot the move the part that generates the cnonce value, so it's always nil.

Verification

- [x] Set up a fake web server that returns a WWW-Authenticate for digest auth
- [x] In msfconsole, go to irb
- [x] Paste the following code in irb:

```ruby
opts = { 'method' => 'GET', 'uri' => '/' }
cli = Rex::Proto::Http::Client.new("127.0.0.1", 8181, {}, nil, nil, nil, 'user', 'password')
cli.connect
r = cli.digest_auth(opts)
puts r.request.to_s
```

- [x] The digest auth request should have a cnonce value