### PR TITLE
metasploit-aggregator as a framework only package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ group :development do
   gem 'pry', git: 'https://github.com/pry/pry', branch: 'master'
   # module documentation
   gem 'octokit'
+  # metasploit-aggregator as a framework only option for now
+  # Metasploit::Aggregator external session proxy
+  gem 'metasploit-aggregator'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,6 @@ PATH
       jsobfu
       json
       metasm
-      metasploit-aggregator
       metasploit-concern
       metasploit-credential
       metasploit-model
@@ -388,6 +387,7 @@ DEPENDENCIES
   cucumber-rails
   factory_girl_rails
   fivemat
+  metasploit-aggregator
   metasploit-framework!
   method_source!
   octokit

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,8 +55,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json'
   # Metasm compiler/decompiler/assembler
   spec.add_runtime_dependency 'metasm'
-  # Metasploit::Aggregator external session proxy
-  spec.add_runtime_dependency 'metasploit-aggregator'
   # Metasploit::Concern hooks
   spec.add_runtime_dependency 'metasploit-concern'
   # Metasploit::Credential database models


### PR DESCRIPTION
Due to issues with dependency detection in windows, for the time being metasploit-aggregator should not be a required dependency

Change moves the inclusion to Gemfile "development" group which is included in Omnibus builds but not required by the gemspec.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** the metasploit-aggregator can be used in source checkout on supported platforms
- [x] **Verify** the omnibus packages built by Rapid7 infrastructure include the metasploit-aggregator


