### PR TITLE
BUG: target_host method had a name collision

### DIFF
--- a/lib/msf/core/exploit/auto_target.rb
+++ b/lib/msf/core/exploit/auto_target.rb
@@ -38,7 +38,7 @@ module Msf
     # @return [Msf::Module::Target] the Target that our automatic routine selected
     def select_target
       return nil unless auto_target?
-      host_record = target_host
+      host_record = auto_target_host
       return nil if host_record.nil?
       filtered_targets = filter_by_os(host_record)
       filtered_targets.first
@@ -48,7 +48,7 @@ module Msf
     #
     # @return [Mdm:Host] the Host record if one exists
     # @return [nil] if no Host record is present, or the DB is not active
-    def target_host
+    def auto_target_host
       return nil unless self.respond_to?(:rhost)
       return nil unless framework.db.active
       current_workspace = framework.db.find_workspace(self.workspace)

--- a/spec/lib/msf/core/exploit/auto_target_spec.rb
+++ b/spec/lib/msf/core/exploit/auto_target_spec.rb
@@ -69,12 +69,12 @@ RSpec.describe Msf::Exploit::AutoTarget do
       host_obj  = FactoryGirl.create(:mdm_host, address: host_addr )
       windows_exploit.datastore['WORKSPACE'] = host_obj.workspace.name
       windows_exploit.datastore['RHOST'] = host_addr
-      expect(windows_exploit.target_host).to eq host_obj
+      expect(windows_exploit.auto_target_host).to eq host_obj
     end
 
     it 'should return nil if there is not one' do
       windows_exploit.datastore['RHOST'] = '192.168.111.115'
-      expect(windows_exploit.target_host).to be_nil
+      expect(windows_exploit.auto_target_host).to be_nil
     end
   end
 


### PR DESCRIPTION
this method appears to have been accidentaly overriding another
method causing sessions to never finish being established


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] run psexec against a windows target
- [x] **Verify** you can actually get a session

