### PR TITLE
change postgres docker image to alpine and add timezone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - 4444:4444
     volumes:
       - $HOME/.msf4:/home/msf/.msf4
+      - /etc/localtime:/etc/localtime:ro
 
   db:
     image: postgres:9-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - $HOME/.msf4:/home/msf/.msf4
 
   db:
-    image: postgres:9.6
+    image: postgres:9-alpine
     volumes:
       - pg_data:/var/lib/postgresql/data
 


### PR DESCRIPTION
This uses the smaller alpine image for the postgres database and mounts /etc/localtime in the container so the timezone will be correct