### PR TITLE
Docker version enhancements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Rapid7
 ARG BUNDLER_ARGS="--jobs=8 --without development test coverage"
 ENV APP_HOME /usr/src/metasploit-framework/
 ENV MSF_USER msf
+ENV NMAP_PRIVILEGED=""
 WORKDIR $APP_HOME
 
 COPY Gemfile* m* Rakefile $APP_HOME
@@ -51,7 +52,5 @@ RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip /usr/bin/nmap
 USER $MSF_USER
 
 ADD ./ $APP_HOME
-
-ENV NMAP_PRIVILEGED=""
 
 CMD ["./msfconsole", "-r", "docker/msfconsole.rc"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN apk update && \
     apk add \
       sqlite-libs \
       nmap \
+      nmap-scripts \
+      nmap-nselibs \
       postgresql-libs \
       # needed as long as metasploit-framework.gemspec contains a 'git ls'
       git \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,9 +46,12 @@ RUN chmod o+r /usr/local/bundle/gems/robots-*/lib/robots.rb
 RUN adduser -g msfconsole -D $MSF_USER
 
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)
+RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip /usr/bin/nmap
 
 USER $MSF_USER
 
 ADD ./ $APP_HOME
+
+ENV NMAP_PRIVILEGED=""
 
 CMD ["./msfconsole", "-r", "docker/msfconsole.rc"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.4.1-alpine
 MAINTAINER Rapid7
 
 ARG BUNDLER_ARGS="--jobs=8 --without development test coverage"

--- a/docker/msfconsole.rc
+++ b/docker/msfconsole.rc
@@ -6,5 +6,5 @@ else
   lhost = %x(hostname -i)
 end
 run_single("setg LHOST #{lhost}")
-run_single("db_connect #{ENV['DATABASE_URL'].gsub('postrgres://', '')}") if ENV['DATABASE_URL']
+run_single("db_connect #{ENV['DATABASE_URL'].gsub('postgres://', '')}") if ENV['DATABASE_URL']
 </ruby>

--- a/docker/msfconsole.rc
+++ b/docker/msfconsole.rc
@@ -6,5 +6,5 @@ else
   lhost = %x(hostname -i)
 end
 run_single("setg LHOST #{lhost}")
-run_single("db_connect #{ENV['DATABASE_URL'].gsub('postgres://', '')}") if ENV['DATABASE_URL']
+run_single("db_connect #{ENV['DATABASE_URL']}") if ENV['DATABASE_URL']
 </ruby>


### PR DESCRIPTION
Hey there, this PR tries to polish msf docker version. Briefly it will:

- Synchronize base ruby image with current `.ruby-version`
- Add capabilities to nmap, so `db_nmap` will work properly (more on this below)
- Remove some unnecessary code in the startup script

Ping @FireFart. Could be related to #8349.

### Nmap capabilities note

[It](https://secwiki.org/w/Running_nmap_as_an_unprivileged_user) [seems](https://github.com/nmap/nmap/blob/master/libpcap/pcap-netfilter-linux.c) nmap needs `CAP_NET_ADMIN` capability, which docker engine do not allow by default. Help wanted here but I didn't notice any problems with only `CAP_NET_RAW` and `CAP_NET_BIND_SERVICE` capabilities applied to `/usr/bin/nmap`, but accidentally things can go wrong.