### PR TITLE
simplify valid credential storage

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -772,6 +772,16 @@ module Exploit::Remote::HttpClient
     fprint[:signature]
   end
 
+  def service_details
+    {
+      origin_type: :service,
+      protocol: 'tcp',
+      service_name: (ssl ? 'https' : 'http'),
+      address: rhost,
+      port: rport
+    }
+  end
+
 protected
 
   attr_accessor :client

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -15,6 +15,7 @@ module Msf
 ###
 class Module
   autoload :Arch, 'msf/core/module/arch'
+  autoload :Auth, 'msf/core/module/auth'
   autoload :Author, 'msf/core/module/author'
   autoload :AuxiliaryAction, 'msf/core/module/auxiliary_action'
   autoload :Compatibility, 'msf/core/module/compatibility'
@@ -40,6 +41,7 @@ class Module
   autoload :UUID, 'msf/core/module/uuid'
 
   include Msf::Module::Arch
+  include Msf::Module::Auth
   include Msf::Module::Author
   include Msf::Module::Compatibility
   include Msf::Module::DataStore

--- a/lib/msf/core/module/auth.rb
+++ b/lib/msf/core/module/auth.rb
@@ -24,10 +24,10 @@ module Msf::Module::Auth
     unless service_data.empty?
       login_data = {
         core: core,
-        proof: proof
-        # last_attempted_at: DateTime.now,
-        # status: Metasploit::Model::Login::Status::SUCCESSFUL
-      }.merge(service_data)
+        proof: proof,
+        last_attempted_at: DateTime.now,
+        status: Metasploit::Model::Login::Status::SUCCESSFUL
+      }.merge(cdata)
       create_credential_login(login_data)
     end
 

--- a/lib/msf/core/module/auth.rb
+++ b/lib/msf/core/module/auth.rb
@@ -1,0 +1,36 @@
+module Msf::Module::Auth
+  def store_valid_credential(user, private, private_type, proof = nil)
+    service_data = {}
+    if self.respond_to? ("service_details")
+      service_data = service_details
+    end
+
+    cdata = {
+        module_fullname: self.fullname,
+        origin_type: :service,
+        username: user,
+        private_data: private,
+        private_type: private_type,
+        workspace_id: myworkspace_id
+    }.merge(service_data)
+
+    if service_data.empty?
+      cdata[:origin_type] = :import
+      cdata[:filename] ='msfconsole' # default as values provided on the console
+    end
+
+
+    core = create_credential(cdata)
+    unless service_data.empty?
+      login_data = {
+        core: core,
+        proof: proof
+        # last_attempted_at: DateTime.now,
+        # status: Metasploit::Model::Login::Status::SUCCESSFUL
+      }.merge(service_data)
+      create_credential_login(login_data)
+    end
+
+    nil
+  end
+end

--- a/lib/msf/core/module/auth.rb
+++ b/lib/msf/core/module/auth.rb
@@ -1,5 +1,5 @@
 module Msf::Module::Auth
-  def store_valid_credential(user, private, private_type, proof = nil)
+  def store_valid_credential(user:, private:, private_type: :password, proof: nil)
     service_data = {}
     if self.respond_to? ("service_details")
       service_data = service_details

--- a/lib/msf/core/module/auth.rb
+++ b/lib/msf/core/module/auth.rb
@@ -5,9 +5,8 @@ module Msf::Module::Auth
       service_data = service_details
     end
 
-    cdata = {
+    creation_data = {
         module_fullname: self.fullname,
-        origin_type: :service,
         username: user,
         private_data: private,
         private_type: private_type,
@@ -15,20 +14,18 @@ module Msf::Module::Auth
     }.merge(service_data)
 
     if service_data.empty?
-      cdata[:origin_type] = :import
-      cdata[:filename] ='msfconsole' # default as values provided on the console
-    end
-
-
-    core = create_credential(cdata)
-    unless service_data.empty?
+      cred_data = {
+        origin_type: :import,
+        filename: 'msfconsole' # default as values provided on the console
+      }.merge(creation_data)
+      create_credential(cred_data)
+    else
       login_data = {
-        core: core,
         proof: proof,
         last_attempted_at: DateTime.now,
         status: Metasploit::Model::Login::Status::SUCCESSFUL
-      }.merge(cdata)
-      create_credential_login(login_data)
+      }.merge(creation_data)
+      create_credential_and_login(login_data)
     end
 
     nil

--- a/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
+++ b/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
@@ -62,21 +62,6 @@ class MetasploitModule < Msf::Auxiliary
     table_prefix
   end
 
