### PR TITLE
bump mettle to 0.1.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 1.2.19)
       metasploit_data_models
-      metasploit_payloads-mettle (= 0.1.7)
+      metasploit_payloads-mettle (= 0.1.8)
       msgpack
       nessus_rest
       net-ssh
@@ -201,7 +201,7 @@ GEM
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.1.7)
+    metasploit_payloads-mettle (0.1.8)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.2.19'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.7'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.8'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/linux/aarch64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 301264
+  CachedSize = 646808
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 295848
+  CachedSize = 639520
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 293160
+  CachedSize = 638320
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 521672
+  CachedSize = 1019344
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 502792
+  CachedSize = 997900
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 502840
+  CachedSize = 997996
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 395276
+  CachedSize = 788788
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 396192
+  CachedSize = 789888
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_x64_mettle_linux'
 
 module MetasploitModule
 
-  CachedSize = 302144
+  CachedSize = 700032
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_x86_mettle_linux'
 
 module MetasploitModule
 
-  CachedSize = 305148
+  CachedSize = 739644
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/mettle_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/mettle_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 380192
+  CachedSize = 864336
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions


### PR DESCRIPTION
This fixes #8127. It also pulls in initial http/https transport support as well as transport refactoring.
