### PR TITLE
Warn when setting RHOST option for module which expects RHOSTS

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1531,6 +1531,16 @@ class Core
       end
     end
 
+    # Warn when setting RHOST option for module which expects RHOSTS
+    if args.first.upcase.eql?('RHOST')
+      mod = active_module
+      unless mod.nil?
+        if !mod.options.include?('RHOST') && mod.options.include?('RHOSTS')
+          print_warning("RHOST is not a valid option for this module. Did you mean RHOSTS?")
+        end
+      end
+    end
+
     # Set the supplied name to the supplied value
     name  = args[0]
     value = args[1, args.length-1].join(' ')


### PR DESCRIPTION
This PR adds a warning to the `set` command, triggered when the user attempts to set `RHOST` for a module which expects `RHOSTS`, providing two minor benefits to user experience.

A quick grep of all framework modules reveals only auxiliary modules make use of the `RHOSTS` option while also de-registering the `RHOST` option.

Firstly, from a user experience perspective, it's nice that the user gets a warning when setting `RHOST` for a module which expects `RHOSTS` as they're immediately notified that they should set `RHOSTS`, rather than attempting to `run` the module only to find it was misconfigured.

Secondly, and more importantly, this patch fixes an edge case. As an example, consider a scenario where a user wishes to brute-force SMB logins for local user accounts. Knowing that some IPs within the target IP range are duplicate adapters for the same host, and wanting to avoid detection, the user carefully selects and scans one remote host at a time rather than running the module against all remote hosts.

After successfully scanning the first few hosts the user forgets that the auxiliary modules play by different rules to ever other module in the framework, mistakenly sets `RHOST` instead of `RHOSTS`, then runs the module. As a result, the `RHOSTS` option is still set to the previous IP address, the user locks out user accounts on the host, the attack gets noticed, the IT support team has to unlock a bunch of accounts, and everyone has a bad day.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] `set RHOST test.local`
- [x] Verify a warning is printed
- [x] `set RHOSTS test.local`
- [x] Verify RHOSTS is set
