### PR TITLE
Signature Evasions

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -430,7 +430,6 @@ module Msf
       window.onload = function() {
         var osInfo = os_detect.getVersion();
         var d = {
-          "os_name"     : osInfo.os_name,
           "os_vendor"   : osInfo.os_vendor,
           "os_device"   : osInfo.os_device,
           "ua_name"     : osInfo.ua_name,
@@ -439,7 +438,8 @@ module Msf
           "java"        : misc_addons_detect.getJavaVersion(),
           "silverlight" : misc_addons_detect.hasSilverlight(),
           "flash"       : misc_addons_detect.getFlashVersion(),
-          "vuln_test"   : <%= js_vuln_test %>
+          "vuln_test"   : <%= js_vuln_test %>,
+          "os_name"     : osInfo.os_name
         };
 
         <% if os.match(OperatingSystems::Match::WINDOWS) and client == HttpClients::IE %>


### PR DESCRIPTION
This changeset focuses on unique string snippets which remain after obfuscation and get caught by SEP's signatures:
- Metasploit OS detection

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploits/windows/browser/ms13_037_svg_dashstyle.rb`
- [x] **Verify**  The base64-encoded post data when decoded does not start with `os_name=`
