### PR TITLE
do not add closed ports to database with TCP portscan

### DIFF
--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -86,7 +86,6 @@ class MetasploitModule < Msf::Auxiliary
             end
           rescue ::Rex::ConnectionRefused
             vprint_status("#{ip}:#{port} - TCP closed")
-            r << [ip,port,"closed"]
           rescue ::Rex::ConnectionError, ::IOError, ::Timeout::Error
           rescue ::Rex::Post::Meterpreter::RequestError
           rescue ::Interrupt


### PR DESCRIPTION
All others `auxiliary/scanner/portscan` modules do not add closed ports to the database, there is no reason it should be different with `auxiliary/scanner/portscan/tcp`.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/portscan/tcp`
- [x] `set RHOSTS 192.168.1.1`
- [x] `run`
- [x] **Verify** no closed ports are added to the database

