### PR TITLE
Updated rails_secret_deserialization to add '.' regex for cookie matc…

### DIFF
--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -235,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => datastore['HTTP_METHOD'],
     }, 25)
     if res && !res.get_cookies.empty?
-      match = res.get_cookies.match(/([_A-Za-z0-9]+)=([A-Za-z0-9%]*)--([0-9A-Fa-f]+);/)
+      match = res.get_cookies.match(/([._A-Za-z0-9]+)=([A-Za-z0-9%]*)--([0-9A-Fa-f]+);/)
     end
 
     if match


### PR DESCRIPTION
When using this module recently, I was attempting to have it match a cookie string that contained a period. It continued to overwrite the period. After manually editing the code, it worked. It has been tested.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/rails_secret_deserialization`
- [x] set the target cookie value to a string containing a '.'
- [x] Check the module output. If the module states that it modified the cookie value then it failed.

