### PR TITLE
Update the kiwi extension to show correct version number

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -32,13 +32,13 @@ class Console::CommandDispatcher::Kiwi
   #
   # Initializes an instance of the priv command interaction. This function
   # also outputs a banner which gives proper acknowledgement to the original
-  # author of the Mimikatz 2.0 software.
+  # author of the Mimikatz software.
   #
   def initialize(shell)
     super
     print_line
     print_line
-    print_line("  .#####.   mimikatz 2.1 (#{client.session_type})")
+    print_line("  .#####.   mimikatz 2.1.1-20170409 (#{client.session_type})")
     print_line(" .## ^ ##.  \"A La Vie, A L'Amour\"")
     print_line(" ## / \\ ##  /* * *")
     print_line(" ## \\ / ##   Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )")


### PR DESCRIPTION
This PR requires https://github.com/rapid7/metasploit-payloads/pull/184 from the Payloads repo. The code change is minor and is intended to show the current version of Mimikatz (ie. matches the underlying code). When the Payloads PR is in, I will update this PR to include the new payloads gem.

## Verification

- [x] Use the Payloads PR
- [x] Create a Meterpreter session as admin
- [x] Make sure that things work like they did before (ie. they don't break).