### PR TITLE
Convert workspace command to Rex::Text::Table

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -177,11 +177,31 @@ class Db
         return
       end
     else
+      workspace = framework.db.workspace
+      col_names = %w{current name hosts services vulns creds loots notes}
+
+      tbl = Rex::Text::Table.new(
+        'Header'    => 'Workspaces',
+        'Columns'   => col_names,
+        'SortIndex' => 1
+      )
+
       # List workspaces
-      framework.db.workspaces.each do |s|
-        pad = (s.name == framework.db.workspace.name) ? "* " : "  "
-        print_line("#{pad}#{s.name}")
+      framework.db.workspaces.each do |ws|
+        tbl << [
+          ws == workspace ? '*' : '',
+          ws.name,
+          ws.hosts.count,
+          ws.services.count,
+          ws.vulns.count,
+          ws.core_credentials.count,
+          ws.loots.count,
+          ws.notes.count
+        ]
       end
+
+      print_line
+      print_line(tbl.to_s)
     end
   }
   end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -546,7 +546,12 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
       it "should list default workspace" do
         db.cmd_workspace
         expect(@output).to match_array [
-          "* default"
+          "",
+          "Workspaces",
+          "==========",
+          "current  name     hosts  services  vulns  creds  loots  notes",
+          "-------  ----     -----  --------  -----  -----  -----  -----",
+          "*        default  0      0         0      0      0      0"
         ]
       end
 
@@ -555,8 +560,13 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
         @output = []
         db.cmd_workspace
         expect(@output).to match_array [
-          "  default",
-          "* foo"
+          "",
+          "Workspaces",
+          "==========",
+          "current  name     hosts  services  vulns  creds  loots  notes",
+          "-------  ----     -----  --------  -----  -----  -----  -----",
+          "         default  0      0         0      0      0      0",
+          "*        foo      0      0         0      0      0      0"
         ]
       end
     end


### PR DESCRIPTION
Adds host, service, vuln, cred, loot, and note counts. Sorts rows alphabetically.

- [x] `workspace -v`
- [x] :tada:

```
msf > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf > 
```

FYI, Metasploit pluralizes loot as "loots." It's odd, but I'm keeping with that.

Resolves #7828.

**Edit:** verification steps updated to reflect changes in #7832.