### PR TITLE
support rails usage of spec files list

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -2,7 +2,7 @@
 
 # During build, the Gemfile is temporarily moved and
 # we must manually define the project root
-if ENV['MSF_ROOT']
+if ENV['MSF_ROOT'] || ENV['RAILS_ENV']
   lib = File.realpath(File.expand_path('lib', ENV['MSF_ROOT']))
   files = `git ls-files`.split($/).reject { |file|
     file =~ /^documentation|^data\/gui|^external/


### PR DESCRIPTION
Enumerate gem files list when a rails environment is detected.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Ensure it works as before.
- [x] Ensure a proper metasploit-framework gem can be build by R7 automation