### PR TITLE
Fix proxy_type references to handle nil case

### DIFF
--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -86,7 +86,7 @@ private
       proxy_host = ''
       if opts[:proxy_host] && opts[:proxy_port]
         prefix = 'http://'
-        prefix = 'socks=' if opts[:proxy_type].downcase == 'socks'
+        prefix = 'socks=' if opts[:proxy_type].to_s.downcase == 'socks'
         proxy_host = "#{prefix}#{opts[:proxy_host]}:#{opts[:proxy_port]}"
       end
       proxy_host = to_str(proxy_host || '', PROXY_HOST_SIZE)

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -730,7 +730,7 @@ private
 
       if opts[:proxy_host] && opts[:proxy_port]
         prefix = 'http://'
-        prefix = 'socks=' if opts[:proxy_type] == 'socks'
+        prefix = 'socks=' if opts[:proxy_type].to_s.downcase == 'socks'
         proxy = "#{prefix}#{opts[:proxy_host]}:#{opts[:proxy_port]}"
         request.add_tlv(TLV_TYPE_TRANS_PROXY_HOST, proxy)
 


### PR DESCRIPTION
This PR contains a simple fix for the issue raised in #8429. The issue was that the `:proxy_type` value wasn't being handled properly in the case of `nil`, and so errors were being thrown when stageless payloads were generated.

## Sample run
```
metasploit-framework git:(master) $ ./msfvenom -p windows/meterpreter_reverse_https PayloadProxyHost=doot PayloadProxyPort=8080 -f exe -o /dev/null
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
Error: undefined method `downcase' for nil:NilClass                  <~ boooooo!
metasploit-framework git:(master) $ git checkout fix-payloadproxytype 
Switched to branch 'fix-payloadproxytype'
oj@ropchain ➜  metasploit-framework git:(fix-payloadproxytype) $ ./msfvenom -p windows/meterpreter_reverse_https PayloadProxyHost=doot PayloadProxyPort=8080 -f exe -o /dev/null
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 958531 bytes
Final size of exe file: 1033728 bytes
Saved as: /dev/null                                                  <~ hooraaay!
```

## Verification (do on x64 and x86 payloads)
On master:
- [x] run `msfvenom -p windows/meterpreter_reverse_https PayloadProxyHost=blerp PayloadProxyPort=8080 -f exe -o /dev/null`
- [x] Notice that is breaks with the error `msfvenom -p windows/meterpreter_reverse_https PayloadProxyHost=doot PayloadProxyPort=8080 -f exe -o /dev/null`

On this fix branch:
- [x] run `msfvenom -p windows/meterpreter_reverse_https PayloadProxyHost=blerp PayloadProxyPort=8080 -f exe -o /dev/null`
- [x] Verify that the error is not thrown and instead the payload is generated correctly.

This was also an issue when using `transport add` from inside Meterpreter.

Fixes #8429 
