### PR TITLE
fix panda_psevents crash

### DIFF
--- a/modules/exploits/windows/local/panda_psevents.rb
+++ b/modules/exploits/windows/local/panda_psevents.rb
@@ -61,10 +61,10 @@ class MetasploitModule < Msf::Exploit::Local
 
   def get_path()
     case sysinfo['OS']
-    when /Windows (7|8|10|2012|2008)/
-      return '%ProgramData%\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171'
     when /Windows (NT|XP)/
       return '%AllUsersProfile%\\Application Data\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171'
+    else #/Windows (7|8|10|2012|2008)/ we assume a modern operating system
+      return '%ProgramData%\\Panda Security\\Panda Devices Agent\\Downloads\\1a2d7253f106c617b45f675e9be08171'
     end
   end
 


### PR DESCRIPTION
attempts to fix #7927 by setting an `else` case, assuming the invalid hit was based on a non-english Windows install not hitting the regex.