### PR TITLE
Specify sname as http/https to keep with standards throughout the code

### DIFF
--- a/modules/auxiliary/scanner/http/http_version.rb
+++ b/modules/auxiliary/scanner/http/http_version.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({ 'uri' => '/', 'method' => 'GET' })
       fp = http_fingerprint(:response => res)
       print_status("#{ip}:#{rport} #{fp}") if fp
-      report_service(:host => rhost, :port => rport, :sname => "www", :info => fp)
+      report_service(:host => rhost, :port => rport, :sname => (ssl ? 'https' : 'http'), :info => fp)
     rescue ::Timeout::Error, ::Errno::EPIPE
     ensure
       disconnect


### PR DESCRIPTION
The fix landed in #7928 used 'www' as the sname for HTTP services. This caused us to lose specificity of whether the connection was secure or not. This change checks to see if the connection is encrypted and uses the proper sname for each case.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/http_version`
- [x]  `set RHOSTS google.com`
- [x]  `run`
- [x] `services -S gws`
- [x] The correct service type should be listed

