### PR TITLE
update Gemfile.local example, use Gemfile.local if it exists

### DIFF
--- a/Gemfile.local.example
+++ b/Gemfile.local.example
@@ -27,8 +27,6 @@ end
 
 # Create a custom group
 group :local do
-  # Use pry-debugger to step through code during development
-  gem 'pry-debugger', '~> 0.2'
   # Add the lab gem so that the 'lab' plugin will work again
   gem 'lab', '~> 0.2.7'
 end

--- a/msfupdate
+++ b/msfupdate
@@ -194,7 +194,11 @@ class Msfupdate
       require 'bundler'
     end
     Bundler.with_clean_env do
-      system("bundle", "install")
+      if File::exist? "Gemfile.local"
+        system("bundle", "install", "--gemfile", "Gemfile.local")
+      else
+        system("bundle", "install")
+      end
     end
   end
 


### PR DESCRIPTION
This fixes #8272:

- [x] Copy Gemfile.local.example to Gemfile.local
- [x] run ./msfupdate
- [x] **Verify** that the bundling works as expected
- [x] **Verify** msfconsole starts