### PR TITLE
Only enumerate framework files in gemspec when building a gem

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -4,10 +4,14 @@
 # we must manually define the project root
 if ENV['MSF_ROOT']
   lib = File.realpath(File.expand_path('lib', ENV['MSF_ROOT']))
+  files = `git ls-files`.split($/).reject { |file|
+    file =~ /^documentation|^data\/gui|^external/
+  }
 else
-  # have to use realpath as metasploit-framework is often loaded through a symlink and tools like Coverage and debuggers
-  # require realpaths.
+  # have to use realpath as metasploit-framework is often loaded through a
+  # symlink and tools like Coverage and debuggers require realpaths.
   lib = File.realpath(File.expand_path('../lib', __FILE__))
+  files = []
 end
 
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -24,10 +28,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://www.metasploit.com'
   spec.license       = 'BSD-3-clause'
 
-  spec.files         = `git ls-files`.split($/).reject { |file|
-    file =~ /^documentation|^data\/gui|^external/
-  }
-  spec.bindir = '.'
+  spec.files         = files
+  spec.bindir        = '.'
   if ENV['CREATE_BINSTUBS']
     spec.executables   = [
       'msfconsole',


### PR DESCRIPTION
Today, we enumerate all of the framework files in the gemspec whenever framework starts using 'git ls', which isn't terribly expensive, but it doesn't really help unless you're building a gem. Let's guard this behind the gem-building environment variables, so we can only do it when it's really needed.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Ensure it works as before.
- [x] Ensure a proper metasploit-framework gem can be build by R7 automation