### PR TITLE
Add new SMB LoginScanner using RubySMB for SMB1/SMB2 Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ PATH
       rex-text
       rex-zip
       robots
+      ruby_smb
       rubyntlm
       rubyzip
       sqlite3
@@ -102,6 +103,7 @@ GEM
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
     bcrypt (3.1.11)
+    bindata (2.3.5)
     bit-struct (0.15.0)
     builder (3.2.3)
     capybara (2.13.0)
@@ -323,6 +325,11 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby_smb (0.0.8)
+      bindata
+      bit-struct
+      rubyntlm (~> 0.5)
+      windows_error
     rubyntlm (0.6.1)
     rubyzip (1.2.1)
     sawyer (0.8.1)

--- a/lib/metasploit/framework/login_scanner/smb2.rb
+++ b/lib/metasploit/framework/login_scanner/smb2.rb
@@ -1,0 +1,142 @@
+require 'metasploit/framework'
+require 'metasploit/framework/tcp/client'
+require 'metasploit/framework/login_scanner/base'
+require 'metasploit/framework/login_scanner/rex_socket'
+require 'ruby_smb'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # This is the LoginScanner class for dealing with the Server Messaging
+      # Block protocol.
+      class SMB2
+        include Metasploit::Framework::Tcp::Client
+        include Metasploit::Framework::LoginScanner::Base
+        include Metasploit::Framework::LoginScanner::RexSocket
+
+        # Constants to be used in {Result#access_level}
+        module AccessLevels
+          # Administrative access. For SMB, this is defined as being
+          # able to successfully Tree Connect to the `ADMIN$` share.
+          # This definition is not without its problems, but suffices to
+          # conclude that such a user will most likely be able to use
+          # psexec.
+          ADMINISTRATOR = "Administrator"
+          # Guest access means our creds were accepted but the logon
+          # session is not associated with a real user account.
+          GUEST = "Guest"
+        end
+
+        CAN_GET_SESSION      = true
+        DEFAULT_REALM        = 'WORKSTATION'
+        LIKELY_PORTS         = [ 139, 445 ]
+        LIKELY_SERVICE_NAMES = [ "smb" ]
+        PRIVATE_TYPES        = [ :password, :ntlm_hash ]
+        REALM_KEY            = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
+
+        module StatusCodes
+          CORRECT_CREDENTIAL_STATUS_CODES = [
+            "STATUS_ACCOUNT_DISABLED",
+            "STATUS_ACCOUNT_EXPIRED",
+            "STATUS_ACCOUNT_RESTRICTION",
+            "STATUS_INVALID_LOGON_HOURS",
+            "STATUS_INVALID_WORKSTATION",
+            "STATUS_LOGON_TYPE_NOT_GRANTED",
+            "STATUS_PASSWORD_EXPIRED",
+            "STATUS_PASSWORD_MUST_CHANGE",
+          ].freeze.map(&:freeze)
+        end
+
+        # @!attribute dispatcher
+        #   @return [RubySMB::Dispatcher::Socket]
+        attr_accessor :dispatcher
+
+        # If login is successul and {Result#access_level} is not set
+        # then arbitrary credentials are accepted. If it is set to
+        # Guest, then arbitrary credentials are accepted, but given
+        # Guest permissions.
+        #
+        # @param domain [String] Domain to authenticate against. Use an
+        #   empty string for local accounts.
+        # @return [Result]
+        def attempt_bogus_login(domain)
+          if defined?(@result_for_bogus)
+            return @result_for_bogus
+          end
+          cred = Credential.new(
+            public: Rex::Text.rand_text_alpha(8),
+            private: Rex::Text.rand_text_alpha(8),
+            realm: domain
+          )
+          @result_for_bogus = attempt_login(cred)
+        end
+
+
+        # (see Base#attempt_login)
+        def attempt_login(credential)
+
+          begin
+            connect
+          rescue ::Rex::ConnectionError => e
+            result = Result.new(
+              credential:credential,
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
+              proof: e,
+              host: host,
+              port: port,
+              protocol: 'tcp',
+              service_name: 'smb'
+            )
+            return result
+          end
+          proof = nil
+
+          begin
+
+            realm       = credential.realm || ""
+            client      = RubySMB::Client.new(self.dispatcher, username: credential.public, password: credential.private, domain: realm)
+            status_code = client.login
+
+            case status_code.name
+              when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
+                status = Metasploit::Model::Login::Status::DENIED_ACCESS
+              when 'STATUS_SUCCESS'
+                status = Metasploit::Model::Login::Status::SUCCESSFUL
+              when 'STATUS_ACCOUNT_LOCKED_OUT'
+                status = Metasploit::Model::Login::Status::LOCKED_OUT
+              when 'STATUS_LOGON_FAILURE', 'STATUS_ACCESS_DENIED'
+                status = Metasploit::Model::Login::Status::INCORRECT
+              else
+                status = Metasploit::Model::Login::Status::INCORRECT
+            end
+          rescue ::Rex::ConnectionError => e
+            status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+            proof = e
+          end
+
+          result = Result.new(credential: credential, status: status, proof: proof)
+          result.host         = host
+          result.port         = port
+          result.protocol     = 'tcp'
+          result.service_name = 'smb'
+          result
+        end
+
+        def connect
+          disconnect
+          self.sock       = super
+          self.dispatcher = RubySMB::Dispatcher::Socket.new(self.sock)
+        end
+
+        def set_sane_defaults
+          self.connection_timeout           = 10 if self.connection_timeout.nil?
+          self.max_send_size                = 0 if self.max_send_size.nil?
+          self.send_delay                   = 0 if self.send_delay.nil?
+        end
+
+      end
+    end
+  end
+end
+

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -106,6 +106,7 @@ Gem::Specification.new do |spec|
   # Protocol Libraries
   #
   spec.add_runtime_dependency 'net-ssh'
