### PR TITLE
Add pkill and pgrep to meterpreter prompt

### DIFF
--- a/lib/rex/parser/arguments.rb
+++ b/lib/rex/parser/arguments.rb
@@ -1,108 +1,94 @@
 # -*- coding: binary -*-
+# frozen_string_literal: true
 require 'shellwords'
 
 module Rex
-module Parser
-
-###
-#
-# This class parses arguments in a getopt style format, kind of.
-# Unfortunately, the default ruby getopt implementation will only
-# work on ARGV, so we can't use it.
-#
-###
-class Arguments
-
-  #
-  # Specifies that an option is expected to have an argument
-  #
-  HasArgument = (1 << 0)
-
-  #
-  # Initializes the format list with an array of formats like:
-  #
-  # Arguments.new(
-  #    '-b' => [ false, "some text" ]
-  # )
-  #
-  def initialize(fmt)
-    self.fmt = fmt
-    # I think reduce is a better name for this method, but it doesn't exist
-    # before 1.8.7, so use the stupid inject instead.
-    self.longest = fmt.keys.inject(0) { |max, str|
-      max = ((max > str.length) ? max : str.length)
-    }
-  end
-
-  #
-  # Takes a string and converts it into an array of arguments.
-  #
-  def self.from_s(str)
-    Shellwords.shellwords(str)
-  end
-
-  #
-  # Parses the supplied arguments into a set of options.
-  #
-  def parse(args, &block)
-    skip_next = false
-
-    args.each_with_index { |arg, idx|
-      if (skip_next == true)
-        skip_next = false
-        next
+  module Parser
+    ###
+    #
+    # This class parses arguments in a getopt style format, kind of.
+    # Unfortunately, the default ruby getopt implementation will only
+    # work on ARGV, so we can't use it.
+    #
+    ###
+    class Arguments
+      #
+      # Initializes the format list with an array of formats like:
+      #
+      # Arguments.new(
+      #    '-b' => [ false, "some text" ]
+      # )
+      #
+      def initialize(fmt)
+        self.fmt = fmt
+        self.longest = fmt.keys.max_by(&:length)
       end
 
-      if (arg.match(/^-/))
-        cfs = arg[0..2]
+      #
+      # Takes a string and converts it into an array of arguments.
+      #
+      def self.from_s(str)
+        Shellwords.shellwords(str)
+      end
 
-        fmt.each_pair { |fmtspec, val|
-          next if (fmtspec != cfs)
+      #
+      # Parses the supplied arguments into a set of options.
+      #
+      def parse(args, &_block)
+        skip_next = false
 
-          param = nil
-
-          if (val[0])
-            param = args[idx+1]
-            skip_next = true
+        args.each_with_index do |arg, idx|
+          if skip_next
+            skip_next = false
+            next
           end
 
-          yield fmtspec, idx, param
-        }
-      else
-        yield nil, idx, arg
+          if arg[0] == '-'
+            cfs = arg[0..2]
+
+            fmt.each_pair do |fmtspec, val|
+              next if fmtspec != cfs
+
+              param = nil
+
+              if val[0]
+                param = args[idx + 1]
+                skip_next = true
+              end
+
+              yield fmtspec, idx, param
+            end
+          else
+            yield nil, idx, arg
+          end
+        end
       end
-    }
+
+      #
+      # Returns usage information for this parsing context.
+      #
+      def usage
+        txt = ["\nOPTIONS:\n"]
+
+        fmt.sort.each do |entry|
+          fmtspec, val = entry
+          opt = val[0] ? " <opt>  " : "        "
+          txt << "    #{fmtspec.ljust(longest.length)}#{opt}#{val[1]}"
+        end
+
+        txt.join("\n")
+      end
+
+      def include?(search)
+        fmt.include?(search)
+      end
+
+      def arg_required?(opt)
+        fmt[opt][0] if fmt[opt]
+      end
+
+      attr_accessor :fmt     # :nodoc:
+      attr_accessor :longest # :nodoc:
+    end
   end
-
-  #
-  # Returns usage information for this parsing context.
-  #
-  def usage
-    txt = "\nOPTIONS:\n\n"
-
-    fmt.sort.each { |entry|
-      fmtspec, val = entry
-
-      txt << "    #{fmtspec.ljust(longest)}" + ((val[0] == true) ? " <opt>  " : "        ")
-      txt << val[1] + "\n"
-    }
-
-    txt << "\n"
-
-    return txt
-  end
-  def include?(search)
-    return fmt.include?(search)
-  end
-
-  def arg_required?(opt)
-    fmt[opt][0] if fmt[opt]
-  end
-
-  attr_accessor :fmt     # :nodoc:
-  attr_accessor :longest # :nodoc:
-
-end
-
-end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -421,9 +421,20 @@ class Console::CommandDispatcher::Stdapi::Sys
       return true
     end
 
