### PR TITLE
Exception handling typo fix - exploits/linux/smtp/haraka.py

### DIFF
--- a/modules/exploits/linux/smtp/haraka.py
+++ b/modules/exploits/linux/smtp/haraka.py
@@ -71,7 +71,7 @@ def send_mail(to, mailserver, cmd, mfrom, port):
     s = smtplib.SMTP(mailserver, port)
     try:
       resp = s.sendmail(mfrom, to, msg.as_string())
-    except smtplib.SMTPDataError, err:
+    except smtplib.SMTPDataError as err:
       if err[0] == 450:
         log("Triggered bug in target server (%s)"%err[1], 'good')
         return(True)


### PR DESCRIPTION
Running msfconsole would generate an Ubuntu crash report (?). This was the culprit.