### PR TITLE
update meterpreter scripts to check the right prerequisites

### DIFF
--- a/scripts/meterpreter/arp_scanner.rb
+++ b/scripts/meterpreter/arp_scanner.rb
@@ -102,7 +102,7 @@ cidr2scan = ""
     save2log = true
   end
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if args.length > 0
     if save2log
       save_found(arp_scan(cidr2scan))

--- a/scripts/meterpreter/checkvm.rb
+++ b/scripts/meterpreter/checkvm.rb
@@ -344,7 +344,7 @@ def qemuchk(session)
 
 end
 
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   print_status("Checking if target is a Virtual Machine .....")
   found = hypervchk(session)
   found = vmwarechk(session) if not found

--- a/scripts/meterpreter/credcollect.rb
+++ b/scripts/meterpreter/credcollect.rb
@@ -26,14 +26,9 @@ opts.parse(args) { |opt, idx, val|
   end
 }
 
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   # Collect even without a database to store them.
-  if client.framework.db.active
-    db_ok = true
-  else
-    db_ok = false
-  end
-
+  db_ok = client.framework.db.active
 
   # Make sure we're rockin Priv and Incognito
   client.core.use("priv") if not client.respond_to?("priv")

--- a/scripts/meterpreter/domain_list_gen.rb
+++ b/scripts/meterpreter/domain_list_gen.rb
@@ -56,7 +56,7 @@ end
 # Create Filename info to be appended to downloaded files
 filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
 
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 
 # Create a directory for the logs
 logs = ::File.join(Msf::Config.log_directory, 'scripts','domain_admins')

--- a/scripts/meterpreter/dumplinks.rb
+++ b/scripts/meterpreter/dumplinks.rb
@@ -369,7 +369,7 @@ def get_time(lo_byte, hi_byte)
   end
   return time
 end
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   enum_users(os).each do |user|
     if user['userpath']
       print_status "Extracting lnk files for user #{user['username']} at #{user['userpath']}..."

--- a/scripts/meterpreter/duplicate.rb
+++ b/scripts/meterpreter/duplicate.rb
@@ -84,7 +84,7 @@ mul.exploit_simple(
   'RunAsJob' => true
 )
 
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   server = client.sys.process.open
 
   print_status("Current server process: #{server.name} (#{server.pid})")

--- a/scripts/meterpreter/enum_firefox.rb
+++ b/scripts/meterpreter/enum_firefox.rb
@@ -254,7 +254,7 @@ end
     kill_frfx = true
   end
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if frfxchk
     user = @client.sys.config.getuid
     if not is_system?

--- a/scripts/meterpreter/enum_logged_on_users.rb
+++ b/scripts/meterpreter/enum_logged_on_users.rb
@@ -89,7 +89,7 @@ end
     ls_current
   end
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if args.length == 0
     print_line "Meterpreter Script for enumerating Current logged users and users that have loged in to the system."
     print_line(@@exec_opts.usage)

--- a/scripts/meterpreter/enum_powershell_env.rb
+++ b/scripts/meterpreter/enum_powershell_env.rb
@@ -124,7 +124,7 @@ def enum_powershell
 
   end
 end
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   enum_powershell
 else
   print_error("This version of Meterpreter is not supported with this Script!")

--- a/scripts/meterpreter/enum_putty.rb
+++ b/scripts/meterpreter/enum_putty.rb
@@ -91,7 +91,7 @@ def enum_saved_sessions(reg_key_base)
     end
   end
 end
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   hkcu_base.each do |hkb|
     if check_putty(hkb)
       enum_known_ssh_hosts(hkb)

--- a/scripts/meterpreter/enum_vmware.rb
+++ b/scripts/meterpreter/enum_vmware.rb
@@ -297,7 +297,7 @@ def enum_vmwarewrk
     end
   end
 end
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if check_vmsoft
     vmware_products = check_prods()
     if vmware_products.include?("VMware VirtualCenter")

--- a/scripts/meterpreter/event_manager.rb
+++ b/scripts/meterpreter/event_manager.rb
@@ -204,7 +204,7 @@ opts.parse(args) { |opt, idx, val|
 }
 
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 
 # Print usage & exit if the user didn't specify an action
 #  to default to just running for all logs)

