### PR TITLE
Fix #7793, incorrect command name in android meterpreter extension

### DIFF
--- a/lib/rex/post/meterpreter/extensions/android/android.rb
+++ b/lib/rex/post/meterpreter/extensions/android/android.rb
@@ -272,7 +272,7 @@ class Android < Extension
   end
 
   def send_sms(dest, body, dr)
-    request = Packet.create_request('android_android_send_sms')
+    request = Packet.create_request('android_send_sms')
     request.add_tlv(TLV_TYPE_SMS_ADDRESS, dest)
     request.add_tlv(TLV_TYPE_SMS_BODY, body)
     request.add_tlv(TLV_TYPE_SMS_DR, dr)


### PR DESCRIPTION
Fixes android send_sms command in the meterpreter extension, it had the wrong name.  Command is defined in metasploit-payloads [here](https://github.com/rapid7/metasploit-payloads/blob/master/java/androidpayload/library/src/com/metasploit/meterpreter/AndroidMeterpreter.java#L136)

rake spec passes:
`Finished in 3 minutes 20.7 seconds (files took 8.36 seconds to load)
9657 examples, 0 failures, 33 pending

Randomized with seed 46905
Coverage report generated for RSpec to /home/ubuntu/git/metasploit-framework/coverage. 51983 / 129515 LOC (40.14%) covered.`

Fixes #7793 


## Verification

- [x] Open meterpreter session with android payload
- [x] send_sms -d ********** <number> -t testing
- [x] see "[+] SMS sent - Transmission successful", instead of "android_android_send_sms: Operation failed: 1"


```
meterpreter > send_sms -d ********* -t testing
[+] SMS sent - Transmission successful
```

