### PR TITLE
Style fixes for HWBridge RF and a couple small bug fixes

### DIFF
--- a/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
+++ b/lib/msf/core/post/hardware/rftransceiver/rftransceiver.rb
@@ -12,9 +12,9 @@ module RFTransceiver
   # @param r [Hash] A hash in expected format { "success" => true }
   # @return [Boolean] if success is true or not, returns false if hash is wrong
   def return_success(r)
-    return false if not r
-    return false if not r.has_key? "success"
-    return r["success"]
+    return false unless r
+    return false unless r.has_key?('success')
+    return r['success']
   end
 
   # Checks to see if this module is a RF Transceiver module
@@ -28,11 +28,9 @@ module RFTransceiver
   # Returns a list of supported USB indexes by relay
   # @return [Array] Example: [ 0, 1 ]
   def get_supported_indexes
-    return [] if not is_rf?
+    return [] unless is_rf?
     r = client.rftransceiver.supported_idx
-    if r.has_key? "indexes"
-      return r["indexes"]
-    end
+    return r['indexes'] if r.has_key?('indexes')
     print_error("Invalid response from relay")
     return []
   end
@@ -50,10 +48,10 @@ module RFTransceiver
   # @param mhz [Integer] Optional Mhz
   # @return [Boolean] success value
   def set_freq(freq, mhz=-1)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     opts = {}
-    opts["mhz"] = mhz if not mhz == -1
+    opts['mhz'] = mhz unless mhz == -1
     r = client.rftransceiver.set_freq(self.index, freq, opts)
     return_success(r)
   end
@@ -63,7 +61,7 @@ module RFTransceiver
   # @param mode [String] Mode type TX/RX/IDLE
   # @return [Boolean] success value
   def set_mode(mode)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_mode(self.index, mode)
     return_success(r)
@@ -73,7 +71,7 @@ module RFTransceiver
   # Gets supported modulations
   # @return [Array] String list of modulations
   def get_modulations
-    return [] if not is_rf?
+    return [] unless is_rf?
     self.index ||= 0
     return client.rftransceiver.get_supported_modulations(self.index)
   end
@@ -83,7 +81,7 @@ module RFTransceiver
   # @param mod [String] Example ASK/OOK
   # @return [Boolean] success value
   def set_modulation(mod)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_modulation(self.index, mod)
     return_success(r)
@@ -94,7 +92,7 @@ module RFTransceiver
   # @param len [Integer] Length of packet
   # @return [Boolean] success value
   def set_flen(len)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.make_pkt_flen(self.index, len)
     return_success(r)
@@ -105,7 +103,7 @@ module RFTransceiver
   # @param len [Integer] Length of packet
   # @return [Boolean] success value
   def set_vlen(len)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.make_pkt_vlen(self.index, len)
     return_success(r)
@@ -118,11 +116,11 @@ module RFTransceiver
   # @param offset [Integer] Optional Offset within data section
   # @return [Boolean] success value
   def rfxmit(data, repeat=-1, offset=-1)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     opts = {}
-    opts["repeat"] = repeat if not repeat == -1
-    opts["offset"] = offset if not offset == -1
+    opts['repeat'] = repeat unless repeat == -1
+    opts['offset'] = offset unless offset == -1
     r = client.rftransceiver.rfxmit(self.index, data, opts)
     return_success(r)
   end
@@ -133,11 +131,11 @@ module RFTransceiver
   # @param blocksize [Integer] Optional blocksize
   # @return [String] Base64 decoded data, could be binary
   def rfrecv(timeout = -1, blocksize = -1)
-    return "" if not is_rf?
+    return '' unless is_rf?
     self.index ||= 0
     opts = {}
-    opts["timeout"] = timeout if not timeout == -1
-    opts["blocksize"] = blocksize if not blocksize == -1
+    opts['timeout'] = timeout unless timeout == -1
+    opts['blocksize'] = blocksize unless blocksize == -1
     client.rftransceiver.rfrecv(self.index, opts)
   end
 
@@ -145,7 +143,7 @@ module RFTransceiver
   # Enable packet CRC
   # @return [Boolean] success value
   def enable_crc
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.enable_packet_crc(self.index)
     return_success(r)
