### PR TITLE
Apache Struts2 S2-045 RCE(CVE-2017-5638)

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -17,27 +17,27 @@ class RPC_Plugin < RPC_Base
   #  # Load the nexpose plugin
   #  rpc.call('plugin.load', 'nexpose')
   def rpc_load(path, xopts = {})
-    opts  = {}
+    opts = {}
 
-    xopts.each do |k,v|
+    xopts.each do |k, v|
       if k.class == String
         opts[k.to_sym] = v
       end
     end
 
-    if (path !~ /#{File::SEPARATOR}/)
+    if path !~ /#{File::SEPARATOR}/
       plugin_file_name = path
 
       # If the plugin isn't in the user direcotry (~/.msf3/plugins/), use the base
       path = Msf::Config.user_plugin_directory + File::SEPARATOR + plugin_file_name
-      if not File.exist?( path  + ".rb" )
+      if not File.exist?(path + ".rb")
         # If the following "path" doesn't exist it will be caught when we attempt to load
         path = Msf::Config.plugin_directory + File::SEPARATOR + plugin_file_name
       end
     end
 
     begin
-      if (self.framework.plugins.load(path, opts))
+      if self.framework.plugins.load(path, opts)
         return { "result" => "success" }
       end
     rescue ::Exception => e
@@ -57,13 +57,13 @@ class RPC_Plugin < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('plugin.unload', 'nexpose')
   def rpc_unload(name)
-    self.framework.plugins.each { |plugin|
+    self.framework.plugins.each do |plugin|
       # Unload the plugin if it matches the name we're searching for
-      if (plugin.name == name)
+      if plugin.name == name
         self.framework.plugins.unload(plugin)
         return { "result" => "success" }
       end
-    }
+    end
     return { "result" => "failure" }
 
   end
@@ -78,7 +78,7 @@ class RPC_Plugin < RPC_Base
   def rpc_loaded
     ret = {}
     ret[:plugins] = []
-    self.framework.plugins.each do  |plugin|
+    self.framework.plugins.each do |plugin|
       ret[:plugins] << plugin.name
     end
     ret

--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -37,12 +37,12 @@ class RPC_Plugin < RPC_Base
     end
 
     begin
-      if (inst = self.framework.plugins.load(path, opts))
-        return 	{ "result" => "success" }
+      if (self.framework.plugins.load(path, opts))
+        return { "result" => "success" }
       end
     rescue ::Exception => e
-      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", src = 'core', level = 0, from = caller)
-      return 	{ "result" => "failure" }
+      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0, caller)
+      return { "result" => "failure" }
     end
 
   end
@@ -61,10 +61,10 @@ class RPC_Plugin < RPC_Base
       # Unload the plugin if it matches the name we're searching for
       if (plugin.name == name)
         self.framework.plugins.unload(plugin)
-        return 	{ "result" => "success" }
+        return { "result" => "success" }
       end
     }
-    return 	{ "result" => "failure" }
+    return { "result" => "failure" }
 
   end
 


### PR DESCRIPTION
The exploit of apache Struts2 S2-045 remote code execution.
See: https://cwiki.apache.org/confluence/display/WW/S2-045

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/struts2_s2045_rce`
- [ ] `info`
- [ ] `set rhost 172.16.0.33`
- [ ] `set rport 8080`
- [ ] `set payload windows/exec`
- [ ] `set cmd whoami`
- [ ] `exploit`
