### PR TITLE
bump metasploit-payloads, enhance windows support in python meterpreter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.19)
+      metasploit-payloads (= 1.2.20)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.1.8)
       msgpack
@@ -215,7 +215,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.19)
+    metasploit-payloads (1.2.20)
     metasploit_data_models (2.0.14)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.19'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.20'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.8'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This adds more windows-specific functionality to python meterpreter. See https://github.com/rapid7/metasploit-payloads/pull/181 for details
