### PR TITLE
fix handler persistence

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -321,7 +321,9 @@ module Msf
               'ExitOnSession'  => exit_on_session,
               'RunAsJob'       => true
             }
+
             handler.datastore.reverse_merge!(payload_datastore)
+            handler.datastore.merge!(handler_opts)
 
             # Launch our Handler and get the Job ID
             handler.exploit_simple(handler_opts)


### PR DESCRIPTION
Using the new `handler` command does not maintain the handler after a session is established (even without `-x`).

Passing the `handler_opts` hash to `exploit_simple` seems to be ineffectual as it won't overwrite existing keys. Explicitly merging the hashes beforehand is one solution.