### PR TITLE
Specify lhost by interface name

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -45,7 +45,7 @@ module ReverseHttp
 
     register_options(
       [
-        OptString.new('LHOST', [true, 'The local listener hostname']),
+        OptAddressLocal.new('LHOST', [true, 'The local listener hostname']),
         OptPort.new('LPORT', [true, 'The local listener port', 8080]),
         OptString.new('LURI', [false, 'The HTTP Path', ''])
       ], Msf::Handler::ReverseHttp)

--- a/lib/msf/core/handler/reverse_https_proxy.rb
+++ b/lib/msf/core/handler/reverse_https_proxy.rb
@@ -38,7 +38,7 @@ module ReverseHttpsProxy
 
     register_options(
       [
-        OptString.new('LHOST', [ true, "The local listener hostname" ,"127.0.0.1"]),
+        OptAddressLocal.new('LHOST', [ true, "The local listener hostname" ,"127.0.0.1"]),
         OptPort.new('LPORT', [ true, "The local listener port", 8443 ]),
         OptString.new('PayloadProxyHost', [true, "The proxy server's IP address", "127.0.0.1"]),
         OptPort.new('PayloadProxyPort', [true, "The proxy port to connect to", 8080 ]),

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -28,7 +28,7 @@ module Msf
 
     # @return [OptAddress]
     def self.LHOST(default=nil, required=true, desc="The listen address")
-      Msf::OptAddress.new(__method__.to_s, [ required, desc, default ])
+      Msf::OptAddressLocal.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptPort]

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+require 'network_interface'
 
 module Msf
 
@@ -7,19 +8,12 @@ module Msf
 # Network address option.
 #
 ###
-class OptAddressLocal < OptBase
-  def type
-    return 'address'
-  end
-  
+class OptAddressLocal < OptAddress
   def normalize(value)
     return nil unless value.kind_of?(String)
     
-    if (value =~ /^iface:(.*)/)
-      iface = $1
-      return false if not NetworkInterface.interfaces.include?(iface)
-
-      ip_address = NetworkInterface.addresses(iface).values.flatten.collect{|x| x['addr']}.select do |addr|
+    if NetworkInterface.interfaces.include?(value)
+      ip_address = NetworkInterface.addresses(value).values.flatten.collect{|x| x['addr']}.select do |addr|
         begin
           IPAddr.new(addr).ipv4?
         rescue IPAddr::InvalidAddressError => e
@@ -28,7 +22,7 @@ class OptAddressLocal < OptBase
       end
 
       return false if ip_address.blank?
-      return ip_address
+      return ip_address.first
     end
     
     return value
@@ -37,20 +31,8 @@ class OptAddressLocal < OptBase
   def valid?(value, check_empty: true)
     return false if check_empty && empty_required_value?(value)
     return false unless value.kind_of?(String) or value.kind_of?(NilClass)
-
-    if (value != nil and not value.empty?)
-      begin
-        getaddr_result = ::Rex::Socket.getaddress(value, true)
-        # Covers a wierdcase where an incomplete ipv4 address will have it's
-        # missing octets filled in  with 0's. (e.g 192.168 become 192.0.0.168)
-        # which does not feel like a legit behaviour
-        if value =~ /^\d{1,3}(\.\d{1,3}){1,3}$/
-          return false unless value =~ Rex::Socket::MATCH_IPV4
-        end
-      rescue
-        return false
-      end
-    end
+   
+    return true if NetworkInterface.interfaces.include?(value)
 
     return super
   end

--- a/lib/msf/core/opt_address_local.rb
+++ b/lib/msf/core/opt_address_local.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Msf
+
+###
+#
+# Network address option.
+#
+###
+class OptAddressLocal < OptBase
+  def type
+    return 'address'
+  end
+  
+  def normalize(value)
+    return nil unless value.kind_of?(String)
+    
+    if (value =~ /^iface:(.*)/)
+      iface = $1
+      return false if not NetworkInterface.interfaces.include?(iface)
+
+      ip_address = NetworkInterface.addresses(iface).values.flatten.collect{|x| x['addr']}.select do |addr|
+        begin
+          IPAddr.new(addr).ipv4?
+        rescue IPAddr::InvalidAddressError => e
+          false
+        end
+      end
+
+      return false if ip_address.blank?
+      return ip_address
+    end
+    
+    return value
+  end
+  
+  def valid?(value, check_empty: true)
+    return false if check_empty && empty_required_value?(value)
+    return false unless value.kind_of?(String) or value.kind_of?(NilClass)
+
+    if (value != nil and not value.empty?)
+      begin
+        getaddr_result = ::Rex::Socket.getaddress(value, true)
+        # Covers a wierdcase where an incomplete ipv4 address will have it's
+        # missing octets filled in  with 0's. (e.g 192.168 become 192.0.0.168)
+        # which does not feel like a legit behaviour
+        if value =~ /^\d{1,3}(\.\d{1,3}){1,3}$/
+          return false unless value =~ Rex::Socket::MATCH_IPV4
+        end
+      rescue
+        return false
+      end
+    end
+
+    return super
+  end
+end
+
+end

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -7,6 +7,7 @@ module Msf
   autoload :OptBase, 'msf/core/opt_base'
 
   autoload :OptAddress, 'msf/core/opt_address'
+  autoload :OptAddressLocal, 'msf/core/opt_address_local'
   autoload :OptAddressRange, 'msf/core/opt_address_range'
   autoload :OptBool, 'msf/core/opt_bool'
   autoload :OptEnum, 'msf/core/opt_enum'

--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(10000),
-        OptAddress.new('LHOST',
+        OptAddressLocal.new('LHOST',
           [
             false,
             "The local IP address to accept the data connection"

--- a/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
+++ b/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new( 'REMOTE_FILENAME', [false, "The remote filename"]),
       OptAddress.new('RHOST',    [true, "The remote TFTP server"]),
       OptPort.new(   'LPORT',    [false, "The local port the TFTP client should listen on (default is random)" ]),
-      OptAddress.new('LHOST',    [false, "The local address the TFTP client should bind to"]),
+      OptAddressLocal.new('LHOST',    [false, "The local address the TFTP client should bind to"]),
       OptString.new( 'MODE',     [false, "The TFTP mode; usual choices are netascii and octet.", "octet"]),
       Opt::RPORT(69)
     ])

--- a/modules/auxiliary/docx/word_unc_injector.rb
+++ b/modules/auxiliary/docx/word_unc_injector.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptAddress.new('LHOST',[true, 'Server IP or hostname that the .docx document points to.']),
+        OptAddressLocal.new('LHOST',[true, 'Server IP or hostname that the .docx document points to.']),
         OptPath.new('SOURCE', [false, 'Full path and filename of .docx file to use as source. If empty, creates new document.']),
         OptString.new('FILENAME', [true, 'Document output filename.', 'msf.docx']),
         OptString.new('DOCAUTHOR',[false,'Document author for empty document.']),

--- a/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
+++ b/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
@@ -34,9 +34,8 @@ class MetasploitModule < Msf::Auxiliary
 
       register_options(
         [
-          OptAddress.new('LHOST', [true, "The spoofed address of a vulnerable ntpd server" ])
+          OptAddressLocal.new('LHOST', [true, "The spoofed address of a vulnerable ntpd server" ])
         ])
-
       deregister_options('FILTER','PCAPFILE')
 
   end

--- a/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
+++ b/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        OptAddress.new('LHOST', [false, "The local IP address to bind to"]),
+        OptAddressLocal.new('LHOST', [false, "The local IP address to bind to"]),
         OptInt.new('RECV_TIMEOUT', [false, "Time (in seconds) to wait between packets", 3]),
         Opt::RPORT(69)
       ])

