### PR TITLE
update to rex-socket 0.1.3, which includes the IPv6 bind fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.2)
+    rex-socket (0.1.3)
       rex-core
     rex-sslscan (0.1.1)
       rex-socket


### PR DESCRIPTION
This fixes #7084 by fixing the semantics of when we try to do a dual bind on a socket to when we actually have no other addresses that we are binding to. This also happens to land some other UDP improvements from @sempervictus. The real fixes are in https://github.com/rapid7/rex-socket/pull/2

## Verification

List the steps needed to make sure this thing works

- [x] Ensure that we bind to the right socket type under a variety of circumstances. Here's my test run:

```
msf auxiliary(tftp) > use auxiliary/server/tftp
msf auxiliary(tftp) > set SRVPORT 6969
SRVPORT => 6969
msf auxiliary(tftp) > run
[*] Auxiliary module execution completed
[*] Starting TFTP server on 0.0.0.0:6969...
[*] Files will be served from /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T
[*] Uploaded files will be saved in /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T

msf auxiliary(tftp) > netstat -an |grep 6969
[*] exec: netstat -an |grep 6969

udp4       0      0  *.6969                 *.*
msf auxiliary(tftp) > jobs -K
Stopping all jobs...
msf auxiliary(tftp) > set SRVHOST ::0
SRVHOST => ::0
msf auxiliary(tftp) > run
[*] Auxiliary module execution completed
[*] Starting TFTP server on ::0:6969...
[*] Files will be served from /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T
[*] Uploaded files will be saved in /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T

msf auxiliary(tftp) > netstat -an |grep 6969
[*] exec: netstat -an |grep 6969

udp46      0      0  *.6969                 *.*
msf auxiliary(tftp) > jobs -K
Stopping all jobs...
msf auxiliary(tftp) > set SRVHOST localhost
SRVHOST => localhost
msf auxiliary(tftp) > run
[*] Auxiliary module execution completed
[*] Starting TFTP server on localhost:6969...
[*] Files will be served from /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T
[*] Uploaded files will be saved in /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T

msf auxiliary(tftp) > netstat -an |grep 6969
[*] exec: netstat -an |grep 6969

udp6       0      0  ::1.6969               *.*
msf auxiliary(tftp) > jobs -K
Stopping all jobs...
msf auxiliary(tftp) > set SRVHOST 127.0.0.1
SRVHOST => 127.0.0.1
msf auxiliary(tftp) > run
[*] Auxiliary module execution completed
[*] Starting TFTP server on 127.0.0.1:6969...
[*] Files will be served from /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T
[*] Uploaded files will be saved in /var/folders/7q/jwhmljqn6nx8lnqft8nf5w2myy7k2k/T

msf auxiliary(tftp) > netstat -an |grep 6969
[*] exec: netstat -an |grep 6969

udp4       0      0  127.0.0.1.6969         *.*
```

 - [x] **Note** how depending on which SRVHOST I set, it binds to the appropriate udp4, udp6, or udp46 socket type.