### PR TITLE
bump metasploit-payloads, fix stageless URI parsing, proxy settings with Windows meterpreter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 1.2.27)
+      metasploit-payloads (= 1.2.28)
       metasploit_data_models
       metasploit_payloads-mettle (= 0.1.9)
       msgpack
@@ -222,7 +222,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.2.27)
+    metasploit-payloads (1.2.28)
     metasploit_data_models (2.0.14)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.2.27'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.2.28'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.1.9'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = :dynamic
+  CachedSize = 42
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions


### PR DESCRIPTION
This bumps metasploit-payloads to include Meterpreter fixes for https://github.com/rapid7/metasploit-payloads/pull/199 and https://github.com/rapid7/metasploit-payloads/pull/198