### PR TITLE
Add -h for the check command

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -122,6 +122,11 @@ module ModuleCommandDispatcher
   # Checks to see if a target is vulnerable.
   #
   def cmd_check(*args)
+    if args.first =~ /^\-h$/i
+      cmd_check_help
+      return
+    end
+
     ip_range_arg = args.shift || mod.datastore['RHOSTS'] || framework.datastore['RHOSTS'] || ''
     opt = Msf::OptAddressRange.new('RHOSTS')
 
@@ -160,6 +165,32 @@ module ModuleCommandDispatcher
       print_status("Caught interrupt from the console...")
       return
     end
+  end
+
+  def cmd_check_help
+    print_line('Usage: check [option] [IP Range]')
+    print_line
+    print_line('Options:')
+    print_line('-h  You are looking at it.')
+    print_line
+    print_line('Examples:')
+    print_line('')
+    print_line('Normally, if a RHOST is already specified, you can just run check.')
+    print_line('But here are different ways to use the command:')
+    print_line
+    print_line('Against a single host:')
+    print_line('check 192.168.1.123')
+    print_line
+    print_line('Against a range of IPs:')
+    print_line('check 192.168.1.1-192.168.1.254')
+    print_line
+    print_line('Against a range of IPs loaded from a file:')
+    print_line('check file:///tmp/ip_list.txt')
+    print_line
+    print_line('Multi-threaded checks:')
+    print_line('1. set THREADS 10')
+    print_line('2. check')
+    print_line
   end
 
   def report_vuln(instance)


### PR DESCRIPTION
## Description

This PR adds a ```-h``` flag to the ```check``` command, because even I don't remember what it can do anymore.

## Verification

- [x] Start msfconsole
- [x] Do: ```use exploit/windows/smb/ms08_067_netapi```
- [x] Do: ```check -h```
- [x] You should see the help menu
