### PR TITLE
Fix ELM327 ISOTP commands

### DIFF
--- a/tools/hardware/elm327_relay.rb
+++ b/tools/hardware/elm327_relay.rb
@@ -269,9 +269,9 @@ module ELM327HWBridgeRelay
       result["success"] = false
       srcid = "%03X" % srcid.to_i(16)
       dstid = "%03X" % dstid.to_i(16)
-      send_cmd("ATMCAF1")  # Turn on ISO-TP formatting
+      send_cmd("ATCAF1")  # Turn on ISO-TP formatting
       send_cmd("ATR1")  # Turn on responses
-      send_cmd("ATSTH#{srcid}")  # Src Header
+      send_cmd("ATSH#{srcid}")  # Src Header
       send_cmd("ATCRA#{dstid}")  # Resp Header
       send_cmd("ATCFC1") # Enable flow control
       resp = send_cmd(data)


### PR DESCRIPTION
My ELM327-compatible chip doesn't seem to understand the two commands I adjusted.
Looking at the [ELM327 datasheet](https://www.elmelectronics.com/wp-content/uploads/2016/07/ELM327DS.pdf) I can't find a mention of them, either. 

But there are commands *CAF* and *SH* that do exactly what the relay documentation states is the intention, hence this pull request to use them. One (SH) is already used in the raw CAN send function.