### PR TITLE
Update payloads 1.2.15

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.14'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.15'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.7'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 53178
+  CachedSize = 53182
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51794
+  CachedSize = 53178
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51758
+  CachedSize = 53142
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51758
+  CachedSize = 53142
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 53142
+  CachedSize = 53146
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -12,7 +12,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 51714
+  CachedSize = 53098
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
Bump metasploit-payloads to 1.2.15 to incorporate https://github.com/rapid7/metasploit-payloads/pull/171