### PR TITLE
Add some binaries to enum_protections

### DIFF
--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -71,7 +71,8 @@ class MetasploitModule < Msf::Post
       "truecrypt", "bulldog", "ufw", "iptables", "logrotate", "logwatch",
       "chkrootkit", "clamav", "snort", "tiger", "firestarter", "avast", "lynis",
       "rkhunter", "tcpdump", "webmin", "jailkit", "pwgen", "proxychains", "bastille",
-      "psad", "wireshark", "nagios", "nagios", "apparmor", "honeyd", "thpot"
+      "psad", "wireshark", "nagios", "nagios", "apparmor", "honeyd", "thpot",
+      "aa-status", "gradm2", "getenforce"
     ]
 
     env_paths = cmd_exec("echo $PATH").split(":")


### PR DESCRIPTION
This PR adds some bonaries to the `post/linux/gather/enum_protections` module:

- gradm2 for grsec
- aa-status for apparmor
- getenforce for setlinux

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] get a session
- [x] run `post/linux/gather/enum_protections`
- [x] **Verify** that grsec/apparmor/selinux are detected