-  def service_details
-    {
-      address: rhost,
-      port: rport,
-      service_name: (ssl ? "https": "http"), # changed from "WorkPress" here
-      protocol: 'tcp',
-      workspace_id: myworkspace_id,
-      module_fullname: fullname,
-      origin_type: :service
-      # moved to Msf::Module::Auth
-      # last_attempted_at: DateTime.now,
-      # status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }
-  end
-
   def run
     username = Rex::Text.rand_text_alpha(10)
     password = Rex::Text.rand_text_alpha(20)

--- a/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
+++ b/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Auxiliary
     # login successful
     if cookie
       print_status("User #{username} with password #{password} successfully created")
-      store_valid_credential(username, password, :password, cookie)
+      store_valid_credential(user: username, private: password, proof: cookie)
     else
       print_error("User creation failed")
       return

--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Failed to authenticate with WordPress")
       return
     end
-    store_valid_credential(username, password, :password, cookie)
+    store_valid_credential(user: username, private: password, proof: cookie)
     print_good("Authenticated with WordPress")
 
     new_email = "#{Rex::Text.rand_text_alpha(5)}@#{Rex::Text.rand_text_alpha(5)}.com"

--- a/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_easycart_privilege_escalation.rb
@@ -78,6 +78,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Failed to authenticate with WordPress")
       return
     end
+    store_valid_credential(username, password, :password, cookie)
     print_good("Authenticated with WordPress")
 
     new_email = "#{Rex::Text.rand_text_alpha(5)}@#{Rex::Text.rand_text_alpha(5)}.com"

--- a/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
@@ -98,6 +98,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Authenticating with WordPress using #{username}:#{password}...")
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
+    store_valid_credential(username, password, :password, cookie)
     print_good("Authenticated with WordPress")
 
     new_email = "#{Rex::Text.rand_text_alpha(5)}@#{Rex::Text.rand_text_alpha(5)}.com"

--- a/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
+++ b/modules/auxiliary/admin/http/wp_wplms_privilege_escalation.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Authenticating with WordPress using #{username}:#{password}...")
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
-    store_valid_credential(username, password, :password, cookie)
+    store_valid_credential(user: username, private: password, proof: cookie)
     print_good("Authenticated with WordPress")
 
     new_email = "#{Rex::Text.rand_text_alpha(5)}@#{Rex::Text.rand_text_alpha(5)}.com"

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -66,20 +66,6 @@ class MetasploitModule < Msf::Auxiliary
     datastore['TIMEOUT']
   end
 
-  def service_details
-    {
-        service_name: (ssl ? 'https' : 'http'),
-        address: rhost,
-        port: rport,
-        protocol: 'tcp',
-        origin_type: :service,
-        module_fullname: fullname
-        # moved to Msf::Module::Auth
-        # last_attempted_at: DateTime.now,
-        # status: Metasploit::Model::Login::Status::SUCCESSFUL
-    }
-  end
-
   def user_exists(user)
     exists = wordpress_user_exists?(user)
     if exists

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -66,43 +66,25 @@ class MetasploitModule < Msf::Auxiliary
     datastore['TIMEOUT']
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
-      service_name: opts[:service_name],
-      protocol: 'tcp',
-      workspace_id: myworkspace_id
+  def service_details
+    {
+        service_name: (ssl ? 'https' : 'http'),
+        address: rhost,
+        port: rport,
+        protocol: 'tcp',
+        origin_type: :service,
+        module_fullname: fullname
+        # moved to Msf::Module::Auth
+        # last_attempted_at: DateTime.now,
+        # status: Metasploit::Model::Login::Status::SUCCESSFUL
     }
-
-    credential_data = {
-      origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user]
-    }.merge(service_data)
-
-    login_data = {
-      last_attempted_at: DateTime.now,
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
   end
 
   def user_exists(user)
     exists = wordpress_user_exists?(user)
     if exists
       print_good("Username \"#{username}\" is valid")
-      report_cred(
-        ip: rhost,
-        port: rport,
-        user: user,
-        service_name: (ssl ? 'https' : 'http'),
-        proof: "WEBAPP=\"Wordpress\", VHOST=#{vhost}"
-      )
-
+      store_valid_credential(user, nil, :password, "WEBAPP=\"Wordpress\", VHOST=#{vhost}")
       return true
     else
       print_error("\"#{user}\" is not a valid username")

--- a/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_long_password_dos.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
     exists = wordpress_user_exists?(user)
     if exists
       print_good("Username \"#{username}\" is valid")
-      store_valid_credential(user, nil, :password, "WEBAPP=\"Wordpress\", VHOST=#{vhost}")
+      store_valid_credential(user: user, private: nil, proof: "WEBAPP=\"Wordpress\", VHOST=#{vhost}")
       return true
     else
       print_error("\"#{user}\" is not a valid username")

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -116,14 +116,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def service_details
-    {
-      address: rhost,
-      port: rport,
-      service_name: 'Cisco IronPort Appliance',
-      protocol: 'tcp',
-      origin_type: :service,
-      module_fullname: fullname
-    }
+    super.merge({service_name: 'Cisco IronPort Appliance'})
   end
 
   #

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Auxiliary
       if res and res.get_cookies.include?('authenticated=')
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
-        store_valid_credential(user, pass, :password, res.get_cookies.inspect)
+        store_valid_credential(user: user, private: pass, proof: res.get_cookies.inspect)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -115,31 +115,15 @@ class MetasploitModule < Msf::Auxiliary
       end
   end
 
-  def report_cred(opts)
-    service_data = {
-      address: opts[:ip],
-      port: opts[:port],
+  def service_details
+    {
+      address: rhost,
+      port: rport,
       service_name: 'Cisco IronPort Appliance',
       protocol: 'tcp',
-      workspace_id: myworkspace_id
-    }
-
-    credential_data = {
       origin_type: :service,
-      module_fullname: fullname,
-      username: opts[:user],
-      private_data: opts[:password],
-      private_type: :password
-    }.merge(service_data)
-
-    login_data = {
-      last_attempted_at: DateTime.now,
-      core: create_credential(credential_data),
-      status: Metasploit::Model::Login::Status::SUCCESSFUL,
-      proof: opts[:proof]
-    }.merge(service_data)
-
-    create_credential_login(login_data)
+      module_fullname: fullname
+    }
   end
 
   #
@@ -166,7 +150,7 @@ class MetasploitModule < Msf::Auxiliary
       if res and res.get_cookies.include?('authenticated=')
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
-        report_cred(ip: rhost, port: rport, user: user, password: pass, proof: res.get_cookies.inspect)
+        store_valid_credential(user, pass, :password, res.get_cookies.inspect)
         return :next_user
 
       else

--- a/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Unable to login as: #{user}")
       return
     end
-    store_valid_credential(user, password, :password, cookie)
+    store_valid_credential(user: user, private: password, proof: cookie)
 
     vprint_status("Trying to get nonce...")
     nonce = get_nonce(cookie)

--- a/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
@@ -98,6 +98,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Unable to login as: #{user}")
       return
     end
+    store_valid_credential(user, password, :password, cookie)
 
     vprint_status("Trying to get nonce...")
     nonce = get_nonce(cookie)

--- a/modules/auxiliary/scanner/http/wp_subscribe_comments_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_subscribe_comments_file_read.rb
@@ -120,6 +120,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Unable to login as: #{user}")
       return
     end
+    store_valid_credential(user, password, :password, cookie)
 
     vprint_status("Trying to get nonce...")
     nonce = get_nonce(cookie)

--- a/modules/auxiliary/scanner/http/wp_subscribe_comments_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_subscribe_comments_file_read.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Unable to login as: #{user}")
       return
     end
-    store_valid_credential(user, password, :password, cookie)
+    store_valid_credential(user: user, private: password, proof: cookie)
 
     vprint_status("Trying to get nonce...")
     nonce = get_nonce(cookie)

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -71,6 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
     print_good("Authenticated with WordPress")
+    store_valid_credential(username, password, :password, cookie)
 
     print_status("Preparing payload...")
     plugin_name = Rex::Text.rand_text_alpha(10)

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
     print_good("Authenticated with WordPress")
-    store_valid_credential(username, password, :password, cookie)
+    store_valid_credential(user: username, private: password, proof: cookie)
 
     print_status("Preparing payload...")
     plugin_name = Rex::Text.rand_text_alpha(10)

--- a/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Trying to login as #{username}")
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, "#{peer} - Unable to login as: #{username}") if cookie.nil?
-    store_valid_credential(username, password, :password, cookie)
+    store_valid_credential(user: username, private: password, proof: cookie)
 
     vprint_status("Trying to get nonce")
     nonce = get_nonce(cookie)

