### PR TITLE
missed userpass_file on CredentialCollection.empty?

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -207,8 +207,8 @@ class Metasploit::Framework::CredentialCollection
 
   # Returns true when #each will have no results to iterate
   def empty?
-    hasUser = username.present? || user_file.present? || !additional_publics.empty?
-    hasPass = password.present? || pass_file.present? || !additional_privates.empty? || blank_passwords
+    hasUser = username.present? || user_file.present? || userpass_file.present? || !additional_publics.empty?
+    hasPass = password.present? || pass_file.present? || userpass_file.present? ||!additional_privates.empty? || blank_passwords
     prepended_creds.empty? && !hasUser || (hasUser && !hasPass)
   end
 

--- a/spec/lib/metasploit/framework/credential_collection_spec.rb
+++ b/spec/lib/metasploit/framework/credential_collection_spec.rb
@@ -141,6 +141,15 @@ RSpec.describe Metasploit::Framework::CredentialCollection do
   end
 
   describe "#empty?" do
+    context "when only :userpass_file is set" do
+      let(:username) { nil }
+      let(:password) { nil }
+      let(:userpass_file) { "test_file" }
+      specify do
+        expect(collection.empty?).to eq false
+      end
+    end
+
     context "when :username is set" do
       context "and :password is set" do
         specify do


### PR DESCRIPTION
Fix issue https://github.com/rapid7/metasploit-framework/issues/7899 empty? should factor in userpass_file value.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] msf > use auxiliary/scanner/ssh/ssh_login
msf auxiliary(ssh_login) > echo "test test" > test.file
[*] exec: echo "test test" > test.file
msf auxiliary(ssh_login) > set USERPASS_FILE test.file
USERPASS_FILE => test.file
msf auxiliary(ssh_login) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(ssh_login) > run
- [x] **Verify** test shows successful attempt
