### PR TITLE
Update Nmap parser to handle masscan

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -299,7 +299,7 @@ module Msf::DBManager::Import
           @import_filedata[:type] = "Nikto XML"
           return :nikto_xml
         when "nmaprun"
-          if line =~ /^<nmaprun scanner="masscan"/
+          if line.start_with?('<nmaprun scanner="masscan"')
             @import_filedata[:type] = "Masscan XML"
           else
             @import_filedata[:type] = "Nmap XML"

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -299,7 +299,11 @@ module Msf::DBManager::Import
           @import_filedata[:type] = "Nikto XML"
           return :nikto_xml
         when "nmaprun"
-          @import_filedata[:type] = "Nmap XML"
+          if line =~ /^<nmaprun scanner="masscan"/
+            @import_filedata[:type] = "Masscan XML"
+          else
+            @import_filedata[:type] = "Nmap XML"
+          end
           return :nmap_xml
         when "openvas-report"
           @import_filedata[:type] = "OpenVAS"

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1316,6 +1316,7 @@ class Db
     print_line "    IP360 ASPL"
     print_line "    IP360 XML v3"
     print_line "    Libpcap Packet Capture"
+    print_line "    Masscan XML"
     print_line "    Metasploit PWDump Export"
     print_line "    Metasploit XML"
     print_line "    Metasploit Zip Export"

--- a/lib/rex/parser/nmap_nokogiri.rb
+++ b/lib/rex/parser/nmap_nokogiri.rb
@@ -37,6 +37,8 @@ module Rex
       block = @block
       @state[:current_tag][name] = true
       case name
+      when "nmaprun"
+        record_nmaprun(attrs)
       when "status"
         record_host_status(attrs)
       when "address"
@@ -94,6 +96,11 @@ module Rex
 
     # We can certainly get fancier with self.send() magic, but
     # leaving this pretty simple for now.
+
+    def record_nmaprun(attrs)
+      nmaprun = attr_hash(attrs)
+      @state[:scanner] = nmaprun['scanner']
+    end
 
     def record_host_hop(attrs)
       return unless in_tag("host")
@@ -228,7 +235,8 @@ module Rex
     end
 
     def collect_host_data
-      if @state[:host_alive]
+      # Treat masscan hosts as always alive
+      if @state[:host_alive] || @state[:scanner] == 'masscan'
         @report_data[:state] = Msf::HostState::Alive
       else
         @report_data[:state] = Msf::HostState::Dead

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "    IP360 ASPL",
           "    IP360 XML v3",
           "    Libpcap Packet Capture",
+          "    Masscan XML",
           "    Metasploit PWDump Export",
           "    Metasploit XML",
           "    Metasploit Zip Export",


### PR DESCRIPTION
masscan is missing `<status>`, meaning hosts aren't treated as alive.

- [x] `nmap -oX` and `db_import`
- [x] See `hosts` and `services`
- [x] `masscan -oX` and `db_import`
- [x] See `hosts` and `services`

Thanks to @jhart-r7 and @jlmurray for working on this previously.

Fixes #6208.