### PR TITLE
Add IP based geolocation auxiliary module

### DIFF
--- a/documentation/modules/auxiliary/gather/ip_geolocate.md
+++ b/documentation/modules/auxiliary/gather/ip_geolocate.md
@@ -1,0 +1,45 @@
+The `ip_geolocate` module utilized a free IP based geolocation API from https://freegeoip.net. IPv4 and IPv6 is supported,
+but the API sometimes trips up on IPv6. A list of IP addresses or a single address can be provided in the `RHOSTS` datastore option. 
+
+
+## Options
+
+  **RHOSTS**
+
+  A list of IPv4 or IPv6 addresses or a single address to query the API for. IPv4 address will be checked when the module is executed.
+
+## Scenarios
+ 
+Example console output of scanning the Google DNS servers (IPv4 and IPv6)
+```
+msf > use auxiliary/gather/ip_geolocate
+msf auxiliary(ip_geolocate) > options
+
+Module options (auxiliary/gather/ip_geolocate):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS                   yes       A comma separated list of addresses to scan
+
+msf auxiliary(ip_geolocate) > set RHOSTS 8.8.8.8, 2001:4860:4860::8888
+RHOSTS => 8.8.8.8, 2001:4860:4860::8888
+msf auxiliary(ip_geolocate) > run
+
+
+[*] Data for 8.8.8.8
+  Country: United States (US)
+  City: California (CA)
+  Zip Code: 94035
+  Latitude: 37.386 (estimation)
+  Longitude: -122.0838 (estimation)
+  Google Maps URL: https://maps.google.com/?q=37.386,-122.0838
+
+[*] Data for 2001:4860:4860::8888
+  Country: United States (US)
+  City:  ()
+  Zip Code: 
+  Latitude: 37.751 (estimation)
+  Longitude: -97.822 (estimation)
+  Google Maps URL: https://maps.google.com/?q=37.751,-97.822
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/gather/ip_geolocate.md
+++ b/documentation/modules/auxiliary/gather/ip_geolocate.md
@@ -6,7 +6,7 @@ but the API sometimes trips up on IPv6. A list of IP addresses or a single addre
 
   **RHOSTS**
 
-  A list of IPv4 or IPv6 addresses or a single address to query the API for. IPv4 address will be checked when the module is executed.
+  A list of IPv4 or IPv6 addresses or a single address to query the API for. The addresses will be checked when the module is executed.
 
 ## Scenarios
  

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
 
 
   def run
-    raw_rhosts = datastore['RHOSTS']
+    raw_rhosts = datastore['TARGETS']
     rhosts = raw_rhosts.split(',')
     rhosts.each do |host|
 

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def valid_ipv4?(host)
     return true if (host =~ Rex::Socket::MATCH_IPV4)
+    return false if (host =~ Rex::Socket::MATCH_IPV4_PRIVATE)
     return false
   end
 
@@ -55,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     rhosts.each do |host|
 
       host.strip!  # Just in cast there are spaces in there
-      if !valid_ipv4?(host) && !valid_ipv6?(host)
+      if !valid_ipv4?(host) || !valid_ipv6?(host)
         print_error("#{host} is not a valid IP address")
         next
       end

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -3,20 +3,16 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
 require 'json'
 
 class MetasploitModule < Msf::Auxiliary
 
-  include Rex::Proto::Http
-  include Msf::Exploit::Remote::HttpClient
-  # HttpClient is only included because of normalize_uri
 
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'IP Based Geolocation',
       'Description'    => %q{
-        This module uses a GeoIP API to locate the location
+        This module uses a GeoIP API to estimate the location
         of a given IP address. Even though an external API is being
         used, a API key is not needed for the module to work properly.
         The shown longitude and latitude values are estimations.
@@ -28,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new("RHOSTS", [true, "A comma separated list of addresses to scan", nil])
+        OptString.new('TARGETS', [true, "A comma separated list of addresses to scan", nil])
       ])
 
     deregister_options( 'RHOST', 'SSL', 'RPORT', 'VHOST', 'Proxies' )
@@ -73,8 +69,8 @@ class MetasploitModule < Msf::Auxiliary
       # Because we're requesting an external site, we aren't actually requesting `rhost`
       # We're requesting the API and passing `rhost` in the URI.
       # This is why Rex::Proto::Http is being used and not send_request_cgi from HttpClient
-      uri = normalize_uri('json', "#{host}")
-      cli = Client.new('freegeoip.net', 80, {}, false)  # The API uses only HTTP unfortunately
+      uri = Msf::Exploit::Remote::HttpClient.normalize_uri('json', "#{host}")
+      cli = Rex::Proto::Http::Client.new('freegeoip.net', 80, {}, false)  # The API uses only HTTP unfortunately
       cli.connect
       req = cli.request_cgi({ 'uri' => uri })
       res = cli.send_recv(req)
@@ -92,11 +88,11 @@ class MetasploitModule < Msf::Auxiliary
       parsed = JSON.parse(res.body)  # Make it fun to use (hash)
       print_line
       print_status("Data for #{host}")
-      print_line("  Country: #{parsed['country_name']} (#{parsed['country_code']})")  # Print the country and country country code
-      print_line("  City: #{parsed['region_name']} (#{parsed['region_code']})")       # Print the city and city code
-      print_line("  Zip Code: #{parsed['zip_code']}")                                 # Print the zip code
-      print_line("  Latitude: #{parsed['latitude']} (estimation)")                    # Print the latitude
-      print_line("  Longitude: #{parsed['longitude']} (estimation)")                  # Print the longitude
+      print_line("  Country: #{parsed['country_name']} (#{parsed['country_code']})")
+      print_line("  City: #{parsed['region_name']} (#{parsed['region_code']})")
+      print_line("  Zip Code: #{parsed['zip_code']}")
+      print_line("  Latitude: #{parsed['latitude']} (estimation)")
+      print_line("  Longitude: #{parsed['longitude']} (estimation)")
       print_line("  Google Maps URL: #{gmap_url(parsed['latitude'], parsed['longitude'])}")
     end
   end

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'json'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Rex::Proto::Http
+  include Msf::Exploit::Remote::HttpClient
+  # HttpClient is only included because of normalize_uri
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'IP Based Geolocation',
+      'Description'    => %q{
+        This module uses a GeoIP API to locate the location
+        of a given IP address. Even though an external API is being
+        used, a API key is not needed for the module to work properly.
+        The shown longitude and latitude values are estimations.
+        If you want a more exact location, use the `wlan_geolocate` module.
+      },
+      'Author'         => [ 'Carter Brainerd <0xCB@protonmail.com>' ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        OptString.new("RHOSTS", [true, "A comma separated list of addresses to scan", nil])
+      ])
+
+    deregister_options( 'RHOST', 'SSL', 'RPORT', 'VHOST', 'Proxies' )
+  end
+
+  def gmap_url(lat, long)
+    "https://maps.google.com/?q=#{lat},#{long}"
+  end
+
+  def valid_ipv4?(host)
+    block = /\d{,2}|1\d{2}|2[0-4]\d|25[0-5]/
+    re = /\A#{block}\.#{block}\.#{block}\.#{block}\z/
+    return re =~ host
+  end
+
+
+  def run
+    raw_rhosts = datastore['RHOSTS']
+    rhosts = raw_rhosts.split(',')
+    rhosts.each do |host|
+
+      host.strip!  # Just in cast there are spaces in there
+      if host.length <= 15
+        if valid_ipv4?(host) != 0  # Check if each ip address is valid
+          print_error("#{host} is not a valid IP address.")
+          next
+        end
+      end
+
+      # Because we're requesting an external site, we aren't actually requesting `rhost`
+      # We're requesting the API and passing `rhost` in the URI.
+      # This is why Rex::Proto::Http is being used and not send_request_cgi from HttpClient
+      uri = normalize_uri('json', "#{host}")
+      cli = Client.new('freegeoip.net', 80, {}, false)  # The API uses only HTTP unfortunately
+      cli.connect
+      req = cli.request_cgi({ 'uri' => uri })
+      res = cli.send_recv(req)
+
+      if res.nil?
+        print_error('Got an empty response from the API')
+        next
+      end
+
+      if res.code != 200
+        print_error("Got an unexpected response from the API (Code: #{res.code})")
+        next
+      end
+
+      parsed = JSON.parse(res.body)  # Make it fun to use (hash)
+      print_line
+      print_status("Data for #{host}")
+      print_line("  Country: #{parsed['country_name']} (#{parsed['country_code']})")  # Print the country and country country code
+      print_line("  City: #{parsed['region_name']} (#{parsed['region_code']})")       # Print the city and city code
+      print_line("  Zip Code: #{parsed['zip_code']}")                                 # Print the zip code
+      print_line("  Latitude: #{parsed['latitude']} (estimation)")                    # Print the latitude
+      print_line("  Longitude: #{parsed['longitude']} (estimation)")                  # Print the longitude
+      print_line("  Google Maps URL: #{gmap_url(parsed['latitude'], parsed['longitude'])}")
+    end
+  end
+end

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
     return true if (host =~ Rex::Socket::MATCH_IPV6)
     return false
   end
-  
+
   def is_local_ip?(host)
     return true if (host =~ Rex::Socket::MATCH_IPV4_PRIVATE)
     return false

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -40,7 +40,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def valid_ipv4?(host)
     return true if (host =~ Rex::Socket::MATCH_IPV4)
-    return false if (host =~ Rex::Socket::MATCH_IPV4_PRIVATE)
     return false
   end
 
@@ -56,8 +55,13 @@ class MetasploitModule < Msf::Auxiliary
     rhosts.each do |host|
 
       host.strip!  # Just in cast there are spaces in there
-      if !valid_ipv4?(host) || !valid_ipv6?(host)
+      if !valid_ipv4?(host) && !valid_ipv6?(host)
         print_error("#{host} is not a valid IP address")
+        next
+      end
+
+      if (host =~ Rex::Socket::MATCH_IPV4_PRIVATE)
+        print_error("#{host} is a local IP address.")
         next
       end
 

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -47,6 +47,11 @@ class MetasploitModule < Msf::Auxiliary
     return true if (host =~ Rex::Socket::MATCH_IPV6)
     return false
   end
+  
+  def is_local_ip?(host)
+    return true if (host =~ Rex::Socket::MATCH_IPV4_PRIVATE)
+    return false
+  end
 
 
   def run
@@ -60,7 +65,7 @@ class MetasploitModule < Msf::Auxiliary
         next
       end
 
-      if (host =~ Rex::Socket::MATCH_IPV4_PRIVATE)
+      if !is_local_ip?(host)
         print_error("#{host} is a local IP address.")
         next
       end

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'json'
-
 class MetasploitModule < Msf::Auxiliary
 
 

--- a/modules/auxiliary/gather/ip_geolocate.rb
+++ b/modules/auxiliary/gather/ip_geolocate.rb
@@ -39,9 +39,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def valid_ipv4?(host)
-    block = /\d{,2}|1\d{2}|2[0-4]\d|25[0-5]/
-    re = /\A#{block}\.#{block}\.#{block}\.#{block}\z/
-    return re =~ host
+    return true if (host =~ Rex::Socket::MATCH_IPV4)
+    return false
+  end
+
+  def valid_ipv6?(host)
+    return true if (host =~ Rex::Socket::MATCH_IPV6)
+    return false
   end
 
 
@@ -51,11 +55,9 @@ class MetasploitModule < Msf::Auxiliary
     rhosts.each do |host|
 
       host.strip!  # Just in cast there are spaces in there
-      if host.length <= 15
-        if valid_ipv4?(host) != 0  # Check if each ip address is valid
-          print_error("#{host} is not a valid IP address.")
-          next
-        end
+      if !valid_ipv4?(host) && !valid_ipv6?(host)
+        print_error("#{host} is not a valid IP address")
+        next
       end
 
       # Because we're requesting an external site, we aren't actually requesting `rhost`


### PR DESCRIPTION
This PR adds an IP based geolocation module. The module queries an external API from https://freegeoip.net. IPv4 and IPv6 are both supported. Compared to the `wlan_geolocate` post module, this module doesn't use MAC addresses, it uses IP addresses.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/ip_geolocate`
- [ ] `set RHOSTS xxx,xxx,xxx`
- [ ] `run`
You should see results that follow the following format:

