### PR TITLE
move external module template to an ERB, allowing for more templates to be added

### DIFF
--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -1,0 +1,23 @@
+module Msf::Module::External
+  def wait_status(mod)
+    while mod.running
+      m = mod.get_status
+      if m
+        case m['level']
+        when 'error'
+          print_error m['message']
+        when 'warning'
+          print_warning m['message']
+        when 'good'
+          print_good m['message']
+        when 'info'
+          print_status m['message']
+        when 'debug'
+          vprint_status m['message']
+        else
+          print_status m['message']
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/modules/external/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/remote_exploit_cmd_stager.erb
@@ -1,8 +1,10 @@
 require 'msf/core/modules/external/bridge'
+require 'msf/core/module/external'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Module::External
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
@@ -48,27 +50,5 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     print_status("Exploiting...")
     execute_cmdstager({:flavor  => :wget})
-  end
-
-  def wait_status(mod)
-    while mod.running
-      m = mod.get_status
-      if m
-        case m['level']
-        when 'error'
-          print_error m['message']
-        when 'warning'
-          print_warning m['message']
-        when 'good'
-          print_good m['message']
-        when 'info'
-          print_status m['message']
-        when 'debug'
-          vprint_status m['message']
-        else
-          print_status m['message']
-        end
-      end
-    end
   end
 end

--- a/lib/msf/core/modules/external/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/remote_exploit_cmd_stager.erb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       register_options([
         <%= meta[:options] %>
-      ], self.class)
+      ])
   end
 
   def execute_command(cmd, opts)
@@ -72,4 +72,3 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 end
-

--- a/lib/msf/core/modules/external/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/remote_exploit_cmd_stager.erb
@@ -1,0 +1,75 @@
+require 'msf/core/modules/external/bridge'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => <%= meta[:name] %>,
+      'Description' => <%= meta[:description] %>,
+      'Author'      =>
+        [
+          <%= meta[:authors] %>
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          <%= meta[:references] %>
+        ],
+      'DisclosureDate' => <%= meta[:date] %>,
+      'Privileged'     => <%= meta[:privileged] %>,
+      'Platform'       => [<%= meta[:platform] %>],
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets'        =>
+        [
+          <%= meta[:targets] %>
+        ],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => { 'WfsDelay' => <%= meta[:delay] %> }
+      ))
+
+      register_options([
+        <%= meta[:options] %>
+      ], self.class)
+  end
+
+  def execute_command(cmd, opts)
+    mod = Msf::Modules::External::Bridge.open(<%= meta[:path] %>)
+    mod.run(datastore.merge(command: cmd))
+    wait_status(mod)
+    true
+  end
+
+  def exploit
+    print_status("Exploiting...")
+    execute_cmdstager({:flavor  => :wget})
+  end
+
+  def wait_status(mod)
+    while mod.running
+      m = mod.get_status
+      if m
+        case m['level']
+        when 'error'
+          print_error m['message']
+        when 'warning'
+          print_warning m['message']
+        when 'good'
+          print_good m['message']
+        when 'info'
+          print_status m['message']
+        when 'debug'
+          vprint_status m['message']
+        else
+          print_status m['message']
+        end
+      end
+    end
+  end
+end
+

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -54,8 +54,6 @@ class Msf::Modules::External::Shim
     meta = mod_meta_common(mod)
     meta = mod_meta_exploit(mod, meta)
     meta[:command_stager_flavor] = mod.meta['payload']['command_stager_flavor'].dump
-    out = render_template('remote_exploit_cmd_stager.erb', meta)
-    File.write("/tmp/blah.rb", out)
-    out
+    render_template('remote_exploit_cmd_stager.erb', meta)
   end
 end

--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -39,7 +39,7 @@ class Msf::Modules::External::Shim
   end
 
   def self.mod_meta_exploit(mod, meta = {})
-    meta[:delay]       = mod.meta['delay'] || 5
+    meta[:wfsdelay]    = mod.meta['wfsdelay'] || 5
     meta[:privileged]  = mod.meta['privileged'].inspect
     meta[:platform]    = mod.meta['targets'].map do |t|
       t['platform'].dump

--- a/lib/msf/core/modules/external/templates/common_metadata.erb
+++ b/lib/msf/core/modules/external/templates/common_metadata.erb
@@ -1,0 +1,7 @@
+      'Name'        => <%= meta[:name] %>,
+      'Description' => <%= meta[:description] %>,
+      'Author'      =>
+        [
+          <%= meta[:authors] %>
+        ],
+      'License'     => MSF_LICENSE,

--- a/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
           <%= meta[:targets] %>
         ],
       'DefaultTarget'  => 0,
-      'DefaultOptions' => { 'WfsDelay' => <%= meta[:delay] %> }
+      'DefaultOptions' => { 'WfsDelay' => <%= meta[:wfsdelay] %> }
       ))
 
       register_options([

--- a/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
+++ b/lib/msf/core/modules/external/templates/remote_exploit_cmd_stager.erb
@@ -9,13 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => <%= meta[:name] %>,
-      'Description' => <%= meta[:description] %>,
-      'Author'      =>
-        [
-          <%= meta[:authors] %>
-        ],
-      'License'     => MSF_LICENSE,
+	  <%= common_metadata meta %>
       'References'  =>
         [
           <%= meta[:references] %>
@@ -49,6 +43,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Exploiting...")
-    execute_cmdstager({:flavor  => :wget})
+    execute_cmdstager({:flavor  => :<%= meta[:command_stager_flavor] %>})
   end
 end

--- a/modules/exploits/linux/smtp/haraka.py
+++ b/modules/exploits/linux/smtp/haraka.py
@@ -34,12 +34,16 @@ metadata = {
         {'type': 'edb', 'ref': '41162'},
         {'type': 'url', 'ref': 'https://github.com/haraka/Haraka/pull/1606'},
      ],
-    'type': 'remote_exploit.cmd_stager.wget',
+    'type': 'remote_exploit_cmd_stager',
+    'wfsdelay': 5,
     'privileged': True,
     'targets': [
         {'platform': 'linux', 'arch': 'x64'},
         {'platform': 'linux', 'arch': 'x86'}
     ],
+    'payload': {
+        'command_stager_flavor': 'wget'
+    },
     'options': {
         'email_to': {'type': 'string', 'description': 'Email to send to, must be accepted by the server', 'required': True, 'default': 'admin@localhost'},
         'email_from': {'type': 'string', 'description': 'Address to send from', 'required': True, 'default': 'foo@example.com'},


### PR DESCRIPTION
This moves the inline external module template into an .erb file, separating the metadata parsing into common and exploit-specific chunks, which allows one to compose the specific functionality needed for a particular module type. When we add a 2nd template, this will likely shift around.

## Verification steps

 - [x] start msfconsole
 - [x] ensure that the info hash, metadata, and functionality of the haraka module are the same as before