### PR TITLE
Msfcrawler improvement (and bug fixes)

### DIFF
--- a/data/msfcrawler/basic.rb
+++ b/data/msfcrawler/basic.rb
@@ -1,17 +1,8 @@
 ##
-# $Id$
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
-##
-
-# $Revision$
-
-require 'rubygems'
 require 'pathname'
 require 'nokogiri'
 require 'uri'
@@ -19,10 +10,7 @@ require 'uri'
 class CrawlerSimple < BaseParser
 
   def parse(request,result)
-
-    if !result['Content-Type'].include? "text/html"
-      return
-    end
+    return unless result['Content-Type'].include?('text/html')
 
     # doc = Hpricot(result.body.to_s)
     doc = Nokogiri::HTML(result.body.to_s)

--- a/data/msfcrawler/comments.rb
+++ b/data/msfcrawler/comments.rb
@@ -1,0 +1,31 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'pathname'
+require 'nokogiri'
+require 'uri'
+
+class CrawlerComments < BaseParser
+
+  def parse(request,result)
+    return unless result['Content-Type'].include?('text/html')
+
+    doc = Nokogiri::HTML(result.body.to_s)
+    doc.xpath('//comment()').each do |comment|
+      # searching for href
+      hr = /href\s*=\s*"([^"]*)"/.match(comment)
+      if hr
+        begin
+          hreq = urltohash('GET', hr[1], request['uri'], nil)
+          insertnewpath(hreq)
+        rescue URI::InvalidURIError
+          # ignored
+        end
+      end
+
+    end
+
+  end
+end

--- a/data/msfcrawler/forms.rb
+++ b/data/msfcrawler/forms.rb
@@ -1,17 +1,8 @@
 ##
-# $Id$
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
-##
-
-# $Revision$
-
-require 'rubygems'
 require 'pathname'
 require 'nokogiri'
 require 'uri'
@@ -19,28 +10,21 @@ require 'uri'
 class CrawlerForms < BaseParser
 
   def parse(request,result)
-
-    if !result['Content-Type'].include? "text/html"
-      return
-    end
-
-    hr = ''
-    m = ''
+    return unless result['Content-Type'].include?('text/html')
 
     doc = Nokogiri::HTML(result.body.to_s)
     doc.css('form').each do |f|
       hr = f['action']
 
-      fname = f['name']
-      fname = "NONE" if fname.empty?
+      # Removed because unused
+      #fname = f['name']
+      #fname = 'NONE' if fname.empty?
 
-      m = f['method'].empty? ? 'GET' : f['method'].upcase
-
-      htmlform = Nokogiri::HTML(f.inner_html)
+      m = (f['method'].empty? ? 'GET' : f['method'].upcase)
 
       arrdata = []
 
-      htmlform.css('input').each do |p|
+      f.css('input').each do |p|
         arrdata << "#{p['name']}=#{Rex::Text.uri_encode(p['value'])}"
       end
 
@@ -51,7 +35,10 @@ class CrawlerForms < BaseParser
         hreq['ctype'] = 'application/x-www-form-urlencoded'
         insertnewpath(hreq)
       rescue URI::InvalidURIError
+        #puts "Parse error"
+        #puts "Error: #{link[0]}"
       end
+
     end
   end
 end

--- a/data/msfcrawler/frames.rb
+++ b/data/msfcrawler/frames.rb
@@ -1,13 +1,8 @@
-
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-require 'rubygems'
 require 'pathname'
 require 'nokogiri'
 require 'uri'
@@ -27,6 +22,7 @@ class CrawlerFrames < BaseParser
           hreq = urltohash('GET', ir, request['uri'], nil)
           insertnewpath(hreq)
         rescue URI::InvalidURIError
+          # ignored
         end
       end
 

--- a/data/msfcrawler/image.rb
+++ b/data/msfcrawler/image.rb
@@ -1,14 +1,8 @@
-
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# $Revision: 9212 $
-
-require 'rubygems'
 require 'pathname'
 require 'nokogiri'
 require 'uri'
