### PR TITLE
Fix Msf::Exploit::EXE shellcode/template mismatch

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -164,6 +164,8 @@ protected
         :sub_method => datastore['EXE::OldMethod']
       })
 
+    # NOTE: If code and platform/arch are supplied, we use those values and skip initialization.
+    #
     # This part is kind of tricky so we need to explain the logic behind the following load order.
     # First off, platform can be seen from different sources:
     #
@@ -180,7 +182,7 @@ protected
     #
     # Architecture shares the same load order.
 
-    unless opts[:platform]
+    unless opts[:code] && opts[:platform]
       if self.respond_to?(:payload_instance) && payload_instance.platform.platforms != [Msf::Module::Platform]
         opts[:platform] = payload_instance.platform
       elsif self.respond_to? :target_platform
@@ -190,11 +192,10 @@ protected
       end
     end
 
-    unless opts[:arch]
+    unless opts[:code] && opts[:arch]
       if self.respond_to? :payload_instance
         opts[:arch] = payload_instance.arch
       elsif self.respond_to? :target_arch
-        $stderr.puts "target specific arch"
         opts[:arch] = target_arch
       elsif self.respond_to? :arch
         opts[:arch] = arch


### PR DESCRIPTION
Initialize EXE options unless code is supplied with platform/arch.

- [x] Pick an exploit with an array of arches
- [x] Pick a payload that isn't the first arch
- [x] :shell:?

The idea here is that payload generation (no code supplied) should prefer the payload's arch first.