### PR TITLE
Change keyscan_extract behavior

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -234,6 +234,10 @@ class UI < Rex::Post::UI
   #
   # Extract the keystroke from the buffer data
   #
+
+  #
+  # method will become deprecated with keyscan updates
+  #
   def keyscan_extract(buffer_data)
     # outp = ""
     # buffer_data.unpack("n*").each do |inp|

--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -235,32 +235,33 @@ class UI < Rex::Post::UI
   # Extract the keystroke from the buffer data
   #
   def keyscan_extract(buffer_data)
-    outp = ""
-    buffer_data.unpack("n*").each do |inp|
-      fl = (inp & 0xff00) >> 8
-      vk = (inp & 0xff)
-      kc = VirtualKeyCodes[vk]
+    # outp = ""
+    # buffer_data.unpack("n*").each do |inp|
+    #   fl = (inp & 0xff00) >> 8
+    #   vk = (inp & 0xff)
+    #   kc = VirtualKeyCodes[vk]
 
-      f_shift = fl & (1<<1)
-      f_ctrl  = fl & (1<<2)
-      f_alt   = fl & (1<<3)
+    #   f_shift = fl & (1<<1)
+    #   f_ctrl  = fl & (1<<2)
+    #   f_alt   = fl & (1<<3)
 
-      if(kc)
-        name = ((f_shift != 0 and kc.length > 1) ? kc[1] : kc[0])
-        case name
-        when /^.$/
-          outp << name
-        when /shift|click/i
-        when 'Space'
-          outp << " "
-        else
-          outp << " <#{name}> "
-        end
-      else
-        outp << " <0x%.2x> " % vk
-      end
-    end
-    return outp
+    #   if(kc)
+    #     name = ((f_shift != 0 and kc.length > 1) ? kc[1] : kc[0])
+    #     case name
+    #     when /^.$/
+    #       outp << name
+    #     when /shift|click/i
+    #     when 'Space'
+    #       outp << " "
+    #     else
+    #       outp << " <#{name}> "
+    #     end
+    #   else
+    #     outp << " <0x%.2x> " % vk
+    #   end
+    # end
+    # return outp
+    return buffer_data
   end
 
 protected


### PR DESCRIPTION
This changes keyscan_extract to return it's own argument, making it pointless.  Whether it should be left as is with the original code commented out, refactored in some way, or eliminated totally remains to be seen.  This is here mostly because it is necessary for testing https://github.com/rapid7/metasploit-payloads/pull/172

If you're up to stress testing everything, see [here](https://github.com/wwebb-r7/miscish/tree/master/keylog_test)
## Verification

List the steps needed to make sure this thing works

- [ ] Get a meterpreter session going on a Windows system
- [ ] Make sure you have the stdapi extension from [here](https://github.com/rapid7/metasploit-payloads/pull/172) placed in data/meterpreter/
- [ ] Interact with it ala `sessions -i 1`
- [ ] `keyscan_start`
- [ ] Type stuff on the windows target
- [ ] `keyscan_dump`
- [ ] **Verify** it dumps whatever you typed

