### PR TITLE
Fix for Console Route Print Error When Table Includes Both IPv4 and IPv6 Routes

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -943,7 +943,11 @@ class Core
       print(tbl_ipv6.to_s) if tbl_ipv6.rows.length > 0
 
       if (tbl_ipv4.rows.length + tbl_ipv6.rows.length) < 1
-        print_status('There are currently no routes defined.')
+        print_status("There are currently no routes defined.")
+      elsif (tbl_ipv4.rows.length < 1) && (tbl_ipv6.rows.length > 0)
+        print_status("There are currently no IPv4 routes defined.")
+      elsif (tbl_ipv4.rows.length > 0) && (tbl_ipv6.rows.length < 1)
+        print_status("There are currently no IPv6 routes defined.")
       end
 
     else

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -890,9 +890,10 @@ class Core
       Rex::Socket::SwitchBoard.flush_routes
 
     when "print"
-      tbl = Table.new(
+      # IPv4 Table
+      tbl_ipv4 = Table.new(
         Table::Style::Default,
-        'Header'  => "Active Routing Table",
+        'Header'  => "IPv4 Active Routing Table",
         'Prefix'  => "\n",
         'Postfix' => "\n",
         'Columns' =>
@@ -907,6 +908,25 @@ class Core
             'Netmask' => { 'MaxWidth' => 17 },
           })
 
+      # IPv6 Table
+      tbl_ipv6 = Table.new(
+        Table::Style::Default,
+        'Header'  => "IPv6 Active Routing Table",
+        'Prefix'  => "\n",
+        'Postfix' => "\n",
+        'Columns' =>
+          [
+            'Subnet',
+            'Netmask',
+            'Gateway',
+          ],
+        'ColProps' =>
+          {
+            'Subnet'  => { 'MaxWidth' => 17 },
+            'Netmask' => { 'MaxWidth' => 17 },
+          })
+
+      # Populate Route Tables
       Rex::Socket::SwitchBoard.each { |route|
         if (route.comm.kind_of?(Msf::Session))
           gw = "Session #{route.comm.sid}"
@@ -914,14 +934,18 @@ class Core
           gw = route.comm.name.split(/::/)[-1]
         end
 
-        tbl << [ route.subnet, route.netmask, gw ]
+        tbl_ipv4 << [ route.subnet, route.netmask, gw ] if Rex::Socket.is_ipv4?(route.netmask)
+        tbl_ipv6 << [ route.subnet, route.netmask, gw ] if Rex::Socket.is_ipv6?(route.netmask)
       }
 
-      if tbl.rows.length == 0
+      # Print Route Tables
+      print(tbl_ipv4.to_s) if tbl_ipv4.rows.length > 0
+      print(tbl_ipv6.to_s) if tbl_ipv6.rows.length > 0
+
+      if (tbl_ipv4.rows.length + tbl_ipv6.rows.length) < 1
         print_status('There are currently no routes defined.')
-      else
-        print(tbl.to_s)
       end
+
     else
       cmd_route_help
     end


### PR DESCRIPTION
This PR fixes the issue #7912 where the console `route print` command will fail when the routing table includes both IPv4 and IPv6 routes. I noticed this while working on adding IPv6 capabilities for PR #7664.

This makes the console `route print` command operate similarly to Meterpreter's `route print` command.

## Verification

- [x] Start a Meterpreter session on a machine with both IPv4 and IPv6 routes available.
- [x] Add an IPv4 route, or two, for that session, type `route`, and hit enter. Ensure that the IPv4 route(s) display correctly.
- [x] Add an IPv6 route, or two, for that session, type `route`, and hit enter. Ensure that the combination of IPv4 and IPv6 route(s) display correctly.
- [x] Remove the IPv4 route(s), type `route`, and hit enter. Ensure that the IPv6 only route(s) display correctly.

## Current Behavior - Before Fix
```
msf > route
[*] There are currently no routes defined.
msf > route add 10.5.5.0 255.255.255.0 1
[*] Route added
msf > route

Active Routing Table
====================

   Subnet             Netmask            Gateway
   ------             -------            -------
   10.5.5.0           255.255.255.0      Session 1

msf > route add fd15:4ba5:5a2b:1008:: ffff:ffff:ffff:ffff:: 1
[*] Route added
msf > route
[-] Error while running command route: comparison of Array with Array failed

Call stack:
/home/jhale/.rvm/gems/ruby-2.3.3@metasploit-framework/gems/rex-text-0.2.11/lib/rex/text/table.rb:195:in `sort!'
/home/jhale/.rvm/gems/ruby-2.3.3@metasploit-framework/gems/rex-text-0.2.11/lib/rex/text/table.rb:195:in `sort_rows'
/home/jhale/.rvm/gems/ruby-2.3.3@metasploit-framework/gems/rex-text-0.2.11/lib/rex/text/table.rb:110:in `to_s'
/home/jhale/git/metasploit-framework/lib/msf/ui/console/table.rb:48:in `to_s'
/home/jhale/git/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:923:in `cmd_route'
/home/jhale/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:430:in `run_command'
/home/jhale/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:392:in `block in run_single'
/home/jhale/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:386:in `each'
/home/jhale/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:386:in `run_single'
/home/jhale/git/metasploit-framework/lib/rex/ui/text/shell.rb:205:in `run'
/home/jhale/git/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/home/jhale/git/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
msf > route remove 10.5.5.0 255.255.255.0 1
[*] Route removed
msf > route

Active Routing Table
====================

   Subnet                 Netmask                Gateway
   ------                 -------                -------
   fd15:4ba5:5a2b:1008::  ffff:ffff:ffff:ffff::  Session 1

msf > route remove fd15:4ba5:5a2b:1008:: ffff:ffff:ffff:ffff:: 1
[*] Route removed
msf > route
[*] There are currently no routes defined.
msf > 
```

## Behavior After Fix
```
msf > route
[*] There are currently no routes defined.
msf > route add 10.5.5.0 255.255.255.0 1
[*] Route added
msf > route

IPv4 Active Routing Table
=========================

   Subnet             Netmask            Gateway
   ------             -------            -------
   10.5.5.0           255.255.255.0      Session 1

[*] There are currently no IPv6 routes defined.
msf > route add fd15:4ba5:5a2b:1008:: ffff:ffff:ffff:ffff:: 1
[*] Route added
msf > route

IPv4 Active Routing Table
=========================

   Subnet             Netmask            Gateway
   ------             -------            -------
   10.5.5.0           255.255.255.0      Session 1


IPv6 Active Routing Table
=========================

   Subnet                 Netmask                Gateway
   ------                 -------                -------
   fd15:4ba5:5a2b:1008::  ffff:ffff:ffff:ffff::  Session 1

msf > route remove 10.5.5.0 255.255.255.0 1
[*] Route removed
msf > route

IPv6 Active Routing Table
=========================

   Subnet                 Netmask                Gateway
   ------                 -------                -------
   fd15:4ba5:5a2b:1008::  ffff:ffff:ffff:ffff::  Session 1

[*] There are currently no IPv4 routes defined.
msf > route remove fd15:4ba5:5a2b:1008:: ffff:ffff:ffff:ffff:: 1
[*] Route removed
msf > route
[*] There are currently no routes defined.
msf > 
```