### PR TITLE
bump mettle gem to include pivoting support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 1.2.6)
       metasploit_data_models
-      metasploit_payloads-mettle (= 0.1.4)
+      metasploit_payloads-mettle (= 0.1.6)
       msgpack
       nessus_rest
       net-ssh
@@ -180,7 +180,7 @@ GEM
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.1.4)
+    metasploit_payloads-mettle (0.1.6)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.2.6'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.4'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.6'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.


### PR DESCRIPTION
This bumps the mettle gem to include TCP and UDP network pivoting support. It also includes support for round-robin DNS on reconnects.

https://github.com/rapid7/mettle/pull/50
https://github.com/rapid7/mettle/pull/39