### PR TITLE
Fix nil bug when creating nonexistent encoder

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -411,6 +411,10 @@ module Msf
         # Allow comma separated list of encoders so users can choose several
         encoder.split(',').each do |chosen_encoder|
           e = framework.encoders.create(chosen_encoder)
+          if e.nil?
+            cli_print "Skipping invalid encoder #{chosen_encoder}"
+            next
+          end
           e.datastore.import_options_from_hash(datastore)
           encoders << e if e
         end


### PR DESCRIPTION
Found by irthewinner on IRC.

> 03:15 < irthewinner> msfvenom -p windows/shell_reverse_tcp lhost=192.168.0.1 lport=443 -b "\x00\x3a\x26...etc" -f c -v shellcode -n 301 -e PexAlphaNum

Ye olde `PexAlphaNum`.