### PR TITLE
Fix report_vuln for aux/scanner checks

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -192,6 +192,8 @@ module ModuleCommandDispatcher
       if (code and code.kind_of?(Array) and code.length > 1)
         if (code == Msf::Exploit::CheckCode::Vulnerable)
           print_good("#{peer} #{code[1]}")
+          # Restore RHOST for report_vuln
+          instance.datastore['RHOST'] ||= rhost
           report_vuln(instance)
         else
           print_status("#{peer} #{code[1]}")


### PR DESCRIPTION
Here's the problem:

```
msf auxiliary(wordpress_content_injection) > check
[+] 192.168.33.129:80 The target is vulnerable.
[-] Check failed: ArgumentError Missing required option :host
[*] Checked 1 of 1 hosts (100% complete)
msf auxiliary(wordpress_content_injection) > vulns
msf auxiliary(wordpress_content_injection) > 
```

- [x] `use` an `auxiliary/scanner` module that has a `check_host` method
- [x] Make sure `check_host` can return `Exploit::CheckCode::Vulnerable`
- [x] Run `check` against a host that satisfies the above requirement
- [x] See the saved vulnerability when you run `vulns`