### PR TITLE
Add more certificate information in office_word_macro documentation

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/office_word_macro.md
+++ b/documentation/modules/exploit/windows/fileformat/office_word_macro.md
@@ -8,10 +8,6 @@ There are many ways to create this type of malicious doc. The module injects the
 payload in the comments field, which will get decoded back by the macro and executed as a Windows
 executable when the Office document is launched.
 
-Please note: By default, Microsoft Office does not execute macros automatically. If a macro is
-present, the user will most likely need to manually click on the "Enable Content" button in order
-to run the macro.
-
 
 ## Vulnerable Application
 
@@ -62,3 +58,38 @@ While editing, you should avoid modifying the following unless you are an advanc
   in front of the payload string. The blank space is for making the payload less obvious
   at first sight if the user views the file properties.
 * The VB code in the macro.
+
+## Trusted Document
+
+By default, Microsoft Office does not execute macros automatically unless it is considered as a
+trusted document. This means that if a macro is present, the user will most likely need to manually
+click on the "Enable Content" button in order to run the macro.
+
+Many in-the-wild attacks face this type of challenge, and most rely on social-engineering to trick
+the user into allowing the macro to run. For example, making the document look like something
+written from a legit source, such as [this attack](https://motherboard.vice.com/en_us/article/these-hackers-cleverly-disguised-their-malware-as-a-document-about-trumps-victory).
+
+To truly make the macro document to run without any warnings, you must somehow figure out a way to
+sign the macro by a trusted publisher, or using a certificate that the targeted machine trusts.
+
+For testing purposes, another way to have a certificate is to create a self-signed one using
+Microsoft Office's SELFCERT.exe utility. This tool can be found in the following path on
+Windows:
+
+```
+C:\Program Files\Microsoft Office\root\Office16\SELFCERT.exe
+```
+
+In Office 2010, the self-signing tool is actually an option in the Office tools folder in the
+start menu. It should be named "Digital Certificate for VBA Projects".
+
+Double-click on the executable, enter a random name and click "OK", at this point you have a
+certificate to play with.
+
+Next, we want to flag this certificate as trusted:
+
+1. Click on Start, and then enter "Internet Options".
+2. Click on the Content tab, and then click on the Certificates button.
+3. You should see your new certificate under the Personal tab, export it.
+4. Click on the Trusted Publishers, and then import your personal certificate.
+5. Try the macro exploit again, it should run the malicious code without warning.


### PR DESCRIPTION
By default, Office macros do not execute automatically. For better attack experiences, I have included more information about how one could use a valid certificate, so that when the macro runs, there is no warning. 

Some info are found from:
https://www.groovypost.com/howto/howto/office-2010-outlook-self-signed-digital-certificate/
https://www.groovypost.com/howto/create-self-signed-digital-certificate-microsoft-office-2016/