### PR TITLE
Add exception when SESSION doesn't exist

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -29,6 +29,11 @@ module Msf::PostMixin
   #
   # @raise [OptionValidateError] if {#session} returns nil
   def setup
+    unless session
+      # Always fail if the session doesn't exist.
+      raise Msf::OptionValidateError.new(['SESSION'])
+    end
+
     unless session_compatible?(session)
       print_warning('SESSION may not be compatible with this module.')
     end


### PR DESCRIPTION
This PR adds one small fix to the session validation during post-module execution. A while back (#7737), we mucked around with this code and forced it to throw an error when sessions were not compatible. This caused issues because it's hard to be sure if a session is compatible or not 100% of the time.

Instead, we removed it, and just added a warning so that users know the session might not work. However, in doing so, we also removed the feature that causes exploitation to stop when the session is invalid (eg. the session doesn't exist). As a result, we got this kind of thing happening:
```
msf exploit(bypassuac_eventvwr) > run

[!] [2017.01.30-09:49:25] SESSION may not be compatible with this module.
[*] [2017.01.30-09:49:25] Started reverse TCP handler on 172.16.200.8:4444
[-] [2017.01.30-09:49:25] Exploit failed: NoMethodError undefined method `type' for nil:NilClass
[*] Exploit completed, but no session was created.
```

With this small fix in place, we instead get:
```
msf exploit(bypassuac_eventvwr) > run

[-] [2017.01.30-10:24:13] Exploit failed: Msf::OptionValidateError The following options failed to validate: SESSION.
[*] Exploit completed, but no session was created.
```

## Validation

- [x] Create a listener and payload, and create a new meterpreter session.
- [x] Try to run a local exploit with an _invalid_ session. The `OptionValidateError` should be thrown.
- [x] Try to run a local exploit with a valid session. The `OptionValidateError` should _not_ be thrown.
