### PR TITLE
Issue #7188 resolved along with checking for all loopback addresses.

### DIFF
--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -82,12 +82,15 @@ module Msf
                 'MsfPayload' => self,
                 'MsfExploit' => assoc_exploit
               })
+	
+	  if (ip=='127.0.0.1' || ip=='127.0.0.2' || ip=='127.0.0.3' || ip=='127.0.0.4'|| ip=='127.0.0.5'||ip=='127.0.0.6' || ip=='127.0.0.7' || 		ip=='127.0.0.8')
+		print_error("Please note that errors might be experienced with this choice of address for LHOST.")
+	  end
           rescue
             ex = $!
             print_error("Handler failed to bind to #{ip}:#{local_port}:- #{comm} -")
           else
             ex = false
-
             via = via_string_for_ip(ip, comm)
             print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
 

--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -48,6 +48,18 @@ module Msf
 
         addrs
       end
+	#Function to check for loopback addresses
+	def loopback_addr(addr)
+	begin
+		a=IPAddr.new(addr.to_s)
+		return true if
+		IPAddr.new('127.0.0.1/8') === a
+		return true if IPAddr.new('::1') ==a
+		rescue
+		end
+		false
+	end
+
 
       # @return [Integer]
       def bind_port
@@ -82,10 +94,11 @@ module Msf
                 'MsfPayload' => self,
                 'MsfExploit' => assoc_exploit
               })
-	
-	  if (ip=='127.0.0.1' || ip=='127.0.0.2' || ip=='127.0.0.3' || ip=='127.0.0.4'|| ip=='127.0.0.5'||ip=='127.0.0.6' || ip=='127.0.0.7' || 		ip=='127.0.0.8')
-		print_error("Please note that errors might be experienced with this choice of address for LHOST.")
-	  end
+	#Checking whether LHOST is a loopback address	
+	if loopback_addr(ip) ==true
+		print_warning ("You are attempting to listen on a loopback address by setting LHOST to #{ip}, did you mean to set ReverseListenerBindAddress instead?\n")
+	end	
+	 
           rescue
             ex = $!
             print_error("Handler failed to bind to #{ip}:#{local_port}:- #{comm} -")


### PR DESCRIPTION
## 	Issue #7188 resolved along with checking for all loopback addresses

## Verification

List the steps needed to make sure this thing works

- [ ] Start 'msfconsole'
- [ ] `use exploit/multi/handler`
- [ ] set payload android/meterpreter/reverse_tcp
- [ ] set LHOST 127.255.255.1
- [ ] set LPORT 4444
- [ ] exploit
- [ ] **Verify**  Sets LHOST to 127.255.255.1 and issues a warning message: "You are attempting to listen on a loopback address by setting 127.255.255.1, did you mean to set ReverseListenerBindAddress"

- [ ] set LHOST 192.168.0.100 (Or any other IP)
- [ ] set LPORT 4444
- [ ] exploit
- [ ] **Verify** Sets LHOST to 192.168.0.100 and doesn't issue a warning message as it is not a loopback adress.

