### PR TITLE
set the correct schema for linux meterpreter reverse_tcp stages

### DIFF
--- a/modules/payloads/stages/linux/armle/meterpreter.rb
+++ b/modules/payloads/stages/linux/armle/meterpreter.rb
@@ -81,6 +81,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
+    opts = {scheme: 'tcp'}
     MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/armle/meterpreter.rb
+++ b/modules/payloads/stages/linux/armle/meterpreter.rb
@@ -81,7 +81,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts = {scheme: 'tcp'}
-    MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', generate_config(opts)).to_binary :process_image
+    MetasploitPayloads::Mettle.new('armv5l-linux-musleabi',
+      generate_config(opts.merge({scheme: 'tcp'}))).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsbe/meterpreter.rb
+++ b/modules/payloads/stages/linux/mipsbe/meterpreter.rb
@@ -92,6 +92,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
+    opts = {scheme: 'tcp'}
     MetasploitPayloads::Mettle.new('mips-linux-muslsf', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsbe/meterpreter.rb
+++ b/modules/payloads/stages/linux/mipsbe/meterpreter.rb
@@ -92,7 +92,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts = {scheme: 'tcp'}
-    MetasploitPayloads::Mettle.new('mips-linux-muslsf', generate_config(opts)).to_binary :process_image
+    MetasploitPayloads::Mettle.new('mips-linux-muslsf',
+      generate_config(opts.merge({scheme: 'tcp'}))).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsle/meterpreter.rb
+++ b/modules/payloads/stages/linux/mipsle/meterpreter.rb
@@ -92,6 +92,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
+    opts = {scheme: 'tcp'}
     MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/mipsle/meterpreter.rb
+++ b/modules/payloads/stages/linux/mipsle/meterpreter.rb
@@ -93,6 +93,7 @@ module MetasploitModule
 
   def generate_stage(opts = {})
     opts = {scheme: 'tcp'}
-    MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', generate_config(opts)).to_binary :process_image
+    MetasploitPayloads::Mettle.new('mipsel-linux-muslsf',
+      generate_config(opts.merge({scheme: 'tcp'}))).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x64/meterpreter.rb
+++ b/modules/payloads/stages/linux/x64/meterpreter.rb
@@ -89,6 +89,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
+    opts = {scheme: 'tcp'}
     MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x64/meterpreter.rb
+++ b/modules/payloads/stages/linux/x64/meterpreter.rb
@@ -89,7 +89,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts = {scheme: 'tcp'}
-    MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :process_image
+    MetasploitPayloads::Mettle.new('x86_64-linux-musl',
+      generate_config(opts.merge({scheme: 'tcp'}))).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x86/meterpreter.rb
+++ b/modules/payloads/stages/linux/x86/meterpreter.rb
@@ -92,6 +92,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
+    opts = {scheme: 'tcp'}
     MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :process_image
   end
 end

--- a/modules/payloads/stages/linux/x86/meterpreter.rb
+++ b/modules/payloads/stages/linux/x86/meterpreter.rb
@@ -92,7 +92,7 @@ module MetasploitModule
   end
 
   def generate_stage(opts = {})
-    opts = {scheme: 'tcp'}
-    MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :process_image
+    MetasploitPayloads::Mettle.new('i486-linux-musl',
+      generate_config(opts.merge({scheme: 'tcp'}))).to_binary :process_image
   end
 end


### PR DESCRIPTION
Oops, forgot to set the schema explicitly for reverse_tcp stagers, which caused stage generation failures.

## Verification

 - [x] verify that the staged linux native meterpreter payloads work