### PR TITLE
Force unloading of already loaded plugins

### DIFF
--- a/lib/msf/core/plugin_manager.rb
+++ b/lib/msf/core/plugin_manager.rb
@@ -69,11 +69,8 @@ class PluginManager < Array
     end
 
     # Force unloading if already loaded
-    self.each do |plugin|
-      if plugin.class == klass
-        unload(plugin)
-      end
-    end
+    plugin = self.find { |p| p.class == klass }
+    unload(plugin) if plugin
 
     # Create an instance of the plugin and let it initialize
     instance = klass.create(framework, opts)

--- a/lib/msf/core/plugin_manager.rb
+++ b/lib/msf/core/plugin_manager.rb
@@ -68,6 +68,13 @@ class PluginManager < Array
       Kernel.load(path + ".rb")
     end
 
+    # Force unloading if already loaded
+    self.each do |plugin|
+      if plugin.class == klass
+        unload(plugin)
+      end
+    end
+
     # Create an instance of the plugin and let it initialize
     instance = klass.create(framework, opts)
 

--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -57,15 +57,16 @@ class RPC_Plugin < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('plugin.unload', 'nexpose')
   def rpc_unload(name)
-    self.framework.plugins.each { |plugin|
-      # Unload the plugin if it matches the name we're searching for
-      if (plugin.name == name)
-        self.framework.plugins.unload(plugin)
-        return 	{ "result" => "success" }
-      end
-    }
-    return 	{ "result" => "failure" }
+    # Find a plugin within the plugins array
+    plugin = self.framework.plugins.find { |p| p.name == name }
 
+    # Unload the plugin if it matches the name we're searching for
+    if plugin
+      self.framework.plugins.unload(plugin)
+      return 	{ "result" => "success" }
+    end
+
+    return 	{ "result" => "failure" }
   end
 
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1653,16 +1653,15 @@ class Core
       return false
     end
 
-    # Walk the plugins array
-    framework.plugins.each { |plugin|
-      # Unload the plugin if it matches the name we're searching for
-      if (plugin.name.downcase == args[0].downcase)
-        print("Unloading plugin #{args[0]}...")
-        framework.plugins.unload(plugin)
-        print_line("unloaded.")
-        break
-      end
-    }
+    # Find a plugin within the plugins array
+    plugin = framework.plugins.find { |p| p.name.downcase == args[0].downcase }
+
+    # Unload the plugin if it matches the name we're searching for
+    if plugin
+      print("Unloading plugin #{args[0]}...")
+      framework.plugins.unload(plugin)
+      print_line("unloaded.")
+    end
   end
 
   #


### PR DESCRIPTION
This prevents the double-loading of plugins.

- [x] `load` any combination of plugins
- [x] `show plugins` and see only once of each
- [x] Ensure that functionality is not duplicated
- [x] Test `unload` command
- [x] Test RPC functionality

Fixes #7799.