### PR TITLE
Add new core_native_arch method to Meterpreter

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -537,6 +537,15 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   end
 
   #
+  # Get a string representation of the architecture of the process in which the
+  # current session is running. This defaults to the same value of arch but can
+  # be overridden by specific meterpreter implementations to add support.
+  #
+  def native_arch
+    arch
+  end
+
+  #
   # Generate a binary suffix based on arch
   #
   def binary_suffix

--- a/lib/msf/base/sessions/meterpreter_python.rb
+++ b/lib/msf/base/sessions/meterpreter_python.rb
@@ -108,6 +108,10 @@ class Meterpreter_Python_Python < Msf::Sessions::Meterpreter
     unknown_error
   end
 
+  def native_arch
+    @native_arch ||= self.core.native_arch
+  end
+
   def supports_ssl?
     false
   end

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -325,6 +325,18 @@ class ClientCore < Extension
     Rex::Text.md5(mid.to_s.downcase.strip)
   end
 
+  def native_arch(timeout=nil)
+    # Not all meterpreter implementations support this
+    request = Packet.create_request('core_native_arch')
+
+    args = [ request ]
+    args << timeout if timeout
+
+    response = client.send_request(*args)
+
+    response.get_tlv_value(TLV_TYPE_STRING)
+  end
+
   def transport_remove(opts={})
     request = transport_prepare_request('core_transport_remove', opts)
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/dll.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/dll.rb
@@ -119,7 +119,7 @@ class DLL
   def process_function_call(function, args, client)
     raise "#{function.params.length} arguments expected. #{args.length} arguments provided." unless args.length == function.params.length
 
-    if client.arch == ARCH_X64
+    if client.native_arch == ARCH_X64
       native = 'Q<'
     else
       native = 'V'


### PR DESCRIPTION
This PR is the metasploit-framework side of the addition of a new core method for meterpreters to specify their process' native architecture. Adding this feature will allow for Metasploit to query the meterpreter session to identify the correct architecture which, in the case of some meterpreters, can't be done properly using sesison.arch or session.sys.config.sysinfo['Architecture'] when running in a WOW64 process. Knowing this information is necessary for interacting with native API methods.

The metasploit-payloads side is rapid7/metasploit-payloads#173 and is required to test this PR.

I paid special attention to ensure that a 32-bit meterpreter running on a 64-bit version of Windows would report the correct information both before and after migrating into a 64-bit process.

## Example Usage
```
metasploit-framework (S:2 J:1) payload(reverse_tcp) > sessions -i -1
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : PWNME-PC
OS              : Windows 7 (Build 7601, Service Pack 1)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
meterpreter > irb
[*] Starting IRB shell
[*] The 'client' variable holds the meterpreter client

>> session.arch
=> "python"
>> session.native_arch
=> "x86"
>> session.sys.config.sysinfo['Architecture']
=> "x64"
>> 
```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use payload/python/meterpreter/reverse_tcp` and generate a payload
- [x] Use a 32-bit installation of Python and execute the payload
- [x] Interact with the session and drop into an `irb` terminal
- [x] Check that `session.arch` is still Python
- [x] Check that `session.native_arch` is the native architecture of the process (x86 when running in WOW64)
- [x] Check that `sysinfo` still reports the correct system architecture


CC @busterb 