@@ -27,6 +21,7 @@ class CrawlerImage < BaseParser
           hreq = urltohash('GET', im, request['uri'], nil)
           insertnewpath(hreq)
         rescue URI::InvalidURIError
+          # ignored
         end
       end
 

--- a/data/msfcrawler/link.rb
+++ b/data/msfcrawler/link.rb
@@ -1,14 +1,8 @@
-
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# $Revision: 9212 $
-
-require 'rubygems'
 require 'pathname'
 require 'nokogiri'
 require 'uri'
@@ -26,6 +20,7 @@ class CrawlerLink < BaseParser
           hreq = urltohash('GET', hr, request['uri'], nil)
           insertnewpath(hreq)
         rescue URI::InvalidURIError
+          # ignored
         end
       end
 

--- a/data/msfcrawler/objects.rb
+++ b/data/msfcrawler/objects.rb
@@ -1,17 +1,8 @@
 ##
-# $Id$
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
-##
-
-# $Revision$
-
-require 'rubygems'
 require 'pathname'
 require 'nokogiri'
 require 'uri'
@@ -29,6 +20,7 @@ class CrawlerObjects < BaseParser
         hreq = urltohash('GET', s, request['uri'], nil)
         insertnewpath(hreq)
       rescue URI::InvalidURIError
+        # ignored
       end
     end
   end

--- a/data/msfcrawler/scripts.rb
+++ b/data/msfcrawler/scripts.rb
@@ -1,17 +1,8 @@
 ##
-# $Id$
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
-##
-
-# $Revision$
-
-require 'rubygems'
 require 'pathname'
 require 'nokogiri'
 require 'uri'
@@ -21,8 +12,6 @@ class CrawlerScripts < BaseParser
   def parse(request,result)
     return unless result['Content-Type'].include? "text/html"
 
-    hr = ''
-    m = ''
     doc = Nokogiri::HTML(result.body.to_s)
     doc.xpath("//script").each do |obj|
       s = obj['src']
@@ -30,6 +19,7 @@ class CrawlerScripts < BaseParser
         hreq = urltohash('GET', s, request['uri'], nil)
         insertnewpath(hreq)
       rescue URI::InvalidURIError
+        # ignored
       end
     end
 

--- a/modules/auxiliary/crawler/msfcrawler.rb
+++ b/modules/auxiliary/crawler/msfcrawler.rb
@@ -180,14 +180,18 @@ class MetasploitModule < Msf::Auxiliary
 
   def storedb(hashreq,response,dbpath)
 
+    # Added host/port/ssl for report_web_page support
     info = {
       :web_site => @current_site,
       :path     => hashreq['uri'],
       :query    => hashreq['query'],
-      :data	=> hashreq['data'],
-      :code     => response['code'],
-      :body     => response['body'],
-      :headers  => response['headers']
+      :host     => hashreq['rhost'],
+      :port     => hashreq['rport'],
+      :ssl      => !hashreq['ssl'].nil?,
+      :data	    => hashreq['data'],
+      :code     => response.code,
+      :body     => response.body,
+      :headers  => response.headers
     }
 
     #if response['content-type']


### PR DESCRIPTION
- Fixing StoreDB function on msfcrawler

- Add sub-module for catching links in html comments
- Fixing errors in 'data/msfcrawler/forms.rb' sub-module : 
```
[*] ERROR
[*] undefined method `empty?' for nil:NilClass: ["(eval):35:in `block in parse'", 
```
and
```
encoding error : output conversion failed due to conv error, bytes 0xA4 0x31 0x2E 0x30
I/O error : encoder error
```
- Remove old banners, "rubygems" requirements, executable marks

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/crawler/msfcrawler`
- [ ] `set StoreDB true`
- [ ] set the other options required
- [ ] `run`
- [ ] **Verify** It should work, you can verify with `wmap_sites -l` for example

