### PR TITLE
fix #8305, escape unadorned periods within SMTP payloads

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -194,6 +194,8 @@ module Exploit::Remote::SMTPDeliver
         full_msg << date unless data =~ /date: /i
         full_msg << subject unless subject.nil? || data =~ /subject: /i
         full_msg << data
+        # Escape leading dots in the mail messages so there are no false EOF
+        full_msg.gsub!(/(?m)^\./, '..')
         send_status = raw_send_recv("#{full_msg}\r\n.\r\n", nsock)
       end
     else


### PR DESCRIPTION
This fixes #8305 by ensuring we do not send messages with unescaped leading periods, avoiding breaking state machines for sendgrind, smtp.com, etc.

## Verification

List the steps needed to make sure this thing works

- [x] Start msf pro
- [x] configure an SE campaign using an sendgrid or smtp.com account
- [x] run the campaign with multiple email addresses, but also include a single period at the end of the message
- [x] ensure that all messages arrive as expected