### PR TITLE
refactor empty test on CredentialCollection

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -205,6 +205,13 @@ class Metasploit::Framework::CredentialCollection
     pass_fd.close if pass_fd && !pass_fd.closed?
   end
 
+  # Returns true when #each will have no results to iterate
+  def empty?
+    hasUser = username.present? || user_file.present? || !additional_publics.empty?
+    hasPass = password.present? || pass_file.present? || !additional_privates.empty? || blank_passwords
+    prepended_creds.empty? && !hasUser || (hasUser && !hasPass)
+  end
+
   private
 
   def private_type(private)

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -305,11 +305,7 @@ module Metasploit
               errors.add(:cred_details, "must respond to :each")
             end
 
-            if cred_details.prepended_creds.empty? &&
-              cred_details.additional_publics.empty? &&
-              cred_details.additional_privates.empty? &&
-              !cred_details.username.present? &&
-              !cred_details.password.present?
+            if cred_details.empty?
               errors.add(:cred_details, "can't be blank")
             end
           end

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       user_file: user_file,
       username: username,
       userpass_file: userpass_file,
+      prepended_creds: prepended_creds,
+      additional_privates: additional_privates,
+      additional_publics: additional_publics
     )
   end
 
@@ -22,6 +25,9 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
   let(:pass_file) { nil }
   let(:user_as_pass) { nil }
   let(:userpass_file) { nil }
+  let(:prepended_creds) { [] }
+  let(:additional_privates) { [] }
+  let(:additional_publics) { [] }
 
   describe "#each" do
     specify do
@@ -132,6 +138,61 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
       end
     end
 
+  end
+
+  describe "#empty?" do
+    context "when :username is set" do
+      context "and :password is set" do
+        specify do
+          expect(collection.empty?).to eq false
+        end
+      end
+
+      context "and :password is not set" do
+        let(:password) { nil }
+        specify do
+          expect(collection.empty?).to eq true
+        end
+
+        context "and :blank_passwords is true" do
+          let(:blank_passwords) { true }
+          specify do
+            expect(collection.empty?).to eq false
+          end
+        end
+      end
+    end
+
+    context "when :username is not set" do
+      context "and :password is not set" do
+        let(:username) { nil }
+        let(:password) { nil }
+        specify do
+          expect(collection.empty?).to eq true
+        end
+
+        context "and :prepended_creds is not empty" do
+          let(:prepended_creds) { [ "test" ] }
+          specify do
+            expect(collection.empty?).to eq false
+          end
+        end
+
+        context "and :additional_privates is not empty" do
+          let(:additional_privates) { [ "test_private" ] }
+          specify do
+            expect(collection.empty?).to eq true
+          end
+        end
+
+        context "and :additional_publics is not empty" do
+          let(:additional_publics) { [ "test_public" ] }
+          specify do
+            expect(collection.empty?).to eq true
+          end
+        end
+      end
+    end
   end
 
   describe "#prepend_cred" do

--- a/spec/lib/metasploit/framework/login_scanner/base_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/base_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Base do
     allow(creds).to receive(:additional_publics).and_return(['user'])
     allow(creds).to receive(:each).and_return(['user', 'pass'])
     allow(creds).to receive(:additional_publics).and_return([])
+    allow(creds).to receive(:empty?).and_return(false)
     creds
   }
 

--- a/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ftp_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::FTP do
     allow(creds).to receive(:prepended_creds).and_return([])
     allow(creds).to receive(:additional_privates).and_return([])
     allow(creds).to receive(:additional_publics).and_return([])
+    allow(creds).to receive(:empty?).and_return(true)
     ftp_scanner.cred_details = creds
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/mssql_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/mssql_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::MSSQL do
     allow(creds).to receive(:prepended_creds).and_return([])
     allow(creds).to receive(:additional_privates).and_return([])
     allow(creds).to receive(:additional_publics).and_return([])
