### PR TITLE
fix #7921, HttpTrace and chunked encoding

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -314,7 +314,7 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         print_line('# Response:')
         print_line('#' * 20)
-        print_line(res.to_s)
+        print_line(res.to_terminal_output)
       end
 
       res
@@ -360,7 +360,7 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         print_line('# Response:')
         print_line('#' * 20)
-        print_line(res.to_s)
+        print_line(res.to_terminal_output)
       end
       disconnect(c)
       res

--- a/lib/rex/proto/http/packet.rb
+++ b/lib/rex/proto/http/packet.rb
@@ -164,9 +164,24 @@ class Packet
   end
 
   #
+  # Outputs a readable string of the packet for terminal output
+  #
+  def to_terminal_output
+    output_packet(true)
+  end
+
+  #
   # Converts the packet to a string.
   #
   def to_s
+    output_packet(false)
+  end
+
+  #
+  # Converts the packet to a string.
+  # If ignore_chunk is set the chunked encoding is omitted (for pretty print)
+  #
+  def output_packet(ignore_chunk=false)
     content = self.body.to_s.dup
 
     # Update the content length field in the header with the body length.
@@ -187,16 +202,18 @@ class Packet
         end
       end
 
-      if (self.auto_cl == true && self.transfer_chunked == true)
-        raise RuntimeError, "'Content-Length' and 'Transfer-Encoding: chunked' are incompatible"
-      elsif self.auto_cl == true
-        self.headers['Content-Length'] = content.length
-      elsif self.transfer_chunked == true
-        if self.proto != '1.1'
-          raise RuntimeError, 'Chunked encoding is only available via 1.1'
+      unless ignore_chunk
+        if (self.auto_cl == true && self.transfer_chunked == true)
+          raise RuntimeError, "'Content-Length' and 'Transfer-Encoding: chunked' are incompatible"
+        elsif self.auto_cl == true
+          self.headers['Content-Length'] = content.length
+        elsif self.transfer_chunked == true
+          if self.proto != '1.1'
+            raise RuntimeError, 'Chunked encoding is only available via 1.1'
+          end
+          self.headers['Transfer-Encoding'] = 'chunked'
+          content = self.chunk(content, self.chunk_min_size, self.chunk_max_size)
         end
-        self.headers['Transfer-Encoding'] = 'chunked'
-        content = self.chunk(content, self.chunk_min_size, self.chunk_max_size)
       end
     end
 
@@ -411,4 +428,3 @@ end
 end
 end
 end
-


### PR DESCRIPTION
This fixes #7921 

The response returned from big responses is often returned as chunked encoding and messes the output of `HttpTrace`.

To check:
- run http module of your choice with `HttpTrace` set to true
- check for messed output like in #7921 
- run the same module again from the new branch. The output should now be correct

I also tried to not break existing behaviour so `to_s` behaves like before