### PR TITLE
bump mettle, pulls in commandline arg parsing for stageless payloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 1.2.9)
       metasploit_data_models
-      metasploit_payloads-mettle (= 0.1.6)
+      metasploit_payloads-mettle (= 0.1.7)
       msgpack
       nessus_rest
       net-ssh
@@ -104,7 +104,7 @@ GEM
     bcrypt (3.1.11)
     bit-struct (0.15.0)
     builder (3.2.3)
-    capybara (2.11.0)
+    capybara (2.12.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -170,7 +170,7 @@ GEM
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
     metasploit-payloads (1.2.9)
-    metasploit_data_models (2.0.13)
+    metasploit_data_models (2.0.14)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
       arel-helpers
@@ -180,7 +180,7 @@ GEM
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.1.6)
+    metasploit_payloads-mettle (0.1.7)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.2.9'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.6'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.7'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.


### PR DESCRIPTION
This just enables the fix in https://github.com/rapid7/mettle/pull/49

With this, a stageless payload generated from msfvenom now will take interactive parameters so it can be reconfigured/directed in flight without having to regenerate or modify the payload itself.