### PR TITLE
Add index to historical hashes in domain_hashdump

### DIFF
--- a/modules/post/windows/gather/credentials/domain_hashdump.rb
+++ b/modules/post/windows/gather/credentials/domain_hashdump.rb
@@ -45,7 +45,8 @@ class MetasploitModule < Msf::Post
           ad_account.nt_history.each_with_index do |nt_hash, index|
             hash_string = ad_account.lm_history[index] || Metasploit::Credential::NTLMHash::BLANK_LM_HASH
             hash_string << ":#{nt_hash}"
-            report_hash(hash_string.downcase,ad_account.name, realm)
+            ad_account_name_indexed = ad_account.name + "_" + index.to_s
+            report_hash(hash_string.downcase,ad_account_name_indexed, realm)
           end
         end
         rm_f(ntds_file)


### PR DESCRIPTION
This appends the index of the historical hash to the account name when dumping hashes via domain_hashdump.  Currently, all dumped hashes for an account will have the same name, making it difficult to tell which is the current password and which are historical.

## Verification

- Run domain_hashdump on a test domain with password history for accounts
- Verify that entries in creds adhere to the following:
  - Current password for user "JSMITH" should have public value "JSMITH"
  - Historical passwords for user "JSMITH" should have public values "JSMITH_0", "JSMITH_1", etc. in order from most recent to oldest

