### PR TITLE
Add missing ranks

### DIFF
--- a/modules/exploits/firefox/local/exec_shellcode.rb
+++ b/modules/exploits/firefox/local/exec_shellcode.rb
@@ -7,6 +7,7 @@ require 'msf/core'
 require 'msf/core/payload/firefox'
 
 class MetasploitModule < Msf::Exploit::Local
+  Rank = GreatRanking # Missing autodetection, but has widespread targetability
 
   include Msf::Payload::Firefox
   include Msf::Exploit::Remote::FirefoxPrivilegeEscalation

--- a/modules/exploits/firefox/local/exec_shellcode.rb
+++ b/modules/exploits/firefox/local/exec_shellcode.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 require 'msf/core/payload/firefox'
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = GreatRanking # Missing autodetection, but has widespread targetability
+  Rank = ExcellentRanking # Missing autodetection, but has widespread targetability
 
   include Msf::Payload::Firefox
   include Msf::Exploit::Remote::FirefoxPrivilegeEscalation

--- a/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
+++ b/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = GreatRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper

--- a/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
+++ b/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper

--- a/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
+++ b/modules/exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Telnet
   include Msf::Exploit::Remote::HttpClient

--- a/modules/exploits/linux/http/efw_chpasswd_exec.rb
+++ b/modules/exploits/linux/http/efw_chpasswd_exec.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
 

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
 
   include Exploit::Remote::Tcp
 

--- a/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
+++ b/modules/exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
 
     include Msf::Exploit::Remote::Telnet
     include Msf::Exploit::Remote::HttpClient

--- a/modules/exploits/linux/local/hp_smhstart.rb
+++ b/modules/exploits/linux/local/hp_smhstart.rb
@@ -9,7 +9,7 @@ require 'msf/core/exploit/local/linux'
 require 'msf/core/exploit/exe'
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = AverageRanking
+  Rank = NormalRanking
 
   include Msf::Exploit::EXE
   include Msf::Post::File

--- a/modules/exploits/linux/local/hp_smhstart.rb
+++ b/modules/exploits/linux/local/hp_smhstart.rb
@@ -9,6 +9,7 @@ require 'msf/core/exploit/local/linux'
 require 'msf/core/exploit/exe'
 
 class MetasploitModule < Msf::Exploit::Local
+  Rank = AverageRanking
 
   include Msf::Exploit::EXE
   include Msf::Post::File


### PR DESCRIPTION
This PR hopes to resolve some of the missing exploit module rankings as per #7923 

I've also included a few lines of justification for each ranking - tell me if I'm off the mark!

../exec_shellcode.rb
Rank = Great
This exploit is missing autodetection and version checks,
but should be ranked Great due to high number of possible targets

../cfme_manageiq_evm_upload_exec.rb
Rank = Great
This exploit implements a check to assess target availability,
and the vulnerability does not require any user action

../dlink_dcs_930l_authenticated_remote_command_execution
Rank = Excellent
Exploit utilizes command injection

../efw_chpasswd_exec
Rank = Excellent
Exploit utilizes command injection

../foreman_openstack_satellite_code_exec
Rank = Excellent
Exploit utilizes code injection

../nginx_chunked_size
Rank = Great
Exploit has explicit targets with nginx version auto-detection

../tp_link_sc2020n_authenticated_telnet_injection
Rank = Excellent
See dlink_dcs_930l_authenticated_remote_command_execution,
exploit uses OS Command Injection

../hp_smhstart
Rank = Average
Must be specific user to exploit, no autodetection,
specific versions only

## Verification

- [ ] Run msftidy on the exploit modules, **verify** the below files no longer throw [INFO] No Rank Specified messages:
    - [ ] ../exploits/firefox/local/exec_shellcode.rb 
    - [ ] ../exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
    - [ ] ../exploits/linux/http/dlink_dcs_930l_authenticated_remote_command_execution.rb
    - [ ] ../exploits/linux/http/efw_chpasswd_exec.rb
    - [ ] ../exploits/linux/http/foreman_openstack_satellite_code_exec.rb
    - [ ] ../exploits/linux/http/nginx_chunked_size.rb
    - [ ] ../exploits/linux/http/tp_link_sc2020n_authenticated_telnet_injection.rb
    - [ ] ../exploits/linux/local/hp_smhstart.rb


