### PR TITLE
Add Advantech WebAccess LoginScanner module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/advantech_webaccess_login.md
+++ b/documentation/modules/auxiliary/scanner/http/advantech_webaccess_login.md
@@ -1,0 +1,31 @@
+## Description
+
+This module allows you to authenticate Advantech WebAccess.
+
+## Vulnerable Application
+
+This module was specifically tested on versions 8.0, 8.1, and 8.2:
+
+**8.2 Download**
+
+http://advcloudfiles.advantech.com/web/Download/webaccess/8.0/AdvantechWebAccessUSANode8.0_20141103_3.4.3.exe
+
+**8.1 Download**
+
+http://advcloudfiles.advantech.com/web/Download/webaccess/8.1/AdvantechWebAccessUSANode8.1_20151230.exe
+
+**8.0 Download**
+
+http://advcloudfiles.advantech.com/web/Download/webaccess/8.0/AdvantechWebAccessUSANode8.0_20141103_3.4.3.exe
+
+
+## Verification Steps
+
+1. Make sure Advantech WebAccess is up and running
+2. Start ```msfconsole```
+3. ```use auxiliary/scanner/http/advantech_webaccess_login
+4. ```set RHOSTS [IP]```
+5. Set credentials
+6. ```run```
+7. You should see that the module is attempting to log in.
+

--- a/documentation/modules/auxiliary/scanner/http/advantech_webaccess_login.md
+++ b/documentation/modules/auxiliary/scanner/http/advantech_webaccess_login.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module allows you to authenticate Advantech WebAccess.
+This module allows you to authenticate to Advantech WebAccess.
 
 ## Vulnerable Application
 
@@ -18,14 +18,22 @@ http://advcloudfiles.advantech.com/web/Download/webaccess/8.1/AdvantechWebAccess
 
 http://advcloudfiles.advantech.com/web/Download/webaccess/8.0/AdvantechWebAccessUSANode8.0_20141103_3.4.3.exe
 
+Note:
+
+By default, Advantech WebAccess comes with a built-in account named ```admin```, with a blank
+password.
+
 
 ## Verification Steps
 
 1. Make sure Advantech WebAccess is up and running
 2. Start ```msfconsole```
-3. ```use auxiliary/scanner/http/advantech_webaccess_login
+3. ```use auxiliary/scanner/http/advantech_webaccess_login```
 4. ```set RHOSTS [IP]```
 5. Set credentials
 6. ```run```
 7. You should see that the module is attempting to log in.
 
