### PR TITLE
Elm327 MCU HWBridge Relay

### DIFF
--- a/documentation/modules/auxiliary/client/hwbridge/connect.md
+++ b/documentation/modules/auxiliary/client/hwbridge/connect.md
@@ -1,0 +1,92 @@
+## Overview
+
+This module connects to any Hardware device that supports the HWBridge API.  For details
+on the HWBridge API see [API Reference].  On successful connection to a HW Bridge a
+hwbridge session will be established.
+
+## Options
+
+ **TARGETURI**
+
+ Specifies the base target URI to communicate to the HW Bridge API.  By default this is '/' but it
+ could be things such as '/api' or the randomly generated URI from the local_hwbridge module
+
+ **DEBUGJSON**
+
+ Prints out all the JSON packets that come from the HWBridge API.  Useful for troubleshooting
+ a device.
+
+ This module also supports all the other HTTP Client options typical to Metaplsoit.
+
+## Sample Connection
+
+For an example, lets say we connect to a HW Bridge that is designed for automotive use
+and has support for multiple CAN buses.  The remote device in our example is called 'carhax'
+
+```
+msf > use auxiliary/client/hwbridge/connect 
+msf auxiliary(connect) > set rhost carhax
+rhost => carhax
+msf auxiliary(connect) > run
+
+[*] Attempting to connect to carhax...
+[*] Hardware bridge interface session 1 opened (127.0.0.1 -> 127.0.0.1) at 2016-12-29 13:49:55 -0800
+[+] HWBridge session established
+[*] HW Specialty: {"automotive"=>true}  Capabilities: {"can"=>true, "custom_methods"=>true}
+[!] NOTICE:  You are about to leave the matrix.  All actions performed on this hardware bridge
+[!]          could have real world consequences.  Use this module in a controlled testing
+[!]          environment and with equipment you are authorized to perform testing on.
+[*] Auxiliary module execution completed
+```
+
+On successful connection to a Hardware device you will be prompted with a special notice to
+remind you that any action you take on the hwbridge could have physical affects and consequences.
+Our lawyers asked us to put that there.  You can verify the session was created by type 'sessions'
+
+```
+msf auxiliary(connect) > sessions
+
+Active sessions
+===============
+
+  Id  Type                   Information  Connection
+  --  ----                   -----------  ----------
+  1   hwbridge cmd/hardware  automotive   127.0.0.1 -> 127.0.0.1 (10.1.10.21)
+
+```
+## Automotive Extension
+
+If a device specifies a hw_specialty then it can load custom extensions.  For instance, if
+a defice defines its specialty is automotive then Metasploit will load a custom automotive
+extension that gives you a few generic commands you can use on autotive systems such as the
+ability to send arbitrary CAN packets down the bus.  It also allows you to run any
+post/hardware/automotive modules.
+
+For instance you can run post/hardware/automtive/getvinfo to retrieve vehicle information
+via UDS Mode $9 commands.
+
+```
+hwbridge > run post/hardware/automotive/getvinfo CANBUS=can2
+
+[*] Supported PIDS: [2, 4, 6, 8]
+[*] VIN: 1G1ZT53826F109149
+[*] Calibration ID: x
+[*] PID 6 Response: ["00", "00", "C4", "E9", "00", "00", "17", "33", "00", "00", "00", "00"]
+[*] PID 8 Response: ["00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00"]
+```
+run 'supported_buses' for a list of available buses provided by your hardware.  And as always you can
+type 'help' for a list of available commands and each command should support '-h' to additional
+argument help.
+
+## Custom Method Extension
+
+It is possible for the hardware device to report functionality that Metasploit has no knowledge
+of.  For instance, perhaps the device has a unique capability that isn't standard or can be done
+100% in hardware.  In order to utilize that functionality the HW device can report that it has
+custom_methods as a capability.  At which point Metasploit will then query the custom methods
+and their argument syntax.  These methods will become available as command line options
+within the hardware bridge.
+
+For a simple example of a custom method see auxiliary/server/local_hwbridge for a more complete
+list on how to define custom methods see the [API Reference]
+

--- a/documentation/modules/auxiliary/server/local_hwbridge.md
+++ b/documentation/modules/auxiliary/server/local_hwbridge.md
@@ -1,0 +1,58 @@
+## Overview
+
+This is a sample hardware bridge that demonstrates how to connect the HWBridge API to metasploit.
+It demonstrates some bare minimum capabilities to report back to the hardware connector and
+establish a hwbridge session.  This module provides an example on how to connect any hardware
+component to Metasploit.  It is also a fully functional interface to SocketCAN and will work
+to create an automotive HW Bridge.
+
+## Setup a Test
+
+To experimient with using Metasploit to send automtovie CAN bus packets you can use
+the SocketCAN capabilities of Linux to create a virtual CAN device.  NOTE: If you have a
+supported CAN sniffer you could also use a real can device.
+
+In order for the local_hwbridge to inteface with SocketCAN you will need:
+
+* can-utils
+
+Once those are installed you can setup a virtual CAN inteface using:
+
+```
+sudo modprobe can
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+```
+
+Once that is setup you can simply launch the module and it should auto detect any
+CAN intefaces you have active on the system.
+
+```
+msf > use auxiliary/server/local_hwbridge 
+msf auxiliary(local_hwbridge) > run
+[*] Auxiliary module execution completed
+
+[*] Using URL: http://0.0.0.0:8080/xaUKu68Va
+[*] Local IP: http://10.1.10.21:8080/xaUKu68Va
+[*] Server started.
+```
+By default it will create a random URI, in this case it's xaUKu68Va.
+
+## Connecting to the HWBridge
+
+You will need to use the auxiliary/client/hwbridge/connect to connect
+to the local_hwbridge.  You can either use the same machine or another machine to
+connect to your local_hwbridge.  Just make sure the TARGETURI matches the randomly
+generated URI
+
+```
+set TARGETURI xaUKu68Va
+```
+Then simply type run and you should connect to the HW bridge and a hwbridge session
+should be established.  You can switch to the hwbridge session to interact with
+this module.
+
+See the documentation for auxiliary/client/hwbridge/connect for more information on
+the hwbridge sessions.
+

--- a/documentation/modules/post/hardware/automotive/getvinfo.md
+++ b/documentation/modules/post/hardware/automotive/getvinfo.md
@@ -1,0 +1,49 @@
+Gathers several pieces of information from the vehicle.  First it reports
+the available PIDS for pulling realtime current_data from Mode $01.  If some of
+the common PIDs are returned it will print those as well, such as Engine Temp and
+Vehicle speed.  If there are any Diagnostic Trouble Codes (DTCs) it will list those.
+The DTCs and Engine Light can be cleared by setting the optional CLEAR_DTC to true.
+Finally it gathers Vehicle information via UDS Mode $09 requests.  The module
+first probes Mode $09 PID $00 to determine what all PIDs are supported then
+iterates through them and prints the response.  The module will format known
+PIDs to ASCII.
+
+## Options ##
+
+  **SRCID**
+
+  This is the SRC CAN ID for the ISO-TP connection.  Default is 0x7E0.
+
+  **DSTID**
+
+  This is the CAN ID of the expected response.  Default is 0x7E8.
+
+  **CANBUS**
+
+  Determines which CAN bus to communicate on.  Type 'supported_buses' for valid options.
+
+  **CLEAR_DTCS***
+
+  If any Diagnostic Trouble Codes (DTCs) are present it will clear those and reset the MIL (Enginge Light)
+
+## Scenarios
+
+  Given a standard vehicle ECU that is connected to can2 of the HWBridge device:
+
+```
+hwbridge > run post/hardware/automotive/getvinfo CANBUS=can2
+
+[*] Avaiable PIDS for pulling realitme data: 46 pids
+[*]   [1, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 24, 25, 28, 31, 32, 32, 33, 44, 45, 46, 47, 48, 49, 50, 51, 60, 61, 64, 65, 66, 67, 68, 69, 70, 71, 73, 74, 76]
+[*]   MIL (Engine Light) : OFF
+[*]   Number of DTCs: 0
+[*]   Engine Temp: 140 °C / 284 °F
+[*]   RPMS: 0
+[*]   Speed: 0 km/h  /  0.0 mph
+[*] Supported OBD Standards: OBD and OBD-II
+[*] Mode $09 Vehicle Info Supported PIDS: [2, 4, 6, 8]
+[*] VIN: 1G1ZT53826F109149
+[*] Calibration ID: UDS ERR: {"RCRRP"=>"Request Correctly Received, but Response is Pending"}
+[*] PID 6 Response: ["00", "00", "C4", "E9", "00", "00", "17", "33", "00", "00", "00", "00"]
+[*] PID 8 Response: ["00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00", "00"]
+```

--- a/documentation/modules/post/hardware/automotive/identifymodules.md
+++ b/documentation/modules/post/hardware/automotive/identifymodules.md
@@ -1,0 +1,30 @@
+Scans the CANBUS for devices responding to UDS DSC queries.  By trying to set
+the Diagnostic Sesscion Control (DSC) devices that support UDS will typically respond
+with an error or an acknowldegment.  We use this information to map out modules in a vehicle.
+
+## Options
+
+  **STARTID**
+
+  The CAN ID to start your scan from.
+
+  **ENDID**
+
+  The CAN ID to stop the CAN scan.
+
+  **CANBUS**
+
+  The bus to scan.  See 'supported_buses' for a list of available buses
+
+## Scenarios
+
+  A Quick scan of buses from 0x600 to 0x7FF
+
+```
+hwbridge > run post/hardware/automotive/identifymodules CANBUS=can2 STARTID=0x600
+
+Starting scan...
+[*] Identified module 7e0
+Scanned 504 IDs and found 1 modules that responded
+  7e0
+```

--- a/lib/msf/base/sessions/hwbridge.rb
+++ b/lib/msf/base/sessions/hwbridge.rb
@@ -1,0 +1,211 @@
+# -*- coding: binary -*-
+
+require 'msf/base'
+
+require 'rex/post/hwbridge'
+
+module Msf
+module Sessions
+
+###
+#
+# This class provides an interactive session with a hardware bridge.
+# The hardware bridge must support the current API supported by Metasploit.
+#
+###
+class HWBridge  < Rex::Post::HWBridge::Client
+
+  #
+  # This interface supports basic interaction.
+  #
+  include Msf::Session::Basic
+
+  #
+  # This interface supports interactive commands.
+  #
+  include Msf::Session::Interactive
+
+  #
+  # Initialize the HWBridge console
+  #
+  def initialize(opts={})
+    super
+    #
+    #  The module will manage it's alive state
+    #
+    self.alive = true
+
+    #
+    # Initialize the hwbridge client
+    #
+    self.init_hwbridge(rstream, opts)
+
+    #
+    # Create the console instance
+    #
+    self.console = Rex::Post::HWBridge::Ui::Console.new(self)
+  end
+
+  #
+  # Returns the type of session.
+  #
+  def self.type
+    "hwbridge"
+  end
+
+  #
+  # Returns the session description.
+  #
+  def desc
+    "Hardware bridge interface"
+  end
+
+  #
+  # We could tie this into payload UUID
+  #
+  def platform
+    "hardware"
+  end
+
+  #
+  # We could tie this into payload UUID
+  #
+  def arch
+    ARCH_CMD
+  end
+
+  #
+  # Session info based on the type of hw bridge we are connected to
+  # This information comes after connecting to a bridge and pulling status info
+  #
+  def info
+   if exploit
+     if exploit.hw_specialty
+       info = ""
+       exploit.hw_specialty.each_key do |k|
+         if exploit.hw_specialty[k] == true
+           info += "," if info.length > 0
+           info += k
+         end
+       end
+       return info
+     end
+   end
+  end
+
+  ##
+  # :category: Msf::Session::Interactive implementors
+  #
+  # Initializes the console's I/O handles.
+  #
+  def init_ui(input, output)
+    self.user_input = input
+    self.user_output = output
+    console.init_ui(input, output)
+    console.set_log_source(log_source)
+
+    super
+  end
+
+  ##
+  # :category: Msf::Session::Interactive implementors
+  #
+  # Resets the console's I/O handles.
+  #
+  def reset_ui
+    console.unset_log_source
+    console.reset_ui
+  end
+
+
+  ##
+  # :category: Msf::Session::Interactive implementors
+  #
+  # Interacts with the hwbridge client at a user interface level.
+  #
+  def _interact
+    framework.events.on_session_interact(self)
+    # Call the console interaction subsystem of the meterpreter client and
+    # pass it a block that returns whether or not we should still be
+    # interacting.  This will allow the shell to abort if interaction is
+    # canceled.
+    console.interact { self.interacting != true }
+
+    # If the stop flag has been set, then that means the user exited.  Raise
+    # the EOFError so we can drop this handle like a bad habit.
+    raise EOFError if (console.stopped? == true)
+  end
+
+  def alive?
+    self.alive
+  end
+
+  #
+  # Calls the class method.
+  #
+  def type
+    self.class.type
+  end
+
+  #
+  # Loads the automotive extension
+  #
+  def load_automotive
+    original = console.disable_output
+    console.disable_output = true
+    console.run_single('load automotive')
+    console.disable_output = original
+  end
+
+  #
+  # Load custom methods provided by the hardware
+  #
+  def load_custom_methods
+    original = console.disable_output
+    console.disable_output = true
+    console.run_single('load_custom_methods')
+    console.disable_output = original
+  end
+
+  #
+  # The shell will have been initialized by default.
+  #
+  def shell_init
+    return true
+  end
+
+#  #
+#  # Read from the command shell.
+#  #
+#  def shell_read(length = nil)
+#    if length.nil?
+#      rv = rstream.get
+#    else
+#      rv = rstream.read(length)
+#    end
+#    return rv
+#  end
+#
+#  #
+#  # Writes to the command shell.
+#  #
+#  def shell_write(buf)
+#    rstream.write(buf)
+#  end
+#
+#  #
+#  # Closes the shell.
+#  #
+#  def shell_close()
+#    rstream.close
+#  end
+
+  attr_accessor :console # :nodoc:
+  attr_accessor :alive # :nodoc:
+private
+  attr_accessor :rstream # :nodoc:
+
+end
+
+end
+end

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -544,4 +544,13 @@ class Msf::Module::Platform
     Rank = 100
     Alias = "multi"
   end
