### PR TITLE
Make shell_command_token time out again

### DIFF
--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -43,6 +43,8 @@ module SingleCommandShell
   # Read data until we find the token
   #
   def shell_read_until_token(token, wanted_idx=0, timeout=10)
+    return if timeout.to_i == 0
+
     if (wanted_idx == 0)
       parts_needed = 2
     else


### PR DESCRIPTION
```
22:49 <@wvu> wvu@kharak:~/metasploit-framework:master$ cat ~/.msf4/scripts/shell/pty.rb 
22:49 <@wvu> session.shell_command_token('script -q /dev/null', 0)
22:49 <@wvu> Don't use 0 yet
22:49 <@wvu> It's an infinite loop if there's no data
22:49 <@wvu> :D
22:49 <@wvu> But 1 will work
```

> A value of 0 or nil will execute the block without any timeout.

https://ruby-doc.org/stdlib-2.3.3/libdoc/timeout/rdoc/Timeout.html