### PR TITLE
Remove external module debugging code

### DIFF
--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -8,9 +8,7 @@ class Msf::Modules::External::Shim
     return '' unless mod.meta
     case mod.meta['type']
     when 'remote_exploit.cmd_stager.wget'
-      s = remote_exploit_cmd_stager(mod)
-      File.open('/tmp/module', 'w') {|f| f.write(s)}
-      s
+      remote_exploit_cmd_stager(mod)
     end
   end
 


### PR DESCRIPTION
Causes EACCESS when run by separate users.

Fixes #8226

- [x] Create an chmod debugging file: `touch /tmp/module; chmod 444 /tmp/module`
- [x] Start `./msfconsole`
- [x] `use exploit/linux/smtp/haraka` should work
