### PR TITLE
set LHOST in docker

### DIFF
--- a/docker/msfconsole.rc
+++ b/docker/msfconsole.rc
@@ -1,5 +1,10 @@
 <ruby>
-run_single("setg LHOST #{ENV['LHOST']}") if ENV['LHOST']
 run_single("setg LPORT #{ENV['LPORT']}") if ENV['LPORT']
+if ENV['LHOST']
+  lhost = ENV['LHOST']
+else
+  lhost = %x(hostname -i)
+end
+run_single("setg LHOST #{lhost}")
 run_single("db_connect #{ENV['DATABASE_URL'].gsub('postrgres://', '')}") if ENV['DATABASE_URL']
 </ruby>


### PR DESCRIPTION
This PR automatically sets LHOST inside the docker container to it's local ip adress when not supplied via an ENV variable