### PR TITLE
remove platform restriction on metasploit-aggregator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,11 +21,6 @@ group :development do
   gem 'pry', git: 'https://github.com/pry/pry', branch: 'master'
   # module documentation
   gem 'octokit', git: 'https://github.com/octokit/octokit.rb', branch: 'master'
-  # session aggregator, native builds have issues on arm platforms for now
-  gem 'metasploit-aggregator' if [
-    'x86-mingw32', 'x64-mingw32',
-    'x86_64-linux', 'x86-linux',
-    'darwin'].include?(RUBY_PLATFORM.gsub(/.*darwin.*/, 'darwin'))
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ PATH
       jsobfu
       json
       metasm
+      metasploit-aggregator
       metasploit-concern
       metasploit-credential
       metasploit-model
@@ -187,7 +188,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    grpc (1.2.0)
+    grpc (1.2.2)
       google-protobuf (~> 3.1)
       googleauth (~> 0.5.1)
     i18n (0.8.1)
@@ -393,7 +394,6 @@ DEPENDENCIES
   cucumber-rails
   factory_girl_rails
   fivemat
-  metasploit-aggregator
   metasploit-framework!
   method_source!
   octokit!

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,6 +55,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json'
   # Metasm compiler/decompiler/assembler
   spec.add_runtime_dependency 'metasm'
+  # Metasploit::Aggregator external session proxy
+  spec.add_runtime_dependency 'metasploit-aggregator'
   # Metasploit::Concern hooks
   spec.add_runtime_dependency 'metasploit-concern'
   # Metasploit::Credential database models


### PR DESCRIPTION
Remove packaging limitation for metasploit-aggregator

As of the grpc 1.2.2 gem release, architectures without native built gems will compile and install properly.  Limitation on metasploit-aggregator include are now cleared.

## Verification

List the steps needed to make sure this thing works

- [x] ```bundle install``` on a now supported architecture
- [x] ***Verify*** metasploit-aggregator and grpc install successfully
- [x] ***Verify*** onmibus builds on armhf and aarch64 build successfully in Rapid7 infrastructure