@@ -155,7 +153,7 @@ module RFTransceiver
   # Enable Manchester encoding
   # @return [Boolean] success value
   def enable_manchester
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.enable_manchester(self.index)
     return_success(r)
@@ -166,7 +164,7 @@ module RFTransceiver
   # @param channel [Integer] Channel number
   # @return [Boolean] success value
   def set_channel(channel)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_channel(self.index, channel)
     return_success(r)
@@ -178,10 +176,10 @@ module RFTransceiver
   # @param mhz [Integer] Mhz
   # @return [Boolean] success value
   def set_channel_bw(bandwidth, mhz=-1)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     opts = {}
-    opts["mhz"] = mhz if not mhz == -1
+    opts['mhz'] = mhz unless mhz == -1
     r = client.rftransceiver.set_channel_bandwidth(self.index, bandwidth, opts)
     return_success(r)
   end
@@ -198,13 +196,13 @@ module RFTransceiver
   # @param mhz [Integer] Mhz
   # @return [Boolean] success value
   def set_channel_spc(chanspc = -1, chanspc_m = -1, chanspc_e = -1, mhz=-1)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     opts = {}
-    opts["chanspc"] = chanspc if not chanspc == -1
-    opts["chanspc_m"] = chanspc_m if not chanspc_m == -1
-    opts["chanspc_e"] = chanspc_e if not chanspc_e == -1
-    opts["mhz"] = mhz if not mhz == -1
+    opts['chanspc'] = chanspc unless chanspc == -1
+    opts['chanspc_m'] = chanspc_m unless chanspc_m == -1
+    opts['chanspc_e'] = chanspc_e unless chanspc_e == -1
+    opts['mhz'] = mhz unless mhz == -1
     r = client.rftransceiver.set_channel_spc(self.index, opts)
     return_success(r)
   end
@@ -215,10 +213,10 @@ module RFTransceiver
   # @param mhz [Integer] Optional Mhz
   # @return [Boolean] success value
   def set_baud(baud, mhz=-1)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     opts = {}
-    opts["mhz"] = mhz if not mhz == -1
+    opts['mhz'] = mhz unless mhz == -1
     r = client.rftransceiver.set_baud_rate(self.index, baud, opts)
     return_success(r)
   end
@@ -229,10 +227,10 @@ module RFTransceiver
   # @param mhz [Integer] Optional mhz
   # @return [Boolean] success value
   def set_deviation(deviat, mhz=-1)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     opts = {}
-    opts["mhz"] = mhz if not mhz == -1
+    opts['mhz'] = mhz unless mhz == -1
     r = client.rftransceiver.set_deviation(self.index, deviat, opts)
     return_success(r)
   end
@@ -242,7 +240,7 @@ module RFTransceiver
   # @param word [Integer] Sync word
   # @return [Boolean] success value
   def set_sync_word(word)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_sync_word(self.index, word)
     return_success(r)
@@ -253,7 +251,7 @@ module RFTransceiver
   # @param mode [Integer] Mode
   # @return [Boolean] success value
   def set_sync_mode(mode)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_sync_mode(self.index, mode)
     return_success(r)
@@ -264,7 +262,7 @@ module RFTransceiver
   # @param bits [Integer] number of preamble bits to use
   # @return [Boolean] success value
   def set_preamble(bits)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_number_preamble(self.index, bits)
     return_success(r)
@@ -274,7 +272,7 @@ module RFTransceiver
   # Sets the power to max.  Ensure you set the frequency first before using this
   # @return [Boolean] success value
   def max_power
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_maxpower(self.index)
     return_success(r)
@@ -285,7 +283,7 @@ module RFTransceiver
   # @param level [Integer] Power level
   # @return [Boolean] success value
   def set_power(level)
-    return false if not is_rf?
+    return false unless is_rf?
     self.index ||= 0
     r = client.rftransceiver.set_power(self.index, level)
     return_success(r)

