### PR TITLE
fix for smb_login errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    ruby_smb (0.0.12)
+    ruby_smb (0.0.14)
       bindata
       rubyntlm
       windows_error


### PR DESCRIPTION
do not try the TreeConnect if the SESSION_SETUP
has already failed.


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Run the smb_login scanner against a valid host
- [x] VERIFY you do not get strange exceptions

