### PR TITLE
Fix variable typos in rfrecv related methods.

### DIFF
--- a/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
+++ b/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
@@ -135,6 +135,7 @@ module RFTransceiver
   def rfrecv(timeout = -1, blocksize = -1)
     return "" if not is_rf?
     self.index ||= 0
+    opts = {}
     opts["timeout"] = timeout if not timeout == -1
     opts["blocksize"] = blocksize if not blocksize == -1
     client.rftransceiver.rfrecv(self.index, opts)

--- a/lib/rex/post/hwbridge/extensions/rftransceiver/rftransceiver.rb
+++ b/lib/rex/post/hwbridge/extensions/rftransceiver/rftransceiver.rb
@@ -106,7 +106,7 @@ class RFTransceiver < Extension
       end
       if opt.has_key? "blocksize"
         request += "&" if not first
-        request += "blocksize=#{blocksize}"
+        request += "blocksize=#{opt['blocksize']}"
       end
     end
     data = client.send_request(request)


### PR DESCRIPTION
This PR fixes 2 bugs where variable related typos have occurred in 2 `rfrecv` methods.

* The first is [here](https://github.com/rapid7/metasploit-framework/blob/7477e44d30e847666ddeef5728985f87bd80505b/lib/rex/post/hwbridge/extensions/rftransceiver/rftransceiver.rb#L109) where `blocksize` is undefined instead of referenced from the `opts` hash.  
* The next is [here](https://github.com/rapid7/metasploit-framework/blob/2fde287424e3f28330d29b8ae69ccc41b308c5ff/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb#L138-L139) where `opts` is not defined before being referenced.

## Verification
Wrote a simple module that uses `rfrecv` to test.

Module:
```
class MetasploitModule < Msf::Post

  include Msf::Post::Hardware::RFTransceiver::RFTransceiver

  def initialize(info={})
    super( update_info( info,
        'Name'          => 'Typo Fixes Test',
        'Description'   => %q{ Simple test to make sure rfrecv works
        },
        'License'       => MSF_LICENSE,
        'Author'        => ['Leon Jacobs'],
        'Platform'      => ['hardware'],
        'SessionTypes'  => ['hwbridge']
      ))
    register_options([
      OptInt.new('FREQ', [true, "Frequency to listen on", nil]),
      OptInt.new('INDEX', [false, "USB Index to use", 0]),
      OptInt.new('BAUD', [false, "Baud rate to use", 4800])
    ], self.class)
  end

  def run
    if not is_rf?
      print_error("Not an RF Transceiver")
      return
    end
    if not set_index(datastore['INDEX'])
      print_error("Couldn't set usb index to #{datastore["INDEX"]}")
      return
    end

    set_modulation("ASK/OOK")
    set_freq(datastore["FREQ"])
    set_sync_mode(0)
    set_flen(0)
    set_baud(datastore["BAUD"])
    max_power

    # should not throw errors
    rf_data = rfrecv()

    print_status("Done")
    set_mode("IDLE")
  end

end
```

Output
```
msf post(simple) > show options

Module options (post/hardware/rftransceiver/simple):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   BAUD     4800             no        Baud rate to use
   FREQ     433400000        yes       Frequency to listen on
   INDEX    0                no        USB Index to use
   SESSION  1                yes       The session to run this module on.

msf post(simple) > run

[*] Done
[*] Post module execution completed
msf post(simple) >
```