### PR TITLE
Fix #8052, remove forgotten OUTPUTPATH option

### DIFF
--- a/modules/auxiliary/pdf/foxit/authbypass.rb
+++ b/modules/auxiliary/pdf/foxit/authbypass.rb
@@ -33,8 +33,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('CMD',        [ false, 'The command to execute.', '/C/Windows/System32/calc.exe']),
-        OptString.new('FILENAME',   [ false, 'The file name.',  'msf.pdf']),
-        OptString.new('OUTPUTPATH', [ false, 'The location of the file.',  './data/exploits/']),
+        OptString.new('FILENAME',   [ false, 'The file name.',  'msf.pdf'])
       ], self.class)
 
   end


### PR DESCRIPTION
Fix #8052

This removes the OUTPUTPATH option because it is no longer needed.

## Verification

- [x] Start msfconsole
- [x] ```use auxiliary/pdf/foxit/authbypass```
- [x] ```run```
- [x] The module should be able to create the malicious PDF
