### PR TITLE
Minor EternalBlue bug fix

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -187,6 +187,10 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Receiving response from exploit packet")
       code, raw = smb1_get_response(sock)
 
+      if code.nil?
+        print_error("Did not receive a response from exploit packet")
+      end
+
       if code == 0xc000000d #STATUS_INVALID_PARAMETER (0xC000000D)
         print_good("ETERNALBLUE overwrite completed successfully (0xC000000D)!")
       end
@@ -225,6 +229,10 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put(pkt)
 
     code, raw, response = smb1_get_response(sock)
+
+    if code.nil?
+      raise RubySMB::Error::UnexpectedStatusCode, "No response to login request"
+    end
 
     unless code == 0 # WindowsError::NTStatus::STATUS_SUCCESS
       raise RubySMB::Error::UnexpectedStatusCode, "Error with anonymous login"
@@ -290,6 +298,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def smb1_get_response(sock)
     raw = sock.get_once
+    return nil unless raw
     response = RubySMB::SMB1::SMBHeader.read(raw[4..-1])
     code = response.nt_status
     return code, raw, response


### PR DESCRIPTION
Fixes a stack trace when the target doesn't reply to SMB requests. The error looks like:
```
[-] 192.168.1.4:445 - undefined method `[]' for nil:NilClass
[-] 192.168.1.4:445 - /home/work/tools/metasploit-framework/modules/exploits/windows/smb/ms17_010_eternalblue.rb:293:in `smb1_get_response'
```
This patch lets the module continue trying in these cases.
