### PR TITLE
fix meterpreter crashes when uploading

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -756,7 +756,11 @@ class Console::CommandDispatcher::Stdapi::Fs
     # Source and destination will be the same
     src_items << last if src_items.empty?
 
-    dest = last
+    if args.size == 1
+      dest = last.split(/(\/|\\)/).last
+    else
+      dest = last
+    end
 
     # Go through each source item and upload them
     src_items.each { |src|


### PR DESCRIPTION
Uploading files without specifying the destination causes meterpreter to crash:
```
meterpreter > upload /etc/issue
[*] uploading  : /etc/issue -> /etc/issue

[*] 10.5.1.46 - Meterpreter session 1 closed.
```

Fixed:
```
meterpreter > upload /etc/issue
[*] uploading  : /etc/issue -> issue
[*] uploaded   : /etc/issue -> issue
meterpreter > ls
Listing: C:\temp
================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  29    fil   2017-02-15 02:51:18 +0000  issue
```
```
meterpreter > upload /etc/issue newname
[*] uploading  : /etc/issue -> newname
[*] uploaded   : /etc/issue -> newname
meterpreter > ls
Listing: C:\temp
================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  29    fil   2017-02-15 02:51:56 +0000  newname
```
```
meterpreter > upload /etc/issue .
[*] uploading  : /etc/issue -> .
[*] uploaded   : /etc/issue -> .\issue
meterpreter > ls
Listing: C:\temp
================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  29    fil   2017-02-15 02:52:09 +0000  issue
```
```
meterpreter > upload /etc/issue c:\\temp\\issue
[*] uploading  : /etc/issue -> c:\temp\issue
[*] uploaded   : /etc/issue -> c:\temp\issue
meterpreter > ls
Listing: C:\temp
================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  29    fil   2017-02-15 02:52:20 +0000  issue
```