### PR TITLE
Add a test module for railgun API calls

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
@@ -1419,7 +1419,7 @@ class Def_kernel32
       ["DWORD","nSize","in"],
       ])
 
-    dll.add_function( 'GetModuleHandleA', 'DWORD',[
+    dll.add_function( 'GetModuleHandleA', 'HANDLE',[
       ["PCHAR","lpModuleName","in"],
       ])
 

--- a/test/modules/post/test/railgun.rb
+++ b/test/modules/post/test/railgun.rb
@@ -1,0 +1,93 @@
+
+require 'msf/core'
+
+lib = File.join(Msf::Config.install_root, "test", "lib")
+require 'module_test'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::ModuleTest::PostTest
+  include Msf::Post::Windows::Railgun
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Railgun API Tests',
+        'Description'   => %q{ This module will test railgun api functions},
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Spencer McIntyre'],
+        'Platform'      => [ 'windows' ]
+      ))
+  end
+
+  def test_api_function_calls
+
+    it "Results should include error information" do
+      ret = true
+      result = session.railgun.kernel32.GetCurrentProcess()
+      ret &&= result['GetLastError'] == 0
+      ret &&= result['ErrorMessage'].is_a? String
+    end
+
+    it "Should support functions with no parameters" do
+      ret = true
+      result = session.railgun.kernel32.GetCurrentThread()
+      ret &&= result['GetLastError'] == 0
+      ret &&= result['return'] != 0
+    end
+
+    it "Should support functions with literal parameters" do
+      ret = true
+      result = session.railgun.kernel32.Sleep(50)
+      ret &&= result['GetLastError'] == 0
+    end
+
+    it "Should support functions with in/out/inout parameter types" do
+      ret = true
+      # DnsHostnameToComputerNameA is ideal because it uses all 3 types see:
+      # https://msdn.microsoft.com/en-us/library/windows/desktop/ms724244(v=vs.85).aspx
+      result = session.railgun.kernel32.DnsHostnameToComputerNameA('localhost', 64, 64)
+      ret &&= result['GetLastError'] == 0
+      ret &&= result['ComputerName'].is_a? String
+      ret &&= result['nSize'].to_i == result['ComputerName'].length
+    end
+
+    it "Should support reading memory" do
+      ret = true
+      result = client.railgun.kernel32.GetModuleHandleA('kernel32')
+      ret &&= result['GetLastError'] == 0
+      ret &&= result['return'] != 0
+      return false unless ret
+
+      handle = result['return']
+      mz_header = client.railgun.memread(handle, 4)
+      ret &&= mz_header == "MZ\x90\x00"
+    end
+
+    it "Should support writing memory" do
+      ret = true
+      result = client.railgun.kernel32.GetProcessHeap()
+      ret &&= result['GetLastError'] == 0
+      ret &&= result['return'] != 0
+      return false unless ret
+
+      buffer_size = 32
+      handle = result['return']
+      result = client.railgun.kernel32.HeapAlloc(handle, 0, buffer_size)
+      ret &&= result['GetLastError'] == 0
+      ret &&= result['return'] != 0
+      return false unless ret
+
+      buffer_value = Rex::Text.rand_text_alphanumeric(buffer_size)
+      buffer = result['return']
+      ret &&= client.railgun.memwrite(buffer, buffer_value, buffer_size)
+      ret &&= client.railgun.memread(buffer, buffer_size) == buffer_value
+
+      client.railgun.kernel32.HeapFree(handle, 0, buffer)
+      ret
+    end
+
+  end
+
+end
+
+


### PR DESCRIPTION
This Pull Request adds a new module for testing the railgun API functions provided by meterpreter. This will come in handy for testing hypothetical future railgun implementations. It makes a series of API calls that ensure each type of parameter (literal, in buffer, out buffer, inout buffer) are all used at least once. 

This also fixes a minor bug in how `kernel32!GetModuleHandleA` is defined to have a DWORD return value when it should be HANDLE per [the MSDN docs](https://msdn.microsoft.com/en-us/library/windows/desktop/ms683199(v=vs.85).aspx).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a native Windows Meterpreter session
- [x] Run `loadpath test/modules` to load the test modules
- [x] `use post/test/railgun` and run it against the session
- [x] Ensure that all tests comeback successful

## Example Output
```
metasploit-framework (S:1 J:1) post(railgun) > set SESSION -1
SESSION => -1
metasploit-framework (S:1 J:1) post(railgun) > run

[*] [2017.02.18-17:45:33] Running against session -1
[*] [2017.02.18-17:45:33] Session type is meterpreter and platform is windows
[+] [2017.02.18-17:45:33] Results should include error information
[+] [2017.02.18-17:45:33] Should support functions with no parameters
[+] [2017.02.18-17:45:33] Should support functions with literal parameters
[+] [2017.02.18-17:45:33] Should support functions with in/out/inout parameter types
[+] [2017.02.18-17:45:34] Should support reading memory
[+] [2017.02.18-17:45:34] Should support writing memory
[*] [2017.02.18-17:45:34] Testing complete in 1.108986496
[*] [2017.02.18-17:45:34] Passed: 6; Failed: 0
[*] Post module execution completed
```