--- a/scripts/meterpreter/file_collector.rb
+++ b/scripts/meterpreter/file_collector.rb
@@ -33,7 +33,7 @@ def usage
 end
 
 # Check that we are running under the right type of Meterpreter
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   # Parse the options
   if args.length > 0
     @opts.parse(args) { |opt, idx, val|

--- a/scripts/meterpreter/get_application_list.rb
+++ b/scripts/meterpreter/get_application_list.rb
@@ -62,7 +62,7 @@ opts.parse(args) { |opt, idx, val|
 
   end
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   app_list
 else
   print_error("This version of Meterpreter is not supported with this Script!")

--- a/scripts/meterpreter/get_env.rb
+++ b/scripts/meterpreter/get_env.rb
@@ -40,7 +40,7 @@ opts.parse(args) { |opt, idx, val|
 
   end
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   list_env_vars(var_names)
 else
   print_error("This version of Meterpreter is not supported with this Script!")

--- a/scripts/meterpreter/get_filezilla_creds.rb
+++ b/scripts/meterpreter/get_filezilla_creds.rb
@@ -150,7 +150,7 @@ def enum_users(os)
 end
 
 ################## MAIN ##################
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   print_status("Running Meterpreter FileZilla Credential harvester script")
   print_status("All services are logged at #{dest}")
   enum_users(os).each do |u|

--- a/scripts/meterpreter/get_pidgin_creds.rb
+++ b/scripts/meterpreter/get_pidgin_creds.rb
@@ -183,7 +183,7 @@ end
 #-------------------------------------------------------------------------------
 
 ################## MAIN ##################
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   print_status("Running Meterpreter Pidgin Credential harvester script")
   print_status("All services are logged at #{dest}")
   enum_users(os).each do |u|

--- a/scripts/meterpreter/get_valid_community.rb
+++ b/scripts/meterpreter/get_valid_community.rb
@@ -38,7 +38,7 @@ end
   end
 }
 
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   print_status("Searching for community strings...")
   strs = get_community(session)
   if strs

--- a/scripts/meterpreter/getcountermeasure.rb
+++ b/scripts/meterpreter/getcountermeasure.rb
@@ -364,7 +364,7 @@ killfw = false
   end
 }
 # get the version of windows
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   wnvr = session.sys.config.sysinfo["OS"]
   print_status("Running Getcountermeasure on the target...")
   check(session,avs,killbt)

--- a/scripts/meterpreter/getgui.rb
+++ b/scripts/meterpreter/getgui.rb
@@ -151,7 +151,7 @@ frwrd = nil
   end
 
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if args.length > 0
     if enbl or (usr and pass)
       message

--- a/scripts/meterpreter/gettelnet.rb
+++ b/scripts/meterpreter/gettelnet.rb
@@ -155,7 +155,7 @@ enbl = nil
 
 }
 
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 
 if enbl or (usr!= nil && pass != nil)
   message

--- a/scripts/meterpreter/getvncpw.rb
+++ b/scripts/meterpreter/getvncpw.rb
@@ -81,7 +81,7 @@ keytosearch = nil
     keytosearch = val
   end
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
 if keytosearch == nil
   print_status("Searching for VNC Passwords in the registry....")
   keys.each { |key|

--- a/scripts/meterpreter/hashdump.rb
+++ b/scripts/meterpreter/hashdump.rb
@@ -244,7 +244,7 @@ def decrypt_user_hash(rid, hbootkey, enchash, pass)
   d1o << d2.final
   d1o + d2o
 end
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   begin
 
     print_status("Obtaining the boot key...")

--- a/scripts/meterpreter/hostsedit.rb
+++ b/scripts/meterpreter/hostsedit.rb
@@ -74,7 +74,7 @@ def cleardnscach(session)
   print_status("Clearing the DNS Cache")
   session.sys.process.execute("cmd /c ipconfig /flushdns",nil, {'Hidden' => true})
 end
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   @@exec_opts.parse(args) { |opt, idx, val|
     case opt
     when "-e"

--- a/scripts/meterpreter/keylogrecorder.rb
+++ b/scripts/meterpreter/keylogrecorder.rb
@@ -196,7 +196,7 @@ kill = false
     kill = true
   end
 }
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if (captype.to_i == 2)
     if startkeylogger(session)
       keycap(session, keytime, logfile)

--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -42,7 +42,7 @@ rport    = 31337
 install  = false
 autoconn = false
 remove   = false
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
 
   #
   # Option parsing

--- a/scripts/meterpreter/migrate.rb
+++ b/scripts/meterpreter/migrate.rb
@@ -61,7 +61,7 @@ end
 
 ### Main ###
 
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   server = client.sys.process.open
   original_pid = server.pid
   print_status("Current server process: #{server.name} (#{server.pid})")

--- a/scripts/meterpreter/multi_meter_inject.rb
+++ b/scripts/meterpreter/multi_meter_inject.rb
@@ -122,7 +122,7 @@ end
 }
 
 # Check for version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 # Create a exploit/multi/handler if desired
 create_multi_handler(payload_type) if start_handler
 

