### PR TITLE
Catching errors where we are passing invalid attributes

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -170,7 +170,7 @@ module Msf::DBManager::Host
     else
       host = addr
     end
-    
+
     # Truncate the info field at the maximum field length
     if opts[:info]
       opts[:info] = opts[:info][0,65535]

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -170,7 +170,7 @@ module Msf::DBManager::Host
     else
       host = addr
     end
-
+    
     # Truncate the info field at the maximum field length
     if opts[:info]
       opts[:info] = opts[:info][0,65535]
@@ -196,6 +196,8 @@ module Msf::DBManager::Host
         unless host.attribute_locked?(k.to_s)
           host[k] = v.to_s.gsub(/[\x00-\x1f]/n, '')
         end
+      elsif v.blank?
+        # eating blank attributes that dont exist
       else
         dlog("Unknown attribute for ::Mdm::Host: #{k}")
       end

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -92,6 +92,8 @@ module Msf::DBManager::Service
     opts.each { |k,v|
       if (service.attribute_names.include?(k.to_s))
         service[k] = ((v and k == :name) ? v.to_s.downcase : v)
+      elsif v.blank?
+        # eating blank attributes that dont exist
       else
         dlog("Unknown attribute for Service: #{k}")
       end


### PR DESCRIPTION
We need to pass :task down for some functionality in pro.
while the error is valid we really shouldnt be passing the task all the way down if its blank but we need
the check there or we will end up with the same problem with pro.

Fixes #8215

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] rail your framework logs
- [x] `db_import masscan.xml`
- [x] **Verify** you do not see `[d(0)] core: Unknown attribute for ::Mdm::Host: task` in the framework.log
- [x] **Verify** you do not see `[d(0)] core: Unknown attribute for Service: task` in the framework.log
