### PR TITLE
Resolve #7959, Automatically login to RPC service after expiration

### DIFF
--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -88,6 +88,10 @@ class Client
   #  # {"version"=>"4.11.0-dev", "ruby"=>"2.1.5 x86_64-darwin14.0 2014-11-13", "api"=>"1.0"}
   #  rpc.call('core.version')
   def call(meth, *args)
+    if meth == 'auth.logout'
+      do_logout_cleanup
+    end
+
     unless meth == "auth.login"
       unless self.token
         raise RuntimeError, "client not authenticated"
@@ -100,7 +104,7 @@ class Client
     begin
       send_rpc_request(args)
     rescue Msf::RPC::ServerException => e
-      if e.message =~ /Invalid Authentication Token/i && meth != 'auth.login'
+      if e.message =~ /Invalid Authentication Token/i && meth != 'auth.login' && @user && @pass
         re_login
         args[1] = self.token
         retry
@@ -158,6 +162,11 @@ class Client
     else
       raise RuntimeError, res.inspect
     end
+  end
+
+  def do_logout_cleanup
+    @user = nil
+    @pass = nil
   end
 
 end


### PR DESCRIPTION
## Description

This patch allows the RPC client to automatically login and renew its token if it has expired. Note that if the program/user specifically calls ```logout```, then it will not renew the token, because logging out implies you don't want the session anymore.

## Verification

This mimics an expired session by removing the token:

- [x] Start a msfrpcd server: ```ruby msfrpcd -P msf -U msf -f```
- [x] Log into the RPC server: ```ruby ./msfrpc -U msf -P msf -a 127.0.0.1```
- [x] In the RPC client's prompt, do: ```rpc.call('auth.token_list')```. You should see a token
- [x] Remove the token by doing this: ```rpc.call('auth.token_remove', 'TOKEN HERE')```
- [x] Do ```rpc.call('auth.token_list')``` again, this time you should see a different token. This means it just automatically logged in and renewed your token.

This test ensures that the client no longer renews the token if the user explicitly logs out:

- [x] See the new token again: ```rpc.call('auth.token_list')```
- [x] This time, log out with that token: ```rpc.call('auth.logout', 'NEW TOKEN HERE')```
- [x] Do: ```rpc.call('auth.token_list')```
- [x] It should raise ```Invalid Authentication Token```