### PR TITLE
changing the syntax to work with ruby 2.1

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -131,10 +131,10 @@ class Creds
       user:         'Public, usually a username',
       password:     'Private, private_type Password.',
       ntlm:         'Private, private_type NTLM Hash.',
-      'ssh-key':    'Private, private_type SSH key, must be a file path.',
+      'ssh-key' =>  'Private, private_type SSH key, must be a file path.',
       hash:         'Private, private_type Nonreplayable hash',
       realm:        'Realm, ',
-      'realm-type': "Realm, realm_type (#{Metasploit::Model::Realm::Key::SHORT_NAMES.keys.join(' ')}), defaults to domain."
+      'realm-type'=>"Realm, realm_type (#{Metasploit::Model::Realm::Key::SHORT_NAMES.keys.join(' ')}), defaults to domain."
     }.each_pair do |keyword, description|
       print_line "    #{keyword.to_s.ljust 10}:  #{description}"
     end


### PR DESCRIPTION
Fixes #7881



Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] `rvm install 2.1`
- [x] `rvm use 2.1.`
- [x] `rvm gemset create metasploit-framework`
- [x] `gem install bundler`
- [x] `bundle install`
- [x] Start `msfconsole`
- [x] msfconsole should start without syntax errors.
