### PR TITLE
check for command injection in smtp email addresses

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -151,11 +151,27 @@ module Exploit::Remote::SMTPDeliver
     [nsock, raw_send_recv("EHLO #{domain}\r\n", nsock)]
   end
 
+  def bad_address(address)
+    address.bytesize > 2048 || /[\r\n]/ =~ address
+  end
+
   #
   # Sends an email message, connecting to the server first if a connection is
   # not already established.
   #
   def send_message(data)
+    mailfrom = datastore['MAILFROM'].strip
+    if bad_address(mailfrom)
+      print_error "Bad from address, not sending: #{mailfrom}"
+      return nil
+    end
+
+    mailto = datastore['MAILTO'].strip
+    if bad_address(mailto)
+      print_error "Bad to address, not sending: #{mailto}"
+      return nil
+    end
+
     send_status = nil
 
     already_connected = connected?
@@ -165,9 +181,6 @@ module Exploit::Remote::SMTPDeliver
     else
       nsock = connect_login(false)
     end
-
-    mailto = datastore['MAILTO'].strip
-    mailfrom = datastore['MAILFROM'].strip
 
     raw_send_recv("MAIL FROM: <#{mailfrom}>\r\n", nsock)
     res = raw_send_recv("RCPT TO: <#{mailto}>\r\n", nsock)

--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -166,8 +166,11 @@ module Exploit::Remote::SMTPDeliver
       nsock = connect_login(false)
     end
 
-    raw_send_recv("MAIL FROM: <#{datastore['MAILFROM']}>\r\n", nsock)
-    res = raw_send_recv("RCPT TO: <#{datastore['MAILTO']}>\r\n", nsock)
+    mailto = datastore['MAILTO'].strip
+    mailfrom = datastore['MAILFROM'].strip
+
+    raw_send_recv("MAIL FROM: <#{mailfrom}>\r\n", nsock)
+    res = raw_send_recv("RCPT TO: <#{mailto}>\r\n", nsock)
     if res[0..2] == '250'
       resp = raw_send_recv("DATA\r\n", nsock)
 
@@ -199,7 +202,7 @@ module Exploit::Remote::SMTPDeliver
         send_status = raw_send_recv("#{full_msg}\r\n.\r\n", nsock)
       end
     else
-      print_error "Server refused to send to <#{datastore['MAILTO']}>"
+      print_error "Server refused to send to <#{mailto}>"
     end
 
     if not already_connected


### PR DESCRIPTION
This prevents smtp_deliver from sending mail containing injected commands, see http://www.mbsd.jp/Whitepaper/smtpi.pdf and https://github.com/mikel/mail/commit/cfff6c866bda6485210d304f72293c29f6045e81

## Verification

 - [x] Send emails containing injected commands, newlines, carriage returns, etc.
 - [x] Verify that an error is printed and mail is not delivered