### PR TITLE
Add -H/--history-file to msfconsole

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -82,6 +82,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
       driver_options['DeferModuleLoads'] = options.modules.defer_loads
       driver_options['DisableBanner'] = options.console.quiet
       driver_options['DisableDatabase'] = options.database.disable
+      driver_options['HistFile'] = options.console.histfile
       driver_options['LocalOutput'] = options.console.local_output
       driver_options['ModulePath'] = options.modules.path
       driver_options['Plugins'] = options.console.plugins

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -10,6 +10,7 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
 
         options.console.commands = []
         options.console.confirm_exit = false
+        options.console.histfile = nil
         options.console.local_output = nil
         options.console.plugins = []
         options.console.quiet = false
@@ -37,6 +38,10 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
 
         option_parser.on('-a', '--ask', "Ask before exiting Metasploit or accept 'exit -y'") do
           options.console.confirm_exit = true
+        end
+
+        option_parser.on('-H', '--history-file FILE', 'Save command history to the specified file') do |file|
+          options.console.histfile = file
         end
 
         option_parser.on('-L', '--real-readline', 'Use the system Readline library instead of RbReadline') do


### PR DESCRIPTION
This allows us to save command history to an alternative file instead of `~/.msf4/history`.

- [x] `msfconsole -H /path/to/history/file`
- [x] `msfconsole --history-file /path/to/history/file`
- [x] `msfconsole -H /dev/null`
- [x] `msfconsole --history-file /dev/null`

Please ensure that `~/.msf4/history` isn't written and `history` and `makerc` still work.