### PR TITLE
handle general failure getting module info for external modules

### DIFF
--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -82,6 +82,11 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
       load_error(full_path, Errno::ENOENT.new)
       return ''
     end
-    Msf::Modules::External::Shim.generate(full_path)
+    begin
+      Msf::Modules::External::Shim.generate(full_path)
+    rescue ::Exception => e
+      elog "Unable to load module #{full_path} #{e.class} #{e}"
+      ''
+    end
   end
 end

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -86,6 +86,9 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
       Msf::Modules::External::Shim.generate(full_path)
     rescue ::Exception => e
       elog "Unable to load module #{full_path} #{e.class} #{e}"
+      # XXX migrate this to a full load_error when we can tell the user why the
+      # module did not load and/or how to resolve it.
+      # load_error(full_path, e)
       ''
     end
   end


### PR DESCRIPTION
While it seems that ENOENT gets handled earlier in the process, running in docker as in #8211 seems to throw an error later when we try to get description, which causes a later EPIPE failure. This catches the exception and logs to framework.log instead of killing the loader.

This fixes #8211

## Verification

- [x] Install Docker / docker-compose
- [x] Follow the steps under docker/README in msf to get a development environment started
- [x] Exit, and start it again (docker-compose run --rm --service-ports ms), don't rebuild.
- [x] **Verify** that framework starts with 1739 modules
- [x] **Verify** this shows up in your ~/.msf4/logs/framework.log:
```
[04/09/2017 16:49:06] [e(0)] core: Unable to load module /usr/src/metasploit-framework/modules/exploits/linux/smtp/haraka.py Errno::EPIPE Broken pipe
```
