### PR TITLE
Fixes #8022

### DIFF
--- a/lib/rex/post/hwbridge/extensions/automotive/uds_errors.rb
+++ b/lib/rex/post/hwbridge/extensions/automotive/uds_errors.rb
@@ -8,6 +8,7 @@ module Automotive
 
 module UDSErrors
 
+# Negative Response Codes (NDC)
 ERR_MNEMONIC = {
   0x10 => "GR",
   0x11 => "SNS",
@@ -54,7 +55,25 @@ ERR_MNEMONIC = {
   0x73 => "WBSC",
   0x78 => "RCRRP",
   0x7E => "SFNSIAS",
-  0x7F => "SNSIAS"
+  0x7F => "SNSIAS",
+  0x81 => "RTH",
+  0x82 => "RTL",
+  0x83 => "EIR",
+  0x84 => "EINR",
+  0x85 => "ERTTL",
+  0x86 => "TTH",
+  0x87 => "TTL",
+  0x88 => "VSTH",
+  0x89 => "VSTL",
+  0x8A => "TPTH",
+  0x8B => "TPTL",
+  0x8C => "TRNIN",
+  0x8D => "TRNIG",
+  0x8F => "BSNC",
+  0x90 => "SLNIP",
+  0x91 => "TCCL",
+  0x92 => "VTH",
+  0x93 => "VTL"
 }
 
 ERR_DESC = {
@@ -80,7 +99,25 @@ ERR_DESC = {
   "WBSC" => "Wrong Block Sequence Counter",
   "RCRRP" => "Request Correctly Received, but Response is Pending",
   "SFNSIAS" => "Sub-Function Not Supoorted In Active Session",
-  "SNSIAS" => "Service Not Supported In Active Session"
+  "SNSIAS" => "Service Not Supported In Active Session",
+  "RTH" => "RPM Too High",
+  "RTL" => "RPM Too Low".
+  "EIR" => "Engine is Running",
+  "EINR" => "Engine is not Running",
+  "ERTTL" => "Engine Run Time Too Low",
+  "TTH" => "Temperature Too High",
+  "TTL" => "Temperature Too Low",
+  "VSTH" => "Vehicle Speed Too High",
+  "VSTL" => "Vehicle Speed Too Low",
+  "TPTH" => "Throttle Pedal Too High",
+  "TPTL" => "Throttle Pedal Too Low",
+  "TRNIN" => "Transmission Range Not in Neutral",
+  "TRNIG" => "Transmission Range Not in Gear",
+  "BSNC" => "Brake Switch Not Closed",
+  "SLNIP" => "Shifter Lever Not In Park",
+  "TCCL" => "Torque Converter Clutch Locked",
+  "VTH" => "Voltage Too High",
+  "VTL" => "Voltage Too Low" 
 }
 
 end

--- a/modules/post/hardware/automotive/getvinfo.rb
+++ b/modules/post/hardware/automotive/getvinfo.rb
@@ -33,8 +33,12 @@ class MetasploitModule < Msf::Post
 
   def run
     pids = get_current_data_pids(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
-    print_status("Available PIDS for pulling realtime data: #{pids.size} pids")
-    print_status("  #{pids.inspect}")
+    if pids.size == 0
+      print_status("No reported PIDs. You may not be properly connected")
+    else
+      print_status("Available PIDS for pulling realtime data: #{pids.size} pids")
+      print_status("  #{pids.inspect}")
+    end
     if pids.include? 1
       data = get_monitor_status(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
       print_status("  MIL (Engine Light) : #{data["MIL"] ? "ON" : "OFF"}") if data.has_key? "MIL"
@@ -58,7 +62,7 @@ class MetasploitModule < Msf::Post
     dtcs = get_dtcs(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
     print_status("DTCs: #{ dtcs.join(",") }") if dtcs.size > 0
     pids = get_vinfo_supported_pids(datastore["CANBUS"], datastore["SRCID"], datastore["DSTID"])
-    print_status("Mode $09 Vehicle Info Supported PIDS: #{pids.inspect}")
+    print_status("Mode $09 Vehicle Info Supported PIDS: #{pids.inspect}") if pids.size > 0
     pids.each do |pid|
       # Handle known pids
       if pid == 2

--- a/tools/hardware/elm327_relay.rb
+++ b/tools/hardware/elm327_relay.rb
@@ -249,6 +249,10 @@ module ELM327HWBridgeRelay
       send_cmd(data)
       @packets_sent += 1
       @last_sent = Time.now()
+      if resp == "CAN ERROR"
+        result["success"] = false
+        return result
+      end
       result["success"] = true
       result
     end
@@ -273,6 +277,10 @@ module ELM327HWBridgeRelay
       resp = send_cmd(data)
       @packets_sent += 1
       @last_sent = Time.now()
+      if resp == "CAN ERROR"
+        result["success"] = false
+        return result
+      end
       result["Packets"] = []
       resp.split(/\r/).each do |line|
         pkt = {}


### PR DESCRIPTION
Adds detection for ELM327 chips reporting CAN ERROR when vehicle is off.
Addes some enhanced UDS Error codes.
Cleaned up reporting from getvinfo if the vehicle is off or not connected.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Use a ELM327 dongle.  Connect to PC and not to car or leave vehicle off.
- [x] run `tools/hardware/elm327_relay.rb`
- [x] **Verify** it says: Connected.  Relay is up and running...
- [x] Start `msfconsole`
- [x] `use auxiliary/client/hwbridge/connect`
- [x] `run`
- [x] **Verify** You see that you connected to the hwbridge (You see the exiting the Matrix message)
- [x] **Verify** you see the session in sessions
- [x] `sessions -i 1`  Connect to the hwbridge session
- [x] `run post/hardware/automotive/getvinfo CANBUS=can0`
- [x] **Verify** you see: [*] No reported PIDs. You may not be properly connected


