### PR TITLE
Fix typo in post/windows/manage/multi_meterpreter_inject.rb

### DIFF
--- a/modules/post/windows/manage/multi_meterpreter_inject.rb
+++ b/modules/post/windows/manage/multi_meterpreter_inject.rb
@@ -30,8 +30,8 @@ class MetasploitModule < Msf::Post
       [
         OptString.new('PAYLOAD', [false, 'Payload to inject in to process memory', "windows/meterpreter/reverse_tcp"]),
         OptInt.new('LPORT',      [false, 'Port number for the payload LPORT variable.', 4444]),
-        OptString.new('IPLIST',  [true, 'List of semicolom separated IP list.', Rex::Socket.source_address("1.2.3.4")]),
-        OptString.new('PIDLIST', [false, 'List of semicolom separated PID list.', '']),
+        OptString.new('IPLIST',  [true, 'List of semicolon separated IP list.', Rex::Socket.source_address("1.2.3.4")]),
+        OptString.new('PIDLIST', [false, 'List of semicolon separated PID list.', '']),
         OptBool.new('HANDLER',   [false, 'Start new exploit/multi/handler job on local box.', false]),
         OptInt.new('AMOUNT',     [false, 'Select the amount of shells you want to spawn.', 1])
       ], self.class)

--- a/modules/post/windows/manage/multi_meterpreter_inject.rb
+++ b/modules/post/windows/manage/multi_meterpreter_inject.rb
@@ -30,8 +30,8 @@ class MetasploitModule < Msf::Post
       [
         OptString.new('PAYLOAD', [false, 'Payload to inject in to process memory', "windows/meterpreter/reverse_tcp"]),
         OptInt.new('LPORT',      [false, 'Port number for the payload LPORT variable.', 4444]),
-        OptString.new('IPLIST',  [true, 'List of semicolon separated IP list.', Rex::Socket.source_address("1.2.3.4")]),
-        OptString.new('PIDLIST', [false, 'List of semicolon separated PID list.', '']),
+        OptString.new('IPLIST',  [true, 'List of semicolom separated IP list.', Rex::Socket.source_address("1.2.3.4")]),
+        OptString.new('PIDLIST', [false, 'List of semicolom separated PID list.', '']),
         OptBool.new('HANDLER',   [false, 'Start new exploit/multi/handler job on local box.', false]),
         OptInt.new('AMOUNT',     [false, 'Select the amount of shells you want to spawn.', 1])
       ], self.class)


### PR DESCRIPTION
Changes "semicolom" to "semicolon" on lines 33 & 34