### PR TITLE
address save for aggregator connect details

### DIFF
--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -112,7 +112,7 @@ module Msf
 
       def cmd_aggregator_save(*args)
         # if we are logged in, save session details to aggregator.yaml
-        if args.length == 0 || args[0] == "-h"
+        if args.length > 0 || args[0] == "-h"
           usage_save
           return
         end


### PR DESCRIPTION
Allow saving connection details for metasploit aggregator

## Verification

List the steps needed to make sure this thing works

- [x] Start `metasploit-aggregator`
- [x] Start `msfconsole`
- [x] `load aggregator`
- [x] `aggregator_connect 127.0.0.1:2447`
- [x] `aggregator_save`
- [x] **Verify** ~/.msf4/aggregator.yaml is created
- [x] `aggregator_disconnect`
- [x] `aggregator_connect`
- [x] **Verify** connection established with saved values - for example call `aggregator_cables`

