### PR TITLE
Sum the results of the module loaders

### DIFF
--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -116,7 +116,9 @@ module Msf::ModuleManager::Loading
 
     loaders.each do |loader|
       if loader.loadable?(path)
-        count_by_type = loader.load_modules(path, options)
+        count_by_type.merge!(loader.load_modules(path, options)) do |key, old, new|
+          old + new
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #8229

Verification
========

- [x] Follow the instructions in #8229 
- [x] The correct module count should be displayed
- [x] Add a non-Ruby module and repeat
- [x] The sum of Ruby and non-Ruby modules should be displayed 