### PR TITLE
Add pattern_create_64.py & pattern_offset_64.py

### DIFF
--- a/tools/exploit/pattern_create_64.py
+++ b/tools/exploit/pattern_create_64.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# coding:utf-8
+
+import sys
+
+start = ord("0")
+
+def getJunk(length):
+    global start
+    result = ""
+    size = (length / 4)
+    padding = length - size * 4
+    for i in range(size):
+        result += chr(start + i) * 2 + "\x00\x00"
+    return result + "@@\x00\x00"[0:padding]
+
+def main():
+    if len(sys.argv) != 2:
+        print "Usage : "
+        print "        python %s [LENGTH]" % (sys.argv[0])
+        print "        python %s [LENGTH] > junk.dat" % (sys.argv[0])
+        print "Tips : "
+        print "        The output data contains unprintable chars , you'd better to save them to a file by using '>'"
+        print "        If you have any questions, please contact me by email. Thank you for your support."
+        print "Author : "
+        print "        WangYihang <wangyihanger@gmail.com>"
+        exit(1)
+    junk = getJunk(int(sys.argv[1]))
+    print junk
+
+if __name__ == "__main__":
+    main()

--- a/tools/exploit/pattern_offset_64.py
+++ b/tools/exploit/pattern_offset_64.py
@@ -1,0 +1,33 @@
+import sys
+
+start = ord("0")
+
+def getSize(address):
+    global start
+    flag1 = int(address[-6:-4], 16)
+    flag2 = int(address[-4:-2], 16)
+    flag3 = int(address[-2:], 16)
+    result = 0
+    if flag1 != 0 and flag2 != 0 and flag3 == 0:
+        result = (flag1 - start) * 4 - 1
+    elif flag1 != 0 and flag2 == 0 and flag3 == 0:
+        result = (flag1 - start) * 4 - 2
+    elif flag1 == 0 and flag2 == 0 and flag3 != 0:
+        result = (flag3 - start) * 4 + 1
+    elif flag1 == 0 and flag2 != 0 and flag3 != 0:
+        result = (flag3 - start) * 4
+    else:
+        print "Illegal Address!"
+        exit(2)
+    return result
+
+def main():
+    if len(sys.argv) != 2:
+        print "Usage : "
+        print "        python getSize.py [OVERWRITED_RIP]"
+        exit(1)
+    size = getSize(sys.argv[1])
+    print "[Length] : [%d]" % size
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hello, I found a tool when using matesploit very useful: it is `pattern_create.rb` and `pattern_offset.rb`, they can help me quickly locate the length of the junk data I need to enter, but I found in 64-bit environment These two tools seem to have lost their effects, so I wrote a 64-bit script to complement these two tools, but unfortunately I wrote them with python because I was not ruby ​​for the time being, and I was a bit puzzled Because this script is out of msfconsole exist, so I do not know how to write the document, I hope you can give me some help, I hope you can through this "pull request", if you have any questions you can always contact me, thank you

## Verification

List the steps needed to make sure this thing works
- [ ] python `locate pattern_create_64.py` 200
- [ ] output 'AABBCCDD...' mean it works well.
 
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

