### PR TITLE
Fixes MS-1716, keep sessions in progress alive.

### DIFF
--- a/lib/rex/post/meterpreter/packet_parser.rb
+++ b/lib/rex/post/meterpreter/packet_parser.rb
@@ -75,22 +75,27 @@ class PacketParser
       end
     end
 
+    in_progress = true
+
+    # TODO: cipher decryption
+    if (cipher)
+    end
+
+    # Deserialize the packet from the raw buffer
+    packet.from_r(self.raw)
+
     # If we've finished reading the entire packet
     if ((self.hdr_length_left == 0) &&
         (self.payload_length_left == 0))
 
-      # TODO: cipher decryption
-      if (cipher)
-      end
-
-      # Deserialize the packet from the raw buffer
-      packet.from_r(self.raw)
-
       # Reset our state
       reset
 
-      return packet
+      # packet is complete!
+      in_progress = false
     end
+
+    return packet, in_progress
   end
 
 protected

--- a/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
+++ b/spec/lib/rex/post/meterpreter/packet_parser_spec.rb
@@ -26,11 +26,12 @@ RSpec.describe Rex::Post::Meterpreter::PacketParser do
 
   it "should parse valid raw data into a packet object" do
     while @raw.length >0
-      parsed_packet = parser.recv(@sock)
+      parsed_packet, in_progress = parser.recv(@sock)
     end
     expect(parsed_packet).to be_a Rex::Post::Meterpreter::Packet
     expect(parsed_packet.type).to eq Rex::Post::Meterpreter::PACKET_TYPE_REQUEST
     expect(parsed_packet.method?("test_method")).to eq true
+    expect(in_progress).to eq false
   end
 
 end


### PR DESCRIPTION
This patch makes slow/unreliable connections to meterpreter "more forgiving" before declaring an in-progress command as timed-out (basically treats incoming frames that are part of a larger, not-yet-complete packet, as proof that response progress is being made).

The verification will require using a tool to simulate lossy/poor network conditions.  OS X has a built-in tool called Network Link Conditioner (under the System Preferences) that works very well, but does require using network connections over physical interfaces on your system.

## Verification

First, on the current master branch, enable the network manipulation tool to enable some delay+loss, and attempt download a 10MB file from a target via a meterpreter session:

- [x] Create a meterpreter standalone payload via msfvenom, copy it to your target.
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload <your meterpreter flavor>` (e.g. `set payload python/meterpreter/reverse_tcp`)
- [x] `set lhost <host IP>`
- [x] `run`
- [x] Start your meterpreter on your target.
- [x] **Verify** meterpreter connects back to your msf instance.
- [x] at the msfconsole meterpreter prompt: `download <some 10MB-or-so file>`
- [x] **Verify** the file does (slowly) download part of the file, but then eventually times out and quits (FWIW, the Network Link Conditioner profile I usually test with is "Very Bad Network", which is 1 Mbps, 10% packet drop, 500ms delay on both down and up)

You may need to remove the downloaded file and repeat the above steps several times before you find network tool settings that end up with part (but not all) of the file being downloaded.  Once you have a setup that reliably downloads part of the file but eventually times out, then do the following:

- [x] Checkout the code of this PR.
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload <your meterpreter flavor>` (e.g. `set payload python/meterpreter/reverse_tcp`)
- [x] `set lhost <host IP>`
- [x] `run`
- [x] Start your meterpreter on your target.
- [x] **Verify** meterpreter connects back to your msf instance.
- [x] at the msfconsole meterpreter prompt: `download <some 10MB-or-so file>`
- [x] **Verify** the file does (slowly) download the file without timing out, despite the network manipulation tool rate-limiting/dropping/delaying packets.