### PR TITLE
changing the rake spec task to auto run db:test:prepare

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,19 @@ require 'metasploit/framework/spec/untested_payloads'
 # the user installs with `bundle install --without db`
 Metasploit::Framework::Require.optionally_active_record_railtie
 
+begin
+  require 'rspec/core'
+rescue LoadError
+  puts "rspec not in bundle, so can't set up spec tasks.  " \
+       "To run specs ensure to install the development and test groups."
+  puts "Bundle currently installed '--without #{Bundler.settings.without.join(' ')}'."
+  puts "To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or " \
+       "`rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`"
+else
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(spec: 'db:test:prepare')
+end
+
 Metasploit::Framework::Application.load_tasks
 Metasploit::Framework::Spec::Constants.define_task
 Metasploit::Framework::Spec::Threads::Suite.define_task


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Fixes #7555 

## Verification

List the steps needed to make sure this thing works

- [x] From `master`
- [x] run `rake db:drop:all db:create:all db:migrate`
- [x] this should migrate your dev database while leaving the test database empty
- [x] run `rake spec`
- [x] **Verify** all the specs that touch the database should fail.
- [x] checkout this branch
- [x]  run `rake spec` again
- [x] **Verify** that all specs pass
