### PR TITLE
Report hosts always add ip to hostname if hostname is blank

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -175,14 +175,14 @@ module Msf::DBManager::Host
     if opts[:info]
       opts[:info] = opts[:info][0,65535]
     end
-        
+
     # Truncate the name field at the maximum field length
     if opts[:name].blank?
       opts[:name] = addr
     else
       opts[:name] = opts[:name][0,255]
     end
-    
+
     if opts[:os_name]
       os_name, os_flavor = split_windows_os_name(opts[:os_name])
       opts[:os_name] = os_name if os_name.present?

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -175,12 +175,14 @@ module Msf::DBManager::Host
     if opts[:info]
       opts[:info] = opts[:info][0,65535]
     end
-
+        
     # Truncate the name field at the maximum field length
     if opts[:name]
       opts[:name] = opts[:name][0,255]
+    else
+      opts[:name] = addr
     end
-
+    
     if opts[:os_name]
       os_name, os_flavor = split_windows_os_name(opts[:os_name])
       opts[:os_name] = os_name if os_name.present?

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -177,10 +177,10 @@ module Msf::DBManager::Host
     end
         
     # Truncate the name field at the maximum field length
-    if opts[:name]
-      opts[:name] = opts[:name][0,255]
-    else
+    if opts[:name].blank?
       opts[:name] = addr
+    else
+      opts[:name] = opts[:name][0,255]
     end
     
     if opts[:os_name]


### PR DESCRIPTION
Every now and then we will get a host in the system with either a empty or nil. This PR
checks to see if the name is blank, if it is we set it to the address.

## Verification

- [x] Start `msfconsole`
- [x] `db_nmap -sV IPRANGE`
- [x] once db_nmap is done, run `hosts`
- [x] **Verify** There are no blank host names.
