### PR TITLE
Added the option to incude entropy in file/directory names

### DIFF
--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Post
       ))
     register_options(
       [
+        OptBool.new("AddEntropy" , [false, "Add entropy token to file and directory names.", false]),
         OptString.new("BaseFileName" , [true, "File/dir base name", "meterpreter-test"])
       ], self.class)
   end
@@ -132,7 +133,12 @@ class MetasploitModule < Msf::Post
 
   def test_fs
     vprint_status("Starting filesystem tests")
-
+    if datastore["AddEntropy"]
+      entropy_value = '-' + ('a'..'z').to_a.shuffle[0,8].join
+    else
+      entropy_value = ""
+    end
+    
     it "should return the proper directory separator" do
       sysinfo = session.sys.config.sysinfo
       if sysinfo["OS"] =~ /windows/i
@@ -167,7 +173,8 @@ class MetasploitModule < Msf::Post
     end
 
     it "should create and remove a dir" do
-      dir_name = "#{datastore["BaseFileName"]}-dir"
+      dir_name = "#{datastore["BaseFileName"]}-dir#{entropy_value}" 
+      vprint_status("Directory Name: #{dir_name}")
       session.fs.dir.rmdir(dir_name) rescue nil
       res = create_directory(dir_name)
       if (res)
@@ -180,7 +187,8 @@ class MetasploitModule < Msf::Post
     end
 
     it "should change directories" do
-      dir_name = "#{datastore["BaseFileName"]}-dir"
+      dir_name = "#{datastore["BaseFileName"]}-dir#{entropy_value}"
+      vprint_status("Directory Name: #{dir_name}")
       session.fs.dir.rmdir(dir_name) rescue nil
       res = create_directory(dir_name)
 
@@ -208,7 +216,8 @@ class MetasploitModule < Msf::Post
 
     it "should create and remove files" do
       res = true
-      file_name = datastore["BaseFileName"]
+      file_name = "#{datastore["BaseFileName"]}#{entropy_value}"
+      vprint_status("File Name: #{file_name}")
       res &&= session.fs.file.open(file_name, "wb") { |fd|
         fd.write("test")
       }
@@ -228,7 +237,8 @@ class MetasploitModule < Msf::Post
 
     it "should upload a file" do
       res = true
-      remote = "#{datastore["BaseFileName"]}-file.txt"
+      remote = "#{datastore["BaseFileName"]}-file#{entropy_value}.txt"
+      vprint_status("Remote File Name: #{remote}")
       local  = __FILE__
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)
@@ -254,8 +264,10 @@ class MetasploitModule < Msf::Post
 
     it "should move files" do
       res = true
-      src_name = datastore["BaseFileName"]
-      dst_name = "#{datastore["BaseFileName"]}-moved"
+      src_name = "#{datastore["BaseFileName"]}#{entropy_value}"
+      vprint_status("Source File Name: #{src_name}")
+      dst_name = "#{src_name}-moved"
+      vprint_status("Destination File Name: #{dst_name}")
 
       # Make sure we don't have leftovers from a previous run
       session.fs.file.rm(src_name) rescue nil
@@ -279,8 +291,10 @@ class MetasploitModule < Msf::Post
 
     it "should copy files" do
       res = true
-      src_name = datastore["BaseFileName"]
-      dst_name = "#{datastore["BaseFileName"]}-copied"
+      src_name = "#{datastore["BaseFileName"]}#{entropy_value}"
+      vprint_status("Source File Name: #{src_name}")
+      dst_name = "#{src_name}-copied"
+      vprint_status("Destination File Name: #{dst_name}")
 
       # Make sure we don't have leftovers from a previous run
       session.fs.file.rm(src_name) rescue nil
@@ -304,7 +318,8 @@ class MetasploitModule < Msf::Post
 
     it "should do md5 and sha1 of files" do
       res = true
-      remote = "#{datastore["BaseFileName"]}-file.txt"
+      remote = "#{datastore["BaseFileName"]}-file#{entropy_value}.txt"
+      vprint_status("Remote File Name: #{remote}")
       local  = __FILE__
       vprint_status("uploading")
       session.fs.file.upload_file(remote, local)


### PR DESCRIPTION
The in-development automated payload testing system runs multiple meterpreter sessions and test scripts on the same VM at the same time.  This creates the possibility of a file or directory name collision for some elements in the  testing scripts which results in a false negative.
This PR adds a new option to the meterpreter test module called `AddEntropy` that tacks a pseudo-random string to the end of any files or directories created by the test script, lowering the probability of a collision when multiple instances of the test script are run in parallel.  The psedo-random string is generated once for each test run and added to all new directories and files created by the script if the `AddEntropy` option is set to true.

## Verification

List the steps needed to make sure this thing works

- [x] Get a meterpreter session
- [x] `background`
- [x] `loadpath test/modules`
- [x] `use post/test/meterpreter`
- [x] `show options`
- [x] **Verify** `AddEntropy` is an option
- [x] **Verify** `AddEntropy` is set to false
- [x] `run`
- [x] **Verify** all tests pass
- [x] `set verbose true`
- [x] `run`
- [x] **Verify** file and directory names do not have trailing pseudo-random strings
- [x] `set AddEntropy true`
- [x] `run`
- [x] **Verify** all tests pass
- [x] **Verify** file and directory names do have trailing pseudo-random strings