--- a/scripts/meterpreter/netenum.rb
+++ b/scripts/meterpreter/netenum.rb
@@ -311,7 +311,7 @@ srvrc = nil
   end
 }
 
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if  pngsp == 1
     if range != nil
       message(logs)

--- a/scripts/meterpreter/packetrecorder.rb
+++ b/scripts/meterpreter/packetrecorder.rb
@@ -200,7 +200,7 @@ end
 }
 
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 
 if !int_id.nil? or !list_int.nil?
   if not is_uac_enabled? or is_admin?

--- a/scripts/meterpreter/panda_2007_pavsrv51.rb
+++ b/scripts/meterpreter/panda_2007_pavsrv51.rb
@@ -62,7 +62,7 @@ end
 
 if rhost.nil? or rport.nil?
   usage
-elsif client.platform =~ /win32|win64/
+elsif client.platform == 'windows'
   client.sys.process.get_processes().each do |m|
 
     if ( m['name'] =~ /PAVSRV51\.EXE/ )

--- a/scripts/meterpreter/pml_driver_config.rb
+++ b/scripts/meterpreter/pml_driver_config.rb
@@ -63,7 +63,7 @@ end
 
 if rhost.nil? or rport.nil?
   usage
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   client.sys.process.get_processes().each do |m|
     if ( m['name'] =~ /HPZipm12\.exe/ )
 

--- a/scripts/meterpreter/prefetchtool.rb
+++ b/scripts/meterpreter/prefetchtool.rb
@@ -147,7 +147,7 @@ check_update  = false
     raise Rex::Script::Completed
   end
 }
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 prefetch_local = ::File.join(Msf::Config.data_directory, "prefetch.exe")
 
 if !(::File.exist?(prefetch_local))

--- a/scripts/meterpreter/process_memdump.rb
+++ b/scripts/meterpreter/process_memdump.rb
@@ -147,9 +147,9 @@ def get_mem_usage( pid )
         # Note: As we get the raw structure back from railgun we need to account
         #       for SIZE_T variables being 32bit on x86 and 64bit on x64
         mem = nil
-        if( @client.platform =~ /win32/ )
+        if( @client.arch == 'x86' )
           mem = pmc[12..15].unpack('V').first
-        elsif( @client.platform =~ /win64/ )
+        elsif( @client.arch == 'x64' )
           mem = pmc[16..23].unpack('Q').first
         end
         return (mem/1024)
@@ -165,7 +165,7 @@ def get_mem_usage( pid )
 end
 
 # Main
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   if resource
     resource.each do |r|
       next if r.strip.length < 1

--- a/scripts/meterpreter/remotewinenum.rb
+++ b/scripts/meterpreter/remotewinenum.rb
@@ -144,7 +144,7 @@ def helpmsg
     @@exec_opts.usage)
 end
 ################## MAIN ##################
-if client.platform =~ /win32|win64/
+if client.platform == 'windows'
   localos = session.sys.config.sysinfo
 
   # Check that the command is not being ran on a Win2k host

--- a/scripts/meterpreter/scheduleme.rb
+++ b/scripts/meterpreter/scheduleme.rb
@@ -241,7 +241,7 @@ password = nil
   end
 
 }
-if client.platform =~ /win32|win64/
+if client.platform != 'windows'
   if helpcall == 1
     usage()
   elsif cmd == nil && file == nil

--- a/scripts/meterpreter/schtasksabuse.rb
+++ b/scripts/meterpreter/schtasksabuse.rb
@@ -153,7 +153,7 @@ end
 
 }
 
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 print_status("Meterpreter session running as #{session.sys.config.getuid}")
 if help == 0 && commands.length != 0
   abuse(session,targets,commands,username,password,delay)

