### PR TITLE
fix typo in failure path of clipboard download

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/extapi/clipboard.rb
@@ -419,7 +419,7 @@ private
             print_line("File size   : #{f[:size]} bytes")
             if get_files
               unless download_file(loot_dir, f[:name])
-                print_error("Download of #{f:name]} failed.")
+                print_error("Download of #{f[:name]} failed.")
               end
             end
             print_line


### PR DESCRIPTION
This fixes a bug in the error path of clipboard downloads pointed out by rw- on IRC.

## Verification

 - [x] Get into the code path in question (force a failure)
 - [x] Make sure it doesn't throw a backtrace in the failure path