### PR TITLE
coerece nil credentials to empty strings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    ruby_smb (0.0.10)
+    ruby_smb (0.0.12)
       bindata
       rubyntlm
       windows_error

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -127,11 +127,13 @@ module Metasploit
               else
                 status = Metasploit::Model::Login::Status::INCORRECT
             end
-          rescue ::Rex::ConnectionError => e
+          rescue ::Rex::ConnectionError, Errno::EINVAL => e
             status = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
             proof = e
           rescue RubySMB::Error::UnexpectedStatusCode => e
             status = Metasploit::Model::Login::Status::INCORRECT
+          ensure
+            client.disconnect!
           end
 
           if status == Metasploit::Model::Login::Status::SUCCESSFUL && credential.public.empty?

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -94,7 +94,9 @@ module Metasploit
 
           begin
 
-            realm       = credential.realm || ""
+            realm       = credential.realm   || ""
+            username    = credential.public  || ""
+            password    = credential.private || ""
             client      = RubySMB::Client.new(self.dispatcher, username: credential.public, password: credential.private, domain: realm)
             status_code = client.login
 

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -97,7 +97,7 @@ module Metasploit
             realm       = credential.realm   || ""
             username    = credential.public  || ""
             password    = credential.private || ""
-            client      = RubySMB::Client.new(self.dispatcher, username: credential.public, password: credential.private, domain: realm)
+            client      = RubySMB::Client.new(self.dispatcher, username: username, password: password, domain: realm)
             status_code = client.login
 
             # Windows SMB will return an error code during Session


### PR DESCRIPTION
rubySMB doesn't take nils for credential data, so coerce any nils into
empty strings before sending it on


