### PR TITLE
Bump metasploit-payloads to 1.2.11 to incorporate changes to metasplo…

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.9'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.11'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.7'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/linux/aarch64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 301456
+  CachedSize = 301264
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 295848
+  CachedSize = 293160
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 521872
+  CachedSize = 521672
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 503004
+  CachedSize = 502792
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 503036
+  CachedSize = 502840
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module MetasploitModule
 
-  CachedSize = 27149
+  CachedSize = 27033
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51758
+  CachedSize = 51594
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51718
+  CachedSize = 51558
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51722
+  CachedSize = 51558
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51674
+  CachedSize = 51510
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
This just bumps the metasploit-framework to use the latest payloads Gem, 1.2.11 to incorporate payload PR https://github.com/rapid7/metasploit-payloads/pull/163