### PR TITLE
fix cred_collection's has_privates? method

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -215,7 +215,7 @@ class Metasploit::Framework::CredentialCollection
   end
 
   def has_privates?
-    password.present? || pass_file.present? || userpass_file.present? || !additional_privates.empty? || blank_passwords
+    password.present? || pass_file.present? || userpass_file.present? || !additional_privates.empty? || blank_passwords || user_as_pass
   end
 
   private


### PR DESCRIPTION
Running smb_login with `USER_AS_PASS` and `USER_FILE` is currently considered invalid. Adding `user_as_pass` to `has_privates?` fixes the issue.

```
...
   USER_AS_PASS      true             no        Try the username as the password for all users
   USER_FILE         /tmp/u           no        File containing usernames, one per line
...
msf auxiliary(smb_login) > run
[*] Error: 1.2.3.4: Metasploit::Framework::LoginScanner::Invalid Cred details can't be blank, Cred details can't be blank (Metasploit::Framework::LoginScanner::SMB)
```