### PR TITLE
Don't run a DoS during wmap scans

### DIFF
--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Auxiliary::WmapScanFile
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Dos


### PR DESCRIPTION
As reported here: https://community.rapid7.com/thread/9920

## Verification

- [x] Start `msfconsole`
- [x] `load wmap`
- [x] `wmap_modules -l`
- [x] **Verify** No denial of service modules are listed

