### PR TITLE
Fix CVE-2017-5229

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -377,9 +377,7 @@ private
     # Basename ends up with a single name/folder. This is the only point where it
     # may be possible to do a dir trav up one folder. We need to check to make sure
     # that the basename doesn't result in a traversal
-    if base == '..'
-      return false
-    end
+    return false if base == '..'
 
     dest = File.join( dest_folder, base )
 
@@ -420,7 +418,7 @@ private
             print_line("Remote Path : #{f[:name]}")
             print_line("File size   : #{f[:size]} bytes")
             if get_files
-              unless download_file( loot_dir, f[:name] )
+              unless download_file(loot_dir, f[:name])
                 print_error("Download of #{f:name]} failed.")
               end
             end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -373,6 +373,14 @@ private
   def download_file( dest_folder, source )
     stat = client.fs.file.stat( source )
     base = ::Rex::Post::Meterpreter::Extensions::Stdapi::Fs::File.basename( source )
+
+    # Basename ends up with a single name/folder. This is the only point where it
+    # may be possible to do a dir trav up one folder. We need to check to make sure
+    # that the basename doesn't result in a traversal
+    if base == '..'
+      return false
+    end
+
     dest = File.join( dest_folder, base )
 
     if stat.directory?
@@ -386,6 +394,8 @@ private
         client.framework.events.on_session_download( client, src, dest ) if msf_loaded?
       }
     end
+
+    return true
   end
 
   def parse_dump(dump, get_images, get_files, download_path)
@@ -406,15 +416,15 @@ private
           print_line(v)
 
         when 'Files'
-          total = 0
           v.each do |f|
             print_line("Remote Path : #{f[:name]}")
             print_line("File size   : #{f[:size]} bytes")
             if get_files
-              download_file( loot_dir, f[:name] )
+              unless download_file( loot_dir, f[:name] )
+                print_error("Download of #{f:name]} failed.")
+              end
             end
             print_line
-            total += f[:size]
           end
 
         when 'Image'


### PR DESCRIPTION
## Verification

From @OJ, this fixes a directory traversal issue when downloading data with Meterpreter's extapi Clipboard.parse_dump method

- [x] Start `msfconsole`
- [x] **Verify** fixes CVE-2017-5229 
- [x] **Verify** does not break anything

