### PR TITLE
Support for LLMNR ANY queries & stdout spam reduction

### DIFF
--- a/modules/auxiliary/spoof/llmnr/llmnr_response.rb
+++ b/modules/auxiliary/spoof/llmnr/llmnr_response.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
 require 'socket'
 require 'ipaddr'
 require 'net/dns'

--- a/modules/auxiliary/spoof/llmnr/llmnr_response.rb
+++ b/modules/auxiliary/spoof/llmnr/llmnr_response.rb
@@ -98,8 +98,27 @@ attr_accessor :sock, :thread
           :type => ::Net::DNS::AAAA,
           :address => (spoof.ipv6? ? spoof : spoof.ipv4_mapped).to_s
         )
+      when ::Net::DNS::ANY
+        # For ANY queries, respond with both an A record as well as an AAAA.
+        dns_pkt.answer << ::Net::DNS::RR::A.new(
+          :name => name,
+          :ttl => datastore['TTL'],
+          :cls => ::Net::DNS::IN,
+          :type => ::Net::DNS::A,
+          :address => spoof.to_s
+        )
+        dns_pkt.answer << ::Net::DNS::RR::AAAA.new(
+          :name => name,
+          :ttl => datastore['TTL'],
+          :cls => ::Net::DNS::IN,
+          :type => ::Net::DNS::AAAA,
+          :address => (spoof.ipv6? ? spoof : spoof.ipv4_mapped).to_s
+        )
+      when ::Net::DNS::PTR
+        # Sometimes PTR queries are received. We will silently ignore them.
+        next
       else
-        print_warning("#{rhost.to_s.ljust 16} llmnr - Unknown RR type, this shouldn't happen. Skipping")
+        print_warning("#{rhost.to_s.ljust 16} llmnr - Unknown RR type (#{question.qType.to_i}), this shouldn't happen. Skipping")
         next
       end
     end


### PR DESCRIPTION
The llmnr_response spoofing module now responds to LLMNR ANY queries with A and AAAA records.  It now silently ignores PTR queries instead of spamming error messages to the console.

## Verification

1. Run the llmnr_response module on a Windows network.
2. Fire up Wireshark and wait for LLMNR ANY records to be generated (I'm not sure how they're made; they just show up from time to time...).
3. Observe that the spoofer responds with both A and AAAA answers.

Also, observe that the spoofer does not spam the console with "Unknown RR type, this shouldn't happen. Skipping" upon receipt of PTR queries.
