### PR TITLE
owa_login Aux Module - No Mailbox bugfix

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Auxiliary
           'Brandon Knight',
           'Pete (Bokojan) Arzamendi', # Outlook 2013 updates
           'Nate Power',                # HTTP timing option
-          'Chapman (R3naissance) Schleiss' # Save username in creds if response is less
+          'Chapman (R3naissance) Schleiss', # Save username in creds if response is less
+          'Andrew Smith' # valid creds, no mailbox
         ],
       'License'        => MSF_LICENSE,
       'Actions'        =>
@@ -218,6 +219,19 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       # No password change required moving on.
+      # Check for valid login but no mailbox setup
+      if res.headers['location'] =~ /owa/ and res.headers['location'] !~ /reason/
+        print_good("#{msg} SUCCESSFUL LOGIN. #{elapsed_time} '#{user}' : '#{pass}': NOTE a mailbox is not setup")
+        report_cred(
+          ip: datastore['RHOST'],
+          port: datastore['RPORT'],
+          service_name: 'owa',
+          user: user,
+          password: pass
+        )
+        return :next_user
+      end
+
       unless location = res.headers['location']
         print_error("#{msg} No HTTP redirect.  This is not OWA 2013, aborting.")
         return :abort


### PR DESCRIPTION
## Description

The owa_login module currently misses a success condition where the
creds are valid but there is no mailbox setup. This commit adds the
check for the condition on OWA 2013.

I went ahead and wrote a fix as opposed to just opening an issue.

Cheers!

## Verification

-first account is valid, but no mailbox setup
-second account is not valid

```
root@segfault:~# msfconsole

msf > use auxiliary/owa_login 
msf auxiliary(owa_login) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf auxiliary(owa_login) > set user_file /root/user.txt
user_file => /root/user.txt
msf auxiliary(owa_login) > set user_as_pass true
user_as_pass => true
msf auxiliary(owa_login) > run

[*] 127.0.0.1:443 OWA - Testing version OWA_2013
[+] Found target domain: MUSHROOMKINGDOM
[*] 127.0.0.1:443 - [1/4] - Trying luigi : luigi
[+] 127.0.0.1:443 OWA - SUCCESSFUL LOGIN. 0.278835418 'MUSHROOMKINGDOM\luigi' : 'luigi': NOTE a mailbox is not setup
[!] No active DB -- Credential data will not be saved!
[*] 127.0.0.1:443 - [2/4] - Trying bob : bob
[-] 127.0.0.1:443 - [2/4] - FAILED LOGIN. 15.350214796 'MUSHROOMKINGDOM\bob' : 'bob' (HTTP redirect with reason 2)
[*] Auxiliary module execution completed
msf auxiliary(owa_login) >

