### PR TITLE
add ruby backports compat library

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ PATH
       actionpack (~> 4.2.6)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
+      backports
       bcrypt
       bit-struct
       filesize
@@ -126,6 +127,7 @@ GEM
       ffi (~> 1.9.10)
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
+    backports (3.8.0)
     bcrypt (3.1.11)
     bindata (2.4.0)
     builder (3.2.3)

--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -12,6 +12,7 @@
 
 # Sanity check this version of ruby
 require 'msf/sanity'
+require 'backports'
 
 # The framework-core depends on Rex
 require 'rex'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -47,6 +47,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Needed for config.action_view for view plugin compatibility for Pro
   spec.add_runtime_dependency 'actionpack', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
+  # Backports Ruby features across language versions
+  spec.add_runtime_dependency 'backports'
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation


### PR DESCRIPTION
This fixes #8405 and other compatibility issues by including the 'backports' library, which patches newer Ruby functionality into older versions. See https://github.com/marcandre/backports for details.

## Verification

- [x] Use Ruby 2.3 or earlier to launch msfconsole
- [x] Note no startup errors about the missing 'match?' method on string objects
