### PR TITLE
temporarily fix bundles on aarch64 platforms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   # module documentation
   gem 'octokit', '~> 4.0'
   # session aggregator, native builds have issues on arm platforms for now
-  gem 'metasploit-aggregator' if !RUBY_PLATFORM.include?('arm')
+  gem 'metasploit-aggregator' if !RUBY_PLATFORM =~ /arm|aarch64/
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,10 @@ group :development do
   # module documentation
   gem 'octokit', '~> 4.0'
   # session aggregator, native builds have issues on arm platforms for now
-  gem 'metasploit-aggregator' if !RUBY_PLATFORM =~ /arm|aarch64/
+  gem 'metasploit-aggregator' if [
+    'x86-mingw32', 'x64-mingw32',
+    'x86_64-linux', 'x86-linux',
+    'darwin'].include?(RUBY_PLATFORM.gsub(/.*darwin.*/, 'darwin'))
 end
 
 group :development, :test do


### PR DESCRIPTION
The grpc gem fails on new platforms where there are not prebuild binaries due to some aggressive build options. Let's whitelist until these issues are resolved upstream.