### PR TITLE
more docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,10 @@ docker-compose*.yml
 docker/
 !docker/msfconsole.rc
 README.md
+.git/
+.github/
+.ruby-version
+.ruby-gemset
 
 .bundle
 Gemfile.local
@@ -93,3 +97,6 @@ data/meterpreter/ext_server_pivot.*.dll
 # https://rapid7.github.io/metasploit-framework. It's an orphan branch.
 /metakitty
 .vagrant
+
+# no need for rspecs
+spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,15 @@ rvm:
   - '2.4.1'
 
 env:
-  - RAKE_TASKS="cucumber cucumber:boot" CREATE_BINSTUBS=true
-  - RAKE_TASKS=spec SPEC_OPTS="--tag content"
-  - RAKE_TASKS=spec SPEC_OPTS="--tag ~content"
+  - CMD=bundle exec rake "cucumber cucumber:boot" CREATE_BINSTUBS=true
+  - CMD=bundle exec rake spec SPEC_OPTS="--tag content"
+  - CMD=bundle exec rake spec SPEC_OPTS="--tag ~content"
 
 matrix:
   fast_finish: true
+  include:
+  - rvm: ruby-head
+    env: CMD=docker-compose -f $TRAVIS_BUILD_DIR/docker-compose.yml build
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - rake --version
@@ -36,7 +39,7 @@ before_script:
   - bundle exec rake db:migrate
 script:
   # fail build if db/schema.rb update is not committed
-  - git diff --exit-code db/schema.rb && bundle exec rake $RAKE_TASKS
+  - git diff --exit-code db/schema.rb && $CMD
 
 notifications:
   irc: "irc.freenode.org#msfnotify"
@@ -49,3 +52,6 @@ branches:
   except:
     - gh-pages
     - metakitty
+
+services:
+  - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
   fast_finish: true
   include:
   - rvm: ruby-head
-    env: CMD=docker-compose -f $TRAVIS_BUILD_DIR/docker-compose.yml build
+    env: CMD="docker-compose -f $TRAVIS_BUILD_DIR/docker-compose.yml build"
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
   - rake --version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
-  ms: &ms
+  ms:
     image: metasploit
     build:
       context: .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3-alpine
 MAINTAINER Rapid7
 
-ARG BUNDLER_ARGS="--system --jobs=8"
+ARG BUNDLER_ARGS="--jobs=8 --without development test coverage"
 ENV APP_HOME /usr/src/metasploit-framework/
 WORKDIR $APP_HOME
 
@@ -9,39 +9,36 @@ COPY Gemfile* m* Rakefile $APP_HOME
 COPY lib $APP_HOME/lib
 
 RUN apk update && \
-	apk add \
-  	ruby-bigdecimal \
-  	ruby-bundler \
-  	ruby-io-console \
-    autoconf \
-  	bison \
-  	subversion \
-  	git \
-  	sqlite \
-  	nmap \
-  	libxslt \
-  	postgresql \
-    ncurses \
-  && apk add --virtual .ruby-builddeps \
-    build-base \
-    ruby-dev \
-    libffi-dev\
-    openssl-dev \
-    readline-dev \
-    sqlite-dev \
-    postgresql-dev \
-    libpcap-dev \
-    libxml2-dev \
-    libxslt-dev \
-    yaml-dev \
-    zlib-dev \
-    ncurses-dev \
-    bison \
-    autoconf \
-  && echo "gem: --no-ri --no-rdoc" > /etc/gemrc \
-  && bundle install $BUNDLER_ARGS \
-  && apk del .ruby-builddeps \
-  && rm -rf /var/cache/apk/*
+    apk add \
+      sqlite-libs \
+      nmap \
+      # libxslt \
+      postgresql-libs \
+      # needed as long as metasploit-framework.gemspec contains a 'git ls'
+      git \
+      ncurses \
+    && apk add --virtual .ruby-builddeps \
+      autoconf \
+      bison \
+      build-base \
+      ruby-dev \
+      libffi-dev\
+      openssl-dev \
+      readline-dev \
+      sqlite-dev \
+      postgresql-dev \
+      libpcap-dev \
+      libxml2-dev \
+      libxslt-dev \
+      yaml-dev \
+      zlib-dev \
+      ncurses-dev \
+      bison \
+      autoconf \
+    && echo "gem: --no-ri --no-rdoc" > /etc/gemrc \
+    && bundle install --system $BUNDLER_ARGS \
+    && apk del .ruby-builddeps \
+    && rm -rf /var/cache/apk/*
 
 ADD ./ $APP_HOME
 CMD ["./msfconsole", "-r", "docker/msfconsole.rc"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN apk update && \
     apk add \
       sqlite-libs \
       nmap \
-      # libxslt \
       postgresql-libs \
       # needed as long as metasploit-framework.gemspec contains a 'git ls'
       git \

--- a/docker/docker-compose.development.override.yml
+++ b/docker/docker-compose.development.override.yml
@@ -1,7 +1,11 @@
 version: '2'
 
 services:
-  ms: &ms
+  ms:
+    build:
+      args:
+        BUNDLER_ARGS: --jobs=8
+    image: metasploit:dev
     environment:
       DATABASE_URL: postgres://postgres@db:5432/msf_dev
 


### PR DESCRIPTION
This changes the following in the docker image:
- By excluding the .git directory we can cut the image size in half (from over 1GB to 512MB on my machine)
- rspecs are excluded from the docker image to save space
- the production image is now built without development and test gems
- the runtime dependencies are reduced
- the `msfconsole-dev` binstub now creates a seperate image tagged with `:dev`
- I added a docker build step to travis as suggested by @busterb so future code changes will not break the docker image. The Travis implementation is not ideal but this way it will not break the current build matrix. Sample build output can be seen here: https://travis-ci.org/FireFart/metasploit-framework/jobs/224560349. If we also want to start the image with `-q -x 'exit'` we need to make sure all warnings and errors such as load_errors change the return code of msfconsole to non zero.

Please also test some non-standard features of metasploit as I removed some runtime dependecies.