### PR TITLE
fix rm to handle multiple files

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -309,15 +309,15 @@ class Console::CommandDispatcher::Stdapi::Fs
   end
 
   #
-  # Delete the specified file.
+  # Delete the specified file(s).
   #
   def cmd_rm(*args)
     if (args.length == 0)
-      print_line("Usage: rm file")
+      print_line("Usage: rm file1 [file2...]")
       return true
     end
 
-    client.fs.file.rm(args[0])
+    args.each { |f| client.fs.file.rm(f) }
 
     return true
   end


### PR DESCRIPTION
Tiny fix to allow `rm`ing multiple files:

```
meterpreter > ls
Listing: C:\temp
================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100666/rw-rw-rw-  4     fil   2017-02-16 00:15:21 +0000  one
100666/rw-rw-rw-  6     fil   2017-02-16 00:15:20 +0000  three
100666/rw-rw-rw-  4     fil   2017-02-16 00:15:21 +0000  two

meterpreter > rm one two three
meterpreter > ls
No entries exist in C:\temp
```