### PR TITLE
Add TCP/UDP hint to RPORT

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -407,7 +407,22 @@ class ReadableText
       next if (opt.evasion?)
       next if (missing && opt.valid?(val))
 
-      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
+      desc = opt.desc.dup
+
+      # Hint at RPORT proto by regexing mixins
+      if name == 'RPORT' && opt.kind_of?(Msf::OptPort)
+        mod.class.included_modules.each do |m|
+          if m.name =~ /tcp/i
+            desc << ' (TCP)'
+            break
+          elsif m.name =~ /udp/i
+            desc << ' (UDP)'
+            break
+          end
+        end
+      end
+
+      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", desc ]
     end
 
     return tbl.to_s

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -412,10 +412,11 @@ class ReadableText
       # Hint at RPORT proto by regexing mixins
       if name == 'RPORT' && opt.kind_of?(Msf::OptPort)
         mod.class.included_modules.each do |m|
-          if m.name =~ /tcp/i
+          case m.name
+          when /tcp/i, /HttpClient$/
             desc << ' (TCP)'
             break
-          elsif m.name =~ /udp/i
+          when /udp/i
             desc << ' (UDP)'
             break
           end


### PR DESCRIPTION
Caveat: works with mixins only (tenuously).

- [x] Do `options` or `info` on a thing that uses TCP or UDP
- [x] See if it shows the right protocol

Resolves #7757.