### PR TITLE
Issue #7188 resolved

### DIFF
--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -82,12 +82,15 @@ module Msf
                 'MsfPayload' => self,
                 'MsfExploit' => assoc_exploit
               })
+	
+	  if (ip=='127.0.0.1' || ip=='127.0.0.2' || ip=='127.0.0.3' || ip=='127.0.0.4'|| ip=='127.0.0.5'||ip=='127.0.0.6' || ip=='127.0.0.7' || 		ip=='127.0.0.8')
+		print_error("Please note that errors might be experienced with this choice of address for LHOST.")
+	  end
           rescue
             ex = $!
             print_error("Handler failed to bind to #{ip}:#{local_port}:- #{comm} -")
           else
             ex = false
-
             via = via_string_for_ip(ip, comm)
             print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
 


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.
Issue number #7188 

## Verification

List the steps needed to make sure this thing works

- [ ] msfconsole
- [ ] use exploit/multi/handler
- [ ] set payload android/meterpreter/reverse_tcp
- [ ] set lhost 127.0.0.1
- [ ] set lport 4444
- [ ] exploit
- [ ] Verify: It will set lhost to 127.0.0.1 and will print a warning : "Please note that errors might be experienced with this choice of address for LHOST."

- [ ] set lhost 127.0.0.54
- [ ] set lport 4444
- [ ] exploit
- [ ] Verify: It will set lhost to 127.0.0.54 and will not print a warning.




