### PR TITLE
Check payload options before showing RHOST warning

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1580,7 +1580,14 @@ class Core
       mod = active_module
       unless mod.nil?
         if !mod.options.include?('RHOST') && mod.options.include?('RHOSTS')
-          print_warning("RHOST is not a valid option for this module. Did you mean RHOSTS?")
+          warn_rhost = false
+          if (mod.exploit? and mod.datastore['PAYLOAD'])
+            p = framework.payloads.create(mod.datastore['PAYLOAD'])
+            warn_rhost = (p and !p.options.include?('RHOST'))
+          else
+            warn_rhost = true
+          end
+          print_warning("RHOST is not a valid option for this module. Did you mean RHOSTS?") if warn_rhost
         end
       end
     end


### PR DESCRIPTION
This pull request fixes a bug in the RHOST warning. Prior to this, if a module supported RHOSTS and not RHOST (such as `exploit/windows/local/ps_wmi_exec`) but was configured to use a payload which did support RHOST (such as `windows/meterpreter/bind_tcp`) then the message would be incorrectly displayed.

## Example Output (Unpatched)
```
metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) > show options 

Module options (exploit/windows/local/ps_wmi_exec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   DOMAIN                     no        Domain or machine name
   PASSWORD                   no        Password to authenticate with
   RHOSTS                     no        Target address range or CIDR identifier
   SESSION                    yes       The session to run this module on.
   USERNAME                   no        Username to authenticate as


Payload options (windows/meterpreter/bind_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LPORT     4444             yes       The listen port
   RHOST                      no        The target address


Exploit target:

   Id  Name
   --  ----
   0   Universal


metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) > set RHOST 1.2.3.4
[!] RHOST is not a valid option for this module. Did you mean RHOSTS?
RHOST => 1.2.3.4
metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) > show options 

Module options (exploit/windows/local/ps_wmi_exec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   DOMAIN                     no        Domain or machine name
   PASSWORD                   no        Password to authenticate with
   RHOSTS                     no        Target address range or CIDR identifier
   SESSION                    yes       The session to run this module on.
   USERNAME                   no        Username to authenticate as


Payload options (windows/meterpreter/bind_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LPORT     4444             yes       The listen port
   RHOST     1.2.3.4          no        The target address


Exploit target:

   Id  Name
   --  ----
   0   Universal


metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) >
```

## Example Output (Patched)
```
metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) > set PAYLOAD windows/meterpreter/bind_tcp
PAYLOAD => windows/meterpreter/bind_tcp
metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) > set RHOST 1.2.3.4
RHOST => 1.2.3.4
metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) > set RHOST 1.2.3.4
[!] RHOST is not a valid option for this module. Did you mean RHOSTS?
RHOST => 1.2.3.4
metasploit-framework (S:0 J:0) exploit(ps_wmi_exec) >
```

## Testing Steps

 - [x] Start msfconsole
 - [x] Load `exploit/windows/local/ps_wmi_exec`
 - [x] Set the payload to one which does not use `RHOST` and set the `RHOST` option
 - [x] See a warning message
 - [x] Set the payload to one which does use `RHOST` and set the `RHOST` option
 - [x] Do not see a warning message
