### PR TITLE
move autoroute to a more sensible location

### DIFF
--- a/documentation/modules/post/multi/manage/autoroute.md
+++ b/documentation/modules/post/multi/manage/autoroute.md
@@ -18,6 +18,8 @@ Netmask Examples `set NETMASK 255.255.255.0` or `set NETMASK /24`
 ### delete
 This CMD option is used to remove a route from Metasploit's routing table. The IPv4 subnet and netmask (IPv4 or CIDR) of the route to be removed are required. The session number of the Meterpreter session to run the module on is also required. Use `route print` or the print CMD option to display the current Metasploit routing table.
 
+To remove all routes associated with the specified session, use CMD delete and leave the subnet option blank.
+
 ### print
 This CMD option is used to display Metasploit's routing table. This option has the same functionality as the `route print` command.
 

--- a/documentation/modules/post/multi/manage/autoroute.md
+++ b/documentation/modules/post/multi/manage/autoroute.md
@@ -84,13 +84,13 @@ You need a Windows Meterpreter session on a host that has a different public IP 
 First set up a default route for the Meterpreter session.
 
 ```
-meterpreter > run post/windows/manage/autoroute CMD=default
+meterpreter > run post/multi/manage/autoroute CMD=default
 ```
 
 or
 
 ```
-msf > use post/windows/manage/autoroute
+msf > use post/multi/manage/autoroute
 msf post(autoroute) > set SESSION session-id
 msf post(autoroute) > set CMD default
 msf post(autoroute) > exploit

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -56,7 +56,7 @@ module Scriptable
   #
   def legacy_script_to_post_module(script_name)
     {
-      'autoroute' => 'post/windows/manage/autoroute',
+      'autoroute' => 'post/multi/manage/autoroute',
       'checkvm' => 'post/windows/gather/checkvm',
       'duplicate' => 'post/windows/manage/multi_meterpreter_inject',
       'enum_chrome' => 'post/windows/gather/enum_chrome',
@@ -68,7 +68,7 @@ module Scriptable
       'file_collector' => 'post/windows/gather/enum_files',
       'get_application_list' => 'post/windows/gather/enum_applications',
       'get_filezilla_creds' => 'post/windows/gather/credentials/filezilla_server',
-      'get_local_subnets' => 'post/windows/manage/autoroute',
+      'get_local_subnets' => 'post/multi/manage/autoroute',
       'get_valid_community' => 'post/windows/gather/enum_snmp',
       'getcountermeasure' => 'post/windows/manage/killav',
       'getgui' => 'post/windows/manage/enable_rdp',

--- a/modules/post/multi/manage/autoroute.rb
+++ b/modules/post/multi/manage/autoroute.rb
@@ -52,6 +52,8 @@ class MetasploitModule < Msf::Post
 
   # Run Method for when run command is issued
   def run
+    return unless session_good?
+
     print_status("Running module against #{sysinfo['Computer']}")
 
     case route_cmd()
@@ -359,6 +361,22 @@ class MetasploitModule < Msf::Post
     if !switch_board.route_exists?(subnet, mask)
       add_route(subnet, mask)
     end
+  end
+
+  # Checks to see if the session is ready.
+  #
+  # Some Meterpreter types, like python, can take a few seconds to
+  # become fully established. This gracefully exits if the session
+  # is not ready yet.
+  #
+  # @return [true class] Session is good
+  # @return [false class] Session is not
+  def session_good?
+    if !session.info
+      print_error("Session is not yet fully established. Try again in a bit.")
+      return false
+    end
+    return true
   end
 
   # Checks to see if the session has routing capabilities

--- a/modules/post/multi/manage/autoroute.rb
+++ b/modules/post/multi/manage/autoroute.rb
@@ -51,6 +51,8 @@ class MetasploitModule < Msf::Post
   end
 
   # Run Method for when run command is issued
+  #
+  # @return [void] A useful return value is not expected here
   def run
     return unless session_good?
 
@@ -170,8 +172,12 @@ class MetasploitModule < Msf::Post
     end
   end
 
+  # Validation check on an IPv4 address
+  #
   # Yet another IP validator. I'm sure there's some Rex
   # function that can just do this.
+  #
+  # @return [string class] IPv4 subnet
   def check_ip(ip=nil)
     return false if(ip.nil? || ip.strip.empty?)
     begin
@@ -182,11 +188,17 @@ class MetasploitModule < Msf::Post
     end
   end
 
+  # Converts a CIDR value to a netmask
+  #
+  # @return [string class] IPv4 netmask
   def cidr_to_netmask(cidr)
     int = cidr.gsub(/\x2f/,"").to_i
     Rex::Socket.addr_ctoa(int)
   end
 
+  # Validates the user input 'NETMASK'
+  #
+  # @return [string class] IPv4 netmask
   def netmask
     case datastore['NETMASK']
     when /^\x2f[0-9]{1,2}/
@@ -432,6 +444,9 @@ class MetasploitModule < Msf::Post
   end
 
   # Validates the command options
+  #
+  # @return [true class] Everything is good
+  # @return [false class] Not so much
   def validate_cmd(subnet=nil,netmask=nil)
     if subnet.nil?
       print_error "Missing subnet option"

--- a/modules/post/multi/manage/autoroute.rb
+++ b/modules/post/multi/manage/autoroute.rb
@@ -6,7 +6,6 @@
 
 class MetasploitModule < Msf::Post
 
-
   def initialize(info={})
     super( update_info( info,
         'Name'          => 'Windows Manage Network Route via Meterpreter Session',
@@ -24,7 +23,6 @@ class MetasploitModule < Msf::Post
              'todb',
              'Josh Hale <jhale85446[at]gmail.com>'
            ],
-        'Platform'      => [ 'win' ],
         'SessionTypes'  => [ 'meterpreter']
       ))
 

--- a/modules/post/multi/manage/autoroute.rb
+++ b/modules/post/multi/manage/autoroute.rb
@@ -34,6 +34,8 @@ class MetasploitModule < Msf::Post
       ])
   end
 
+  # Get the CMD string vs ACTION
+  #
   # Backwards compatability: This was changed because the option name of "ACTION"
   # is special for some things, and indicates the :action attribute, not a datastore option.
   # However, this is a semi-popular module, though, so I'd prefer not to break people's
@@ -41,6 +43,8 @@ class MetasploitModule < Msf::Post
   #
   # TODO: The better solution is to use 'Action' and 'DefaultAction' info elements,
   # but there are some squirelly problems right now with rendering these for post modules.
+  #
+  # @return [string class] cmd string
   def route_cmd
     if datastore['ACTION'].to_s.empty?
       datastore['CMD'].to_s.downcase.to_sym

--- a/scripts/meterpreter/autoroute.rb
+++ b/scripts/meterpreter/autoroute.rb
@@ -28,6 +28,20 @@ remove_all_routes = false
   "-D" => [false, "Delete all routes (does not require a subnet)"]
 )
 
+# Defines usage
+def usage()
+  print_status "Usage:   run autoroute [-r] -s subnet -n netmask"
+  print_status "Examples:"
+  print_status "  run autoroute -s 10.1.1.0 -n 255.255.255.0  # Add a route to 10.10.10.1/255.255.255.0"
+  print_status "  run autoroute -s 10.10.10.1                 # Netmask defaults to 255.255.255.0"
+  print_status "  run autoroute -s 10.10.10.1/24              # CIDR notation is also okay"
+  print_status "  run autoroute -p                            # Print active routing table"
+  print_status "  run autoroute -d -s 10.10.10.1              # Deletes the 10.10.10.1/255.255.255.0 route"
+  print_status "Use the \"route\" and \"ipconfig\" Meterpreter commands to learn about available routes"
+  print_error "Deprecation warning: This script has been replaced by the post/multi/manage/autoroute module"
+end
+
+
 @@exec_opts.parse(args) { |opt, idx, val|
   v = val.to_s.strip
   case opt
@@ -132,20 +146,6 @@ def delete_route(opts={})
   subnet = opts[:subnet]
   netmask = opts[:netmask] || "255.255.255.0" # Default class C
   Rex::Socket::SwitchBoard.remove_route(subnet, netmask, session)
-end
-
-
-# Defines usage
-def usage()
-  print_status "Usage:   run autoroute [-r] -s subnet -n netmask"
-  print_status "Examples:"
-  print_status "  run autoroute -s 10.1.1.0 -n 255.255.255.0  # Add a route to 10.10.10.1/255.255.255.0"
-  print_status "  run autoroute -s 10.10.10.1                 # Netmask defaults to 255.255.255.0"
-  print_status "  run autoroute -s 10.10.10.1/24              # CIDR notation is also okay"
-  print_status "  run autoroute -p                            # Print active routing table"
-  print_status "  run autoroute -d -s 10.10.10.1              # Deletes the 10.10.10.1/255.255.255.0 route"
-  print_status "Use the \"route\" and \"ipconfig\" Meterpreter commands to learn about available routes"
-  print_error "Deprecation warning: This script has been replaced by the post/multi/manage/autoroute module"
 end
 
 # Validates the command options

--- a/scripts/meterpreter/autoroute.rb
+++ b/scripts/meterpreter/autoroute.rb
@@ -145,7 +145,7 @@ def usage()
   print_status "  run autoroute -p                            # Print active routing table"
   print_status "  run autoroute -d -s 10.10.10.1              # Deletes the 10.10.10.1/255.255.255.0 route"
   print_status "Use the \"route\" and \"ipconfig\" Meterpreter commands to learn about available routes"
-  print_error "Deprecation warning: This script has been replaced by the post/windows/manage/autoroute module"
+  print_error "Deprecation warning: This script has been replaced by the post/multi/manage/autoroute module"
 end
 
 # Validates the command options


### PR DESCRIPTION
This moves the autoroute module, which used to be an autoroute meterpreter script, to a place where any meterpreter can use it, since multiple meterpreters actually support autoroute.

## Verification

- [ ] Start `msfconsole` and get a linux meterpreter session (use mettle or python meterpreter)
- [ ] `use post/multi/manage/autoroute`
- [ ] `set session -1` and run it
- [ ] **Verify** that you get routes automatically added

Sorry, I'm not a huge user of this module yet, so I'm not sure how to better test its ins and outs. This also fixes a bug using the autoroute meterpreter script where the '-h' help command fails the first time you run it on a session.

https://www.youtube.com/watch?v=hdcTmpvDO0I