### PR TITLE
Fix cisco_firepower_download to pass the username properly

### DIFF
--- a/modules/auxiliary/scanner/http/cisco_firepower_download.rb
+++ b/modules/auxiliary/scanner/http/cisco_firepower_download.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
       cgi_sid = res_cookie.scan(/CGISESSID=(\w+);/).flatten.first
       vprint_status("CGI Session ID: #{cgi_sid}")
       print_good("Authenticated as #{console_user}:#{console_pass}")
-      report_cred(ip: ip, username: console_user, password: console_pass)
+      report_cred(ip: ip, user: console_user, password: console_pass)
       return cgi_sid
     end
 


### PR DESCRIPTION
I made a typo in https://github.com/rapid7/metasploit-framework/pull/7805, which is causing the module to not report the user in the cred database.