### PR TITLE
Fix how the psh mixin issues Meterpreter commands

### DIFF
--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -29,7 +29,7 @@ module Msf
         # Returns true if powershell is installed
         #
         def have_powershell?
-          cmd_exec('cmd.exe /c "echo. | powershell get-host"') =~ /Name.*Version.*InstanceId/m
+          cmd_exec('cmd.exe', '/c "echo. | powershell get-host"') =~ /Name.*Version.*InstanceId/m
         end
 
         #
@@ -88,9 +88,9 @@ module Msf
             script = encode_script(script.to_s)
           end
 
-          ps_string = "#{ps_bin} -EncodedCommand #{script} -InputFormat None"
-          vprint_good "EXECUTING:\n#{ps_string}"
-          cmd_out = session.sys.process.execute(ps_string, nil, { 'Hidden' => true, 'Channelized' => true })
+          ps_string = "-EncodedCommand #{script} -InputFormat None"
+          vprint_good "EXECUTING:\n#{ps_bin} #{ps_string}"
+          cmd_out = session.sys.process.execute(ps_bin, ps_string, { 'Hidden' => true, 'Channelized' => true })
 
           # Subtract prior PIDs from current
           if greedy_kill


### PR DESCRIPTION
This PR fixes how the Powershell mixin issues commands to Meterpreter sessions. Prior to this the command was issued as a single string, leading the Python Meterpreter implementation to use this string as a binary and fail. The string should be broken into two parts, allowing the arguments to be in the second. This issue did not seem to affect the Windows Meterpreter implementation, and I did verify that it still continues to function with this patch in place.

## Verification

- [x] Start `msfconsole`
- [x] `use payload/python/meterpreter/reverse_tcp`, generate a payload and corresponding handler
- [x] Execute the payload on a Windows system where Outlook is installed and in use
- [x] Enable VERBOSE output
- [x] `use post/windows/gather/outlook` and run it against the newly opened session
- [x] See the output get to at least the `EXECUTING:` stage with the powershell command below it

```
metasploit-framework (S:4 J:1) post(outlook) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : Windows8VM
OS              : Windows 8.1 (Build 9600)
Architecture    : x64
System Language : en_US
Meterpreter     : python/windows
meterpreter > background
[*] Backgrounding session 2...
metasploit-framework (S:4 J:1) post(outlook) > set SESSION 2
SESSION => 2
metasploit-framework (S:4 J:1) post(outlook) > run

[+] [2017.03.04-12:05:09] PowerShell is installed.
[+] [2017.03.04-12:05:09] Available folders in the mailbox: 
[+] [2017.03.04-12:05:09] EXECUTING:
...
```

**Please note:** with [rapid7/metasploit-payloads#180](https://github.com/rapid7/metasploit-payloads/pull/180) landed the module will finish execution without any errors, however without it the module will fail due to the missing `stdapi_ui_get_idle_time` method.