### PR TITLE
Allow start_service to specify a resource

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -160,7 +160,7 @@ module Exploit::Remote::HttpServer
                       filter_request_uri(cli, req)
                     ) ? nil : on_request_uri(cli, req)
         },
-      'Path' => resource_uri
+      'Path' => opts['Path'] || resource_uri
     }.update(opts['Uri'] || {})
 
     proto = (datastore["SSL"] ? "https" : "http")


### PR DESCRIPTION
This overrides `URIPATH` and `random_uri` if `opts['Path']` is specified.

#7968