### PR TITLE
Upstream Msf namespace PSH decompressor & decoder

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -54,6 +54,7 @@ module Exploit::Powershell
 
     script
   end
+
   #
   # Return an encoded powershell script
   # Will invoke PSH modifiers as enabled
@@ -72,6 +73,21 @@ module Exploit::Powershell
   end
 
   #
+  # Return an decoded powershell script
+  #
+  # @param script_in [String] Encoded contents
+  #
+  # @return [String] Decoded script
+  def decode_script(script_in)
+    if script_in.to_s.match( /[A-Za-z0-9+\/]+={0,3}/)[0] == script_in.to_s and 
+    script_in.to_s.length % 4 == 0
+      return Rex::Powershell::Command.decode_script(script_in)
+    else
+      return script_in
+    end
+  end
+
+  #
   # Return a gzip compressed powershell script
   # Will invoke PSH modifiers as enabled
   #
@@ -87,6 +103,17 @@ module Exploit::Powershell
     end
 
     Rex::Powershell::Command.compress_script(script_in, eof, opts)
+  end
+
+  #
+  # Return a decompressed powershell sript
+  #
+  # @param script_in [String] Compressed contents with decompression stub
+  #
+  # @return [String] Decompressed script
+  def decompress_script(script_in)
+    return script_in if script_in.match(/FromBase64String/).nil?
+    Rex::Powershell::Command.decompress_script(script_in)
   end
 
   #


### PR DESCRIPTION
Present convenience interfaces in Msf::Exploit::Powershell ns for
decoding and decompressing PSH strings built with Rex::Powershell
or compatible implementations.