### PR TITLE
Run dockerized metasploit as a non-root user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - 4444:4444
     volumes:
-      - $HOME/.msf4:/root/.msf4
+      - /tmp/.msf4:/home/msf/.msf4
 
   db:
     image: postgres:9.6

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apk update && \
       # needed as long as metasploit-framework.gemspec contains a 'git ls'
       git \
       ncurses \
+      libcap \
     && apk add --virtual .ruby-builddeps \
       autoconf \
       bison \
@@ -32,12 +33,21 @@ RUN apk update && \
       yaml-dev \
       zlib-dev \
       ncurses-dev \
-      bison \
-      autoconf \
-    && echo "gem: --no-ri --no-rdoc" > /etc/gemrc \
-    && bundle install --system $BUNDLER_ARGS \
-    && apk del .ruby-builddeps \
-    && rm -rf /var/cache/apk/*
+    && echo "gem: --no-ri --no-rdoc" > /etc/gemrc
 
 ADD ./ $APP_HOME
+
+RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)
+RUN adduser -D msf
+RUN chown -R msf:msf $APP_HOME
+
+USER msf
+ENV GEM_HOME $HOME/.gem
+RUN bundle install $BUNDLER_ARGS
+
+USER root
+RUN apk del .ruby-builddeps \
+    && rm -rf /var/cache/apk/*
+
+USER msf
 CMD ["./msfconsole", "-r", "docker/msfconsole.rc"]

--- a/docker/bin/msfconsole
+++ b/docker/bin/msfconsole
@@ -19,6 +19,10 @@ fi
 
 cd $MSF_PATH
 
+if [[ -n "$MSF_BUILD" ]]; then
+  docker-compose -f $MSF_PATH/docker-compose.yml build
+fi
+
 source ./docker/make-volume.sh
 
 docker-compose run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$@"

--- a/docker/bin/msfconsole
+++ b/docker/bin/msfconsole
@@ -4,7 +4,7 @@ if [[ -z "$MSF_PATH" ]]; then
   path=`dirname $0`
 
   # check for ./docker/msfconsole.rc
-  if [[ ! -f $path/../msfconsole.rc ]] ; then
+  if [[ ! -f $path/../msfconsole.rc ]]; then
 
     # we are not inside the project
     realpath --version > /dev/null 2>&1 || { echo >&2 "I couldn't find where metasploit is. Set \$MSF_PATH or execute this from the project root"; exit 1 ;}
@@ -21,6 +21,33 @@ cd $MSF_PATH
 
 if [[ -n "$MSF_BUILD" ]]; then
   docker-compose -f $MSF_PATH/docker-compose.yml build
+fi
+
+if [[ ! -z "$DOT_MSF" ]]; then
+  DOT_MSF="/tmp/.msf4"
+fi
+
+# check if .msf4 doesn't exist
+if [[ -d "$DOT_MSF" ]]; then
+
+  # check if root
+  if [[ $EUID -eq 0 ]]; then
+
+    # notify user about the folder creation
+    read -p "Script is going to make $DOT_MSF directory for docker mount
+Proceed? (Y/n)" -n 1 -r
+    echo
+
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      mkdir "$DOT_MSF" && chmod 777 "$DOT_MSF"
+    else
+      exit 1
+    fi
+
+  # if non-root user
+  else
+    mkdir "$DOT_MSF"
+  fi
 fi
 
 docker-compose run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$@"

--- a/docker/bin/msfconsole
+++ b/docker/bin/msfconsole
@@ -19,35 +19,6 @@ fi
 
 cd $MSF_PATH
 
-if [[ -n "$MSF_BUILD" ]]; then
-  docker-compose -f $MSF_PATH/docker-compose.yml build
-fi
-
-if [[ ! -z "$DOT_MSF" ]]; then
-  DOT_MSF="/tmp/.msf4"
-fi
-
-# check if .msf4 doesn't exist
-if [[ -d "$DOT_MSF" ]]; then
-
-  # check if root
-  if [[ $EUID -eq 0 ]]; then
-
-    # notify user about the folder creation
-    read -p "Script is going to make $DOT_MSF directory for docker mount
-Proceed? (Y/n)" -n 1 -r
-    echo
-
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      mkdir "$DOT_MSF" && chmod 777 "$DOT_MSF"
-    else
-      exit 1
-    fi
-
-  # if non-root user
-  else
-    mkdir "$DOT_MSF"
-  fi
-fi
+source ./docker/make-volume.sh
 
 docker-compose run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$@"

--- a/docker/bin/msfconsole-dev
+++ b/docker/bin/msfconsole-dev
@@ -23,5 +23,7 @@ if [[ -n "$MSF_BUILD" ]]; then
   docker-compose -f $MSF_PATH/docker-compose.yml -f $MSF_PATH/docker/docker-compose.development.override.yml build
 fi
 
+source ./docker/make-volume.sh
+
 docker-compose -f $MSF_PATH/docker-compose.yml -f $MSF_PATH/docker/docker-compose.development.override.yml run --rm --service-ports ms ./msfconsole -r docker/msfconsole.rc "$@"
 

--- a/docker/bin/msfvenom
+++ b/docker/bin/msfvenom
@@ -18,4 +18,7 @@ if [[ -z "$MSF_PATH" ]]; then
 fi
 
 cd $MSF_PATH
+
+source ./docker/make-volume.sh
+
 docker-compose run --rm --service-ports ms ./msfvenom "$@"

--- a/docker/make-volume.sh
+++ b/docker/make-volume.sh
@@ -1,0 +1,26 @@
+if [[ -z "$DOT_MSF" ]]; then
+  DOT_MSF="/tmp/.msf4"
+fi
+
+# check if .msf4 doesn't exist
+if [[ ! -d "$DOT_MSF" ]]; then
+
+  # check if root
+  if [[ $EUID -eq 0 ]]; then
+
+    # notify user about the folder creation
+    read -p "Script is going to make $DOT_MSF directory for docker mount
+Proceed? (Y/n)" -n 1 -r
+    echo
+
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      mkdir "$DOT_MSF" && chmod 777 "$DOT_MSF"
+    else
+      exit 1
+    fi
+
+  # if non-root user
+  else
+    mkdir "$DOT_MSF" && chmod 777 "$DOT_MSF"
+  fi
+fi


### PR DESCRIPTION
Continuing #8277, I made an attempt to run metasploit docker as a non-root user.

There is a caveat: to share files between non-root user inside container and your host it seems that the mounting directory requires `rwxrwxrwx` permissions, so it leads to security implications if you share your host with anybody else, say they could read your framework logs, browse downloaded files etc. Maybe there is a workaround that I'm not aware of.

## Verification

List the steps needed to make sure this thing works

- [ ] docker/bin/msfconsole
- [ ] docker/bin/msfconsole-dev
- [ ] docker/bin/msfvenom

