### PR TITLE
Per PR #8054, we don't need the OUTPUTPATH option here.

### DIFF
--- a/modules/auxiliary/sqli/oracle/droptable_trigger.rb
+++ b/modules/auxiliary/sqli/oracle/droptable_trigger.rb
@@ -32,9 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           OptString.new('SQL',      [ false, 'The SQL to execute.',  'GRANT DBA TO SCOTT']),
           OptString.new('USER',      [ false, 'The current user. ',  'SCOTT']),
-          OptString.new('FILENAME', [ false, 'The file name.',  'msf.sql']),
-          OptString.new('OUTPUTPATH', [ false, 'The location of the file.',  './data/exploits/']),
-
+          OptString.new('FILENAME', [ false, 'The file name.',  'msf.sql'])
         ], self.class)
   end
 


### PR DESCRIPTION
This removes the OUTPUTPATH option because it is no longer needed.

Similar to [PR #8054](https://github.com/rapid7/metasploit-framework/pull/8054).

## Verification

- [x] Start msfconsole
- [x] `use auxiliary/sqli/oracle/droptable_trigger`
- [x] `show options`
- [x] **Verify** you do NOT see an entry for OUTPUTPATH
- [x] `run`
- [x] **Verify** a malicious sql file is created