+    allow(creds).to receive(:empty?).and_return(true)
     login_scanner.cred_details = creds
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/smb_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smb_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SMB do
         allow(creds).to receive(:prepended_creds).and_return([])
         allow(creds).to receive(:additional_privates).and_return([])
         allow(creds).to receive(:additional_publics).and_return([])
+        allow(creds).to receive(:empty?).and_return(true)
         login_scanner.cred_details = creds
     end
 

--- a/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/ssh_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::SSH do
     allow(creds).to receive(:prepended_creds).and_return([])
     allow(creds).to receive(:additional_privates).and_return([])
     allow(creds).to receive(:additional_publics).and_return([])
+    allow(creds).to receive(:empty?).and_return(true)
     ssh_scanner.cred_details = creds
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/telnet_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/telnet_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Telnet do
     allow(creds).to receive(:prepended_creds).and_return([])
     allow(creds).to receive(:additional_privates).and_return([])
     allow(creds).to receive(:additional_publics).and_return([])
+    allow(creds).to receive(:empty?).and_return(true)
     login_scanner.cred_details = creds
   end
 

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/login_scanner_base.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/login_scanner_base.rb
@@ -75,6 +75,7 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts 
     allow(creds).to receive(:prepended_creds).and_return([])
     allow(creds).to receive(:additional_privates).and_return([])
     allow(creds).to receive(:additional_publics).and_return(['user'])
+    allow(creds).to receive(:empty?).and_return(true)
     login_scanner.cred_details = creds
   end
 
@@ -182,6 +183,7 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts 
         allow(creds).to receive(:prepended_creds).and_return([])
         allow(creds).to receive(:additional_privates).and_return([])
         allow(creds).to receive(:additional_publics).and_return([])
+        allow(creds).to receive(:empty?).and_return(true)
         login_scanner.cred_details = creds
         expect(login_scanner).to_not be_valid
         expect(login_scanner.errors[:cred_details]).to include "can't be blank"
@@ -198,6 +200,7 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::Base' do | opts 
         allow(creds).to receive(:prepended_creds).and_return([])
         allow(creds).to receive(:additional_privates).and_return([])
         allow(creds).to receive(:additional_publics).and_return(['user'])
+        allow(creds).to receive(:empty?).and_return(true)
         login_scanner.cred_details = creds
         expect(login_scanner).to_not be_valid
         expect(login_scanner.errors[:cred_details]).to include "must respond to :each"

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/ntlm.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/ntlm.rb
@@ -21,6 +21,7 @@ RSpec.shared_examples_for 'Metasploit::Framework::LoginScanner::NTLM' do
         allow(creds).to receive(:prepended_creds).and_return([])
         allow(creds).to receive(:additional_privates).and_return([])
         allow(creds).to receive(:additional_publics).and_return([])
+        allow(creds).to receive(:empty?).and_return(true)
         login_scanner.cred_details = creds
     end
 

--- a/spec/support/shared/examples/metasploit/framework/tcp/client.rb
+++ b/spec/support/shared/examples/metasploit/framework/tcp/client.rb
@@ -15,6 +15,7 @@ RSpec.shared_examples_for 'Metasploit::Framework::Tcp::Client' do
     allow(creds).to receive(:prepended_creds).and_return([])
     allow(creds).to receive(:additional_privates).and_return([])
     allow(creds).to receive(:additional_publics).and_return(['user'])
+    allow(creds).to receive(:empty?).and_return(true)
     login_scanner.cred_details = creds
   end
 


### PR DESCRIPTION
Refactor the login scanner validation of CredentialCollection to be an empty? evaluation in the class.

.empty? will now evaluate if the currently configured CredentialCollection would return any credentials when called for .each

## Verification

List the steps needed to make sure this thing works

- [x] Travis build passed
- [x] Start `msfconsole`
- [x] retest https://github.com/rapid7/metasploit-framework/pull/7876
- [x] validate execution of other various login scanners

