### PR TITLE
fix execute and kill cmd usage/help

### DIFF
--- a/lib/rex/parser/arguments.rb
+++ b/lib/rex/parser/arguments.rb
@@ -76,6 +76,7 @@ module Rex
           txt << "    #{fmtspec.ljust(longest.length)}#{opt}#{val[1]}"
         end
 
+        txt << ""
         txt.join("\n")
       end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -372,6 +372,15 @@ class Console::CommandDispatcher::Stdapi::Sys
   end
 
   #
+  # help for the kill command
+  #
+  def cmd_kill_help
+    print_line("Usage: kill [pid1 [pid2 [pid3 ...]]] [-s]")
+    print_line("Terminate one or more processes.")
+    print_line("     -s        Kills the pid associated with the current session.")
+  end
+
+  #
   # Kills one or more processes by name.
   #
   def cmd_pkill(*args)


### PR DESCRIPTION
Fixes a minor bug with command usage introduced with https://github.com/rapid7/metasploit-framework/pull/8117

## Verification
Before:
```
meterpreter > kill
[-] Error running command kill: NameError undefined local variable or method `cmd_kill_help' for #<Rex::Post::Meterpreter::Ui::Console::CommandDispatcher::Stdapi::Sys:0x007fab8caba498>
Did you mean?  cmd_pkill_help
               cmd_kill
               cmd_pkill
               cmd_help
               cmd_ps_help
               cmd_shell
               cmd_help_help
meterpreter > execute
Usage: execute -f file [options]

Executes a command on the remote machine.

OPTIONS:

    -H        Create the process hidden from view.
    -a <opt>  The arguments to pass to the command.
    -c        Channelized I/O (required for interaction).
    -d <opt>  The 'dummy' executable to launch when using -m.
    -f <opt>  The executable command to run.
    -h        Help menu.
    -i        Interact with the process after creating it.
    -k        Execute process on the meterpreters current desktop
    -m        Execute from memory.
    -s <opt>  Execute process in a given session as the session user
    -t        Execute process with currently impersonated thread tokenmeterpreter >
```
After:
```
meterpreter > kill
Usage: kill [pid1 [pid2 [pid3 ...]]] [-s]
Terminate one or more processes.
     -s        Kills the pid associated with the current session.
meterpreter > execute
Usage: execute -f file [options]

Executes a command on the remote machine.

OPTIONS:

    -H        Create the process hidden from view.
    -a <opt>  The arguments to pass to the command.
    -c        Channelized I/O (required for interaction).
    -d <opt>  The 'dummy' executable to launch when using -m.
    -f <opt>  The executable command to run.
    -h        Help menu.
    -i        Interact with the process after creating it.
    -k        Execute process on the meterpreters current desktop
    -m        Execute from memory.
    -s <opt>  Execute process in a given session as the session user
    -t        Execute process with currently impersonated thread token
meterpreter >
```
