### PR TITLE
cleanup leaked constants

### DIFF
--- a/spec/lib/msf/core/exploit/auto_target_spec.rb
+++ b/spec/lib/msf/core/exploit/auto_target_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe Msf::Exploit::AutoTarget do
 
   include_context 'Msf::DBManager'
+  include_context 'Metasploit::Framework::Spec::Constants cleaner'
 
   let(:windows_exploit) {
     framework.modules.add_module_path(File.join(FILE_FIXTURES_PATH, 'modules'))


### PR DESCRIPTION
use constant cleaner to cleanup the loaded modules in the auto-target specs
Fixes https://github.com/rapid7/metasploit-framework/issues/7824

## Verification

List the steps needed to make sure this thing works

- [x] VERIFY travis build passes