--- a/lib/rex/post/hwbridge/extensions/rftransceiver/rftransceiver.rb
+++ b/lib/rex/post/hwbridge/extensions/rftransceiver/rftransceiver.rb
@@ -40,7 +40,7 @@ class RFTransceiver < Extension
   # @param freq [Integer] Frequency to set
   def set_freq(idx, freq, opt={})
     request = "/rftransceiver/#{idx}/set_freq?freq=#{freq}"
-    request += "&mhz=#{opt["mhz"]}" if opt.has_key? "mhz"
+    request << "&mhz=#{opt['mhz']}" if opt.has_key? 'mhz'
     client.send_request(request)
   end
 
@@ -86,8 +86,8 @@ class RFTransceiver < Extension
   def rfxmit(idx, data, opt={})
     data = Base64.urlsafe_encode64(data)
     request = "/rftransceiver/#{idx}/rfxmit?data=#{data}"
-    request += "&repeat=#{opt["repeat"]}" if opt.has_key? "repeat"
-    request += "&offset=#{opt["offset"]}" if opt.has_key? "offset"
+    request << "&repeat=#{opt['repeat']}" if opt.has_key? 'repeat'
+    request << "&offset=#{opt['offset']}" if opt.has_key? 'offset'
     client.send_request(request)
   end
 
@@ -99,20 +99,20 @@ class RFTransceiver < Extension
     request = "/rftransceiver/#{idx}/rfrecv"
     if opt.size() > 0
       first = true
-      request += "?"
-      if opt.has_key? "timeout"
-        request += "timeout=#{opt["timeout"]}"
+      request << '?'
+      if opt.has_key? 'timeout'
+        request << "timeout=#{opt['timeout']}"
         first = false
       end
-      if opt.has_key? "blocksize"
-        request += "&" if not first
-        request += "blocksize=#{opt['blocksize']}"
+      if opt.has_key? 'blocksize'
+        request << '&' unless first
+        request << "blocksize=#{opt['blocksize']}"
       end
     end
     data = client.send_request(request)
     # Note the data is initially base64 encoded
     if data.size() > 0
-      data["data"] = Base64.urlsafe_decode64(data["data"]) if data.has_key? "data"
+      data['data'] = Base64.urlsafe_decode64(data['data']) if data.has_key? 'data'
     end
     data
   end
@@ -131,32 +131,32 @@ class RFTransceiver < Extension
 
   def set_channel_bandwidth(idx, bandwidth, opt={})
     request = "/rftransceiver/#{idx}/set_channel_bandwidth?bw=#{bandwidth}"
-    request += "&mhz=#{opt["mhz"]}" if opt.has_key? "mhz"
+    request << "&mhz=#{opt['mhz']}" if opt.has_key? 'mhz'
     client.send_request(request)
   end
 
   def set_channel_spc(idx, opt={})
     request = "/rftransceiver/#{idx}/set_channel_spc"
     if opt.size > 0
-      request += "?"
+      request << '?'
       first = true
-      if opt.has_key? "chanspc"
-        request += "chanspc=#{opt["chanspc"]}"
+      if opt.has_key? 'chanspc'
+        request << "chanspc=#{opt['chanspc']}"
         first = false
       end
-      if opt.has_key? "chanspc_m"
-        request += "&" if not first
-        request += "chanspc_m=#{opt["chanspc_m"]}"
+      if opt.has_key? 'chanspc_m'
+        request << '&' unless first
+        request << "chanspc_m=#{opt['chanspc_m']}"
         first = false
       end
-      if opt.has_key? "chanspc_e"
-        request += "&" if not first
-        request += "chanspc_e=#{opt["chanspc_e"]}"
+      if opt.has_key? 'chanspc_e'
+        request << '&' unless first
+        request << "chanspc_e=#{opt['chanspc_e']}"
         first = false
       end
-      if opt.has_key? "mhz"
-        request += "&" if not first
-        request += "mhz=#{opt["mhz"]}"
+      if opt.has_key? 'mhz'
+        request << '&' unless first
+        request << "mhz=#{opt['mhz']}"
       end
     end
     client.send_request(request)
@@ -164,13 +164,13 @@ class RFTransceiver < Extension
 
   def set_baud_rate(idx, rate, opt={})
     request = "/rftransceiver/#{idx}/set_baud_rate?rate=#{rate}"
