### PR TITLE
add optional output to merterp run_cmd

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -277,8 +277,23 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   #
   # Explicitly runs a command in the meterpreter console.
   #
-  def run_cmd(cmd)
-    console.run_single(cmd)
+  def run_cmd(cmd,output_object=nil)
+    stored_output_state = nil
+    # If the user supplied an Output IO object, then we tell
+    # the console to use that, while saving it's previous output/
+    if output_object
+      stored_output_state = console.output
+      console.send(:output=, output_object)
+    end
+    success = console.run_single(cmd)
+    # If we stored the previous output object of the channel
+    # we restore it here to put everything back the way we found it
+    # We re-use the conditional above, because we expect in many cases for
+    # the stored state to actually be nil here.
+    if output_object
+      console.send(:output=,stored_output_state)
+    end
+    success
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1236,7 +1236,7 @@ class Core
               session.response_timeout = response_timeout
             end
 
-            output = session.run_cmd cmd
+            output = session.run_cmd(cmd, driver.output)
           end
         end
     when 'kill'


### PR DESCRIPTION
the run_cmd method on meterpreter sessions can now
take an optiona output IO to redirect output. This allows
backgrounded sessions to also run commands and still output
to the console


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] get a windows meterpreter sessions
- [x] background the session with the `background` command
- [x] `sessions -i <session ID> -C sysinfo`
- [x] **Verify** you see the output from the sysinfo command

