### PR TITLE
remove downcase on password

### DIFF
--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -419,7 +419,7 @@ class MetasploitModule < Msf::Exploit::Remote
         origin_type: :service,
         module_fullname: self.fullname,
         private_type: :password,
-        private_data: datastore['HttpPassword'].downcase,
+        private_data: datastore['HttpPassword'],
         username: datastore['HttpUsername']
     }
 


### PR DESCRIPTION
Fixes #7961 and is related to #7529.  Removes `downcase` on a password, which if unset is nil and therefore causes a crash.