--- a/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_ajax_load_more_file_upload.rb
@@ -77,6 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Trying to login as #{username}")
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, "#{peer} - Unable to login as: #{username}") if cookie.nil?
+    store_valid_credential(username, password, :password, cookie)
 
     vprint_status("Trying to get nonce")
     nonce = get_nonce(cookie)

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       else
         print_good("Authenticated with WordPress")
-        store_valid_credential(username, password, :password, cookie)
+        store_valid_credential(user: username, private: password, proof: cookie)
       end
     end
 

--- a/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_easycart_unrestricted_file_upload.rb
@@ -128,6 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       else
         print_good("Authenticated with WordPress")
+        store_valid_credential(username, password, :password, cookie)
       end
     end
 

--- a/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
@@ -75,6 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
     print_good("Authenticated with WordPress")
+    store_valid_credential(username, password, :password, cookie)
 
     print_status("Preparing payload...")
     payload_name = Rex::Text.rand_text_alpha(10)

--- a/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_photo_gallery_unrestricted_file_upload.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cookie = wordpress_login(username, password)
     fail_with(Failure::NoAccess, 'Failed to authenticate with WordPress') if cookie.nil?
     print_good("Authenticated with WordPress")
-    store_valid_credential(username, password, :password, cookie)
+    store_valid_credential(user: username, private: password, proof: cookie)
 
     print_status("Preparing payload...")
     payload_name = Rex::Text.rand_text_alpha(10)

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("Unable to login as #{user}")
       return
     end