+  spec.add_runtime_dependency 'ruby_smb'
 
   #
   # REX Libraries

--- a/modules/auxiliary/scanner/smb/smb2_login.rb
+++ b/modules/auxiliary/scanner/smb/smb2_login.rb
@@ -24,6 +24,10 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'           => 'SMB Login Check Scanner',
       'Description'    => %q{
+        SMB1 and SMB2 Compatible Login Scanner module. This version of
+        smb_login will seemlessly work with either version of the protocol.
+        SMB3 support will come at a future date.
+
         This module will test a SMB login on a range of machines and
         report successful logins.  If you have loaded a database plugin
         and connected to a database this module will record successful

--- a/modules/auxiliary/scanner/smb/smb2_login.rb
+++ b/modules/auxiliary/scanner/smb/smb2_login.rb
@@ -1,0 +1,217 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'metasploit/framework/login_scanner/smb2'
+require 'metasploit/framework/credential_collection'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::DCERPC
+  include Msf::Exploit::Remote::SMB::Client
+  include Msf::Exploit::Remote::SMB::Client::Authenticated
+
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+
+  def proto
+    'smb'
+  end
+  def initialize
+    super(
+      'Name'           => 'SMB Login Check Scanner',
+      'Description'    => %q{
+        This module will test a SMB login on a range of machines and
+        report successful logins.  If you have loaded a database plugin
+        and connected to a database this module will record successful
+        logins and hosts so you can track your access.
+      },
+      'Author'         =>
+        [
+          'thelightcosine', # RubySMB/SMB2 refactor
+          'tebo <tebo[at]attackresearch.com>', # Original
+          'Ben Campbell', # Refactoring
+          'Brandon McCann "zeknox" <bmccann[at]accuvant.com>', # admin check
+          'Tom Sellers <tom[at]fadedcode.net>' # admin check/bug fix
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '1999-0506'], # Weak password
+        ],
+      'License'     => MSF_LICENSE,
+      'DefaultOptions' =>
+        {
+          'DB_ALL_CREDS'    => false,
+          'BLANK_PASSWORDS' => false,
+          'USER_AS_PASS'    => false
+        }
+    )
+    deregister_options('RHOST','USERNAME','PASSWORD')
+
+    # These are normally advanced options, but for this module they have a
+    # more active role, so make them regular options.
+    register_options(
+      [
+        Opt::Proxies,
+        OptBool.new('ABORT_ON_LOCKOUT', [ true, "Abort the run when an account lockout is detected", false ]),
+        OptBool.new('PRESERVE_DOMAINS', [ false, "Respect a username that contains a domain name.", true ]),
+        OptBool.new('DETECT_ANY_AUTH', [false, 'Enable detection of systems accepting any authentication', true])
+      ], self.class)
+
+  end
+
+  def run_host(ip)
+    print_brute(:level => :vstatus, :ip => ip, :msg => "Starting SMB login bruteforce")
+
+    domain = datastore['SMBDomain'] || ""
+
+    @scanner = Metasploit::Framework::LoginScanner::SMB2.new(
+      host: ip,
+      port: rport,
+      local_port: datastore['CPORT'],
+      stop_on_success: datastore['STOP_ON_SUCCESS'],
+      bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+      connection_timeout: 5,
+      max_send_size: datastore['TCP::max_send_size'],
+      send_delay: datastore['TCP::send_delay'],
+      framework: framework,
+      framework_module: self,
+    )
+
+    if datastore['DETECT_ANY_AUTH']
+      bogus_result = @scanner.attempt_bogus_login(domain)
+      if bogus_result.success?
+        print_error("This system accepts authentication with any credentials, brute force is ineffective.")
+        return
+      else
+        vprint_status('This system does not accept authentication with any credentials, proceeding with brute force')
+      end
+    end
+
+    cred_collection = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['SMBPass'],
+      user_file: datastore['USER_FILE'],
+      userpass_file: datastore['USERPASS_FILE'],
+      username: datastore['SMBUser'],
+      user_as_pass: datastore['USER_AS_PASS'],
+      realm: domain,
+    )
+
+    cred_collection = prepend_db_passwords(cred_collection)
+    cred_collection = prepend_db_hashes(cred_collection)
+
+    @scanner.cred_details = cred_collection
+
+    @scanner.scan! do |result|
+      case result.status
+      when Metasploit::Model::Login::Status::LOCKED_OUT
+        if datastore['ABORT_ON_LOCKOUT']
+          print_error("Account lockout detected on '#{result.credential.public}', aborting.")
+          return
+        else
+          print_error("Account lockout detected on '#{result.credential.public}', skipping this user.")
+        end
+
+      when Metasploit::Model::Login::Status::DENIED_ACCESS
+        print_brute :level => :status, :ip => ip, :msg => "Correct credentials, but unable to login: '#{result.credential}', #{result.proof}"
+        report_creds(ip, rport, result)
+        :next_user
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}' #{result.access_level}"
+        report_creds(ip, rport, result)
+        :next_user
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        if datastore['VERBOSE']
+          print_brute :level => :verror, :ip => ip, :msg => "Could not connect"
+        end
+        invalidate_login(
+            address: ip,
+            port: rport,
+            protocol: 'tcp',
+            public: result.credential.public,
+            private: result.credential.private,
+            realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+            realm_value: result.credential.realm,
+            status: result.status
+        )
+        :abort
+      when Metasploit::Model::Login::Status::INCORRECT
+        if datastore['VERBOSE']
+          print_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}', #{result.proof}"
+        end
+        invalidate_login(
+          address: ip,
+          port: rport,
+          protocol: 'tcp',
+          public: result.credential.public,
+          private: result.credential.private,
+          realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+          realm_value: result.credential.realm,
+          status: result.status
+        )
+      end
+    end
+
+  end
+
+
+  # This logic is not universal ie a local account will not care about workgroup
+  # but remote domain authentication will so check each instance
+  def accepts_bogus_domains?(user, pass)
+    bogus_domain = @scanner.attempt_login(
+      Metasploit::Framework::Credential.new(
+        public: user,
+        private: pass,
+        realm: Rex::Text.rand_text_alpha(8)
+      )
+    )
+
+    return bogus_domain.success?
+  end
+
+  def report_creds(ip, port, result)
+    service_data = {
+      address: ip,
+      port: port,
+      service_name: 'smb',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      module_fullname: self.fullname,
+      origin_type: :service,
+      private_data: result.credential.private,
+      private_type: (
+        Rex::Proto::NTLM::Utils.is_pass_ntlm_hash?(result.credential.private) ? :ntlm_hash : :password
+      ),
+      username: result.credential.public,
+    }.merge(service_data)
+
+    if domain.present?
+      if accepts_bogus_domains?(result.credential.public, result.credential.private)
+        print_brute(:level => :vstatus, :ip => ip, :msg => "Domain is ignored for user #{result.credential.public}")
+      else
+        credential_data.merge!(
+          realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+          realm_value: result.credential.realm
+        )
+      end
+    end
+
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: result.status
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+end