+
+  #
+  # Hardware
+  #
+  class Hardware < Msf::Module::Platform
+    Rank = 100
+    Alias = "hardware"
+  end
+
 end

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -31,6 +31,7 @@ class Payload < Msf::Module
   require 'msf/core/payload/android'
   require 'msf/core/payload/firefox'
   require 'msf/core/payload/mainframe'
+  require 'msf/core/payload/hardware'
 
   # Universal payload includes
   require 'msf/core/payload/multi'

--- a/lib/msf/core/payload/hardware.rb
+++ b/lib/msf/core/payload/hardware.rb
@@ -1,0 +1,24 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+###
+# This class is here to implement advanced features for hardware bridged
+# payloads. HWBridge payloads are expected to include this module if
+# they want to support these features.
+###
+module Msf::Payload::Hardware
+  def initialize(info = {})
+    super(info)
+  end
+
+  ##
+  # Returns a list of compatible encoders based on mainframe architecture
+  # most will not work because of the different architecture
+  # an XOR-based encoder will be defined soon
+  ##
+  def compatible_encoders
+    encoders2 = ['/generic\/none/', 'none']
+    encoders2
+  end
+
+end

--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -17,6 +17,7 @@ class Msf::Post < Msf::Module
   require 'msf/core/post/unix'
   require 'msf/core/post/windows'
   require 'msf/core/post/android'
+  require 'msf/core/post/hardware'
 
   include Msf::PostMixin
 

--- a/lib/msf/core/post/hardware.rb
+++ b/lib/msf/core/post/hardware.rb
@@ -1,0 +1,4 @@
+# -*- coding: binary -*-
+module Msf::Post::Hardware
+  require 'msf/core/post/hardware/automotive/uds'
+end

--- a/lib/msf/core/post/hardware/automotive/uds.rb
+++ b/lib/msf/core/post/hardware/automotive/uds.rb
@@ -1,0 +1,825 @@
+# -*- coding: binary -*-
+module Msf
+class Post
+module Hardware
+module Automotive
+
+module UDS
+
+  #
+  # Helper method to take client.automotive response hashes and return a single array in order, This
+  # takes the ISO-TP Packets and assembles them in order, strips out the ISO-TP/UDS related info
+  # and returns just the data section as an array
+  #
+  # @param id [String] Hex value as string. Example: 7e0
+  # @param hash [Hash] Hash that includes "Packets" => [ { "ID" => "0xXXX", "DATA => [ "XX", "XX" ] } ]
+  #
+  # @return [Array] Just the data portion of an ISO-TP response represented as Hex Strings
+  #
+  def response_hash_to_data_array(id, hash)
+    data = []
+    return data if not hash
+    bad_count = 0
+    if hash.has_key? "Packets"
+      if not hash["Packets"].size > 1 # Not multiple packets
+        pktdata = hash["Packets"][0]["DATA"]
+        if pktdata[1] == 0x7F
+          print_line("Packet response was an error")
+        else
+          data = pktdata[3, pktdata.size-1]
+        end
+        return data
+      end
+      left2combine = hash["Packets"].size
+      counter = 0
+      while left2combine > 0 and bad_count < (hash["Packets"].size * 2)
+        #print_line("DEBUG Current status combine=#{left2combine} data=#{data.inspect}")
+        hash["Packets"].each do |pkt|
+          if pkt.has_key? "ID" and pkt["ID"].hex == id.hex
+            if pkt.has_key? "DATA"
+              if counter == 0  # Get starting packet
+                if pkt["DATA"][0] == "10"
+                  data += pkt["DATA"][5,3]
+                  left2combine -= 1
+                  counter += 1
+                else
+                  bad_count += 1
+                end
+              else # Got the first packet, get the 2x series
+                # TODO: Support rollover counter, rare but technically possible
+                if pkt["DATA"][0] == "%02x" % (0x20 + counter)
+                  data += pkt["DATA"][1, pkt["DATA"].size]
+                  left2combine -= 1
+                  counter += 1
+                else
+                  bad_count += 1
+                end
+              end
+            end
+          end
+        end
+      end
+      if bad_count >= (hash["Packets"].size * 2)
+        print_error("bad packet count exceeded normal limits.  Packet parser failed")
+      end
+    end
+    data
+  end
+
+  ### Mode $01 ###
+
+  #
+  # Shows the vehicles current data
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param pid [Integer] Integer of the PID to get data about
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  #
+  # @return [Hash] client.automotive response
+  def get_current_data(bus, srcId, dstId, pid, opt={})
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x01, pid], opt)
+  end
+
+  #
+  # Get all supported pids for current data
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [Array] All supported pids from Mode $01 get current data
+  def get_current_data_pids(bus, srcId, dstId)
+    pids = []
+    packets = get_current_data(bus, srcId, dstId, 0, {"MAXPKTS" => 1})
+    if packets.has_key? "Packets" and packets["Packets"].size > 0
+      hexpids = packets["Packets"][0]["DATA"][3,6]
+      hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+      (1..0x20).each do |pid|
+        pids << pid if hexpids[pid-1] == "1"
+      end
+    end
+    if pids.include? 0x20
+      packets = get_current_data(bus, srcId, dstId, 0x20, {"MAXPKTS" => 1})
+      if packets.has_key? "Packets" and packets["Packets"].size > 0
+        hexpids = packets["Packets"][0]["DATA"][3,6]
+        hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+        (0x20..0x40).each do |pid|
+          pids << pid if hexpids[pid-0x21] == "1"
+        end
+      end
+    end
+    if pids.include? 0x40
+      packets = get_current_data(bus, srcId, dstId, 0x40, {"MAXPKTS" => 1})
+      if packets.has_key? "Packets" and packets["Packets"].size > 0
+        hexpids = packets["Packets"][0]["DATA"][3,6]
+        hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+        (0x40..0x60).each do |pid|
+          pids << pid if hexpids[pid-0x41] == "1"
+        end
+      end
+    end
+    if pids.include? 0x60
+      packets = get_current_data(bus, srcId, dstId, 0x60, {"MAXPKTS" => 1})
+      if packets.has_key? "Packets" and packets["Packets"].size > 0
+        hexpids = packets["Packets"][0]["DATA"][3,6]
+        hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+        (0x60..0x80).each do |pid|
+          pids << pid if hexpids[pid-0x61] == "1"
+        end
+      end
+    end
+    if pids.include? 0x80
+      packets = get_current_data(bus, srcId, dstId, 0x80, {"MAXPKTS" => 1})
+      if packets.has_key? "Packets" and packets["Packets"].size > 0
+        hexpids = packets["Packets"][0]["DATA"][3,6]
+        hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+        (0x80..0xA0).each do |pid|
+          pids << pid if hexpids[pid-0x81] == "1"
+        end
+      end
+    end
+    if pids.include? 0xA0
+      packets = get_current_data(bus, srcId, dstId, 0xA0, {"MAXPKTS" => 1})
+      if packets.has_key? "Packets" and packets["Packets"].size > 0
+        hexpids = packets["Packets"][0]["DATA"][3,6]
+        hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+        (0xA0..0xC0).each do |pid|
+          pids << pid if hexpids[pid-0xA1] == "1"
+        end
+      end
+    end
+    if pids.include? 0xC0
+      packets = get_current_data(bus, srcId, dstId, 0xC0, {"MAXPKTS" => 1})
+      if packets.has_key? "Packets" and packets["Packets"].size > 0
+        hexpids = packets["Packets"][0]["DATA"][3,6]
+        hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+        (0xC0..0xE0).each do |pid|
+          pids << pid if hexpids[pid-0xC1] == "1"
+        end
+      end
+    end
+    pids
+  end
+
+  #
+  # Mode $01 Pid $01 gets and parses the monitor status
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [Hash] Packet Hash with { "MIL" => true|false "DTC_COUNT" => 0 }
+  def get_monitor_status(bus, srcId, dstId)
+    packets = get_current_data(bus, srcId, dstId, 0x01, {"MAXPKTS" => 1})
+    return packets if packets.has_key? "error"
+    return packets if not packets.has_key? "Packets"
+    packets["MIL"] = packets["Packets"][0]["DATA"][3].hex & 0xB0 == 1 ? true : false
+    packets["DTC_COUNT"] = packets["Packets"][0]["DATA"][3].hex & 0x7F
+    packets
+  end
+
+  #
+  # Gets the engine coolant temprature in both Celcious and Fahrenheit
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [Hash] Packet Hash with { "TEMP_C" => <Celcious Temp>, "TEMP_F" => <Fahrenheit TEmp> }
+  def get_engine_coolant_temp(bus, srcId, dstId)
+    packets = get_current_data(bus, srcId, dstId, 0x05, {"MAXPKTS" => 1})
+    return packets if packets.has_key? "error"
+    return packets if not packets.has_key? "Packets"
+    celcious = packets["Packets"][0]["DATA"][3].hex - 40
+    fahrenheit = celcious * 9/5 + 32
+    packets["TEMP_C"] = celcious
+    packets["TEMP_F"] = fahrenheit
+    packets
+  end
+
+  #
+  # Gets the engine's current RPMs
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [Hash] Packet Hash with { "RPM" => <RPMs> }
+  def get_rpms(bus, srcId, dstId)
+    packets = get_current_data(bus, srcId, dstId, 0x0C, {"MAXPKTS" => 1})
+    return packets if packets.has_key? "error"
+    return packets if not packets.has_key? "Packets"
+    packets["RPM"] = (256 * packets["Packets"][0]["DATA"][3].hex + packets["Packets"][0]["DATA"][4].hex) / 4
+    packets
+  end
+
+  #
+  # Gets the engine's current vehicle speed in km/h and mph
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [Hash] Packet Hash with { "SPEED_K" => <km/h>, "SPEED_M" => <mph> }
+  def get_vehicle_speed(bus, srcId, dstId)
+    packets = get_current_data(bus, srcId, dstId, 0x0D, {"MAXPKTS" => 1})
+    return packets if packets.has_key? "error"
+    return packets if not packets.has_key? "Packets"
+    packets["SPEED_K"] = packets["Packets"][0]["DATA"][3].hex
+    packets["SPEED_M"] = packets["SPEED_K"] / 1.609344
+    packets
+  end
+
+  #
+  # Return which OBD standard this bus confirms to.  This method could utilizes bitmasks
+  # but currently creates a human readable string instead.  This may change in the future.
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [String] Description of standard
+  def get_obd_standards(bus, srcId, dstId)
+    packets = get_current_data(bus, srcId, dstId, 0x1C, {"MAXPKTS" => 1})
+    if packets.has_key? "error"
+      print_error("OBD ERR: #{packets["error"]}")
+      return ""
+    end
+    return "" if not packets.has_key? "Packets"
+    case packets["Packets"][0]["DATA"][3].hex
+    when 1
+      return "OBD-II as defined by CARB"
+    when 2
+      return "OBD as defined by EPA"
+    when 3
+      return "OBD and OBD-II"
+    when 4
+      return "OBD-I"
+    when 5
+      return "Not OBD Compliant"
+    when 6
+      return "EOBD Europe"
+    when 7
+      return "EOBD and OBD-II"
+    when 8
+      return "EOBD and OBD"
+    when 9
+      return "EOBD, OBD, OBD-II"
+    when 10
+      return "JOBD Japan"
+    when 11
+      return "JOBD and OBD-II"
+    when 12
+      return "JOBD and EOBD"
+    when 13
+      return "JOBD, EOBD, OBD-II"
+    when 17
+      return "Engine Manufacturer Diagnostics (EMD)"
+    when 18
+      return "Engine Manufacturer Diagnostics Enhanced (EMD+)"
+    when 19
+      return "Heavy Duty On-Board Diagnostics (Child/Partial) (HD OBD-C)"
+    when 20
+      return "Heavy Duty On-Board Diagnostics (HD OBD)"
+    when 21
+      return "World Wide Harmonized OBD (WWH OBD)"
+    when 23
+      return "Heavy Duty Euro OBD Stage I without NOx control (HD EOBD-I)"
+    when 24
+      return "Heavy Duty Euro OBD Stage I with NOx control (HD EOBD-I N)"
+    when 25
+      return "Heavy Duty Euro OBD Stage II without NOx control (HD EOBD-II)"
+    when 26
+      return "Heavy Duty Euro OBD Stage II with NOx control (HD EOBD-II N)"
+    when 28
+      return "Brazil OBD Phase 1 (OBDBr-1)"
+    when 29
+      return "Brazil OBD Phase 2 (OBDBr-2)"
+    when 30
+      return "Korean OBD (KOBD)"
+    when 31
+      return "India OBD I (IOBD I)"
+    when 32
+      return "India OBD II (IOBD II)"
+    when 33
+      return "Heavy Duty Euro OBD Stage VI (HD EOBD-IV)"
+    when 14..16,22,27,34..250
+      return "Reserved"
+    end
+    return "SAE J1939 Special Meanings"
+  end
+
+  ### Mode $02 ###
+
+  #
+  # Shows the vehicles freeze frame data, Use the same PIDs as supported from Mode $01
+  # #get_current_data_pids.  You must specify which freeze frame you want to recall data from.
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param pid [Integer] Integer of the PID to get data about
+  # @param frame [Integer] Freeze Frame Number
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  #
+  # @return [Hash] client.automotive response
+  def get_freeze_frame_data(bus, srcId, dstId, pid, frame, opt={})
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    pid = pid.to_s(16)
+    frame = frame.to_s(16)
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x02, pid, frame], opt)
+  end
+
+  ### Mode $03 ###
+
+  #
+  # Retrieves the Diagnostic Trouble Codes (DTCs)
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  #
+  # @return [Array] Array of DTCs
+  def get_dtcs(bus, srcId, dstId, opt={})
+    dtcs = []
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    data = client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x03], opt)
+    if data.has_key? "error"
+      print_error("UDS ERR: #{data["error"]}")
+      return []
+    end
+    if data.has_key? "Packets" and data["Packets"].size > 0
+      data = response_hash_to_data_array(dstId, data)
+      if data.size > 0 and data.size % 2 == 0
+        (0..data.size).step(2) do |idx|
+          code = ""
+          case data[idx].hex & 0xC0
+          when 0
+            code = "P"
+          when 1
+            code = "C"
+          when 2
+            code = "B"
+          when 3
+            code = "U"
+          end
+          code += (data[idx].hex & 0x3F).to_s(16)
+          code += data[idx+1]
+          dtcs << code
+        end
+      end
+    end
+    dtcs
+  end
+
+  ### Mode $04 ###
+
+  #
+  # Clears the DTCs and Resets the MIL light back to the off position
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  #
+  # @return [Hash] No packets are expected to return but an error could be returned
+  def clear_dtcs(bus, srcId, dstId, opt={})
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x04], opt)
+  end
+
+  ### Mode  $09 ###
+
+  #
+  # Requests diagnostics 0x09 vehicle information for any given mode
+  # No formatting is done on the response
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  #
+  # @return [Hash] client.automotive response
+  def get_vehicle_info(bus, srcId, dstId, mode, opt={})
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    mode = mode.to_s(16)
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x09, mode], opt)
+  end
+
+  #
+  # Get all the supported pids by mode 0x09 Vehicle info
+  # Returns them as an array of ints
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [Array] Array of PIDS supported by Mode $09
+  def get_vinfo_supported_pids(bus, srcId, dstId)
+    pids = []
+    packets = get_vehicle_info(bus, srcId, dstId, 0, {"MAXPKTS" => 1})
+    if packets.has_key? "Packets" and packets["Packets"].size > 0
+      hexpids = packets["Packets"][0]["DATA"][3,6]
+      hexpids = hexpids.join.hex.to_s(2).rjust(32, '0').split('') # Array of 1s and 0s
+      (1..20).each do |pid|
+        pids << pid if hexpids[pid-1] == "1"
+      end
+    end
+    pids
+  end
+
+  #
+  # Requests a VIN and formats the response as ASCII
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [String] VIN as ASCII
+  def get_vin(bus, srcId, dstId)
+    packets = get_vehicle_info(bus, srcId, dstId, 0x02)
+    return "UDS ERR: #{packets["error"]}" if packets.has_key? "error"
+    data = response_hash_to_data_array(dstId.to_s(16), packets)
+    data.map! { |d| d.hex.chr }
+    data.join
+  end
+
+  # Gets the vehicle calibration ID and returns it as an ASCII string
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [String] Calibration ID as ASCII
+  def get_calibration_id(bus, srcId, dstId)
+    packets = get_vehicle_info(bus, srcId, dstId, 0x04)
+    return "UDS ERR: #{packets["error"]}" if packets.has_key? "error"
+    data = response_hash_to_data_array(dstId.to_s(16), packets)
+    data.map! { |d| d.hex.chr }
+    data.join
+  end
+
+  # Get the vehicles ECU name pid 0x0A
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  #
+  # @return [String] ECU Name as ASCII
+  def get_ecu_name(bus, srcId, dstId)
+    packets = get_vehicle_info(bus, srcId, dstId, 0x0A)
+    return "UDS ERR: #{packets["error"]}" if packets.has_key? "error"
+    data = response_hash_to_data_array(dstId.to_s(16), packets)
+    data.map! { |d| d.hex.chr }
+    data.join
+  end
+
+  ###############################################################################
+  # Technically from here on down these are known as Service IDs or SIDs but we #
+  # will keep calling them Modes for consitency in our comments                 #
+  ###############################################################################
+  #### Mode $10 ###
+
+  # Set the diagnostic session code
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param level [Integer] The desired DSC level
+  #
+  # @return [Hash] client.automtoive response
+  def set_dsc(bus, srcId, dstId, level)
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    level = level.to_s(16)
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    opt = {}
+    opt["TIMEOUT"]=20
+    opt["MAXPKTS"]=1
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x10, level], opt)
+  end
+
+  ### Mode $11 ###
+
+  #
+  # Issues a reset of the ECU
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param hard [Boolean] If true a hard reset will be peformed
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  #
+  # @return [Hash] client.automtoive response (Could be no response)
+  def reset_ecu(bus, srcId, dstId, hard, opt={})
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    reset_type = hard ? 1 : 0
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x11, reset_type], opt)
+  end
+
+  ### Mode $22 ###
+
+  #
+  # Reads data from a memory region given a lookup ID value
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param id [Array] 2 Bytes in an array of the identifier.  Example [ 0xF1, 0x90 ]
+  # @param show_error [Boolean] If an error, return the Packet hash instead, Default false
+  #
+  # @return [Array] Data retrieved.  If show_error is true and an error is detected, then packet hash will be returned instead
+  def read_data_by_id(bus, srcId, dstId, id, show_error=false)
+    data = []
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {} if show_error
+      return []
+    end
+    if not id.is_a? Array
+      print_error("ID paramater must be a two byte array")
+      return {} if show_error
+      return []
+    end
+    if not id.size == 2
+      print_error("ID paramater must be a two byte array")
+      return {} if show_error
+      return []
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    id.map! { |i| i.to_s(16) } if id[0].is_a? Integer
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    opt = {}
+    opt["MAXPKTS"] = 15
+    packets = client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x22] + id, opt)
+    if packets.has_key? "error"
+      return packets if show_error
+    else
+      data = response_hash_to_data_array(dstId, packets)
+    end
+    data
+  end
+
+  ### Mode $27 ###
+
+  #
+  # Retrieves the security access token
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param level [Integer] Requested security access level. Default is 1
+  #
+  # @return [Hash] Packet Hash with { "SEED" => [ XX, XX ] }
+  def get_security_token(bus, srcId, dstId, level=1)
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    level = level.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    opt={}
+    opt["MAXPKTS"]=1
+    packets = client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x27, level], opt)
+    if not packets.has_key? "error"
+      packets["SEED"] = response_hash_to_data_array(dstId, packets)
+    end
+    packets
+  end
+
+  #
+  # Sends a security access tokens response to the seed request
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # param key [Array] Array of Hex to be used as the key.  Same size as the seed
+  # @param response_level [Integer] Requested security access level response. Usually level + 1. Default is 2
+  #
+  # @return [Hash] packet response from client.automotoive
+  def send_security_token_response(bus, srcId, dstId, key, response_level=2)
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    if not key.is_a? Array
+      print_error("Key must be an array of hex values")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    key.map! { |k| k.to_s(16) } if key[0].is_a? Integer
+    response_level = response_level.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    opt = {}
+    opt["MAXPKTS"]=1
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x27, response_level] + key, opt)
+  end
+
+  ### Mode $2E ###
+
+  #
+  # Writes data by ID
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param id [Array] 2 Bytes in an array of the identifier.  Example [ 0xF1, 0x90 ]
+  # @param data [Array] Array of bytes to write
+  #
+  # @return [Hash] Packet hash from client.automotive
+  def write_data_by_id(bus, srcId, dstId, id, data)
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    if not id.is_a? Array
+      print_error("ID must be an array of hex values")
+      return {}
+    end
+    if not data.is_a? Array
+      print_error("DATA must be an array of hex values")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    id.map! { |i| i.to_s(16) } if id[0].is_a? Integer
+    data.map! { |d| d.to_s(16) } if data[0].is_a? Integer
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    opt={}
+    opt["MAXPKTS"]=1
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x27] + id + data, opt)
+  end
+
+  ### Mode $31 ###
+
+  #
+  # Executes a builtin routine. Routines are a series of pre-programmed acutions setup by the
+  # manufacturer.
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param routine_type [Integer] Type or routine request. Example: 1 = Start, 3 = Report
+  # param id [Array] 2 byte Array for the routine identifier
+  # @param data [Array] Array of routine data/params. Specific to the routine. Optional, Default []
+  # @param opt [Hash] Additional options to be passed to automotive.send_isotp_and_wait_for_response
+  #
+  # @return [Hash] Packet hash from client.automotive
+  def routine_control(bus, srcId, dstId, routine_type, id, data=[], opt={})
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    if not id.is_a? Array
+      print_error("ID must be an array of hex values")
+      return {}
+    end
+    if not data.is_a? Array
+      print_error("DATA must be an array of hex values")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    routine_type = routine_type.to_s(16)
+    id.map! { |i| i.to_s(16) } if id[0].is_a? Integer
+    data.map! { |d| d.to_s(16) } if data.size > 0 and data[0].is_a? Integer
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x31, routine_type] + id + data, opt)
+  end
+
+  ### Mode $3E ###
+
+  #
+  # Sends a TestPresent message.  This message maintains previously set DSCs or Security Access levels so
+  # they don't timeout and revert back to normal.  TesterPresent is typically transmitted on 2-3 second
+  # intervals
+  #
+  # @param bus [String] unique CAN bus identifier
+  # @param srcId [Integer] Integer representation of the Sending CAN ID
+  # @param dstId [Integer] Integer representation of the receiving CAN ID
+  # @param suppress_response [Boolean] By default suppress ACK from ECU.  Set to false if you want confirmation
+  #
+  # @return [Hash] Packet hash from client.automotive.  Typically blank unless suppress_response is false
+  def send_tester_present(bus, srcId, dstId, suppress_response=true)
+    if not client.automotive
+      print_error("Not an automotive hwbridge session")
+      return {}
+    end
+    srcId = srcId.to_s(16)
+    dstId = dstId.to_s(16)
+    bus = client.automotive.active_bus if not bus
+    if not bus
+      print_line("No active bus, use 'connect' or specify bus via the options")
+      return {}
+    end
+    suppress = 0x80
+    suppress = 0 if not suppress_reponse
+    opt={}
+    opt["MAXPKTS"] = 1
+    client.automotive.send_isotp_and_wait_for_response(bus,srcId, dstId, [0x3E, suppress], opt)
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post.rb
+++ b/lib/rex/post.rb
@@ -5,3 +5,6 @@ require 'rex/post/permission'
 
 # Post-exploitation clients
 require 'rex/post/meterpreter'
