### PR TITLE
Add Railgun Support To The Python Meterpreter

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
@@ -1591,7 +1591,7 @@ class Def_kernel32
       ["PDWORD","pdwHandleCount","out"],
       ])
 
-    dll.add_function( 'GetProcessHeap', 'DWORD',[
+    dll.add_function( 'GetProcessHeap', 'HANDLE',[
       ])
 
     dll.add_function( 'GetProcessHeaps', 'DWORD',[
@@ -2078,7 +2078,7 @@ class Def_kernel32
       ["DWORD","dwFlags","in"],
       ])
 
-    dll.add_function( 'HeapCreate', 'DWORD',[
+    dll.add_function( 'HeapCreate', 'HANDLE',[
       ["DWORD","flOptions","in"],
       ["DWORD","dwInitialSize","in"],
       ["DWORD","dwMaximumSize","in"],

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
@@ -1435,7 +1435,7 @@ class Def_kernel32
       ["PDWORD","phModule","out"],
       ])
 
-    dll.add_function( 'GetModuleHandleW', 'DWORD',[
+    dll.add_function( 'GetModuleHandleW', 'HANDLE',[
       ["PWCHAR","lpModuleName","in"],
       ])
 
@@ -2258,23 +2258,23 @@ class Def_kernel32
       ["PBLOB","lpCriticalSection","inout"],
       ])
 
-    dll.add_function( 'LoadLibraryA', 'DWORD',[
+    dll.add_function( 'LoadLibraryA', 'HANDLE',[
       ["PCHAR","lpLibFileName","in"],
       ])
 
-    dll.add_function( 'LoadLibraryExA', 'DWORD',[
+    dll.add_function( 'LoadLibraryExA', 'HANDLE',[
       ["PCHAR","lpLibFileName","in"],
       ["HANDLE","hFile","inout"],
       ["DWORD","dwFlags","in"],
       ])
 
-    dll.add_function( 'LoadLibraryExW', 'DWORD',[
+    dll.add_function( 'LoadLibraryExW', 'HANDLE',[
       ["PWCHAR","lpLibFileName","in"],
       ["HANDLE","hFile","inout"],
       ["DWORD","dwFlags","in"],
       ])
 
-    dll.add_function( 'LoadLibraryW', 'DWORD',[
+    dll.add_function( 'LoadLibraryW', 'HANDLE',[
       ["PWCHAR","lpLibFileName","in"],
       ])
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
@@ -49,7 +49,7 @@ class MultiCaller
       # needed by DLL helper
       @win_consts = win_consts
 
-      if @client.arch == ARCH_X64
+      if @client.native_arch == ARCH_X64
         @native = 'Q<'
       else
         @native = 'V'


### PR DESCRIPTION
This is the metasploit-framework side of the additions to add Railgun support to the Python Meterpreter. This specifically adds the ability to use `railgun_api_multi` with the native architecture and tests this functionality. I tested this with Python 2.7 32 and 64-bit as well as 3.5 32 and 64-bit to ensure all the pointer sizes are correct even in WOW64 environments using the new `native_arch` information.

This PR requires rapid7/metasploit-payloads#179 to test.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use payload/python/meterpreter/reverse_tcp`
- [x] Get a session on a Windows host using Python
- [x]  Run `loadpath test/modules` to load the test modules
- [x] `use post/test/railgun` and run it against the new session
- [x] Ensure that all tests comeback successful

## Example Usage
```
metasploit-framework (S:1 J:1) payload(reverse_tcp) > use post/test/railgun
metasploit-framework (S:1 J:1) post(railgun) > set SESSION -1
SESSION => -1
metasploit-framework (S:1 J:1) post(railgun) > run

[*] [2017.03.01-19:34:20] Running against session -1
[*] [2017.03.01-19:34:20] Session type is meterpreter and platform is windows
[+] [2017.03.01-19:34:20] Should include error information in the results
[+] [2017.03.01-19:34:20] Should support functions with no parameters
[+] [2017.03.01-19:34:20] Should support functions with literal parameters
[+] [2017.03.01-19:34:20] Should support functions with in/out/inout parameter types
[+] [2017.03.01-19:34:20] Should support calling multiple functions at once
[+] [2017.03.01-19:34:20] Should support reading memory
[+] [2017.03.01-19:34:20] Should support writing memory
[*] [2017.03.01-19:34:20] Testing complete in 0.096736179
[*] [2017.03.01-19:34:20] Passed: 7; Failed: 0
[*] Post module execution completed
metasploit-framework (S:1 J:1) post(railgun) > 
```

## Additional Modules
Some additional modules I tested that leverage Railgun and now function with the Python Meterpreter include:
 * post/windows/gather/tcpnetstat
 * post/windows/gather/reverse_lookup
 * post/windows/gather/dnscache_dump

While testing additional modules, I came across an unrelated bug that appears to be causing `have_powershell?` to return false on 2.7 and break on 3.5. I'll get this addressed in a follow up PR as I'm confident it's an issue in how external processes are started and unrelated to the work here.