### PR TITLE
nfsmount and snmp_login docs

### DIFF
--- a/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
+++ b/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
@@ -1,0 +1,97 @@
+## Vulnerable Application
+
+  NFS is very common, and this scanner searches for a mis-configuration, not a vulnerable software version.  Installation instructions for NFS can be found for every operating system.
+  The [Ubuntu 14.04](https://help.ubuntu.com/14.04/serverguide/network-file-system.html) instructions can be used as an example for installing and configuring NFS.  The
+  following was done on Kali linux:
+  
+  1. `apt-get install nfs-kernel-server`
+  2. Create 2 folders to share:
+    ```
+    mkdir /tmp/open_share
+    mkdir /tmp/closed_share
+    ```
+  3. Add them to the list of shares:
+  ```
+  echo "/tmp/closed_share  10.1.2.3(ro,sync,no_root_squash)" >> /etc/exports
+  echo "/tmp/open_share    *(rw,sync,no_root_squash)" >> /etc/exports
+  ```
+  4. Restart the service: `service nfs-kernel-server restart`
+
+  In this scenario, `closed_share` is set to read only, and only mountable by the IP 10.1.2.3.  `open_share` is mountable by anyone (`*`) in read/write mode.
+
+## Verification Steps
+
+  1. Install and configure NFS
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/nfs/nfsmount`
+  4. Do: `run`
+
+## Scenarios
+
+  A run against the configuration from these docs
+
+  ```
+    msf > use auxiliary/scanner/nfs/nfsmount
+    msf auxiliary(nfsmount) > set rhosts 127.0.0.1
+    rhosts => 127.0.0.1
+    msf auxiliary(nfsmount) > run
+    
+    [+] 127.0.0.1:111         - 127.0.0.1 NFS Export: /tmp/open_share [*]
+    [+] 127.0.0.1:111         - 127.0.0.1 NFS Export: /tmp/closed_share [10.1.2.3]
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
+  ```
+
+## Confirming
+
+Since NFS has been around since 1989, with modern NFS(v4) being released in 2000, there are many tools which can also be used to verify this configuration issue.
+The following are other industry tools which can also be used.
+
+### [nmap](https://nmap.org/nsedoc/scripts/nfs-showmount.html)
+
+```
+nmap -p 111 --script=nfs-showmount 127.0.0.1
+
+Starting Nmap 7.40 ( https://nmap.org ) at 2017-02-12 19:41 EST
+Nmap scan report for localhost (127.0.0.1)
+Host is up (0.000037s latency).
+PORT    STATE SERVICE
+111/tcp open  rpcbind
+| nfs-showmount: 
+|   /tmp/open_share *
+|_  /tmp/closed_share 10.1.2.3
+
+Nmap done: 1 IP address (1 host up) scanned in 0.32 seconds
+```
+
+### [showmount](https://packages.debian.org/sid/amd64/nfs-common/filelist)
+
+showmount is a part of the `nfs-common` package for debian.
+
+```
+showmount -e 127.0.0.1
+Export list for 127.0.0.1:
+/tmp/open_share   *
+/tmp/closed_share 10.1.2.3
+```
+
+## Exploitation
+
+Exploiting this mis-configuration is trivial, however exploitation doesn't necessarily give access (command execution) to the system.
+If a share is mountable, ie you either are the IP listed in the filter (or could assume it through a DoS), or it is open (*), mounting is trivial.
+The following instructions were written for Kali linux.
+
+1. Create a new directory to mount the remote volume to: `mkdir /mnt/remote`
+2. Use `mount` to link the remote volume to the local folder: `mount -t nfs 127.0.0.1:/tmp/open_share /mnt/remote`
+
+The mount and its writability can now be tested:
+
+1. Write a file:  `echo "hello" > /mnt/remote/test`
+2. The remote end now has the file locally: ```
+cat /tmp/open_share/test 
+hello
+```
+
+1. To unmount: `umount /mnt/remote`
+
+At this point, its time to hope for a file of value.  Maybe code with hardcoded credentials, a `passwords.txt`, or an `id_rsa`.

--- a/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
+++ b/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
@@ -41,6 +41,21 @@
     [*] Scanned 1 of 1 hosts (100% complete)
     [*] Auxiliary module execution completed
   ```
+  
+  Another example can be found at this [source](http://bitvijays.github.io/blog/2016/03/03/learning-from-the-field-basic-network-hygiene/):
+  
+  ```
+    [*] Scanned  24 of 240 hosts (10% complete)
+    [+] 10.10.xx.xx NFS Export: /data/iso [0.0.0.0/0.0.0.0]
+    [*] Scanned  48 of 240 hosts (20% complete)
+    [+] 10.10.xx.xx NFS Export: /DataVolume/Public [*]
+    [+] 10.10.xx.xx NFS Export: /DataVolume/Download [*]
+    [+] 10.10.xx.xx NFS Export: /DataVolume/Softshare [*]
+    [*] Scanned  72 of 240 hosts (30% complete)
+    [+] 10.10.xx.xx NFS Export: /var/ftp/pub [10.0.0.0/255.255.255.0]
+    [*] Scanned  96 of 240 hosts (40% complete)
+    [+] 10.10.xx.xx NFS Export: /common []
+  ```
 
 ## Confirming
 

--- a/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
+++ b/documentation/modules/auxiliary/scanner/nfs/nfsmount.md
@@ -1,8 +1,8 @@
 ## Vulnerable Application
 
-  NFS is very common, and this scanner searches for a mis-configuration, not a vulnerable software version.  Installation instructions for NFS can be found for every operating system.
-  The [Ubuntu 14.04](https://help.ubuntu.com/14.04/serverguide/network-file-system.html) instructions can be used as an example for installing and configuring NFS.  The
-  following was done on Kali linux:
+NFS is very common, and this scanner searches for a mis-configuration, not a vulnerable software version.  Installation instructions for NFS can be found for every operating system.
+The [Ubuntu 14.04](https://help.ubuntu.com/14.04/serverguide/network-file-system.html) instructions can be used as an example for installing and configuring NFS.  The
+following was done on Kali linux:
   
   1. `apt-get install nfs-kernel-server`
   2. Create 2 folders to share:
@@ -17,7 +17,7 @@
   ```
   4. Restart the service: `service nfs-kernel-server restart`
 
-  In this scenario, `closed_share` is set to read only, and only mountable by the IP 10.1.2.3.  `open_share` is mountable by anyone (`*`) in read/write mode.
+In this scenario, `closed_share` is set to read only, and only mountable by the IP 10.1.2.3.  `open_share` is mountable by anyone (`*`) in read/write mode.
 
 ## Verification Steps
 
@@ -102,7 +102,8 @@ The following instructions were written for Kali linux.
 The mount and its writability can now be tested:
 
 1. Write a file:  `echo "hello" > /mnt/remote/test`
-2. The remote end now has the file locally: ```
+2. The remote end now has the file locally:
+```
 cat /tmp/open_share/test 
 hello
 ```

--- a/documentation/modules/auxiliary/scanner/snmp/snmp_login.md
+++ b/documentation/modules/auxiliary/scanner/snmp/snmp_login.md
@@ -1,0 +1,94 @@
+## Vulnerable Application
+
+  Installation instructions for SNMP server can be found for every operating system.
+  The [Ubuntu 14.04](https://www.digitalocean.com/community/tutorials/how-to-install-and-configure-an-snmp-daemon-and-client-on-ubuntu-14-04) instructions can be used as an example for installing and configuring NFS.  The
+  following was done on Kali linux:
+  
+  1. `sudo apt-get install snmpd`
+  2. Set SNMP to listen on non-localhost: `nano /etc/snmp/snmpd.conf`
+  ```
+    #  Listen for connections from the local system only
+    #agentAddress  udp:127.0.0.1:161
+    #  Listen for connections on all interfaces (both IPv4 *and* IPv6)
+    agentAddress udp:161,udp6:[::1]:161
+  ```
+  3. Restart the service: `service snmpd restart`
+
+### SNMP Versions
+
+SNMP has 3 main versions.
+* ***1**, ***2c**: both use simple password protection (string), and are often defaulted to `public` (read only), and `private` (read/write).  Version 2 is backwards compatible with version 1.  This is a plaintext protocol and is vulenrable to being intercepted.
+* ***3**: has several security levels and is significantly more complex, but also not covered in this module.
+
+## Verification Steps
+
+  1. Install and configure SNMP
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/snmp/snmp_login`
+  4. Do: `run`
+
+## Scenarios
+
+  A run against the configuration from these docs
+
+  ```
+    msf > use auxiliary/scanner/snmp/snmp_login 
+    msf auxiliary(snmp_login) > set rhosts 127.0.0.1
+    rhosts => 127.0.0.1
+    msf auxiliary(snmp_login) > run
+    
+    [!] No active DB -- Credential data will not be saved!
+    [+] 127.0.0.1:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): Linux hostname 4.9.0-kali1-amd64 #1 SMP Debian 4.9.6-3kali2 (2017-01-30) x86_64
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
+  ```
+  
+  Another example can be found at this [source](http://bitvijays.github.io/blog/2016/03/03/learning-from-the-field-basic-network-hygiene/):
+  
+  ```
+    [+] 10.4.xx.xx:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): Cisco IOS Software, C1130 Software (C1130-K9W7-M), Version 12.4(10b)JA, RELEASE SOFTWARE (fc2)
+    Technical Support: http://www.cisco.com/techsupport
+    Copyright (c) 1986-2007 by Cisco Systems, Inc.
+    Compiled Wed 24-Oct-07 15:17 by prod_rel_team
+    [*] Scanned 12 of 58 hosts (20% complete)
+    [*] Scanned 18 of 58 hosts (31% complete)
+    [+] 10.10.xx.xx:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): Digi Connect ME Version 82000856_F6 07/21/2006
+    [+] 10.10.xx.xx:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): Digi Connect ME Version 82000856_F6 07/21/2006
+    [*] Scanned 24 of 58 hosts (41% complete)
+    [+] 10.11.xx.xx:161 - LOGIN SUCCESSFUL: private (Access level: read-write); Proof (sysDescr.0): ExtremeXOS version 12.2.2.11 v1222b11 by release-manager on Mon Mar 23 17:54:47 PDT 2009
+    [+] 10.11.xx.xx:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): ExtremeXOS version 12.2.2.11 v1222b11 by release-manager on Mon Mar 23 17:54:47 PDT 2009
+    [+] 10.11.xx.xx:161 - LOGIN SUCCESSFUL: private (Access level: read-write); Proof (sysDescr.0): ExtremeXOS version 12.2.2.11 v1222b11 by release-manager on Mon Mar 23 17:54:47 PDT 2009
+    [+] 10.11.xx.xx:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): ExtremeXOS version 12.2.2.11 v1222b11 by release-manager on Mon Mar 23 17:54:47 PDT 2009
+    [+] 10.11.xx.xx:161 - LOGIN SUCCESSFUL: private (Access level: read-write); Proof (sysDescr.0): ExtremeXOS version 12.2.2.11 v1222b11 by release-manager on Mon Mar 23 17:54:47 PDT 2009
+    [+] 10.11.xx.xx:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): ExtremeXOS version 12.2.2.11 v1222b11 by release-manager on Mon Mar 23 17:54:47 PDT 2009
+    [*] Scanned 29 of 58 hosts (50% complete)
+    [*] Scanned 35 of 58 hosts (60% complete)
+    [*] Scanned 41 of 58 hosts (70% complete)
+    [*] Scanned 47 of 58 hosts (81% complete)
+    [+] 10.25.xx.xx:161 - LOGIN SUCCESSFUL: public (Access level: read-only); Proof (sysDescr.0): Digi Connect ME Version 82000856_F6 07/21/2006
+  ```
+
+## Confirming
+
+Since SNMP has been around for quite a while, there are many tools which can also be used to verify this configuration issue.
+The following are other industry tools which can also be used.
+
+### [nmap](https://nmap.org/nsedoc/scripts/snmp-info.html)
+
+```
+nmap -p 161 -sU --script=snmp-info 127.0.0.1
+
+Starting Nmap 7.40 ( https://nmap.org ) at 2017-02-12 23:00 EST
+Nmap scan report for localhost (127.0.0.1)
+Host is up (0.00017s latency).
+PORT    STATE SERVICE
+161/udp open  snmp
+| snmp-info: 
+|   enterprise: net-snmp
+|   engineIDFormat: unknown
+|   engineIDData: 54ad55664725a15800000000
+|   snmpEngineBoots: 2
+|_  snmpEngineTime: 31m30s
+
+Nmap done: 1 IP address (1 host up) scanned in 0.38 seconds
+```

--- a/documentation/modules/auxiliary/scanner/snmp/snmp_login.md
+++ b/documentation/modules/auxiliary/scanner/snmp/snmp_login.md
@@ -17,8 +17,8 @@
 ### SNMP Versions
 
 SNMP has 3 main versions.
-* ***1**, ***2c**: both use simple password protection (string), and are often defaulted to `public` (read only), and `private` (read/write).  Version 2 is backwards compatible with version 1.  This is a plaintext protocol and is vulenrable to being intercepted.
-* ***3**: has several security levels and is significantly more complex, but also not covered in this module.
+* **1**, **2c**: both use simple password protection (string), and are often defaulted to `public` (read only), and `private` (read/write).  Version 2 is backwards compatible with version 1.  This is a plaintext protocol and is vulenrable to being intercepted.
+* **3**: has several security levels and is significantly more complex, but also not covered in this module.
 
 ## Verification Steps
 


### PR DESCRIPTION
Adds docs for nfsmount and snmp_login.

- [x] Check my spelling

Since these protocols are OLD and there's a million tools to exploit them, i added how to get the same info from other tools, and in the case of nfsmount, how to do the mounts etc.  While this may be too thorough, I think it really adds to the completeness of the docs.  However, lemme know what you think!