### PR TITLE
Make msfupdate check user.name and user.email

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -145,6 +145,35 @@ class Msfupdate
     end
   end
 
+
+  # We could also do this by running `git config --global user.name` and `git config --global user.email` 
+  # and check the output of those
+  def git_globals_okay?
+    conf_out_status = system('git config --list')  # Just see if it runs or not
+    if conf_out_status.nil?
+      stderr.puts '[-] ERROR: Failed to check git settings'
+      return false
+    end
+    
+    conf = `git config --list`  # Need the output for this
+    
+    if !conf.include? 'user.name'
+      stderr.puts '[-] ERROR: user.name is not set in your global git configuration'
+      stderr.puts ''
+      stderr.puts '[-] Set it by running: \'git config --global user.name "NAME HERE"\''
+      return false
+    end
+    if !conf.include? 'user.email'
+      stderr.puts '[-] ERROR: user.email is not set in your global git configuration'
+      stderr.puts ''
+      stderr.puts '[-] Set it by running: \'git config --global user.email "email@example.com"\''
+      return false
+    end
+
+    true
+
+  end
+
   def update_git!
     ####### Since we're Git, do it all that way #######
     stdout.puts "[*] Checking for updates via git"
@@ -163,8 +192,15 @@ class Msfupdate
     # to begin with.
     #
     # Note, this requires at least user.name and user.email
-    # to be configured in the global git config. Installers should
-    # take care that this is done. TODO: Enforce this in msfupdate
+    # to be configured in the global git config. Installers
+    # will be told to set them if they aren't already set.
+
+    # Checks user.name and user.email
+    global_status = git_globals_okay?
+    maybe_wait_and_exit(1) if !global_status
+    
+      
+    # We shouldn't get here if the globals dont check out
     committed = system("git", "diff", "--quiet", "HEAD")
     if committed.nil?
       stderr.puts "[-] ERROR: Failed to run git"
@@ -197,6 +233,8 @@ class Msfupdate
       system("bundle", "install")
     end
   end
+
+  
 
   def update_binary_install!
     update_script = File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))

--- a/msfupdate
+++ b/msfupdate
@@ -145,28 +145,45 @@ class Msfupdate
     end
   end
 
-
   # We could also do this by running `git config --global user.name` and `git config --global user.email` 
-  # and check the output of those
+  # and check the output of those. (it's a bit quieter)
   def git_globals_okay?
-    conf_out_status = system('git config --list')  # Just see if it runs or not
-    if conf_out_status.nil?
+    require 'tempfile'
+    require 'os'
+    output = ''
+
+    # Make it cross platform
+    if !OS.windows?
+      conf_out_status = system('git config --list > /dev/null 2>&1')  # Just see if it runs or not
+    else
+      conf_out_status = system('git config --list > nul 2&>1')
+    end
+    if !conf_out_status || conf_out_status.nil?
       stderr.puts '[-] ERROR: Failed to check git settings'
       return false
     end
+
+    begin
+      conf = Tempfile.new('gitconf')  # Create a tempfile
+      path = conf.path
+      system("git config --list > #{path}")  # Write to the tempfile (Pretty sure this command is cross platform)
+      output >> conf.read
+    ensure
+      conf.close
+      conf.unlink  # Delete the temp file
+    end
     
-    conf = `git config --list`  # Need the output for this
-    
-    if !conf.include? 'user.name'
+    if !output.include? 'user.name'
       stderr.puts '[-] ERROR: user.name is not set in your global git configuration'
-      stderr.puts ''
       stderr.puts '[-] Set it by running: \'git config --global user.name "NAME HERE"\''
+      stderr.puts ''
       return false
     end
-    if !conf.include? 'user.email'
+
+    if !output.include? 'user.email'
       stderr.puts '[-] ERROR: user.email is not set in your global git configuration'
-      stderr.puts ''
       stderr.puts '[-] Set it by running: \'git config --global user.email "email@example.com"\''
+      stderr.puts ''
       return false
     end
 
@@ -233,8 +250,6 @@ class Msfupdate
       system("bundle", "install")
     end
   end
-
-  
 
   def update_binary_install!
     update_script = File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))


### PR DESCRIPTION
This PR makes `msfupdate` check for `user.name` and `user.email` in the global git configuration. In order to suppress command output, a tempfile will be created with the output. The file will then be read, saved in a string, and deleted.

I've tested this on OS X 10.11, but it may be useful to know how other platforms go about it (especially Windows).