### PR TITLE
Use obfuscated JS in BES

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -501,7 +501,7 @@ module Msf
 
       %Q|
       <script>
-      #{code}
+      #{js}
       </script>
       <noscript>
       <img style="visibility:hidden" src="#{get_resource.chomp("/")}/#{@noscript_receiver_page}/">


### PR DESCRIPTION
`BrowserExploitServer.get_detection_html` wraps the JavaScript detection code in `JSObfu` but mistakenly delivers the raw JavaScript instead of the obfuscated version.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Use any BrowserExpoitServer based exploit e.g. `use exploits/windows/browser/adobe_toolbutton.rb`
- [x] **Verify** the initial page delivered by the BrowserExploitServer delivers an obfuscated JavaScript detection code

