### PR TITLE
Fix #8191 (msfvenom cannot create exe-service)

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -631,7 +631,7 @@ require 'msf/core/exe/segment_appender'
 
       opts[:framework] = framework
       opts[:payload] = 'stdin'
-      opts[:encoder] = '@x86/service,'+opts[:serviceencoder]
+      opts[:encoder] = '@x86/service,'+(opts[:serviceencoder] || '')
 
       venom_generator = Msf::PayloadGenerator.new(opts)
       code_service = venom_generator.multiple_encode_payload(code)


### PR DESCRIPTION
This fixes issue #8191: Cannot create exe-service from msfvenom

### Verification Steps:
1. run `msfvenom -p windows/meterpreter/bind_tcp -f exe-service LPORT=16103 -o /tmp/service.exe`

Current behavior causes it to fail (implicit nil into String). With this patch, the file will be created successfully. 

### Expected console output:
```
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 299 bytes
Final size of exe-service file: 15872 bytes
Saved as: /tmp/service.exe
```

Previous console output:
```
...
Payload size: 299 bytes
Error: no implicit conversion of nil into String
```