### PR TITLE
Feature/expand aggregator session lists

### DIFF
--- a/lib/metasploit/framework/afp/client.rb
+++ b/lib/metasploit/framework/afp/client.rb
@@ -214,14 +214,14 @@ module Metasploit
           parsed_data[:machine_type] = read_pascal_string(body, machine_type_offset)
           parsed_data[:versions] = read_array(body, afp_versions_offset)
           parsed_data[:uams] = read_array(body, uam_count_offset)
-          # skiped icon
+          # skipped icon
           parsed_data[:server_flags] = parse_flags(server_flags)
           parsed_data[:signature] = body.unpack("@#{server_signature_offset}H32").first
 
           network_addresses = read_array(body, network_addresses_offset, true)
           parsed_data[:network_addresses] = parse_network_addresses(network_addresses)
-          # skiped directory names
-          #Error catching for offset issues on this field. Need better error ahndling all through here
+          # skipped directory names
+          #Error catching for offset issues on this field. Need better error handling all through here
           begin
             parsed_data[:utf8_server_name] = read_utf8_pascal_string(body, utf8_servername_offset)
           rescue

--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -82,6 +82,34 @@ module Msf
         usage("aggregator_session_forward")
       end
 
+      def show_session(details, target, local_id)
+        status = pad_space("  #{local_id}", 4)
+        status += "  #{details['ID']}" unless local_id.nil?
+        status = pad_space(status, 15)
+        status += "  meterpreter "
+        status += "#{guess_target_platform(details['OS'])} "
+        status = pad_space(status, 43)
+        status += "#{details['USER']} @ #{details['HOSTNAME']} "
+        status = pad_space(status, 64)
+        status += "#{details['LOCAL_SOCKET']} -> #{details['REMOTE_SOCKET']}"
+        print_status status
+      end
+
+      def show_session_detailed(details, target, local_id)
+        print_status "\t Remote ID: #{details['ID']}"
+        print_status "\t      Type: meterpreter #{guess_target_platform(details['OS'])}"
+        print_status "\t      Info: #{details['USER']} @ #{details['HOSTNAME']}"
+        print_status "\t    Tunnel: #{details['LOCAL_SOCKET']} -> #{details['REMOTE_SOCKET']}"
+        print_status "\t       Via: exploit/multi/handler"
+        print_status "\t      UUID: #{details['UUID']}"
+        print_status "\t MachineID: #{details['MachineID']}"
+        print_status "\t   CheckIn: #{details['LAST_SEEN'].to_i}s ago" unless details['LAST_SEEN'].nil?
+        print_status "\tRegistered: Not Yet Implemented"
+        print_status "\t   Forward: #{target}"
+        print_status "\tSession ID: #{local_id}" unless local_id.nil?
+        print_status ""
+      end
+
       def cmd_aggregator_save(*args)
         # if we are logged in, save session details to aggregator.yaml
         if args.length == 0 || args[0] == "-h"
@@ -137,14 +165,28 @@ module Msf
         aggregator_login
       end
 
-      def cmd_aggregator_sessions(*_args)
+      def cmd_aggregator_sessions(*args)
+        case args.length
+          when 0
+            isDetailed = false
+          when 1
+            unless args[0] == "-v"
+              usage_sessions
+              return
+            end
+            isDetailed = true
+          else
+            usage_sessions
+            return
+        end
         return unless aggregator_verify
 
         sessions_list = @aggregator.sessions
         return if sessions_list.nil?
 
+        session_map = {}
+
         # get details for each session and print in format of sessions -v
-        print_status("Sessions found:")
         sessions_list.each do |session|
           session_id, target = session
           details = @aggregator.session_details(session_id)
@@ -155,19 +197,27 @@ module Msf
           end
           # filter session that do not have details as forwarding options (this may change later)
           next unless details && details['ID']
+          session_map[details['ID']] = [details, target, local_id]
+        end
 
-          print_status "\t Remote ID: #{details['ID']}"
-          print_status "\t      Type: meterpreter #{guess_target_platform(details['OS'])}"
-          print_status "\t      Info: #{details['USER']} @ #{details['HOSTNAME']}"
-          print_status "\t    Tunnel: #{details['LOCAL_SOCKET']} -> #{details['REMOTE_SOCKET']}"
-          print_status "\t       Via: exploit/multi/handler"
-          print_status "\t      UUID: #{details['UUID']}"
-          print_status "\t MachineID: #{details['MachineID']}"
-          print_status "\t   CheckIn: #{details['LAST_SEEN'].to_i}s ago" unless details['LAST_SEEN'].nil?
-          print_status "\tRegistered: Not Yet Implemented"
-          print_status "\t   Forward: #{target}"
-          print_status "\tSession ID: #{local_id}" unless local_id.nil?
-          print_status ""
+        print_status("Remote sessions")
+        print_status("===============")
+        print_status("")
+        if session_map.length == 0
+          print_status("No remote sessions.")
+        else
+          unless isDetailed
+            print_status("  Id  Remote Id  Type                      Information          Connection")
+            print_status("  --  ---------  ----                      -----------          ----------")
+          end
+          session_map.keys.sort.each do |key|
+            details, target, local_id = session_map[key]
+            unless isDetailed
+              show_session(details, target, local_id)
+            else
+              show_session_detailed(details, target, local_id)
+            end
+          end
         end
       end
 
