### PR TITLE
meterpreter bugfixes for Windows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.24)
+      metasploit-payloads (= 1.2.27)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.1.9)
       msgpack
@@ -222,7 +222,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.24)
+    metasploit-payloads (1.2.27)
     metasploit_data_models (2.0.14)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.24'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.27'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.9'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
fixed stdapi_fs_mount_show to show full mapped drive path for Python
Meterpreter on Windows

Updated the Windows Meterpreter `getprivs` command to list all privileges