### PR TITLE
Override `empty?` for the weird ones

### DIFF
--- a/lib/metasploit/framework/community_string_collection.rb
+++ b/lib/metasploit/framework/community_string_collection.rb
@@ -59,6 +59,10 @@ module Metasploit
         end
       end
 
+      def empty?
+        prepended_creds.empty? && !pass_file.present? && !password.present?
+      end
+
       # Add {Credential credentials} that will be yielded by {#each}
       #
       # @see prepended_creds

--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -207,9 +207,15 @@ class Metasploit::Framework::CredentialCollection
 
   # Returns true when #each will have no results to iterate
   def empty?
-    hasUser = username.present? || user_file.present? || userpass_file.present? || !additional_publics.empty?
-    hasPass = password.present? || pass_file.present? || userpass_file.present? ||!additional_privates.empty? || blank_passwords
-    prepended_creds.empty? && !hasUser || (hasUser && !hasPass)
+    prepended_creds.empty? && !has_users? || (has_users? && !has_privates?)
+  end
+
+  def has_users?
+    username.present? || user_file.present? || userpass_file.present? || !additional_publics.empty?
+  end
+
+  def has_privates?
+    password.present? || pass_file.present? || userpass_file.present? || !additional_privates.empty? || blank_passwords
   end
 
   private

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -265,6 +265,11 @@ class MetasploitModule < Msf::Auxiliary
       valid!
     end
 
+    # Override CredentialCollection#has_privates?
+    def has_privates?
+      !@key_data.empty?
+    end
+
     def realm
       nil
     end


### PR DESCRIPTION
Fixes #7899 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/ssh_login_pubkey`
  - [x] `set USERNAME` appropriately
  - [x] `set KEY_PATH`  to a key file
  - [x] `run`
  - [x] **Verify** shell
  - [x] **Verify** no `Metasploit::Framework::LoginScanner::Invalid` exception
  - [ ] `creds`
  - [ ] **Verify** has creds

- [x] `use auxiliary/scanner/snmp/snmp_login`
  - [x] `set PASSWORD` approrpriately for your target
  - [x] `run`
  - [x] **Verify** no `Metasploit::Framework::LoginScanner::Invalid` exception
  - [ ] `creds`
  - [ ] **Verify** has creds