+
+# Hardware Bridge clients
+require 'rex/post/hwbridge'

--- a/lib/rex/post/hwbridge.rb
+++ b/lib/rex/post/hwbridge.rb
@@ -1,0 +1,4 @@
+# -*- coding: binary -*-
+
+require 'rex/post/hwbridge/client'
+require 'rex/post/hwbridge/ui/console'

--- a/lib/rex/post/hwbridge/client.rb
+++ b/lib/rex/post/hwbridge/client.rb
@@ -1,0 +1,241 @@
+# -*- coding: binary -*-
+
+require 'rex/post/hwbridge/extension'
+require 'rex/post/hwbridge/object_aliases'
+
+module Rex
+module Post
+module HWBridge
+
+# Used for merging constants from extensions
+module Extensions
+end
+
+class Client
+  @@ext_hash = {}
+
+  #
+  # Checks the extension hash to see if a class has already been associated
+  # with the supplied extension name.
+  #
+  def self.check_ext_hash(name)
+    @@ext_hash[name]
+  end
+
+  #
+  # Stores the name to class association for the supplied extension name.
+  #
+  def self.set_ext_hash(name, klass)
+    @@ext_hash[name] = klass
+  end
+
+  #
+  # Initializes the client context
+  #
+  def initialize(sock,opts={})
+    init_hwbridge(sock,opts)
+  end
+
+  #
+  # Initialize the hwbridge instance
+  #
+  def init_hwbridge(sock,opts={})
+    self.sock        = sock
+    self.ext         = ObjectAliases.new
+    self.ext_aliases = ObjectAliases.new
+  end
+
+  #
+  # sends request through 'exploit' which is the hwbridge/connect
+  #
+  def send_request(uri)
+    if not exploit
+      $stdout.puts("Exploit module not connected")
+      return {}
+    end
+    exploit.fetch_json(uri)
+  end
+
+  #
+  # Gets/refreshes HW status & capabilities
+  #
+  def get_status
+    send_request("/status")
+  end
+
+  #
+  # Fetches custom methods from HW, if any
+  #
+  def get_custom_methods
+    send_request("/custom_methods")
+  end
+
+  ##
+  #
+  # Alias processor
+  #
+  ##
+
+  #
+  # Translates unhandled methods into registered extension aliases
+  # if a matching extension alias exists for the supplied symbol.
+  #
+  def method_missing(symbol, *args)
+    #$stdout.puts("method_missing: #{symbol}")
+    self.ext_aliases.aliases[symbol.to_s]
+  end
+
+  ##
+  #
+  # Extension registration
+  #
+  ##
+
+  #
+  # Loads the client half of the supplied extension and initializes it as a
+  # registered extension that can be reached through client.ext.[extension].
+  #
+  def add_extension(name, commands=[])
+    self.commands |= commands
+
+    # Check to see if this extension has already been loaded.
+    if ((klass = self.class.check_ext_hash(name.downcase)) == nil)
+      old = Rex::Post::HWBridge::Extensions.constants
+      require("rex/post/hwbridge/extensions/#{name.downcase}/#{name.downcase}")
+      new = Rex::Post::HWBridge::Extensions.constants
+
+      # No new constants added?
+      if ((diff = new - old).empty?)
+        diff = [ name.capitalize ]
+      end
+
+      klass = Rex::Post::HWBridge::Extensions.const_get(diff[0]).const_get(diff[0])
+
+      # Save the module name to class association now that the code is
+      # loaded.
+      self.class.set_ext_hash(name.downcase, klass)
+    end
+
+    # Create a new instance of the extension
+    inst = klass.new(self)
+
+    self.ext.aliases[inst.name] = inst
+
+    return true
+  end
+
+  #
+  # Deregisters an extension alias of the supplied name.
+  #
+  def deregister_extension(name)
+    self.ext.aliases.delete(name)
+  end
+
+  #
+  # Enumerates all of the loaded extensions.
+  #
+  def each_extension(&block)
+    self.ext.aliases.each(block)
+  end
+
+  #
+  # Registers an aliased extension that can be referenced through
+  # client.name.
+  #
+  def register_extension_alias(name, ext)
+    self.ext_aliases.aliases[name] = ext
+    # Whee!  Syntactic sugar, where art thou?
+    #
+    # Create an instance method on this object called +name+ that returns
+    # +ext+.  We have to do it this way instead of simply
+    # self.class.class_eval so that other meterpreter sessions don't get
+    # extension methods when this one does
+    (class << self; self; end).class_eval do
+      define_method(name.to_sym) do
+        ext
+      end
+    end
+    ext
+  end
+
+  #
+  # Registers zero or more aliases that are provided in an array.
+  #
+  def register_extension_aliases(aliases)
+    aliases.each { |a|
+      register_extension_alias(a['name'], a['ext'])
+    }
+  end
+
+  #
+  # Deregisters a previously registered extension alias.
+  #
+  def deregister_extension_alias(name)
+    self.ext_aliases.aliases.delete(name)
+  end
+
+  #
+  # Dumps the extension tree.
+  #
+  def dump_extension_tree()
+    items = []
+    items.concat(self.ext.dump_alias_tree('client.ext'))
+    items.concat(self.ext_aliases.dump_alias_tree('client'))
+
+    return items.sort
+  end
+
+  #
+  # Encodes (or not) a UTF-8 string
+  #
+  def unicode_filter_encode(str)
+    self.encode_unicode ? Rex::Text.unicode_filter_encode(str) : str
+  end
+
+  #
+  # Decodes (or not) a UTF-8 string
+  #
+  def unicode_filter_decode(str)
+    self.encode_unicode ? Rex::Text.unicode_filter_decode(str) : str
+  end
+
+  # A list of the commands
+  #
+  attr_reader :commands
+  attr_reader :ext, :sock
+protected
+  attr_writer   :commands # :nodoc:
+  attr_accessor :ext_aliases # :nodoc:
+  attr_writer   :ext, :sock # :nodoc:
+
+end
+
+###
+#
+# Exception thrown when a request fails.
+#
+###
+class RequestError < ArgumentError
+  def initialize(method, einfo, ecode=nil)
+    @method = method
+    @result = einfo
+    @code   = ecode || einfo
+  end
+
+  def to_s
+    "#{@method}: Operation failed: #{@result}"
+  end
+
+  # The method that failed.
+  attr_reader :method
+
+  # The error result that occurred, typically a windows error message.
+  attr_reader :result
+
+  # The error result that occurred, typically a windows error code.
+  attr_reader :code
+end
+
+end
+end
+end

