### PR TITLE
Dockerfile and Docker Compose for Metasploit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,11 @@
+.dockerignore
+.gitignore
+.env*
+docker-compose*.yml
+docker/
+!docker/msfconsole.rc
+README.md
+
 .bundle
 Gemfile.local
 Gemfile.local.lock
@@ -85,6 +93,3 @@ data/meterpreter/ext_server_pivot.*.dll
 # https://rapid7.github.io/metasploit-framework. It's an orphan branch.
 /metakitty
 .vagrant
-
-# local docker compose overrides
-docker-compose.local*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  ms: &ms
+    image: metasploit
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile
+    environment:
+      DATABASE_URL: postgres://postgres@db:5432/msf
+    links:
+      - db
+    ports:
+      - 4444:4444
+    volumes:
+      - $HOME/.msf4:/root/.msf4
+
+  db:
+    image: postgres:9.6
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+
+volumes:
+  pg_data:
+    driver: local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,47 @@
+FROM ruby:2.3-alpine
+MAINTAINER Rapid7
+
+ARG BUNDLER_ARGS="--system --jobs=8"
+ENV APP_HOME /usr/src/metasploit-framework/
+WORKDIR $APP_HOME
+
+COPY Gemfile* m* Rakefile $APP_HOME
+COPY lib $APP_HOME/lib
+
+RUN apk update && \
+	apk add \
+  	ruby-bigdecimal \
+  	ruby-bundler \
+  	ruby-io-console \
+    autoconf \
+  	bison \
+  	subversion \
+  	git \
+  	sqlite \
+  	nmap \
+  	libxslt \
+  	postgresql \
+    ncurses \
+  && apk add --virtual .ruby-builddeps \
+    build-base \
+    ruby-dev \
+    libffi-dev\
+    openssl-dev \
+    readline-dev \
+    sqlite-dev \
+    postgresql-dev \
+    libpcap-dev \
+    libxml2-dev \
+    libxslt-dev \
+    yaml-dev \
+    zlib-dev \
+    ncurses-dev \
+    bison \
+    autoconf \
+  && echo "gem: --no-ri --no-rdoc" > /etc/gemrc \
+  && bundle install $BUNDLER_ARGS \
+  && apk del .ruby-builddeps \
+  && rm -rf /var/cache/apk/*
+
+ADD ./ $APP_HOME
+CMD ["./msfconsole", "-r", "docker/msfconsole.rc"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,65 @@
+# Metasploit in Docker
+## Getting Started
+
+To run `msfconsole`
+```bash
+docker-compose run --rm --service-ports ms
+```
+
+To run `msfvenom`
+```bash
+docker-compose run --rm ms ./msfvenom
+```
+
+### I don't like typing `docker-compose --rm ...`
+
+We have included some binstubs `./bin`, you can symlink them to your path.
+
+Assuming you have `$HOME/bin`, and it's in your `$PATH`. You can run this from the project root:
+
+```bash
+ln -s `pwd`/docker/bin/msfconsole $HOME/bin/
+ln -s `pwd`/docker/bin/msfvenom $HOME/bin/
+```
+
+### But I want reverse shells...
+
+By default we expose port `4444`. You'll need to set `LHOST` to be a hostname/ip
+of your host machine.
+
+If you want to expose more ports, or have `LHOST` prepopulated with a specific
+value; you'll need to setup a local docker-compose override for this.
+
+Create `docker/docker-compose.local.override.yml` with:
+```yml
+version: '2'
+services:
+  ms:
+    environment:
+      # example of setting LHOST
+      LHOST: 10.0.8.2
+    # example of adding more ports
+    ports:
+      - 8080:8080
+```
+
+Make sure you set `LHOST` to valid hostname that resolves to your host machine.
+
+Now you need to set the `COMPOSE_FILE` environment variable to load your local
+override.
+
+```bash
+echo "COMPOSE_FILE=./docker-compose.yml:./docker/docker-compose.local.override.yml" >> .env
+```
+Now you should be able get reverse shells working
+
+## Developing
+
+To setup you environment for development, you need to `docker/docker-compose.development.override.yml`
+to your `COMPOSE_FILE` environment variable.
+
+If you don't have a `COMPOSE_FILE` environment variable, you can set it up with this:
+
+```bash
+echo "COMPOSE_FILE=./docker-compose.yml:./docker/docker-compose.development.override.yml" >> .env
+```

--- a/docker/bin/msfconsole
+++ b/docker/bin/msfconsole
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+if [[ -z "$MSF_PATH" ]]; then
+  path=`dirname $0`
+
+  # check for ./docker/msfconsole.rc
+  if [[ ! -f $path/../msfconsole.rc ]] ; then
+
+    # we are not inside the project
+    realpath --version > /dev/null 2>&1 || { echo >&2 "I couldn't find where metasploit is. Set \$MSF_PATH or execute this from the project root"; exit 1 ;}
+
+    # determine script path
+    pushd $(dirname $(realpath $0)) > /dev/null
+    path=$(pwd)
+    popd > /dev/null
+  fi
+  MSF_PATH=$(dirname $(dirname $path))
+fi
+
+cd $MSF_PATH
+docker-compose run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$@"

--- a/docker/bin/msfvenom
+++ b/docker/bin/msfvenom
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+if [[ -z "$MSF_PATH" ]]; then
+  path=`dirname $0`
+
+  # check for ./docker/msfconsole.rc
+  if [[ ! -f $path/../msfconsole.rc ]] ; then
+
+    # we are not inside the project
+    realpath --version > /dev/null 2>&1 || { echo >&2 "I couldn't find where metasploit is. Set \$MSF_PATH or execute this from the project root"; exit 1 ;}
+
+    # determine script path
+    pushd $(dirname $(realpath $0)) > /dev/null
+    path=$(pwd)
+    popd > /dev/null
+  fi
+  MSF_PATH=$(dirname $(dirname $path))
+fi
+
+cd $MSF_PATH
+docker-compose run --rm --service-ports ms ./msfvenom "$@"

--- a/docker/docker-compose.development.override.yml
+++ b/docker/docker-compose.development.override.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  ms: &ms
+    environment:
+      DATABASE_URL: postgres://postgres@db:5432/msf_dev
+
+    volumes:
+      - .:/usr/src/app

--- a/docker/msfconsole.rc
+++ b/docker/msfconsole.rc
@@ -1,0 +1,5 @@
+<ruby>
+run_single("setg LHOST #{ENV['LHOST']}") if ENV['LHOST']
+run_single("setg LPORT #{ENV['LPORT']}") if ENV['LPORT']
+run_single("db_connect #{ENV['DATABASE_URL'].gsub('postrgres://', '')}") if ENV['DATABASE_URL']
+</ruby>


### PR DESCRIPTION
Adds a basic Dockerfile and docker-compose config. `docker-compose.yml`
adds a named volume for postgres so data should persist.

`$HOME/.msf4` will be mounted to `/root/.msf4` by default.
port 4444 is bound by default

Basic Usage:

	docker/bin/msfconsole
	docker/bin/msfvenom

Check out the docker/README.md for more details
closes #5284

## Verification

List the steps needed to make sure this thing works.

- [x] `docker/bin/msfconsole`
- [x] `docker/bin/msfvenom`
- [x] or outside of docker-compose `docker run -i metasploit`
