### PR TITLE
Update client to use TLS1.2

### DIFF
--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -36,7 +36,7 @@ class Client
       :port => 3790,
       :uri  => '/api/',
       :ssl  => true,
-      :ssl_version => 'TLS1',
+      :ssl_version => 'TLS1.2',
       :context     => {}
     }.merge(info)
 


### PR DESCRIPTION
Update RPC Client to use TLSv1.2.

## Verification

- [x] Start `msfconsole`