-    pids = processes.collect { |p| p['pid'] }
-    pids.each do | pid |
-      print_line(pid.to_s)
+    # XXX fix Rex parser to properly handle adjacent short flags
+    f_flag = args.include?('-f') || args.include?('-lf') || args.include?('-fl')
+    l_flag = args.include?('-l') || args.include?('-lf') || args.include?('-fl')
+
+    processes.each do |p|
+      if l_flag
+        if f_flag
+          print_line("#{p['pid']} #{p['path']}")
+        else
+          print_line("#{p['pid']} #{p['name']}")
+        end
+      else
+        print_line("#{p['pid']}")
+      end
     end
     true
   end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -393,7 +393,7 @@ class Console::CommandDispatcher::Stdapi::Sys
       return true
     end
 
-    pids = processes.collect { |p| p['pid'] }
+    pids = processes.collect { |p| p['pid'] }.reverse
     print_line("Killing: #{pids.join(', ')}")
     client.sys.process.kill(*(pids.map { |x| x }))
     true

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -63,12 +63,13 @@ class Console::CommandDispatcher::Stdapi::Sys
   # Options for the 'ps' command.
   #
   @@ps_opts = Rex::Parser::Arguments.new(
-    "-S" => [ true,  "String to search for (converts to regex)" ],
-    "-h" => [ false, "Help menu." ],
-    "-A" => [ true,  "Filters processes on architecture" ],
-    "-s" => [ false, "Show only SYSTEM processes" ],
-    "-c" => [ false, "Show only child processes of the current shell" ],
-    "-U" => [ true,  "Filters processes on the user using the supplied RegEx"])
+    "-S" => [ true,  "Filter on process name" ],
+    "-U" => [ true,  "Filter on user name" ],
+    "-A" => [ true,  "Filter on architecture" ],
+    "-x" => [ false, "Filter for exact matches rather than regex" ],
+    "-s" => [ false, "Filter only SYSTEM processes" ],
+    "-c" => [ false, "Filter only child processes of the current shell" ],
+    "-h" => [ false, "Help menu." ])
 
   #
   # Options for the 'suspend' command.
@@ -92,6 +93,7 @@ class Console::CommandDispatcher::Stdapi::Sys
       "getsid"      => "Get the SID of the user that the server is running as",
       "getenv"      => "Get one or more environment variable values",
       "kill"        => "Terminate a process",
+      "pkill"       => "Terminate a process by name",
       "ps"          => "List running processes",
       "reboot"      => "Reboots the remote computer",
       "reg"         => "Modify and interact with the remote registry",
@@ -113,6 +115,7 @@ class Console::CommandDispatcher::Stdapi::Sys
       "getsid"      => [ "stdapi_sys_config_getsid" ],
       "getenv"      => [ "stdapi_sys_config_getenv" ],
       "kill"        => [ "stdapi_sys_process_kill" ],