--- a/lib/rex/post/hwbridge/extension.rb
+++ b/lib/rex/post/hwbridge/extension.rb
@@ -1,0 +1,32 @@
+# -*- coding: binary -*-
+
+module Rex
+module Post
+module HWBridge
+
+###
+#
+# Base class for all extensions that holds a reference to the
+# client context that they are part of.  Each extension also has a defined
+# name through which it is referenced.
+#
+###
+class Extension
+
+  #
+  # Initializes the client and name attributes.
+  #
+  def initialize(client, name)
+    self.client = client
+    self.name   = name
+  end
+
+  #
+  # The name of the extension.
+  #
+  attr_accessor :name
+protected
+  attr_accessor :client # :nodoc:
+end
+
+end; end; end

--- a/lib/rex/post/hwbridge/extensions/automotive/automotive.rb
+++ b/lib/rex/post/hwbridge/extensions/automotive/automotive.rb
@@ -1,0 +1,128 @@
+#
+# -*- coding: binary -*-
+require 'rex/post/hwbridge/extensions/automotive/uds_errors'
+require 'rex/post/hwbridge/client'
+
+module Rex
+module Post
+module HWBridge
+module Extensions
+module Automotive
+
+###
+# Automotive extension - set of commands to be executed on automotive hw bridges
+###
+
+class Automotive < Extension
+
+  include Rex::Post::HWBridge::Extensions::Automotive::UDSErrors
+
+  def initialize(client)
+    super(client, 'automotive')
+
+    # Alias the following things on the client object so that they
+    # can be directly referenced
+    client.register_extension_aliases(
+      [
+        {
+          'name' => 'automotive',
+          'ext'  => self
+        }
+      ])
+  end
+
+  #
+  # Checks to see if the specified bus is valid
+  #
+  # @param bus [String] bus name
+  #
+  # @return [Boolean] return true if bus is valid
+  def is_valid_bus? bus
+    valid = false
+    get_supported_buses if self.buses == nil
+    if not bus.blank?
+      self.buses.each do |b|
+        valid = true if b["bus_name"] == bus
+      end
+    end
+    valid
+  end
+
+  # Checks for Errors in ISO-TP responses.  If an error is present
+  # Document the error with an additional "error" => { "ACRONYMN" => "Definition" }
+  #
+  # @param data [Hash] client.send_request response
+  #
+  # @return [Hash] client.send_request response with "Error" if any exist
+  def check_for_errors(data)
+    if data and data.has_key? "Packets"
+      if data["Packets"].size == 1
+        if data["Packets"][0]["DATA"].size > 3 and data["Packets"][0]["DATA"][1].hex == 0x7F
+          if ERR_MNEMONIC.has_key? data["Packets"][0]["DATA"][3].hex
+            err = data["Packets"][0]["DATA"][3].hex
+            data["error"] = { ERR_MNEMONIC[err] => ERR_DESC[ERR_MNEMONIC[err]] }
+          else
+            data["error"] = { "UNK" => "An Unknown error detected" }
+          end
+        end
+      end
+    end
+    data
+  end
+
+  #
+  # Pass an array of bytes and return an array of ASCII byte representation
+  #
+  # @param arr [Array] Array of integers (bytes)
+  #
+  # @return [Array] Array of Hex string equivalents
+  def array2hex(arr)
+    arr.map { |b| "%02x" % b }
+  end
+
+  def set_active_bus(bus)
+    self.active_bus = bus
+  end
+
+  def get_supported_buses
+    self.buses = client.send_request("/automotive/supported_buses")
+    self.buses
+  end
+
+  def get_bus_config(bus)
+    status = client.send_request("/automotive/#{bus}/config")
+    status
+  end
+
+  def get_supported_methods(bus)
+    client.send_request("/automotive/#{bus}/supported_methods")
+  end
+
+  def cansend(bus, id, data)
+    client.send_request("/automotive/#{bus}/cansend?id=#{id}&data=#{data}")
+  end
+
+  def send_isotp_and_wait_for_response(bus, srcId, dstId, data, opt={})
+    # TODO Implement sending ISO-TP > 8 bytes
+    data = [ data ] if data.is_a? Integer
+    if data.size < 8
+      data = array2hex(data).join
+      request_str = "/automotive/#{bus}/isotpsend_and_wait?srcid=#{srcId}&dstid=#{dstId}&data=#{data}"
+      request_str += "&timeout=#{opt["TIMEOUT"]}" if opt.has_key? "TIMEOUT"
+      request_str += "&maxpkts=#{opt["MAXPKTS"]}" if opt.has_key? "MAXPKTS"
+      return check_for_errors(client.send_request(request_str))
+    end
+    return nil
+  end
+
+  attr_reader :buses, :active_bus
+private
+  attr_writer :buses, :active_bus
+
+end
+
+end
+end
+end
+end
+end

--- a/lib/rex/post/hwbridge/extensions/automotive/uds_errors.rb
+++ b/lib/rex/post/hwbridge/extensions/automotive/uds_errors.rb
@@ -1,0 +1,92 @@
+# -*- coding: binary -*-
+
+module Rex
+module Post
+module HWBridge
+module Extensions
+module Automotive
+
+module UDSErrors
+
+ERR_MNEMONIC = {
+  0x10 => "GR",
+  0x11 => "SNS",
+  0x12 => "SFNS",
+  0x13 => "IMLOIF",
+  0x14 => "RTL",
+  0x21 => "BRR",
+  0x22 => "CNC",
+  0x24 => "RSE",
+  0x25 => "NRFSC",
+  0x26 => "FPEORA",
+  0x31 => "ROOR",
+  0x33 => "SAD",
+  0x35 => "IK",
+  0x36 => "ENOA",
+  0x37 => "RTDNE",
+  0x38 => "RBEDLSD",
+  0x39 => "RBEDLSD",
+  0x3A => "RBEDLSD",
+  0x3B => "RBEDLSD",
+  0x3C => "RBEDLSD",
+  0x3D => "RBEDLSD",
+  0x3E => "RBEDLSD",
+  0x3F => "RBEDLSD",
+  0x40 => "RBEDLSD",
+  0x41 => "RBEDLSD",
+  0x42 => "RBEDLSD",
+  0x43 => "RBEDLSD",
+  0x44 => "RBEDLSD",
+  0x45 => "RBEDLSD",
+  0x46 => "RBEDLSD",
+  0x47 => "RBEDLSD",
+  0x48 => "RBEDLSD",
+  0x49 => "RBEDLSD",
+  0x4A => "RBEDLSD",
+  0x4B => "RBEDLSD",
+  0x4C => "RBEDLSD",
+  0x4D => "RBEDLSD",
+  0x4E => "RBEDLSD",
+  0x4F => "RBEDLSD",
+  0x70 => "UDNA",
+  0x71 => "TDS",
+  0x72 => "GPF",
+  0x73 => "WBSC",
+  0x78 => "RCRRP",
+  0x7E => "SFNSIAS",
+  0x7F => "SNSIAS"
+}
+
+ERR_DESC = {
+  "GR" => "General Reject",
+  "SNS" => "Service Not Supported",
+  "SFNS" => "Sub-Function Not Supported",
+  "IMLOIF" => "Incorrect Message Length Or Invalid Format",
+  "RTL" => "Response Too Long",
+  "BRR" => "Busy Repeat Request",
+  "CNC" => "Conditions Not Correct",
+  "RSE" => "Request Sequence Error",
+  "NRFSC" => "No Response From Sub-net Component",
+  "FPEORA" => "Failure Prevents Execution Of Requested Action",
+  "ROOR" => "Request Out Of Range",
+  "SAD" => "Security Access Denied",
+  "IK" => "Invalid Key",
+  "ENOA" => "Exceeded Number Of Attempts",
+  "RTDNE" => "Required Time Delay Not Expired",
+  "RBEDLSD" => "Reserved By Extended Data Link Security Document",
+  "UDNA" => "Upload/Download Not Accepted",
+  "TDS" => "Transfer Data Suspended",
+  "GPF" => "General Programming Failure",
+  "WBSC" => "Wrong Block Sequence Counter",
+  "RCRRP" => "Request Correctly Received, but Response is Pending",
+  "SFNSIAS" => "Sub-Function Not Supoorted In Active Session",
+  "SNSIAS" => "Service Not Supported In Active Session"
+}
+
+end
+
+end
+end
+end
+end
+end

--- a/lib/rex/post/hwbridge/extensions/custom_methods/custom_methods.rb
+++ b/lib/rex/post/hwbridge/extensions/custom_methods/custom_methods.rb
@@ -1,0 +1,78 @@
+#
+# -*- coding: binary -*-
+require 'rex/post/hwbridge/client'
+
+module Rex
+module Post
+module HWBridge
+module Extensions
+module CustomMethods
+
+###
+# Custom Methods extension - set of commands provided by the HW itself
+###
+
+class CustomMethods < Extension
+
+  def initialize(client)
+    super(client, 'automotive')
+
+    # Alias the following things on the client object so that they
+    # can be directly referenced
+    client.register_extension_aliases(
+      [
+        {
+          'name' => 'custom_methods',
+          'ext'  => self
+        }
+      ])
+  end
+
+  #
+  # Converts a cmd and args to a request to the hardware device
+  # cmd is the cmd without a path
+  # args are all KEY=value pairs.  All checks are assumed to have already been done
+  # methods is a hash of all methods and their formatting
+  # returns a formated response
+  #
+  def send_request(cmd, args, methods)
+    arguments = ""
+    if args.size > 0
+      arguments = "?"
+      first = true
+      args.each do |arg|
+        arguments += "&" if not first
+        arguments += arg
+        first = false
+      end
+    end
+    resp = { "success" => false }
+    methods.each do |meth|
+      if meth["method_name"] =~ /#{cmd}$/
+        resp = client.send_request("#{meth["method_name"]}#{arguments}")
+        if resp.has_key? "value" and meth.has_key? "return"
+          case meth["return"]
+          when "nil"
+            print_warning("A return was given when none was expected")
+          when "int"
+            resp["value"] = resp["value"].to_i
+          when "hex"
+            resp["value"] = "0x" + resp["value"].to_s(16)
+          when "boolean"
+            resp["value"] = resp["value"] == "true" ? true : false
+          when "float"
+            resp["value"] = resp["value"].to_f
+          end
+        end
+      end
+    end
+    resp
+  end
+
+end
+
+end
+end
+end
+end
+end

--- a/lib/rex/post/hwbridge/object_aliases.rb
+++ b/lib/rex/post/hwbridge/object_aliases.rb
@@ -1,0 +1,83 @@
+# -*- coding: binary -*-
+
+module Rex
+module Post
+module HWBridge
+
+###
+#
+# Mixin for classes that wish to have object aliases but do not
+# really need to inherit from the ObjectAliases class.
+#
+###
+module ObjectAliasesContainer
+
+  #
+  # Initialize the instance's aliases.
+  #
+  def initialize_aliases(aliases = {})
+    self.aliases = aliases
+  end
+
+  #
+  # Pass-thru aliases.
+  #
+  def method_missing(symbol, *args)
+    self.aliases[symbol.to_s]
+  end
+
+  #
+  # Recursively dumps all of the aliases registered with a class that
+  # is kind_of? ObjectAliases.
+  #
+  def dump_alias_tree(parent_path, current = nil)
+    items = []
+
+    if (current == nil)
+      current = self
+    end
+
+    # If the current object may have object aliases...
+    if (current.kind_of?(Rex::Post::HWBridge::ObjectAliases))
+      current.aliases.each_key { |x|
+        current_path = parent_path + '.' + x
+
+        items << current_path
+
+        items.concat(dump_alias_tree(current_path,
+          current.aliases[x]))
+      }
+    end
+
+    return items
+  end
+
+  #
+  # The hash of aliases.
+  #
+  attr_accessor :aliases
+end
+
+###
+#
+# Generic object aliases from a class instance referenced symbol to an
+# associated object of an arbitrary type
+#
+###
+class ObjectAliases
+  include Rex::Post::HWBridge::ObjectAliasesContainer
+
+  ##
+  #
+  # Constructor
+  #
+  ##
+
+  # An instance
+  def initialize(aliases = {})
+    initialize_aliases(aliases)
+  end
+end
+
+
+end; end; end

