### PR TITLE
http_version now stores the fingerprints

### DIFF
--- a/modules/auxiliary/scanner/http/http_version.rb
+++ b/modules/auxiliary/scanner/http/http_version.rb
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({ 'uri' => '/', 'method' => 'GET' })
       fp = http_fingerprint(:response => res)
       print_status("#{ip}:#{rport} #{fp}") if fp
+      report_service(:host => rhost, :port => rport, :sname => "www", :info => fp)
     rescue ::Timeout::Error, ::Errno::EPIPE
     ensure
       disconnect


### PR DESCRIPTION
Currently, the `http_version` module doesn't store the fingerprints
into the database; this commit should fix this behaviour.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/http_version`
- [x] `set RHOSTS google.com`
- [x] `run`
- [x] `services -S gws`
- [x] You should see the Google™ in your listing

