### PR TITLE
Add rcheck/recheck to aux modules and exploits

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -27,9 +27,11 @@ class Auxiliary
   #
   def commands
     super.update({
-      "run"   => "Launches the auxiliary module",
-      "rerun" => "Reloads and launches the auxiliary module",
-      "exploit" => "This is an alias for the run command",
+      "run"      => "Launches the auxiliary module",
+      "rcheck"   => "Reloads the module and checks if the target is vulnerable",
+      "rerun"    => "Reloads and launches the auxiliary module",
+      "exploit"  => "This is an alias for the run command",
+      "recheck"  => "This is an alias for the rcheck command",
       "rexploit" => "This is an alias for the rerun command",
       "reload"   => "Reloads the auxiliary module"
     }).merge( (mod ? mod.auxiliary_commands : {}) )
@@ -146,6 +148,18 @@ class Auxiliary
   end
 
   alias cmd_exploit_help cmd_run_help
+
+  #
+  # Reloads an auxiliary module and checks the target to see if it's
+  # vulnerable.
+  #
+  def cmd_rcheck(*args)
+    reload()
+
+    cmd_check(*args)
+  end
+
+  alias cmd_recheck cmd_rcheck
 
 end
 

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -32,9 +32,10 @@ class Exploit
       "exploit"  => "Launch an exploit attempt",
       "rcheck"   => "Reloads the module and checks if the target is vulnerable",
       "rexploit" => "Reloads the module and launches an exploit attempt",
-      "reload"   => "Just reloads the module",
       "run"      => "Alias for exploit",
+      "recheck"  => "Alias for rcheck",
       "rerun"    => "Alias for rexploit",
+      "reload"   => "Just reloads the module"
     })
   end
 
@@ -185,6 +186,8 @@ class Exploit
 
     cmd_check(*args)
   end
+
+  alias cmd_recheck cmd_rcheck
 
   #
   # Reloads an exploit module and launches an exploit.


### PR DESCRIPTION
This has been annoying me for quite some time.

Now you can `reload` a module and run `check` again in one fell swoop. Also corrects a frequent typo of `recheck`.

- [x] Test `rcheck` and `recheck` (alias) for an aux module
- [x] Test `rcheck` and `recheck` (alias) for an exploit
- [x] Make sure the `help` messages look good