### PR TITLE
Fix run_as_psh with domain accounts

### DIFF
--- a/documentation/modules/post/windows/manage/run_as_psh.md
+++ b/documentation/modules/post/windows/manage/run_as_psh.md
@@ -21,6 +21,7 @@ The process will use the Start-Process command of powershell to run a process as
 - Hidden Mode does not work with older powershell versions
 - Interactive mode needs to be run from a meterpreter console
 - Certain SYSTEM Services cannot run Start-Process with the -credential switch, causing the module to fail
+- SYSTEM processes without I/O pipes cannot use interactive mode
 
 ## Examples
 

--- a/documentation/modules/post/windows/manage/run_as_psh.md
+++ b/documentation/modules/post/windows/manage/run_as_psh.md
@@ -20,6 +20,7 @@ The process will use the Start-Process command of powershell to run a process as
 - Requires Powershell
 - Hidden Mode does not work with older powershell versions
 - Interactive mode needs to be run from a meterpreter console
+- Certain SYSTEM Services cannot run Start-Process with the -credential switch, causing the module to fail
 
 ## Examples
 

--- a/modules/post/windows/manage/run_as_psh.rb
+++ b/modules/post/windows/manage/run_as_psh.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Post
         'Name'         => 'Windows \'Run As\' Using Powershell',
         'Description'  => %q( This module will start a process as another user using powershell. ),
         'License'      => MSF_LICENSE,
-        'Author'       => [ 'p3nt4' ],
-        'Platform'     => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'Author'       => ['p3nt4'],
+        'Platform'     => ['win'],
+        'SessionTypes' => ['meterpreter']
       )
     )
     register_options(
@@ -41,28 +41,32 @@ class MetasploitModule < Msf::Post
     user = datastore['user']
     pass = datastore['pass']
     domain = datastore['domain']
-    exe = datastore['exe'].gsub("\\", "\\\\\\\\")
+    exe = datastore['exe'].gsub('\\', '\\\\\\\\')
     inter = datastore['interactive']
     args = datastore['args']
-    path = datastore['path'].gsub("\\", "\\\\\\\\")
+    path = datastore['path'].gsub('\\', '\\\\\\\\')
     channelized = datastore['channelize']
     hidden = datastore['hidden']
+    if user.include? '\\'
+      domain = user.split('\\')[0]
+      user = user.split('\\')[1]
+    end
     # Check if session is interactive
-    if (!session.interacting and inter)
-      print_error("Interactive mode can only be used in a meterpreter console")
+    if !session.interacting && inter
+      print_error('Interactive mode can only be used in a meterpreter console')
       print_error("Use 'run post/windows/manage/run_as_psh USER=x PASS=X EXE=X' or 'SET INTERACTIVE false'")
       raise 'Invalide console'
     end
     # Prepare powershell script
     scr = "$pw = convertto-securestring '#{pass}' -asplaintext -force; "
-    scr << "$pp = new-object -typename System.Management.Automation.PSCredential -argumentlist '#{domain}\\\\#{user}',$pw; "
+    scr << "$pp = new-object -typename System.Management.Automation.PSCredential -argumentlist '#{domain}\\#{user}',$pw; "
     scr << "Start-process '#{exe}' -WorkingDirectory '#{path}' -Credential $pp"
-    if (args and args != '')
+    if args && args != ''
       scr << " -argumentlist '#{args}' "
     end
     if hidden
-      print_status("Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false")
-      scr << " -WindowStyle hidden"
+      print_status('Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false')
+      scr << ' -WindowStyle hidden'
     end
     scr = " -c \"#{scr}\""
     # Execute script
@@ -75,12 +79,12 @@ class MetasploitModule < Msf::Post
       'InMemory'    => false,
       'UseThreadToken' => false)
     print_status("Process #{p.pid} created.")
-    print_status("Channel #{p.channel.cid} created.") if (p.channel)
+    print_status("Channel #{p.channel.cid} created.") if p.channel
     # Process output
-    if (inter and p.channel)
+    if inter && p.channel
       client.console.interact_with_channel(p.channel)
     elsif p.channel
-      data = p.channel.read()
+      data = p.channel.read
       print_line(data) if data
     end
   end


### PR DESCRIPTION
The current versions has too many escape backslashes, as a result, running run_as_psh for domain users does not work.
Also added support for DOMAIN\\User format in the USER parameter.

## Verification
`
meterpreter > run post/windows/manage/run_as_psh USER=evil\\\\doejo PASS=password 

[*] Hidden mode may not work on older powershell versions, if it fails, try HIDDEN=false
[*] Process 3028 created.
[*] Channel 15 created.
Microsoft Windows [Version 10.0.14393]
(c) 2016 Microsoft Corporation. All rights reserved.

C:\>whoami 
whoami
evil\doejo

C:\>

`
