### PR TITLE
deregeister smb2_login from pro bruteforce

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb2.rb
+++ b/lib/metasploit/framework/login_scanner/smb2.rb
@@ -30,8 +30,8 @@ module Metasploit
 
         CAN_GET_SESSION      = true
         DEFAULT_REALM        = 'WORKSTATION'
-        LIKELY_PORTS         = [ 139, 445 ]
-        LIKELY_SERVICE_NAMES = [ "smb" ]
+        #LIKELY_PORTS         = [ 139, 445 ]
+        #LIKELY_SERVICE_NAMES = [ "smb" ]
         PRIVATE_TYPES        = [ :password, :ntlm_hash ]
         REALM_KEY            = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
 


### PR DESCRIPTION
this loginscanner is temporary while we continue
to add the smb2 support and so we don't want the
Metasploit Pro bruteforcer picking it up

MS-2609


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Have an SMB service stored in your database
- [x] `irb`
- [x] enter the following:
```
service = Mdm::Service.where(name: 'smb').first
Metasploit::Framework::LoginScanner.classes_for_service(service)
```
- [x] **VERIFY** that you only get one entry back, the Metasploit::Framework::LoginScanner::SMB

