### PR TITLE
make office_word_hta backward compat with older Rubies

### DIFF
--- a/modules/exploits/windows/fileformat/office_word_hta.rb
+++ b/modules/exploits/windows/fileformat/office_word_hta.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uri.delete!("\\")
 
     padding_length = uri_maxlength * 2 - uri.length
-    fail_with(Failure::BadConfig, "please use a uri < #{uri_maxlength} bytes ") if padding_length.negative?
+    fail_with(Failure::BadConfig, "please use a uri < #{uri_maxlength} bytes ") if padding_length < 0
     padding_length.times { uri << "0" }
     uri
   end


### PR DESCRIPTION
It uses a keyword that did not appear until ruby 2.3 - some distros still don't have Ruby 2.3 or higher. Note that if you use the omnibus installer, you will always get the latest supported version of Ruby.