### PR TITLE
Fix the typo3_spec.rb failures.

### DIFF
--- a/lib/msf/core/exploit/http/typo3/login.rb
+++ b/lib/msf/core/exploit/http/typo3/login.rb
@@ -100,8 +100,13 @@ module Msf::Exploit::Remote::HTTP::Typo3::Login
     key = OpenSSL::PKey::RSA.new
     exponent = OpenSSL::BN.new e.hex.to_s
     modulus = OpenSSL::BN.new n.hex.to_s
-    key.e = exponent
-    key.n = modulus
+    if key.respond_to?(:set_key)
+      # Ruby 2.4+
+      key.set_key(modulus, exponent, nil)
+    else
+      key.e = exponent
+      key.n = modulus
+    end
     enc = key.public_encrypt(password)
     enc_b64 = Rex::Text.encode_base64(enc)
     "rsa:#{enc_b64}"


### PR DESCRIPTION
`rake spec` is giving some failures on the `typo3_spec` test unit.
See later comments for the full story; _OpenSSL 1.1.0+_ is the reason for the failures.

This patch should solve them.
Shall I open an issue too?

## These are the errors from `rake spec`:

```
Msf::Exploit::Remote::HTTP::Typo3 ......FF.

  5) Msf::Exploit::Remote::HTTP::Typo3#typo3_backend_login returns a cookie string when TYPO3 credentials are valid
     Failure/Error: key.e = exponent
     
     NoMethodError:
       undefined method `e=' for #<OpenSSL::PKey::RSA:0x0055fc518e7d00>
       Did you mean?  e
     # ./lib/msf/core/exploit/http/typo3/login.rb:103:in `typo3_helper_login_rsa'
     # ./lib/msf/core/exploit/http/typo3/login.rb:37:in `typo3_backend_login'
     # ./spec/lib/msf/core/exploit/http/typo3_spec.rb:135:in `block (3 levels) in <top (required)>'

  6) Msf::Exploit::Remote::HTTP::Typo3#typo3_backend_login returns nil when TYPO3 credentials are invalid
     Failure/Error: key.e = exponent
     
     NoMethodError:
       undefined method `e=' for #<OpenSSL::PKey::RSA:0x0055fc518e0668>
       Did you mean?  e
     # ./lib/msf/core/exploit/http/typo3/login.rb:103:in `typo3_helper_login_rsa'
     # ./lib/msf/core/exploit/http/typo3/login.rb:37:in `typo3_backend_login'
     # ./spec/lib/msf/core/exploit/http/typo3_spec.rb:112:in `block (3 levels) in <top (required)>'
```


## Verification

List the steps needed to make sure this thing works

- [x] Start `rake spec`
- [x] No more typo3 failures
- [x] Test it with ruby 2.3 too
- [x] No typo3 failures either.
- [x] Hurrah! :)

Note that I had to follow the suggestion in:

https://github.com/rvm/rvm/issues/3958

to use RVM and Ruby 2.3 under Kali.