--- a/spec/lib/metasploit/framework/login_scanner/smb2_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smb2_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/smb2'
+
+RSpec.describe Metasploit::Framework::LoginScanner::SMB2 do
+  let(:public) { 'root' }
+  let(:private) { 'toor' }
+
+  let(:pub_blank) {
+    Metasploit::Framework::Credential.new(
+        paired: true,
+        public: public,
+        private: ''
+    )
+  }
+
+  let(:pub_pub) {
+    Metasploit::Framework::Credential.new(
+        paired: true,
+        public: public,
+        private: public
+    )
+  }
+
+  let(:pub_pri) {
+    Metasploit::Framework::Credential.new(
+        paired: true,
+        public: public,
+        private: private
+    )
+  }
+
+
+  subject(:login_scanner) { described_class.new }
+
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: true
+  it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
+  it_behaves_like 'Metasploit::Framework::Tcp::Client'
+
+
+  context '#attempt_login' do
+    context 'when it cannot connect to the server' do
+      it 'returns a result with an UNABLE_TO_CONNECT status' do
+        expect(login_scanner).to receive(:connect).and_raise Rex::ConnectionError
+        expect(login_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+      end
+    end
+
+    context 'when it can connect' do
+      before(:each) do
+        allow(login_scanner).to receive(:connect)
+        login_scanner.dispatcher = RubySMB::Dispatcher::Socket.new(StringIO.new)
+      end
+
+      let(:success) { WindowsError::NTStatus::STATUS_SUCCESS }
+      let(:locked) { WindowsError::NTStatus::STATUS_ACCOUNT_LOCKED_OUT }
+      let(:fail) { WindowsError::NTStatus::STATUS_LOGON_FAILURE }
+
+      it 'returns a result with SUCCESSFUL status if it succeeds' do
+        expect_any_instance_of(RubySMB::Client).to receive(:login).and_return(success)
+        expect(login_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::SUCCESSFUL
+      end
+
+      it 'returns a result with LOCKED_OUT status if the account is locked' do
+        expect_any_instance_of(RubySMB::Client).to receive(:login).and_return(locked)
+        expect(login_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::LOCKED_OUT
+      end
+
+      it 'returns a result with INCORRECT status if it fails' do
+        expect_any_instance_of(RubySMB::Client).to receive(:login).and_return(fail)
+        expect(login_scanner.attempt_login(pub_pri).status).to eq Metasploit::Model::Login::Status::INCORRECT
+      end
+
+      it 'returns the result with the credential the result is for' do
+        expect_any_instance_of(RubySMB::Client).to receive(:login).and_return(success)
+        expect(login_scanner.attempt_login(pub_pri).credential).to eq pub_pri
+      end
+
+      it 'returns the result with the protocol set to tcp' do
+        expect_any_instance_of(RubySMB::Client).to receive(:login).and_return(success)
+        expect(login_scanner.attempt_login(pub_pri).protocol).to eq 'tcp'
+      end
+
+      it 'returns the result with the  service_name set to smb' do
+        expect_any_instance_of(RubySMB::Client).to receive(:login).and_return(success)
+        expect(login_scanner.attempt_login(pub_pri).service_name).to eq 'smb'
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
This PR adds a new temporary LoginScanner and module for ongoing RubySMB work.
The module auxiliary/scanner/smb/smb2_login works much like the original smb_login module except that it uses the new ruby_smb gem and can handle both SMB1 and SMB2 as well as doing signing all transparent to the user. no extra configuration is required.

Lands MS-2557

## Verification
**Note**
 Click [Here](https://support.microsoft.com/en-us/help/2696547/how-to-enable-and-disable-smbv1,-smbv2,-and-smbv3-in-windows-vista,-windows-server-2008,-windows-7,-windows-server-2008-r2,-windows-8,-and-windows-server-2012) To see an article on how to enable or disable different SMB version. inside the same  part of the registry there is a key called 'requiresecuritysignature' setting this to 1 enforce signature requirements, and setting it to 0 disables it. a reboot is required

List the steps needed to make sure this thing works
- [x] Set up a windows VM that talks only SMB1
- [x] Set up a windows VM that talks only SMB2
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/smb/smb2_login`
- [x] Set RHOSTS to the addresses for your two VM
- [x] Set some username and password options as you would for any login scanner module
- [x] run the modules
- [x] **Verify**  that the module works correctly against both targets
- [x] Set both of your target VMs to require security signatures and reboot them
- [x] run the module again
- [x] **Verify** the module STILL works as expected

