### PR TITLE
fix migrate by process name

### DIFF
--- a/modules/post/windows/manage/migrate.rb
+++ b/modules/post/windows/manage/migrate.rb
@@ -23,8 +23,8 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptBool.new(   'SPAWN',[ false,'Spawn process to migrate to. If name for process not given notepad.exe is used.', true]),
-        OptInt.new(    'PID',  [false, 'PID of process to migrate to.']),
-        OptString.new( 'NAME', [false, 'Name of process to migrate to.']),
+        OptInt.new(    'PID',  [false, 'PID of process to migrate to.', nil]),
+        OptString.new( 'NAME', [false, 'Name of process to migrate to.', nil]),
         OptBool.new(   'KILL', [false, 'Kill original process for the session.', false])
       ], self.class)
   end
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
     if datastore['SPAWN']
       print_status("Spawning notepad.exe process to migrate to")
       target_pid = create_temp_proc
-    elsif datastore['PID'] != 0
+    elsif datastore['PID']
       target_pid = datastore['PID']
     elsif datastore['NAME']
       target_pid = session.sys.process[datastore['NAME']]


### PR DESCRIPTION
Fixes #8109

This fixes the ability to migrate into a process by name (e.g., explorer.exe). The if/else block would never reach the NAME check because `pid != 0` is always true (unless for some reason you specifically set it to 0).