### PR TITLE
adding '-' to rails deserialization regex for cookie matching

### DIFF
--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => datastore['HTTP_METHOD'],
     }, 25)
     if res && !res.get_cookies.empty?
-      match = res.get_cookies.match(/([_A-Za-z0-9]+)=([A-Za-z0-9%]*)--([0-9A-Fa-f]+);/)
+        match = res.get_cookies.match(/([-_A-Za-z0-9]+)=([A-Za-z0-9%]*)--([0-9A-Fa-f]+);/)
     end
 
     if match


### PR DESCRIPTION
I was on a recent engagement where I needed to use this module to target a cookie with a '-' in the name. The module kept rewriting the cookie name value which caused the exploit to fail. When I manually edited the module to include this character in the regex, it worked perfectly. It is common to have '-'s in cookie names, so this change should apply to more than this case alone.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/rails_secret_deserialization`
- [ ] set the target cookie value to a string containing a '-'
- [ ] This can be verified by checking the module output (it doesn't need to actually throw the exploit), if the module claims to have modified the cookie value (outputting "Adjusting cookie name to <name>"), then it has not worked.

