### PR TITLE
remote id should be not suppressed based on local id

### DIFF
--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -84,7 +84,7 @@ module Msf
 
       def show_session(details, target, local_id)
         status = pad_space("  #{local_id}", 4)
-        status += "  #{details['ID']}" unless local_id.nil?
+        status += "  #{details['ID']}"
         status = pad_space(status, 15)
         status += "  meterpreter "
         status += "#{guess_target_platform(details['OS'])} "


### PR DESCRIPTION
Session listing from aggregator should show any remote id found.

## Verification

List the steps needed to make sure this thing works
- [x] Start `metasploit-aggregator`
- [x] Create local payload `msfvenom -p python/meterpreter_reverse_https LHOST=127.0.0.1 LPORT=8443 > metPy_127_8443`
- [x] Start payload `python metPy_127_8443`
- [x] Start `msfconsole`
- [x] `load aggregator`
- [x] `aggregator_connect 127.0.0.1:2447`
- [x] `aggregator_default_forward`
- [x] `aggregator_cable_add 127.0.0.1:8443`
- [x] after session connects `aggregator_sessions`
- [x] Start another `msfconsole`
- [x] `load aggregator`
- [x] `aggregator_connect 127.0.0.1:2447`
- [x] `aggregator_sessions`
- [x] **Verify** the remote id is shown in the first console is shown in the new console while local id is not populated.