--- a/scripts/meterpreter/scraper.rb
+++ b/scripts/meterpreter/scraper.rb
@@ -77,7 +77,7 @@ logs = ::File.join(Msf::Config.log_directory, 'scripts','scraper', host + "_" + 
 # Create the log directory
 ::FileUtils.mkdir_p(logs)
 
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 begin
 
   tmp = client.sys.config.getenv('TEMP')

--- a/scripts/meterpreter/screen_unlock.rb
+++ b/scripts/meterpreter/screen_unlock.rb
@@ -43,7 +43,7 @@ def unsupported
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 os = client.sys.config.sysinfo['OS']
 
 targets.each do |t|

--- a/scripts/meterpreter/screenspy.rb
+++ b/scripts/meterpreter/screenspy.rb
@@ -60,7 +60,7 @@ def wrong_meter_version(meter = meter_type)
 end
 
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 session = client
 
 

--- a/scripts/meterpreter/search_dwld.rb
+++ b/scripts/meterpreter/search_dwld.rb
@@ -83,7 +83,7 @@ def unsupported
 end
 
 
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 # Get arguments
 basedir = args[0] || "C:\\"
 filter  = args[1] || "office"

--- a/scripts/meterpreter/service_manager.rb
+++ b/scripts/meterpreter/service_manager.rb
@@ -70,7 +70,7 @@ end
 
 ################## Main ##################
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 
 @exec_opts.parse(args) { |opt, idx, val|
   case opt

--- a/scripts/meterpreter/sound_recorder.rb
+++ b/scripts/meterpreter/sound_recorder.rb
@@ -85,7 +85,7 @@ end
 }
 
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 
 # Create Folder for logs and get path for logs
 if not log_folder

--- a/scripts/meterpreter/srt_webdrive_priv.rb
+++ b/scripts/meterpreter/srt_webdrive_priv.rb
@@ -51,7 +51,7 @@ def unsupported
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 #
 # Option parsing
 #

--- a/scripts/meterpreter/uploadexec.rb
+++ b/scripts/meterpreter/uploadexec.rb
@@ -93,7 +93,7 @@ def unsupported
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 #parsing of Options
 file = ""
 cmdopt = nil
@@ -132,7 +132,7 @@ print_status("Running Upload and Execute Meterpreter script....")
 exec = upload(session,file,path)
 if sleep_sec
   print_status("\tSleeping for #{sleep_sec}s...")
-  Rex.sleep(sleep_sec) 
+  Rex.sleep(sleep_sec)
 end
 cmd_on_trgt_exec(session,exec,cmdopt,verbose)
 if remove == 1

--- a/scripts/meterpreter/virtualbox_sysenter_dos.rb
+++ b/scripts/meterpreter/virtualbox_sysenter_dos.rb
@@ -27,7 +27,7 @@ def unsupported
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 
 # Spawn calculator
 pid = client.sys.process.execute("calc.exe", nil, {'Hidden' => 'true'}).pid

--- a/scripts/meterpreter/vnc.rb
+++ b/scripts/meterpreter/vnc.rb
@@ -88,7 +88,7 @@ def unsupported
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 
 #
 # Create the raw payload

--- a/scripts/meterpreter/webcam.rb
+++ b/scripts/meterpreter/webcam.rb
@@ -60,7 +60,7 @@ opts.parse(args) { |opt, idx, val|
   end
 }
 
-if !(client.platform =~ /win32|win64/)
+if client.platform != 'windows'
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end

--- a/scripts/meterpreter/win32-sshclient.rb
+++ b/scripts/meterpreter/win32-sshclient.rb
@@ -307,7 +307,7 @@ downloaded = nil
 }
 
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 
 
 if not rhost or not username

--- a/scripts/meterpreter/win32-sshserver.rb
+++ b/scripts/meterpreter/win32-sshserver.rb
@@ -179,7 +179,7 @@ type = "auto"
 }
 
 # Check for Version of Meterpreter
-wrong_meter_version(meter_type) if meter_type !~ /win32|win64/i
+wrong_meter_version(meter_type) if meter_type != 'windows'
 
 #
 # Uninstall if selected

--- a/scripts/meterpreter/winbf.rb
+++ b/scripts/meterpreter/winbf.rb
@@ -150,7 +150,7 @@ def unsupported
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 
 ################## MAIN ##################
 

--- a/scripts/meterpreter/winenum.rb
+++ b/scripts/meterpreter/winenum.rb
@@ -569,7 +569,7 @@ def unsupported
   print_error("This version of Meterpreter is not supported with this Script!")
   raise Rex::Script::Completed
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 
 ################## MAIN ##################
 

--- a/scripts/meterpreter/wmic.rb
+++ b/scripts/meterpreter/wmic.rb
@@ -127,7 +127,7 @@ end
 if args.length == 0
   usage
 end
-unsupported if client.platform !~ /win32|win64/i
+unsupported if client.platform != 'windows'
 
 if outfile == nil
   print_status wmicexec(session,commands)


### PR DESCRIPTION
Updates Meterpreter scripts that are checking for platform the wrong way.

Fixes #7754 for example.