+      "pkill"       => [ "stdapi_sys_process_kill" ],
       "ps"          => [ "stdapi_sys_process_get_processes" ],
       "reboot"      => [ "stdapi_sys_power_exitwindows" ],
       "reg"	      => [
@@ -367,12 +370,37 @@ class Console::CommandDispatcher::Stdapi::Sys
   end
 
   #
-  # help for the kill command
+  # Kills one or more processes by name.
   #
-  def cmd_kill_help
-    print_line("Usage: kill [pid1 [pid2 [pid3 ...]]] [-s]")
-    print_line("Terminate one or more processes.")
-    print_line(" -s : Kills the pid associated with the current session.")
+  def cmd_pkill(*args)
+    if args.include?('-h')
+      cmd_pkill_help
+      return true
+    end
+
+    all_processes = client.sys.process.get_processes
+    processes = match_processes(all_processes, args)
+
+    if processes.length == 0
+      print_line("No matching processes were found.")
+      return true
+    end
+
+    if processes.length == all_processes.length && !args.include?('-f')
+      print_error("All processes will be killed, use '-f' to force.")
+      return true
+    end
+
+    pids = processes.collect { |p| p['pid'] }
+    print_line("Killing: #{pids.join(', ')}")
+    client.sys.process.kill(*(pids.map { |x| x }))
+    true
+  end
+
+  def cmd_pkill_help
+    print_line("Usage: pkill [ options ] pattern")
+    print_line("Terminate one or more processes by name.")
+    print_line @@ps_opts.usage
   end
 
   #
@@ -418,7 +446,87 @@ class Console::CommandDispatcher::Stdapi::Sys
         valid_pids << pid
       end
     end
-    return valid_pids
+    valid_pids
+  end
+
+  def match_processes(processes, args)
+
+    search_proc = nil
+    search_user = nil
+    exact_match = false
+
+    # Parse opts
+    @@ps_opts.parse(args) do |opt, idx, val|
+      case opt
+      when '-S', nil
+        if val.nil? || val.empty?
+          print_error "Enter a process name"
+          processes = []
+        else
+          search_proc = val
+        end
+      when "-U"
+        if val.nil? || val.empty?
+          print_line "Enter a process user"
+          processes = []
+        else
+          search_user = val
+        end
+      when '-x'
+        exact_match = true
+      when "-A"
+        if val.nil? || val.empty?
+          print_error "Enter an architecture"
+          processes = []
+        else
+          print_line "Filtering on arch '#{val}"
+          processes = processes.select do |p|
+            p['arch'] == val
+          end
+        end
+      when "-s"
+        print_line "Filtering on SYSTEM processes..."
+        processes = processes.select do |p|
+          ["NT AUTHORITY\\SYSTEM", "root"].include? p['user']
+        end
+      when "-c"
+        print_line "Filtering on child processes of the current shell..."
+        current_shell_pid = client.sys.process.getpid
+        processes = processes.select do |p|
+          p['ppid'] == current_shell_pid
+        end
+      end
+    end
+
+    unless search_proc.nil?
+      print_line "Filtering on '#{search_proc}'"
+      if exact_match
+        processes = processes.select do |p|
+          p['name'] == search_proc
+        end
+      else
+        match = /#{search_proc}/
+        processes = processes.select do |p|
+          p['name'] =~ match
+        end
+      end
+    end
+
+    unless search_user.nil?
+      print_line "Filtering on user '#{search_user}'"
+      if exact_match
+        processes = processes.select do |p|
+          p['user'] == search_user
+        end
+      else
+        match = /#{search_user}/
+        processes = processes.select do |p|
+          p['user'] =~ match
+        end
+      end
+    end
+
+    Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new(processes)
   end
 
   #
@@ -430,79 +538,27 @@ class Console::CommandDispatcher::Stdapi::Sys
       return true
     end
 
-    # Init vars
-    processes = client.sys.process.get_processes
-    search_term = nil
+    all_processes = client.sys.process.get_processes
+    processes = match_processes(all_processes, args)
 
-    # Parse opts
-    @@ps_opts.parse(args) { |opt, idx, val|
-      case opt
-      when '-S'
-        search_term = val
-        if search_term.nil?
-          print_error("Enter a search term")
-          return true
-        end
-      when "-A"
-        print_line "Filtering on arch..."
-        searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
-        processes.each do |proc|
-          next if proc['arch'].nil? or proc['arch'].empty?
-          if val.nil? or val.empty?
-            return false
-          end
-          searched_procs << proc if proc["arch"] == val
-        end
-        processes = searched_procs
-      when "-s"
-        print_line "Filtering on SYSTEM processes..."
-        searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
-        processes.each do |proc|
-          searched_procs << proc if proc["user"] == "NT AUTHORITY\\SYSTEM"
-        end
-        processes = searched_procs
-      when "-c"
-        print_line "Filtering on child processes of the current shell..."
-        current_shell_pid = client.sys.process.getpid
-        searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
-        processes.each do |proc|
-          searched_procs << proc if proc['ppid'] == current_shell_pid
-        end
-        processes = searched_procs
-      when "-U"
-        print_line "Filtering on user name..."
-        searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
-        processes.each do |proc|
-          if val.nil? or val.empty?
-            print_line "You must supply a search term!"
-            return false
-          end
-          searched_procs << proc if proc["user"].match(/#{val}/)
-        end
-        processes = searched_procs
-      end
-    }
-
-    if (processes.length == 0)
-      print_line("No running processes were found.")
-    else
-      tbl = processes.to_table('SearchTerm' => search_term)
-      print_line
-      print_line(tbl.to_s)
+    if processes.length == 0
+      print_line("No matching processes were found.")
+      return true
     end
-    return true
+
+    tbl = processes.to_table
+    print_line
+    print_line(tbl.to_s)
+    true
   end
 
   def cmd_ps_help
-    print_line "Usage: ps [ options ]"
+    print_line "Usage: ps [ options ] pattern"
     print_line
     print_line "Use the command with no arguments to see all running processes."
     print_line "The following options can be used to filter those results:"
-
     print_line @@ps_opts.usage
   end
-
-
 
   #
   # Reboots the remote computer.


### PR DESCRIPTION
This adds work-alikes for the `pgrep` and `pkill` commands. They both take the same arguments as 'ps', and this adds the additional flag '-x' to all 3 commands for specifying an exact match for the pattern parameters.

This also updates the '-s' flag to filter for root-owned processes, and allows all commands to treat the default argument as a pattern. It also cleans up some code in the Rex argument parser, which was consulted heavily to make sure we could parse things nicely.

Finally, the undocumented `pkill -f` can be used to kill all processes, similar to `killall` on Solaris / SunOS.

This is intended to be a more general improvement inspired by @umerov1999 's Meterpreter patch here: https://github.com/rapid7/metasploit-payloads/pull/157

## Verification

List the steps needed to make sure this thing works

- [ ] Obtain a meterpreter session
- [ ] **Verify** that pkill works as expected
- [ ] **Verify** that pgrep works as expected
- [ ] **Verify** that ps continues working as expected
- [ ] **Verify** that the `-s` flag filters root and system processes
- [ ] **Verify** that the process pattern can be specified with or without `-S`
- [ ] **Verify** that the '-x' flag properly makes exact matches for user and process name
- [ ] **Verify** that pkill with no arguments does not kill every process

Sample workflow:
```
meterpreter > ps -h
Usage: ps [ options ] pattern

Use the command with no arguments to see all running processes.
The following options can be used to filter those results:

OPTIONS:

    -A <opt>  Filter on architecture
    -S <opt>  Filter on process name
    -U <opt>  Filter on user name
    -c        Filter only child processes of the current shell
    -h        Help menu.
    -s        Filter only SYSTEM processes
    -x        Filter for exact matches rather than regex
meterpreter > ps -c
Filtering on child processes of the current shell...

Process List
============

 PID    PPID   Name  User  Path
 ---    ----   ----  ----  ----
 34927  34900  ps    root  ps ax -w -o pid,ppid,user,command

meterpreter > ps iTunes
Filtering on 'iTunes'

Process List
============

 PID    PPID  Name          User   Path
 ---    ----  ----          ----   ----
 32036  1     iTunesHelper  bcook  /Applications/iTunes.app/Contents/MacOS/iTunesHelper.app/Contents/MacOS/iTunesHelper
 34956  1     iTunes        bcook  /Applications/iTunes.app/Contents/MacOS/iTunes

meterpreter > ps -x iTunes
Filtering on 'iTunes'

Process List
============

 PID    PPID  Name    User   Path
 ---    ----  ----    ----   ----
 34956  1     iTunes  bcook  /Applications/iTunes.app/Contents/MacOS/iTunes

meterpreter > pgrep iTunes
32036
34956
meterpreter > pgrep -x iTunes
34956
meterpreter > pkill
[-] All processes will be killed, use '-f' to force.
meterpreter > pkill -x iTunes
Filtering on 'iTunes'
Killing: 34956
meterpreter > pkill iTunes
Filtering on 'iTunes'
Killing: 32036
meterpreter > pkill iTunes
Filtering on 'iTunes'
No matching processes were found.
meterpreter > pkill -h
Usage: pkill [ options ] pattern
Terminate one or more processes by name.

OPTIONS:

    -A <opt>  Filter on architecture
    -S <opt>  Filter on process name
    -U <opt>  Filter on user name
    -c        Filter only child processes of the current shell
    -h        Help menu.
    -s        Filter only SYSTEM processes
    -x        Filter for exact matches rather than regex
meterpreter > pgrep -h
Usage: pgrep [ options ] pattern
Filter processes by name.

OPTIONS:

    -A <opt>  Filter on architecture
    -S <opt>  Filter on process name
    -U <opt>  Filter on user name
    -c        Filter only child processes of the current shell
    -h        Help menu.
    -s        Filter only SYSTEM processes
    -x        Filter for exact matches rather than regex
meterpreter > ps -s
Filtering on SYSTEM processes...

Process List
============

 PID    PPID   Name                                          User  Path
 ---    ----   ----                                          ----  ----
 1      0      launchd                                       root  /sbin/launchd
 60     1      syslogd                                       root  /usr/sbin/syslogd
 61     1      UserEventAgent                                root  /usr/libexec/UserEventAgent (System)
```