+## Demo
+
+![webaccess_login_demo](https://cloud.githubusercontent.com/assets/1170914/22352301/26549236-e3e1-11e6-9710-506166a8bee3.gif)

--- a/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
+++ b/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
@@ -1,0 +1,83 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      class AdvantechWebAccess < HTTP
+
+        DEFAULT_PORT  = 80
+        PRIVATE_TYPES = [ :password ]
+        LOGIN_STATUS  = Metasploit::Model::Login::Status # Shorter name
+
+        def check_setup
+          uri = normalize_uri("#{uri}broadWeb/bwRoot.asp")
+
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => uri
+          })
+
+          if res && res.body =~ /Welcome to Advantech WebAccess/i
+            return true
+          end
+
+          false
+        end
+
+        def do_login(user, pass)
+          uri  = normalize_uri("#{uri}broadweb/user/signin.asp")
+
+          res = send_request({
+            'method' => 'POST',
+            'uri'    => uri,
+            'vars_post' =>
+              {
+                'page'     => '/',
+                'pos'      => '',
+                'remMe'    => '',
+                'submit1'  => 'Login',
+                'username' => user,
+                'password' => pass
+              }
+          })
+
+          unless res
+            return {status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: 'Connection timed out for signin.asp'}
+          end
+
+          if res.headers['Location'] && res.headers['Location'] == '/broadweb/bwproj.asp'
+            return {status: LOGIN_STATUS::SUCCESSFUL, proof: res.body}
+          end
+
+          {status: LOGIN_STATUS::INCORRECT, proof: res.body}
+        end
+
+        # Attempts to login to Advantech WebAccess.
+        #
+        # @param credential [Metasploit::Framework::Credential] The credential object
+        # @return [Result] A Result object indicating success or failure
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            status: Metasploit::Model::Login::Status::INCORRECT,
+            proof: nil,
+            host: host,
+            port: port,
+            protocol: 'tcp'
+          }
+
+          begin
+            result_opts.merge!(do_login(credential.public, credential.private))
+          rescue ::Rex::ConnectionError => e
+            # Something went wrong during login. 'e' knows what's up.
+            result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
+          end
+
+          Result.new(result_opts)
+        end
+
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
+++ b/modules/auxiliary/scanner/http/advantech_webaccess_login.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'metasploit/framework/login_scanner/advantech_webaccess'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'Advantech WebAccess Login',
+      'Description' => %q{
+        This module will attempt to authenticate to Advantech WebAccess.
+      },
+      'Author'      => [ 'sinn3r' ],
+      'License'     => MSF_LICENSE,
+      'DefaultOptions' =>
+        {
+          'RPORT'      => 80
+        }
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to Advantech WebAccess', '/']),
+        OptBool.new('TRYDEFAULT', [false, 'Try the default credential admin:[empty]', false])
+      ], self.class)
+  end
+
+
+  def scanner(ip)
+    @scanner ||= lambda {
+      cred_collection = Metasploit::Framework::CredentialCollection.new(
+        blank_passwords: datastore['BLANK_PASSWORDS'],
+        pass_file:       datastore['PASS_FILE'],
+        password:        datastore['PASSWORD'],
+        user_file:       datastore['USER_FILE'],
+        userpass_file:   datastore['USERPASS_FILE'],
+        username:        datastore['USERNAME'],
+        user_as_pass:    datastore['USER_AS_PASS']
+      )
+
+      if datastore['TRYDEFAULT']
+        print_status("Default credential admin:[empty] added to the credential queue for testing.")
+        cred_collection.add_public('admin')
+        cred_collection.add_private('')
+      end
+
+      return Metasploit::Framework::LoginScanner::AdvantechWebAccess.new(
+        configure_http_login_scanner(
+          host: ip,
+          port: datastore['RPORT'],
+          cred_details:       cred_collection,
+          stop_on_success:    datastore['STOP_ON_SUCCESS'],
+          bruteforce_speed:   datastore['BRUTEFORCE_SPEED'],
+          connection_timeout: 5,
+          http_username:      datastore['HttpUsername'],
+          http_password:      datastore['HttpPassword'],
+          uri:                target_uri.path
+        ))
+    }.call
+  end
+
+
+  def report_good_cred(ip, port, result)
+    service_data = {
+      address: ip,
+      port: port,
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      private_data: result.credential.private,
+      private_type: :password,
+      username: result.credential.public,
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      last_attempted_at: DateTime.now,
+      status: result.status,
+      proof: result.proof
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+
+  def report_bad_cred(ip, rport, result)
+    invalidate_login(
+      address: ip,
+      port: rport,
+      protocol: 'tcp',
+      public: result.credential.public,
+      private: result.credential.private,
+      realm_key: result.credential.realm_key,
+      realm_value: result.credential.realm,
+      status: result.status,
+      proof: result.proof
+    )
+  end
+
+  def bruteforce(ip)
+    scanner(ip).scan! do |result|
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        print_brute(:level => :good, :ip => ip, :msg => "Success: '#{result.credential}'")
+        report_good_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        vprint_brute(:level => :verror, :ip => ip, :msg => result.proof)
+        report_bad_cred(ip, rport, result)
+      when Metasploit::Model::Login::Status::INCORRECT
+        vprint_brute(:level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'")
+        report_bad_cred(ip, rport, result)
+      end
+    end
+  end
+
+  def run_host(ip)
+    unless scanner(ip).check_setup
+      print_brute(:level => :error, :ip => ip, :msg => 'Target is not Advantech WebAccess')
+      return
+    end
+
+    bruteforce(ip)
+  end
+
+end

--- a/spec/lib/metasploit/framework/login_scanner/advantech_webaccess_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/advantech_webaccess_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/advantech_webaccess'
+
+RSpec.describe Metasploit::Framework::LoginScanner::AdvantechWebAccess do
+
+    it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
+    it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
+
+    subject do
+      described_class.new
+    end
+
+    let(:successful_auth_response) do
+      res = Rex::Proto::Http::Response.new(302, 'Found')
+      res.headers['Location'] = '/broadweb/bwproj.asp'
+      res
+    end
+
+    let(:fail_auth_response) do
+      Rex::Proto::Http::Response.new(200, 'OK')
+    end
+
+    describe '#attempt_login' do
+
+      context 'when the credential is valid' do
+        let(:username) { 'user' }
+        let(:password) { 'goddpass' }
+
+        before do
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(successful_auth_response)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:close)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
+        end
+
+        it 'returns a Result object indicating a successful login' do
+          cred = Metasploit::Framework::Credential.new(public: username, private: password)
+          result = subject.attempt_login(cred)
+          expect(result).to be_kind_of(Metasploit::Framework::LoginScanner::Result)
+          expect(result.status).to eq(Metasploit::Model::Login::Status::SUCCESSFUL)
+        end
+      end
+
+      context 'when the credential is invalid' do
+        let(:username) { 'admin' }
+        let(:password) { 'badpass' }
+
+        before(:example) do
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:request_cgi).with(any_args)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).with(any_args).and_return(fail_auth_response)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:set_config).with(any_args)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:close)
+          allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect)
+        end
+
+        it 'returns a Result object indicating a failed login' do
+          cred = Metasploit::Framework::Credential.new(public: username, private: password)
+          result = subject.attempt_login(cred)
+          expect(result).to be_kind_of(Metasploit::Framework::LoginScanner::Result)
+          expect(result.status).to eq(Metasploit::Model::Login::Status::INCORRECT)
+        end
+      end
+    end
+
+
+end


### PR DESCRIPTION
## Description

This module allows you to auth to AdvanTech WebAccess.

## Verification

1. Install Advantech WebAccess: http://advcloudfiles.advantech.com/web/Download/webaccess/8.1/AdvantechWebAccessUSANode8.1_20151230.exe
2. Add some users to WebAccess
3. Start msfconsole
4. ```use auxiliary/scanner/http/advantech_webaccess_login```
5. ```set RHOSTS [IP]```
6. Provide some credentials for testing
7. ```run```
8. If a valid user/pass is found, it should print green and report to database

## Demo

![webaccess_login_demo](https://cloud.githubusercontent.com/assets/1170914/22352301/26549236-e3e1-11e6-9710-506166a8bee3.gif)
