### PR TITLE
Augment msftidy to pass quote-enclosed $stdout text

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -578,7 +578,7 @@ class Msftidy
       next if ln =~ /^[[:space:]]*#/
 
       if ln =~ /\$std(?:out|err)/i or ln =~ /[[:space:]]puts/
-        next if ln =~ /^[\s]*["][^"]+\$std(?:out|err)/
+        next if ln =~ /["'][^"'\n]*\$std(?:out|err)(?:[^'"\n]*["']|)/
         no_stdio = false
         error("Writes to stdout", idx)
       end


### PR DESCRIPTION
This pull request attempts to resolve the specific msftidy errors being thrown due to quote-enclosed $stdout text, as per #7923. The PR **only** resolves cases in which $stdout appears within quotes, and is all on one line, so it probably isn't a sustainable solution :(

I'm a Google Summer of Code student looking to work with Metasploit in May, particularly related to automated reliability scoring and developing a static code analyzer to remove some of these msftidy issues!

## Verification

- [x] Run msftidy on modules/exploits/linux/local/service_persistence.rb, should no longer throw ERROR warnings