-    request += "&mhz=#{opt["mhz"]}" if opt.has_key? "mhz"
+    request << "&mhz=#{opt['mhz']}" if opt.has_key? 'mhz'
     client.send_request(request)
   end
 
   def set_deviation(idx, deviat, opt={})
     request = "/rftransceiver/#{idx}/set_deviation?deviat=#{deviat}"
-    request += "&mhz=#{opt["mhz"]}" if opt.has_key? "mhz"
+    request << "&mhz=#{opt['mhz']}" if opt.has_key? 'mhz'
     client.send_request(request)
   end
 

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
@@ -134,7 +134,7 @@ class Console::CommandDispatcher::Core
   def cmd_info(*args)
     return unless msf_loaded?
 
-    if args.length != 1 or args.include?("-h")
+    if args.length != 1 || args.include?('-h')
       cmd_info_help
       return
     end
@@ -146,10 +146,10 @@ class Console::CommandDispatcher::Core
       print_error 'Invalid module: ' << module_name
     end
 
-    if (mod)
+    if mod
       print_line(::Msf::Serializer::ReadableText.dump_module(mod))
       mod_opt = ::Msf::Serializer::ReadableText.dump_options(mod, '   ')
-      print_line("\nModule options (#{mod.fullname}):\n\n#{mod_opt}") if (mod_opt and mod_opt.length > 0)
+      print_line("\nModule options (#{mod.fullname}):\n\n#{mod_opt}") if mod_opt && mod_opt.length > 0
     end
   end
 
@@ -173,15 +173,15 @@ class Console::CommandDispatcher::Core
       return true
     end
     status = client.get_status
-    if status.has_key? "operational"
-      op = "Unknown"
-      op = "Yes" if status["operational"] == 1
-      op = "No" if status["operational"] == 2
+    if status.has_key? 'operational'
+      op = 'Unknown'
+      op = 'Yes' if status['operational'] == 1
+      op = 'No' if status['operational'] == 2
       print_status("Operational: #{op}")
     end
-    print_status("Device: #{status["device_name"]}") if status.has_key? "device_name"
-    print_status("FW Version: #{status["fw_version"]}") if status.has_key? "fw_version"
-    print_status("HW Version: #{status["hw_version"]}") if status.has_key? "hw_version"
+    print_status("Device: #{status['device_name']}") if status.has_key? 'device_name'
+    print_status("FW Version: #{status['fw_version']}") if status.has_key? 'fw_version'
+    print_status("HW Version: #{status['hw_version']}") if status.has_key? 'hw_version'
   end
 
   def cmd_specialty_help
@@ -250,14 +250,14 @@ class Console::CommandDispatcher::Core
       return true
     end
     res = client.get_custom_methods
-    if res.has_key? "Methods"
+    if res.has_key? 'Methods'
       cmd_load("custom_methods")
       self.shell.dispatcher_stack.each do |dispatcher|
         if dispatcher.name =~/custom methods/i
-          dispatcher.load_methods(res["Methods"])
+          dispatcher.load_methods(res['Methods'])
         end
       end
-      print_status("Loaded #{res["Methods"].size} method(s)")
+      print_status("Loaded #{res['Methods'].size} method(s)")
     else
       print_status("Not supported")
     end
@@ -274,13 +274,13 @@ class Console::CommandDispatcher::Core
   # Loads one or more meterpreter extensions.
   #
   def cmd_load(*args)