--- a/lib/rex/post/hwbridge/ui/console.rb
+++ b/lib/rex/post/hwbridge/ui/console.rb
@@ -1,0 +1,142 @@
+# -*- coding: binary -*-
+require 'rex/ui'
+require 'rex/post/hwbridge'
+require 'rex/logging'
+
+module Rex
+module Post
+module HWBridge
+module Ui
+
+###
+#
+# This class provides a shell driven interface to the hwbridge client API.
+#
+###
+class Console
+
+  include Rex::Ui::Text::DispatcherShell
+
+  # Dispatchers
+  require 'rex/post/hwbridge/ui/console/interactive_channel'
+  require 'rex/post/hwbridge/ui/console/command_dispatcher'
+  require 'rex/post/hwbridge/ui/console/command_dispatcher/core'
+
+  #
+  # Initialize the hardware bridge console.
+  #
+  def initialize(client)
+    if (Rex::Compat.is_windows())
+      super("hwbridge")
+    else
+      super("%undhwbridge%clr")
+    end
+
+    # The hwbridge client context
+    self.client = client
+
+    # Queued commands array
+    self.commands = []
+
+    # Point the input/output handles elsewhere
+    reset_ui
+
+    enstack_dispatcher(Console::CommandDispatcher::Core)
+
+    # Set up logging to whatever logsink 'core' is using
+    if ! $dispatcher['hwbridge']
+      $dispatcher['hwbridge'] = $dispatcher['core']
+    end
+  end
+
+  #
+  # Called when someone wants to interact with the hwbridge client.  It's
+  # assumed that init_ui has been called prior.
+  #
+  def interact(&block)
+    init_tab_complete
+
+    # Run queued commands
+    commands.delete_if { |ent|
+      run_single(ent)
+      true
+    }
+
+    # Run the interactive loop
+    run { |line|
+      # Run the command
+      run_single(line)
+
+      # If a block was supplied, call it, otherwise return false
+      if (block)
+        block.call
+      else
+        false
+      end
+    }
+  end
+
+  #
+  # Interacts with the supplied channel.
+  #
+  def interact_with_channel(channel)
+    channel.extend(InteractiveChannel) unless (channel.kind_of?(InteractiveChannel) == true)
+    channel.on_command_proc = self.on_command_proc if self.on_command_proc
+    channel.on_print_proc   = self.on_print_proc if self.on_print_proc
+    channel.on_log_proc = method(:log_output) if self.respond_to?(:log_output, true)
+
+    channel.interact(input, output)
+    channel.reset_ui
+  end
+
+  #
+  # Queues a command to be run when the interactive loop is entered.
+  #
+  def queue_cmd(cmd)
+    self.commands << cmd
+  end
+
+  #
+  # Runs the specified command wrapper in something to catch hwbridge
+  # exceptions.
+  #
+  def run_command(dispatcher, method, arguments)
+    begin
+      super
+    rescue Timeout::Error
+      log_error("Operation timed out.")
+    rescue RequestError => info
+      log_error(info.to_s)
+    rescue Rex::InvalidDestination => e
+      log_error(e.message)
+    rescue ::Errno::EPIPE, ::OpenSSL::SSL::SSLError, ::IOError
+      self.client.kill
+    rescue  ::Exception => e
+      log_error("Error running command #{method}: #{e.class} #{e}")
+    end
+  end
+
+  #
+  # Logs that an error occurred and persists the callstack.
+  #
+  def log_error(msg)
+    print_error(msg)
+
+    elog(msg, 'hwbridge')
+
+    dlog("Call stack:\n#{$@.join("\n")}", 'hwbridge')
+  end
+
+  attr_reader :client # :nodoc:
+
+protected
+
+  attr_writer :client # :nodoc:
+  attr_accessor :commands # :nodoc:
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher.rb
@@ -1,0 +1,86 @@
+# -*- coding: binary -*-
+require 'rex/logging'
+
+module Rex
+module Post
+module HWBridge
+module Ui
+
+###
+#
+# Base class for all command dispatchers within the hwbridge console user
+# interface.
+#
+###
+module Console::CommandDispatcher
+
+  include Rex::Ui::Text::DispatcherShell::CommandDispatcher
+
+  #
+  # The hash of file names to class names after a module has already been
+  # loaded once on the client side.
+  #
+  @@file_hash = {}
+
+  #
+  # Checks the file name to hash association to see if the module being
+  # requested has already been loaded once.
+  #
+  def self.check_hash(name)
+    @@file_hash[name]
+  end
+
+  #
+  # Sets the file path to class name association for future reference.
+  #
+  def self.set_hash(name, klass)
+    @@file_hash[name] = klass
+  end
+
+  def initialize(shell)
+    @msf_loaded = nil
+    super
+  end
+
+  #
+  # Returns the hwbridge client context.
+  #
+  def client
+    shell.client
+  end
+
+  #
+  # Returns true if the client has a framework object.
+  #
+  # Used for firing framework session events
+  #
+  def msf_loaded?
+    return @msf_loaded unless @msf_loaded.nil?
+    # if we get here we must not have initialized yet
+
+    if client.framework
+      # We have a framework instance so the msf libraries should be
+      # available.  Load up the ones we're going to use
+      require 'msf/base/serializer/readable_text'
+    end
+    @msf_loaded = !!(client.framework)
+    @msf_loaded
+  end
+
+  #
+  # Log that an error occurred.
+  #
+  def log_error(msg)
+    print_error(msg)
+
+    elog(msg, 'hwbridge')
+
+    dlog("Call stack:\n#{$@.join("\n")}", 'hwbridge')
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
@@ -1,0 +1,173 @@
+# -*- coding: binary -*-
+require 'rex/post/hwbridge'
+require 'msf/core/auxiliary/report'
+
+module Rex
+module Post
+module HWBridge
+module Ui
+###
+# Automotive extension - set of commands to be executed on CAN bus
+###
+class Console::CommandDispatcher::Automotive
+  include Console::CommandDispatcher
+  include Msf::Auxiliary::Report
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    all = {
+      'supported_buses'   => 'Get supported buses',
+      'busconfig'         => 'Get buad configs',
+      'connect'           => 'Get HW supported methods for a bus',
+      'cansend'           => 'Send a CAN packet'
+    }
+
+    reqs = {
+      'supported_buses'  => ['get_supported_buses'],
+      'busconfig'        => ['get_bus_config'],
+      'connect'          => ['get_supported_methods'],
+      'cansend'          => ['cansend']
+    }
+
+    # Ensure any requirements of the command are met
+#    all.delete_if do |cmd, _desc|
+#      reqs[cmd].any? { |req| !client.commands.include?(req) }
+#    end
+    all
+  end
+
+  #
+  # Lists all thesupported buses
+  #
+  def cmd_supported_buses
+    buses = client.automotive.get_supported_buses
+    if not buses.size > 0
+      print_line("none")
+      return
+    end
+    str = "Available buses\n\n"
+    first = true
+    buses.each do |bus|
+      if not first
+        str += ", "
+      end
+      first = false
+      str += bus["bus_name"] if bus.has_key? "bus_name"
+    end
+    str+="\n"
+    print_line(str)
+  end
+
+  #
+  # Retrives the current confiugration of a bus
+  #
+  def cmd_busconfig(*args)
+    bus = ''
+    bus_config_opts = Rex::Parser::Arguments.new(
+      '-h' => [ false, 'Help Banner' ],
+      '-b' => [ true, 'Target bus']
+    )
+    bus_config_opts.parse(args) do |opt, _idx, val|
+      case opt
+      when '-h'
+        print_line("Usage: bus_config -b <busname>\n")
+        print_line(bus_config_opts.usage)
+        return
+      when '-b'
+        bus = val
+      end
+    end
+    if not client.automotive.is_valid_bus? bus
+      print_error("You must specify a valid bus via -b")
+      return
+    end
+    config = client.automotive.get_bus_config(bus)
+  end
+
+  #
+  # 'connects' to a bus, this retrives the supported_methods
+  # specific to this bus
+  #
+  def cmd_connect(*args)
+    bus = ''
+    connect_opts = Rex::Parser::Arguments.new(
+      '-h' => [ false, 'Help Banner' ],
+      '-b' => [ true, 'Target bus']
+    )
+    connect_opts.parse(args) do |opt, _idx, val|
+      case opt
+      when '-h'
+        print_line("Usage: connect -b <busname>\n")
+        print_line(connect_opts.usage)
+        return
+      when '-b'
+        bus = val
+      end
+    end
+    if not client.automotive.is_valid_bus? bus
+      print_error("You must specify a valid bus via -b")
+      return
+    end
+    self.active_bus = bus
+    client.automotive.set_active_bus(bus)
+    hw_methods = client.automotive.get_supported_methods(bus)
+  end
+
+  #
+  # Generic CAN send packet command
+  #
+  def cmd_cansend(*args)
+    bus = ''
+    id = ''
+    data = ''
+    cansend_opts = Rex::Parser::Arguments.new(
+      '-h' => [ false, 'Help Banner' ],
+      '-b' => [ true, 'Target bus'],
+      '-I' => [ true, 'CAN ID'],
+      '-D' => [ true, 'Data packet in Hex']
+    )
+    cansend_opts.parse(args) do |opt, _idx, val|
+      case opt
+      when '-h'
+        print_line("Usage: cansend -I <ID> -D <data>\n")
+        print_line(cansend_opts.usage)
+        return
+      when '-b'
+        bus = val
+      when '-I'
+        id = val
+      when '-D'
+        data = val
+      end
+    end
+    bus = self.active_bus if bus.blank? and not self.active_bus == nil
+    if not client.automotive.is_valid_bus? bus
+      print_error("You must specify a valid bus via -b")
+      return
+    end
+    if id.blank? or data.blank?
+      print_error("You must specify a CAN ID (-I) and the data packets (-D)")
+      return
+    end
+    success = client.automotive.cansend(bus, id, data)
+  end
+
+  #
+  # Name for this dispatcher
+  #
+  def name
+    'Automotive'
+  end
+
+private
+  attr_accessor :active_bus
+
+end
+
+end
+end
+end
+end
+

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
@@ -1,0 +1,516 @@
+# -*- coding: binary -*-
+require 'set'
+require 'rex/post/hwbridge'
+require 'rex/parser/arguments'
+
+module Rex
+module Post
+module HWBridge
+module Ui
+
+###
+#
+# Core hwbridge client commands that provide only the required set of
+# commands for having a functional hwbridge client<->hardware  instance.
+#
+###
+class Console::CommandDispatcher::Core
+
+  include Console::CommandDispatcher
+
+  #
+  # Initializes an instance of the core command set using the supplied shell
+  # for interactivity.
+  #
+  def initialize(shell)
+    super
+
+    self.extensions = []
+    self.bgjobs     = []
+    self.bgjob_id   = 0
+
+    # keep a lookup table to refer to transports by index
+    @transport_map = {}
+
+  end
+
+  @@irb_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner."                  ],
+    "-e" => [ true,  "Expression to evaluate."       ])
+
+  @@load_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help menu."                    ])
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    c = {
+      "?"          => "Help menu",
+      "exit"       => "Terminate the hardware bridge session",
+      "help"       => "Help menu",
+      "irb"        => "Drop into irb scripting mode",
+      "load"       => "Load one or more meterpreter extensions",
+      "run"        => "Executes a meterpreter script or Post module",
+      "bgrun"      => "Executes a meterpreter script as a background thread",
+      "bgkill"     => "Kills a background meterpreter script",
+      "bglist"     => "Lists running background scripts",
+      "status"     => "Fetch bridge status information",
+      "specialty"  => "Hardware devices specialty",
+      "load_custom_methods" => "Loads custom HW commands if any"
+    }
+
+    if msf_loaded?
+      c["info"] = "Displays information about a Post module"
+    end
+
+    c
+  end
+
+  def name
+    "Core"
+  end
+
+  #
+  # Terminates the hwbridge
+  #
+  def cmd_exit(*args)
+    print_status("Shutting down the hardware bridge...")
+    shell.stop
+  end
+
+  alias cmd_quit cmd_exit
+
+  def cmd_irb_help
+    print_line "Usage: irb"
+    print_line
+    print_line "Execute commands in a Ruby environment"
+    print @@irb_opts.usage
+  end
+
+  #
+  # Runs the IRB scripting shell
+  #
+  def cmd_irb(*args)
+    expressions = []
+
+    # Parse the command options
+    @@irb_opts.parse(args) do |opt, idx, val|
+      case opt
+      when '-e'
+        expressions << val
+      when '-h'
+        return cmd_irb_help
+      end
+    end
+
+    session = client
+    framework = client.framework
+
+    if expressions.empty?
+      print_status("Starting IRB shell")
+      print_status("The 'client' variable holds the hwbridge client\n")
+
+      Rex::Ui::Text::IrbShell.new(binding).run
+    else
+      expressions.each { |expression| eval(expression, binding) }
+    end
+  end
+
+  def cmd_info_help
+    print_line 'Usage: info <module>'
+    print_line
+    print_line 'Prints information about a post-exploitation module'
+    print_line
+  end
+
+  #
+  # Show info for a given Post module.
+  #
+  # See also +cmd_info+ in lib/msf/ui/console/command_dispatcher/core.rb
+  #
+  def cmd_info(*args)
+    return unless msf_loaded?
+
+    if args.length != 1 or args.include?("-h")
+      cmd_info_help
+      return
+    end
+
+    module_name = args.shift
+    mod = client.framework.modules.create(module_name);
+
+    if mod.nil?
+      print_error 'Invalid module: ' << module_name
+    end
+
+    if (mod)
+      print_line(::Msf::Serializer::ReadableText.dump_module(mod))
+      mod_opt = ::Msf::Serializer::ReadableText.dump_options(mod, '   ')
+      print_line("\nModule options (#{mod.fullname}):\n\n#{mod_opt}") if (mod_opt and mod_opt.length > 0)
+    end
+  end
+
+  def cmd_info_tabs(*args)
+    return unless msf_loaded?
+    tab_complete_postmods
+  end
+
+  def cmd_status_help
+    print_line("Usage: status")
+    print_line
+    print_line "Retrives the devices current status and capabilities"
+  end
+
+  #
+  # Get the HW bridge devices status
+  #
+  def cmd_status(*args)
+    if args.length > 0
+      cmd_status_help
+      return true
+    end
+    status = client.get_status
+    if status.has_key? "operational"
+      op = "Unknown"
+      op = "Yes" if status["operational"] == 1
+      op = "No" if status["operational"] == 2
+      print_status("Operational: #{op}")
+    end
+  end
+
+  def cmd_specialty_help
+    print_line("Usage: specialty")
+    print_line
+    print_line "Simple helper function to see what the devices specialty is"
+  end
+
+  #
+  # Get the Hardware specialty
+  #
+  def cmd_specialty(*args)
+    if args.length > 0
+      cmd_specialty_help
+      return true
+    end
+    print_line client.exploit.hw_specialty.to_s
+  end
+
+  def cmd_load_custom_methods_help
+    print_line("Usage: load_custom_methods")
+    print_line
+    print_line "Checks to see if there are any custom HW commands and loads as"
+    print_line "interactive commands in your session."
+  end
+
+  #
+  # Loads custom methods if any exist
+  #
+  def cmd_load_custom_methods(*args)
+    if args.length > 0
+      cmd_load_custom_methods_help
+      return true
+    end
+    res = client.get_custom_methods
+    if res.has_key? "Methods"
+      cmd_load("custom_methods")
+      self.shell.dispatcher_stack.each do |dispatcher|
+        if dispatcher.name =~/custom methods/i
+          dispatcher.load_methods(res["Methods"])
+        end
+      end
+      print_status("Loaded #{res["Methods"].size} method(s)")
+    else
+      print_status("Not supported")
+    end
+  end
+
+  def cmd_load_help
+    print_line("Usage: load ext1 ext2 ext3 ...")
+    print_line
+    print_line "Loads a hardware extension module or modules."
+    print_line @@load_opts.usage
+  end
+
+  #
+  # Loads one or more meterpreter extensions.
+  #
+  def cmd_load(*args)
+    if (args.length == 0)
+      args.unshift("-h")
+    end
+
+    @@load_opts.parse(args) { |opt, idx, val|
+      case opt
+      when "-h"
+        cmd_load_help
+        return true
+      end
+    }
+
+    # Load each of the modules
+    args.each { |m|
+      md = m.downcase
+
+      if (extensions.include?(md))
+        print_error("The '#{md}' extension has already been loaded.")
+        next
+      end
+
+      print("Loading extension #{md}...")
+
+      begin
+        # Use the remote side, then load the client-side
+        #if (client.core.use(md) == true)
+          client.add_extension(md) # NOTE: Doesn't work, going to use core instead
+          add_extension_client(md)
+        #end
+      rescue
+        print_line
+        log_error("Failed to load extension: #{$!}")
+        next
+      end
+
+      print_line("success.")
+    }
+
+    return true
+  end
+
+  def cmd_run_help
+    print_line "Usage: run <script> [arguments]"
+    print_line
+    print_line "Executes a ruby script or Metasploit Post module in the context of the"
+    print_line "hardware bridge session.  Post modules can take arguments in var=val format."
+    print_line "Example: run post/foo/bar BAZ=abcd"
+    print_line
+  end
+
+  #
+  # Executes a script in the context of the hwbridge session.
+  #
+  def cmd_run(*args)
+    if args.length == 0
+      cmd_run_help
+      return true
+    end
+
+    # Get the script name
+    begin
+      script_name = args.shift
+      # First try it as a Post module if we have access to the Metasploit
+      # Framework instance.  If we don't, or if no such module exists,
+      # fall back to using the scripting interface.
+      if (msf_loaded? and mod = client.framework.modules.create(script_name))
+        original_mod = mod
+        reloaded_mod = client.framework.modules.reload_module(original_mod)
+
+        unless reloaded_mod
+          error = client.framework.modules.module_load_error_by_path[original_mod.file_path]
+          print_error("Failed to reload module: #{error}")
+
+          return
+        end
+
+        opts = (args + [ "SESSION=#{client.sid}" ]).join(',')
+        reloaded_mod.run_simple(
+          #'RunAsJob' => true,
+          'LocalInput'  => shell.input,
+          'LocalOutput' => shell.output,
+          'OptionStr'   => opts
+        )
+      else
+        # the rest of the arguments get passed in through the binding
+        client.execute_script(script_name, args)
+      end
+    rescue
+      print_error("Error in script: #{$!.class} #{$!}")
+      elog("Error in script: #{$!.class} #{$!}")
+      dlog("Callstack: #{$@.join("\n")}")
+    end
+  end
+
+  def cmd_run_tabs(str, words)
+    tabs = []
+    if(not words[1] or not words[1].match(/^\//))
+      begin
+        if (msf_loaded?)
+          tabs += tab_complete_postmods
+        end
+        [  # We can just use Meterpreters script path
+          ::Msf::Sessions::Meterpreter.script_base,
+          ::Msf::Sessions::Meterpreter.user_script_base
+        ].each do |dir|
+          next if not ::File.exist? dir
+          tabs += ::Dir.new(dir).find_all { |e|
+            path = dir + ::File::SEPARATOR + e
+            ::File.file?(path) and ::File.readable?(path)
+          }
+        end
+      rescue Exception
+      end
+    end
+    return tabs.map { |e| e.sub(/\.rb$/, '') }
+  end
+
+  #
+  # Executes a script in the context of the hardware bridge session in the background
+  #
+  def cmd_bgrun(*args)
+    if args.length == 0
+      print_line(
+        "Usage: bgrun <script> [arguments]\n\n" +
+        "Executes a ruby script in the context of the hardware bridge session.")
+      return true
+    end
+
+    jid = self.bgjob_id
+    self.bgjob_id += 1
+
+    Z# Get the script name
+    self.bgjobs[jid] = Rex::ThreadFactory.spawn("HWBridgeBGRun(#{args[0]})-#{jid}", false, jid, args) do |myjid,xargs|
+      ::Thread.current[:args] = xargs.dup
+      begin
+        # the rest of the arguments get passed in through the binding
+        client.execute_script(args.shift, args)
+      rescue ::Exception
+        print_error("Error in script: #{$!.class} #{$!}")
+        elog("Error in script: #{$!.class} #{$!}")
+        dlog("Callstack: #{$@.join("\n")}")
+      end
+      self.bgjobs[myjid] = nil
+      print_status("Background script with Job ID #{myjid} has completed (#{::Thread.current[:args].inspect})")
+    end
+
+    print_status("Executed HWBridge with Job ID #{jid}")
+  end
+
+  #
+  # Map this to the normal run command tab completion
+  #
+  def cmd_bgrun_tabs(*args)
+    cmd_run_tabs(*args)
+  end
+
+  #
+  # Kill a background job
+  #
+  def cmd_bgkill(*args)
+    if args.length == 0
+      print_line("Usage: bgkill [id]")
+      return
+    end
+
+    args.each do |jid|
+      jid = jid.to_i
+      if self.bgjobs[jid]
+        print_status("Killing background job #{jid}...")
+        self.bgjobs[jid].kill
+        self.bgjobs[jid] = nil
+      else
+        print_error("Job #{jid} was not running")
+      end
+    end
+  end
+
+  #
+  # List background jobs
+  #
+  def cmd_bglist(*args)
+    self.bgjobs.each_index do |jid|
+      if self.bgjobs[jid]
+        print_status("Job #{jid}: #{self.bgjobs[jid][:args].inspect}")
+      end
+    end
+  end
+
+  def cmd_info_help
+    print_line 'Usage: info <module>'
+    print_line
+    print_line 'Prints information about a post-exploitation module'
+    print_line
+  end
+
+
+  @@client_extension_search_paths = [ ::File.join(Rex::Root, "post", "hwbridge", "ui", "console", "command_dispatcher") ]
+
+  def self.add_client_extension_search_path(path)
+    @@client_extension_search_paths << path unless @@client_extension_search_paths.include?(path)
+  end
+  def self.client_extension_search_paths
+    @@client_extension_search_paths
+  end
+
+protected
+
+  attr_accessor :extensions # :nodoc:
+  attr_accessor :bgjobs, :bgjob_id # :nodoc:
+
+  CommDispatcher = Console::CommandDispatcher
+
+  #
+  # Loads the client extension specified in mod
+  #
+  def add_extension_client(mod)
+    loaded = false
+    klass = nil
+    self.class.client_extension_search_paths.each do |path|
+      path = ::File.join(path, "#{mod}.rb")
+      klass = CommDispatcher.check_hash(path)
+      if (klass == nil)
+        old   = CommDispatcher.constants
+        next unless ::File.exist? path
+
+        if (require(path))
+          new  = CommDispatcher.constants
+          diff = new - old
+
+          next if (diff.empty?)
+
+          klass = CommDispatcher.const_get(diff[0])
+
+          CommDispatcher.set_hash(path, klass)
+          loaded = true
+          break
+        else
+          print_error("Failed to load client script file: #{path}")
+          return false
+        end
+      else
+        # the klass is already loaded, from a previous invocation
+        loaded = true
+        break
+      end
+    end
+    unless loaded
+      print_error("Failed to load client portion of #{mod}.")
+      return false
+    end
+
+    # Enstack the dispatcher
+    self.shell.enstack_dispatcher(klass)
+
+    # Insert the module into the list of extensions
+    self.extensions << mod
+  end
+
+  def tab_complete_postmods
+    tabs = client.framework.modules.post.map { |name,klass|
+      mod = client.framework.modules.post.create(name)
+      if mod and mod.session_compatible?(client)
+        mod.fullname.dup
+      else
+        nil
+      end
+    }
+
+    # nils confuse readline
+    tabs.compact
+  end
+
+end
+
+end
+end
+end
+end

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/custom_methods.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/custom_methods.rb
@@ -1,0 +1,122 @@
+# -*- coding: binary -*-
+require 'rex/post/hwbridge'
+require 'msf/core/auxiliary/report'
+require 'rex/parser/arguments'
+
+module Rex
+module Post
+module HWBridge
+module Ui
+###
+# Custom Methods extension - a set of commands defined by the HW itself
+###
+class Console::CommandDispatcher::CustomMethods
+  include Console::CommandDispatcher
+  include Msf::Auxiliary::Report
+
+  def initialize(shell)
+    super
+    @cmds = {}
+    @custom_methods = {}
+  end
+
+  @@generic_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help menu."                    ])
+
+  #
+  # List of supported commands.
+  #
+  def commands
+    @cmds ||= {}
+  end
+
+  def name
+    "Custom Methods"
+  end
+
+  #
+  # Loaded from core and passed hash from custom_methods rest call
+  #
+  def load_methods(m)
+    @custom_methods = m
+    m.each do |method|
+      if method.has_key? "method_name"
+        desc = "See HW manual for command description"
+        desc = method["method_desc"] if method.has_key? "method_desc"
+        cmd = method["method_name"]
+        cmd = $1 if cmd=~/\/(\S+)$/
+        @cmds[cmd] = method["method_desc"]
+        eval("alias cmd_#{cmd} cmd_generic_handler")
+      end
+    end
+  end
+
+  #
+  # A generic help system to show the arguments needed for custom commands
+  #
+  def cmd_generic_handler_help(cmd)
+    @custom_methods.each do |meth|
+      if meth["method_name"] =~ /#{cmd}$/
+        args = ""
+        args = "<args>" if meth["args"].size > 0
+        print_line("Usage: #{cmd} #{args}")
+        print_line
+        meth["args"].each do |arg|
+          req = ""
+          req = "  *required*" if arg.has_key? "required" and arg["required"] == true
+          print_line("  #{arg["arg_name"]}=<#{arg["arg_type"]}> #{req}")
+        end
+      end
+    end
+  end
+
+  #
+  # A generic handler for all custom commands
+  #
+  def cmd_generic_handler(*args)
+    cmd = __callee__.to_s.gsub(/^cmd_/,'')
+    @@generic_opts.parse(args) { |opt, idx, val|
+      case opt
+      when "-h"
+        cmd_generic_handler_help(cmd)
+        return true
+      end
+    }
+    if not has_required_args(cmd, args)
+      print_error("Not all required arguments were used.  See command help (-h)")
+      return true
+    end
+    res = client.custom_methods.send_request(cmd, args, @custom_methods)
+    print_status(res["status"]) if res.has_key? "status"
+    print_status(res["value"]) if res.has_key? "value"
+  end
+
+  #
+  # Verify all required args are used
+  #
+  def has_required_args(cmd, args)
+    all_found = true
+    arguments = {}
+    args.each do |arg|
+      (key, value) = arg.split('=')
+      arguments[key] = value
+    end
+    @custom_methods.each do |meth|
+      if meth["method_name"] =~ /#{cmd}$/
+        meth["args"].each do |arg|
+          if arg.has_key? "required" and arg["required"] == true
+            all_found = false if not arguments.has_key? arg["arg_name"]
+          end
+        end
+      end
+    end
+    all_found
+  end
+
+end
+
+end
+end
+end
+end
+

--- a/lib/rex/post/hwbridge/ui/console/interactive_channel.rb
+++ b/lib/rex/post/hwbridge/ui/console/interactive_channel.rb
@@ -1,0 +1,102 @@
+# -*- coding: binary -*-
+module Rex
+module Post
+module HWBridge
+module Ui
+
+###
+#
+# Mixin that is meant to extend the base channel class from hwbridge in a
+# manner that adds interactive capabilities.
+#
+###
+module Console::InteractiveChannel
+
+  include Rex::Ui::Interactive
+
+  #
+  # Interacts with self.
+  #
+  def _interact
+    # If the channel has a left-side socket, then we can interact with it.
+    if (self.lsock)
+      self.interactive(true)
+
+      interact_stream(self)
+
+      self.interactive(false)
+    else
+      print_error("Channel #{self.cid} does not support interaction.")
+
+      self.interacting = false
+    end
+  end
+
+  #
+  # Called when an interrupt is sent.
+  #
+  def _interrupt
+    prompt_yesno("Terminate channel #{self.cid}?")
+  end
+
+  #
+  # Suspends interaction with the channel.
+  #
+  def _suspend
+    # Ask the user if they would like to background the session
+    if (prompt_yesno("Background channel #{self.cid}?") == true)
+      self.interactive(false)
+
+      self.interacting = false
+    end
+  end
+
+  #
+  # Closes the channel like it aint no thang.
+  #
+  def _interact_complete
+    begin
+      self.interactive(false)
+
+      self.close
+    rescue IOError
+    end
+  end
+
+  #
+  # Reads data from local input and writes it remotely.
+  #
+  def _stream_read_local_write_remote(channel)
+    data = user_input.gets
+    return if not data
+
+    self.on_command_proc.call(data.strip) if self.on_command_proc
+    self.write(data)
+  end
+
+  #
+  # Reads from the channel and writes locally.
+  #
+  def _stream_read_remote_write_local(channel)
+    data = self.lsock.sysread(16384)
+
+    self.on_print_proc.call(data.strip) if self.on_print_proc
+    self.on_log_proc.call(data.strip) if self.on_log_proc
+    user_output.print(data)
+  end
+
+  #
+  # Returns the remote file descriptor to select on
+  #
+  def _remote_fd(stream)
+    self.lsock
+  end
+
+  attr_accessor :on_log_proc
+
+end
+
+end
+end
+end
+end

--- a/modules/auxiliary/client/hwbridge/connect.rb
+++ b/modules/auxiliary/client/hwbridge/connect.rb
@@ -1,0 +1,153 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/base/sessions/hwbridge'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+
+  def initialize(info={})
+    super( update_info( info, {
+        'Name'          => 'Hardware Bridge Session Connector',
+        'Description'   => %q{
+          The Hardware Bridge (HWBridge) is a standardized method for
+          Metasploit to interact with Hardware Devices.  This extends
+          the normal exploit capabilities to the non-ethernet realm and
+          enables direct hardware and alternative bus manipulations.  You
+          mush have compatible bridging hardware attached to this machine or
+          reachable on your network to use any HWBridge exploits.
+
+          Use this exploit module to connect the the physical HWBridge which
+          will start an interactive hwbridge session.  You can launch a hwbridge
+          server locally by using compliant hardware and executing the local_hwbridge
+          module.  After that module has started, pass the HWBRIDGE_BASE_URL
+          options to this connector module.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        =>
+          [
+            'Craig Smith'                       # hwbridge metaspliot module
+          ],
+        'Session'       => Msf::Sessions::HWBridge,
+        'SessionTypes'  => [ 'hwbridge' ],
+        'References'    =>
+          [
+            [ 'URL', 'http://api.hwbridge.reference.rapid7.com' ]  # TODO
+          ],
+      }
+      ))
+    register_options(
+      [
+        Opt::RPORT(8080),
+        Opt::RHOST("127.0.0.1"),
+        OptBool.new("DEBUGJSON", [false, "Additional debugging out for JSON requests to HW Bridge", false]),
+        OptString.new('TARGETURI', [ true,  "The path to the hwbridge API", '/'])
+      ],
+      self.class
+    )
+    @last_access = nil
+  end
+
+  #
+  # Generic fetch json call. returns hash of json
+  #
+  def fetch_json(uri)
+    tpath = normalize_uri("#{datastore["TARGETURI"]}/#{uri}")
+    res = send_request_cgi({
+      'uri' => tpath,
+      'method' => 'GET',
+    })
+    return nil if not res or not res.body or not res.code
+    if (res.code == 200)
+      print_status res.body if datastore["DEBUGJSON"] == true
+      return JSON.parse(res.body)
+    end
+    return nil
+
+    rescue OpenSSL::SSL::SSLError
+      vprint_error("SSL error")
+      return nil
+    rescue Errno::ENOPROTOOPT, Errno::ECONNRESET, ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::ArgumentError
+      vprint_error("Unable to Connect")
+      return nil
+    rescue ::Timeout::Error, ::Errno::EPIPE
+      vprint_error("Timeout error")
+      return nil
+
+  end
+
+  #
+  # Disclaimer for legal and those without common sense...
+  #
+  def print_disclaimer
+    print_warning("NOTICE:  You are about to leave the matrix.  All actions performed on this hardware bridge")
+    print_warning("         could have real world consequences.  Use this module in a controlled testing")
+    print_warning("         environment and with equipment you are authorized to perform testing on.")
+  end
+
+  #
+  # Uses status information to automatically load proper extensions
+  #
+  def autoload_extensions(sess)
+    if self.hw_specialty.has_key? "automotive"
+      sess.load_automotive if self.hw_specialty["automotive"] == true
+    end
+  end
+
+  #
+  # If the hardware contains custom methods, create functions for those
+  #
+  def load_custom_methods(sess)
+    if self.hw_capabilities.has_key? "custom_methods"
+      sess.load_custom_methods if self.hw_capabilities["custom_methods"] == true
+    end
+  end
+
+  #
+  # Fetches the status of the hwbridge
+  #
+  def get_status
+    data = fetch_json("/status")
+    if not data == nil
+      if data.has_key? "operational"
+        @last_access = Time.now
+        if data.has_key? "hw_specialty"
+          self.hw_specialty = data["hw_specialty"]
+        end
+        if data.has_key? "hw_capabilities"
+          self.hw_capabilities = data["hw_capabilities"]
+        end
+      end
+    end
+  end
+
+  def run
+    print_status "Attempting to connect to #{datastore["RHOST"]}..."
+    self.get_status()
+    if not @last_access == nil
+      sess = Msf::Sessions::HWBridge.new(self)
+      sess.set_from_exploit(self)
+
+      framework.sessions.register(sess)
+      print_good "HWBridge session established"
+      autoload_extensions(sess)
+      load_custom_methods(sess)
+      print_status "HW Specialty: #{self.hw_specialty}  Capabilities: #{self.hw_capabilities}"
+      print_disclaimer
+    else
+      print_bad "Could not connect to API"
+    end
+  end
+
+  attr_reader :hw_specialty
+  attr_reader :hw_capabilities
+protected
+  attr_writer :hw_specialty
+  attr_writer :hw_capabilities
+end

--- a/modules/post/hardware/automotive/getvinfo.rb
+++ b/modules/post/hardware/automotive/getvinfo.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/hardware/automotive/uds'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::Hardware::Automotive::UDS
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Get the Vehicle Information Such as the VIN from the Target Module',
+        'Description'   => %q{ Post Module to query DTCs, Some common engine info and Vehicle Info.
+                               It returns such things as engine speed, coolant temp, Diagnostic
+                               Trouble Codes as well as All info stored by Mode $09 Vehicle Info, VIN, etc},
+        'License'       => MSF_LICENSE,
+        'Author'        => ['Craig Smith'],
+        'Platform'      => ['hardware'],
+        'SessionTypes'  => ['hwbridge']
+      ))
+    register_options([
+      OptInt.new('SRCID', [true, "Module ID to query", 0x7e0]),
+      OptInt.new('DSTID', [false, "Expected reponse ID, defaults to SRCID + 8", 0x7e8]),
+      OptBool.new('CLEAR_DTCS', [false, "Clear any DTCs and reset MIL if errors are present", false]),
+      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
+    ], self.class)
+
+  end
+
+  def run
+    pids = get_current_data_pids(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+    print_status("Avaiable PIDS for pulling realitme data: #{pids.size} pids")
+    print_status("  #{pids.inspect}")
+    if pids.include? 1
+      data = get_monitor_status(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+      print_status("  MIL (Engine Light) : #{data["MIL"] ? "ON" : "OFF"}") if data.has_key? "MIL"
+      print_status("  Number of DTCs: #{data["DTC_COUNT"]}") if data.has_key? "DTC_COUNT"
+    end
+    if pids.include? 5
+      data = get_engine_coolant_temp(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+      print_status("  Engine Temp: #{data["TEMP_C"]} \u00b0C / #{data["TEMP_F"]} \u00b0F") if data.has_key? "TEMP_C"
+    end
+    if pids.include? 0x0C
+      data = get_rpms(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+      print_status("  RPMS: #{data["RPM"]}") if data.has_key? "RPM"
+    end
+    if pids.include? 0x0D
+      data = get_vehicle_speed(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+      print_status("  Speed: #{data["SPEED_K"]} km/h  /  #{data["SPEED_M"]} mph") if data.has_key? "SPEED_K"
+    end
+    if pids.include? 0x1C
+      print_status("Supported OBD Standards: #{get_obd_standards(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])}")
+    end
+    dtcs = get_dtcs(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+    print_status("DTCs: #{ dtcs.join(",") }") if dtcs.size > 0
+    pids = get_vinfo_supported_pids(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+    print_status("Mode $09 Vehicle Info Supported PIDS: #{pids.inspect}")
+    pids.each do |pid|
+      # Handle known pids
+      if pid == 2
+        vin = get_vin(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+        print_status("VIN: #{vin}")
+      elsif pid == 4
+        calid = get_calibration_id(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+        print_status("Calibration ID: #{calid}")
+      elsif pid == 0x0A
+        ecuname = get_ecu_name(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+        print_status("ECU Name: #{ecuname}")
+      else
+        data = get_vehicle_info(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"], pid)
+        data = response_hash_to_data_array(datastore["DSTID"].to_s(16), data)
+        print_status("PID #{pid} Response: #{data.inspect}")
+      end
+    end
+    if datastore['CLEAR_DTCS'] == true
+      clear_dtcs(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
+      print_status("Cleared DTCs and reseting MIL")
+    end
+  end
+
+end

--- a/modules/post/hardware/automotive/getvinfo.rb
+++ b/modules/post/hardware/automotive/getvinfo.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
 
   def run
     pids = get_current_data_pids(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
-    print_status("Avaiable PIDS for pulling realitme data: #{pids.size} pids")
+    print_status("Available PIDS for pulling realtime data: #{pids.size} pids")
     print_status("  #{pids.inspect}")
     if pids.include? 1
       data = get_monitor_status(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])

--- a/modules/post/hardware/automotive/identifymodules.rb
+++ b/modules/post/hardware/automotive/identifymodules.rb
@@ -1,0 +1,53 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/hardware/automotive/uds'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::Hardware::Automotive::UDS
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Scan CAN Bus for Diagnostic Modules',
+        'Description'   => %q{ Post Module to scan the CAN bus for any modules that can respond to UDS DSC queries},
+        'License'       => MSF_LICENSE,
+        'Author'        => ['Craig Smith'],
+        'Platform'      => ['hardware'],
+        'SessionTypes'  => ['hwbridge']
+      ))
+    register_options([
+      OptInt.new('STARTID', [true, "Start scan from this ID", 0x600]),
+      OptInt.new('ENDID', [true, "End scan at this ID", 0x7F7]),
+      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
+    ], self.class)
+    @found_id = Array.new
+  end
+
+  def run
+    scanned_ids = 0
+    print_line("Starting scan...")
+    (datastore["STARTID"]..datastore["ENDID"]).each do |id|
+      res = set_dsc(datastore["CANBUS"], id, id+8, 1)
+      scanned_ids += 1
+      next if res == nil
+      next if not res.has_key? "Packets"
+      next if not res["Packets"].size > 0
+      if res["Packets"][0].has_key? "DATA" and res["Packets"][0]["DATA"].size > 3
+        if res["Packets"][0]["DATA"][0].hex == 3 and res["Packets"][0]["DATA"][1].hex == 0x7f and res["Packets"][0]["DATA"][2].hex == 0x10
+          print_status("Identified module #{"%3x" % id}")
+          @found_id << id
+        end
+      end
+    end
+    print_line("Scanned #{scanned_ids} IDs and found #{@found_id.size} modules that responded")
+    @found_id.each do |id|
+      print_line("  #{"%3x" % id}")
+    end
+  end
+
+end

--- a/modules/post/hardware/automotive/malibu_overheat.rb
+++ b/modules/post/hardware/automotive/malibu_overheat.rb
@@ -1,0 +1,37 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Sample Module to Flood Temp Guage on 2006 Malibu',
+        'Description'   => %q{ Simple sample temp flood for the 2006 Malibu},
+        'License'       => MSF_LICENSE,
+        'Author'        => ['Craig Smith'],
+        'Platform'      => ['hardware'],
+        'SessionTypes'  => ['hwbridge']
+      ))
+    register_options([
+      OptInt.new('PACKET_COUNT', [false, "How many packets to send before stopping", 200]),
+      OptString.new('CANBUS', [false, "CAN Bus to perform scan on, defaults to connected bus", nil])
+    ], self.class)
+  end
+
+  def run
+    if not client.automotive
+      print_error("The hwbridge requires a functional automotive extention")
+      return
+    end
+    print_status("Forcing Engine Temp to max...")
+    (0..datastore["PACKET_COUNT"]).each do |cnt|
+      client.automotive.cansend(datastore['CANBUS'], "510", "10AD013CF048120B")
+    end
+  end
+
+end

--- a/tools/hardware/README.md
+++ b/tools/hardware/README.md
@@ -1,0 +1,12 @@
+HWBridge Tools
+--------------
+This folder contains hardware related tools that are compatible with the HWBridge interface.
+Commonly this will be a repository of different hardware relay services.  If your device
+requires communication via serial or USB or some other non-ethernet means and you want
+to utilize the metasploit framework for handling the HTTP server then feel free to put
+your relay here.
+
+If however your device supports WiFi or Ethernet, then consider building the HWBridge
+support directly into your hardware.  Check your development board to see if there is
+a library available that supports your chipset and the MSF HWBridge.  Often the
+library will be called MSF_Relay or something similar.

--- a/tools/hardware/elm327_relay.rb
+++ b/tools/hardware/elm327_relay.rb
@@ -1,0 +1,382 @@
+#!/usr/bin/env ruby
+
+# ELM327 and STN1100 MCU interface to the Metasploit HWBridge
+
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+####
+# This module requires a connected ELM327 or STN1100 is connected to
+# the machines serial.  Sets up a basic RESTful web server to communicate
+# Requers MSF and the serialport gem
+####
+
+
+### Non-typical gem ###
+require 'serialport'
+
+#
+# Load our MSF API
+#
+
+msfbase = __FILE__
+while File.symlink?(msfbase)
+  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
+require 'msfenv'
+require 'rex'
+require 'msf/core'
+require 'optparse'
+
+# Prints with [*] that represents the message is a status
+#
+# @param msg [String] The message to print
+# @return [void]
+def print_status(msg='')
+  $stdout.puts "[*] #{msg}"
+end
+
+# Prints with [-] that represents the message is an error
+#
+# @param msg [String] The message to print
+# @return [void]
+def print_error(msg='')
+  $stdout.puts "[-] #{msg}"
+end
+
+# Base ELM327 Class for the Realy
+module ELM327HWBridgeRelay
+
+  class ELM327Relay < Msf::Auxiliary
+
+    include Msf::Exploit::Remote::HttpServer::HTML
+
+    # @!attribute serial_port
+    #  @return [String] The serial port device name
+    attr_accessor :serial_port
+
+    # @!attribute serial_baud
+    #  @return [Integer] Baud rate of serial device
+    attr_accessor :serial_baud
+
+    # @!attribute serial_bits
+    #  @return [Integer] Number of serial data bits
+    attr_accessor :serial_bits
+
+    # @!attribute serial_stop_bits
+    #  @return [Integer] Stop bit
+    attr_accessor :serial_stop_bits
+
+    def initialize(info={})
+      begin
+        @opts = OptsConsole.parse(ARGV)
+      rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e
+        print_error("#{e.message} (please see -h)")
+        exit
+      end
+
+    super(update_info(info,
+      'Name'        => 'ELM327/STN1100 HWBridge Relay Server',
+      'Description' => %q{
+          This module sets up a web server to bridge communications between
+        Metasploit and the EML327 or STN1100 chipset.
+      },
+      'Author'      => [ 'Craig Smith' ],
+      'License'     => MSF_LICENSE,
+      'Actions'     =>
+        [
+          [ 'WebServer' ]
+        ],
+      'PassiveActions' =>
+        [
+          'WebServer'
+        ],
+      'DefaultAction'  => 'WebServer',
+        'DefaultOptions' =>
+         {
+            'URIPATH' => "/" 
+          }))
+       self.serial_port = @opts[:serial]
+       self.serial_baud = @opts[:baud]
+       self.serial_bits = 8
+       self.serial_stop_bits = 1
+       @operational_status = 0
+       @ser = nil # Serial Interface
+       @device_name = ""
+       @packets_sent = 0
+       @last_sent = 0
+       @starttime = Time.now()
+       @supported_buses = [ { "bus_name" => "can0" } ]
+    end
+
+    # Sends a serial command to the ELM327.  Automatically appends \r\n
+    #
+    # @param cmd [String] Serial AT command for ELM327
+    # @return [String] Response between command and '>' prompt
+    def send_cmd(cmd)
+      @ser.write(cmd + "\r\n")
+      resp = @ser.readline(">")
+      resp = resp[0, resp.length - 2]
+      resp.chomp!
+      resp
+    end
+
+    # Connects to the ELM327, resets paramters, gets device version and sets up general comms.
+    # Serial params are set via command options or during initialization
+    #
+    # @return [SerialPort] SerialPort object for communications.  Also available as @ser
+    def connect_to_device()
+      @ser = SerialPort.new(self.serial_port, self.serial_baud, self.serial_bits, self.serial_stop_bits, SerialPort::NONE)
+      resp = send_cmd("ATZ")  # Turn off ECHO
+      if resp =~ /ELM327/
+        send_cmd("ATE0")  # Turn off ECHO
+        send_cmd("ATL0")  # Disble linefeeds
+        @device_name = send_cmd("ATI")
+        send_cmd("ATH1") # Show Headers
+        @operational_status = 1
+        $stdout.puts("Connected.  Relay is up and running...")
+      else
+        $stdout.puts("Connected but invalid ELM response: #{resp.inspect}")
+        @operational_status = 2
+      end
+      @ser
+    end
+
+    # HWBridge Status call
+    #
+    # @return [Hash] Status return hash
+    def get_status()
+      status = Hash.new
+      status["operational"] = @operational_status
+      status["hw_specialty"] = { "automotive" => true }
+      status["hw_capabilities"] = { "can" => true}
+      status["last_10_errors"] = @last_errors # NOTE: no support for this yet
+      status["api_version"] = "0.0.1"
+      status["fw_version"] = "not supported"
+      status["hw_version"] = "not supported"
+      status["device_name"] = @device_name
+      status
+    end
+
+    # HWBridge Statistics Call
+    #
+    # @return [Hash] Statistics return hash
+    def get_statistics()
+      stats = Hash.new
+      stats["uptime"] = Time.now - @starttime
+      stats["packet_stats"] = @packets_sent
+      stats["last_request"] = @last_sent
+      volt = send_cmd("ATRV")
+      stats["voltage"] = volt.gsub(/V/,'')
+      stats
+    end
+
+    # HWBRidge DateTime Call
+    #
+    # @return [Hash] System DateTime Hash
+    def get_datetime()
+      { "sytem_datetime" => Time.now() }
+    end
+
+    # HWBridge Timezone Call
+    #
+    # @return [Hash] System Timezone as String
+    def get_timezone()
+      { "system_timezone" => Time.now.getlocal.zone }
+    end
+
+    # Returns supported buses.  Can0 is always available
+    # TODO: Use custom methods to force non-standard buses such as kline
+    #
+    # @return [Hash] Hash of supported_buses
+    def get_supported_buses()
+      @supported_buses
+    end
+
+    # Sends CAN packet
+    #
+    # @param id [String]  ID as a hex string
+    # @param data [String] String of HEX bytes to send
+    # @return [Hash] Success Hash
+    def cansend(id, data)
+      result = {}
+      result["success"] = false
+      id = "%03X" % id.to_i(16)
+      resp = send_cmd("ATSH#{id}")
+      if resp == "OK"
+        send_cmd("ATR0") # Disable response checks
+        send_cmd("ATCAF0") # Turn off ISO-TP formating
+      else
+        return result
+      end
+      if data.scan(/../).size > 8
+        $stdout.puts("Error: Data size > 8 bytes")
+        return result
+      end
+      send_cmd(data)
+      @packets_sent += 1
+      @last_sent = Time.now()
+      result["success"] = true
+      result
+    end
+
+    # Sends ISO-TP Packets
+    #
+    # @param srcid [String] Sender ID as hex string
+    # @param dstid [String] Responder ID as hex string
+    # @param data [String] Hex String of data to send
+    # @param timeout [Integer] Millisecond timeout, currently not implemented
+    # @param maxpkts [Integer] Max number of packets in response, currently not implemented
+    def isotpsend_and_wait(srcid, dstid, data, timeout, maxpkts)
+      result = {}
+      result["success"] = false
+      srcid = "%03X" % srcid.to_i(16)
+      dstid = "%03X" % dstid.to_i(16)
+      send_cmd("ATMCAF1")  # Turn on ISO-TP formatting
+      send_cmd("ATR1")  # Turn on responses
+      send_cmd("ATSTH#{srcid}")  # Src Header
+      send_cmd("ATCRA#{dstid}")  # Resp Header
+      send_cmd("ATCFC1") # Enable flow control
+      resp = send_cmd(data)
+      @packets_sent += 1
+      @last_sent = Time.now()
+      result["Packets"] = []
+      resp.split(/\r/).each do |line|
+        pkt = {}
+        if line=~/^(\w+) (.+)/
+          pkt["ID"] = $1
+          pkt["DATA"] = $2.split
+        end
+        result["Packets"] << pkt
+      end
+      result["success"] = true
+      result
+    end
+
+    # Generic Not supported call
+    #
+    # @return [Hash] Status not supported
+    def not_supported()
+      { "status" => "not supported" }
+    end
+
+    # Handles incomming URI requests and calls their respective API functions
+    #
+    # @param cli [Socket] Socket for the browser
+    # @param request [Rex::Proto::Http::Request] HTTP Request sent by the browser
+    def on_request_uri(cli, request)
+      if request.uri =~ /status$/i
+        send_response_html(cli, get_status().to_json(), { 'Content-Type' => 'application/json' })
+      elsif request.uri =~ /statistics$/i
+        send_response_html(cli, get_stats().to_json(), { 'Content-Type' => 'applicaiton/json' })
+      elsif request.uri =~/settings\/datetime$/i
+        send_response_html(cli, get_datetime().to_json(), { 'Content-Type' => 'application/json' })
+      elsif request.uri =~/settings\/timezone$/i
+        send_response_html(cli, get_timezone().to_json(), { 'Content-Type' => 'application/json' })
+#      elsif request.uri =~/custom_methods$/i
+#        send_response_html(cli, get_custom_methods().to_json(), { 'Content-Type' => 'application/json' })
+      elsif request.uri =~/automotive/i
+        if request.uri =~/automotive\/supported_buses/i
+          send_response_html(cli, get_supported_buses().to_json(), { 'Content-Type' => 'application/json' })
+        elsif request.uri =~/automotive\/can0\/cansend/
+          params = CGI.parse(URI(request.uri).query)
+          if params.has_key? "id" and params.has_key? "data"
+            send_response_html(cli, cansend(params["id"][0], params["data"][0]).to_json(), { 'Content-Type' => 'application/json' })
+          else
+            send_response_html(cli, not_supported().to_json(), { 'Content-Type' => 'application/json' })
+          end
+        elsif request.uri =~/automotive\/can0\/isotpsend_and_wait/
+          params = CGI.parse(URI(request.uri).query)
+          if params.has_key? "srcid" and params.has_key? "dstid" and params.has_key? "data"
+            timeout = 1500
+            maxpkts = 3
+            timeout = params["timeout"][0] if params.has_key? "timeout"
+            maxpkts = params["maxpkts"][0] if params.has_key? "maxpkts"
+            send_response_html(cli, isotpsend_and_wait(params["srcid"][0], params["dstid"][0], params["data"][0], timeout, maxpkts).to_json(), { 'Content-Type' => 'application/json' })
+          else
+            send_response_html(cli, not_supported().to_json(), { 'Content-Type' => 'application/json' })
+          end
+        else
+          send_response_html(cli, not_supported().to_json(), { 'Content-Type' => 'application/json' })
+        end
+      else
+        send_response_html(cli, not_supported().to_json(), { 'Content-Type' => 'application/json' })
+      end
+    end
+
+    # Main run operation.  Connects to device then runs the server
+    def run
+      connect_to_device()
+      exploit()
+    end
+
+  end
+
+  # This class parses the user-supplied options (inputs)
+  class OptsConsole
+
+    DEFAULT_BAUD = 115200
+    DEFAULT_SERIAL = "/dev/ttyUSB0"
+
+    # Returns the normalized user inputs
+    #
+    # @param args [Array] This should be Ruby's ARGV
+    # @raise [OptionParser::MissingArgument] Missing arguments
+    # @return [Hash] The normalized options
+    def self.parse(args)
+      parser, options = get_parsed_options
+
+      # Now let's parse it
+      # This may raise OptionParser::InvalidOption
+      parser.parse!(args)
+
+      options
+    end
+
+    # Returns the parsed options from ARGV
+    #
+    # raise [OptionParser::InvalidOption] Invalid option found
+    # @return [OptionParser, Hash] The OptionParser object and an hash containg the options
+    def self.get_parsed_options
+      options = {}
+      parser = OptionParser.new do |opt|
+        opt.banner = "Usage: #{__FILE__} [options]"
+        opt.separator ''
+        opt.separator 'Specific options:'
+
+        opt.on('-b', '--baud <serial_baud>',
+          "(Optional) Sets the baud speed for the serial device (Default=#{DEFAULT_BAUD})") do |v|
+          options[:baud] = v
+        end
+
+        opt.on('-s', '--serial <serial_device>',
+          "(Optional) Sets the serial device (Default=#{DEFAULT_SERIAL})") do |v|
+          options[:serial] = v
+        end
+
+        opt.on_tail('-h', '--help', 'Show this message') do
+          $stdout.puts opt
+          exit
+        end
+      end
+      return parser, options
+    end
+  end
+end
+
+
+
+#
+# Main
+#
+if __FILE__ == $PROGRAM_NAME
+  begin
+    bridge = ELM327HWBridgeRelay::ELM327Relay.new
+    bridge.run
+  rescue Interrupt
+    $stdout.puts("Shutting down")
+  end
+end


### PR DESCRIPTION
This tool provides a HWBridge serial relay for ELM327 and ST1100 MCUs.  These are traditionally very affordable and common vehicle dongles.  These dongles typically use either Bluetooth or direct serial to communicate to a phone app or other tool.  This relay enables the use of the HWBridge using these cheap devices.

Example device: http://www.ebay.com/itm/like/221821719820

## Verification

You will need an ELM327 or ELM327 compatible (ST1100) device attached via serial.  This could be bluetooth's serial interface.  The device should be plugged into your car if you want to run the final tests of pulling the vehicle info.

- [ ] cd tools/hardware
- [ ] `ruby ./elm327_relay.rb -b 115200 -s /dev/ttyUSB0`  -b is Baud -s is Serial
- [ ] **Verify** you see: Connected.  Relay is up and running...
In another terminal window
- [ ] ./msfconsole
- [ ] `use auxiliary/client/hwbridge/connect`
- [ ] `run`
- [ ] **Verify** You connect and get NOTICE about leaving the matrix
- [ ] `sess 1`
- [ ] `supported_buses`
- [ ] **Verify** you see can0
- [ ] `run post/hardware/automotive/getvinfo CANBUS=can0`
- [ ] **Verify** you see vehicle info from you car

