### PR TITLE
Fix #7984, Fix NoMethodError `match' for bavision_cameras.rb

### DIFF
--- a/lib/metasploit/framework/login_scanner/bavision_cameras.rb
+++ b/lib/metasploit/framework/login_scanner/bavision_cameras.rb
@@ -19,7 +19,7 @@ module Metasploit
           login_uri = normalize_uri("#{uri}")
           res = send_request({'uri'=> login_uri})
 
-          if res && res.headers['WWW-Authenticate'].match(/realm="IPCamera Login"/)
+          if res && res.headers['WWW-Authenticate'] && res.headers['WWW-Authenticate'].match(/realm="IPCamera Login"/)
             return true
           end
 


### PR DESCRIPTION
Fix #7984 

This fixes ```NoMethodError `match'``` for bavision_cameras.rb when the web server does not have a ```WWW-Authenticate``` HTTP header.
