### PR TITLE
Bug/disable smb login nbss

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,7 +350,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    ruby_smb (0.0.10)
+    ruby_smb (0.0.12)
       bindata
       rubyntlm
       windows_error

--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -30,7 +30,7 @@ module Metasploit
 
         CAN_GET_SESSION      = true
         DEFAULT_REALM        = 'WORKSTATION'
-        LIKELY_PORTS         = [ 139, 445 ]
+        LIKELY_PORTS         = [ 445 ]
         LIKELY_SERVICE_NAMES = [ "smb" ]
         PRIVATE_TYPES        = [ :password, :ntlm_hash ]
         REALM_KEY            = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN

--- a/spec/lib/metasploit/framework/login_scanner_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Metasploit::Framework::LoginScanner do
 
 
   context "with port 445" do
-    let(:port) { foo }
+    let(:port) { 445 }
 
     it { is_expected.to include Metasploit::Framework::LoginScanner::SMB }
     it { is_expected.not_to include Metasploit::Framework::LoginScanner::HTTP }

--- a/spec/lib/metasploit/framework/login_scanner_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner_spec.rb
@@ -24,15 +24,15 @@ RSpec.describe Metasploit::Framework::LoginScanner do
     it { is_expected.not_to include Metasploit::Framework::LoginScanner::HTTP }
   end
 
-  [ 139, 445 ].each do |foo|
-    context "with port #{foo}" do
-      let(:port) { foo }
 
-      it { is_expected.to include Metasploit::Framework::LoginScanner::SMB }
-      it { is_expected.not_to include Metasploit::Framework::LoginScanner::HTTP }
-      it { is_expected.not_to include Metasploit::Framework::LoginScanner::VNC }
-    end
+  context "with port 445" do
+    let(:port) { foo }
+
+    it { is_expected.to include Metasploit::Framework::LoginScanner::SMB }
+    it { is_expected.not_to include Metasploit::Framework::LoginScanner::HTTP }
+    it { is_expected.not_to include Metasploit::Framework::LoginScanner::VNC }
   end
+
 
   context "with name 'http'" do
     let(:name) { 'http' }


### PR DESCRIPTION
Disable port 139 on the SMB LoginScanner. SMB over NetBIOS hasn't actually worked properly in a long time, our old code just lied about it.
