### PR TITLE
Add a reference to the original PR

### DIFF
--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DisclosureDate' => 'Apr 15 2017',
       'References' => [
         ['URL', 'https://github.com/rapid7/metasploit-framework/pull/8245']
-      ],
+      ]
     ))
     register_options(
       [

--- a/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
+++ b/modules/exploits/linux/http/huawei_hg532n_cmdinject.rb
@@ -53,7 +53,10 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Apr 15 2017'
+      'DisclosureDate' => 'Apr 15 2017',
+      'References' => [
+        ['URL', 'https://github.com/rapid7/metasploit-framework/pull/8245']
+      ],
     ))
     register_options(
       [


### PR DESCRIPTION
This adds a reference to the recent Huawei module from PR #8245.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `info exploit/linux/http/huawei_hg532n_cmdinject`
- [x] **Verify** the reference to the MSF PR queue is shown.
