### PR TITLE
Add documentation requirement to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,5 @@ List the steps needed to make sure this thing works
 - [ ] ...
 - [ ] **Verify** the thing does what it should
 - [ ] **Verify** the thing does not do what it should not
+- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
 


### PR DESCRIPTION
This changes the default PR template to require PR submitters to provide documentation for their respective modules.

## Verification

List the steps needed to make sure this thing works

- [x] Get peer review from MSF devs on this being ok