-    if (args.length == 0)
+    if args.length == 0
       args.unshift("-h")
     end
 
     @@load_opts.parse(args) { |opt, idx, val|
       case opt
-      when "-h"
+      when '-h'
         cmd_load_help
         return true
       end
@@ -290,7 +290,7 @@ class Console::CommandDispatcher::Core
     args.each { |m|
       md = m.downcase
 
-      if (extensions.include?(md))
+      if extensions.include?(md)
         print_error("The '#{md}' extension has already been loaded.")
         next
       end
@@ -339,7 +339,7 @@ class Console::CommandDispatcher::Core
       # First try it as a Post module if we have access to the Metasploit
       # Framework instance.  If we don't, or if no such module exists,
       # fall back to using the scripting interface.
-      if (msf_loaded? and mod = client.framework.modules.create(script_name))
+      if msf_loaded? && mod = client.framework.modules.create(script_name)
         original_mod = mod
         reloaded_mod = client.framework.modules.reload_module(original_mod)
 
@@ -370,16 +370,16 @@ class Console::CommandDispatcher::Core
 
   def cmd_run_tabs(str, words)
     tabs = []
-    if(not words[1] or not words[1].match(/^\//))
+    if !words[1] || !words[1].match(/^\//)
       begin
-        if (msf_loaded?)
-          tabs += tab_complete_postmods
+        if msf_loaded?
+          tabs << tab_complete_postmods
         end
         [  # We can just use Meterpreters script path
           ::Msf::Sessions::Meterpreter.script_base,
           ::Msf::Sessions::Meterpreter.user_script_base
         ].each do |dir|
-          next if not ::File.exist? dir
+          next unless ::File.exist? dir
           tabs += ::Dir.new(dir).find_all { |e|
             path = dir + ::File::SEPARATOR + e
             ::File.file?(path) and ::File.readable?(path)
@@ -405,7 +405,7 @@ class Console::CommandDispatcher::Core
     jid = self.bgjob_id
     self.bgjob_id += 1
 
-    Z# Get the script name
+    # Get the script name
     self.bgjobs[jid] = Rex::ThreadFactory.spawn("HWBridgeBGRun(#{args[0]})-#{jid}", false, jid, args) do |myjid,xargs|
       ::Thread.current[:args] = xargs.dup
       begin
@@ -495,15 +495,15 @@ protected
     self.class.client_extension_search_paths.each do |path|
       path = ::File.join(path, "#{mod}.rb")
       klass = CommDispatcher.check_hash(path)
-      if (klass == nil)
-        old   = CommDispatcher.constants
+      if klass.nil?
+        old = CommDispatcher.constants
         next unless ::File.exist? path
 
-        if (require(path))
-          new  = CommDispatcher.constants
+        if require(path)
+          new = CommDispatcher.constants
           diff = new - old
 
-          next if (diff.empty?)
+          next if diff.empty?
 
           klass = CommDispatcher.const_get(diff[0])
 
@@ -535,7 +535,7 @@ protected
   def tab_complete_postmods
     tabs = client.framework.modules.post.map { |name,klass|
       mod = client.framework.modules.post.create(name)
-      if mod and mod.session_compatible?(client)
+      if mod && mod.session_compatible?(client)
         mod.fullname.dup
       else
         nil

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/rftransceiver.rb
@@ -43,19 +43,19 @@ class Console::CommandDispatcher::RFtransceiver
 
   def cmd_supported_idx
     indexes = client.rftransceiver.supported_idx
-    if not indexes or not indexes.has_key? "indexes"
+    if !indexes || !indexes.has_key?('indexes')
       print_line("error retrieving index list")
       return
     end
-    indexes = indexes["indexes"]
-    if not indexes.size > 0
-      print_line("none")
+    indexes = indexes['indexes']
+    unless indexes.size > 0
+      print_line('none')
       return
     end
     self.idx = indexes[0].to_i if indexes.size == 0
     str = "Supported Indexes: "
-    str += indexes.join(', ')
-    str += "\nUse idx to set your desired bus, default is 0"
+    str << indexes.join(', ')
+    str << "\nUse idx to set your desired bus, default is 0"
     print_line(str)
   end
 
@@ -91,7 +91,7 @@ class Console::CommandDispatcher::RFtransceiver
   # Takes the results of a client request and prints Ok on success
   #
   def print_success(r)
-    if r.has_key? "success" and r["success"] == true
+    if r.has_key?('success') && r['success'] == true
       print_line("Ok")
     else
       print_line("Error")
@@ -127,7 +127,7 @@ class Console::CommandDispatcher::RFtransceiver
       cmd_freq_help
       return
     end
-    arg["mhz"] = mhz if mhz
+    arg['mhz'] = mhz if mhz
     r = client.rftransceiver.set_freq(idx, freq, arg)
     print_success(r)
   end
@@ -159,7 +159,7 @@ class Console::CommandDispatcher::RFtransceiver
         mod = val
       end
     end
-    if not mod
+    unless mod
       cmd_modulation_help
       return
     end
@@ -252,12 +252,12 @@ class Console::CommandDispatcher::RFtransceiver
         offset = val.to_i
       end
     end
-    if not data
+    unless data
       print_line("You must specify the data argument (-d)")
       return
     end
-    arg["repeat"] = repeat if not repeat == -1
-    arg["offset"] = offset if not offset == -1
+    arg['repeat'] = repeat unless repeat == -1
+    arg['offset'] = offset unless offset == -1
     r = client.rftransceiver.rfxmit(idx, data, arg)
     print_success(r)
   end
@@ -287,11 +287,11 @@ class Console::CommandDispatcher::RFtransceiver
         blocksize = val.to_i
       end
     end
-    arg["blocksize"] = blocksize if not blocksize == -1
-    arg["timeout"] = timeout if not timeout == -1
+    arg['blocksize'] = blocksize unless blocksize == -1
+    arg['timeout'] = timeout unless timeout == -1
     r = client.rftransceiver.rfrecv(idx, arg)
-    if r.has_key? "data" and r.has_key? "timestamp"
-      print_line(" #{r["timestamp"]}: #{r["data"].inspect}")
+    if r.has_key?('data') && r.has_key?('timestamp')
+      print_line(" #{r['timestamp']}: #{r['data'].inspect}")
     else
       print_line("Error")
     end
@@ -334,7 +334,7 @@ class Console::CommandDispatcher::RFtransceiver
       end
     end
     r = client.rftransceiver.enable_manchester(idx)
-    print_sucess(r)
+    print_success(r)
   end
 
   #
@@ -394,7 +394,7 @@ class Console::CommandDispatcher::RFtransceiver
       print_line("You must specify the bandwidth (-b)")
       return
     end
-    arg["mhz"] = mhz if mhz
+    arg['mhz'] = mhz if mhz
     r = client.rftransceiver.set_channel_bandwidth(idx, bandwidth, arg)
     print_success(r)
   end
@@ -428,7 +428,7 @@ class Console::CommandDispatcher::RFtransceiver
       print_line("You must specify a baud rate")
       return
     end
-    arg["mhz"] = mhz if mhz
+    arg['mhz'] = mhz if mhz
     r = client.rftransceiver.set_baud_rate(idx, baud, arg)
     print_success(r)
   end
@@ -462,7 +462,7 @@ class Console::CommandDispatcher::RFtransceiver
       print_line("You must specify a deviat value")
       return
     end
-    arg["mhz"] = mhz if mhz
+    arg['mhz'] = mhz if mhz
     r = client.rftransceiver.set_deviation(idx, deviat, arg)
     print_success(r)
   end
@@ -488,7 +488,7 @@ class Console::CommandDispatcher::RFtransceiver
       end
     end
     if word == -1
-      print_line("you must specify a sync word")
+      print_line("You must specify a sync word")
       return
     end
     r = client.rftransceiver.set_sync_word(idx, word)

--- a/modules/auxiliary/client/hwbridge/connect.rb
+++ b/modules/auxiliary/client/hwbridge/connect.rb
@@ -45,8 +45,8 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(8080),
-        Opt::RHOST("127.0.0.1"),
-        OptBool.new("DEBUGJSON", [false, "Additional debugging out for JSON requests to HW Bridge", false]),
+        Opt::RHOST('127.0.0.1'),
+        OptBool.new('DEBUGJSON', [false, "Additional debugging out for JSON requests to HW Bridge", false]),
         OptString.new('TARGETURI', [ true, "The path to the hwbridge API", '/'])
       ],
       self.class
@@ -97,14 +97,14 @@ class MetasploitModule < Msf::Auxiliary
   # Uses status information to automatically load proper extensions
   #
   def autoload_extensions(sess)
-    if self.hw_specialty.key? "automotive"
-      sess.load_automotive if self.hw_specialty["automotive"] == true
+    if self.hw_specialty.key? 'automotive'
+      sess.load_automotive if self.hw_specialty['automotive'] == true
     end
-    if self.hw_specialty.has_key? "zigbee"
-      sess.load_zigbee if self.hw_specialty["zigbee"] == true
+    if self.hw_specialty.has_key? 'zigbee'
+      sess.load_zigbee if self.hw_specialty['zigbee'] == true
     end
-    if self.hw_specialty.has_key? "rftransceiver"
-      sess.load_rftransceiver if self.hw_specialty["rftransceiver"] == true
+    if self.hw_specialty.has_key? 'rftransceiver'
+      sess.load_rftransceiver if self.hw_specialty['rftransceiver'] == true
     end
   end
 
@@ -112,8 +112,8 @@ class MetasploitModule < Msf::Auxiliary
   # If the hardware contains custom methods, create functions for those
   #
   def load_custom_methods(sess)
-    if self.hw_capabilities.key? "custom_methods"
-      sess.load_custom_methods if self.hw_capabilities["custom_methods"] == true
+    if self.hw_capabilities.key? 'custom_methods'
+      sess.load_custom_methods if self.hw_capabilities['custom_methods'] == true
     end
   end
 
@@ -123,13 +123,13 @@ class MetasploitModule < Msf::Auxiliary
   def get_status
     data = fetch_json("/status")
     unless data.nil?
-      if data.key? "operational"
+      if data.key? 'operational'
         @last_access = Time.now
-        if data.key? "hw_specialty"
-          self.hw_specialty = data["hw_specialty"]
+        if data.key? 'hw_specialty'
+          self.hw_specialty = data['hw_specialty']
         end
-        if data.key? "hw_capabilities"
-          self.hw_capabilities = data["hw_capabilities"]
+        if data.key? 'hw_capabilities'
+          self.hw_capabilities = data['hw_capabilities']
         end
       end
     end
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     print_status "Attempting to connect to #{datastore['RHOST']}..."
     self.get_status()
-    if !@last_access.nil?
+    unless @last_access.nil?
       sess = Msf::Sessions::HWBridge.new(self)
       sess.set_from_exploit(self)
 

--- a/modules/post/hardware/rftransceiver/rfpwnon.rb
+++ b/modules/post/hardware/rftransceiver/rfpwnon.rb
@@ -74,15 +74,15 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    if not is_rf?
+    unless is_rf?
       print_error("Not an RF Transceiver")
       return
     end
-    if not set_index(datastore['INDEX'])
-      print_error("Couldn't set usb index to #{datastore["INDEX"]}")
+    unless set_index(datastore['INDEX'])
+      print_error("Couldn't set usb index to #{datastore['INDEX']}")
       return
     end
-    if datastore["TRI"]
+    if datastore['TRI']
       @zeropwm = "10001000"
       @onepwm = "11101110"
       @twopwm = "10001110"
@@ -90,9 +90,9 @@ class MetasploitModule < Msf::Post
     end
 
     set_modulation("ASK/OOK")
-    set_freq(datastore["FREQ"])
+    set_freq(datastore['FREQ'])
     set_sync_mode(0)
-    set_baud(datastore["BAUD"])
+    set_baud(datastore['BAUD'])
     max_power
 
     print_status("Generating de bruijn sequence...")
@@ -101,31 +101,31 @@ class MetasploitModule < Msf::Post
     brutepacket = seq + tail
 
     print_status("Brute forcing frequency: #{datastore['FREQ']}")
-    print_status("Padding before binary: #{datastore['PPAD']}") if datastore["PPAD"]
-    print_status("Padding after binary: #{datastore["TPAD"]}") if datastore["TPAD"]
-    print_status("De Bruijin Sequence: #{brutepacket}") if datastore["EXTRAVERBOSE"]
+    print_status("Padding before binary: #{datastore['PPAD']}") if datastore['PPAD']
+    print_status("Padding after binary: #{datastore['TPAD']}") if datastore['TPAD']
+    print_status("De Bruijin Sequence: #{brutepacket}") if datastore['EXTRAVERBOSE']
 
     startn = 0
     endy = 512
     brutepackettmp = ""
     addr = 512
-    if datastore["TRI"]
+    if datastore['TRI']
       endy = 128
       addr = 128
     end
-    if datastore["REPEAT"] >= 2 or datastore["PPAD"] or datastore["TPAD"]
-      endy = datastore["BINLENGTH"]
+    if datastore['REPEAT'] >= 2 || datastore['PPAD'] || datastore['TPAD']
+      endy = datastore['BINLENGTH']
       addr = 1
     end
     # Transmit
     while startn < brutepacket.length
-      (0..datastore["REPEAT"]-1).each do |i|
+      (0..datastore['REPEAT']-1).each do |i|
         brutepackettemp = brutepacket[startn..endy-1]
-        next if brutepackettemp.length < datastore["BINLENGTH"]
+        next if brutepackettemp.length < datastore['BINLENGTH']
         # Pad if asked to
-        brutepackettemp = datastore["PPAD"] + brutepackettemp if datastore["PPAD"]
-        brutepackettemp += datastore["TPAD"] if datastore["TPAD"]
-        if datastore["RAW"]
+        brutepackettemp = datastore['PPAD'] + brutepackettemp if datastore['PPAD']
+        brutepackettemp += datastore['TPAD'] if datastore['TPAD']
+        if datastore['RAW']
           key_packed = brutepackettemp.scan(/.{1,8}/).collect{|x| x.to_i(2).chr}
         else
           key_packed = convert_ook(brutepackettemp)
@@ -137,14 +137,14 @@ class MetasploitModule < Msf::Post
         print_status("#{brutepackettemp}")
         print_status("Binary after PWM encoding:")
         print_status("#{key_packed.join.unpack("H*")[0].hex.to_s(2)}")
-        sleep(datastore["DELAY"] / 1000) if datastore["DELAY"] > 0
+        sleep(datastore['DELAY'] / 1000) if datastore['DELAY'] > 0
       end
-      if datastore["REPEAT"] >= 2 or datastore["PPAD"] or datastore["TPAD"]
+      if datastore['REPEAT'] >= 2 or datastore['PPAD'] or datastore['TPAD']
         startn += addr
         endy += addr
       else
-        startn = startn + addr - datastore["BINLENGTH"]
-        endy = endy + addr - datastore["BINLENGTH"]
+        startn = startn + addr - datastore['BINLENGTH']
+        endy = endy + addr - datastore['BINLENGTH']
       end
     end
     print_status("Done")

--- a/modules/post/hardware/rftransceiver/transmitter.rb
+++ b/modules/post/hardware/rftransceiver/transmitter.rb
@@ -34,21 +34,21 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    if not is_rf?
+    unless is_rf?
       print_error("Not an RF Transceiver")
       return
     end
-    if not set_index(datastore['INDEX'])
-      print_error("Couldn't set usb index to #{datastore["INDEX"]}")
+    unless set_index(datastore['INDEX'])
+      print_error("Couldn't set usb index to #{datastore['INDEX']}")
       return
     end
     set_modulation("ASK/OOK")
-    set_freq(datastore["FREQ"])
+    set_freq(datastore['FREQ'])
     set_sync_mode(0)
-    set_baud(datastore["BAUD"])
+    set_baud(datastore['BAUD'])
     set_channel_spc(24000)
     set_mode("idle")
-    set_power(datastore["POWER"])
+    set_power(datastore['POWER'])
 
     print_status("Transmitting on #{datastore['FREQ']} for #{datastore['SECONDS']} seconds...")
     set_mode("tx")


### PR DESCRIPTION
I should have tweaked these earlier, my bad.

No associated ticket, no release notes needed, IMO.

## Verification

A simple verification can be done following the same verification steps from [PR-7935](https://github.com/rapid7/metasploit-framework/pull/7935):

- [x] Start rfcat_msfrelay
- [x] **Verify** you see: RfCat MSFRelay running.
- [x] Start `msfconsole` (In another terminal window)
- [x] `use auxiliary/client/hwbridge/connect`
- [x] At auxiliary(connect) > `run`
- [x] **Verify** You see the NOTICE: leaving the matrix message
- [x] `sessions`
- [x] **Verify** You see a hwbridge session of type rftransceiver
- [x] `sessions -i 1`
- [x] `status`
- [x] **Verify** The device name reports YARDSTICKONE

