### PR TITLE
Adds a new http fuzzer module

### DIFF
--- a/modules/auxiliary/fuzzers/http/http_post_strings.rb
+++ b/modules/auxiliary/fuzzers/http/http_post_strings.rb
@@ -24,7 +24,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
 def run
-  print_status("Aamir's HTTP Fuzzer Metasploit module")
   head = "POST / HTTP/1.0\r\n"
   char = datastore['CHAR']
   header = datastore['HEADER']

--- a/modules/auxiliary/fuzzers/http/http_post_strings.rb
+++ b/modules/auxiliary/fuzzers/http/http_post_strings.rb
@@ -15,11 +15,11 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
       ))
     register_options([
-      Opt::RPORT(8000),
+      Opt::RPORT(80),
       OptInt.new("LENGTH", [true, "The length of the string being sent", 10]),
       OptString.new("HEADER", [true, "HTTP Header to Fuzz, Options: none, content-type, user-agent, referer, auth, host, cookie","none"]),
       OptString.new("CHAR", [true, "The character used to build the string", "A"]),
-      OptBool.new("PATTERN", [true, "If true the string will be created using msf parrern create rather than the set char","false"]),
+      OptBool.new("PATTERN", [true, "If true the string will be created using msf pattern create rather than the value of CHAR","false"]),
     ], self.class)
   end
 

--- a/modules/auxiliary/fuzzers/http/http_post_strings.rb
+++ b/modules/auxiliary/fuzzers/http/http_post_strings.rb
@@ -3,7 +3,6 @@ require 'msf/core'
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::Tcp
-  include Msf::Auxiliary::Fuzzer
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/auxiliary/fuzzers/http/http_post_strings.rb
+++ b/modules/auxiliary/fuzzers/http/http_post_strings.rb
@@ -1,0 +1,67 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Fuzzer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => "HTTP POST Fuzzer",
+      'Description'    => %q{
+        This module will fuzz a http server by sending a string generated from the options set as HTTP POST data
+      },
+      'Author'         => [ 'Aamir Mir <aamir[at]aamir.info>' ],
+      'License'        => MSF_LICENSE
+      ))
+    register_options([
+      Opt::RPORT(8000),
+      OptInt.new("LENGTH", [true, "The length of the string being sent", 10]),
+      OptString.new("HEADER", [true, "HTTP Header to Fuzz, Options: none, content-type, user-agent, referer, auth, host, cookie","none"]),
+      OptString.new("CHAR", [true, "The character used to build the string", "A"]),
+      OptBool.new("PATTERN", [true, "If true the string will be created using msf parrern create rather than the set char","false"]),
+    ], self.class)
+  end
+
+def run
+  print_status("Aamir's HTTP Fuzzer Metasploit module")
+  head = "POST / HTTP/1.0\r\n"
+  char = datastore['CHAR']
+  header = datastore['HEADER']
+  len = datastore['LENGTH'].to_i
+
+  if header == "none"
+    bad_head = "\r\n"
+  elsif header == "user-agent"
+    bad_head = "User-Agent: "
+  elsif header == "content-type"
+    bad_head = "Content-Type: "
+  elsif header == "referer"
+    bad_head = "Referer: "
+  elsif header == "auth"
+    bad_head = "Authorization: Basic "
+  elsif header == "host"
+    bad_head = "Host: "
+  elsif header == "cookie"
+    bad_head = "Cookie: "
+  else
+    abort("Header is not a valid option")
+  end
+
+  if datastore['PATTERN']
+    bad = Rex::Text.pattern_create(len)
+  else
+    bad = char * len
+  end
+
+  foot = "\r\n\r\n"
+
+  final_bad = head + bad_head + bad + foot
+  print_status("The fuzz string being sent is: ")
+  print_status(final_bad.dump)
+  connect
+  sock.put(final_bad)
+  sock.get_once(timeout = 5)
+  disconnect
+ end
+end


### PR DESCRIPTION
This module allows the user to generate a sting to be sent as HTTP post data. it allows it to be sent as POST data without a field type or select a specific header to use. There are user settable options for, RHOST, string length, header type, character used to build the string and the option to use pattern_create to form the string.

This differs from http_form_field as it contains headers that are different as well as allowing more control over the string being sent. It is intended that this will be used towards the end of the fuzzing process to fine tune a fuzz string.

All the options are required, however they are all set by default so as long as a http server is running on the RHOST:RPORT then nothing needs to be done. Checks are done to make sure the header option does not contain an invalid header type.

## Verification
List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/fuzzers/http/http_post_strings`
- [ ]  `set RHOST`
- [ ]  `set RPORT`
- [ ]  Optionally change default values of other options
- [ ]  `run` and check if the generated string is outputted to the console

Console Output
```
msf > use auxiliary/fuzzers/http/http_post_strings 
msf auxiliary(http_post_strings) > set RHOST 192.168.201.78
RHOST => 192.168.201.78
msf auxiliary(http_post_strings) > set RPORT 8000
RPORT => 8000
msf auxiliary(http_post_strings) > run

[*] 192.168.201.78:8000 - Aamir's HTTP Fuzzer Metasploit module
[*] 192.168.201.78:8000 - The fuzz string being sent is: 
[*] 192.168.201.78:8000 - "POST / HTTP/1.0\r\n\r\nAAAAAAAAAA\r\n\r\n"
[*] Auxiliary module execution completed
```