--- a/modules/auxiliary/gather/darkcomet_filedownloader.rb
+++ b/modules/auxiliary/gather/darkcomet_filedownloader.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(1604),
         Opt::RHOST('0.0.0.0'),
 
-        OptString.new('LHOST', [true, 'This is our IP (as it appears to the DarkComet C2 server)', '0.0.0.0']),
+        OptAddressLocal.new('LHOST', [true, 'This is our IP (as it appears to the DarkComet C2 server)', '0.0.0.0']),
         OptString.new('KEY', [false, 'DarkComet RC4 key (include DC prefix with key eg. #KCMDDC51#-890password)', '']),
         OptBool.new('NEWVERSION', [false, 'Set to true if DarkComet version >= 5.1, set to false if version < 5.1', true]),
         OptString.new('TARGETFILE', [false, 'Target file to download (assumes password is set)', '']),

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('CLIENT',   [true,  'SAP client', '001']),
       OptString.new('HttpUsername', [false, 'Username (Ex SAP*)']),
       OptString.new('HttpPassword', [false, 'Password (Ex 06071992)']),
-      OptAddress.new('LHOST',   [true,  'Server IP or hostname of the SMB Capture system']),
+      OptAddressLocal.new('LHOST',   [true,  'Server IP or hostname of the SMB Capture system']),
       OptEnum.new('ABUSE',      [true,  'SMB Relay abuse to use', "MMR",
         [
           "MMR",

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptEnum.new("SOURCE", [true, "Grab the startup (3) or running (4) configuration", "4", ["3","4"]]),
       OptString.new('OUTPUTDIR', [ false, "The directory where we should save the configuration files (disabled by default)"]),
-      OptAddress.new('LHOST', [ false, "The IP address of the system running this module" ])
+      OptAddressLocal.new('LHOST', [ false, "The IP address of the system running this module" ])
     ])
   end
 

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_options([
       OptPath.new('SOURCE', [true, "The filename to upload" ]),
-      OptAddress.new('LHOST', [ false, "The IP address of the system running this module" ])
+      OptAddressLocal.new('LHOST', [ false, "The IP address of the system running this module" ])
     ])
   end
 

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultAction'  => 'WebServer'))
 
     register_options([
-      OptAddress.new('LHOST', [true,
+      OptAddressLocal.new('LHOST', [true,
         'The IP address to use for reverse-connect payloads'
       ])
     ])

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'admin' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
-        OptAddress.new('LHOST', [ true, 'The listen IP address from where the victim downloads the MIPS payload' ]),
+        OptAddressLocal.new('LHOST', [ true, 'The listen IP address from where the victim downloads the MIPS payload' ]),
         OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
         OptInt.new('DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 10])
       ])

--- a/modules/exploits/linux/http/trueonline_p660hn_v2_rce.rb
+++ b/modules/exploits/linux/http/trueonline_p660hn_v2_rce.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(80),
         OptString.new('USERNAME', [true, 'Username for the web interface (using default credentials)', 'supervisor']),
         OptString.new('PASSWORD', [true, 'Password for the web interface (using default credentials)', 'zyad1234']),
-        OptAddress.new('LHOST', [ true, 'The listen IP address from where the victim downloads the MIPS payload' ]),
+        OptAddressLocal.new('LHOST', [ true, 'The listen IP address from where the victim downloads the MIPS payload' ]),
         OptInt.new('DELAY', [true, "How long to wait for the device to download the payload", 30]),
       ])
   end

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Post
       ))
     register_options(
       [
-        OptAddress.new('LHOST',
+        OptAddressLocal.new('LHOST',
           [false, 'IP of host that will receive the connection from the payload (Will try to auto detect).', nil]),
         OptInt.new('LPORT',
           [true, 'Port for payload to connect to.', 4433]),

--- a/modules/post/multi/manage/system_session.rb
+++ b/modules/post/multi/manage/system_session.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Post
       ))
     register_options(
       [
-        OptAddress.new('LHOST',
+        OptAddressLocal.new('LHOST',
           [true, 'IP of host that will receive the connection from the payload.']),
         OptInt.new('LPORT',
           [false, 'Port for Payload to connect to.', 4433]),

--- a/modules/post/windows/manage/payload_inject.rb
+++ b/modules/post/windows/manage/payload_inject.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('PAYLOAD',   [false, 'Windows Payload to inject into memory of a process.', "windows/meterpreter/reverse_tcp"]),
-        OptAddress.new('LHOST', [true, 'IP of host that will receive the connection from the payload.']),
+        OptAddressLocal.new('LHOST', [true, 'IP of host that will receive the connection from the payload.']),
         OptInt.new('LPORT', [false, 'Port for Payload to connect to.', 4433]),
         OptInt.new('PID', [false, 'Process Identifier to inject of process to inject payload.']),
         OptBool.new('HANDLER', [ false, 'Start an exploit/multi/handler to receive the connection', false]),

--- a/spec/lib/msf/core/opt_address_local_spec.rb
+++ b/spec/lib/msf/core/opt_address_local_spec.rb
@@ -1,0 +1,34 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+require 'msf/core/option_container'
+
+RSpec.describe Msf::OptAddressLocal do
+  valid_values = [
+    { :value => "192.0.2.0/24", :normalized => "192.0.2.0/24" },
+    { :value => "192.0.2.0",    :normalized => "192.0.2.0" },
+    { :value => "127.0.0.1",    :normalized => "127.0.0.1" },
+    { :value => "2001:db8::",   :normalized => "2001:db8::" },
+    { :value => "::1",          :normalized => "::1" }
+  ]
+  
+  invalid_values = [
+    # Too many dots
+    { :value => "192.0.2.0.0" },
+    # Not enough
+    { :value => "192.0.2" },
+    # Non-string values
+    { :value => true},
+    { :value => 5 },
+    { :value => []},
+    { :value => [1,2]},
+    { :value => {}},
+  ]
+
+  it_behaves_like "an option", valid_values, invalid_values, 'address'
+
+
+
+end
+
+

--- a/spec/lib/msf/core/opt_address_local_spec.rb
+++ b/spec/lib/msf/core/opt_address_local_spec.rb
@@ -4,12 +4,23 @@ require 'spec_helper'
 require 'msf/core/option_container'
 
 RSpec.describe Msf::OptAddressLocal do
+  iface = NetworkInterface.interfaces.collect do |iface|
+    ip_address = NetworkInterface.addresses(iface).values.flatten.collect{|x| x['addr']}.select do |addr|
+      begin
+        IPAddr.new(addr).ipv4? && !addr[/^127.*/]
+      rescue IPAddr::InvalidAddressError => e
+        false
+      end
+    end.first
+    {name: iface, addr: ip_address}
+  end.select {|ni| ni[:addr]}.first
+  
   valid_values = [
-    { :value => "192.0.2.0/24", :normalized => "192.0.2.0/24" },
     { :value => "192.0.2.0",    :normalized => "192.0.2.0" },
     { :value => "127.0.0.1",    :normalized => "127.0.0.1" },
     { :value => "2001:db8::",   :normalized => "2001:db8::" },
-    { :value => "::1",          :normalized => "::1" }
+    { :value => "::1",          :normalized => "::1" },
+    { :value => iface[:name],   :normalized => iface[:addr]}
   ]
   
   invalid_values = [
@@ -27,8 +38,18 @@ RSpec.describe Msf::OptAddressLocal do
 
   it_behaves_like "an option", valid_values, invalid_values, 'address'
 
-
-
+  let(:required_opt) {  Msf::OptAddressLocal.new('LHOST', [true, 'local address', '']) }
+  
+  # context 'the normalizer' do
+  #   it 'should handle a call for random IPs' do
+  #     random_addresses = required_opt.normalize('rand:5')
+  #     expect(random_addresses.kind_of?(String)).to eq true
+  #     ips = random_addresses.split(' ')
+  #     expect(ips.count).to eq 5
+  #     ips.each do |ip|
+  #       expect(ip).to match Rex::Socket::MATCH_IPV4
+  #     end
+  #   end
+  # end
+  
 end
-
-

--- a/spec/lib/msf/core/opt_address_local_spec.rb
+++ b/spec/lib/msf/core/opt_address_local_spec.rb
@@ -40,16 +40,4 @@ RSpec.describe Msf::OptAddressLocal do
 
   let(:required_opt) {  Msf::OptAddressLocal.new('LHOST', [true, 'local address', '']) }
   
-  # context 'the normalizer' do
-  #   it 'should handle a call for random IPs' do
-  #     random_addresses = required_opt.normalize('rand:5')
-  #     expect(random_addresses.kind_of?(String)).to eq true
-  #     ips = random_addresses.split(' ')
-  #     expect(ips.count).to eq 5
-  #     ips.each do |ip|
-  #       expect(ip).to match Rex::Socket::MATCH_IPV4
-  #     end
-  #   end
-  # end
-  
 end


### PR DESCRIPTION
You can now specify the LHOST by interface name on POSIX systems
This will grab the first valid IPV4 address on a given interface.

## Verification
- [x] run `ifconfig` find your local 
on a Mac its en# most linux systems use eth#, for me its en0
- [x] Start `msfconsole`
- [x] `use exploit/multi/handler`
- [x] `set payload windows/meterpreter/reverse_tcp`
- [x] `set LHOST en0`
- [x] `run`
- [x] **Verify** you see
`[*] Started reverse TCP handler on <ipaddress>:4444 `