@@ -425,11 +475,21 @@ module Msf
         end
       end
 
+      def pad_space(status, length)
+        while status.length < length
+          status << " "
+        end
+        status
+      end
+
       private :guess_target_platform
       private :aggregator_login
       private :aggregator_compatibility_check
       private :aggregator_verify
       private :local_handler
+      private :pad_space
+      private :show_session
+      private :show_session_detailed
     end
 
     #


### PR DESCRIPTION
* adjust session lists generated from a metasploit aggregator connection to be match calls to sessions and sessions -v against the local console

* order sessions list from a aggregator connection by "Remote Id"

*  fixed a few typos found in comments lately.

## Verification

List the steps needed to make sure this thing works

- [x] Start `metasploit-aggregator` in separate shell (currently hardcode to 127.0.0.1:2447 listener)
- [x] Start `msfconsole`
- [x] `load aggregator`
- [x] **Verify** `aggregator_connect 127.0.0.1:2447`
- [x] **Verify** `aggregator_default_forward`
- [x] **Verify** `aggregator_cable_add host:port pem.file(optional)`
newly listening ports will be reported on stderr of the metasploit-aggregator process
- [x] **Verify** start a https meterpreter session to host:port of a listening cable
this should produce a session on the default registered console
- [x] **Verify** `aggregator_sessions`
- [x] **Verify** `aggregator_sessions -v`

```
msf > load aggregator 
[*] Aggregator interaction has been enabled
[*] Successfully loaded plugin: aggregator
msf > aggregator_connect 
[*] Connecting to Aggregator instance at 127.0.0.1:2447...
msf > aggregator_addresses 
[*] Remote addresses found:
[*]     127.0.0.1
[*]     172.16.69.1
[*]     172.16.239.1
msf > aggregator_cable_add 172.16.69.1:8443
msf > aggregator_default_forward 
msf > [*] Meterpreter session 1 opened (127.0.0.1:62891 -> 127.0.0.1:64405) at 2017-04-19 14:09:15 -0500
sessions

Active sessions
===============

  Id  Type                      Information          Connection
  --  ----                      -----------          ----------
  1   meterpreter python/linux  root @ 7bacdcd350a9  127.0.0.1:62891 -> 127.0.0.1:64405 (127.0.0.1)

msf > sessions -v

Active sessions
===============

  Session ID: 1
        Type: meterpreter linux
        Info: root @ 7bacdcd350a9
      Tunnel: 127.0.0.1:62891 -> 127.0.0.1:64405 (127.0.0.1)
         Via: exploit/multi/handler
        UUID: 32410cb7a67da350/python=20/linux=6/2017-04-19T18:54:52Z
   MachineID: e535c7195785c84fda0ffdd90393d3d9
     CheckIn: 1s ago @ 2017-04-19 14:09:30 -0500
  Registered: No



msf > aggregator_sessions
[*] Remote sessions
[*] ===============
[*] 
[*]   Id  Remote Id  Type                      Information          Connection
[*]   --  ---------  ----                      -----------          ----------
[*]   1   1          meterpreter linux         root @ 7bacdcd350a9  172.16.69.1:8443 -> 172.16.69.1:64408
msf > aggregator_sessions -v
[*] Remote sessions
[*] ===============
[*] 
[*] 	 Remote ID: 1
[*] 	      Type: meterpreter linux
[*] 	      Info: root @ 7bacdcd350a9
[*] 	    Tunnel: 172.16.69.1:8443 -> 172.16.69.1:64408
[*] 	       Via: exploit/multi/handler
[*] 	      UUID: 35e659d64d3dadb3/python=20/python=0/2017-04-19T18:54:52Z
[*] 	 MachineID: e535c7195785c84fda0ffdd90393d3d9
[*] 	   CheckIn: 0s ago
[*] 	Registered: Not Yet Implemented
[*] 	   Forward: 8fb92adb-def4-4ac1-9956-2cf9fee5f24c
[*] 	Session ID: 1
[*] 
msf > 
```