-    store_valid_credential(username, password, :password, cookie)
+    store_valid_credential(user: username, private: password, proof: cookie)
 
     print_status("Trying to upload payload")
     filename = "#{rand_text_alpha_lower(8)}.php"

--- a/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
+++ b/modules/exploits/unix/webapp/wp_slideshowgallery_upload.rb
@@ -64,6 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("Unable to login as #{user}")
       return
     end
+    store_valid_credential(username, password, :password, cookie)
 
     print_status("Trying to upload payload")
     filename = "#{rand_text_alpha_lower(8)}.php"

--- a/modules/exploits/unix/webapp/wp_total_cache_exec.rb
+++ b/modules/exploits/unix/webapp/wp_total_cache_exec.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{peer} - Login wasn't successful")
       end
       print_status("login successful")
-      store_valid_credential(@user, @password, :password, @cookie)
+      store_valid_credential(user: @user, private: @password, proof: @cookie)
     else
       print_status("Trying unauthenticated exploitation...")
     end

--- a/modules/exploits/unix/webapp/wp_total_cache_exec.rb
+++ b/modules/exploits/unix/webapp/wp_total_cache_exec.rb
@@ -112,6 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "#{peer} - Login wasn't successful")
       end
       print_status("login successful")
+      store_valid_credential(@user, @password, :password, @cookie)
     else
       print_status("Trying unauthenticated exploitation...")
     end

--- a/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("Unable to login as #{user}")
       return
     end
-    store_valid_credential(user, password, :password, cookie)
+    store_valid_credential(user: user, private: password, proof: cookie)
 
     print_status("Trying to get nonce")
     nonce = get_nonce(cookie)

--- a/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
@@ -121,6 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("Unable to login as #{user}")
       return
     end
+    store_valid_credential(user, password, :password, cookie)
 
     print_status("Trying to get nonce")
     nonce = get_nonce(cookie)


### PR DESCRIPTION
An alternative to changes in https://github.com/rapid7/metasploit-framework/pull/8274 embedding credential storage work in the wordpress library.

This provides an example of an idea discussed with @egypt about why module writers often skip storing/reporting valid credentials.  Discussion determined this may be due to the amount of code required to create the object map(s) and gather all the details needed. By reducing the burden on the module writer it is hoped that successful credential usage will be stored more often by module authors.

This example starts with wordpress modules and moves much of the standard or static details common across most modules and required for credential creation into the client negotiating the connection service communication (in this case ```Exploit::Remote::HttpClient```) and adds a new mixin adding a single method call that accepts the more volatile values often used in credential creation and then perform the credential storage.

A couple examples of how to override the details used for storage are found in ```wp_custom_contact_forms.rb``` and ```cisco_ironport_enum.rb``` which also happens to consume ```Exploit::Remote::HttpClient```.

Further migration will be added in a later PR if this simplification is accepted as a reasonable way to reduce the complexity of credential creation for typical modules.

When no ```service_details()``` method is defined the credential is stored alone, otherwise a login result of the described type is also stored.

A possible drawback to current implementation, an assumption exists that the keys in the map generated and consumed will not need diverging values between those consumed in credential creation and those needed for service creation after the credential "core" has been stored.

Suggestions on Module and method names will be considered.  Also @wvu-r7 or @wchen-r7 please take a look to determine if this looks helpful.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use <A_MODULE_UPDATED_HERE>`
- [ ] set appropriate options and run
- [ ] **Verify** the module still functions and the credential stores successfully when a database is available
- [ ] **Verify** when the database is not available the module functions and at most notification that the credential was not stored is added to the output
- [ ] **Document** No changes however wiki updates or documentation in the new core mixin can be added if this idea is agreed to be an improvement