### PR TITLE
update docker stuff

### DIFF
--- a/docker/bin/msfconsole-dev
+++ b/docker/bin/msfconsole-dev
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+if [[ -z "$MSF_PATH" ]]; then
+  path=`dirname $0`
+
+  # check for ./docker/msfconsole.rc
+  if [[ ! -f $path/../msfconsole.rc ]] ; then
+
+    # we are not inside the project
+    realpath --version > /dev/null 2>&1 || { echo >&2 "I couldn't find where metasploit is. Set \$MSF_PATH or execute this from the project root"; exit 1 ;}
+
+    # determine script path
+    pushd $(dirname $(realpath $0)) > /dev/null
+    path=$(pwd)
+    popd > /dev/null
+  fi
+  MSF_PATH=$(dirname $(dirname $path))
+fi
+
+cd $MSF_PATH
+
+if [[ -n "$MSF_BUILD" ]]; then
+  docker-compose -f $MSF_PATH/docker-compose.yml -f $MSF_PATH/docker/docker-compose.development.override.yml build
+fi
+
+docker-compose -f $MSF_PATH/docker-compose.yml -f $MSF_PATH/docker/docker-compose.development.override.yml run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$@"
+

--- a/docker/docker-compose.development.override.yml
+++ b/docker/docker-compose.development.override.yml
@@ -6,4 +6,4 @@ services:
       DATABASE_URL: postgres://postgres@db:5432/msf_dev
 
     volumes:
-      - .:/usr/src/app
+      - .:/usr/src/metasploit-framework


### PR DESCRIPTION
This PR changes some docker stuff:

- The path in the development override was incorrect resulting in non working dev images
- I added a new `msfconsole-dev` binstub with the override file and a new env variable: `MSF_BUILD`
If you set this variable and call `msfconsole-dev` the image will be rebuild (used when the gemfile changes between branches)

![a](https://cloud.githubusercontent.com/assets/105281/24624114/148bd36c-18ab-11e7-88dd-e8d696a511f7.png)