```
 Data for: <ip>
   Country: <country> (<code>)
   City: <city> (<code>)
   Zip Code: <zip>
   Latitude: <lat>
   Longitude: <long>
   Google Maps URL: https://maps.google.com/?q=<lat>,<long>
```

### Output
Sample console output using IPv4 and IPv6:

```
msf > use auxiliary/gather/ip_geolocate
msf auxiliary(ip_geolocate) > options

Module options (auxiliary/gather/ip_geolocate):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS                   yes       A comma separated list of addresses to scan

msf auxiliary(ip_geolocate) > set RHOSTS 8.8.8.8, 2001:4860:4860::8888
RHOSTS => 8.8.8.8, 2001:4860:4860::8888
msf auxiliary(ip_geolocate) > run


[*] Data for 8.8.8.8
  Country: United States (US)
  City: California (CA)
  Zip Code: 94035
  Latitude: 37.386 (estimation)
  Longitude: -122.0838 (estimation)
  Google Maps URL: https://maps.google.com/?q=37.386,-122.0838

[*] Data for 2001:4860:4860::8888
  Country: United States (US)
  City:  ()
  Zip Code: 
  Latitude: 37.751 (estimation)
  Longitude: -97.822 (estimation)
  Google Maps URL: https://maps.google.com/?q=37.751,-97.822
[*] Auxiliary module execution completed
```