### PR TITLE
Restore USERNAME and PASSWORD options for owa_login

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('AD_DOMAIN', [ false, "Optional AD domain to prepend to usernames", ''])
       ], self.class)
 
-    deregister_options('BLANK_PASSWORDS', 'RHOSTS','PASSWORD','USERNAME')
+    deregister_options('BLANK_PASSWORDS', 'RHOSTS')
   end
 
   def setup


### PR DESCRIPTION
## Description

Requested by our own pentesters, the username & password options should be restored so users can more easily try one password but multiple users.

Although secretly, people can do it already. Because even though the options are deregistered, mixins don't respect this state, they will still use it anyway.

## Verification

- [x] Start msfconsole
- [x] Do: ```use auxiliary/scanner/http/owa_login```
- [x] Do: ```show options```
- [x] You should see the USERNAME and PASSWORD options