### PR TITLE
Provide more informative error messages when the ipboard_login scanner module fails to connect (fixes #7849)

### DIFF
--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
           :next_user
         when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           if datastore['VERBOSE']
-            print_brute :level => :verror, :ip => ip, :msg => "Could not connect"
+            print_brute :level => :verror, :ip => ip, :msg => result.proof
           end
           invalidate_login(credential_data)
           :abort


### PR DESCRIPTION
Use result.proof which has the right message. Thanks to Wei for pointing it out.

Fixes #7849.

## Verification

List the steps needed to make sure this thing works

assume you have apache server installed and listening on port 80 and you have a file `userpass.lst` with content:
```
root password
admin admin
jdole abc123
```
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/ipboard_login`
- [x] `set RHOSTS 127.0.0.1`
- [x] `set USERPASS_FILE userpass.lst`
- [x] `run`

```
[-] IPBOARD - Server nonce not present, potentially not an IP Board install or bad URI.
[!] No active DB -- Credential data will not be saved!
[-] IPBOARD - Server nonce not present, potentially not an IP Board install or bad URI.
[-] IPBOARD - Server nonce not present, potentially not an IP Board install or bad URI.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
