### PR TITLE
Fix typo in smtp fuzzer

### DIFF
--- a/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       Opt::RPORT(25),
-      OptInt.new("STARTLEN", [true, "Lenght of the string - start number", 100] ),
+      OptInt.new("STARTLEN", [true, "Length of the string - start number", 100] ),
       OptInt.new("INTERACTIONS", [false, "Number of interactions to run", 100] ),
       OptBool.new("RESPECTORDER", [false, "Respect order of commands", true] ),
       OptEnum.new("CMD", [true,"Command to fuzzer",'EHLO',


### PR DESCRIPTION
Turns out I had this change lined up since April last year, but failed to send it to the right project.

Here you go.